### PR TITLE
feat(advisory-wait-policy): treat a secondary-bot decline as zero-wait

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -392,7 +392,14 @@ PRIMARY bot's own pending state, not a late secondary-bot arrival. **#2544**:
 once the secondary bot has already posted a genuine review for the current
 HEAD, only a short fixed confirmation buffer applies from that review's own
 timestamp instead of the full configured duration -- a HEAD the bot has not
-yet reviewed still waits the full period unchanged.
+yet reviewed still waits the full period unchanged. **#2547**: a rate-limit
+/ skip-review notice for the current HEAD, with no later genuine comment,
+is a third outcome distinct from `#2544`'s pending/settled split -- a
+definitive decline, not "might still be reviewing" -- and skips the wait
+entirely (no buffer, no remaining window). A repository need not configure
+anything extra for this: it applies automatically whenever
+`advisoryWait.secondaryQuietWindow` and `advisoryWait.secondaryBotLogin`
+are both set.
 
 `advisoryWait.capExhaustedRoute` is intentionally fail-closed. The
 default `phase-specific` behavior keeps the current E14 skip / F2-F3

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -246,7 +246,17 @@ posted a genuine (non-notice) review for the current HEAD, the gate no
 longer requires the full configured duration -- only a short, fixed
 confirmation buffer applies from that review's own timestamp, so the wait
 stays a fallback for a genuinely unreviewed HEAD rather than a fixed tax on
