### PR TITLE
docs(idd-design-rationale): trace output fields to their print site

### DIFF
--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -773,3 +773,32 @@ in the instruction text remains acceptable in place of that link when
 no paired entry exists — both forms fit inside the tight
 instruction-bundle budget that motivates the exemption; neither is
 required.
+
+### Trace a documented output field to its print/return call site, not a type or variable name
+
+While drafting #2474's documentation of field-name variance across
+this repository's evidence-collector helper scripts, an initial pass
+made several confident, specific claims about which top-level JSON
+keys a given helper actually returns. A fact-checking pass found that
+roughly half of those claims were wrong — not because the underlying
+behavior was misunderstood, but because a TypeScript **type name** or
+an internal **local variable name** had been mistaken for an actual
+printed/returned field. For example, `advisory-convergence.mts`'s
+printed object was described as returning a `verdict` field: `verdict`
+is only the local variable name holding the whole printed document
+(the `AdvisoryConvergenceVerdict` type), never a key nested inside it.
+`discover-viability-gate.mts` was described as returning a `passed`
+field: `passed` exists only on an internal per-issue helper result and
+is never copied into the printed top-level object. A second,
+independent verification pass, re-tracing every claim to the file's
+actual `JSON.stringify(...)` / `process.stdout.write(...)` call site
+rather than to the nearest plausible-looking name, caught and
+corrected every instance before the documentation merged (observed
+2026-09-03, #2474).
+
+When documenting what a script or function actually returns or
+prints, trace every claimed field name to its literal
+`JSON.stringify(...)` / `process.stdout.write(...)` / `return` call
+site in the current source — never infer it from a type name, an
+interface field, or a local variable name that merely looks like it
+could be the same thing.

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -752,3 +752,33 @@ in the instruction text remains acceptable in place of that link when
 no paired entry exists — both forms fit inside the tight
 instruction-bundle budget that motivates the exemption; neither is
 required.
+
+### Trace a documented output field to its print/return call site, not a type or variable name
+
+While drafting kurone-kito/idd-skill#2474's documentation of
+field-name variance across that repository's evidence-collector helper
+scripts, an initial pass made several confident, specific claims about
+which top-level JSON keys a given helper actually returns. A
+fact-checking pass found that roughly half of those claims were wrong
+— not because the underlying behavior was misunderstood, but because a
+TypeScript **type name** or an internal **local variable name** had
+been mistaken for an actual printed/returned field. For example,
+`advisory-convergence.mts`'s printed object was described as returning
+a `verdict` field: `verdict` is only the local variable name holding
+the whole printed document (the `AdvisoryConvergenceVerdict` type),
+never a key nested inside it. `discover-viability-gate.mts` was
+described as returning a `passed` field: `passed` exists only on an
+internal per-issue helper result and is never copied into the printed
+top-level object. A second, independent verification pass, re-tracing
+every claim to the file's actual `JSON.stringify(...)` /
+`process.stdout.write(...)` call site rather than to the nearest
+plausible-looking name, caught and corrected every instance before the
+documentation merged (observed 2026-09-03,
+kurone-kito/idd-skill#2474).
+
+When documenting what a script or function actually returns or
+prints, trace every claimed field name to its literal
+`JSON.stringify(...)` / `process.stdout.write(...)` / `return` call
+site in the current source — never infer it from a type name, an
+interface field, or a local variable name that merely looks like it
+could be the same thing.


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Add a dated entry under `docs/idd-design-rationale.md`'s (and the
canonical `idd-template/docs/idd-design-rationale.md` source's)
"## Documentation conventions" section, recording a documentation trap
observed while drafting #2474: a claimed JSON output field name can
actually be a TypeScript type name or a local variable name that only
looks like the real field, never a key the script actually prints or
returns. The entry states the actionable takeaway plainly — trace every
documented output field to its literal `JSON.stringify(...)` /
`process.stdout.write(...)` / `return` call site in the current source,
never infer it from a type name, an interface field, or a
similarly-named local variable.

Both files were edited by hand (structure-mode sync pair — content is
not auto-generated) and kept consistent except for the established
adopter-portable issue-reference convention: the `idd-template/` source
uses fully-qualified `kurone-kito/idd-skill#2474`, and the `docs/`
mirror uses the bare `#2474` form.

## Linked issue

Closes #2553

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

`.github/instructions/idd-work.instructions.md` was deliberately left
unedited: `bundle-work` sits at ~94.5% utilization as of 2026-09-03,
essentially no headroom before the 95% notice / 98% hard-fail
thresholds, and the existing "cite the observed incident" convention
already routes citation-bearing rationale to the budget-exempt
`docs/idd-design-rationale.md` instead.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance to verify documented output fields against actual returned or emitted values.
  * Documented examples of incorrect field attribution and the associated fact-checking process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->