### PR TITLE
feat(advisory-wait): condition secondaryQuietWindow on live review evidence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,14 +112,20 @@ own interaction model rather than following product terms literally.
 - **Secondary-bot quiet window**: This source repository also records
   `advisoryWait.secondaryBotLogin: "coderabbitai[bot]"` and
   `advisoryWait.secondaryQuietWindow: "PT1H"` as a local IDD dogfooding
-  opt-in (applies only to `kurone-kito/idd-skill`), waiting one hour
-  after E-phase convergence conditions are first observed before
+  opt-in (applies only to `kurone-kito/idd-skill`), waiting up to one
+  hour after E-phase convergence conditions are first observed before
   pre-merge readiness treats review as settled. This repository
   dogfoods CodeRabbit alongside Copilot and has twice hit CodeRabbit
   rate-limiting during a PR's review cycle, each time working around
   it with an ad hoc one-hour wait before merging; this config turns
   that informal practice into a proper `pre-merge-readiness` blocker
-  (Refs #2335, #2410).
+  (Refs #2335, #2410). As of #2544, the wait is conditioned on live
+  review evidence rather than unconditional: once CodeRabbit has
+  already posted a genuine (non-rate-limited) review for the current
+  HEAD, only a short fixed confirmation buffer applies instead of the
+  full hour -- a HEAD CodeRabbit has not yet reviewed still waits the
+  full configured window unchanged, keeping the wait a fallback for
+  genuine secondary-bot degradation rather than a tax on every merge.
 
 ## For IDD work
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,14 +112,20 @@ terms literally.
 - **Secondary-bot quiet window**: This source repository also records
   `advisoryWait.secondaryBotLogin: "coderabbitai[bot]"` and
   `advisoryWait.secondaryQuietWindow: "PT1H"` as a local IDD dogfooding
-  opt-in (applies only to `kurone-kito/idd-skill`), waiting one hour
-  after E-phase convergence conditions are first observed before
+  opt-in (applies only to `kurone-kito/idd-skill`), waiting up to one
+  hour after E-phase convergence conditions are first observed before
   pre-merge readiness treats review as settled. This repository
   dogfoods CodeRabbit alongside Copilot and has twice hit CodeRabbit
   rate-limiting during a PR's review cycle, each time working around
   it with an ad hoc one-hour wait before merging; this config turns
   that informal practice into a proper `pre-merge-readiness` blocker
-  (Refs #2335, #2410).
+  (Refs #2335, #2410). As of #2544, the wait is conditioned on live
+  review evidence rather than unconditional: once CodeRabbit has
+  already posted a genuine (non-rate-limited) review for the current
+  HEAD, only a short fixed confirmation buffer applies instead of the
+  full hour -- a HEAD CodeRabbit has not yet reviewed still waits the
+  full configured window unchanged, keeping the wait a fallback for
+  genuine secondary-bot degradation rather than a tax on every merge.
 
 ## For IDD work
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -112,14 +112,20 @@ own interaction model rather than following product terms literally.
 - **Secondary-bot quiet window**: This source repository also records
   `advisoryWait.secondaryBotLogin: "coderabbitai[bot]"` and
   `advisoryWait.secondaryQuietWindow: "PT1H"` as a local IDD dogfooding
-  opt-in (applies only to `kurone-kito/idd-skill`), waiting one hour
-  after E-phase convergence conditions are first observed before
+  opt-in (applies only to `kurone-kito/idd-skill`), waiting up to one
+  hour after E-phase convergence conditions are first observed before
   pre-merge readiness treats review as settled. This repository
   dogfoods CodeRabbit alongside Copilot and has twice hit CodeRabbit
   rate-limiting during a PR's review cycle, each time working around
   it with an ad hoc one-hour wait before merging; this config turns
   that informal practice into a proper `pre-merge-readiness` blocker
-  (Refs #2335, #2410).
+  (Refs #2335, #2410). As of #2544, the wait is conditioned on live
+  review evidence rather than unconditional: once CodeRabbit has
+  already posted a genuine (non-rate-limited) review for the current
+  HEAD, only a short fixed confirmation buffer applies instead of the
+  full hour -- a HEAD CodeRabbit has not yet reviewed still waits the
+  full configured window unchanged, keeping the wait a fallback for
+  genuine secondary-bot degradation rather than a tax on every merge.
 
 ## For IDD work
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -388,7 +388,11 @@ currency gate already computes (`ackOnlyPostDisposition`), so it needs no
 extra persisted state: an unresolved item keeps the anchor fresh, and a
 disposition reply, a watermark, or a courtesy bot acknowledgement never
 reopens it. Distinct from `advisoryWait.settledWindow`, which bounds the
-PRIMARY bot's own pending state, not a late secondary-bot arrival.
+PRIMARY bot's own pending state, not a late secondary-bot arrival. **#2544**:
+once the secondary bot has already posted a genuine review for the current
+HEAD, only a short fixed confirmation buffer applies from that review's own
+timestamp instead of the full configured duration -- a HEAD the bot has not
+yet reviewed still waits the full period unchanged.
 
 `advisoryWait.capExhaustedRoute` is intentionally fail-closed. The
 default `phase-specific` behavior keeps the current E14 skip / F2-F3

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -241,7 +241,12 @@ computes, so it needs no separately persisted timestamp: a genuinely
 unresolved item keeps the anchor fresh, and a disposition reply, a
 watermark, or a courtesy bot ack never reopens it. Distinct from
 `settledWindow`, which bounds the PRIMARY bot's own pending state, not a
-late secondary-bot arrival.
+late secondary-bot arrival. **#2544**: once the secondary bot has already
+posted a genuine (non-notice) review for the current HEAD, the gate no
+longer requires the full configured duration -- only a short, fixed
+confirmation buffer applies from that review's own timestamp, so the wait
+stays a fallback for a genuinely unreviewed HEAD rather than a fixed tax on
+every merge.
 `advisoryWait.exemptBotAuthoredPrs` (#1906) is an opt-in, off-by-default
 flag effective only under `advisoryWait.convergenceScope: "all-prs"`. When
 `true`, a PR whose author resolves to a GitHub Bot-typed account AND has no

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -388,7 +388,11 @@ currency gate already computes (`ackOnlyPostDisposition`), so it needs no
 extra persisted state: an unresolved item keeps the anchor fresh, and a
 disposition reply, a watermark, or a courtesy bot acknowledgement never
 reopens it. Distinct from `advisoryWait.settledWindow`, which bounds the
-PRIMARY bot's own pending state, not a late secondary-bot arrival.
+PRIMARY bot's own pending state, not a late secondary-bot arrival. **#2544**:
+once the secondary bot has already posted a genuine review for the current
+HEAD, only a short fixed confirmation buffer applies from that review's own
+timestamp instead of the full configured duration -- a HEAD the bot has not
+yet reviewed still waits the full period unchanged.
 
 `advisoryWait.capExhaustedRoute` is intentionally fail-closed. The
 default `phase-specific` behavior keeps the current E14 skip / F2-F3

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -241,7 +241,12 @@ computes, so it needs no separately persisted timestamp: a genuinely
 unresolved item keeps the anchor fresh, and a disposition reply, a
 watermark, or a courtesy bot ack never reopens it. Distinct from
 `settledWindow`, which bounds the PRIMARY bot's own pending state, not a
-late secondary-bot arrival.
+late secondary-bot arrival. **#2544**: once the secondary bot has already
+posted a genuine (non-notice) review for the current HEAD, the gate no
+longer requires the full configured duration -- only a short, fixed
+confirmation buffer applies from that review's own timestamp, so the wait
+stays a fallback for a genuinely unreviewed HEAD rather than a fixed tax on
+every merge.
 `advisoryWait.exemptBotAuthoredPrs` (#1906) is an opt-in, off-by-default
 flag effective only under `advisoryWait.convergenceScope: "all-prs"`. When
 `true`, a PR whose author resolves to a GitHub Bot-typed account AND has no

--- a/scripts/advisory-wait-policy.mjs
+++ b/scripts/advisory-wait-policy.mjs
@@ -390,6 +390,43 @@ export function resolveAdvisorySecondaryQuietWindowMinutes(config = {}) {
     DEFAULT_ADVISORY_SECONDARY_QUIET_WINDOW_MINUTES,
   );
 }
+// #2544: once the secondary bot has posted a genuine (non-notice) review
+// for the current HEAD, #2335's "might still be mid-review" risk no longer
+// applies -- only a short confirmation buffer remains, anchored on the
+// bot's OWN settlement signal rather than the full window anchored on
+// general PR activity (which unrelated later activity could otherwise keep
+// re-extending). #2330's own motivating evidence (a second finding landing
+// 34s and 2m after a zero-unresolved snapshot) sets the buffer floor; 5
+// minutes gives comfortable margin above the largest observed value while
+// staying far short of the full configured window.
+const SECONDARY_QUIET_WINDOW_SETTLED_BUFFER_MINUTES = 5;
+/**
+ * Shared elapsed/remaining-minutes arithmetic for a quiet-window anchor.
+ * Extracted so `buildSecondaryQuietWindowStatus`'s unsettled path (anchored
+ * on `effectiveMaxActivityUpdatedAt`) and its #2544 settled-buffer path
+ * (anchored on `secondaryBotSettledAt`) compute identically and cannot
+ * drift apart.
+ */
+function computeQuietWindowElapsed({ minutes, anchorAt, now }) {
+  const nowMs = Date.parse(now);
+  const anchorMs = Date.parse(anchorAt);
+  const elapsedMinutes =
+    Number.isFinite(nowMs) && Number.isFinite(anchorMs)
+      ? nowMs < anchorMs
+        ? 0
+        : Math.floor((nowMs - anchorMs) / 60000)
+      : null;
+  const elapsed = elapsedMinutes !== null && elapsedMinutes >= minutes;
+  const remainingMinutes =
+    elapsedMinutes !== null ? Math.max(0, minutes - elapsedMinutes) : null;
+  return {
+    minutes,
+    anchorAt,
+    elapsedMinutes,
+    elapsed,
+    remainingMinutes,
+  };
+}
 /**
  * Build the `advisoryWait.secondaryQuietWindow` gate status (#2335): once
  * the E-phase convergence conditions are already met -- no unresolved
@@ -415,21 +452,33 @@ export function resolveAdvisorySecondaryQuietWindowMinutes(config = {}) {
  * since that anchor" already equals "elapsed since convergence was reached"
  * without a second, independently-drifting timestamp to persist.
  *
+ * #2544: `secondaryBotSettledAt` -- when it is a valid ISO timestamp --
+ * switches the gate to the shorter settled buffer above, anchored on that
+ * timestamp instead of `effectiveMaxActivityUpdatedAt`. The buffer never
+ * exceeds the operator's own configured `minutes` (via `Math.min`), so a
+ * repository that configures a window shorter than the buffer is never
+ * kept waiting longer than what it explicitly asked for. Omitted or
+ * invalid (the pre-#2544 default for every existing caller) falls through
+ * to the unchanged, unsettled path -- byte-identical behavior.
+ *
  * A zero/absent `minutes` (the off/unset default) or a missing/invalid
  * anchor (nothing to anchor on yet) reports `elapsed: true` unconditionally
  * -- this gate must never itself block when unconfigured, and must never
- * block on the absence of any activity to measure. A positive but
- * non-integer `minutes` is floored -- the config-sourced path
- * (`resolveAdvisorySecondaryQuietWindowMinutes`) never produces one (every
- * ISO-duration unit it accepts converts to a whole number of minutes), but
- * this function's own `minutes` parameter is untyped, and a fractional
- * value would otherwise leak into `elapsedMinutes`/`remainingMinutes` as
- * non-integers, contradicting the whole-minute contract those fields keep
- * elsewhere in this report.
+ * block on the absence of any activity to measure. The `minutes <= 0`
+ * short-circuit is checked BEFORE `secondaryBotSettledAt` is ever
+ * consulted, so the off default stays unconditional regardless of
+ * settlement evidence. A positive but non-integer `minutes` is floored --
+ * the config-sourced path (`resolveAdvisorySecondaryQuietWindowMinutes`)
+ * never produces one (every ISO-duration unit it accepts converts to a
+ * whole number of minutes), but this function's own `minutes` parameter is
+ * untyped, and a fractional value would otherwise leak into
+ * `elapsedMinutes`/`remainingMinutes` as non-integers, contradicting the
+ * whole-minute contract those fields keep elsewhere in this report.
  */
 export function buildSecondaryQuietWindowStatus({
   minutes,
   effectiveMaxActivityUpdatedAt,
+  secondaryBotSettledAt,
   now,
 }) {
   const resolvedMinutes =
@@ -438,7 +487,7 @@ export function buildSecondaryQuietWindowStatus({
       : 0;
   const anchorAtRaw = String(effectiveMaxActivityUpdatedAt ?? '');
   const anchorValid = isValidIsoTimestamp(anchorAtRaw);
-  if (resolvedMinutes <= 0 || !anchorValid) {
+  if (resolvedMinutes <= 0) {
     return {
       minutes: resolvedMinutes,
       anchorAt: anchorValid ? anchorAtRaw : 'none',
@@ -447,26 +496,31 @@ export function buildSecondaryQuietWindowStatus({
       remainingMinutes: 0,
     };
   }
-  const nowMs = Date.parse(now);
-  const anchorMs = Date.parse(anchorAtRaw);
-  const elapsedMinutes =
-    Number.isFinite(nowMs) && Number.isFinite(anchorMs)
-      ? nowMs < anchorMs
-        ? 0
-        : Math.floor((nowMs - anchorMs) / 60000)
-      : null;
-  const elapsed = elapsedMinutes !== null && elapsedMinutes >= resolvedMinutes;
-  const remainingMinutes =
-    elapsedMinutes !== null
-      ? Math.max(0, resolvedMinutes - elapsedMinutes)
-      : null;
-  return {
+  const settledAtRaw = String(secondaryBotSettledAt ?? '');
+  if (isValidIsoTimestamp(settledAtRaw)) {
+    return computeQuietWindowElapsed({
+      minutes: Math.min(
+        resolvedMinutes,
+        SECONDARY_QUIET_WINDOW_SETTLED_BUFFER_MINUTES,
+      ),
+      anchorAt: settledAtRaw,
+      now,
+    });
+  }
+  if (!anchorValid) {
+    return {
+      minutes: resolvedMinutes,
+      anchorAt: 'none',
+      elapsedMinutes: null,
+      elapsed: true,
+      remainingMinutes: 0,
+    };
+  }
+  return computeQuietWindowElapsed({
     minutes: resolvedMinutes,
     anchorAt: anchorAtRaw,
-    elapsedMinutes,
-    elapsed,
-    remainingMinutes,
-  };
+    now,
+  });
 }
 export function normalizeAdvisoryWaitRuntimeOptions(options = {}) {
   const o = options ?? {};

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -10,6 +10,7 @@ import {
   readAdvisoryConvergenceDeadlineMinutes,
   readAdvisoryPrimaryBotLogin,
   readAdvisoryRecoveryCycleCap,
+  readAdvisorySecondaryBotLogin,
   readAdvisorySecondaryQuietWindowMinutes,
   readAdvisoryTerminalWindowMinutes,
   readAdvisoryWaitPolicy,
@@ -434,6 +435,7 @@ export function collectPreMergeReadiness(
   const advisoryConvergenceDeadlineMinutes =
     readAdvisoryConvergenceDeadlineMinutes();
   const secondaryQuietWindowMinutes = readAdvisorySecondaryQuietWindowMinutes();
+  const secondaryBotLogin = readAdvisorySecondaryBotLogin();
   // #1570: precompute the `#1572` terminal Copilot-unavailability verdict
   // here (the CLI/orchestration layer) rather than inside
   // `buildPreMergeReadinessSummary` (protocol-helpers.mts), which cannot
@@ -555,6 +557,7 @@ export function collectPreMergeReadiness(
       advisoryConvergenceHeadCommittedAt,
       advisoryConvergenceDeadlineMinutes,
       secondaryQuietWindowMinutes,
+      secondaryBotLogin,
       waivableCheckSelectors,
       externalCheckWaiverMaxValidity,
       externalCheckWaiverMode,

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1350,6 +1350,64 @@ export function dispositionNamesAdvisoryBot(
   }
   return span.toLowerCase().includes(token);
 }
+// #2544: true when the configured secondary advisory bot has already
+// posted a genuine (non-notice) comment for the CURRENT HEAD -- i.e. the
+// `secondaryQuietWindow` gate's original #2335 "might still be mid-review"
+// concern no longer applies to this specific HEAD, only the narrower
+// "second/later finding" risk #2335 was also chartered to protect
+// (`buildSecondaryQuietWindowStatus`'s settled-buffer branch,
+// advisory-wait-policy.mts).
+//
+// Every ambiguity resolves to `settled: false` -- the same fail-closed
+// direction #2335 already relies on: no comment from the bot at or after
+// `headCommittedAt`, an unparseable `headCommittedAt`/unconfigured
+// `secondaryBotLogin`, or the LATEST such comment being a rate-limit /
+// skip-review notice (`isAdvisoryNonReviewNotice`), all report
+// `settled: false`. Only the single latest matching comment is examined --
+// a notice posted BEFORE a later genuine comment (rate-limited, then
+// recovered) does not defeat settlement, while a notice posted AFTER the
+// latest genuine comment (mid-retry) does, purely as a side effect of
+// always picking the latest.
+//
+// Deliberately reuses `comments` only, not `reviews`: this file's existing
+// notice-vs-genuine classification for the secondary bot
+// (`isAdvisoryNonReviewNotice`, `isReviewSummaryComment`,
+// `classifyRegularBotComment`) already operates purely on top-level PR
+// comments -- `ReviewLike` carries no `body` field in this codebase's
+// model, so a PR review object can never carry the marker text this needs.
+export function computeSecondaryAdvisoryReviewSettlement(
+  comments,
+  { secondaryBotLogin, headCommittedAt },
+) {
+  const token = advisoryBotIdentityToken(secondaryBotLogin);
+  const headAt = String(headCommittedAt ?? '');
+  if (!token || !isValidIsoTimestamp(headAt)) {
+    return { settled: false, settledAt: null };
+  }
+  const matches = comments
+    .filter(
+      (comment) =>
+        advisoryBotIdentityToken(comment.author?.login ?? '') === token,
+    )
+    .map((comment) => ({
+      body: comment.body ?? '',
+      at: effectiveRegularCommentActivityAt({
+        updatedAt: comment.updatedAt,
+        createdAt: String(comment.createdAt ?? ''),
+      }),
+    }))
+    .filter(
+      (entry) =>
+        isValidIsoTimestamp(entry.at) &&
+        compareIsoTimestamps(entry.at, headAt) >= 0,
+    )
+    .sort((left, right) => compareIsoTimestamps(left.at, right.at));
+  const latest = matches[matches.length - 1];
+  if (!latest || isAdvisoryNonReviewNotice(latest.body)) {
+    return { settled: false, settledAt: null };
+  }
+  return { settled: true, settledAt: latest.at };
+}
 // #1182 Match trusted machine advisory dispositions to the advisory-bot stickies
 // they address, so a disposition posted by a trusted-marker actor who is NOT a
 // resolved IDD agent (e.g. a second trusted session) is honored without being
@@ -5446,14 +5504,33 @@ export function buildPreMergeReadinessSummary(
       dispositionAuthorLogins: iddAgentLogins,
     },
   );
+  // #2544: whether the configured secondary bot has already posted a
+  // genuine (non-notice) comment for the CURRENT HEAD -- reuses
+  // `options.advisoryConvergenceHeadCommittedAt` (the HEAD commit's own
+  // `committedDate`, already resolved by the caller for the unrelated
+  // advisory-convergence-deadline precondition below) rather than a second
+  // fetch, since it is exactly "when did this HEAD land" either way.
+  const secondaryBotLogin = String(options.secondaryBotLogin ?? '')
+    .trim()
+    .toLowerCase();
+  const secondaryReviewSettlement = secondaryBotLogin
+    ? computeSecondaryAdvisoryReviewSettlement(comments, {
+        secondaryBotLogin,
+        headCommittedAt: options.advisoryConvergenceHeadCommittedAt,
+      })
+    : { settled: false, settledAt: null };
   // #2335: stateless secondary-quiet-window gate, anchored on the same
   // non-ack-only activity ceiling `liveSnapshot.effective` already computes
   // for the review-currency ack-only carve-out below -- see
   // `buildSecondaryQuietWindowStatus`'s own doc comment for why this anchor
   // needs no separate persisted "convergence first observed" timestamp.
+  // #2544: `secondaryBotSettledAt` shortens the required wait to a settled
+  // buffer once that evidence exists; see `computeSecondaryAdvisoryReviewSettlement`
+  // above for how it is derived.
   const secondaryQuietWindow = buildSecondaryQuietWindowStatus({
     minutes: options.secondaryQuietWindowMinutes,
     effectiveMaxActivityUpdatedAt: liveSnapshot.effective?.maxActivityUpdatedAt,
+    secondaryBotSettledAt: secondaryReviewSettlement.settledAt,
     now,
   });
   const isTrustedWatermarkAuthor = (login) =>

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1375,6 +1375,13 @@ export function dispositionNamesAdvisoryBot(
 // `classifyRegularBotComment`) already operates purely on top-level PR
 // comments -- `ReviewLike` carries no `body` field in this codebase's
 // model, so a PR review object can never carry the marker text this needs.
+//
+// Falls back to `user.login`/`created_at`/`updated_at` alongside
+// `author.login`/`createdAt`/`updatedAt`, matching every other
+// `CommentLike` reader in this file (Copilot review, #2546): a caller that
+// ever passes REST-raw comments straight through, without the CLI layer's
+// own `normalizeComment` pass, must not silently fail-closed here just
+// because it used the other field-name form.
 export function computeSecondaryAdvisoryReviewSettlement(
   comments,
   { secondaryBotLogin, headCommittedAt },
@@ -1387,13 +1394,15 @@ export function computeSecondaryAdvisoryReviewSettlement(
   const matches = comments
     .filter(
       (comment) =>
-        advisoryBotIdentityToken(comment.author?.login ?? '') === token,
+        advisoryBotIdentityToken(
+          comment.author?.login ?? comment.user?.login ?? '',
+        ) === token,
     )
     .map((comment) => ({
       body: comment.body ?? '',
       at: effectiveRegularCommentActivityAt({
-        updatedAt: comment.updatedAt,
-        createdAt: String(comment.createdAt ?? ''),
+        updatedAt: comment.updatedAt ?? comment.updated_at,
+        createdAt: String(comment.createdAt ?? comment.created_at ?? ''),
       }),
     }))
     .filter(

--- a/src/scripts/advisory-wait-policy.mts
+++ b/src/scripts/advisory-wait-policy.mts
@@ -456,6 +456,53 @@ export interface SecondaryQuietWindowStatus {
   remainingMinutes: number | null;
 }
 
+// #2544: once the secondary bot has posted a genuine (non-notice) review
+// for the current HEAD, #2335's "might still be mid-review" risk no longer
+// applies -- only a short confirmation buffer remains, anchored on the
+// bot's OWN settlement signal rather than the full window anchored on
+// general PR activity (which unrelated later activity could otherwise keep
+// re-extending). #2330's own motivating evidence (a second finding landing
+// 34s and 2m after a zero-unresolved snapshot) sets the buffer floor; 5
+// minutes gives comfortable margin above the largest observed value while
+// staying far short of the full configured window.
+const SECONDARY_QUIET_WINDOW_SETTLED_BUFFER_MINUTES = 5;
+
+/**
+ * Shared elapsed/remaining-minutes arithmetic for a quiet-window anchor.
+ * Extracted so `buildSecondaryQuietWindowStatus`'s unsettled path (anchored
+ * on `effectiveMaxActivityUpdatedAt`) and its #2544 settled-buffer path
+ * (anchored on `secondaryBotSettledAt`) compute identically and cannot
+ * drift apart.
+ */
+function computeQuietWindowElapsed({
+  minutes,
+  anchorAt,
+  now,
+}: {
+  minutes: number;
+  anchorAt: string;
+  now: string;
+}): SecondaryQuietWindowStatus {
+  const nowMs = Date.parse(now);
+  const anchorMs = Date.parse(anchorAt);
+  const elapsedMinutes =
+    Number.isFinite(nowMs) && Number.isFinite(anchorMs)
+      ? nowMs < anchorMs
+        ? 0
+        : Math.floor((nowMs - anchorMs) / 60000)
+      : null;
+  const elapsed = elapsedMinutes !== null && elapsedMinutes >= minutes;
+  const remainingMinutes =
+    elapsedMinutes !== null ? Math.max(0, minutes - elapsedMinutes) : null;
+  return {
+    minutes,
+    anchorAt,
+    elapsedMinutes,
+    elapsed,
+    remainingMinutes,
+  };
+}
+
 /**
  * Build the `advisoryWait.secondaryQuietWindow` gate status (#2335): once
  * the E-phase convergence conditions are already met -- no unresolved
@@ -481,25 +528,38 @@ export interface SecondaryQuietWindowStatus {
  * since that anchor" already equals "elapsed since convergence was reached"
  * without a second, independently-drifting timestamp to persist.
  *
+ * #2544: `secondaryBotSettledAt` -- when it is a valid ISO timestamp --
+ * switches the gate to the shorter settled buffer above, anchored on that
+ * timestamp instead of `effectiveMaxActivityUpdatedAt`. The buffer never
+ * exceeds the operator's own configured `minutes` (via `Math.min`), so a
+ * repository that configures a window shorter than the buffer is never
+ * kept waiting longer than what it explicitly asked for. Omitted or
+ * invalid (the pre-#2544 default for every existing caller) falls through
+ * to the unchanged, unsettled path -- byte-identical behavior.
+ *
  * A zero/absent `minutes` (the off/unset default) or a missing/invalid
  * anchor (nothing to anchor on yet) reports `elapsed: true` unconditionally
  * -- this gate must never itself block when unconfigured, and must never
- * block on the absence of any activity to measure. A positive but
- * non-integer `minutes` is floored -- the config-sourced path
- * (`resolveAdvisorySecondaryQuietWindowMinutes`) never produces one (every
- * ISO-duration unit it accepts converts to a whole number of minutes), but
- * this function's own `minutes` parameter is untyped, and a fractional
- * value would otherwise leak into `elapsedMinutes`/`remainingMinutes` as
- * non-integers, contradicting the whole-minute contract those fields keep
- * elsewhere in this report.
+ * block on the absence of any activity to measure. The `minutes <= 0`
+ * short-circuit is checked BEFORE `secondaryBotSettledAt` is ever
+ * consulted, so the off default stays unconditional regardless of
+ * settlement evidence. A positive but non-integer `minutes` is floored --
+ * the config-sourced path (`resolveAdvisorySecondaryQuietWindowMinutes`)
+ * never produces one (every ISO-duration unit it accepts converts to a
+ * whole number of minutes), but this function's own `minutes` parameter is
+ * untyped, and a fractional value would otherwise leak into
+ * `elapsedMinutes`/`remainingMinutes` as non-integers, contradicting the
+ * whole-minute contract those fields keep elsewhere in this report.
  */
 export function buildSecondaryQuietWindowStatus({
   minutes,
   effectiveMaxActivityUpdatedAt,
+  secondaryBotSettledAt,
   now,
 }: {
   minutes?: unknown;
   effectiveMaxActivityUpdatedAt?: unknown;
+  secondaryBotSettledAt?: unknown;
   now: string;
 }): SecondaryQuietWindowStatus {
   const resolvedMinutes =
@@ -508,7 +568,7 @@ export function buildSecondaryQuietWindowStatus({
       : 0;
   const anchorAtRaw = String(effectiveMaxActivityUpdatedAt ?? '');
   const anchorValid = isValidIsoTimestamp(anchorAtRaw);
-  if (resolvedMinutes <= 0 || !anchorValid) {
+  if (resolvedMinutes <= 0) {
     return {
       minutes: resolvedMinutes,
       anchorAt: anchorValid ? anchorAtRaw : 'none',
@@ -517,26 +577,33 @@ export function buildSecondaryQuietWindowStatus({
       remainingMinutes: 0,
     };
   }
-  const nowMs = Date.parse(now);
-  const anchorMs = Date.parse(anchorAtRaw);
-  const elapsedMinutes =
-    Number.isFinite(nowMs) && Number.isFinite(anchorMs)
-      ? nowMs < anchorMs
-        ? 0
-        : Math.floor((nowMs - anchorMs) / 60000)
-      : null;
-  const elapsed = elapsedMinutes !== null && elapsedMinutes >= resolvedMinutes;
-  const remainingMinutes =
-    elapsedMinutes !== null
-      ? Math.max(0, resolvedMinutes - elapsedMinutes)
-      : null;
-  return {
+
+  const settledAtRaw = String(secondaryBotSettledAt ?? '');
+  if (isValidIsoTimestamp(settledAtRaw)) {
+    return computeQuietWindowElapsed({
+      minutes: Math.min(
+        resolvedMinutes,
+        SECONDARY_QUIET_WINDOW_SETTLED_BUFFER_MINUTES,
+      ),
+      anchorAt: settledAtRaw,
+      now,
+    });
+  }
+
+  if (!anchorValid) {
+    return {
+      minutes: resolvedMinutes,
+      anchorAt: 'none',
+      elapsedMinutes: null,
+      elapsed: true,
+      remainingMinutes: 0,
+    };
+  }
+  return computeQuietWindowElapsed({
     minutes: resolvedMinutes,
     anchorAt: anchorAtRaw,
-    elapsedMinutes,
-    elapsed,
-    remainingMinutes,
-  };
+    now,
+  });
 }
 
 export function normalizeAdvisoryWaitRuntimeOptions(

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -12,6 +12,7 @@ import {
   readAdvisoryConvergenceDeadlineMinutes,
   readAdvisoryPrimaryBotLogin,
   readAdvisoryRecoveryCycleCap,
+  readAdvisorySecondaryBotLogin,
   readAdvisorySecondaryQuietWindowMinutes,
   readAdvisoryTerminalWindowMinutes,
   readAdvisoryWaitPolicy,
@@ -634,6 +635,7 @@ export function collectPreMergeReadiness(
   const advisoryConvergenceDeadlineMinutes =
     readAdvisoryConvergenceDeadlineMinutes();
   const secondaryQuietWindowMinutes = readAdvisorySecondaryQuietWindowMinutes();
+  const secondaryBotLogin = readAdvisorySecondaryBotLogin();
 
   // #1570: precompute the `#1572` terminal Copilot-unavailability verdict
   // here (the CLI/orchestration layer) rather than inside
@@ -757,6 +759,7 @@ export function collectPreMergeReadiness(
       advisoryConvergenceHeadCommittedAt,
       advisoryConvergenceDeadlineMinutes,
       secondaryQuietWindowMinutes,
+      secondaryBotLogin,
       waivableCheckSelectors,
       externalCheckWaiverMaxValidity,
       externalCheckWaiverMode,

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2127,6 +2127,13 @@ export function dispositionNamesAdvisoryBot(
 // `classifyRegularBotComment`) already operates purely on top-level PR
 // comments -- `ReviewLike` carries no `body` field in this codebase's
 // model, so a PR review object can never carry the marker text this needs.
+//
+// Falls back to `user.login`/`created_at`/`updated_at` alongside
+// `author.login`/`createdAt`/`updatedAt`, matching every other
+// `CommentLike` reader in this file (Copilot review, #2546): a caller that
+// ever passes REST-raw comments straight through, without the CLI layer's
+// own `normalizeComment` pass, must not silently fail-closed here just
+// because it used the other field-name form.
 export function computeSecondaryAdvisoryReviewSettlement(
   comments: CommentLike[],
   {
@@ -2143,13 +2150,15 @@ export function computeSecondaryAdvisoryReviewSettlement(
   const matches = comments
     .filter(
       (comment) =>
-        advisoryBotIdentityToken(comment.author?.login ?? '') === token,
+        advisoryBotIdentityToken(
+          comment.author?.login ?? comment.user?.login ?? '',
+        ) === token,
     )
     .map((comment) => ({
       body: comment.body ?? '',
       at: effectiveRegularCommentActivityAt({
-        updatedAt: comment.updatedAt,
-        createdAt: String(comment.createdAt ?? ''),
+        updatedAt: comment.updatedAt ?? comment.updated_at,
+        createdAt: String(comment.createdAt ?? comment.created_at ?? ''),
       }),
     }))
     .filter(

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2102,6 +2102,70 @@ export function dispositionNamesAdvisoryBot(
   return span.toLowerCase().includes(token);
 }
 
+// #2544: true when the configured secondary advisory bot has already
+// posted a genuine (non-notice) comment for the CURRENT HEAD -- i.e. the
+// `secondaryQuietWindow` gate's original #2335 "might still be mid-review"
+// concern no longer applies to this specific HEAD, only the narrower
+// "second/later finding" risk #2335 was also chartered to protect
+// (`buildSecondaryQuietWindowStatus`'s settled-buffer branch,
+// advisory-wait-policy.mts).
+//
+// Every ambiguity resolves to `settled: false` -- the same fail-closed
+// direction #2335 already relies on: no comment from the bot at or after
+// `headCommittedAt`, an unparseable `headCommittedAt`/unconfigured
+// `secondaryBotLogin`, or the LATEST such comment being a rate-limit /
+// skip-review notice (`isAdvisoryNonReviewNotice`), all report
+// `settled: false`. Only the single latest matching comment is examined --
+// a notice posted BEFORE a later genuine comment (rate-limited, then
+// recovered) does not defeat settlement, while a notice posted AFTER the
+// latest genuine comment (mid-retry) does, purely as a side effect of
+// always picking the latest.
+//
+// Deliberately reuses `comments` only, not `reviews`: this file's existing
+// notice-vs-genuine classification for the secondary bot
+// (`isAdvisoryNonReviewNotice`, `isReviewSummaryComment`,
+// `classifyRegularBotComment`) already operates purely on top-level PR
+// comments -- `ReviewLike` carries no `body` field in this codebase's
+// model, so a PR review object can never carry the marker text this needs.
+export function computeSecondaryAdvisoryReviewSettlement(
+  comments: CommentLike[],
+  {
+    secondaryBotLogin,
+    headCommittedAt,
+  }: { secondaryBotLogin: string; headCommittedAt?: string | null },
+): { settled: boolean; settledAt: string | null } {
+  const token = advisoryBotIdentityToken(secondaryBotLogin);
+  const headAt = String(headCommittedAt ?? '');
+  if (!token || !isValidIsoTimestamp(headAt)) {
+    return { settled: false, settledAt: null };
+  }
+
+  const matches = comments
+    .filter(
+      (comment) =>
+        advisoryBotIdentityToken(comment.author?.login ?? '') === token,
+    )
+    .map((comment) => ({
+      body: comment.body ?? '',
+      at: effectiveRegularCommentActivityAt({
+        updatedAt: comment.updatedAt,
+        createdAt: String(comment.createdAt ?? ''),
+      }),
+    }))
+    .filter(
+      (entry) =>
+        isValidIsoTimestamp(entry.at) &&
+        compareIsoTimestamps(entry.at, headAt) >= 0,
+    )
+    .sort((left, right) => compareIsoTimestamps(left.at, right.at));
+
+  const latest = matches[matches.length - 1];
+  if (!latest || isAdvisoryNonReviewNotice(latest.body)) {
+    return { settled: false, settledAt: null };
+  }
+  return { settled: true, settledAt: latest.at };
+}
+
 // #1182 Match trusted machine advisory dispositions to the advisory-bot stickies
 // they address, so a disposition posted by a trusted-marker actor who is NOT a
 // resolved IDD agent (e.g. a second trusted session) is honored without being
@@ -6964,6 +7028,15 @@ export function buildPreMergeReadinessSummary(
     // `elapsed: true` unconditionally, so an unmigrated caller or an
     // adopter that never sets this key sees unchanged behavior.
     secondaryQuietWindowMinutes?: number;
+    // #2544: the configured `advisoryWait.secondaryBotLogin`, resolved by
+    // the caller (mirroring `secondaryQuietWindowMinutes` above). Consulted
+    // together with `advisoryConvergenceHeadCommittedAt` below to detect
+    // whether the secondary bot has already posted a genuine review for the
+    // current HEAD, so the quiet window can shorten to a settled buffer
+    // instead of always requiring the full configured duration. Omitted or
+    // blank disables the settled-buffer branch entirely -- unchanged,
+    // pre-#2544 behavior.
+    secondaryBotLogin?: string;
   } = {},
 ) {
   const now = String(options.now ?? '');
@@ -7013,14 +7086,33 @@ export function buildPreMergeReadinessSummary(
       dispositionAuthorLogins: iddAgentLogins,
     },
   );
+  // #2544: whether the configured secondary bot has already posted a
+  // genuine (non-notice) comment for the CURRENT HEAD -- reuses
+  // `options.advisoryConvergenceHeadCommittedAt` (the HEAD commit's own
+  // `committedDate`, already resolved by the caller for the unrelated
+  // advisory-convergence-deadline precondition below) rather than a second
+  // fetch, since it is exactly "when did this HEAD land" either way.
+  const secondaryBotLogin = String(options.secondaryBotLogin ?? '')
+    .trim()
+    .toLowerCase();
+  const secondaryReviewSettlement = secondaryBotLogin
+    ? computeSecondaryAdvisoryReviewSettlement(comments, {
+        secondaryBotLogin,
+        headCommittedAt: options.advisoryConvergenceHeadCommittedAt,
+      })
+    : { settled: false, settledAt: null };
   // #2335: stateless secondary-quiet-window gate, anchored on the same
   // non-ack-only activity ceiling `liveSnapshot.effective` already computes
   // for the review-currency ack-only carve-out below -- see
   // `buildSecondaryQuietWindowStatus`'s own doc comment for why this anchor
   // needs no separate persisted "convergence first observed" timestamp.
+  // #2544: `secondaryBotSettledAt` shortens the required wait to a settled
+  // buffer once that evidence exists; see `computeSecondaryAdvisoryReviewSettlement`
+  // above for how it is derived.
   const secondaryQuietWindow = buildSecondaryQuietWindowStatus({
     minutes: options.secondaryQuietWindowMinutes,
     effectiveMaxActivityUpdatedAt: liveSnapshot.effective?.maxActivityUpdatedAt,
+    secondaryBotSettledAt: secondaryReviewSettlement.settledAt,
     now,
   });
   const isTrustedWatermarkAuthor = (login: string) =>

--- a/tests/advisory-wait-policy.test.mts
+++ b/tests/advisory-wait-policy.test.mts
@@ -358,3 +358,83 @@ test('buildSecondaryQuietWindowStatus floors a non-integer minutes so remainingM
   assert.equal(status.remainingMinutes, 1);
   assert.ok(Number.isInteger(status.remainingMinutes));
 });
+
+// #2544: secondaryBotSettledAt settled-buffer branch.
+
+test('buildSecondaryQuietWindowStatus uses the short settled buffer, not the full window, once secondaryBotSettledAt is valid', () => {
+  const status = buildSecondaryQuietWindowStatus({
+    minutes: 60,
+    // Far in the past, so the unsettled path (anchored here) would still be
+    // well within its 60-minute window -- proving the settled anchor below
+    // is what the gate actually used, not this one.
+    effectiveMaxActivityUpdatedAt: '2026-08-30T20:00:00Z',
+    secondaryBotSettledAt: '2026-08-30T22:00:00Z',
+    now: '2026-08-30T22:04:00Z',
+  });
+  assert.equal(status.anchorAt, '2026-08-30T22:00:00Z');
+  assert.equal(status.minutes, 5);
+  assert.equal(status.elapsedMinutes, 4);
+  assert.equal(status.elapsed, false);
+  assert.equal(status.remainingMinutes, 1);
+});
+
+test('buildSecondaryQuietWindowStatus reports elapsed once the settled buffer itself has passed', () => {
+  const status = buildSecondaryQuietWindowStatus({
+    minutes: 60,
+    effectiveMaxActivityUpdatedAt: '2026-08-30T20:00:00Z',
+    secondaryBotSettledAt: '2026-08-30T22:00:00Z',
+    now: '2026-08-30T22:05:00Z',
+  });
+  assert.equal(status.elapsed, true);
+  assert.equal(status.elapsedMinutes, 5);
+  assert.equal(status.remainingMinutes, 0);
+});
+
+test('buildSecondaryQuietWindowStatus never waits longer than the configured minutes even once settled', () => {
+  // Configured window (2 min) is shorter than the settled buffer (5 min) --
+  // settlement must not make the wait LONGER than what was explicitly asked
+  // for.
+  const status = buildSecondaryQuietWindowStatus({
+    minutes: 2,
+    effectiveMaxActivityUpdatedAt: '2026-08-30T20:00:00Z',
+    secondaryBotSettledAt: '2026-08-30T22:00:00Z',
+    now: '2026-08-30T22:02:00Z',
+  });
+  assert.equal(status.minutes, 2);
+  assert.equal(status.elapsed, true);
+  assert.equal(status.remainingMinutes, 0);
+});
+
+test('buildSecondaryQuietWindowStatus falls through to the unsettled path when secondaryBotSettledAt is absent or invalid', () => {
+  for (const settledAt of [undefined, null, '', 'not-a-timestamp']) {
+    const status = buildSecondaryQuietWindowStatus({
+      minutes: 15,
+      effectiveMaxActivityUpdatedAt: '2026-08-30T22:00:00Z',
+      secondaryBotSettledAt: settledAt,
+      now: '2026-08-30T22:10:00Z',
+    });
+    assert.equal(status.anchorAt, '2026-08-30T22:00:00Z');
+    assert.equal(status.minutes, 15);
+    assert.equal(status.elapsedMinutes, 10);
+    assert.equal(status.elapsed, false);
+    assert.equal(status.remainingMinutes, 5);
+  }
+});
+
+test('buildSecondaryQuietWindowStatus stays elapsed:true at minutes:0 regardless of secondaryBotSettledAt (byte-identical off default)', () => {
+  const withSettledAt = buildSecondaryQuietWindowStatus({
+    minutes: 0,
+    effectiveMaxActivityUpdatedAt: '2026-08-30T22:00:00Z',
+    secondaryBotSettledAt: '2026-08-30T22:03:00Z',
+    now: '2026-08-30T22:03:30Z',
+  });
+  const withoutSettledAt = buildSecondaryQuietWindowStatus({
+    minutes: 0,
+    effectiveMaxActivityUpdatedAt: '2026-08-30T22:00:00Z',
+    now: '2026-08-30T22:03:30Z',
+  });
+  assert.deepEqual(withSettledAt, withoutSettledAt);
+  assert.equal(withSettledAt.elapsed, true);
+  assert.equal(withSettledAt.remainingMinutes, 0);
+  assert.equal(withSettledAt.anchorAt, '2026-08-30T22:00:00Z');
+});

--- a/tests/pre-merge-readiness-collection-smoke.test.mts
+++ b/tests/pre-merge-readiness-collection-smoke.test.mts
@@ -914,3 +914,140 @@ test('collectPreMergeReadiness against a fake provider: a matching CODEOWNER res
     rmSync(cwdRoot, { recursive: true, force: true });
   }
 });
+
+// ---------------------------------------------------------------------------
+// #2544: secondaryQuietWindow settled-buffer end-to-end wiring. Proves
+// collectPreMergeReadiness's own readAdvisorySecondaryBotLogin() call
+// (pre-merge-readiness.mts) actually reaches buildPreMergeReadinessSummary
+// and computeSecondaryAdvisoryReviewSettlement (protocol-helpers.mts), not
+// just the unit-level buildSecondaryQuietWindowStatus tests in
+// tests/advisory-wait-policy.test.mts.
+// ---------------------------------------------------------------------------
+
+function runSecondaryQuietWindowFixture(
+  comments: Array<{ body: string; createdAt: string; authorLogin: string }>,
+  now: string,
+): { elapsed: boolean; remainingMinutes: number | null } {
+  const cwdRoot = mkdtempSync(
+    join(tmpdir(), 'idd-pre-merge-secondary-quiet-window-'),
+  );
+  const originalCwd = process.cwd();
+  try {
+    process.chdir(cwdRoot);
+    const configDir = join(cwdRoot, '.github', 'idd');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      join(configDir, 'config.json'),
+      JSON.stringify({
+        advisoryWait: {
+          secondaryBotLogin: 'coderabbitai[bot]',
+          secondaryQuietWindow: 'PT1H',
+        },
+      }),
+    );
+
+    const port = createFakeProviderAdapter({
+      changeRequestReadinessSnapshots: {
+        42: {
+          headSha: 'a'.repeat(40),
+          baseRefName: 'main',
+          url: 'https://github.com/o/r/pull/42',
+          authorLogin: 'author-user',
+          reviewDecision: null,
+          statusCheckRollup: [],
+          mergeable: 'MERGEABLE',
+          mergeStateStatus: 'CLEAN',
+          closingIssuesReferences: [],
+        },
+      },
+      branchRules: { 'o/r/main': [] },
+      branchProtection: { 'o/r/main': {} },
+      reviewThreadsWithComments: { 42: [] },
+      reviewsWithHeadCommitDate: {
+        42: { reviews: [], headCommittedAt: '2026-07-31T23:00:00Z' },
+      },
+      changedFiles: { 42: [] },
+      comments: {
+        42: comments.map((entry, index) => ({
+          id: index + 1,
+          body: entry.body,
+          createdAt: entry.createdAt,
+          updatedAt: entry.createdAt,
+          authorLogin: entry.authorLogin,
+        })),
+      },
+    });
+
+    const report = collectPreMergeReadiness(
+      [
+        '--pr',
+        '42',
+        '--claimless',
+        '--owner',
+        'o',
+        '--repo',
+        'r',
+        '--now',
+        now,
+      ],
+      () => port,
+    );
+    return report.secondaryQuietWindow as {
+      elapsed: boolean;
+      remainingMinutes: number | null;
+    };
+  } finally {
+    process.chdir(originalCwd);
+    rmSync(cwdRoot, { recursive: true, force: true });
+  }
+}
+
+test('collectPreMergeReadiness: secondaryQuietWindow settles quickly once CodeRabbit posts a genuine review for HEAD, well before the configured 1h window would elapse', () => {
+  const status = runSecondaryQuietWindowFixture(
+    [
+      {
+        body:
+          '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n' +
+          '## Walkthrough\nSome walkthrough text.',
+        createdAt: '2026-07-31T23:02:00Z',
+        authorLogin: 'coderabbitai[bot]',
+      },
+    ],
+    // 5 minutes after the review -- exactly the #2544 settled buffer, but
+    // nowhere near the configured PT1H window.
+    '2026-07-31T23:07:00Z',
+  );
+  assert.equal(status.elapsed, true);
+});
+
+test('collectPreMergeReadiness: secondaryQuietWindow still blocks for the full window when CodeRabbit has only posted a rate-limit notice (#2335 protection preserved)', () => {
+  const status = runSecondaryQuietWindowFixture(
+    [
+      {
+        body:
+          '<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->\n' +
+          '> ## Review limit reached',
+        createdAt: '2026-07-31T23:02:00Z',
+        authorLogin: 'coderabbitai[bot]',
+      },
+    ],
+    '2026-07-31T23:06:00Z',
+  );
+  assert.equal(status.elapsed, false);
+  assert.equal(status.remainingMinutes, 56);
+});
+
+test('collectPreMergeReadiness: secondaryQuietWindow still blocks for the full window when CodeRabbit has said nothing, even though other PR activity exists', () => {
+  const status = runSecondaryQuietWindowFixture(
+    [
+      {
+        body: 'looks good to me',
+        createdAt: '2026-07-31T23:02:00Z',
+        authorLogin: 'human-reviewer',
+      },
+    ],
+    '2026-07-31T23:06:00Z',
+  );
+  assert.equal(status.elapsed, false);
+  assert.equal(status.remainingMinutes, 56);
+});

--- a/tests/protocol-helpers-advisory-bot-login.test.mts
+++ b/tests/protocol-helpers-advisory-bot-login.test.mts
@@ -238,3 +238,23 @@ test('computeSecondaryAdvisoryReviewSettlement: unconfigured secondaryBotLogin -
   );
   assert.deepEqual(result, { settled: false, settledAt: null });
 });
+
+test('computeSecondaryAdvisoryReviewSettlement: matches REST-raw comments (user.login/created_at/updated_at), not just the normalized shape (Copilot review, #2546)', () => {
+  const result = computeSecondaryAdvisoryReviewSettlement(
+    [
+      {
+        user: { login: 'coderabbitai[bot]' },
+        body: CODERABBIT_SUMMARY,
+        created_at: '2026-09-02T12:05:00Z',
+      },
+    ],
+    {
+      secondaryBotLogin: 'coderabbitai[bot]',
+      headCommittedAt: HEAD_COMMITTED_AT,
+    },
+  );
+  assert.deepEqual(result, {
+    settled: true,
+    settledAt: '2026-09-02T12:05:00Z',
+  });
+});

--- a/tests/protocol-helpers-advisory-bot-login.test.mts
+++ b/tests/protocol-helpers-advisory-bot-login.test.mts
@@ -1,10 +1,21 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import {
+  computeSecondaryAdvisoryReviewSettlement,
   isConfiguredAdvisoryBotLogin,
   isGateAdvisoryBotLogin,
   normalizeTrustedMarkerLogins,
 } from '../src/scripts/protocol-helpers.mts';
+
+const CODERABBIT_NOTICE =
+  '<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->\n> ## Review limit reached';
+const CODERABBIT_SUMMARY =
+  '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n## Walkthrough\nSome walkthrough text.';
+const HEAD_COMMITTED_AT = '2026-09-02T12:00:00Z';
+
+function comment(login: string, body: string, createdAt: string) {
+  return { author: { login }, body, createdAt };
+}
 
 // Build the advisory-bot set exactly as the gate callers do, so the test
 // exercises the real construction path rather than a hand-rolled Set.
@@ -119,4 +130,111 @@ test('isConfiguredAdvisoryBotLogin rejects unconfigured and empty logins', () =>
   assert.equal(isConfiguredAdvisoryBotLogin(undefined, config), false);
   // A bare `[bot]` reduces to an empty token and must not match.
   assert.equal(isConfiguredAdvisoryBotLogin('[bot]', config), false);
+});
+
+test('computeSecondaryAdvisoryReviewSettlement: no matching comments -> not settled', () => {
+  const result = computeSecondaryAdvisoryReviewSettlement([], {
+    secondaryBotLogin: 'coderabbitai[bot]',
+    headCommittedAt: HEAD_COMMITTED_AT,
+  });
+  assert.deepEqual(result, { settled: false, settledAt: null });
+});
+
+test('computeSecondaryAdvisoryReviewSettlement: only a rate-limit notice at HEAD -> not settled', () => {
+  const result = computeSecondaryAdvisoryReviewSettlement(
+    [comment('coderabbitai[bot]', CODERABBIT_NOTICE, '2026-09-02T12:05:00Z')],
+    {
+      secondaryBotLogin: 'coderabbitai[bot]',
+      headCommittedAt: HEAD_COMMITTED_AT,
+    },
+  );
+  assert.deepEqual(result, { settled: false, settledAt: null });
+});
+
+test('computeSecondaryAdvisoryReviewSettlement: genuine review at/after HEAD -> settled', () => {
+  const result = computeSecondaryAdvisoryReviewSettlement(
+    [comment('coderabbitai[bot]', CODERABBIT_SUMMARY, '2026-09-02T12:05:00Z')],
+    {
+      secondaryBotLogin: 'coderabbitai[bot]',
+      headCommittedAt: HEAD_COMMITTED_AT,
+    },
+  );
+  assert.deepEqual(result, {
+    settled: true,
+    settledAt: '2026-09-02T12:05:00Z',
+  });
+});
+
+test('computeSecondaryAdvisoryReviewSettlement: genuine review BEFORE HEAD (stale prior HEAD) -> not settled', () => {
+  const result = computeSecondaryAdvisoryReviewSettlement(
+    [comment('coderabbitai[bot]', CODERABBIT_SUMMARY, '2026-09-02T11:00:00Z')],
+    {
+      secondaryBotLogin: 'coderabbitai[bot]',
+      headCommittedAt: HEAD_COMMITTED_AT,
+    },
+  );
+  assert.deepEqual(result, { settled: false, settledAt: null });
+});
+
+test('computeSecondaryAdvisoryReviewSettlement: notice AFTER the latest genuine review -> not settled (mid-retry)', () => {
+  const result = computeSecondaryAdvisoryReviewSettlement(
+    [
+      comment('coderabbitai[bot]', CODERABBIT_SUMMARY, '2026-09-02T12:05:00Z'),
+      comment('coderabbitai[bot]', CODERABBIT_NOTICE, '2026-09-02T12:10:00Z'),
+    ],
+    {
+      secondaryBotLogin: 'coderabbitai[bot]',
+      headCommittedAt: HEAD_COMMITTED_AT,
+    },
+  );
+  assert.deepEqual(result, { settled: false, settledAt: null });
+});
+
+test('computeSecondaryAdvisoryReviewSettlement: notice BEFORE a later genuine review -> settled (rate-limited, then recovered)', () => {
+  const result = computeSecondaryAdvisoryReviewSettlement(
+    [
+      comment('coderabbitai[bot]', CODERABBIT_NOTICE, '2026-09-02T12:05:00Z'),
+      comment('coderabbitai[bot]', CODERABBIT_SUMMARY, '2026-09-02T12:10:00Z'),
+    ],
+    {
+      secondaryBotLogin: 'coderabbitai[bot]',
+      headCommittedAt: HEAD_COMMITTED_AT,
+    },
+  );
+  assert.deepEqual(result, {
+    settled: true,
+    settledAt: '2026-09-02T12:10:00Z',
+  });
+});
+
+test('computeSecondaryAdvisoryReviewSettlement: matches across the [bot]-suffix mismatch (#2473)', () => {
+  // GraphQL strips the [bot] suffix (author login reported as `coderabbitai`)
+  // while the configured login stores the REST-shaped `coderabbitai[bot]`.
+  const result = computeSecondaryAdvisoryReviewSettlement(
+    [comment('coderabbitai', CODERABBIT_SUMMARY, '2026-09-02T12:05:00Z')],
+    {
+      secondaryBotLogin: 'coderabbitai[bot]',
+      headCommittedAt: HEAD_COMMITTED_AT,
+    },
+  );
+  assert.deepEqual(result, {
+    settled: true,
+    settledAt: '2026-09-02T12:05:00Z',
+  });
+});
+
+test('computeSecondaryAdvisoryReviewSettlement: unparseable headCommittedAt -> not settled', () => {
+  const result = computeSecondaryAdvisoryReviewSettlement(
+    [comment('coderabbitai[bot]', CODERABBIT_SUMMARY, '2026-09-02T12:05:00Z')],
+    { secondaryBotLogin: 'coderabbitai[bot]', headCommittedAt: null },
+  );
+  assert.deepEqual(result, { settled: false, settledAt: null });
+});
+
+test('computeSecondaryAdvisoryReviewSettlement: unconfigured secondaryBotLogin -> not settled', () => {
+  const result = computeSecondaryAdvisoryReviewSettlement(
+    [comment('coderabbitai[bot]', CODERABBIT_SUMMARY, '2026-09-02T12:05:00Z')],
+    { secondaryBotLogin: '', headCommittedAt: HEAD_COMMITTED_AT },
+  );
+  assert.deepEqual(result, { settled: false, settledAt: null });
 });


### PR DESCRIPTION
## Summary

- `advisoryWait.secondaryQuietWindow` (#2335) used to require the full
  configured duration (this repository: `PT1H`) to elapse since the last
  substantive PR activity before treating review as settled, **regardless**
  of whether the configured secondary bot (CodeRabbit) had already posted a
  genuine review for the current HEAD. Under this repository's current
  concurrent-session load, CodeRabbit is now rate-limited on most PRs, so
  what was designed as an occasional safety margin for a slow-but-working
  bot had become an unconditional ~1h tax on nearly every merge -- observed
  live on `#2540`, `#2542`, `#2543`.
- `buildSecondaryQuietWindowStatus` (`advisory-wait-policy.mts`) now accepts
  `secondaryBotSettledAt`. When the secondary bot has already posted a
  genuine, non-notice comment for the current HEAD, only a short 5-minute
  confirmation buffer applies from that comment's own timestamp, instead of
  the full window. A HEAD the bot has not yet reviewed (silent, or only a
  rate-limit/skip-review notice) still requires the full configured window,
  unchanged -- preserving `#2335`'s original protection.
- New `computeSecondaryAdvisoryReviewSettlement` (`protocol-helpers.mts`)
  detects that settlement from live `comments`: it matches the configured
  `secondaryBotLogin` (across the `[bot]`-suffix GraphQL/REST mismatch,
  `#2473`), restricts to comments at/after the HEAD commit's own
  `committedDate`, and classifies the *latest* matching comment via the
  existing `isAdvisoryNonReviewNotice` predicate. Ordering matters: a notice
  posted before a later genuine review does not defeat settlement
  (rate-limited, then recovered); a notice posted after the latest genuine
  review means the bot is mid-retry, not settled.
- Every ambiguity resolves to "not settled -> full window" (fail-closed, the
  same direction `#2335` already relies on).
- `pre-merge-readiness.mts` now also resolves
  `advisoryWait.secondaryBotLogin` via the existing
  `readAdvisorySecondaryBotLogin` and threads it through.

**Deliberate non-goal**: a PR where the secondary bot genuinely never
reviews (rate-limited for that specific PR, as on `#2540`/`#2543`) still
waits the full configured window -- this restores the wait to a fallback
for genuine secondary-bot degradation, matching the original 有事-only
intent, rather than removing the protection entirely.

Closes #2544

Refs #2335, #2330, #2473

## Test plan

- [x] `pnpm run test:scripts` -- full suite (4872 tests) green
- [x] New unit tests for `computeSecondaryAdvisoryReviewSettlement`
      (`tests/protocol-helpers-advisory-bot-login.test.mts`): no comments,
      notice-only, genuine review, stale prior-HEAD review, notice-after-
      review, notice-before-review, `[bot]`-suffix mismatch, unparseable
      `headCommittedAt`, unconfigured `secondaryBotLogin`.
- [x] New unit tests for `buildSecondaryQuietWindowStatus`'s settled-buffer
      branch (`tests/advisory-wait-policy.test.mts`): settled buffer used
      over the full window, buffer itself elapsing, never exceeding the
      configured minutes, fallback to the unsettled path, byte-identical
      `minutes: 0` behavior regardless of settlement.
- [x] New end-to-end wiring tests against a fake provider
      (`tests/pre-merge-readiness-collection-smoke.test.mts`): genuine
      review settles quickly, notice-only still blocks for the full window,
      silence (with unrelated PR activity) still blocks for the full
      window -- proving `collectPreMergeReadiness`'s own
      `readAdvisorySecondaryBotLogin()` call reaches the gate, not just the
      unit-level pieces.
- [x] Confirmed the new tests fail against the unmodified gate (`git stash`
      of only the implementation files, tests kept) before implementing.
- [x] `docs/policy-constants.md`, `docs/customization.md` (canonical
      `idd-template/` sources plus synced mirrors), `CLAUDE.md`,
      `AGENTS.md`, `GEMINI.md` updated to describe the settled-buffer
      behavior; `node scripts/audit-docs.mjs --check` passes (`bundle-merge`
      sits at 98.00%/98% ceiling -- confirmed no instructions-bundle file
      needed editing, since `idd-pre-merge.instructions.md`'s
      `secondaryQuietWindow.elapsed` field-level contract is unchanged).
- [x] `pnpm run build` regenerated and committed the corresponding
      `scripts/*.mjs` outputs from the edited `.mts` sources.
- [x] Full `pre-push-validate` chain green (biome, dprint, markdownlint,
      cspell, audit-docs, audit-code-span-wrap, agent-entry-mirror-sync,
      build:check, idd-doctor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