-every merge.
+every merge. **#2547**: a rate-limit / skip-review notice for the current
+HEAD, with no later genuine comment, is a third, distinct outcome from
+`#2544`'s two-way pending/settled split -- a definitive decline, not
+"might still be reviewing." The gate skips the wait entirely for it
+(no buffer, no remaining window) rather than treating it the same as
+still-pending silence, since nothing further can arrive from the bot for
+that exact commit. Live investigation across several PRs' head commits
+(commit-status history reaching its terminal entry within seconds of
+being queued, never observed to change afterward even 15+ hours later)
+found the notice comment alone sufficient; no separate commit-status
+corroboration is required.
 `advisoryWait.exemptBotAuthoredPrs` (#1906) is an opt-in, off-by-default
 flag effective only under `advisoryWait.convergenceScope: "all-prs"`. When
 `true`, a PR whose author resolves to a GitHub Bot-typed account AND has no

--- a/fixtures/pre-merge-readiness/ack-only-current.json
+++ b/fixtures/pre-merge-readiness/ack-only-current.json
@@ -198,7 +198,8 @@
       "anchorAt": "2026-05-11T23:56:00Z",
       "elapsedMinutes": null,
       "elapsed": true,
-      "remainingMinutes": 0
+      "remainingMinutes": 0,
+      "declined": false
     },
     "threads": {
       "unresolvedCount": 1,

--- a/fixtures/pre-merge-readiness/changes-requested.json
+++ b/fixtures/pre-merge-readiness/changes-requested.json
@@ -142,7 +142,8 @@
       "anchorAt": "2026-05-11T23:55:00Z",
       "elapsedMinutes": null,
       "elapsed": true,
-      "remainingMinutes": 0
+      "remainingMinutes": 0,
+      "declined": false
     },
     "threads": {
       "unresolvedCount": 0,

--- a/fixtures/pre-merge-readiness/ci-not-ready.json
+++ b/fixtures/pre-merge-readiness/ci-not-ready.json
@@ -145,7 +145,8 @@
       "anchorAt": "2026-05-11T23:55:00Z",
       "elapsedMinutes": null,
       "elapsed": true,
-      "remainingMinutes": 0
+      "remainingMinutes": 0,
+      "declined": false
     },
     "threads": {
       "unresolvedCount": 0,

--- a/fixtures/pre-merge-readiness/claim-lost.json
+++ b/fixtures/pre-merge-readiness/claim-lost.json
@@ -167,7 +167,8 @@
       "anchorAt": "2026-05-11T23:56:00Z",
       "elapsedMinutes": null,
       "elapsed": true,
-      "remainingMinutes": 0
+      "remainingMinutes": 0,
+      "declined": false
     },
     "threads": {
       "unresolvedCount": 1,

--- a/fixtures/pre-merge-readiness/clean.json
+++ b/fixtures/pre-merge-readiness/clean.json
@@ -167,7 +167,8 @@
       "anchorAt": "2026-05-11T23:56:00Z",
       "elapsedMinutes": null,
       "elapsed": true,
-      "remainingMinutes": 0
+      "remainingMinutes": 0,
+      "declined": false
     },
     "threads": {
       "unresolvedCount": 1,

--- a/fixtures/pre-merge-readiness/disposition-reply-latest.json
+++ b/fixtures/pre-merge-readiness/disposition-reply-latest.json
@@ -173,7 +173,8 @@
       "anchorAt": "2026-05-11T23:55:00Z",
       "elapsedMinutes": null,
       "elapsed": true,
-      "remainingMinutes": 0
+      "remainingMinutes": 0,
+      "declined": false
     },
     "threads": {
       "unresolvedCount": 0,

--- a/fixtures/pre-merge-readiness/stale-watermark.json
+++ b/fixtures/pre-merge-readiness/stale-watermark.json
@@ -167,7 +167,8 @@
       "anchorAt": "2026-05-11T23:56:00Z",
       "elapsedMinutes": null,
       "elapsed": true,
-      "remainingMinutes": 0
+      "remainingMinutes": 0,
+      "declined": false
     },
     "threads": {
       "unresolvedCount": 1,

--- a/fixtures/pre-merge-readiness/unreplied-comment.json
+++ b/fixtures/pre-merge-readiness/unreplied-comment.json
@@ -151,7 +151,8 @@
       "anchorAt": "2026-05-11T23:56:00Z",
       "elapsedMinutes": null,
       "elapsed": true,
-      "remainingMinutes": 0
+      "remainingMinutes": 0,
+      "declined": false
     },
     "threads": {
       "unresolvedCount": 0,

--- a/fixtures/pre-merge-readiness/unresolved-thread.json
+++ b/fixtures/pre-merge-readiness/unresolved-thread.json
@@ -167,7 +167,8 @@
       "anchorAt": "2026-05-11T23:56:00Z",
       "elapsedMinutes": null,
       "elapsed": true,
-      "remainingMinutes": 0
+      "remainingMinutes": 0,
+      "declined": false
     },
     "threads": {
       "unresolvedCount": 1,

--- a/fixtures/schemas/pre-merge-readiness.valid.json
+++ b/fixtures/schemas/pre-merge-readiness.valid.json
@@ -46,7 +46,8 @@
     "anchorAt": "2026-05-11T23:56:00Z",
     "elapsedMinutes": null,
     "elapsed": true,
-    "remainingMinutes": 0
+    "remainingMinutes": 0,
+    "declined": false
   },
   "threads": {
     "unresolvedCount": 1,

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -392,7 +392,14 @@ PRIMARY bot's own pending state, not a late secondary-bot arrival. **#2544**:
 once the secondary bot has already posted a genuine review for the current
 HEAD, only a short fixed confirmation buffer applies from that review's own
 timestamp instead of the full configured duration -- a HEAD the bot has not
-yet reviewed still waits the full period unchanged.
+yet reviewed still waits the full period unchanged. **#2547**: a rate-limit
+/ skip-review notice for the current HEAD, with no later genuine comment,
+is a third outcome distinct from `#2544`'s pending/settled split -- a
+definitive decline, not "might still be reviewing" -- and skips the wait
+entirely (no buffer, no remaining window). A repository need not configure
+anything extra for this: it applies automatically whenever
+`advisoryWait.secondaryQuietWindow` and `advisoryWait.secondaryBotLogin`
+are both set.
 
 `advisoryWait.capExhaustedRoute` is intentionally fail-closed. The
 default `phase-specific` behavior keeps the current E14 skip / F2-F3

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -246,7 +246,17 @@ posted a genuine (non-notice) review for the current HEAD, the gate no
 longer requires the full configured duration -- only a short, fixed
 confirmation buffer applies from that review's own timestamp, so the wait
 stays a fallback for a genuinely unreviewed HEAD rather than a fixed tax on
-every merge.
+every merge. **#2547**: a rate-limit / skip-review notice for the current
+HEAD, with no later genuine comment, is a third, distinct outcome from
+`#2544`'s two-way pending/settled split -- a definitive decline, not
+"might still be reviewing." The gate skips the wait entirely for it
+(no buffer, no remaining window) rather than treating it the same as
+still-pending silence, since nothing further can arrive from the bot for
+that exact commit. Live investigation across several PRs' head commits
+(commit-status history reaching its terminal entry within seconds of
+being queued, never observed to change afterward even 15+ hours later)
+found the notice comment alone sufficient; no separate commit-status
+corroboration is required.
 `advisoryWait.exemptBotAuthoredPrs` (#1906) is an opt-in, off-by-default
 flag effective only under `advisoryWait.convergenceScope: "all-prs"`. When
 `true`, a PR whose author resolves to a GitHub Bot-typed account AND has no

--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -1528,7 +1528,7 @@
         "elapsedMinutes": {
           "type": ["integer", "null"],
           "minimum": 0,
-          "description": "Whole minutes elapsed from anchorAt to now, or null when the window is off, anchorAt is invalid/absent, or now failed to parse."
+          "description": "Whole minutes elapsed from anchorAt to now, or null when the window is off, declined is true (anchorAt is the literal 'declined', not a timestamp), anchorAt is otherwise invalid/absent, or now failed to parse."
         },
         "elapsed": {
           "type": "boolean",

--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -1510,7 +1510,8 @@
         "anchorAt",
         "elapsedMinutes",
         "elapsed",
-        "remainingMinutes"
+        "remainingMinutes",
+        "declined"
       ],
       "additionalProperties": false,
       "properties": {
@@ -1521,8 +1522,8 @@
         },
         "anchorAt": {
           "type": "string",
-          "pattern": "^(none|\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z)$",
-          "description": "ISO timestamp of the last substantive (non-ack-only) activity this window anchors on, or the literal 'none' when no such activity exists. Still the real timestamp (not 'none') when minutes is 0 but a valid activity timestamp exists."
+          "pattern": "^(none|declined|\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z)$",
+          "description": "ISO timestamp of the last substantive (non-ack-only) activity this window anchors on, the literal 'none' when no such activity exists, or the literal 'declined' when the #2547 secondaryBotDeclined short-circuit fired. Still the real timestamp (not 'none') when minutes is 0 but a valid activity timestamp exists."
         },
         "elapsedMinutes": {
           "type": ["integer", "null"],
@@ -1531,12 +1532,16 @@
         },
         "elapsed": {
           "type": "boolean",
-          "description": "True when the configured window has elapsed since anchorAt -- always true when minutes is 0 (off) or anchorAt is unavailable."
+          "description": "True when the configured window has elapsed since anchorAt -- always true when minutes is 0 (off), anchorAt is unavailable, or declined is true."
         },
         "remainingMinutes": {
           "type": ["integer", "null"],
           "minimum": 0,
-          "description": "Whole minutes remaining until the window elapses. 0 when the window is off (minutes is 0) or anchorAt is invalid/absent; otherwise null only when elapsedMinutes itself is null (now failed to parse)."
+          "description": "Whole minutes remaining until the window elapses. 0 when the window is off (minutes is 0), declined is true, or anchorAt is invalid/absent; otherwise null only when elapsedMinutes itself is null (now failed to parse)."
+        },
+        "declined": {
+          "type": "boolean",
+          "description": "#2547: true when the configured secondary advisory bot has definitively declined (a rate-limit / skip-review notice, with no later genuine comment) to review the CURRENT HEAD -- the wait is skipped entirely (elapsed: true, remainingMinutes: 0) rather than requiring the full configured window."
         }
       }
     },

