### PR TITLE
feat(discover): mark non-duplicate A4.5 rejections with a marker

### DIFF
--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -195,6 +195,26 @@ A5 is never reached for a candidate that fails any check, labeled or not.
   structure/relationship edits, and any label other than the optional
   `triage:{outcome}` label above.
 
+**Machine-readable outcome marker (kurone-kito/idd-skill#2243).** For a
+rejection whose outcome is `unclear`, `duplicate`, `out-of-scope`, or
+`invalid` — the four outcomes with no dedicated label — append a hidden
+HTML-comment marker to the same rejection comment, mirroring the
+`<!-- idd-skill-autopilot-suitability: N -->` authoring
+convention:
+
+```markdown
+<!-- idd-skill-triage-verdict: <outcome> -->
+```
+
+Never emit this marker for `needs-decision` or `blocked-by-human`: those
+two already carry a stable label and need no second signal. Discover's own
+candidate-selection pass (`idd-discover.instructions.md`) reads this
+marker to skip a previously-rejected candidate without a full manual
+comment-history read, applying the same staleness rule as every other
+evidentiary marker in this workflow: a rejection whose comment predates
+the issue's own latest substantive (title/body) edit is stale and never
+suppresses a genuinely improved issue.
+
 ## Decision Flow
 
 ```text

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -112,7 +112,14 @@ in this preamble, since the fallback differs per helper.
   with opt-in `--with-claim-state` / `--current-claim-id` active-claim
   annotation parity with `discover-roadmap-graph`'s flag of the same name
   (referenced in
-  [kurone-kito/idd-skill#1395](https://github.com/kurone-kito/idd-skill/issues/1395))
+  [kurone-kito/idd-skill#1395](https://github.com/kurone-kito/idd-skill/issues/1395)).
+  Default-on (not opt-in): excludes a candidate whose most recent trusted
+  `A4.5 suitability gate rejection` comment carries a still-current
+  `<!-- {prefix}-triage-verdict: <outcome> -->` marker for one of the four
+  non-label outcomes, bucketed under `filtered.triage_verdict_rejected`
+  (referenced in
+  [kurone-kito/idd-skill#2243](https://github.com/kurone-kito/idd-skill/issues/2243);
+  see its `--help` for the fetch-scope and staleness details)
 - `scripts/discover-roadmap-graph.mjs` for A1.5/A2 recursive roadmap graph
   enumeration and classification
 - `scripts/idd-roadmap-audit-execute.mjs` for the A1.5 roadmap-completion
@@ -128,7 +135,12 @@ in this preamble, since the fallback differs per helper.
   [kurone-kito/idd-skill#1071](https://github.com/kurone-kito/idd-skill/issues/1071))
 - `scripts/discover-readiness-check.mjs` for A3 readiness criterion
   evaluation (referenced in
-  [kurone-kito/idd-skill#391](https://github.com/kurone-kito/idd-skill/issues/391))
+  [kurone-kito/idd-skill#391](https://github.com/kurone-kito/idd-skill/issues/391)).
+  Default-on (not opt-in): the same triage-verdict marker exclusion as
+  `discover-orphan-filter.mjs` above, surfaced as a
+  `triage_verdict:<outcome>` entry in `filteredOut[].reasons` (referenced
+  in
+  [kurone-kito/idd-skill#2243](https://github.com/kurone-kito/idd-skill/issues/2243))
 - `scripts/discover-viability-gate.mjs` for A4 viability gate evaluation
   across limited scope, clear verification, and autonomous completion
   criteria (referenced in
@@ -541,6 +553,12 @@ node scripts/discover-readiness-check.mjs --swarm-floor <N>
 - **Boundary**: read-only and advisory — selecting the next issue still runs
   the A3/A4/A4.5/A5 gates. Optional flags: `--owner` / `--repo` / `--policy`
   / `--now`.
+- **kurone-kito/idd-skill#2243 triage-verdict cost note**: the default-on
+  triage-verdict exclusion (see the `discover-readiness-check.mjs` bullet
+  above) runs for every candidate every cheaper check already lets
+  through, so a full repo-wide `--swarm-floor` sweep makes one extra
+  comments-plus-timeline API call pair per otherwise-ready candidate, not
+  just per swept issue.
 
 ### Discover Viability Gate Contract
 

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -190,6 +190,26 @@ A5 is never reached for a candidate that fails any check, labeled or not.
   structure/relationship edits, and any label other than the optional
   `triage:{outcome}` label above.
 
+**Machine-readable outcome marker (kurone-kito/idd-skill#2243).** For a
+rejection whose outcome is `unclear`, `duplicate`, `out-of-scope`, or
+`invalid` — the four outcomes with no dedicated label — append a hidden
+HTML-comment marker to the same rejection comment, mirroring the
+`<!-- {{PROJECT_MARKER_PREFIX}}-autopilot-suitability: N -->` authoring
+convention:
+
+```markdown
+<!-- {{PROJECT_MARKER_PREFIX}}-triage-verdict: <outcome> -->
+```
+
+Never emit this marker for `needs-decision` or `blocked-by-human`: those
+two already carry a stable label and need no second signal. Discover's own
+candidate-selection pass (`idd-discover.instructions.md`) reads this
+marker to skip a previously-rejected candidate without a full manual
+comment-history read, applying the same staleness rule as every other
+evidentiary marker in this workflow: a rejection whose comment predates
+the issue's own latest substantive (title/body) edit is stale and never
+suppresses a genuinely improved issue.
+
 ## Decision Flow
 
 ```text

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -112,7 +112,14 @@ in this preamble, since the fallback differs per helper.
   with opt-in `--with-claim-state` / `--current-claim-id` active-claim
   annotation parity with `discover-roadmap-graph`'s flag of the same name
   (referenced in
-  [kurone-kito/idd-skill#1395](https://github.com/kurone-kito/idd-skill/issues/1395))
+  [kurone-kito/idd-skill#1395](https://github.com/kurone-kito/idd-skill/issues/1395)).
+  Default-on (not opt-in): excludes a candidate whose most recent trusted
+  `A4.5 suitability gate rejection` comment carries a still-current
+  `<!-- {prefix}-triage-verdict: <outcome> -->` marker for one of the four
+  non-label outcomes, bucketed under `filtered.triage_verdict_rejected`
+  (referenced in
+  [kurone-kito/idd-skill#2243](https://github.com/kurone-kito/idd-skill/issues/2243);
+  see its `--help` for the fetch-scope and staleness details)
 - `scripts/discover-roadmap-graph.mjs` for A1.5/A2 recursive roadmap graph
   enumeration and classification
 - `scripts/idd-roadmap-audit-execute.mjs` for the A1.5 roadmap-completion
@@ -128,7 +135,12 @@ in this preamble, since the fallback differs per helper.
   [kurone-kito/idd-skill#1071](https://github.com/kurone-kito/idd-skill/issues/1071))
 - `scripts/discover-readiness-check.mjs` for A3 readiness criterion
   evaluation (referenced in
-  [kurone-kito/idd-skill#391](https://github.com/kurone-kito/idd-skill/issues/391))
+  [kurone-kito/idd-skill#391](https://github.com/kurone-kito/idd-skill/issues/391)).
+  Default-on (not opt-in): the same triage-verdict marker exclusion as
+  `discover-orphan-filter.mjs` above, surfaced as a
+  `triage_verdict:<outcome>` entry in `filteredOut[].reasons` (referenced
+  in
+  [kurone-kito/idd-skill#2243](https://github.com/kurone-kito/idd-skill/issues/2243))
 - `scripts/discover-viability-gate.mjs` for A4 viability gate evaluation
   across limited scope, clear verification, and autonomous completion
   criteria (referenced in
@@ -541,6 +553,12 @@ node scripts/discover-readiness-check.mjs --swarm-floor <N>
 - **Boundary**: read-only and advisory — selecting the next issue still runs
   the A3/A4/A4.5/A5 gates. Optional flags: `--owner` / `--repo` / `--policy`
   / `--now`.
+- **kurone-kito/idd-skill#2243 triage-verdict cost note**: the default-on
+  triage-verdict exclusion (see the `discover-readiness-check.mjs` bullet
+  above) runs for every candidate every cheaper check already lets
+  through, so a full repo-wide `--swarm-floor` sweep makes one extra
+  comments-plus-timeline API call pair per otherwise-ready candidate, not
+  just per swept issue.
 
 ### Discover Viability Gate Contract
 

--- a/scripts/discover-orphan-filter.mjs
+++ b/scripts/discover-orphan-filter.mjs
@@ -432,17 +432,32 @@ export async function filterOrphanIssues(issues, options = {}) {
         : undefined;
     const survivors = [];
     for (const orphan of orphans) {
-      const record = findTrustedSuitabilityRejection(
-        fetchComments(orphan.number),
-        trustedMarkerLogins,
-        markerPrefix,
-      );
-      const editedAt = record?.markerOutcome
-        ? resolveLatestSubstantiveIssueEditAt(
+      // CodeRabbit review, PR #2557: mirror resolveIssueLabelEvents's own
+      // fail-open contract for a per-candidate opportunistic fetch -- a
+      // transient GitHub API failure here must not abort the whole
+      // default-on discover pass; it degrades to "no evidence" (same as an
+      // absent marker) and the candidate stays selectable.
+      let record = null;
+      try {
+        record = findTrustedSuitabilityRejection(
+          fetchComments(orphan.number),
+          trustedMarkerLogins,
+          markerPrefix,
+        );
+      } catch {
+        record = null;
+      }
+      let editedAt = null;
+      if (record?.markerOutcome) {
+        try {
+          editedAt = resolveLatestSubstantiveIssueEditAt(
             issueCreatedAtByNumber.get(orphan.number),
             fetchTimeline(orphan.number),
-          )
-        : null;
+          );
+        } catch {
+          editedAt = null;
+        }
+      }
       if (record && isSuitabilityTriageVerdictCurrent(record, editedAt)) {
         filtered.triage_verdict_rejected.push({
           number: orphan.number,

--- a/scripts/discover-orphan-filter.mjs
+++ b/scripts/discover-orphan-filter.mjs
@@ -29,10 +29,16 @@ import { loadPolicyConfig } from './idd-config.mjs';
 import { stripMarkdownCodeRegions } from './markdown-code.mjs';
 import { createMarkerRegex } from './marker-regex.mjs';
 import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mjs';
+import { resolveTrustedMarkerActors } from './protocol-helpers.mjs';
 import {
   createGithubProviderAdapter,
   resolveCurrentGithubRepository,
 } from './provider-adapter-github.mjs';
+import {
+  findTrustedSuitabilityRejection,
+  isSuitabilityTriageVerdictCurrent,
+  resolveLatestSubstantiveIssueEditAt,
+} from './supersession-detection.mjs';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
 // A runtime/production-observation precondition (#2467) carries no
@@ -307,6 +313,7 @@ export async function filterOrphanIssues(issues, options = {}) {
     blocked_by_open_reference: [],
     open_dependency_reference: [],
     unresolvable_reference: [],
+    triage_verdict_rejected: [],
   };
   const orphans = [];
   const unresolvable = [];
@@ -323,6 +330,11 @@ export async function filterOrphanIssues(issues, options = {}) {
       candidate.number,
       { title: candidate.title, labels: candidate.labels },
     ]),
+  );
+  // #2243 staleness anchor lookup: each candidate's own createdAt, used as
+  // the resolveLatestSubstantiveIssueEditAt fallback below.
+  const issueCreatedAtByNumber = new Map(
+    issues.map((candidate) => [candidate.number, candidate.createdAt]),
   );
   for (const issue of issues) {
     const result = classifyIssue(issue, {
@@ -391,6 +403,61 @@ export async function filterOrphanIssues(issues, options = {}) {
       url: issue.url ?? '',
     };
     filtered[result.reason].push(entry);
+  }
+  // #2243: exclude a candidate whose most recent trusted `A4.5
+  // suitability gate rejection` comment carries a still-current
+  // `<!-- {prefix}-triage-verdict: <outcome> -->` marker for one of the
+  // four non-label outcomes (unclear/duplicate/out-of-scope/invalid).
+  // Survivors-only: runs after every free (body/label) filter above has
+  // already narrowed the candidate set, so this is at most one
+  // comments-plus-timeline fetch pair per surviving candidate, never per
+  // scanned issue. Default-on for the live CLI (see
+  // `FilterOrphanIssuesOptions.fetchCommentsByIssueNumber`'s doc comment)
+  // but a no-op here when either input is absent, keeping this file's
+  // existing tests and any other caller byte-stable by default.
+  if (
+    typeof options.fetchCommentsByIssueNumber === 'function' &&
+    Array.isArray(options.trustedMarkerLogins) &&
+    options.trustedMarkerLogins.length > 0
+  ) {
+    const fetchComments = options.fetchCommentsByIssueNumber;
+    const fetchTimeline =
+      typeof options.fetchTimelineByIssueNumber === 'function'
+        ? options.fetchTimelineByIssueNumber
+        : () => [];
+    const trustedMarkerLogins = options.trustedMarkerLogins;
+    const markerPrefix =
+      typeof options.markerPrefix === 'string'
+        ? options.markerPrefix
+        : undefined;
+    const survivors = [];
+    for (const orphan of orphans) {
+      const record = findTrustedSuitabilityRejection(
+        fetchComments(orphan.number),
+        trustedMarkerLogins,
+        markerPrefix,
+      );
+      const editedAt = record?.markerOutcome
+        ? resolveLatestSubstantiveIssueEditAt(
+            issueCreatedAtByNumber.get(orphan.number),
+            fetchTimeline(orphan.number),
+          )
+        : null;
+      if (record && isSuitabilityTriageVerdictCurrent(record, editedAt)) {
+        filtered.triage_verdict_rejected.push({
+          number: orphan.number,
+          title: orphan.title,
+          state: orphan.state,
+          reason: 'triage_verdict_rejected',
+          details: record.markerOutcome,
+          url: orphan.url,
+        });
+        continue;
+      }
+      survivors.push(orphan);
+    }
+    orphans.length = 0;
+    orphans.push(...survivors);
   }
   // Opt-in (#1395): annotate each orphan candidate with active-claim
   // eligibility, mirroring `discover-roadmap-graph`'s own sequential
@@ -485,12 +552,26 @@ async function runCli() {
         args.currentClaimId,
       )
     : undefined;
+  // #2243: always resolved (unlike claimState above) -- the triage-verdict
+  // exclusion is default-on, not an opt-in flag. An empty resolution (no
+  // flag/env/config trusted actors configured) makes the check a no-op via
+  // filterOrphanIssues's own trustedMarkerLogins-empty guard, matching
+  // every other trusted-marker consumer's fail-safe default.
+  const { actors: trustedMarkerLogins } = resolveTrustedMarkerActors({
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
+    config: { trustedMarkerActors: policy.trustedMarkerActors },
+  });
   const result = await filterOrphanIssues(openIssues, {
     issueStateByNumber: openStateByNumber,
     fetchIssueStateByNumber: (issueNumber) =>
       fetchIssueState(port, issueNumber),
     fetchLabelEventsByIssueNumber: (issueNumber) =>
       fetchIssueLabelEvents(port, issueNumber),
+    fetchCommentsByIssueNumber: (issueNumber) =>
+      fetchIssueCommentsForTriageVerdict(port, issueNumber),
+    fetchTimelineByIssueNumber: (issueNumber) =>
+      port.getWorkItemTimeline(issueNumber),
+    trustedMarkerLogins,
     markerPrefix: policy.markerPrefix,
     authoringLabelName: policy.authoringLabelName,
     authoringStaleAgeMs: policy.authoringStaleAgeMs,
@@ -623,7 +704,8 @@ Output schema:
     "runtime_observation_precondition": [...],
     "blocked_by_open_reference": [...],
     "open_dependency_reference": [...],
-    "unresolvable_reference": [...]
+    "unresolvable_reference": [...],
+    "triage_verdict_rejected": [...]
   },
   "unresolvable": [{"issue": 1, "reference": 2, "reason": "issue-not-found-or-inaccessible"}],
   "warnings": [{"issueNumber": 1, "message": "Warning: ..."}],
@@ -654,6 +736,23 @@ first; equal scores tie-break by lowest issue number). With --autopilot
 (default 3) are moved to routed_to_human; without it (attended runs) they
 stay in orphans, ranked last. A missing or out-of-range score is treated
 as no score: the issue stays in orphans and is never routed out.
+
+"filtered.triage_verdict_rejected" (#2243, default-on, not opt-in) excludes
+a candidate whose most recent trusted "A4.5 suitability gate rejection"
+comment carries a still-current
+"<!-- {markerPrefix}-triage-verdict: <outcome> -->" marker for one of the
+four non-label outcomes (unclear/duplicate/out-of-scope/invalid); each
+filtered entry's "details" field is that outcome string.
+"needs-decision"/"blocked-by-human" never emit this marker -- those already
+carry a stable label. Only runs for a candidate every cheaper (label/body)
+filter above has already let through (one comments-plus-timeline fetch pair
+per surviving candidate, never per scanned issue), and requires trusted
+marker actors to be configured (env/flag/repo config); with none
+configured, this check is a no-op and makes no extra GitHub API call.
+Staleness-checked (fail-closed toward NOT excluding): the marker only
+excludes when the rejection comment is at or after the issue's latest
+substantive (title/body) edit, so an issue legitimately improved after
+being rejected stays selectable.
 
 --with-claim-state (opt-in) annotates each candidate in "orphans" and
 "routed_to_human" with active-claim eligibility, exactly mirroring
@@ -732,6 +831,7 @@ function normalizeIssue(issue) {
     body: issue.body ?? '',
     url: issue.url ?? issue.html_url ?? '',
     milestone: issue.milestone,
+    createdAt: issue.createdAt,
   };
 }
 /**
@@ -801,6 +901,21 @@ function fetchIssueLabelEvents(port, issueNumber) {
     .getWorkItemTimeline(issueNumber)
     .filter((event) => event.event === 'labeled');
 }
+/**
+ * #2243: adapts {@link ProviderPort.listWorkItemComments}'s camelCase
+ * `ProviderComment` shape to the raw-REST-shaped
+ * `SuitabilityRejectionComment` `findTrustedSuitabilityRejection` expects
+ * (mirroring `suitability-triage.mts`'s own direct `gh api` comment fetch).
+ * `html_url` is intentionally omitted -- this file never reads the
+ * resulting record's `url` field, only `markerOutcome`/`createdAt`.
+ */
+function fetchIssueCommentsForTriageVerdict(port, issueNumber) {
+  return port.listWorkItemComments(issueNumber).map((comment) => ({
+    body: comment.body,
+    created_at: comment.createdAt,
+    user: { login: comment.authorLogin },
+  }));
+}
 function normalizeMarkerPrefix(prefix) {
   if (typeof prefix !== 'string' || prefix.length === 0) {
     return DEFAULT_MARKER_PREFIX;
@@ -847,6 +962,7 @@ function fetchOpenIssues(port) {
       url: item.url,
       html_url: item.htmlUrl,
       milestone: item.milestone,
+      createdAt: item.createdAt,
     }),
   );
 }

--- a/scripts/discover-readiness-check.mjs
+++ b/scripts/discover-readiness-check.mjs
@@ -353,19 +353,35 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
     // a candidate every cheaper (label/body) check above has already let
     // through, never per scanned issue.
     if (reasons.size === 0 && triageVerdictCheckEnabled) {
-      const record = findTrustedSuitabilityRejection(
-        fetchCommentsByIssueNumber(issue.number),
-        trustedMarkerLogins,
-        resolvedMarkerPrefix,
-      );
-      const editedAt = record?.markerOutcome
-        ? resolveLatestSubstantiveIssueEditAt(
+      // CodeRabbit review, PR #2557: mirror this file's own fail-open
+      // contract for optional per-candidate lookups (e.g.
+      // resolveLabelEvents in discover-orphan-filter.mts) -- a transient
+      // GitHub API failure here must not abort the whole default-on
+      // readiness pass; it degrades to "no evidence" and the candidate
+      // stays selectable.
+      let record = null;
+      try {
+        record = findTrustedSuitabilityRejection(
+          fetchCommentsByIssueNumber(issue.number),
+          trustedMarkerLogins,
+          resolvedMarkerPrefix,
+        );
+      } catch {
+        record = null;
+      }
+      let editedAt = null;
+      if (record?.markerOutcome) {
+        try {
+          editedAt = resolveLatestSubstantiveIssueEditAt(
             issue.createdAt,
             typeof fetchTimelineByIssueNumber === 'function'
               ? fetchTimelineByIssueNumber(issue.number)
               : [],
-          )
-        : null;
+          );
+        } catch {
+          editedAt = null;
+        }
+      }
       if (record && isSuitabilityTriageVerdictCurrent(record, editedAt)) {
         reasons.add(`triage_verdict:${record.markerOutcome}`);
       }

--- a/scripts/discover-readiness-check.mjs
+++ b/scripts/discover-readiness-check.mjs
@@ -18,10 +18,16 @@ import { loadPolicyConfig } from './idd-config.mjs';
 import { stripMarkdownCodeRegions } from './markdown-code.mjs';
 import { escapeRegex } from './marker-regex.mjs';
 import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mjs';
+import { resolveTrustedMarkerActors } from './protocol-helpers.mjs';
 import {
   createGithubProviderAdapter,
   resolveCurrentGithubRepository,
 } from './provider-adapter-github.mjs';
+import {
+  findTrustedSuitabilityRejection,
+  isSuitabilityTriageVerdictCurrent,
+  resolveLatestSubstantiveIssueEditAt,
+} from './supersession-detection.mjs';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
 // Leading-anchor source shared by the `Blocked by` / `Depends on` line parsers.
@@ -91,9 +97,20 @@ if (import.meta.main) {
     args.swarmFloor === null
       ? args.issueNumbers
       : listOpenIssueNumbers(owner, repo);
+  // #2243: resolved unconditionally (not opt-in) -- the triage-verdict
+  // exclusion is default-on. An empty resolution (no flag/env/config
+  // trusted actors configured) makes the check a no-op via
+  // evaluateDiscoverReadiness's own trustedMarkerLogins-empty guard.
+  const { actors: trustedMarkerLogins } = resolveTrustedMarkerActors({
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
+    config: policyConfig,
+  });
   const summary = await evaluateDiscoverReadiness(issueNumbers, {
     includeUnresolvable: args.includeUnresolvable,
     loadIssue: buildIssueLoader(owner, repo),
+    fetchCommentsByIssueNumber: buildIssueCommentsLoader(owner, repo),
+    fetchTimelineByIssueNumber: buildIssueTimelineLoader(owner, repo),
+    trustedMarkerLogins,
     // `--swarm-floor` output never surfaces the stale-authoring warning, so
     // skip the per-issue timeline fetch this loader runs — over a whole-repo
     // sweep that is one extra paginated API call per open issue. The
@@ -140,7 +157,14 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
     autopilotSuitabilityFloor,
     autopilotSuitabilityEnabled,
     now = new Date(),
+    fetchCommentsByIssueNumber,
+    fetchTimelineByIssueNumber,
+    trustedMarkerLogins,
   } = options ?? {};
+  const triageVerdictCheckEnabled =
+    typeof fetchCommentsByIssueNumber === 'function' &&
+    Array.isArray(trustedMarkerLogins) &&
+    trustedMarkerLogins.length > 0;
   // Route the three label-name options through normalizePolicyConfig rather
   // than a bare destructure default (which only applies on `undefined`), so
   // an invalid or empty-string input also falls back to POLICY_DEFAULTS
@@ -318,6 +342,32 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
       }
       if (markerMatches.some((candidate) => candidate.state === 'OPEN')) {
         reasons.add(`blocked_by_open_roadmap_marker:${marker}`);
+      }
+    }
+    // #2243: exclude an otherwise-ready candidate whose most recent
+    // trusted `A4.5 suitability gate rejection` comment carries a
+    // still-current `<!-- {prefix}-triage-verdict: <outcome> -->` marker
+    // for one of the four non-label outcomes. Gated on
+    // `reasons.size === 0` so far -- this is the one check in the loop
+    // that needs a live comments-plus-timeline fetch, so it only runs for
+    // a candidate every cheaper (label/body) check above has already let
+    // through, never per scanned issue.
+    if (reasons.size === 0 && triageVerdictCheckEnabled) {
+      const record = findTrustedSuitabilityRejection(
+        fetchCommentsByIssueNumber(issue.number),
+        trustedMarkerLogins,
+        resolvedMarkerPrefix,
+      );
+      const editedAt = record?.markerOutcome
+        ? resolveLatestSubstantiveIssueEditAt(
+            issue.createdAt,
+            typeof fetchTimelineByIssueNumber === 'function'
+              ? fetchTimelineByIssueNumber(issue.number)
+              : [],
+          )
+        : null;
+      if (record && isSuitabilityTriageVerdictCurrent(record, editedAt)) {
+        reasons.add(`triage_verdict:${record.markerOutcome}`);
       }
     }
     const signal = suitabilitySignal(issue.body);
@@ -596,6 +646,20 @@ function printHelp() {
   rather than a silent coercion. A "no score" issue is never below floor,
   matching discovery ranking.
 
+  #2243 triage-verdict exclusion (default-on, not opt-in): for a candidate
+  every cheaper (label/body) check already lets through, this makes one
+  comments-plus-timeline GitHub API call to look for a still-current
+  trusted "A4.5 suitability gate rejection" comment carrying a
+  "<!-- {markerPrefix}-triage-verdict: <outcome> -->" marker for one of the
+  four non-label outcomes (unclear/duplicate/out-of-scope/invalid). A match
+  excludes the candidate with reasons: ["triage_verdict:<outcome>"].
+  "needs-decision"/"blocked-by-human" never emit this marker -- those
+  already carry a stable label. Requires trusted marker actors to be
+  configured (env/flag/repo config); with none configured, this check is a
+  no-op and makes no extra GitHub API call. Staleness-checked (fail-closed
+  toward NOT excluding): the marker only excludes when the rejection
+  comment is at or after the issue's latest substantive (title/body) edit.
+
 Output schema (JSON mode):
   {
     "ready": [{ "number": 123, "title": "...", "autopilotSuitability": 4, "belowFloor": false, "isRoadmap": false }],
@@ -633,6 +697,7 @@ function normalizeIssue(issue) {
     labels: normalizeLabels(issue.labels),
     labelEvents: Array.isArray(issue.labelEvents) ? issue.labelEvents : [],
     url: String(issue.url ?? ''),
+    createdAt: String(issue.createdAt ?? ''),
   };
 }
 function normalizeLabels(labelsInput) {
@@ -785,6 +850,30 @@ function fetchIssueLabelEvents(port, issueNumber) {
   return port
     .getWorkItemTimeline(issueNumber)
     .filter((event) => event.event === 'labeled');
+}
+/** #2243: full raw timeline (unfiltered), for
+ * {@link resolveLatestSubstantiveIssueEditAt}'s `edited`-event scan. */
+function buildIssueTimelineLoader(owner, repo) {
+  const port = createGithubProviderAdapter(owner, repo);
+  return (issueNumber) => port.getWorkItemTimeline(issueNumber);
+}
+/**
+ * #2243: adapts {@link ProviderPort.listWorkItemComments}'s camelCase
+ * `ProviderComment` shape to the raw-REST-shaped
+ * `SuitabilityRejectionComment` `findTrustedSuitabilityRejection` expects
+ * (mirroring `discover-orphan-filter.mts`'s identical adapter and
+ * `suitability-triage.mts`'s own direct `gh api` comment fetch).
+ * `html_url` is intentionally omitted -- this file never reads the
+ * resulting record's `url` field, only `markerOutcome`/`createdAt`.
+ */
+function buildIssueCommentsLoader(owner, repo) {
+  const port = createGithubProviderAdapter(owner, repo);
+  return (issueNumber) =>
+    port.listWorkItemComments(issueNumber).map((comment) => ({
+      body: comment.body,
+      created_at: comment.createdAt,
+      user: { login: comment.authorLogin },
+    }));
 }
 export function buildRoadmapMarkerSearchQuery(
   owner,

--- a/scripts/provider-adapter-github.mjs
+++ b/scripts/provider-adapter-github.mjs
@@ -544,6 +544,14 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
           htmlUrl:
             row.html_url === undefined ? undefined : String(row.html_url),
           milestone: row.milestone,
+          // #2243 (Copilot review, PR #2557): populate createdAt like
+          // getWorkItem() above already does -- discover-orphan-filter.mts's
+          // triage-verdict staleness anchor reads this field straight off
+          // the bulk listOpenWorkItems() result (no secondary per-issue
+          // fetch), so an absent value here silently made that exclusion
+          // never fire for a never-edited issue in real runs.
+          createdAt:
+            row.created_at === undefined ? undefined : String(row.created_at),
         }));
     },
     searchWorkItems(query) {

--- a/scripts/supersession-detection.mjs
+++ b/scripts/supersession-detection.mjs
@@ -23,7 +23,12 @@
 // `suitability-triage.mts`'s own CLI glue, which the issue does not name as
 // part of the extraction.
 import { normalizeContentionPath } from './discover-shared-file-overlap.mjs';
+import { stripMarkdownCodeRegions } from './markdown-code.mjs';
+import { escapeRegex } from './marker-regex.mjs';
 
+/** Default `{prefix}` for every marker this module parses, matching
+ * `autopilot-suitability.mts`'s own default. */
+const DEFAULT_MARKER_PREFIX = 'idd-skill';
 /** Upper bound on the #1484 bounded merged-PR scan (mirrors B2.0's own
  * documented `gh pr list --limit 50`). */
 const MERGED_PR_SCAN_LIMIT = 50;
@@ -182,6 +187,137 @@ export const SUITABILITY_REJECTION_PREFIX = 'A4.5 suitability gate rejection';
 const SUITABILITY_REJECTION_OUTCOME_PATTERN =
   /outcome:\s*(unclear|needs-decision|blocked-by-human|duplicate|out-of-scope|invalid)\b/i;
 const SUITABILITY_REJECTION_CHECK_PATTERN = /Check\s+\d+\s*\([^)]+\)/i;
+/** The four A4.5 outcomes with no dedicated label (#2243): the only values
+ * `<!-- {prefix}-triage-verdict: <outcome> -->` may declare.
+ * `needs-decision`/`blocked-by-human` are deliberately excluded -- those
+ * two already carry a stable label and never emit this marker. */
+export const SUITABILITY_TRIAGE_VERDICT_OUTCOMES = [
+  'unclear',
+  'duplicate',
+  'out-of-scope',
+  'invalid',
+];
+function isSuitabilityTriageVerdictOutcome(value) {
+  return SUITABILITY_TRIAGE_VERDICT_OUTCOMES.includes(value);
+}
+/**
+ * Canonical parser for the authored `<!-- {prefix}-triage-verdict:
+ * <outcome> -->` marker (#2243), mirroring
+ * `autopilot-suitability.mts`'s `parseAutopilotSuitabilityMarker` shape and
+ * fail-safe rules: `present` is false only when no marker appears at all;
+ * `outcome` is the single coherent token when it is one of
+ * {@link SUITABILITY_TRIAGE_VERDICT_OUTCOMES}, or `null` (fail-safe = "no
+ * marker") when the marker is absent, carries an unrecognized token, or
+ * repeats with disagreeing values; `malformed` is true only when a marker
+ * is present but does not resolve to a coherent outcome.
+ *
+ * `body` is masked with {@link stripMarkdownCodeRegions} first so a marker
+ * merely *quoted* in prose (for example, an issue or comment explaining
+ * this marker's own syntax in a code span, as #2243's own body does)
+ * cannot be mistaken for a live one (#1614, #1121 precedent).
+ */
+export function parseSuitabilityTriageVerdictMarker(
+  body,
+  markerPrefix = DEFAULT_MARKER_PREFIX,
+) {
+  const prefix =
+    typeof markerPrefix === 'string' && markerPrefix.length > 0
+      ? markerPrefix
+      : DEFAULT_MARKER_PREFIX;
+  const regex = new RegExp(
+    `<!--\\s*${escapeRegex(prefix)}-triage-verdict:\\s*([^\\s>]+)\\s*-->`,
+    'gi',
+  );
+  const text = stripMarkdownCodeRegions(String(body ?? ''));
+  let present = false;
+  let outcome = null;
+  let match = regex.exec(text);
+  while (match) {
+    present = true;
+    const raw = (match[1] ?? '').toLowerCase();
+    if (
+      !isSuitabilityTriageVerdictOutcome(raw) ||
+      (outcome !== null && raw !== outcome)
+    ) {
+      return { present: true, outcome: null, malformed: true };
+    }
+    outcome = raw;
+    match = regex.exec(text);
+  }
+  return { present, outcome, malformed: false };
+}
+/**
+ * Staleness anchor for a suitability-rejection marker (#2243): the latest
+ * GitHub `created_at` among the issue's own creation and every timeline
+ * `edited` event that changed the title or body. Mirrors
+ * `claim-approval-gate.mts`'s private `resolveLatestSubstantiveEditAt` --
+ * duplicated rather than imported to keep this module's dependency-light,
+ * I/O-free kernel contract intact (see the file header). Returns `null`
+ * only when neither `issueCreatedAt` nor any qualifying event yields a
+ * parseable timestamp -- callers must treat that as "unknown", never as
+ * "always stale" or "never stale".
+ */
+export function resolveLatestSubstantiveIssueEditAt(
+  issueCreatedAt,
+  timelineEvents,
+) {
+  const candidates = [];
+  if (typeof issueCreatedAt === 'string' && issueCreatedAt) {
+    candidates.push(issueCreatedAt);
+  }
+  if (Array.isArray(timelineEvents)) {
+    for (const raw of timelineEvents) {
+      const event = raw ?? {};
+      if (String(event.event ?? '') !== 'edited') {
+        continue;
+      }
+      if (!event.changes?.title && !event.changes?.body) {
+        continue;
+      }
+      if (typeof event.created_at === 'string' && event.created_at) {
+        candidates.push(event.created_at);
+      }
+    }
+  }
+  let latest = null;
+  let latestTimestamp = Number.NEGATIVE_INFINITY;
+  for (const candidate of candidates) {
+    const timestamp = Date.parse(candidate);
+    if (!Number.isFinite(timestamp) || timestamp < latestTimestamp) {
+      continue;
+    }
+    latestTimestamp = timestamp;
+    latest = candidate;
+  }
+  return latest;
+}
+/**
+ * Whether a trusted rejection record's marker outcome (#2243) is still
+ * current enough to exclude a candidate from Discover's selection pass:
+ * `true` only when the marker resolved to one of
+ * {@link SUITABILITY_TRIAGE_VERDICT_OUTCOMES} AND the rejection comment's
+ * own `createdAt` is at or after `latestSubstantiveEditAt` -- an issue
+ * legitimately improved after being rejected must not stay excluded by a
+ * now-stale marker. `latestSubstantiveEditAt: null` (unknown anchor) fails
+ * closed toward NOT excluding the candidate, matching this module's
+ * existing fail-safe direction: a wrongly-kept candidate still reaches
+ * A4.5, which re-derives its own verdict; a wrongly-skipped one is
+ * silently lost.
+ */
+export function isSuitabilityTriageVerdictCurrent(
+  record,
+  latestSubstantiveEditAt,
+) {
+  if (!record.markerOutcome || !latestSubstantiveEditAt) {
+    return false;
+  }
+  const rejectionTimestamp = Date.parse(record.createdAt);
+  const editTimestamp = Date.parse(latestSubstantiveEditAt);
+  if (!Number.isFinite(rejectionTimestamp) || !Number.isFinite(editTimestamp)) {
+    return false;
+  }
+  return rejectionTimestamp >= editTimestamp;
+}
 /**
  * Scan `comments` for the most recent trusted-actor `A4.5 suitability gate
  * rejection` comment (#1887): the acceptance-criteria-required detect-only
@@ -208,7 +344,11 @@ const SUITABILITY_REJECTION_CHECK_PATTERN = /Check\s+\d+\s*\([^)]+\)/i;
  * fail-safe contract (an untrusted rejection-shaped comment is never
  * treated as authoritative).
  */
-export function findTrustedSuitabilityRejection(comments, trustedMarkerLogins) {
+export function findTrustedSuitabilityRejection(
+  comments,
+  trustedMarkerLogins,
+  markerPrefix = DEFAULT_MARKER_PREFIX,
+) {
   const trusted = new Set(
     (trustedMarkerLogins ?? [])
       .map((login) =>
@@ -244,6 +384,10 @@ export function findTrustedSuitabilityRejection(comments, trustedMarkerLogins) {
     latestTimestamp = timestamp;
     const outcomeMatch = SUITABILITY_REJECTION_OUTCOME_PATTERN.exec(body);
     const checkMatch = SUITABILITY_REJECTION_CHECK_PATTERN.exec(body);
+    const markerDetection = parseSuitabilityTriageVerdictMarker(
+      body,
+      markerPrefix,
+    );
     latest = {
       author,
       createdAt,
@@ -256,6 +400,7 @@ export function findTrustedSuitabilityRejection(comments, trustedMarkerLogins) {
       // downstream string comparison brittle. Normalize before returning.
       outcome: outcomeMatch ? (outcomeMatch[1]?.toLowerCase() ?? null) : null,
       check: checkMatch ? checkMatch[0] : null,
+      markerOutcome: markerDetection.malformed ? null : markerDetection.outcome,
     };
   }
   return latest;

--- a/src/scripts/discover-orphan-filter.mts
+++ b/src/scripts/discover-orphan-filter.mts
@@ -32,11 +32,18 @@ import { loadPolicyConfig } from './idd-config.mts';
 import { stripMarkdownCodeRegions } from './markdown-code.mts';
 import { createMarkerRegex } from './marker-regex.mts';
 import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mts';
+import { resolveTrustedMarkerActors } from './protocol-helpers.mts';
 import {
   createGithubProviderAdapter,
   resolveCurrentGithubRepository,
 } from './provider-adapter-github.mts';
 import type { ProviderPort } from './provider-port.mts';
+import {
+  findTrustedSuitabilityRejection,
+  isSuitabilityTriageVerdictCurrent,
+  resolveLatestSubstantiveIssueEditAt,
+  type SuitabilityRejectionComment,
+} from './supersession-detection.mts';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
 
@@ -71,7 +78,8 @@ export type OrphanFilteredReason =
   | 'runtime_observation_precondition'
   | 'blocked_by_open_reference'
   | 'open_dependency_reference'
-  | 'unresolvable_reference';
+  | 'unresolvable_reference'
+  | 'triage_verdict_rejected';
 
 /** Classification verdict for one issue in the orphan filter. */
 export type OrphanClassification =
@@ -106,6 +114,10 @@ interface OrphanIssueInput {
   body?: unknown;
   url?: unknown;
   milestone?: unknown;
+  /** GitHub `created_at` (#2243): the staleness-check fallback anchor
+   * consumed by {@link resolveLatestSubstantiveIssueEditAt} when the
+   * candidate has never been substantively edited. */
+  createdAt?: unknown;
 }
 
 interface ClassifyIssueOptions {
@@ -148,6 +160,29 @@ interface FilterOrphanIssuesOptions {
    * byte-stable.
    */
   claimState?: ClaimStateResolution;
+  /**
+   * #2243 triage-verdict exclusion (default-on, unlike `claimState` above):
+   * fetches each surviving candidate's comments to look for a still-current
+   * trusted `A4.5 suitability gate rejection` marker. Only actually runs
+   * when BOTH this and {@link trustedMarkerLogins} are supplied and
+   * non-empty -- the CLI wiring always supplies both, so the live default
+   * output does carry this check; a caller (including this file's own
+   * tests) that omits either gets the prior byte-stable shape with no
+   * extra fetch, matching this module's existing fail-safe direction (a
+   * missing evidence source never skips a candidate, it just leaves the
+   * candidate unfiltered by this specific check).
+   */
+  fetchCommentsByIssueNumber?: (
+    issueNumber: number,
+  ) => SuitabilityRejectionComment[];
+  /** #2243: per-candidate timeline fetch for the staleness anchor
+   * ({@link resolveLatestSubstantiveIssueEditAt}). Defaults to "no events"
+   * when omitted, which only widens the staleness window (never narrows
+   * it), so an absent fetcher cannot itself cause a wrongful skip. */
+  fetchTimelineByIssueNumber?: (issueNumber: number) => unknown[];
+  /** #2243: trust-actor allowlist for the triage-verdict marker scan, same
+   * semantics as `idd-claim.instructions.md`'s trusted marker actors. */
+  trustedMarkerLogins?: string[];
 }
 
 interface FilteredIssueEntry {
@@ -488,6 +523,7 @@ export async function filterOrphanIssues(
     blocked_by_open_reference: [],
     open_dependency_reference: [],
     unresolvable_reference: [],
+    triage_verdict_rejected: [],
   };
   const orphans: OrphanCandidate[] = [];
   const unresolvable: {
@@ -512,6 +548,11 @@ export async function filterOrphanIssues(
           { title: candidate.title, labels: candidate.labels },
         ] as const,
     ),
+  );
+  // #2243 staleness anchor lookup: each candidate's own createdAt, used as
+  // the resolveLatestSubstantiveIssueEditAt fallback below.
+  const issueCreatedAtByNumber = new Map(
+    issues.map((candidate) => [candidate.number, candidate.createdAt] as const),
   );
 
   for (const issue of issues) {
@@ -584,6 +625,62 @@ export async function filterOrphanIssues(
       url: issue.url ?? '',
     };
     filtered[result.reason].push(entry);
+  }
+
+  // #2243: exclude a candidate whose most recent trusted `A4.5
+  // suitability gate rejection` comment carries a still-current
+  // `<!-- {prefix}-triage-verdict: <outcome> -->` marker for one of the
+  // four non-label outcomes (unclear/duplicate/out-of-scope/invalid).
+  // Survivors-only: runs after every free (body/label) filter above has
+  // already narrowed the candidate set, so this is at most one
+  // comments-plus-timeline fetch pair per surviving candidate, never per
+  // scanned issue. Default-on for the live CLI (see
+  // `FilterOrphanIssuesOptions.fetchCommentsByIssueNumber`'s doc comment)
+  // but a no-op here when either input is absent, keeping this file's
+  // existing tests and any other caller byte-stable by default.
+  if (
+    typeof options.fetchCommentsByIssueNumber === 'function' &&
+    Array.isArray(options.trustedMarkerLogins) &&
+    options.trustedMarkerLogins.length > 0
+  ) {
+    const fetchComments = options.fetchCommentsByIssueNumber;
+    const fetchTimeline =
+      typeof options.fetchTimelineByIssueNumber === 'function'
+        ? options.fetchTimelineByIssueNumber
+        : () => [];
+    const trustedMarkerLogins = options.trustedMarkerLogins;
+    const markerPrefix =
+      typeof options.markerPrefix === 'string'
+        ? options.markerPrefix
+        : undefined;
+    const survivors: typeof orphans = [];
+    for (const orphan of orphans) {
+      const record = findTrustedSuitabilityRejection(
+        fetchComments(orphan.number),
+        trustedMarkerLogins,
+        markerPrefix,
+      );
+      const editedAt = record?.markerOutcome
+        ? resolveLatestSubstantiveIssueEditAt(
+            issueCreatedAtByNumber.get(orphan.number),
+            fetchTimeline(orphan.number),
+          )
+        : null;
+      if (record && isSuitabilityTriageVerdictCurrent(record, editedAt)) {
+        filtered.triage_verdict_rejected.push({
+          number: orphan.number,
+          title: orphan.title,
+          state: orphan.state,
+          reason: 'triage_verdict_rejected',
+          details: record.markerOutcome,
+          url: orphan.url,
+        });
+        continue;
+      }
+      survivors.push(orphan);
+    }
+    orphans.length = 0;
+    orphans.push(...survivors);
   }
 
   // Opt-in (#1395): annotate each orphan candidate with active-claim
@@ -689,12 +786,27 @@ async function runCli() {
       )
     : undefined;
 
+  // #2243: always resolved (unlike claimState above) -- the triage-verdict
+  // exclusion is default-on, not an opt-in flag. An empty resolution (no
+  // flag/env/config trusted actors configured) makes the check a no-op via
+  // filterOrphanIssues's own trustedMarkerLogins-empty guard, matching
+  // every other trusted-marker consumer's fail-safe default.
+  const { actors: trustedMarkerLogins } = resolveTrustedMarkerActors({
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
+    config: { trustedMarkerActors: policy.trustedMarkerActors },
+  });
+
   const result = await filterOrphanIssues(openIssues, {
     issueStateByNumber: openStateByNumber,
     fetchIssueStateByNumber: (issueNumber) =>
       fetchIssueState(port, issueNumber),
     fetchLabelEventsByIssueNumber: (issueNumber) =>
       fetchIssueLabelEvents(port, issueNumber),
+    fetchCommentsByIssueNumber: (issueNumber) =>
+      fetchIssueCommentsForTriageVerdict(port, issueNumber),
+    fetchTimelineByIssueNumber: (issueNumber) =>
+      port.getWorkItemTimeline(issueNumber),
+    trustedMarkerLogins,
     markerPrefix: policy.markerPrefix,
     authoringLabelName: policy.authoringLabelName,
     authoringStaleAgeMs: policy.authoringStaleAgeMs,
@@ -832,7 +944,8 @@ Output schema:
     "runtime_observation_precondition": [...],
     "blocked_by_open_reference": [...],
     "open_dependency_reference": [...],
-    "unresolvable_reference": [...]
+    "unresolvable_reference": [...],
+    "triage_verdict_rejected": [...]
   },
   "unresolvable": [{"issue": 1, "reference": 2, "reason": "issue-not-found-or-inaccessible"}],
   "warnings": [{"issueNumber": 1, "message": "Warning: ..."}],
@@ -863,6 +976,23 @@ first; equal scores tie-break by lowest issue number). With --autopilot
 (default 3) are moved to routed_to_human; without it (attended runs) they
 stay in orphans, ranked last. A missing or out-of-range score is treated
 as no score: the issue stays in orphans and is never routed out.
+
+"filtered.triage_verdict_rejected" (#2243, default-on, not opt-in) excludes
+a candidate whose most recent trusted "A4.5 suitability gate rejection"
+comment carries a still-current
+"<!-- {markerPrefix}-triage-verdict: <outcome> -->" marker for one of the
+four non-label outcomes (unclear/duplicate/out-of-scope/invalid); each
+filtered entry's "details" field is that outcome string.
+"needs-decision"/"blocked-by-human" never emit this marker -- those already
+carry a stable label. Only runs for a candidate every cheaper (label/body)
+filter above has already let through (one comments-plus-timeline fetch pair
+per surviving candidate, never per scanned issue), and requires trusted
+marker actors to be configured (env/flag/repo config); with none
+configured, this check is a no-op and makes no extra GitHub API call.
+Staleness-checked (fail-closed toward NOT excluding): the marker only
+excludes when the rejection comment is at or after the issue's latest
+substantive (title/body) edit, so an issue legitimately improved after
+being rejected stays selectable.
 
 --with-claim-state (opt-in) annotates each candidate in "orphans" and
 "routed_to_human" with active-claim eligibility, exactly mirroring
@@ -953,6 +1083,7 @@ function normalizeIssue(issue: {
   url?: unknown;
   html_url?: unknown;
   milestone?: unknown;
+  createdAt?: unknown;
 }) {
   return {
     number: Number.parseInt(String(issue.number), 10),
@@ -963,6 +1094,7 @@ function normalizeIssue(issue: {
     body: issue.body ?? '',
     url: issue.url ?? issue.html_url ?? '',
     milestone: issue.milestone,
+    createdAt: issue.createdAt,
   };
 }
 
@@ -1042,6 +1174,25 @@ function fetchIssueLabelEvents(port: ProviderPort, issueNumber: number) {
     .filter((event) => (event as { event?: unknown }).event === 'labeled');
 }
 
+/**
+ * #2243: adapts {@link ProviderPort.listWorkItemComments}'s camelCase
+ * `ProviderComment` shape to the raw-REST-shaped
+ * `SuitabilityRejectionComment` `findTrustedSuitabilityRejection` expects
+ * (mirroring `suitability-triage.mts`'s own direct `gh api` comment fetch).
+ * `html_url` is intentionally omitted -- this file never reads the
+ * resulting record's `url` field, only `markerOutcome`/`createdAt`.
+ */
+function fetchIssueCommentsForTriageVerdict(
+  port: ProviderPort,
+  issueNumber: number,
+): SuitabilityRejectionComment[] {
+  return port.listWorkItemComments(issueNumber).map((comment) => ({
+    body: comment.body,
+    created_at: comment.createdAt,
+    user: { login: comment.authorLogin },
+  }));
+}
+
 function normalizeMarkerPrefix(prefix: unknown): string {
   if (typeof prefix !== 'string' || prefix.length === 0) {
     return DEFAULT_MARKER_PREFIX;
@@ -1095,6 +1246,7 @@ function fetchOpenIssues(
       url: item.url,
       html_url: item.htmlUrl,
       milestone: item.milestone,
+      createdAt: item.createdAt,
     }),
   );
 }

--- a/src/scripts/discover-orphan-filter.mts
+++ b/src/scripts/discover-orphan-filter.mts
@@ -655,17 +655,32 @@ export async function filterOrphanIssues(
         : undefined;
     const survivors: typeof orphans = [];
     for (const orphan of orphans) {
-      const record = findTrustedSuitabilityRejection(
-        fetchComments(orphan.number),
-        trustedMarkerLogins,
-        markerPrefix,
-      );
-      const editedAt = record?.markerOutcome
-        ? resolveLatestSubstantiveIssueEditAt(
+      // CodeRabbit review, PR #2557: mirror resolveIssueLabelEvents's own
+      // fail-open contract for a per-candidate opportunistic fetch -- a
+      // transient GitHub API failure here must not abort the whole
+      // default-on discover pass; it degrades to "no evidence" (same as an
+      // absent marker) and the candidate stays selectable.
+      let record: ReturnType<typeof findTrustedSuitabilityRejection> = null;
+      try {
+        record = findTrustedSuitabilityRejection(
+          fetchComments(orphan.number),
+          trustedMarkerLogins,
+          markerPrefix,
+        );
+      } catch {
+        record = null;
+      }
+      let editedAt: string | null = null;
+      if (record?.markerOutcome) {
+        try {
+          editedAt = resolveLatestSubstantiveIssueEditAt(
             issueCreatedAtByNumber.get(orphan.number),
             fetchTimeline(orphan.number),
-          )
-        : null;
+          );
+        } catch {
+          editedAt = null;
+        }
+      }
       if (record && isSuitabilityTriageVerdictCurrent(record, editedAt)) {
         filtered.triage_verdict_rejected.push({
           number: orphan.number,

--- a/src/scripts/discover-readiness-check.mts
+++ b/src/scripts/discover-readiness-check.mts
@@ -521,19 +521,35 @@ export async function evaluateDiscoverReadiness(
     // a candidate every cheaper (label/body) check above has already let
     // through, never per scanned issue.
     if (reasons.size === 0 && triageVerdictCheckEnabled) {
-      const record = findTrustedSuitabilityRejection(
-        fetchCommentsByIssueNumber(issue.number),
-        trustedMarkerLogins,
-        resolvedMarkerPrefix,
-      );
-      const editedAt = record?.markerOutcome
-        ? resolveLatestSubstantiveIssueEditAt(
+      // CodeRabbit review, PR #2557: mirror this file's own fail-open
+      // contract for optional per-candidate lookups (e.g.
+      // resolveLabelEvents in discover-orphan-filter.mts) -- a transient
+      // GitHub API failure here must not abort the whole default-on
+      // readiness pass; it degrades to "no evidence" and the candidate
+      // stays selectable.
+      let record: ReturnType<typeof findTrustedSuitabilityRejection> = null;
+      try {
+        record = findTrustedSuitabilityRejection(
+          fetchCommentsByIssueNumber(issue.number),
+          trustedMarkerLogins,
+          resolvedMarkerPrefix,
+        );
+      } catch {
+        record = null;
+      }
+      let editedAt: string | null = null;
+      if (record?.markerOutcome) {
+        try {
+          editedAt = resolveLatestSubstantiveIssueEditAt(
             issue.createdAt,
             typeof fetchTimelineByIssueNumber === 'function'
               ? fetchTimelineByIssueNumber(issue.number)
               : [],
-          )
-        : null;
+          );
+        } catch {
+          editedAt = null;
+        }
+      }
       if (record && isSuitabilityTriageVerdictCurrent(record, editedAt)) {
         reasons.add(`triage_verdict:${record.markerOutcome}`);
       }

--- a/src/scripts/discover-readiness-check.mts
+++ b/src/scripts/discover-readiness-check.mts
@@ -20,11 +20,18 @@ import { loadPolicyConfig } from './idd-config.mts';
 import { stripMarkdownCodeRegions } from './markdown-code.mts';
 import { escapeRegex } from './marker-regex.mts';
 import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mts';
+import { resolveTrustedMarkerActors } from './protocol-helpers.mts';
 import {
   createGithubProviderAdapter,
   resolveCurrentGithubRepository,
 } from './provider-adapter-github.mts';
 import type { ProviderPort } from './provider-port.mts';
+import {
+  findTrustedSuitabilityRejection,
+  isSuitabilityTriageVerdictCurrent,
+  resolveLatestSubstantiveIssueEditAt,
+  type SuitabilityRejectionComment,
+} from './supersession-detection.mts';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
 
@@ -126,6 +133,9 @@ interface NormalizedIssue {
   labels: Set<string>;
   labelEvents: LabelEvent[];
   url: string;
+  /** GitHub `created_at` (#2243): the staleness-check fallback anchor for
+   * the triage-verdict marker exclusion below. */
+  createdAt: string;
 }
 
 interface EvaluateDiscoverReadinessOptions {
@@ -145,6 +155,28 @@ interface EvaluateDiscoverReadinessOptions {
   autopilotSuitabilityFloor?: number;
   autopilotSuitabilityEnabled?: boolean;
   now?: Date | string;
+  /**
+   * #2243 triage-verdict exclusion (default-on for the live CLI, unlike
+   * every other opt-in-flag option in this file): fetches an
+   * otherwise-ready candidate's comments to look for a still-current
+   * trusted `A4.5 suitability gate rejection` marker. Only actually runs
+   * when BOTH this and {@link trustedMarkerLogins} are supplied and
+   * non-empty; a caller (including this file's own tests) that omits
+   * either gets the prior behavior with no extra fetch -- a missing
+   * evidence source never skips a candidate, it just leaves it unfiltered
+   * by this specific check.
+   */
+  fetchCommentsByIssueNumber?: (
+    issueNumber: number,
+  ) => SuitabilityRejectionComment[];
+  /** #2243: per-candidate timeline fetch for the staleness anchor
+   * ({@link resolveLatestSubstantiveIssueEditAt}). Defaults to "no events"
+   * when omitted, which only widens the staleness window (never narrows
+   * it), so an absent fetcher cannot itself cause a wrongful skip. */
+  fetchTimelineByIssueNumber?: (issueNumber: number) => unknown[];
+  /** #2243: trust-actor allowlist for the triage-verdict marker scan, same
+   * semantics as `idd-claim.instructions.md`'s trusted marker actors. */
+  trustedMarkerLogins?: string[];
 }
 
 interface ParsedArgs {
@@ -218,9 +250,21 @@ if (import.meta.main) {
       ? args.issueNumbers
       : listOpenIssueNumbers(owner, repo);
 
+  // #2243: resolved unconditionally (not opt-in) -- the triage-verdict
+  // exclusion is default-on. An empty resolution (no flag/env/config
+  // trusted actors configured) makes the check a no-op via
+  // evaluateDiscoverReadiness's own trustedMarkerLogins-empty guard.
+  const { actors: trustedMarkerLogins } = resolveTrustedMarkerActors({
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
+    config: policyConfig as { trustedMarkerActors?: unknown } | null,
+  });
+
   const summary = await evaluateDiscoverReadiness(issueNumbers, {
     includeUnresolvable: args.includeUnresolvable,
     loadIssue: buildIssueLoader(owner, repo),
+    fetchCommentsByIssueNumber: buildIssueCommentsLoader(owner, repo),
+    fetchTimelineByIssueNumber: buildIssueTimelineLoader(owner, repo),
+    trustedMarkerLogins,
     // `--swarm-floor` output never surfaces the stale-authoring warning, so
     // skip the per-issue timeline fetch this loader runs — over a whole-repo
     // sweep that is one extra paginated API call per open issue. The
@@ -272,7 +316,14 @@ export async function evaluateDiscoverReadiness(
     autopilotSuitabilityFloor,
     autopilotSuitabilityEnabled,
     now = new Date(),
+    fetchCommentsByIssueNumber,
+    fetchTimelineByIssueNumber,
+    trustedMarkerLogins,
   } = options ?? {};
+  const triageVerdictCheckEnabled =
+    typeof fetchCommentsByIssueNumber === 'function' &&
+    Array.isArray(trustedMarkerLogins) &&
+    trustedMarkerLogins.length > 0;
   // Route the three label-name options through normalizePolicyConfig rather
   // than a bare destructure default (which only applies on `undefined`), so
   // an invalid or empty-string input also falls back to POLICY_DEFAULTS
@@ -458,6 +509,33 @@ export async function evaluateDiscoverReadiness(
       }
       if (markerMatches.some((candidate) => candidate.state === 'OPEN')) {
         reasons.add(`blocked_by_open_roadmap_marker:${marker}`);
+      }
+    }
+
+    // #2243: exclude an otherwise-ready candidate whose most recent
+    // trusted `A4.5 suitability gate rejection` comment carries a
+    // still-current `<!-- {prefix}-triage-verdict: <outcome> -->` marker
+    // for one of the four non-label outcomes. Gated on
+    // `reasons.size === 0` so far -- this is the one check in the loop
+    // that needs a live comments-plus-timeline fetch, so it only runs for
+    // a candidate every cheaper (label/body) check above has already let
+    // through, never per scanned issue.
+    if (reasons.size === 0 && triageVerdictCheckEnabled) {
+      const record = findTrustedSuitabilityRejection(
+        fetchCommentsByIssueNumber(issue.number),
+        trustedMarkerLogins,
+        resolvedMarkerPrefix,
+      );
+      const editedAt = record?.markerOutcome
+        ? resolveLatestSubstantiveIssueEditAt(
+            issue.createdAt,
+            typeof fetchTimelineByIssueNumber === 'function'
+              ? fetchTimelineByIssueNumber(issue.number)
+              : [],
+          )
+        : null;
+      if (record && isSuitabilityTriageVerdictCurrent(record, editedAt)) {
+        reasons.add(`triage_verdict:${record.markerOutcome}`);
       }
     }
 
@@ -767,6 +845,20 @@ function printHelp() {
   rather than a silent coercion. A "no score" issue is never below floor,
   matching discovery ranking.
 
+  #2243 triage-verdict exclusion (default-on, not opt-in): for a candidate
+  every cheaper (label/body) check already lets through, this makes one
+  comments-plus-timeline GitHub API call to look for a still-current
+  trusted "A4.5 suitability gate rejection" comment carrying a
+  "<!-- {markerPrefix}-triage-verdict: <outcome> -->" marker for one of the
+  four non-label outcomes (unclear/duplicate/out-of-scope/invalid). A match
+  excludes the candidate with reasons: ["triage_verdict:<outcome>"].
+  "needs-decision"/"blocked-by-human" never emit this marker -- those
+  already carry a stable label. Requires trusted marker actors to be
+  configured (env/flag/repo config); with none configured, this check is a
+  no-op and makes no extra GitHub API call. Staleness-checked (fail-closed
+  toward NOT excluding): the marker only excludes when the rejection
+  comment is at or after the issue's latest substantive (title/body) edit.
+
 Output schema (JSON mode):
   {
     "ready": [{ "number": 123, "title": "...", "autopilotSuitability": 4, "belowFloor": false, "isRoadmap": false }],
@@ -807,6 +899,7 @@ function normalizeIssue(issue: {
   labels?: unknown;
   labelEvents?: unknown;
   url?: unknown;
+  createdAt?: unknown;
 }): NormalizedIssue {
   return {
     number: Number.parseInt(String(issue.number ?? issue.id ?? 0), 10),
@@ -816,6 +909,7 @@ function normalizeIssue(issue: {
     labels: normalizeLabels(issue.labels),
     labelEvents: Array.isArray(issue.labelEvents) ? issue.labelEvents : [],
     url: String(issue.url ?? ''),
+    createdAt: String(issue.createdAt ?? ''),
   };
 }
 
@@ -995,6 +1089,32 @@ function fetchIssueLabelEvents(port: ProviderPort, issueNumber: number) {
   return port
     .getWorkItemTimeline(issueNumber)
     .filter((event) => (event as { event?: unknown }).event === 'labeled');
+}
+
+/** #2243: full raw timeline (unfiltered), for
+ * {@link resolveLatestSubstantiveIssueEditAt}'s `edited`-event scan. */
+function buildIssueTimelineLoader(owner: string, repo: string) {
+  const port = createGithubProviderAdapter(owner, repo);
+  return (issueNumber: number) => port.getWorkItemTimeline(issueNumber);
+}
+
+/**
+ * #2243: adapts {@link ProviderPort.listWorkItemComments}'s camelCase
+ * `ProviderComment` shape to the raw-REST-shaped
+ * `SuitabilityRejectionComment` `findTrustedSuitabilityRejection` expects
+ * (mirroring `discover-orphan-filter.mts`'s identical adapter and
+ * `suitability-triage.mts`'s own direct `gh api` comment fetch).
+ * `html_url` is intentionally omitted -- this file never reads the
+ * resulting record's `url` field, only `markerOutcome`/`createdAt`.
+ */
+function buildIssueCommentsLoader(owner: string, repo: string) {
+  const port = createGithubProviderAdapter(owner, repo);
+  return (issueNumber: number): SuitabilityRejectionComment[] =>
+    port.listWorkItemComments(issueNumber).map((comment) => ({
+      body: comment.body,
+      created_at: comment.createdAt,
+      user: { login: comment.authorLogin },
+    }));
 }
 
 export function buildRoadmapMarkerSearchQuery(

--- a/src/scripts/provider-adapter-github.mts
+++ b/src/scripts/provider-adapter-github.mts
@@ -737,6 +737,14 @@ export function createGithubProviderAdapter(
           htmlUrl:
             row.html_url === undefined ? undefined : String(row.html_url),
           milestone: row.milestone,
+          // #2243 (Copilot review, PR #2557): populate createdAt like
+          // getWorkItem() above already does -- discover-orphan-filter.mts's
+          // triage-verdict staleness anchor reads this field straight off
+          // the bulk listOpenWorkItems() result (no secondary per-issue
+          // fetch), so an absent value here silently made that exclusion
+          // never fire for a never-edited issue in real runs.
+          createdAt:
+            row.created_at === undefined ? undefined : String(row.created_at),
         }));
     },
 

--- a/src/scripts/supersession-detection.mts
+++ b/src/scripts/supersession-detection.mts
@@ -24,6 +24,12 @@
 // part of the extraction.
 
 import { normalizeContentionPath } from './discover-shared-file-overlap.mts';
+import { stripMarkdownCodeRegions } from './markdown-code.mts';
+import { escapeRegex } from './marker-regex.mts';
+
+/** Default `{prefix}` for every marker this module parses, matching
+ * `autopilot-suitability.mts`'s own default. */
+const DEFAULT_MARKER_PREFIX = 'idd-skill';
 
 /** Upper bound on the #1484 bounded merged-PR scan (mirrors B2.0's own
  * documented `gh pr list --limit 50`). */
@@ -289,6 +295,157 @@ const SUITABILITY_REJECTION_OUTCOME_PATTERN =
   /outcome:\s*(unclear|needs-decision|blocked-by-human|duplicate|out-of-scope|invalid)\b/i;
 const SUITABILITY_REJECTION_CHECK_PATTERN = /Check\s+\d+\s*\([^)]+\)/i;
 
+/** The four A4.5 outcomes with no dedicated label (#2243): the only values
+ * `<!-- {prefix}-triage-verdict: <outcome> -->` may declare.
+ * `needs-decision`/`blocked-by-human` are deliberately excluded -- those
+ * two already carry a stable label and never emit this marker. */
+export const SUITABILITY_TRIAGE_VERDICT_OUTCOMES = [
+  'unclear',
+  'duplicate',
+  'out-of-scope',
+  'invalid',
+] as const;
+
+export type SuitabilityTriageVerdictOutcome =
+  (typeof SUITABILITY_TRIAGE_VERDICT_OUTCOMES)[number];
+
+function isSuitabilityTriageVerdictOutcome(
+  value: string,
+): value is SuitabilityTriageVerdictOutcome {
+  return (SUITABILITY_TRIAGE_VERDICT_OUTCOMES as readonly string[]).includes(
+    value,
+  );
+}
+
+/**
+ * Canonical parser for the authored `<!-- {prefix}-triage-verdict:
+ * <outcome> -->` marker (#2243), mirroring
+ * `autopilot-suitability.mts`'s `parseAutopilotSuitabilityMarker` shape and
+ * fail-safe rules: `present` is false only when no marker appears at all;
+ * `outcome` is the single coherent token when it is one of
+ * {@link SUITABILITY_TRIAGE_VERDICT_OUTCOMES}, or `null` (fail-safe = "no
+ * marker") when the marker is absent, carries an unrecognized token, or
+ * repeats with disagreeing values; `malformed` is true only when a marker
+ * is present but does not resolve to a coherent outcome.
+ *
+ * `body` is masked with {@link stripMarkdownCodeRegions} first so a marker
+ * merely *quoted* in prose (for example, an issue or comment explaining
+ * this marker's own syntax in a code span, as #2243's own body does)
+ * cannot be mistaken for a live one (#1614, #1121 precedent).
+ */
+export function parseSuitabilityTriageVerdictMarker(
+  body: unknown,
+  markerPrefix: string = DEFAULT_MARKER_PREFIX,
+): {
+  present: boolean;
+  outcome: SuitabilityTriageVerdictOutcome | null;
+  malformed: boolean;
+} {
+  const prefix =
+    typeof markerPrefix === 'string' && markerPrefix.length > 0
+      ? markerPrefix
+      : DEFAULT_MARKER_PREFIX;
+  const regex = new RegExp(
+    `<!--\\s*${escapeRegex(prefix)}-triage-verdict:\\s*([^\\s>]+)\\s*-->`,
+    'gi',
+  );
+  const text = stripMarkdownCodeRegions(String(body ?? ''));
+  let present = false;
+  let outcome: SuitabilityTriageVerdictOutcome | null = null;
+  let match = regex.exec(text);
+  while (match) {
+    present = true;
+    const raw = (match[1] ?? '').toLowerCase();
+    if (
+      !isSuitabilityTriageVerdictOutcome(raw) ||
+      (outcome !== null && raw !== outcome)
+    ) {
+      return { present: true, outcome: null, malformed: true };
+    }
+    outcome = raw;
+    match = regex.exec(text);
+  }
+  return { present, outcome, malformed: false };
+}
+
+/**
+ * Staleness anchor for a suitability-rejection marker (#2243): the latest
+ * GitHub `created_at` among the issue's own creation and every timeline
+ * `edited` event that changed the title or body. Mirrors
+ * `claim-approval-gate.mts`'s private `resolveLatestSubstantiveEditAt` --
+ * duplicated rather than imported to keep this module's dependency-light,
+ * I/O-free kernel contract intact (see the file header). Returns `null`
+ * only when neither `issueCreatedAt` nor any qualifying event yields a
+ * parseable timestamp -- callers must treat that as "unknown", never as
+ * "always stale" or "never stale".
+ */
+export function resolveLatestSubstantiveIssueEditAt(
+  issueCreatedAt: unknown,
+  timelineEvents: unknown,
+): string | null {
+  const candidates: string[] = [];
+  if (typeof issueCreatedAt === 'string' && issueCreatedAt) {
+    candidates.push(issueCreatedAt);
+  }
+  if (Array.isArray(timelineEvents)) {
+    for (const raw of timelineEvents) {
+      const event = (raw ?? {}) as {
+        event?: unknown;
+        created_at?: unknown;
+        changes?: { title?: unknown; body?: unknown } | null;
+      };
+      if (String(event.event ?? '') !== 'edited') {
+        continue;
+      }
+      if (!event.changes?.title && !event.changes?.body) {
+        continue;
+      }
+      if (typeof event.created_at === 'string' && event.created_at) {
+        candidates.push(event.created_at);
+      }
+    }
+  }
+  let latest: string | null = null;
+  let latestTimestamp = Number.NEGATIVE_INFINITY;
+  for (const candidate of candidates) {
+    const timestamp = Date.parse(candidate);
+    if (!Number.isFinite(timestamp) || timestamp < latestTimestamp) {
+      continue;
+    }
+    latestTimestamp = timestamp;
+    latest = candidate;
+  }
+  return latest;
+}
+
+/**
+ * Whether a trusted rejection record's marker outcome (#2243) is still
+ * current enough to exclude a candidate from Discover's selection pass:
+ * `true` only when the marker resolved to one of
+ * {@link SUITABILITY_TRIAGE_VERDICT_OUTCOMES} AND the rejection comment's
+ * own `createdAt` is at or after `latestSubstantiveEditAt` -- an issue
+ * legitimately improved after being rejected must not stay excluded by a
+ * now-stale marker. `latestSubstantiveEditAt: null` (unknown anchor) fails
+ * closed toward NOT excluding the candidate, matching this module's
+ * existing fail-safe direction: a wrongly-kept candidate still reaches
+ * A4.5, which re-derives its own verdict; a wrongly-skipped one is
+ * silently lost.
+ */
+export function isSuitabilityTriageVerdictCurrent(
+  record: Pick<SuitabilityRejectionRecord, 'createdAt' | 'markerOutcome'>,
+  latestSubstantiveEditAt: string | null,
+): boolean {
+  if (!record.markerOutcome || !latestSubstantiveEditAt) {
+    return false;
+  }
+  const rejectionTimestamp = Date.parse(record.createdAt);
+  const editTimestamp = Date.parse(latestSubstantiveEditAt);
+  if (!Number.isFinite(rejectionTimestamp) || !Number.isFinite(editTimestamp)) {
+    return false;
+  }
+  return rejectionTimestamp >= editTimestamp;
+}
+
 /**
  * One GitHub REST issue-comment entry, as consumed by
  * {@link findTrustedSuitabilityRejection}. Loosely typed (every field
@@ -323,6 +480,14 @@ export interface SuitabilityRejectionRecord {
   /** Best-effort `Check N (<Name>)` excerpt parsed from the comment body's
    * own headline convention; `null` when absent. */
   check: string | null;
+  /** Outcome declared by the comment's `<!-- {prefix}-triage-verdict:
+   * <outcome> -->` marker (#2243), or `null` when absent, malformed, or
+   * outside {@link SUITABILITY_TRIAGE_VERDICT_OUTCOMES}. Distinct from
+   * {@link outcome} above: this is the stable, machine-parseable marker
+   * signal Discover's candidate-selection pass consumes; `outcome` is the
+   * older, best-effort prose-derived signal `#1887` surfaces for a
+   * re-running `suitability-triage.mjs` only. */
+  markerOutcome: SuitabilityTriageVerdictOutcome | null;
 }
 
 /**
@@ -354,6 +519,7 @@ export interface SuitabilityRejectionRecord {
 export function findTrustedSuitabilityRejection(
   comments: SuitabilityRejectionComment[] | null | undefined,
   trustedMarkerLogins: string[] | null | undefined,
+  markerPrefix: string = DEFAULT_MARKER_PREFIX,
 ): SuitabilityRejectionRecord | null {
   const trusted = new Set(
     (trustedMarkerLogins ?? [])
@@ -391,6 +557,10 @@ export function findTrustedSuitabilityRejection(
     latestTimestamp = timestamp;
     const outcomeMatch = SUITABILITY_REJECTION_OUTCOME_PATTERN.exec(body);
     const checkMatch = SUITABILITY_REJECTION_CHECK_PATTERN.exec(body);
+    const markerDetection = parseSuitabilityTriageVerdictMarker(
+      body,
+      markerPrefix,
+    );
     latest = {
       author,
       createdAt,
@@ -403,6 +573,7 @@ export function findTrustedSuitabilityRejection(
       // downstream string comparison brittle. Normalize before returning.
       outcome: outcomeMatch ? (outcomeMatch[1]?.toLowerCase() ?? null) : null,
       check: checkMatch ? checkMatch[0] : null,
+      markerOutcome: markerDetection.malformed ? null : markerDetection.outcome,
     };
   }
   return latest;

--- a/tests/cli-entry-smoke.test.mts
+++ b/tests/cli-entry-smoke.test.mts
@@ -328,6 +328,11 @@ if (args[0] === 'api' && String(args[1]).startsWith('repos/o/r/issues/900/timeli
   process.stdout.write('[]');
   process.exit(0);
 }
+// #2243 triage-verdict marker scan: gh api repos/o/r/issues/900/comments --paginate --jq .[]
+if (args[0] === 'api' && args[1] === 'repos/o/r/issues/900/comments') {
+  process.stdout.write('[]');
+  process.exit(0);
+}
 process.stderr.write('unexpected gh invocation: ' + args.join(' ') + '\\n');
 process.exit(1);
 `,

--- a/tests/discover-orphan-filter.test.mts
+++ b/tests/discover-orphan-filter.test.mts
@@ -1340,13 +1340,18 @@ function triageVerdictRejectionComment(
   };
 }
 
-test('without fetchCommentsByIssueNumber/trustedMarkerLogins, no comment fetch happens and nothing is excluded (byte-stable default)', async () => {
+test('without trustedMarkerLogins, the comments fetcher is never invoked and nothing is excluded (byte-stable default)', async () => {
   const issues = [triageVerdictIssue()];
-  const called = false;
+  let called = false;
   const result = await filterOrphanIssues(issues, {
     issueStateByNumber: new Map(),
     fetchIssueStateByNumber: () => 'UNRESOLVABLE',
-    fetchCommentsByIssueNumber: undefined,
+    // A real spy fetcher is supplied, but trustedMarkerLogins is omitted --
+    // if the guard were broken, `called` would flip to true below.
+    fetchCommentsByIssueNumber: () => {
+      called = true;
+      return [];
+    },
     trustedMarkerLogins: undefined,
   });
   assert.equal(called, false);

--- a/tests/discover-orphan-filter.test.mts
+++ b/tests/discover-orphan-filter.test.mts
@@ -12,6 +12,7 @@ import {
   filterOrphanIssues,
   getOrphanFirstPolicy,
 } from '../src/scripts/discover-orphan-filter.mts';
+import { SUITABILITY_REJECTION_PREFIX } from '../src/scripts/supersession-detection.mts';
 
 const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
 
@@ -1304,4 +1305,124 @@ test('CLI path fails when the default-path config exists but is malformed (not s
       ),
     /failed to load policy from .*config\.json/,
   );
+});
+
+// ---------------------------------------------------------------------------
+// #2243: triage-verdict marker exclusion (fetchCommentsByIssueNumber /
+// fetchTimelineByIssueNumber / trustedMarkerLogins), covering the four
+// acceptance-criteria scenarios: marker present and current (skip), marker
+// present but stale relative to a later body edit (do not skip), no marker
+// / never-triaged (do not skip), and an untrusted/forged marker comment (do not
+// skip -- same #1887 trust boundary).
+// ---------------------------------------------------------------------------
+
+function triageVerdictIssue(overrides: Record<string, unknown> = {}) {
+  return {
+    number: 901,
+    title: 'candidate 901',
+    state: 'OPEN',
+    labels: [],
+    body: '',
+    createdAt: '2026-08-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function triageVerdictRejectionComment(
+  outcome: string,
+  createdAt: string,
+  { author = 'kurone-kito' } = {},
+) {
+  return {
+    body: `${SUITABILITY_REJECTION_PREFIX} — Check 2 (Coherence): reason.\n\n<!-- idd-skill-triage-verdict: ${outcome} -->`,
+    created_at: createdAt,
+    user: { login: author },
+  };
+}
+
+test('without fetchCommentsByIssueNumber/trustedMarkerLogins, no comment fetch happens and nothing is excluded (byte-stable default)', async () => {
+  const issues = [triageVerdictIssue()];
+  const called = false;
+  const result = await filterOrphanIssues(issues, {
+    issueStateByNumber: new Map(),
+    fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    fetchCommentsByIssueNumber: undefined,
+    trustedMarkerLogins: undefined,
+  });
+  assert.equal(called, false);
+  assert.equal(result.orphans.length, 1);
+  assert.equal(result.filtered.triage_verdict_rejected.length, 0);
+});
+
+test('a current trusted triage-verdict marker excludes the candidate', async () => {
+  const issues = [triageVerdictIssue()];
+  const result = await filterOrphanIssues(issues, {
+    issueStateByNumber: new Map(),
+    fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    fetchCommentsByIssueNumber: (issueNumber) =>
+      issueNumber === 901
+        ? [triageVerdictRejectionComment('duplicate', '2026-08-10T00:00:00Z')]
+        : [],
+    fetchTimelineByIssueNumber: () => [],
+    trustedMarkerLogins: ['kurone-kito'],
+  });
+  assert.equal(result.orphans.length, 0);
+  assert.equal(result.filtered.triage_verdict_rejected.length, 1);
+  assert.equal(result.filtered.triage_verdict_rejected[0]?.number, 901);
+  assert.equal(
+    result.filtered.triage_verdict_rejected[0]?.details,
+    'duplicate',
+  );
+});
+
+test('a stale marker (issue edited after the rejection) does not exclude the candidate', async () => {
+  const issues = [triageVerdictIssue({ createdAt: '2026-08-01T00:00:00Z' })];
+  const result = await filterOrphanIssues(issues, {
+    issueStateByNumber: new Map(),
+    fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    fetchCommentsByIssueNumber: () => [
+      triageVerdictRejectionComment('duplicate', '2026-08-05T00:00:00Z'),
+    ],
+    // A body edit landed AFTER the rejection comment -- the marker is stale.
+    fetchTimelineByIssueNumber: () => [
+      {
+        event: 'edited',
+        created_at: '2026-08-12T00:00:00Z',
+        changes: { body: {} },
+      },
+    ],
+    trustedMarkerLogins: ['kurone-kito'],
+  });
+  assert.equal(result.orphans.length, 1);
+  assert.equal(result.filtered.triage_verdict_rejected.length, 0);
+});
+
+test('no marker (never-triaged) does not exclude the candidate', async () => {
+  const issues = [triageVerdictIssue()];
+  const result = await filterOrphanIssues(issues, {
+    issueStateByNumber: new Map(),
+    fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    fetchCommentsByIssueNumber: () => [],
+    fetchTimelineByIssueNumber: () => [],
+    trustedMarkerLogins: ['kurone-kito'],
+  });
+  assert.equal(result.orphans.length, 1);
+  assert.equal(result.filtered.triage_verdict_rejected.length, 0);
+});
+
+test("an untrusted actor's marker-bearing comment does not exclude the candidate (#1887 trust boundary)", async () => {
+  const issues = [triageVerdictIssue()];
+  const result = await filterOrphanIssues(issues, {
+    issueStateByNumber: new Map(),
+    fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    fetchCommentsByIssueNumber: () => [
+      triageVerdictRejectionComment('duplicate', '2026-08-10T00:00:00Z', {
+        author: 'random-untrusted-user',
+      }),
+    ],
+    fetchTimelineByIssueNumber: () => [],
+    trustedMarkerLogins: ['kurone-kito'],
+  });
+  assert.equal(result.orphans.length, 1);
+  assert.equal(result.filtered.triage_verdict_rejected.length, 0);
 });

--- a/tests/discover-orphan-filter.test.mts
+++ b/tests/discover-orphan-filter.test.mts
@@ -1431,3 +1431,35 @@ test("an untrusted actor's marker-bearing comment does not exclude the candidate
   assert.equal(result.orphans.length, 1);
   assert.equal(result.filtered.triage_verdict_rejected.length, 0);
 });
+
+test('a throwing comments fetcher fails open: the candidate stays selectable (CodeRabbit review, PR #2557)', async () => {
+  const issues = [triageVerdictIssue()];
+  const result = await filterOrphanIssues(issues, {
+    issueStateByNumber: new Map(),
+    fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    fetchCommentsByIssueNumber: () => {
+      throw new Error('transient GitHub API failure');
+    },
+    fetchTimelineByIssueNumber: () => [],
+    trustedMarkerLogins: ['kurone-kito'],
+  });
+  assert.equal(result.orphans.length, 1);
+  assert.equal(result.filtered.triage_verdict_rejected.length, 0);
+});
+
+test('a throwing timeline fetcher fails open: the candidate stays selectable (CodeRabbit review, PR #2557)', async () => {
+  const issues = [triageVerdictIssue()];
+  const result = await filterOrphanIssues(issues, {
+    issueStateByNumber: new Map(),
+    fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    fetchCommentsByIssueNumber: () => [
+      triageVerdictRejectionComment('duplicate', '2026-08-10T00:00:00Z'),
+    ],
+    fetchTimelineByIssueNumber: () => {
+      throw new Error('transient GitHub API failure');
+    },
+    trustedMarkerLogins: ['kurone-kito'],
+  });
+  assert.equal(result.orphans.length, 1);
+  assert.equal(result.filtered.triage_verdict_rejected.length, 0);
+});

--- a/tests/discover-readiness-check.test.mts
+++ b/tests/discover-readiness-check.test.mts
@@ -1525,3 +1525,38 @@ test('a candidate already filtered for another reason never triggers the comment
     'label:status:blocked-by-human',
   ]);
 });
+
+test('a throwing comments fetcher fails open: the candidate stays ready (CodeRabbit review, PR #2557)', async () => {
+  const issue = triageVerdictReadinessIssue();
+  const summary = await evaluateDiscoverReadiness([1901], {
+    loadIssue: async () => issue,
+    findRoadmapsByMarker: async () => [],
+    fetchCommentsByIssueNumber: () => {
+      throw new Error('transient GitHub API failure');
+    },
+    fetchTimelineByIssueNumber: () => [],
+    trustedMarkerLogins: ['kurone-kito'],
+  });
+  assert.equal(summary.ready.length, 1);
+  assert.equal(summary.filteredOut.length, 0);
+});
+
+test('a throwing timeline fetcher fails open: the candidate stays ready (CodeRabbit review, PR #2557)', async () => {
+  const issue = triageVerdictReadinessIssue();
+  const summary = await evaluateDiscoverReadiness([1901], {
+    loadIssue: async () => issue,
+    findRoadmapsByMarker: async () => [],
+    fetchCommentsByIssueNumber: () => [
+      triageVerdictReadinessRejectionComment(
+        'duplicate',
+        '2026-08-10T00:00:00Z',
+      ),
+    ],
+    fetchTimelineByIssueNumber: () => {
+      throw new Error('transient GitHub API failure');
+    },
+    trustedMarkerLogins: ['kurone-kito'],
+  });
+  assert.equal(summary.ready.length, 1);
+  assert.equal(summary.filteredOut.length, 0);
+});

--- a/tests/discover-readiness-check.test.mts
+++ b/tests/discover-readiness-check.test.mts
@@ -19,6 +19,7 @@ import {
   summarizeSwarmFloorEligibility,
 } from '../src/scripts/discover-readiness-check.mts';
 import { createFakeProviderAdapter } from '../src/scripts/provider-adapter-fake.mts';
+import { SUITABILITY_REJECTION_PREFIX } from '../src/scripts/supersession-detection.mts';
 
 const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
 
@@ -1370,4 +1371,149 @@ test('evaluateDiscoverReadiness runs end to end against a fake provider, no gh p
       process.env.PATH = originalPath;
     }
   }
+});
+
+// ---------------------------------------------------------------------------
+// #2243: triage-verdict marker exclusion (fetchCommentsByIssueNumber /
+// fetchTimelineByIssueNumber / trustedMarkerLogins), covering the four
+// acceptance-criteria scenarios: marker present and current (excluded, with
+// a `triage_verdict:<outcome>` reason), marker present but stale relative to
+// a later body edit (ready), no marker / never-triaged (ready), and an
+// untrusted/forged marker comment (ready -- same #1887 trust boundary).
+// ---------------------------------------------------------------------------
+
+function triageVerdictReadinessIssue(overrides: Record<string, unknown> = {}) {
+  return {
+    number: 1901,
+    title: 'candidate 1901',
+    state: 'OPEN',
+    body: '',
+    labels: [],
+    createdAt: '2026-08-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function triageVerdictReadinessRejectionComment(
+  outcome: string,
+  createdAt: string,
+  { author = 'kurone-kito' } = {},
+) {
+  return {
+    body: `${SUITABILITY_REJECTION_PREFIX} — Check 2 (Coherence): reason.\n\n<!-- idd-skill-triage-verdict: ${outcome} -->`,
+    created_at: createdAt,
+    user: { login: author },
+  };
+}
+
+test('without fetchCommentsByIssueNumber/trustedMarkerLogins, no comment fetch happens and the candidate stays ready (byte-stable default)', async () => {
+  const issue = triageVerdictReadinessIssue();
+  const summary = await evaluateDiscoverReadiness([1901], {
+    loadIssue: async () => issue,
+    findRoadmapsByMarker: async () => [],
+  });
+  assert.equal(summary.ready.length, 1);
+  assert.equal(summary.filteredOut.length, 0);
+});
+
+test('a current trusted triage-verdict marker excludes the otherwise-ready candidate', async () => {
+  const issue = triageVerdictReadinessIssue();
+  const summary = await evaluateDiscoverReadiness([1901], {
+    loadIssue: async () => issue,
+    findRoadmapsByMarker: async () => [],
+    fetchCommentsByIssueNumber: () => [
+      triageVerdictReadinessRejectionComment(
+        'duplicate',
+        '2026-08-10T00:00:00Z',
+      ),
+    ],
+    fetchTimelineByIssueNumber: () => [],
+    trustedMarkerLogins: ['kurone-kito'],
+  });
+  assert.equal(summary.ready.length, 0);
+  assert.deepEqual(summary.filteredOut[0]?.reasons, [
+    'triage_verdict:duplicate',
+  ]);
+});
+
+test('a stale marker (issue edited after the rejection) leaves the candidate ready', async () => {
+  const issue = triageVerdictReadinessIssue({
+    createdAt: '2026-08-01T00:00:00Z',
+  });
+  const summary = await evaluateDiscoverReadiness([1901], {
+    loadIssue: async () => issue,
+    findRoadmapsByMarker: async () => [],
+    fetchCommentsByIssueNumber: () => [
+      triageVerdictReadinessRejectionComment(
+        'duplicate',
+        '2026-08-05T00:00:00Z',
+      ),
+    ],
+    // A body edit landed AFTER the rejection comment -- the marker is stale.
+    fetchTimelineByIssueNumber: () => [
+      {
+        event: 'edited',
+        created_at: '2026-08-12T00:00:00Z',
+        changes: { body: {} },
+      },
+    ],
+    trustedMarkerLogins: ['kurone-kito'],
+  });
+  assert.equal(summary.ready.length, 1);
+  assert.equal(summary.filteredOut.length, 0);
+});
+
+test('no marker (never-triaged) leaves the candidate ready', async () => {
+  const issue = triageVerdictReadinessIssue();
+  const summary = await evaluateDiscoverReadiness([1901], {
+    loadIssue: async () => issue,
+    findRoadmapsByMarker: async () => [],
+    fetchCommentsByIssueNumber: () => [],
+    fetchTimelineByIssueNumber: () => [],
+    trustedMarkerLogins: ['kurone-kito'],
+  });
+  assert.equal(summary.ready.length, 1);
+  assert.equal(summary.filteredOut.length, 0);
+});
+
+test("an untrusted actor's marker-bearing comment leaves the candidate ready (#1887 trust boundary)", async () => {
+  const issue = triageVerdictReadinessIssue();
+  const summary = await evaluateDiscoverReadiness([1901], {
+    loadIssue: async () => issue,
+    findRoadmapsByMarker: async () => [],
+    fetchCommentsByIssueNumber: () => [
+      triageVerdictReadinessRejectionComment(
+        'duplicate',
+        '2026-08-10T00:00:00Z',
+        {
+          author: 'random-untrusted-user',
+        },
+      ),
+    ],
+    fetchTimelineByIssueNumber: () => [],
+    trustedMarkerLogins: ['kurone-kito'],
+  });
+  assert.equal(summary.ready.length, 1);
+  assert.equal(summary.filteredOut.length, 0);
+});
+
+test('a candidate already filtered for another reason never triggers the comments fetch', async () => {
+  const issue = triageVerdictReadinessIssue({
+    labels: [{ name: 'status:blocked-by-human' }],
+  });
+  let called = false;
+  const summary = await evaluateDiscoverReadiness([1901], {
+    loadIssue: async () => issue,
+    findRoadmapsByMarker: async () => [],
+    fetchCommentsByIssueNumber: () => {
+      called = true;
+      return [];
+    },
+    fetchTimelineByIssueNumber: () => [],
+    trustedMarkerLogins: ['kurone-kito'],
+  });
+  assert.equal(called, false);
+  assert.deepEqual(summary.filteredOut[0]?.reasons, [
+    'label:status:blocked-by-human',
+  ]);
 });

--- a/tests/discover-readiness-check.test.mts
+++ b/tests/discover-readiness-check.test.mts
@@ -1406,12 +1406,20 @@ function triageVerdictReadinessRejectionComment(
   };
 }
 
-test('without fetchCommentsByIssueNumber/trustedMarkerLogins, no comment fetch happens and the candidate stays ready (byte-stable default)', async () => {
+test('without trustedMarkerLogins, the comments fetcher is never invoked and the candidate stays ready (byte-stable default)', async () => {
   const issue = triageVerdictReadinessIssue();
+  let called = false;
   const summary = await evaluateDiscoverReadiness([1901], {
     loadIssue: async () => issue,
     findRoadmapsByMarker: async () => [],
+    // A real spy fetcher is supplied, but trustedMarkerLogins is omitted --
+    // if the guard were broken, `called` would flip to true below.
+    fetchCommentsByIssueNumber: () => {
+      called = true;
+      return [];
+    },
   });
+  assert.equal(called, false);
   assert.equal(summary.ready.length, 1);
   assert.equal(summary.filteredOut.length, 0);
 });

--- a/tests/provider-adapter-github.test.mts
+++ b/tests/provider-adapter-github.test.mts
@@ -106,6 +106,36 @@ test('searchWorkItems preserves REST raw lowercase state, like listOpenWorkItems
 });
 
 // ---------------------------------------------------------------------------
+// listOpenWorkItems createdAt (#2243, Copilot review on PR #2557):
+// getWorkItem already mapped REST's created_at into ProviderWorkItem's
+// createdAt field, but listOpenWorkItems's own row mapping omitted it --
+// discover-orphan-filter.mts's triage-verdict staleness anchor reads
+// createdAt straight off this bulk result (no secondary per-issue fetch),
+// so the gap silently made that exclusion never fire for a never-edited
+// issue in real runs, while every test using a hand-built fixture (bypassing
+// this REST-shape mapping) stayed green.
+// ---------------------------------------------------------------------------
+
+test('listOpenWorkItems maps REST created_at into createdAt, like getWorkItem', () => {
+  const port = createGithubProviderAdapter(
+    'kurone-kito',
+    'idd-skill',
+    fakeDeps({
+      ghApiJson: () => [
+        {
+          number: 900,
+          title: 'issue 900',
+          state: 'open',
+          created_at: '2026-08-01T00:00:00Z',
+        },
+      ],
+    }),
+  );
+  const [item] = port.listOpenWorkItems();
+  assert.equal(item.createdAt, '2026-08-01T00:00:00Z');
+});
+
+// ---------------------------------------------------------------------------
 // listRequiredChecks (#2266): the pre-migration ghJson/
 // recoverJsonFromGhFailure recovery this method replaces, verified through
 // the injectable deps seam (both recoveries have zero coverage otherwise --

--- a/tests/supersession-detection.test.mts
+++ b/tests/supersession-detection.test.mts
@@ -9,8 +9,11 @@ import {
   evaluateHighConfidenceDuplicate,
   findCandidateFileOverlap,
   findTrustedSuitabilityRejection,
+  isSuitabilityTriageVerdictCurrent,
+  parseSuitabilityTriageVerdictMarker,
   prReferencesIssue,
   resolveCandidateFileSet,
+  resolveLatestSubstantiveIssueEditAt,
   SUITABILITY_REJECTION_PREFIX,
   type SuitabilityRejectionComment,
 } from '../src/scripts/supersession-detection.mts';
@@ -1077,4 +1080,206 @@ test('findTrustedSuitabilityRejection: an unparseable created_at is skipped rath
     ['kurone-kito'],
   );
   assert.equal(result?.createdAt, '2026-08-05T03:55:11Z');
+});
+
+// --- #2243: parseSuitabilityTriageVerdictMarker -----------------------------
+
+test('parseSuitabilityTriageVerdictMarker: a well-formed marker is detected', () => {
+  const result = parseSuitabilityTriageVerdictMarker(
+    'some prose\n<!-- idd-skill-triage-verdict: duplicate -->\nmore prose',
+  );
+  assert.deepEqual(result, {
+    present: true,
+    outcome: 'duplicate',
+    malformed: false,
+  });
+});
+
+test('parseSuitabilityTriageVerdictMarker: no marker returns present:false, outcome:null (never-triaged case)', () => {
+  const result = parseSuitabilityTriageVerdictMarker('plain prose, no marker');
+  assert.deepEqual(result, { present: false, outcome: null, malformed: false });
+});
+
+test('parseSuitabilityTriageVerdictMarker: an out-of-whitelist token (e.g. a label outcome) is malformed, never a synthesized outcome', () => {
+  const result = parseSuitabilityTriageVerdictMarker(
+    '<!-- idd-skill-triage-verdict: needs-decision -->',
+  );
+  assert.deepEqual(result, { present: true, outcome: null, malformed: true });
+});
+
+test('parseSuitabilityTriageVerdictMarker: two disagreeing markers are malformed', () => {
+  const result = parseSuitabilityTriageVerdictMarker(
+    '<!-- idd-skill-triage-verdict: unclear -->\n<!-- idd-skill-triage-verdict: invalid -->',
+  );
+  assert.equal(result.malformed, true);
+  assert.equal(result.outcome, null);
+});
+
+test('parseSuitabilityTriageVerdictMarker: two agreeing markers are not malformed', () => {
+  const result = parseSuitabilityTriageVerdictMarker(
+    '<!-- idd-skill-triage-verdict: unclear -->\n<!-- idd-skill-triage-verdict: unclear -->',
+  );
+  assert.deepEqual(result, {
+    present: true,
+    outcome: 'unclear',
+    malformed: false,
+  });
+});
+
+test('parseSuitabilityTriageVerdictMarker: a marker merely quoted in a code span is never treated as live (#1614, #1121 precedent)', () => {
+  const result = parseSuitabilityTriageVerdictMarker(
+    'The convention looks like `<!-- idd-skill-triage-verdict: duplicate -->`.',
+  );
+  assert.deepEqual(result, { present: false, outcome: null, malformed: false });
+});
+
+test('parseSuitabilityTriageVerdictMarker: a namespaced adopter marker prefix is honored', () => {
+  const result = parseSuitabilityTriageVerdictMarker(
+    '<!-- acme-triage-verdict: invalid -->',
+    'acme',
+  );
+  assert.deepEqual(result, {
+    present: true,
+    outcome: 'invalid',
+    malformed: false,
+  });
+});
+
+test('parseSuitabilityTriageVerdictMarker: token comparison is case-insensitive', () => {
+  const result = parseSuitabilityTriageVerdictMarker(
+    '<!-- idd-skill-triage-verdict: OUT-OF-SCOPE -->',
+  );
+  assert.equal(result.outcome, 'out-of-scope');
+});
+
+// --- #2243: findTrustedSuitabilityRejection markerOutcome -------------------
+
+test("findTrustedSuitabilityRejection: markerOutcome surfaces a trusted comment's current triage-verdict marker", () => {
+  const result = findTrustedSuitabilityRejection(
+    [
+      makeRejectionComment({
+        body: `${SUITABILITY_REJECTION_PREFIX} — Check 2 (Coherence): reason.\n\n<!-- idd-skill-triage-verdict: unclear -->`,
+      }),
+    ],
+    ['kurone-kito'],
+  );
+  assert.equal(result?.markerOutcome, 'unclear');
+});
+
+test('findTrustedSuitabilityRejection: markerOutcome is null when the rejection comment carries no marker (never-triaged-marker case)', () => {
+  const result = findTrustedSuitabilityRejection(
+    [makeRejectionComment()],
+    ['kurone-kito'],
+  );
+  assert.equal(result?.markerOutcome, null);
+});
+
+test("findTrustedSuitabilityRejection: an untrusted actor's marker-bearing comment is not surfaced at all (same #1887 trust boundary)", () => {
+  const result = findTrustedSuitabilityRejection(
+    [
+      makeRejectionComment({
+        body: `${SUITABILITY_REJECTION_PREFIX} — Check 2 (Coherence): reason.\n\n<!-- idd-skill-triage-verdict: unclear -->`,
+        user: { login: 'random-untrusted-user' },
+      }),
+    ],
+    ['kurone-kito'],
+  );
+  assert.equal(result, null);
+});
+
+// --- #2243: resolveLatestSubstantiveIssueEditAt -----------------------------
+
+test("resolveLatestSubstantiveIssueEditAt: falls back to the issue's own createdAt with no edit events", () => {
+  assert.equal(
+    resolveLatestSubstantiveIssueEditAt('2026-08-01T00:00:00Z', []),
+    '2026-08-01T00:00:00Z',
+  );
+});
+
+test('resolveLatestSubstantiveIssueEditAt: a later body edit wins over createdAt', () => {
+  const result = resolveLatestSubstantiveIssueEditAt('2026-08-01T00:00:00Z', [
+    {
+      event: 'edited',
+      created_at: '2026-08-10T00:00:00Z',
+      changes: { body: {} },
+    },
+  ]);
+  assert.equal(result, '2026-08-10T00:00:00Z');
+});
+
+test('resolveLatestSubstantiveIssueEditAt: a title edit counts too', () => {
+  const result = resolveLatestSubstantiveIssueEditAt('2026-08-01T00:00:00Z', [
+    {
+      event: 'edited',
+      created_at: '2026-08-10T00:00:00Z',
+      changes: { title: {} },
+    },
+  ]);
+  assert.equal(result, '2026-08-10T00:00:00Z');
+});
+
+test('resolveLatestSubstantiveIssueEditAt: a non-body/title event (e.g. labeled) is ignored', () => {
+  const result = resolveLatestSubstantiveIssueEditAt('2026-08-01T00:00:00Z', [
+    { event: 'labeled', created_at: '2026-08-10T00:00:00Z' },
+  ]);
+  assert.equal(result, '2026-08-01T00:00:00Z');
+});
+
+test('resolveLatestSubstantiveIssueEditAt: an unparseable timestamp never wins', () => {
+  const result = resolveLatestSubstantiveIssueEditAt('2026-08-01T00:00:00Z', [
+    { event: 'edited', created_at: 'not-a-date', changes: { body: {} } },
+  ]);
+  assert.equal(result, '2026-08-01T00:00:00Z');
+});
+
+test('resolveLatestSubstantiveIssueEditAt: null when neither createdAt nor any qualifying event is parseable', () => {
+  assert.equal(resolveLatestSubstantiveIssueEditAt(null, []), null);
+});
+
+// --- #2243: isSuitabilityTriageVerdictCurrent (staleness) -------------------
+// The four acceptance-criteria scenarios from #2243: marker present and
+// current (skip), marker present but stale relative to a later body edit
+// (do not skip), no marker / never-triaged (do not skip), and an
+// untrusted/forged marker comment (do not skip -- covered above by
+// findTrustedSuitabilityRejection returning null entirely, so it never
+// reaches this staleness check).
+
+test('isSuitabilityTriageVerdictCurrent: a marker at/after the latest substantive edit is current (skip)', () => {
+  const current = isSuitabilityTriageVerdictCurrent(
+    { createdAt: '2026-08-10T00:00:00Z', markerOutcome: 'unclear' },
+    '2026-08-05T00:00:00Z',
+  );
+  assert.equal(current, true);
+});
+
+test('isSuitabilityTriageVerdictCurrent: a marker strictly before a later substantive edit is stale (do not skip)', () => {
+  const current = isSuitabilityTriageVerdictCurrent(
+    { createdAt: '2026-08-05T00:00:00Z', markerOutcome: 'unclear' },
+    '2026-08-10T00:00:00Z',
+  );
+  assert.equal(current, false);
+});
+
+test('isSuitabilityTriageVerdictCurrent: no marker outcome is never current, regardless of timestamps (never-triaged case)', () => {
+  const current = isSuitabilityTriageVerdictCurrent(
+    { createdAt: '2026-08-10T00:00:00Z', markerOutcome: null },
+    '2026-08-05T00:00:00Z',
+  );
+  assert.equal(current, false);
+});
+
+test('isSuitabilityTriageVerdictCurrent: an unknown staleness anchor (null) fails closed toward NOT excluding the candidate', () => {
+  const current = isSuitabilityTriageVerdictCurrent(
+    { createdAt: '2026-08-10T00:00:00Z', markerOutcome: 'unclear' },
+    null,
+  );
+  assert.equal(current, false);
+});
+
+test('isSuitabilityTriageVerdictCurrent: an unparseable rejection createdAt fails closed toward NOT excluding the candidate', () => {
+  const current = isSuitabilityTriageVerdictCurrent(
+    { createdAt: 'not-a-date', markerOutcome: 'unclear' },
+    '2026-08-05T00:00:00Z',
+  );
+  assert.equal(current, false);
 });


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Extend the A4.5 suitability-gate rejection convention with a stable,
machine-parseable outcome marker for the four A4.5 outcomes with no
dedicated label (`unclear`, `duplicate`, `out-of-scope`, `invalid`):

```markdown
<!-- {prefix}-triage-verdict: <outcome> -->
```

`needs-decision` / `blocked-by-human` already carry a stable label and
never emit this marker. Discover's own candidate-selection pass now
skips a candidate whose most recent trusted rejection comment carries a
still-current marker, without a full manual comment-history read.

**Note on the issue's literal wording**: there is no code "renderer"
that composes the rejection comment body — that comment is agent-composed
prose per `idd-suitability.instructions.md`'s Mutation Policy, not a
generated artifact. This PR implements the read side (a marker parser
plus the Discover-side exclusion) and updates the Mutation Policy
instructions to define the write-side convention, rather than inventing
a comment-posting helper the codebase doesn't otherwise have.

## What changed

- `supersession-detection.mts`: `parseSuitabilityTriageVerdictMarker`
  (the marker parser, mirroring `autopilot-suitability.mts`'s own
  parser shape and code-span-quoting guard), a staleness kernel
  (`resolveLatestSubstantiveIssueEditAt` /
  `isSuitabilityTriageVerdictCurrent`, mirroring
  `claim-approval-gate.mts`'s private latest-substantive-edit anchor),
  and a new `markerOutcome` field on
  `findTrustedSuitabilityRejection`'s result.
- `discover-orphan-filter.mts` / `discover-readiness-check.mts`: wire
  the above in as a **default-on** (not opt-in) exclusion — a
  survivors-only lazy fetch (comments + timeline) that only runs for a
  candidate every cheaper label/body filter has already let through,
  and only when trusted marker actors are configured. `--help` and
  `docs/idd-helper-scripts.md` document the new default GitHub API
  calls this adds.
- `idd-suitability.instructions.md` (canonical `idd-template/` source):
  a new Mutation Policy paragraph defining the marker format and the
  staleness rule.
- Tests: the four acceptance-criteria scenarios (marker present and
  current → skip; marker present but stale relative to a later body
  edit → do not skip; no marker → do not skip; untrusted/forged marker
  → do not skip) at both the kernel level
  (`tests/supersession-detection.test.mts`) and the integration level
  (`tests/discover-orphan-filter.test.mts`,
  `tests/discover-readiness-check.test.mts`), plus an extended `gh`
  stub in `tests/cli-entry-smoke.test.mts` for the new default comments
  fetch.

## Linked issue

Closes #2243

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Staleness handling mirrors this repository's existing pattern of
comparing an evidentiary comment's timestamp against the state it
evaluated (e.g. `docs/token-cost.md`'s staleness handling, the
advisory-convergence watermark comparisons): an issue rejected as
`unclear` and later substantively improved is not permanently excluded
by a now-stale marker.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic filtering of candidates rejected by trusted triage verdicts.
  - Rejections are ignored when an issue has been substantively updated since the verdict.
  - Filtering results now identify triage-verdict rejections.
  - Issue timestamps are preserved to support freshness checks.

- **Documentation**
  - Documented triage-based filtering, behavior, and additional API usage for repository-wide scans.

- **Tests**
  - Added coverage for current, stale, absent, and untrusted verdict markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->