### PR TITLE
docs(idd-work): warn B3 to check for a generated-from banner

### DIFF
--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -341,6 +341,18 @@ pre-push-validate requirements above. Otherwise treat it as a real
 failure and fix it. See
 [rationale](../../docs/idd-design-rationale.md#b3--local-test-flakiness-under-concurrent-load-hosted-ci-is-authoritative).
 
+**Editing a docs/instructions file**: before editing any `docs/**.md`
+or `.github/instructions/**.md` file, check whether it is a generated
+mirror. A `.github/instructions/**.instructions.md` file carries an
+`idd-generated-from` banner at its top when it is one -- the banner
+itself names the canonical source and the resync command. A
+`docs/**.md` file never carries that banner even when it is a mirror;
+check `audit/sync-manifest.json`'s `syncPairs` for an entry whose
+`target` matches the file path instead. Either signal means edit the
+named canonical `source` and run its resync command there -- an edit
+to the mirror itself is silently discarded on the next sync. See
+[rationale](../../docs/idd-design-rationale.md#b3--edit-the-canonical-source-of-a-generated-docsinstructions-file-not-its-mirror).
+
 If B3 or C must stop for a hold, use the shared Hold / suspend rules in
 `idd-overview-appendix.instructions.md` and update the issue digest with the
 blocking condition before stopping. Do not use the digest as the only

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -346,15 +346,20 @@ or `.github/instructions/**.md` file, check whether it is a generated
 mirror. A `.github/instructions/**.instructions.md` file carries an
 `idd-generated-from` banner at its top when it is one -- the banner
 itself names the canonical source and the resync command, valid only
-for `exact`/`concreted` pairs. A `docs/**.md` file never carries that
-banner even when it is a mirror; check `audit/sync-manifest.json`'s
-`syncPairs` for an entry whose `target` matches the file path instead,
-and read its `mode`. For `exact`/`concreted`, edit only the named
-canonical `source` and run its resync command -- an edit to the mirror
-itself is silently discarded on the next sync. For `structure`/
-`contains`, the sync tool does not auto-regenerate the mirror at all;
-edit both the canonical `source` and the mirror by hand, keeping only
-the structural elements the manifest requires in sync. See
+for an `exact`/`concreted`-style pair. A `docs/**.md` file may not
+carry that banner even when it is a mirror; check this repository's
+sync manifest (for example `audit/sync-manifest.json` in the
+`idd-skill` source repository, or your own repository's equivalent
+config) for an entry naming this file as a mirror target instead, and
+follow that entry's own mode contract. An `exact`/`concreted`-style
+entry auto-regenerates the mirror from its named canonical source when
+the resync command runs -- edit only that source, never the mirror
+directly, or the edit is silently discarded on the next sync. Any
+other mode (for example one that only requires certain text or
+patterns to be present, with no single canonical source to
+auto-regenerate from) follows its own stated contract instead --
+consult the manifest entry itself rather than assuming auto-regenerate
+applies. See
 [rationale](../../docs/idd-design-rationale.md#b3--edit-the-canonical-source-of-a-generated-docsinstructions-file-not-its-mirror).
 
 If B3 or C must stop for a hold, use the shared Hold / suspend rules in

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -345,12 +345,16 @@ failure and fix it. See
 or `.github/instructions/**.md` file, check whether it is a generated
 mirror. A `.github/instructions/**.instructions.md` file carries an
 `idd-generated-from` banner at its top when it is one -- the banner
-itself names the canonical source and the resync command. A
-`docs/**.md` file never carries that banner even when it is a mirror;
-check `audit/sync-manifest.json`'s `syncPairs` for an entry whose
-`target` matches the file path instead. Either signal means edit the
-named canonical `source` and run its resync command there -- an edit
-to the mirror itself is silently discarded on the next sync. See
+itself names the canonical source and the resync command, valid only
+for `exact`/`concreted` pairs. A `docs/**.md` file never carries that
+banner even when it is a mirror; check `audit/sync-manifest.json`'s
+`syncPairs` for an entry whose `target` matches the file path instead,
+and read its `mode`. For `exact`/`concreted`, edit only the named
+canonical `source` and run its resync command -- an edit to the mirror
+itself is silently discarded on the next sync. For `structure`/
+`contains`, the sync tool does not auto-regenerate the mirror at all;
+edit both the canonical `source` and the mirror by hand, keeping only
+the structural elements the manifest requires in sync. See
 [rationale](../../docs/idd-design-rationale.md#b3--edit-the-canonical-source-of-a-generated-docsinstructions-file-not-its-mirror).
 
 If B3 or C must stop for a hold, use the shared Hold / suspend rules in

--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -418,10 +418,11 @@ does, so checking for the banner alone misses exactly this file class.
 Both real occurrences in this repository were `docs/**.md` files
 (`docs/idd-helper-scripts.md` and `docs/policy-constants.md`, both
 caught pre-commit via `git status` plus a manual
-`sync-manifest.json` lookup, in one 2026-09-03 session, never merged
-but each costing a revert-and-redo cycle), and a structurally identical
-bug independently surfaced the same session inside a brand-new
-`audit-docs.mjs` checker (`#2477`): its file-attribution logic
+`audit/sync-manifest.json` lookup, never merged but each costing a
+revert-and-redo cycle -- observed 2026-09-03, `#2548`), and a
+structurally identical bug independently surfaced the same session
+inside a brand-new `audit-docs.mjs` checker (observed 2026-09-03,
+`#2477`): its file-attribution logic
 initially cited the generated mirror in a drift finding instead of the
 canonical source, for the same root cause. Checking
 `audit/sync-manifest.json`'s `syncPairs` for a matching `target` entry

--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -404,6 +404,29 @@ adopters scale out concurrent sessions (#1391). Hosted CI governs when
 it disagrees with a local outcome for the same commit; that does not
 waive the fix-validate / pre-push-validate requirements themselves.
 
+### B3 — Edit the canonical source of a generated docs/instructions file, not its mirror
+
+This repository generates several `docs/**.md` and
+`.github/instructions/**.md` files from an `idd-template/` canonical
+source via `sync-docs.mjs`. Editing the generated mirror directly is
+silently discarded on the next `sync-docs.mjs --apply` run, since the
+mirror and its canonical source are often byte-identical or
+near-identical, giving no visual cue at a glance. Only a
+`.github/instructions/**.instructions.md` mirror carries an
+`idd-generated-from` banner at its top -- a `docs/**.md` mirror never
+does, so checking for the banner alone misses exactly this file class.
+Both real occurrences in this repository were `docs/**.md` files
+(`docs/idd-helper-scripts.md` and `docs/policy-constants.md`, both
+caught pre-commit via `git status` plus a manual
+`sync-manifest.json` lookup, in one 2026-09-03 session, never merged
+but each costing a revert-and-redo cycle), and a structurally identical
+bug independently surfaced the same session inside a brand-new
+`audit-docs.mjs` checker (`#2477`): its file-attribution logic
+initially cited the generated mirror in a drift finding instead of the
+canonical source, for the same root cause. Checking
+`audit/sync-manifest.json`'s `syncPairs` for a matching `target` entry
+closes that gap and catches this before any work is lost.
+
 ## Review triage
 
 ### Merge-main livelock under fast-moving `main`

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -336,6 +336,18 @@ pre-push-validate requirements above. Otherwise treat it as a real
 failure and fix it. See
 [rationale](../../docs/idd-design-rationale.md#b3--local-test-flakiness-under-concurrent-load-hosted-ci-is-authoritative).
 
+**Editing a docs/instructions file**: before editing any `docs/**.md`
+or `.github/instructions/**.md` file, check whether it is a generated
+mirror. A `.github/instructions/**.instructions.md` file carries an
+`idd-generated-from` banner at its top when it is one -- the banner
+itself names the canonical source and the resync command. A
+`docs/**.md` file never carries that banner even when it is a mirror;
+check `audit/sync-manifest.json`'s `syncPairs` for an entry whose
+`target` matches the file path instead. Either signal means edit the
+named canonical `source` and run its resync command there -- an edit
+to the mirror itself is silently discarded on the next sync. See
+[rationale](../../docs/idd-design-rationale.md#b3--edit-the-canonical-source-of-a-generated-docsinstructions-file-not-its-mirror).
+
 If B3 or C must stop for a hold, use the shared Hold / suspend rules in
 `idd-overview-appendix.instructions.md` and update the issue digest with the
 blocking condition before stopping. Do not use the digest as the only

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -340,12 +340,16 @@ failure and fix it. See
 or `.github/instructions/**.md` file, check whether it is a generated
 mirror. A `.github/instructions/**.instructions.md` file carries an
 `idd-generated-from` banner at its top when it is one -- the banner
-itself names the canonical source and the resync command. A
-`docs/**.md` file never carries that banner even when it is a mirror;
-check `audit/sync-manifest.json`'s `syncPairs` for an entry whose
-`target` matches the file path instead. Either signal means edit the
-named canonical `source` and run its resync command there -- an edit
-to the mirror itself is silently discarded on the next sync. See
+itself names the canonical source and the resync command, valid only
+for `exact`/`concreted` pairs. A `docs/**.md` file never carries that
+banner even when it is a mirror; check `audit/sync-manifest.json`'s
+`syncPairs` for an entry whose `target` matches the file path instead,
+and read its `mode`. For `exact`/`concreted`, edit only the named
+canonical `source` and run its resync command -- an edit to the mirror
+itself is silently discarded on the next sync. For `structure`/
+`contains`, the sync tool does not auto-regenerate the mirror at all;
+edit both the canonical `source` and the mirror by hand, keeping only
+the structural elements the manifest requires in sync. See
 [rationale](../../docs/idd-design-rationale.md#b3--edit-the-canonical-source-of-a-generated-docsinstructions-file-not-its-mirror).
 
 If B3 or C must stop for a hold, use the shared Hold / suspend rules in

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -341,15 +341,20 @@ or `.github/instructions/**.md` file, check whether it is a generated
 mirror. A `.github/instructions/**.instructions.md` file carries an
 `idd-generated-from` banner at its top when it is one -- the banner
 itself names the canonical source and the resync command, valid only
-for `exact`/`concreted` pairs. A `docs/**.md` file never carries that
-banner even when it is a mirror; check `audit/sync-manifest.json`'s
-`syncPairs` for an entry whose `target` matches the file path instead,
-and read its `mode`. For `exact`/`concreted`, edit only the named
-canonical `source` and run its resync command -- an edit to the mirror
-itself is silently discarded on the next sync. For `structure`/
-`contains`, the sync tool does not auto-regenerate the mirror at all;
-edit both the canonical `source` and the mirror by hand, keeping only
-the structural elements the manifest requires in sync. See
+for an `exact`/`concreted`-style pair. A `docs/**.md` file may not
+carry that banner even when it is a mirror; check this repository's
+sync manifest (for example `audit/sync-manifest.json` in the
+`idd-skill` source repository, or your own repository's equivalent
+config) for an entry naming this file as a mirror target instead, and
+follow that entry's own mode contract. An `exact`/`concreted`-style
+entry auto-regenerates the mirror from its named canonical source when
+the resync command runs -- edit only that source, never the mirror
+directly, or the edit is silently discarded on the next sync. Any
+other mode (for example one that only requires certain text or
+patterns to be present, with no single canonical source to
+auto-regenerate from) follows its own stated contract instead --
+consult the manifest entry itself rather than assuming auto-regenerate
+applies. See
 [rationale](../../docs/idd-design-rationale.md#b3--edit-the-canonical-source-of-a-generated-docsinstructions-file-not-its-mirror).
 
 If B3 or C must stop for a hold, use the shared Hold / suspend rules in

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -419,10 +419,11 @@ revert-and-redo cycle before the guidance below existed
 (kurone-kito/idd-skill#2548). The mistake is easy to make because the
 mirror and its canonical source are often byte-identical or
 near-identical, giving no visual cue at a glance. Only a
-`.github/instructions/**.instructions.md` mirror carries a visible
-`idd-generated-from` banner at its top; a `docs/**.md` mirror does not,
-so the banner check alone misses exactly the file class most likely to
-be mistaken for hand-editable prose. Checking the sync tool's own
+`.github/instructions/**.instructions.md` mirror is guaranteed to
+carry a visible `idd-generated-from` banner at its top; a `docs/**.md`
+mirror may not, depending on the sync tool's own behavior, so the
+banner check alone can miss exactly the file class most likely to be
+mistaken for hand-editable prose. Checking the sync tool's own
 manifest for a matching target entry closes that gap for `docs/**.md`
 files, at the cost of one extra lookup.
 

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -407,6 +407,23 @@ concurrent sessions (kurone-kito/idd-skill#1391). Hosted CI governs
 when it disagrees with a local outcome for the same commit; that does
 not waive the fix-validate / pre-push-validate requirements themselves.
 
+### B3 — Edit the canonical source of a generated docs/instructions file, not its mirror
+
+An adopter repository that generates some of its own `docs/**.md` or
+`.github/instructions/**.md` files from a canonical source (via a
+sync-docs-style tool) can lose a fix silently: an agent edits the
+generated mirror directly, the change looks correct locally, but the
+next sync run regenerates the mirror from its canonical source and
+discards the edit without any error. The mistake is easy to make
+because the mirror and its canonical source are often byte-identical
+or near-identical, giving no visual cue at a glance. Only a
+`.github/instructions/**.instructions.md` mirror carries a visible
+`idd-generated-from` banner at its top; a `docs/**.md` mirror does not,
+so the banner check alone misses exactly the file class most likely to
+be mistaken for hand-editable prose. Checking the sync tool's own
+manifest for a matching target entry closes that gap for `docs/**.md`
+files, at the cost of one extra lookup.
+
 ## Review triage
 
 ### Merge-main livelock under fast-moving `main`

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -414,9 +414,11 @@ An adopter repository that generates some of its own `docs/**.md` or
 sync-docs-style tool) can lose a fix silently: an agent edits the
 generated mirror directly, the change looks correct locally, but the
 next sync run regenerates the mirror from its canonical source and
-discards the edit without any error. The mistake is easy to make
-because the mirror and its canonical source are often byte-identical
-or near-identical, giving no visual cue at a glance. Only a
+discards the edit without any error -- a real incident cost a
+revert-and-redo cycle before the guidance below existed
+(kurone-kito/idd-skill#2548). The mistake is easy to make because the
+mirror and its canonical source are often byte-identical or
+near-identical, giving no visual cue at a glance. Only a
 `.github/instructions/**.instructions.md` mirror carries a visible
 `idd-generated-from` banner at its top; a `docs/**.md` mirror does not,
 so the banner check alone misses exactly the file class most likely to


### PR DESCRIPTION
# Summary

Editing a generated `docs/**.md` or `.github/instructions/**.md`
mirror directly is silently discarded on the next `sync-docs.mjs`
run, since the mirror and its canonical source are often
byte-identical. Add a B3 self-check callout so an agent catches this
before editing, not after a wasted revert-and-redo cycle.

## Linked issue

Closes #2548

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

The issue as originally filed proposed a banner-only check ("check
for an `idd-generated-from` banner before editing"). During drafting,
an independent critique pass found that claim factually incomplete:
`isBannerScopedInstructionTarget`
(`src/scripts/consistency-helpers.mts`) only stamps the banner on
`.github/instructions/**.instructions.md` targets in `exact`/`concreted`
mode -- a `docs/**.md` mirror never carries it, confirmed by grepping
every `docs/**.md` file in the repo (no real banner hits) and a
`sync-docs.mjs` dry run reporting the banner-less state as correct.

Both real incidents this session that motivated the issue
(`docs/idd-helper-scripts.md`, `docs/policy-constants.md`) are exactly
this file class -- a banner-only callout would have let an agent check,
find nothing, and proceed to make the identical mistake the callout
exists to prevent. Widened the callout to cover both signals: the
banner for `.github/instructions/**.instructions.md` files, and an
`audit/sync-manifest.json` `syncPairs` lookup for `docs/**.md` files.
Updated both design-rationale sides to match (the `idd-template/`
generic version and this repo's own version, which cites the two real
occurrences plus issue #2477's structurally identical
`audit-docs.mjs` file-attribution bug as concrete evidence).

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (4875/4875 pass)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (if applicable) -- not applicable,
      docs-only change
- [x] `node scripts/audit-code-span-wrap.mjs`

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none)
- [x] Context budget impact reviewed (`bundle-work` stays under the
      95% notice threshold after this addition)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for maintaining generated documentation and instruction mirrors through their authoritative source files.
  - Documented the required resynchronization process to keep mirrored content consistent.
  - Added clarification on how to identify generated documentation and instruction files before making edits.
  - Expanded the design rationale to explain synchronization behavior and prevent changes to mirrors from being overwritten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->