--- a/scripts/advisory-wait-policy.mjs
+++ b/scripts/advisory-wait-policy.mjs
@@ -425,6 +425,7 @@ function computeQuietWindowElapsed({ minutes, anchorAt, now }) {
     elapsedMinutes,
     elapsed,
     remainingMinutes,
+    declined: false,
   };
 }
 /**
@@ -461,6 +462,19 @@ function computeQuietWindowElapsed({ minutes, anchorAt, now }) {
  * invalid (the pre-#2544 default for every existing caller) falls through
  * to the unchanged, unsettled path -- byte-identical behavior.
  *
+ * #2547: `secondaryBotDeclined: true` skips the wait entirely (`elapsed:
+ * true`, same as the off/no-anchor branches below) once the secondary bot
+ * has definitively declined to review this exact HEAD (a rate-limit /
+ * skip-review notice, no genuine comment after it) -- #2335's "might still
+ * be mid-review" protection has nothing left to protect once the bot has
+ * already, conclusively, said it will not review this commit. Checked
+ * immediately after the `minutes <= 0` short-circuit and before
+ * `secondaryBotSettledAt`, since the two flags are mutually exclusive by
+ * construction (`computeSecondaryAdvisoryReviewSettlement` never reports
+ * both `settled` and `declined` true for the same call) -- the ordering
+ * only matters for which unconditional-pass branch a reader sees, not for
+ * any behavioral overlap.
+ *
  * A zero/absent `minutes` (the off/unset default) or a missing/invalid
  * anchor (nothing to anchor on yet) reports `elapsed: true` unconditionally
  * -- this gate must never itself block when unconfigured, and must never
@@ -479,6 +493,7 @@ export function buildSecondaryQuietWindowStatus({
   minutes,
   effectiveMaxActivityUpdatedAt,
   secondaryBotSettledAt,
+  secondaryBotDeclined,
   now,
 }) {
   const resolvedMinutes =
@@ -494,6 +509,17 @@ export function buildSecondaryQuietWindowStatus({
       elapsedMinutes: null,
       elapsed: true,
       remainingMinutes: 0,
+      declined: false,
+    };
+  }
+  if (secondaryBotDeclined === true) {
+    return {
+      minutes: resolvedMinutes,
+      anchorAt: 'declined',
+      elapsedMinutes: null,
+      elapsed: true,
+      remainingMinutes: 0,
+      declined: true,
     };
   }
   const settledAtRaw = String(secondaryBotSettledAt ?? '');
@@ -514,6 +540,7 @@ export function buildSecondaryQuietWindowStatus({
       elapsedMinutes: null,
       elapsed: true,
       remainingMinutes: 0,
+      declined: false,
     };
   }
   return computeQuietWindowElapsed({

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1350,24 +1350,42 @@ export function dispositionNamesAdvisoryBot(
   }
   return span.toLowerCase().includes(token);
 }
-// #2544: true when the configured secondary advisory bot has already
-// posted a genuine (non-notice) comment for the CURRENT HEAD -- i.e. the
-// `secondaryQuietWindow` gate's original #2335 "might still be mid-review"
-// concern no longer applies to this specific HEAD, only the narrower
-// "second/later finding" risk #2335 was also chartered to protect
-// (`buildSecondaryQuietWindowStatus`'s settled-buffer branch,
-// advisory-wait-policy.mts).
+// #2544/#2547: classifies the configured secondary advisory bot's current
+// standing for the CURRENT HEAD into exactly one of three outcomes --
+// still pending, definitively declined, or genuinely settled -- so
+// `buildSecondaryQuietWindowStatus` can give each its own wait treatment
+// (full window / zero-wait / short settled buffer respectively) instead of
+// #2544's original two-way `settled: boolean` collapsing "no evidence yet"
+// and "the bot already, conclusively, declined this exact commit" into the
+// same slow path.
 //
-// Every ambiguity resolves to `settled: false` -- the same fail-closed
-// direction #2335 already relies on: no comment from the bot at or after
-// `headCommittedAt`, an unparseable `headCommittedAt`/unconfigured
-// `secondaryBotLogin`, or the LATEST such comment being a rate-limit /
-// skip-review notice (`isAdvisoryNonReviewNotice`), all report
-// `settled: false`. Only the single latest matching comment is examined --
-// a notice posted BEFORE a later genuine comment (rate-limited, then
-// recovered) does not defeat settlement, while a notice posted AFTER the
-// latest genuine comment (mid-retry) does, purely as a side effect of
-// always picking the latest.
+// - `settled: true` -- the LATEST matching comment for this HEAD is a
+//   genuine (non-notice) comment: #2335's "might still be mid-review"
+//   concern no longer applies, only the narrower "second/later finding"
+//   risk `buildSecondaryQuietWindowStatus`'s settled-buffer branch still
+//   protects against.
+// - `declined: true` -- the LATEST matching comment for this HEAD is a
+//   rate-limit / skip-review notice (`isAdvisoryNonReviewNotice`). #2547's
+//   live investigation (`gh api .../commits/{sha}/statuses` across several
+//   PRs' head commits, corroborated by hours of subsequent silence on the
+//   oldest sampled PR) found every sampled rate-limit decline reaches its
+//   terminal commit-status entry within ~6-16 seconds of being queued and
+//   is never observed to change afterward, even 15+ hours later -- so a
+//   notice for the CURRENT HEAD is itself sufficient, corroborating
+//   commit-status data is not required to treat it as definitive. (An
+//   implementer's judgment call the issue explicitly left open: a notice
+//   with no separately-fetched corroborating commit status still reports
+//   `declined: true` here, not the ambiguous/pending case.)
+// - Neither `settled` nor `declined` -- still pending: no comment from the
+//   bot at or after `headCommittedAt` at all, or an unparseable
+//   `headCommittedAt`/unconfigured `secondaryBotLogin`. #2335's original
+//   full-window protection is unchanged for this case.
+//
+// Only the single latest matching comment is examined -- a notice posted
+// BEFORE a later genuine comment (rate-limited, then recovered) reports
+// `settled: true`, not `declined`, while a notice posted AFTER the latest
+// genuine comment (mid-retry) reports `declined: true`, purely as a side
+// effect of always picking the latest.
 //
 // Deliberately reuses `comments` only, not `reviews`: this file's existing
 // notice-vs-genuine classification for the secondary bot
@@ -1389,7 +1407,7 @@ export function computeSecondaryAdvisoryReviewSettlement(
   const token = advisoryBotIdentityToken(secondaryBotLogin);
   const headAt = String(headCommittedAt ?? '');
   if (!token || !isValidIsoTimestamp(headAt)) {
-    return { settled: false, settledAt: null };
+    return { settled: false, settledAt: null, declined: false };
   }
   const matches = comments
     .filter(
@@ -1412,10 +1430,13 @@ export function computeSecondaryAdvisoryReviewSettlement(
     )
     .sort((left, right) => compareIsoTimestamps(left.at, right.at));
   const latest = matches[matches.length - 1];
-  if (!latest || isAdvisoryNonReviewNotice(latest.body)) {
-    return { settled: false, settledAt: null };
+  if (!latest) {
+    return { settled: false, settledAt: null, declined: false };
   }
-  return { settled: true, settledAt: latest.at };
+  if (isAdvisoryNonReviewNotice(latest.body)) {
+    return { settled: false, settledAt: null, declined: true };
+  }
+  return { settled: true, settledAt: latest.at, declined: false };
 }
 // #1182 Match trusted machine advisory dispositions to the advisory-bot stickies
 // they address, so a disposition posted by a trusted-marker actor who is NOT a
@@ -5542,19 +5563,22 @@ export function buildPreMergeReadinessSummary(
         secondaryBotLogin,
         headCommittedAt: options.advisoryConvergenceHeadCommittedAt,
       })
-    : { settled: false, settledAt: null };
+    : { settled: false, settledAt: null, declined: false };
   // #2335: stateless secondary-quiet-window gate, anchored on the same
   // non-ack-only activity ceiling `liveSnapshot.effective` already computes
   // for the review-currency ack-only carve-out below -- see
   // `buildSecondaryQuietWindowStatus`'s own doc comment for why this anchor
   // needs no separate persisted "convergence first observed" timestamp.
   // #2544: `secondaryBotSettledAt` shortens the required wait to a settled
-  // buffer once that evidence exists; see `computeSecondaryAdvisoryReviewSettlement`
-  // above for how it is derived.
+  // buffer once that evidence exists. #2547: `secondaryBotDeclined` skips
+  // the wait entirely once the bot has definitively declined this exact
+  // HEAD; see `computeSecondaryAdvisoryReviewSettlement` above for how
+  // both are derived.
   const secondaryQuietWindow = buildSecondaryQuietWindowStatus({
     minutes: options.secondaryQuietWindowMinutes,
     effectiveMaxActivityUpdatedAt: liveSnapshot.effective?.maxActivityUpdatedAt,
     secondaryBotSettledAt: secondaryReviewSettlement.settledAt,
+    secondaryBotDeclined: secondaryReviewSettlement.declined,
     now,
   });
   const isTrustedWatermarkAuthor = (login) =>

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1384,8 +1384,9 @@ export function dispositionNamesAdvisoryBot(
 // Only the single latest matching comment is examined -- a notice posted
 // BEFORE a later genuine comment (rate-limited, then recovered) reports
 // `settled: true`, not `declined`, while a notice posted AFTER the latest
-// genuine comment (mid-retry) reports `declined: true`, purely as a side
-// effect of always picking the latest.
+// genuine comment reports `declined: true` as a fresh, terminal decline
+// for this HEAD -- not "might still produce another review" -- purely as
+// a side effect of always picking the latest.
 //
 // Deliberately reuses `comments` only, not `reviews`: this file's existing
 // notice-vs-genuine classification for the secondary bot

--- a/src/scripts/advisory-wait-policy.mts
+++ b/src/scripts/advisory-wait-policy.mts
@@ -454,6 +454,7 @@ export interface SecondaryQuietWindowStatus {
   elapsedMinutes: number | null;
   elapsed: boolean;
   remainingMinutes: number | null;
+  declined: boolean;
 }
 
 // #2544: once the secondary bot has posted a genuine (non-notice) review
@@ -500,6 +501,7 @@ function computeQuietWindowElapsed({
     elapsedMinutes,
     elapsed,
     remainingMinutes,
+    declined: false,
   };
 }
 
@@ -537,6 +539,19 @@ function computeQuietWindowElapsed({
  * invalid (the pre-#2544 default for every existing caller) falls through
  * to the unchanged, unsettled path -- byte-identical behavior.
  *
+ * #2547: `secondaryBotDeclined: true` skips the wait entirely (`elapsed:
+ * true`, same as the off/no-anchor branches below) once the secondary bot
+ * has definitively declined to review this exact HEAD (a rate-limit /
+ * skip-review notice, no genuine comment after it) -- #2335's "might still
+ * be mid-review" protection has nothing left to protect once the bot has
+ * already, conclusively, said it will not review this commit. Checked
+ * immediately after the `minutes <= 0` short-circuit and before
+ * `secondaryBotSettledAt`, since the two flags are mutually exclusive by
+ * construction (`computeSecondaryAdvisoryReviewSettlement` never reports
+ * both `settled` and `declined` true for the same call) -- the ordering
+ * only matters for which unconditional-pass branch a reader sees, not for
+ * any behavioral overlap.
+ *
  * A zero/absent `minutes` (the off/unset default) or a missing/invalid
  * anchor (nothing to anchor on yet) reports `elapsed: true` unconditionally
  * -- this gate must never itself block when unconfigured, and must never
@@ -555,11 +570,13 @@ export function buildSecondaryQuietWindowStatus({
   minutes,
   effectiveMaxActivityUpdatedAt,
   secondaryBotSettledAt,
+  secondaryBotDeclined,
   now,
 }: {
   minutes?: unknown;
   effectiveMaxActivityUpdatedAt?: unknown;
   secondaryBotSettledAt?: unknown;
+  secondaryBotDeclined?: unknown;
   now: string;
 }): SecondaryQuietWindowStatus {
   const resolvedMinutes =
@@ -575,6 +592,18 @@ export function buildSecondaryQuietWindowStatus({
       elapsedMinutes: null,
       elapsed: true,
       remainingMinutes: 0,
+      declined: false,
+    };
+  }
+
+  if (secondaryBotDeclined === true) {
+    return {
+      minutes: resolvedMinutes,
+      anchorAt: 'declined',
+      elapsedMinutes: null,
+      elapsed: true,
+      remainingMinutes: 0,
+      declined: true,
     };
   }
 
@@ -597,6 +626,7 @@ export function buildSecondaryQuietWindowStatus({
       elapsedMinutes: null,
       elapsed: true,
       remainingMinutes: 0,
+      declined: false,
     };
   }
   return computeQuietWindowElapsed({

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2102,24 +2102,42 @@ export function dispositionNamesAdvisoryBot(
   return span.toLowerCase().includes(token);
 }
 
-// #2544: true when the configured secondary advisory bot has already
-// posted a genuine (non-notice) comment for the CURRENT HEAD -- i.e. the
-// `secondaryQuietWindow` gate's original #2335 "might still be mid-review"
-// concern no longer applies to this specific HEAD, only the narrower
-// "second/later finding" risk #2335 was also chartered to protect
-// (`buildSecondaryQuietWindowStatus`'s settled-buffer branch,
-// advisory-wait-policy.mts).
+// #2544/#2547: classifies the configured secondary advisory bot's current
+// standing for the CURRENT HEAD into exactly one of three outcomes --
+// still pending, definitively declined, or genuinely settled -- so
+// `buildSecondaryQuietWindowStatus` can give each its own wait treatment
+// (full window / zero-wait / short settled buffer respectively) instead of
+// #2544's original two-way `settled: boolean` collapsing "no evidence yet"
+// and "the bot already, conclusively, declined this exact commit" into the
+// same slow path.
 //
-// Every ambiguity resolves to `settled: false` -- the same fail-closed
-// direction #2335 already relies on: no comment from the bot at or after
-// `headCommittedAt`, an unparseable `headCommittedAt`/unconfigured
-// `secondaryBotLogin`, or the LATEST such comment being a rate-limit /
-// skip-review notice (`isAdvisoryNonReviewNotice`), all report
-// `settled: false`. Only the single latest matching comment is examined --
-// a notice posted BEFORE a later genuine comment (rate-limited, then
-// recovered) does not defeat settlement, while a notice posted AFTER the
-// latest genuine comment (mid-retry) does, purely as a side effect of
-// always picking the latest.
+// - `settled: true` -- the LATEST matching comment for this HEAD is a
+//   genuine (non-notice) comment: #2335's "might still be mid-review"
+//   concern no longer applies, only the narrower "second/later finding"
+//   risk `buildSecondaryQuietWindowStatus`'s settled-buffer branch still
+//   protects against.
+// - `declined: true` -- the LATEST matching comment for this HEAD is a
+//   rate-limit / skip-review notice (`isAdvisoryNonReviewNotice`). #2547's
+//   live investigation (`gh api .../commits/{sha}/statuses` across several
+//   PRs' head commits, corroborated by hours of subsequent silence on the
+//   oldest sampled PR) found every sampled rate-limit decline reaches its
+//   terminal commit-status entry within ~6-16 seconds of being queued and
+//   is never observed to change afterward, even 15+ hours later -- so a
+//   notice for the CURRENT HEAD is itself sufficient, corroborating
+//   commit-status data is not required to treat it as definitive. (An
+//   implementer's judgment call the issue explicitly left open: a notice
+//   with no separately-fetched corroborating commit status still reports
+//   `declined: true` here, not the ambiguous/pending case.)
+// - Neither `settled` nor `declined` -- still pending: no comment from the
+//   bot at or after `headCommittedAt` at all, or an unparseable
+//   `headCommittedAt`/unconfigured `secondaryBotLogin`. #2335's original
+//   full-window protection is unchanged for this case.
+//
+// Only the single latest matching comment is examined -- a notice posted
+// BEFORE a later genuine comment (rate-limited, then recovered) reports
+// `settled: true`, not `declined`, while a notice posted AFTER the latest
+// genuine comment (mid-retry) reports `declined: true`, purely as a side
+// effect of always picking the latest.
 //
 // Deliberately reuses `comments` only, not `reviews`: this file's existing
 // notice-vs-genuine classification for the secondary bot
@@ -2140,11 +2158,11 @@ export function computeSecondaryAdvisoryReviewSettlement(
     secondaryBotLogin,
     headCommittedAt,
   }: { secondaryBotLogin: string; headCommittedAt?: string | null },
-): { settled: boolean; settledAt: string | null } {
+): { settled: boolean; settledAt: string | null; declined: boolean } {
   const token = advisoryBotIdentityToken(secondaryBotLogin);
   const headAt = String(headCommittedAt ?? '');
   if (!token || !isValidIsoTimestamp(headAt)) {
-    return { settled: false, settledAt: null };
+    return { settled: false, settledAt: null, declined: false };
   }
 
   const matches = comments
@@ -2169,10 +2187,13 @@ export function computeSecondaryAdvisoryReviewSettlement(
     .sort((left, right) => compareIsoTimestamps(left.at, right.at));
 
   const latest = matches[matches.length - 1];
-  if (!latest || isAdvisoryNonReviewNotice(latest.body)) {
-    return { settled: false, settledAt: null };
+  if (!latest) {
+    return { settled: false, settledAt: null, declined: false };
   }
-  return { settled: true, settledAt: latest.at };
+  if (isAdvisoryNonReviewNotice(latest.body)) {
+    return { settled: false, settledAt: null, declined: true };
+  }
+  return { settled: true, settledAt: latest.at, declined: false };
 }
 
 // #1182 Match trusted machine advisory dispositions to the advisory-bot stickies
@@ -7124,19 +7145,22 @@ export function buildPreMergeReadinessSummary(
         secondaryBotLogin,
         headCommittedAt: options.advisoryConvergenceHeadCommittedAt,
       })
-    : { settled: false, settledAt: null };
+    : { settled: false, settledAt: null, declined: false };
   // #2335: stateless secondary-quiet-window gate, anchored on the same
   // non-ack-only activity ceiling `liveSnapshot.effective` already computes
   // for the review-currency ack-only carve-out below -- see
   // `buildSecondaryQuietWindowStatus`'s own doc comment for why this anchor
   // needs no separate persisted "convergence first observed" timestamp.
   // #2544: `secondaryBotSettledAt` shortens the required wait to a settled
-  // buffer once that evidence exists; see `computeSecondaryAdvisoryReviewSettlement`
-  // above for how it is derived.
+  // buffer once that evidence exists. #2547: `secondaryBotDeclined` skips
+  // the wait entirely once the bot has definitively declined this exact
+  // HEAD; see `computeSecondaryAdvisoryReviewSettlement` above for how
+  // both are derived.
   const secondaryQuietWindow = buildSecondaryQuietWindowStatus({
     minutes: options.secondaryQuietWindowMinutes,
     effectiveMaxActivityUpdatedAt: liveSnapshot.effective?.maxActivityUpdatedAt,
     secondaryBotSettledAt: secondaryReviewSettlement.settledAt,
+    secondaryBotDeclined: secondaryReviewSettlement.declined,
     now,
   });
   const isTrustedWatermarkAuthor = (login: string) =>

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2136,8 +2136,9 @@ export function dispositionNamesAdvisoryBot(
 // Only the single latest matching comment is examined -- a notice posted
 // BEFORE a later genuine comment (rate-limited, then recovered) reports
 // `settled: true`, not `declined`, while a notice posted AFTER the latest
-// genuine comment (mid-retry) reports `declined: true`, purely as a side
-// effect of always picking the latest.
+// genuine comment reports `declined: true` as a fresh, terminal decline
+// for this HEAD -- not "might still produce another review" -- purely as
+// a side effect of always picking the latest.
 //
 // Deliberately reuses `comments` only, not `reviews`: this file's existing
 // notice-vs-genuine classification for the secondary bot

--- a/tests/advisory-wait-policy.test.mts
+++ b/tests/advisory-wait-policy.test.mts
@@ -438,3 +438,85 @@ test('buildSecondaryQuietWindowStatus stays elapsed:true at minutes:0 regardless
   assert.equal(withSettledAt.remainingMinutes, 0);
   assert.equal(withSettledAt.anchorAt, '2026-08-30T22:00:00Z');
 });
+
+// #2547: `secondaryBotDeclined: true` skips the wait entirely -- the bot
+// has already, definitively, declined to review this exact HEAD, so
+// #2335's "might still be mid-review" protection has nothing left to wait
+// for.
+test('buildSecondaryQuietWindowStatus reports elapsed unconditionally when secondaryBotDeclined is true, even with a fresh activity anchor', () => {
+  const status = buildSecondaryQuietWindowStatus({
+    minutes: 60,
+    effectiveMaxActivityUpdatedAt: '2026-08-30T22:00:00Z',
+    secondaryBotDeclined: true,
+    now: '2026-08-30T22:00:30Z',
+  });
+  assert.equal(status.elapsed, true);
+  assert.equal(status.remainingMinutes, 0);
+  assert.equal(status.declined, true);
+});
+
+test('buildSecondaryQuietWindowStatus still requires the full window when secondaryBotDeclined is absent (still pending, #2335 protection preserved)', () => {
+  const status = buildSecondaryQuietWindowStatus({
+    minutes: 60,
+    effectiveMaxActivityUpdatedAt: '2026-08-30T22:00:00Z',
+    now: '2026-08-30T22:00:30Z',
+  });
+  assert.equal(status.elapsed, false);
+  assert.equal(status.declined, false);
+});
+
+test('buildSecondaryQuietWindowStatus reports declined:false on every non-declined path (settled buffer, off, no-anchor, unsettled)', () => {
+  assert.equal(
+    buildSecondaryQuietWindowStatus({
+      minutes: 60,
+      effectiveMaxActivityUpdatedAt: '2026-08-30T22:00:00Z',
+      secondaryBotSettledAt: '2026-08-30T22:03:00Z',
+      now: '2026-08-30T22:03:30Z',
+    }).declined,
+    false,
+  );
+  assert.equal(
+    buildSecondaryQuietWindowStatus({
+      minutes: 0,
+      now: '2026-08-30T22:03:30Z',
+    }).declined,
+    false,
+  );
+  assert.equal(
+    buildSecondaryQuietWindowStatus({
+      minutes: 60,
+      now: '2026-08-30T22:03:30Z',
+    }).declined,
+    false,
+  );
+});
+
+test('buildSecondaryQuietWindowStatus: secondaryBotDeclined false is treated the same as absent (still the full window)', () => {
+  const declinedFalse = buildSecondaryQuietWindowStatus({
+    minutes: 60,
+    effectiveMaxActivityUpdatedAt: '2026-08-30T22:00:00Z',
+    secondaryBotDeclined: false,
+    now: '2026-08-30T22:00:30Z',
+  });
+  const declinedAbsent = buildSecondaryQuietWindowStatus({
+    minutes: 60,
+    effectiveMaxActivityUpdatedAt: '2026-08-30T22:00:00Z',
+    now: '2026-08-30T22:00:30Z',
+  });
+  assert.deepEqual(declinedFalse, declinedAbsent);
+});
+
+test('buildSecondaryQuietWindowStatus: minutes<=0 stays unconditional even when secondaryBotDeclined is true (off default wins)', () => {
+  const withDeclined = buildSecondaryQuietWindowStatus({
+    minutes: 0,
+    effectiveMaxActivityUpdatedAt: '2026-08-30T22:00:00Z',
+    secondaryBotDeclined: true,
+    now: '2026-08-30T22:00:30Z',
+  });
+  const withoutDeclined = buildSecondaryQuietWindowStatus({
+    minutes: 0,
+    effectiveMaxActivityUpdatedAt: '2026-08-30T22:00:00Z',
+    now: '2026-08-30T22:00:30Z',
+  });
+  assert.deepEqual(withDeclined, withoutDeclined);
+});

--- a/tests/pre-merge-readiness-collection-smoke.test.mts
+++ b/tests/pre-merge-readiness-collection-smoke.test.mts
@@ -1020,7 +1020,11 @@ test('collectPreMergeReadiness: secondaryQuietWindow settles quickly once CodeRa
   assert.equal(status.elapsed, true);
 });
 
-test('collectPreMergeReadiness: secondaryQuietWindow still blocks for the full window when CodeRabbit has only posted a rate-limit notice (#2335 protection preserved)', () => {
+// #2547: a rate-limit notice for the current HEAD is a definitive decline,
+// not "still might be mid-review" -- the wait is skipped entirely (zero
+// remaining minutes), unlike the pre-#2547 behavior this test used to
+// assert (full window, `elapsed: false`, `remainingMinutes: 56`).
+test('collectPreMergeReadiness: secondaryQuietWindow skips the wait entirely once CodeRabbit has posted a rate-limit notice for HEAD (#2547 decline, not #2335 mid-review)', () => {
   const status = runSecondaryQuietWindowFixture(
     [
       {
@@ -1033,8 +1037,8 @@ test('collectPreMergeReadiness: secondaryQuietWindow still blocks for the full w
     ],
     '2026-07-31T23:06:00Z',
   );
-  assert.equal(status.elapsed, false);
-  assert.equal(status.remainingMinutes, 56);
+  assert.equal(status.elapsed, true);
+  assert.equal(status.remainingMinutes, 0);
 });
 
 test('collectPreMergeReadiness: secondaryQuietWindow still blocks for the full window when CodeRabbit has said nothing, even though other PR activity exists', () => {

--- a/tests/protocol-helpers-advisory-bot-login.test.mts
+++ b/tests/protocol-helpers-advisory-bot-login.test.mts
@@ -132,15 +132,30 @@ test('isConfiguredAdvisoryBotLogin rejects unconfigured and empty logins', () =>
   assert.equal(isConfiguredAdvisoryBotLogin('[bot]', config), false);
 });
 
-test('computeSecondaryAdvisoryReviewSettlement: no matching comments -> not settled', () => {
+test('computeSecondaryAdvisoryReviewSettlement: no matching comments -> not settled, not declined (still pending)', () => {
   const result = computeSecondaryAdvisoryReviewSettlement([], {
     secondaryBotLogin: 'coderabbitai[bot]',
     headCommittedAt: HEAD_COMMITTED_AT,
   });
-  assert.deepEqual(result, { settled: false, settledAt: null });
+  assert.deepEqual(result, {
+    settled: false,
+    settledAt: null,
+    declined: false,
+  });
 });
 
-test('computeSecondaryAdvisoryReviewSettlement: only a rate-limit notice at HEAD -> not settled', () => {
+// #2547: a rate-limit/skip-review notice for the CURRENT HEAD is itself
+// sufficient to report `declined: true` -- this function only ever sees
+// `comments`, never a separately-fetched commit-status entry, so it cannot
+// distinguish "notice with a corroborating rate-limited commit status"
+// from "notice alone, no status checked" -- both inputs are identical from
+// here. This is a deliberate implementer's-judgment call the issue left
+// open: #2547's live investigation (`gh api .../commits/{sha}/statuses`
+// across several PRs, corroborated by 15+ hours of subsequent silence on
+// the oldest sampled PR) found the notice comment alone was already 100%
+// reliable as a terminal signal, so no additional corroboration is
+// required before treating it as definitive.
+test('computeSecondaryAdvisoryReviewSettlement: only a rate-limit notice at HEAD -> declined (#2547, no corroborating commit status checked)', () => {
   const result = computeSecondaryAdvisoryReviewSettlement(
     [comment('coderabbitai[bot]', CODERABBIT_NOTICE, '2026-09-02T12:05:00Z')],
     {
@@ -148,10 +163,14 @@ test('computeSecondaryAdvisoryReviewSettlement: only a rate-limit notice at HEAD
       headCommittedAt: HEAD_COMMITTED_AT,
     },
   );
-  assert.deepEqual(result, { settled: false, settledAt: null });
+  assert.deepEqual(result, {
+    settled: false,
+    settledAt: null,
+    declined: true,
+  });
 });
 
-test('computeSecondaryAdvisoryReviewSettlement: genuine review at/after HEAD -> settled', () => {
+test('computeSecondaryAdvisoryReviewSettlement: genuine review at/after HEAD -> settled, not declined', () => {
   const result = computeSecondaryAdvisoryReviewSettlement(
     [comment('coderabbitai[bot]', CODERABBIT_SUMMARY, '2026-09-02T12:05:00Z')],
     {
@@ -162,10 +181,11 @@ test('computeSecondaryAdvisoryReviewSettlement: genuine review at/after HEAD -> 
   assert.deepEqual(result, {
     settled: true,
     settledAt: '2026-09-02T12:05:00Z',
+    declined: false,
   });
 });
 
-test('computeSecondaryAdvisoryReviewSettlement: genuine review BEFORE HEAD (stale prior HEAD) -> not settled', () => {
+test('computeSecondaryAdvisoryReviewSettlement: genuine review BEFORE HEAD (stale prior HEAD) -> not settled, not declined (still pending)', () => {
   const result = computeSecondaryAdvisoryReviewSettlement(
     [comment('coderabbitai[bot]', CODERABBIT_SUMMARY, '2026-09-02T11:00:00Z')],
     {
@@ -173,10 +193,14 @@ test('computeSecondaryAdvisoryReviewSettlement: genuine review BEFORE HEAD (stal
       headCommittedAt: HEAD_COMMITTED_AT,
     },
   );
-  assert.deepEqual(result, { settled: false, settledAt: null });
+  assert.deepEqual(result, {
+    settled: false,
+    settledAt: null,
+    declined: false,
+  });
 });
 
-test('computeSecondaryAdvisoryReviewSettlement: notice AFTER the latest genuine review -> not settled (mid-retry)', () => {
+test('computeSecondaryAdvisoryReviewSettlement: notice AFTER the latest genuine review -> declined (mid-retry)', () => {
   const result = computeSecondaryAdvisoryReviewSettlement(
     [
       comment('coderabbitai[bot]', CODERABBIT_SUMMARY, '2026-09-02T12:05:00Z'),
@@ -187,7 +211,11 @@ test('computeSecondaryAdvisoryReviewSettlement: notice AFTER the latest genuine 
       headCommittedAt: HEAD_COMMITTED_AT,
     },
   );
-  assert.deepEqual(result, { settled: false, settledAt: null });
+  assert.deepEqual(result, {
+    settled: false,
+    settledAt: null,
+    declined: true,
+  });
 });
 
 test('computeSecondaryAdvisoryReviewSettlement: notice BEFORE a later genuine review -> settled (rate-limited, then recovered)', () => {
@@ -204,6 +232,7 @@ test('computeSecondaryAdvisoryReviewSettlement: notice BEFORE a later genuine re
   assert.deepEqual(result, {
     settled: true,
     settledAt: '2026-09-02T12:10:00Z',
+    declined: false,
   });
 });
 
@@ -220,23 +249,32 @@ test('computeSecondaryAdvisoryReviewSettlement: matches across the [bot]-suffix 
   assert.deepEqual(result, {
     settled: true,
     settledAt: '2026-09-02T12:05:00Z',
+    declined: false,
   });
 });
 
-test('computeSecondaryAdvisoryReviewSettlement: unparseable headCommittedAt -> not settled', () => {
+test('computeSecondaryAdvisoryReviewSettlement: unparseable headCommittedAt -> not settled, not declined', () => {
   const result = computeSecondaryAdvisoryReviewSettlement(
     [comment('coderabbitai[bot]', CODERABBIT_SUMMARY, '2026-09-02T12:05:00Z')],
     { secondaryBotLogin: 'coderabbitai[bot]', headCommittedAt: null },
   );
-  assert.deepEqual(result, { settled: false, settledAt: null });
+  assert.deepEqual(result, {
+    settled: false,
+    settledAt: null,
+    declined: false,
+  });
 });
 
-test('computeSecondaryAdvisoryReviewSettlement: unconfigured secondaryBotLogin -> not settled', () => {
+test('computeSecondaryAdvisoryReviewSettlement: unconfigured secondaryBotLogin -> not settled, not declined', () => {
   const result = computeSecondaryAdvisoryReviewSettlement(
     [comment('coderabbitai[bot]', CODERABBIT_SUMMARY, '2026-09-02T12:05:00Z')],
     { secondaryBotLogin: '', headCommittedAt: HEAD_COMMITTED_AT },
   );
-  assert.deepEqual(result, { settled: false, settledAt: null });
+  assert.deepEqual(result, {
+    settled: false,
+    settledAt: null,
+    declined: false,
+  });
 });
 
 test('computeSecondaryAdvisoryReviewSettlement: matches REST-raw comments (user.login/created_at/updated_at), not just the normalized shape (Copilot review, #2546)', () => {
@@ -256,5 +294,6 @@ test('computeSecondaryAdvisoryReviewSettlement: matches REST-raw comments (user.
   assert.deepEqual(result, {
     settled: true,
     settledAt: '2026-09-02T12:05:00Z',
+    declined: false,
   });
 });

--- a/tests/protocol-helpers-advisory-bot-login.test.mts
+++ b/tests/protocol-helpers-advisory-bot-login.test.mts
@@ -200,7 +200,7 @@ test('computeSecondaryAdvisoryReviewSettlement: genuine review BEFORE HEAD (stal
   });
 });
 
-test('computeSecondaryAdvisoryReviewSettlement: notice AFTER the latest genuine review -> declined (mid-retry)', () => {
+test('computeSecondaryAdvisoryReviewSettlement: notice AFTER the latest genuine review -> declined (fresh decline, not a still-pending retry)', () => {
   const result = computeSecondaryAdvisoryReviewSettlement(
     [
       comment('coderabbitai[bot]', CODERABBIT_SUMMARY, '2026-09-02T12:05:00Z'),

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -1280,6 +1280,7 @@ const preMergeReadinessFixture = {
     elapsedMinutes: null,
     elapsed: true,
     remainingMinutes: 0,
+    declined: false,
   },
   threads: {
     unresolvedCount: 1,


### PR DESCRIPTION
# Summary

`secondaryQuietWindow`'s #2544 settled/pending split collapsed two very
different cases into the same "keep waiting the full window" bucket:
the secondary bot might still be reviewing (#2335's original concern),
or it has already, conclusively, rate-limit-declined this exact HEAD.
Nothing further can arrive from the bot for that commit once declined,
so waiting out the rest of the window protects nothing -- and this
issue itself was prompted directly by PR #2546 sitting blocked on
exactly this gate.

Splits `computeSecondaryAdvisoryReviewSettlement`'s `settled: false`
bucket into still-pending (no comment from the bot at all) and
definitively declined (the latest matching comment is a
rate-limit/skip-review notice), and wires the new `declined` flag into
`buildSecondaryQuietWindowStatus` as a third, zero-wait short-circuit
alongside the existing off-switch and settled-buffer branches.

Live investigation (`gh api commits/{sha}/statuses` history across
several PRs, including ~18 hours of subsequent silence on the oldest
sample) found no case of CodeRabbit automatically revisiting a
declined commit once its allowance resets, so the notice alone is
treated as sufficient without a separate corroborating commit-status
fetch -- a deliberate, documented judgment call per the issue's own
"implementer's judgment, document either way" latitude, not a silent
assumption.

## Linked issue

Closes #2547

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

See issue #2547's own Background section for the full live-evidence
writeup (three PRs' commit-status histories, each terminating within
6-16 seconds of being queued and never observed to change afterward).

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed