### PR TITLE
feat(a4.5): authorize gated pre-claim close of duplicate issues

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -84,6 +84,7 @@ scripts/review-comment-origin.mjs linguist-generated=true
 scripts/review-disposition-verify.mjs linguist-generated=true
 scripts/select-desynced-index.mjs linguist-generated=true
 scripts/stalled-session-quiet-check.mjs linguist-generated=true
+scripts/suitability-close-execute.mjs linguist-generated=true
 scripts/suitability-triage.mjs linguist-generated=true
 scripts/supersession-detection.mjs linguist-generated=true
 scripts/sync-docs.mjs linguist-generated=true

--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -234,7 +234,8 @@ report-and-stop path unchanged):
    `branch: suitability-close/<number>-<slug>` — outside the
    `issue/*`/`roadmap-audit/*` scope the core cwd-vs-claim gate checks
    (`idd-overview-core.instructions.md`), so no worktree is needed.
-2. Re-validate that claim, then run (dry-run without `--apply`):
+2. Re-validate that claim, then run (add `--apply` to mutate; omit it
+   to dry-run first):
 
    ```sh
    node scripts/suitability-close-execute.mjs --issue <number> \

--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -238,7 +238,7 @@ report-and-stop path unchanged):
 
    ```sh
    node scripts/suitability-close-execute.mjs --issue <number> \
-     --claim-id <id> --agent-id <id> --apply
+     --claim-id <claim-id> --agent-id <agent-id> --apply
    ```
 
    It re-collects the same mechanical evidence, posts the

--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -234,14 +234,18 @@ report-and-stop path unchanged):
    `branch: suitability-close/<number>-<slug>` — outside the
    `issue/*`/`roadmap-audit/*` scope the core cwd-vs-claim gate checks
    (`idd-overview-core.instructions.md`), so no worktree is needed.
-2. Re-validate that claim, then run `node
-   scripts/suitability-close-execute.mjs --issue <number> --claim-id
-   <id> --agent-id <id> --apply` (dry-run without `--apply`). It
-   re-collects the same mechanical evidence, posts the evidence-bound
-   closing comment (the accepted human-notification mechanism — no
-   separate step), closes the issue, and releases the claim, or fails
-   closed on a lost/stale/non-owned claim or a no-longer-eligible
-   re-evaluation.
+2. Re-validate that claim, then run (dry-run without `--apply`):
+
+   ```sh
+   node scripts/suitability-close-execute.mjs --issue <number> \
+     --claim-id <id> --agent-id <id> --apply
+   ```
+
+   It re-collects the same mechanical evidence, posts the
+   evidence-bound closing comment (the accepted human-notification
+   mechanism — no separate step), closes the issue, and releases the
+   claim, or fails closed on a lost/stale/non-owned claim or a
+   no-longer-eligible re-evaluation.
 3. Drop the closed candidate from Candidates and continue the Decision
    Flow loop.
 

--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -115,8 +115,13 @@ collection failure follows the "Timeout on duplicate detection" Edge
 Case below.
 
 Same **detect-only** boundary as the rest of A4.5 (label + comment
-only). The acceptance-criteria-hold-on-`main` bullet is deferred to
-the gated-close follow-up.
+only), except a `tier: 'high-confidence'` hit — never the weak
+heuristic — which the high-confidence coordination-close in
+[Mutation Policy](#mutation-policy-and-coordination-rule) below
+(`#1485`) may additionally close. The acceptance-criteria-hold-on-
+`main` signal from `#1484`'s original proposal remains unimplemented
+and authorizes no close on its own; only the mechanical signals
+`evaluateHighConfidenceDuplicate` actually evaluates do.
 
 `suitability-triage.mjs` evaluates both signals as part of Check 4.
 
@@ -189,11 +194,39 @@ A5 is never reached for a candidate that fails any check, labeled or not.
   must never masquerade as an implementation claim); linking related
   issues as context (e.g., "Related to #NNN which addresses similar
   work") without treating them as confirmed duplicates.
-- **Prohibited**: implementation claim comments or claim markers,
-  branches or worktrees, other operational markers (review-watermark,
+- **Prohibited** (except the high-confidence coordination-close
+  below): implementation claim comments or claim markers, branches or
+  worktrees, other operational markers (review-watermark,
   review-baseline, etc.), unilateral issue closes, roadmap
   structure/relationship edits, and any label other than the optional
   `triage:{outcome}` label above.
+
+### High-confidence coordination-close (#1485)
+
+On a Check 4 `tier: 'high-confidence'` hit only — never the weak
+heuristic — for a discovery-path candidate (A2/A3 roadmap traversal or
+A0-O orphan-first; never an A0-T explicit target, which keeps its
+report-and-stop path unchanged):
+
+1. Post a no-worktree coordination claim on the candidate, structurally
+   identical to A1.5's roadmap-audit claim
+   (`idd-roadmap-audit.instructions.md`) but with
+   `branch: suitability-close/<number>-<slug>` — outside the
+   `issue/*`/`roadmap-audit/*` scope the core cwd-vs-claim gate checks
+   (`idd-overview-core.instructions.md`), so no worktree is needed.
+2. Re-validate that claim, then run `node
+   scripts/suitability-close-execute.mjs --issue <number> --claim-id
+   <id> --agent-id <id> --apply` (dry-run without `--apply`). It
+   re-collects the same mechanical evidence, posts the evidence-bound
+   closing comment (the accepted human-notification mechanism — no
+   separate step), closes the issue, and releases the claim, or fails
+   closed on a lost/stale/non-owned claim or a no-longer-eligible
+   re-evaluation.
+3. Drop the closed candidate from Candidates and continue the Decision
+   Flow loop.
+
+A close here is reopenable; a wrong close is an accepted, recoverable
+risk, not a blocker on the gate above.
 
 ## Decision Flow
 

--- a/bin/idd-suitability-close-execute.mjs
+++ b/bin/idd-suitability-close-execute.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-suitability-close-execute.mts
+//
+// The bin/idd-suitability-close-execute.mjs copy is generated from the .mts source named above
+// by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+import { runHelper } from './run-helper.mjs';
+
+runHelper('../scripts/suitability-close-execute.mjs');

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -233,7 +233,7 @@ report-and-stop path unchanged):
 
    ```sh
    node scripts/suitability-close-execute.mjs --issue <number> \
-     --claim-id <id> --agent-id <id> --apply
+     --claim-id <claim-id> --agent-id <agent-id> --apply
    ```
 
    It re-collects the same mechanical evidence, posts the

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -229,14 +229,18 @@ report-and-stop path unchanged):
    `branch: suitability-close/<number>-<slug>` — outside the
    `issue/*`/`roadmap-audit/*` scope the core cwd-vs-claim gate checks
    (`idd-overview-core.instructions.md`), so no worktree is needed.
-2. Re-validate that claim, then run `node
-   scripts/suitability-close-execute.mjs --issue <number> --claim-id
-   <id> --agent-id <id> --apply` (dry-run without `--apply`). It
-   re-collects the same mechanical evidence, posts the evidence-bound
-   closing comment (the accepted human-notification mechanism — no
-   separate step), closes the issue, and releases the claim, or fails
-   closed on a lost/stale/non-owned claim or a no-longer-eligible
-   re-evaluation.
+2. Re-validate that claim, then run (dry-run without `--apply`):
+
+   ```sh
+   node scripts/suitability-close-execute.mjs --issue <number> \
+     --claim-id <id> --agent-id <id> --apply
+   ```
+
+   It re-collects the same mechanical evidence, posts the
+   evidence-bound closing comment (the accepted human-notification
+   mechanism — no separate step), closes the issue, and releases the
+   claim, or fails closed on a lost/stale/non-owned claim or a
+   no-longer-eligible re-evaluation.
 3. Drop the closed candidate from Candidates and continue the Decision
    Flow loop.
 

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -110,8 +110,13 @@ collection failure follows the "Timeout on duplicate detection" Edge
 Case below.
 
 Same **detect-only** boundary as the rest of A4.5 (label + comment
-only). The acceptance-criteria-hold-on-`main` bullet is deferred to
-the gated-close follow-up.
+only), except a `tier: 'high-confidence'` hit — never the weak
+heuristic — which the high-confidence coordination-close in
+[Mutation Policy](#mutation-policy-and-coordination-rule) below
+(`#1485`) may additionally close. The acceptance-criteria-hold-on-
+`main` signal from `#1484`'s original proposal remains unimplemented
+and authorizes no close on its own; only the mechanical signals
+`evaluateHighConfidenceDuplicate` actually evaluates do.
 
 `suitability-triage.mjs` evaluates both signals as part of Check 4.
 
@@ -184,11 +189,39 @@ A5 is never reached for a candidate that fails any check, labeled or not.
   must never masquerade as an implementation claim); linking related
   issues as context (e.g., "Related to #NNN which addresses similar
   work") without treating them as confirmed duplicates.
-- **Prohibited**: implementation claim comments or claim markers,
-  branches or worktrees, other operational markers (review-watermark,
+- **Prohibited** (except the high-confidence coordination-close
+  below): implementation claim comments or claim markers, branches or
+  worktrees, other operational markers (review-watermark,
   review-baseline, etc.), unilateral issue closes, roadmap
   structure/relationship edits, and any label other than the optional
   `triage:{outcome}` label above.
+
+### High-confidence coordination-close (#1485)
+
+On a Check 4 `tier: 'high-confidence'` hit only — never the weak
+heuristic — for a discovery-path candidate (A2/A3 roadmap traversal or
+A0-O orphan-first; never an A0-T explicit target, which keeps its
+report-and-stop path unchanged):
+
+1. Post a no-worktree coordination claim on the candidate, structurally
+   identical to A1.5's roadmap-audit claim
+   (`idd-roadmap-audit.instructions.md`) but with
+   `branch: suitability-close/<number>-<slug>` — outside the
+   `issue/*`/`roadmap-audit/*` scope the core cwd-vs-claim gate checks
+   (`idd-overview-core.instructions.md`), so no worktree is needed.
+2. Re-validate that claim, then run `node
+   scripts/suitability-close-execute.mjs --issue <number> --claim-id
+   <id> --agent-id <id> --apply` (dry-run without `--apply`). It
+   re-collects the same mechanical evidence, posts the evidence-bound
+   closing comment (the accepted human-notification mechanism — no
+   separate step), closes the issue, and releases the claim, or fails
+   closed on a lost/stale/non-owned claim or a no-longer-eligible
+   re-evaluation.
+3. Drop the closed candidate from Candidates and continue the Decision
+   Flow loop.
+
+A close here is reopenable; a wrong close is an accepted, recoverable
+risk, not a blocker on the gate above.
 
 ## Decision Flow
 

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -229,7 +229,8 @@ report-and-stop path unchanged):
    `branch: suitability-close/<number>-<slug>` — outside the
    `issue/*`/`roadmap-audit/*` scope the core cwd-vs-claim gate checks
    (`idd-overview-core.instructions.md`), so no worktree is needed.
-2. Re-validate that claim, then run (dry-run without `--apply`):
+2. Re-validate that claim, then run (add `--apply` to mutate; omit it
+   to dry-run first):
 
    ```sh
    node scripts/suitability-close-execute.mjs --issue <number> \

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "idd-roadmap-audit-execute": "./bin/idd-roadmap-audit-execute.mjs",
     "idd-select-desynced-index": "./bin/idd-select-desynced-index.mjs",
     "idd-stalled-session-quiet-check": "./bin/idd-stalled-session-quiet-check.mjs",
+    "idd-suitability-close-execute": "./bin/idd-suitability-close-execute.mjs",
     "idd-suitability-triage": "./bin/idd-suitability-triage.mjs"
   },
   "scripts": {

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -522,6 +522,15 @@ const HELPER_COMMANDS = [
     contractPaths: ['schemas/stalled-session-quiet-check.schema.json'],
   },
   {
+    id: 'suitability-close-execute',
+    scriptName: 'idd:suitability-close-execute',
+    binName: 'idd-suitability-close-execute',
+    entryPath: 'scripts/suitability-close-execute.mjs',
+    vendoredCommand: 'node scripts/suitability-close-execute.mjs',
+    description:
+      'Evaluate the #1485 gated A4.5 high-confidence duplicate/superseded close (dry-run) and, with --apply, post the evidence comment, close the issue, and release the suitability-close coordination claim.',
+  },
+  {
     id: 'suitability-triage',
     scriptName: 'idd:suitability-triage',
     binName: 'idd-suitability-triage',

--- a/scripts/suitability-close-execute.mjs
+++ b/scripts/suitability-close-execute.mjs
@@ -134,14 +134,22 @@ export function evaluateSuitabilityCloseEligibility(checkOutcome) {
 /** Render the evidence-bound closing comment. `evidence` is always the
  * machine-derivable string `evaluateHighConfidenceDuplicate` itself already
  * produces (PR number(s) and/or overlapping file path(s)) -- this renderer
- * adds no prose evidence of its own. */
+ * adds no prose evidence of its own.
+ *
+ * Copilot review finding on PR #2558: `runSuitabilityCloseExecute` posts
+ * this comment BEFORE calling `closeIssue` (evidence-first, matching
+ * `idd-roadmap-audit-execute.mts`'s own evidence-then-close order), so the
+ * wording below deliberately describes the close as in-progress rather
+ * than already complete -- a `closeIssue` failure after this comment posts
+ * must never leave a false "already closed" claim on an issue that is
+ * still open. */
 export function buildSuitabilityCloseComment(evidence) {
   return [
     'A4.5 high-confidence duplicate/superseded close',
     '',
     evidence,
     '',
-    '_This candidate was closed autonomously under the `#1485` gated',
+    '_Closing this candidate autonomously under the `#1485` gated',
     'pre-claim close path: a strong mechanical signal only (closing-PR',
     'reference, same-`## Candidate files` overlap, or an exact',
     'branch-name match), never the weak title/declaration heuristic. If',
@@ -159,6 +167,25 @@ export function buildSuitabilityCloseComment(evidence) {
  * on a lost/stale/non-owned claim or a no-longer-eligible fresh evaluation.
  */
 export function runSuitabilityCloseExecute(args, deps) {
+  // Copilot review finding on PR #2558: `runCli` validates `args.issue !==
+  // null` before ever constructing `args`, but that guard lives outside
+  // this exported function -- a direct caller (bypassing `runCli`) could
+  // still pass `issue: null`. Re-check here instead of trusting the `as
+  // number` cast, so a direct call degrades to a clean not-found verdict
+  // rather than an unsafe null flowing into `deps.getIssue`.
+  if (args.issue === null || !Number.isInteger(args.issue)) {
+    return {
+      protocolVersion: '1',
+      mode: args.apply ? 'apply' : 'dry-run',
+      issueNumber: Number.NaN,
+      ready: false,
+      eligible: false,
+      evidence: null,
+      claim: null,
+      closed: false,
+      result: '--issue is required and must be a positive integer',
+    };
+  }
   const issueNumber = args.issue;
   const issue = deps.getIssue(issueNumber);
   if (!issue) {

--- a/scripts/suitability-close-execute.mjs
+++ b/scripts/suitability-close-execute.mjs
@@ -259,6 +259,38 @@ export function runSuitabilityCloseExecute(args, deps) {
   }
   const evidence = eligibility.evidence;
   deps.postCloseComment(issueNumber, buildSuitabilityCloseComment(evidence));
+  // Copilot review finding on PR #2558 (suppressed comment): the claim was
+  // validated once, above, before posting the comment -- but the comment
+  // POST is itself a network round-trip another session's takeover could
+  // race during. Re-validate immediately before the actual close mutation,
+  // mirroring idd-roadmap-audit-execute.mts's own re-validate-before-close
+  // pattern, so a claim lost in the comment->close gap aborts the close
+  // (the claim's rightful new owner still sees the evidence comment, but
+  // this session never closes an issue it no longer owns).
+  const finalClaim = evaluateSuitabilityCloseClaim(
+    deps.loadIssueComments(issueNumber),
+    {
+      issueNumber,
+      expectedClaimId: args.claimId,
+      expectedAgentId: args.agentId,
+      isTrustedAuthor: deps.isTrustedAuthor,
+      nowIso: deps.now(),
+      staleAgeMs: deps.staleAgeMs,
+    },
+  );
+  if (!finalClaim.owned) {
+    return {
+      protocolVersion: '1',
+      mode: 'apply',
+      issueNumber,
+      ready: true,
+      eligible: true,
+      evidence,
+      claim: finalClaim,
+      closed: false,
+      result: `coordination claim lost between the comment and the close (${finalClaim.reason}); issue left open`,
+    };
+  }
   deps.closeIssue(issueNumber);
   deps.releaseClaim(issueNumber, {
     agentId: args.agentId,
@@ -272,7 +304,7 @@ export function runSuitabilityCloseExecute(args, deps) {
     ready: true,
     eligible: true,
     evidence,
-    claim,
+    claim: finalClaim,
     closed: true,
     result: 'closed: high-confidence duplicate/superseded, evidence posted',
   };
@@ -388,14 +420,18 @@ const SUITABILITY_CLOSE_EXECUTE_FLAG_SPEC = {
   '--now': { type: 'string' },
   '--help': { type: 'boolean', short: 'h' },
 };
-function parseArgs(argv) {
+export function parseArgs(argv) {
   const { values, help } = parseCliArgs(
     argv,
     SUITABILITY_CLOSE_EXECUTE_FLAG_SPEC,
   );
+  // Copilot review finding on PR #2558 (suppressed comment): /^\d+$/ alone
+  // accepts "0", which would then attempt to load/close issue #0. Require a
+  // genuinely positive integer, matching runCli's own --issue validation.
   const issueRaw = values.issue;
-  const issue =
+  const parsedIssue =
     issueRaw !== undefined && /^\d+$/.test(issueRaw) ? Number(issueRaw) : null;
+  const issue = parsedIssue !== null && parsedIssue > 0 ? parsedIssue : null;
   return {
     issue,
     apply: Boolean(values.apply),

--- a/scripts/suitability-close-execute.mjs
+++ b/scripts/suitability-close-execute.mjs
@@ -471,13 +471,26 @@ export function parseArgs(argv) {
   const parsedIssue =
     issueRaw !== undefined && /^\d+$/.test(issueRaw) ? Number(issueRaw) : null;
   const issue = parsedIssue !== null && parsedIssue > 0 ? parsedIssue : null;
+  const owner = (values.owner ?? '').trim();
+  const repo = (values.repo ?? '').trim();
+  // Copilot review finding on PR #2558: exactly one of --owner/--repo would
+  // mix a caller-supplied repo with resolveCurrentGithubRepository()'s
+  // current-directory repo in createProductionDeps, potentially targeting
+  // the wrong repository for issue lookup/close. Mirrors
+  // idd-roadmap-audit-execute.mts's own --owner/--repo pairing guard:
+  // require both or neither.
+  if ((owner === '') !== (repo === '')) {
+    throw new Error(
+      'suitability-close-execute: --owner and --repo must be provided together or not at all',
+    );
+  }
   return {
     issue,
     apply: Boolean(values.apply),
     claimId: (values['claim-id'] ?? '').trim(),
     agentId: (values['agent-id'] ?? '').trim(),
-    owner: (values.owner ?? '').trim(),
-    repo: (values.repo ?? '').trim(),
+    owner,
+    repo,
     policy: (values.policy ?? '').trim(),
     now: (values.now ?? '').trim(),
     help: Boolean(help),

--- a/scripts/suitability-close-execute.mjs
+++ b/scripts/suitability-close-execute.mjs
@@ -1,0 +1,432 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/suitability-close-execute.mts
+//
+// The scripts/suitability-close-execute.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// #1485: the gated pre-claim high-confidence duplicate/superseded close
+// path. Reuses `#1484`'s detect-only Check 4 evidence collection
+// (`collectHighConfidenceDuplicateEvidence` in `suitability-triage.mts`) and
+// evaluation kernel (`evaluateHighConfidenceDuplicate` in
+// `supersession-detection.mts`) verbatim -- this file introduces NO new
+// detection logic, only the gated mutation on top of an already-established
+// `tier: 'high-confidence'` verdict.
+//
+// This helper does NOT post the initial coordination claim itself -- exactly
+// like `idd-roadmap-audit-execute.mts` does not post the A1.5 roadmap-audit
+// claim -- the caller posts it with the generic `post-idd-marker.mjs --type
+// claim --branch suitability-close/<n>-<slug>` path first, then invokes this
+// helper to re-validate it, evaluate close-eligibility, and (under --apply)
+// post the evidence-bound close comment, close the issue, and release the
+// claim, in that order. `--apply` fails closed (no mutation) on any lost /
+// stale / non-owned claim, or when the fresh re-evaluation no longer finds a
+// high-confidence signal.
+import { parseCliArgs } from './cli-args.mjs';
+import {
+  isClaimStaleByAge,
+  parseClaimStaleAgeMs,
+} from './discover-roadmap-graph.mjs';
+import { loadPolicyConfig } from './idd-config.mjs';
+import {
+  renderUnclaimedByMarker,
+  resolveTrustedMarkerActors,
+  summarizeClaimValidation,
+} from './protocol-helpers.mjs';
+import {
+  createGithubProviderAdapter,
+  resolveCurrentGithubRepository,
+} from './provider-adapter-github.mjs';
+import { collectHighConfidenceDuplicateEvidence } from './suitability-triage.mjs';
+import { evaluateHighConfidenceDuplicate } from './supersession-detection.mjs';
+
+const DEFAULT_CLAIM_STALE_AGE_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_MANIFEST_PATH = 'audit/sync-manifest.json';
+const DEFAULT_BUNDLE_IDS = ['bundle-review', 'bundle-merge'];
+/**
+ * Branch pattern for a suitability-close coordination claim on issue
+ * `issueNumber`: a logical coordination name (no worktree), mirroring A1.5's
+ * `roadmap-audit/<n>-<slug>` shape. Scoped to `issueNumber` so this never
+ * matches a claim posted for a different candidate, and its `suitability-
+ * close/*` prefix never matches `issue/*`, so the core cwd-vs-claim gate
+ * (`idd-overview-core.instructions.md`) naturally excludes it from the
+ * worktree-mutation checks that gate applies only to `issue/*` claims.
+ */
+export function suitabilityCloseBranchPattern(issueNumber) {
+  return new RegExp(`^suitability-close/${issueNumber}-`);
+}
+/**
+ * Re-validate a suitability-close coordination claim on `options.issueNumber`
+ * against the live comment stream: the active claim must match the expected
+ * claim-id/agent-id (`summarizeClaimValidation`), use the
+ * `suitability-close/<issueNumber>-*` coordination branch (a normal
+ * `issue/*` implementation claim on the same issue never authorizes this
+ * close), and not be stale.
+ */
+export function evaluateSuitabilityCloseClaim(comments, options) {
+  const summary = summarizeClaimValidation(comments, {
+    isTrustedAuthor: options.isTrustedAuthor,
+    expectedClaimId: options.expectedClaimId,
+    expectedAgentId: options.expectedAgentId,
+  });
+  if (!summary.matchesExpectedClaim) {
+    return {
+      owned: false,
+      reason: summary.reason,
+      stale: false,
+      activeClaim: summary.activeClaim,
+    };
+  }
+  if (
+    !suitabilityCloseBranchPattern(options.issueNumber).test(
+      summary.activeClaim.branch,
+    )
+  ) {
+    return {
+      owned: false,
+      reason: 'claim-branch-mismatch',
+      stale: false,
+      activeClaim: summary.activeClaim,
+    };
+  }
+  const stale = isClaimStaleByAge(
+    summary.activeClaim.createdAt,
+    options.nowIso,
+    options.staleAgeMs ?? DEFAULT_CLAIM_STALE_AGE_MS,
+  );
+  if (stale) {
+    return {
+      owned: false,
+      reason: 'claim-stale',
+      stale: true,
+      activeClaim: summary.activeClaim,
+    };
+  }
+  return {
+    owned: true,
+    reason: 'match',
+    stale: false,
+    activeClaim: summary.activeClaim,
+  };
+}
+/**
+ * The pure close-eligibility decision (#1485's own acceptance criteria:
+ * "on the strong signal only... on any weaker signal it does not close").
+ * Gates on `tier === 'high-confidence'` EXACTLY, never on `pass: false` or
+ * `outcome: duplicate` alone -- a weak title/declaration heuristic hit
+ * shares the identical `pass: false` shape and MUST NOT authorize a close.
+ * `checkOutcome` is `evaluateHighConfidenceDuplicate`'s own return value
+ * (`null` when no strong signal fires, matching that kernel's own
+ * never-fail-toward-a-false-positive contract). Exported and pure so
+ * `tests/*.test.mts` can cover strong-signal-close and no-signal-no-close
+ * without shelling out to `gh`.
+ */
+export function evaluateSuitabilityCloseEligibility(checkOutcome) {
+  if (
+    checkOutcome &&
+    checkOutcome.pass === false &&
+    checkOutcome.tier === 'high-confidence'
+  ) {
+    return { eligible: true, evidence: checkOutcome.evidence };
+  }
+  return { eligible: false, evidence: null };
+}
+/** Render the evidence-bound closing comment. `evidence` is always the
+ * machine-derivable string `evaluateHighConfidenceDuplicate` itself already
+ * produces (PR number(s) and/or overlapping file path(s)) -- this renderer
+ * adds no prose evidence of its own. */
+export function buildSuitabilityCloseComment(evidence) {
+  return [
+    'A4.5 high-confidence duplicate/superseded close',
+    '',
+    evidence,
+    '',
+    '_This candidate was closed autonomously under the `#1485` gated',
+    'pre-claim close path: a strong mechanical signal only (closing-PR',
+    'reference, same-`## Candidate files` overlap, or an exact',
+    'branch-name match), never the weak title/declaration heuristic. If',
+    'this close is wrong, reopen the issue -- the close is reversible and',
+    'a wrong close is an accepted, recoverable risk._',
+  ].join('\n');
+}
+/**
+ * Evaluate (dry-run) and, when ready and `--apply` is set, execute the
+ * `#1485` gated close. Dry-run performs NO mutation. `--apply` re-validates
+ * the coordination claim and re-collects evidence immediately before
+ * mutating -- both must still hold at that instant, not merely at some
+ * earlier check -- then posts the evidence-bound close comment, closes the
+ * issue, and releases the claim, in that order. Fails closed (no mutation)
+ * on a lost/stale/non-owned claim or a no-longer-eligible fresh evaluation.
+ */
+export function runSuitabilityCloseExecute(args, deps) {
+  const issueNumber = args.issue;
+  const issue = deps.getIssue(issueNumber);
+  if (!issue) {
+    return {
+      protocolVersion: '1',
+      mode: args.apply ? 'apply' : 'dry-run',
+      issueNumber,
+      ready: false,
+      eligible: false,
+      evidence: null,
+      claim: null,
+      closed: false,
+      result: `issue #${issueNumber} not found or inaccessible`,
+    };
+  }
+  const checkOutcome = deps.collectEvidence(issue);
+  const eligibility = evaluateSuitabilityCloseEligibility(checkOutcome);
+  if (!args.apply) {
+    return {
+      protocolVersion: '1',
+      mode: 'dry-run',
+      issueNumber,
+      ready: eligibility.eligible,
+      eligible: eligibility.eligible,
+      evidence: eligibility.evidence,
+      claim: null,
+      closed: false,
+      result: eligibility.eligible
+        ? 'high-confidence signal found; ready for --apply'
+        : 'no high-confidence signal; not ready to close',
+    };
+  }
+  if (!eligibility.eligible) {
+    return {
+      protocolVersion: '1',
+      mode: 'apply',
+      issueNumber,
+      ready: false,
+      eligible: false,
+      evidence: null,
+      claim: null,
+      closed: false,
+      result:
+        'no high-confidence signal on this fresh re-evaluation; no mutation',
+    };
+  }
+  const nowIso = deps.now();
+  const claim = evaluateSuitabilityCloseClaim(
+    deps.loadIssueComments(issueNumber),
+    {
+      issueNumber,
+      expectedClaimId: args.claimId,
+      expectedAgentId: args.agentId,
+      isTrustedAuthor: deps.isTrustedAuthor,
+      nowIso,
+      staleAgeMs: deps.staleAgeMs,
+    },
+  );
+  if (!claim.owned) {
+    return {
+      protocolVersion: '1',
+      mode: 'apply',
+      issueNumber,
+      ready: true,
+      eligible: true,
+      evidence: eligibility.evidence,
+      claim,
+      closed: false,
+      result: `coordination claim not owned (${claim.reason}); no mutation`,
+    };
+  }
+  const evidence = eligibility.evidence;
+  deps.postCloseComment(issueNumber, buildSuitabilityCloseComment(evidence));
+  deps.closeIssue(issueNumber);
+  deps.releaseClaim(issueNumber, {
+    agentId: args.agentId,
+    claimId: args.claimId,
+    timestamp: nowIso,
+  });
+  return {
+    protocolVersion: '1',
+    mode: 'apply',
+    issueNumber,
+    ready: true,
+    eligible: true,
+    evidence,
+    claim,
+    closed: true,
+    result: 'closed: high-confidence duplicate/superseded, evidence posted',
+  };
+}
+// ---------------------------------------------------------------------------
+// Production dependency wiring (live gh)
+// ---------------------------------------------------------------------------
+function loadIssueComments(port, issueNumber) {
+  return port.listWorkItemComments(issueNumber).map((comment) => ({
+    body: comment.body,
+    createdAt: comment.createdAt,
+    author: { login: comment.authorLogin },
+  }));
+}
+function buildTrustedAuthorPredicate({ owner, viewerLogin, rawConfig }) {
+  const { actors } = resolveTrustedMarkerActors({
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+    config: rawConfig,
+  });
+  const trusted = new Set(
+    [owner, viewerLogin, ...actors]
+      .filter(Boolean)
+      .map((login) => login.trim().toLowerCase()),
+  );
+  return (login) =>
+    trusted.has(
+      String(login ?? '')
+        .trim()
+        .toLowerCase(),
+    );
+}
+function loadPolicy(policyPath) {
+  if (!policyPath) {
+    return null;
+  }
+  try {
+    return loadPolicyConfig(policyPath);
+  } catch {
+    return null;
+  }
+}
+function createProductionDeps(args) {
+  const currentRepo =
+    args.owner && args.repo ? null : resolveCurrentGithubRepository();
+  const owner = args.owner || currentRepo?.owner || '';
+  const repo = args.repo || currentRepo?.repo || '';
+  const port = createGithubProviderAdapter(owner, repo);
+  const rawConfig = loadPolicy(args.policy);
+  const { viewerLogin } = port.resolveViewerLoginSafe();
+  const isTrustedAuthor = buildTrustedAuthorPredicate({
+    owner,
+    viewerLogin,
+    rawConfig: rawConfig,
+  });
+  const staleAgeMs =
+    parseClaimStaleAgeMs(rawConfig?.claimTiming?.staleAge) ??
+    DEFAULT_CLAIM_STALE_AGE_MS;
+  const repoRef = `${owner}/${repo}`;
+  return {
+    getIssue: (issueNumber) => {
+      const item = port.getWorkItem(issueNumber);
+      if (!item) {
+        return null;
+      }
+      return {
+        number: item.number,
+        title: item.title,
+        body: item.body,
+        createdAt: item.createdAt ?? '',
+      };
+    },
+    loadIssueComments: (issueNumber) => loadIssueComments(port, issueNumber),
+    collectEvidence: (issue) => {
+      const { highConfidenceDuplicate } =
+        collectHighConfidenceDuplicateEvidence(
+          owner,
+          repo,
+          repoRef,
+          issue,
+          DEFAULT_MANIFEST_PATH,
+          DEFAULT_BUNDLE_IDS,
+        );
+      return evaluateHighConfidenceDuplicate(
+        highConfidenceDuplicate,
+        issue.number,
+      );
+    },
+    isTrustedAuthor,
+    postCloseComment: (issueNumber, body) => {
+      port.postWorkItemComment(issueNumber, body);
+    },
+    closeIssue: (issueNumber) => {
+      port.closeWorkItem(issueNumber, 'not_planned');
+    },
+    releaseClaim: (issueNumber, fields) => {
+      port.postWorkItemComment(issueNumber, renderUnclaimedByMarker(fields));
+    },
+    now: () => args.now || new Date().toISOString(),
+    staleAgeMs,
+  };
+}
+// ---------------------------------------------------------------------------
+// CLI glue
+// ---------------------------------------------------------------------------
+const SUITABILITY_CLOSE_EXECUTE_FLAG_SPEC = {
+  '--issue': { type: 'string' },
+  '--apply': { type: 'boolean', default: false },
+  '--claim-id': { type: 'string' },
+  '--agent-id': { type: 'string' },
+  '--owner': { type: 'string' },
+  '--repo': { type: 'string' },
+  '--policy': { type: 'string' },
+  '--now': { type: 'string' },
+  '--help': { type: 'boolean', short: 'h' },
+};
+function parseArgs(argv) {
+  const { values, help } = parseCliArgs(
+    argv,
+    SUITABILITY_CLOSE_EXECUTE_FLAG_SPEC,
+  );
+  const issueRaw = values.issue;
+  const issue =
+    issueRaw !== undefined && /^\d+$/.test(issueRaw) ? Number(issueRaw) : null;
+  return {
+    issue,
+    apply: Boolean(values.apply),
+    claimId: (values['claim-id'] ?? '').trim(),
+    agentId: (values['agent-id'] ?? '').trim(),
+    owner: (values.owner ?? '').trim(),
+    repo: (values.repo ?? '').trim(),
+    policy: (values.policy ?? '').trim(),
+    now: (values.now ?? '').trim(),
+    help: Boolean(help),
+  };
+}
+function printHelp() {
+  process.stdout.write(`
+Usage:
+  node scripts/suitability-close-execute.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--policy <path>] [--now <ISO8601>]
+  node scripts/suitability-close-execute.mjs --issue <number> --claim-id <claim-id> --agent-id <agent-id> [--owner <owner>] [--repo <repo>] [--policy <path>] [--now <ISO8601>] [--apply]
+
+  #1485: the gated pre-claim high-confidence duplicate/superseded close.
+  Default (no --apply): dry-run. Evaluates Check 4's high-confidence tier
+  (reusing #1484's detection kernel verbatim) and prints { ready, eligible,
+  evidence } without mutating.
+
+  --apply: requires --claim-id and --agent-id (the already-posted
+  suitability-close/<issue>-<slug> coordination claim -- this helper does
+  NOT post that claim itself). Re-validates the claim and re-collects
+  evidence immediately before mutating; posts the evidence-bound close
+  comment, closes the issue, and releases the claim, in that order. Fails
+  closed (exit 1, no mutation) on any lost/stale/non-owned claim or a
+  no-longer-eligible fresh evaluation.
+
+  Never fires on the weak title/declaration heuristic -- only a
+  tier: 'high-confidence' verdict from evaluateHighConfidenceDuplicate.
+`);
+}
+function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (args.issue === null) {
+    throw new Error('--issue is required and must be a positive integer');
+  }
+  if (args.apply && (!args.claimId || !args.agentId)) {
+    throw new Error('--apply requires --claim-id and --agent-id');
+  }
+  const deps = createProductionDeps(args);
+  const verdict = runSuitabilityCloseExecute(args, deps);
+  process.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
+  const success = args.apply ? verdict.closed : verdict.ready;
+  process.exit(success ? 0 : 1);
+}
+if (import.meta.main) {
+  try {
+    runCli();
+  } catch (error) {
+    process.stderr.write(`Error: ${error.message}\n`);
+    process.exit(1);
+  }
+}

--- a/scripts/suitability-close-execute.mjs
+++ b/scripts/suitability-close-execute.mjs
@@ -158,6 +158,27 @@ export function buildSuitabilityCloseComment(evidence) {
   ].join('\n');
 }
 /**
+ * Validate and normalize the apply-time "now" to UTC second-precision ISO
+ * (`YYYY-MM-DDTHH:mm:ssZ`), or `null` when unparseable. Mirrors
+ * `idd-roadmap-audit-execute.mts`'s own `normalizeApplyNow` (Copilot review
+ * finding on PR #2558): `deps.now()`'s production wiring is plain
+ * `new Date().toISOString()`, which always carries millisecond precision,
+ * but `renderUnclaimedByMarker` accepts only second-precision `…Z` and
+ * throws otherwise -- and by the time `releaseClaim` runs, the evidence
+ * comment and the close have already landed, so a throw here would leave
+ * the issue closed with the coordination claim never released. Normalizing
+ * once, fail-closed, before any mutation avoids that partial-completion
+ * state entirely; the single normalized value is reused for both claim
+ * re-validation and the release-marker timestamp.
+ */
+export function normalizeApplyNow(raw) {
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return parsed.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+/**
  * Evaluate (dry-run) and, when ready and `--apply` is set, execute the
  * `#1485` gated close. Dry-run performs NO mutation. `--apply` re-validates
  * the coordination claim and re-collects evidence immediately before
@@ -236,7 +257,21 @@ export function runSuitabilityCloseExecute(args, deps) {
         'no high-confidence signal on this fresh re-evaluation; no mutation',
     };
   }
-  const nowIso = deps.now();
+  const rawNow = deps.now();
+  const nowIso = normalizeApplyNow(rawNow);
+  if (nowIso === null) {
+    return {
+      protocolVersion: '1',
+      mode: 'apply',
+      issueNumber,
+      ready: true,
+      eligible: true,
+      evidence: eligibility.evidence,
+      claim: null,
+      closed: false,
+      result: `deps.now() returned an unparseable timestamp (${rawNow}); no mutation`,
+    };
+  }
   const claim = evaluateSuitabilityCloseClaim(
     deps.loadIssueComments(issueNumber),
     {
@@ -278,7 +313,7 @@ export function runSuitabilityCloseExecute(args, deps) {
       expectedClaimId: args.claimId,
       expectedAgentId: args.agentId,
       isTrustedAuthor: deps.isTrustedAuthor,
-      nowIso: deps.now(),
+      nowIso,
       staleAgeMs: deps.staleAgeMs,
     },
   );

--- a/scripts/suitability-close-execute.mjs
+++ b/scripts/suitability-close-execute.mjs
@@ -27,6 +27,10 @@ import {
   isClaimStaleByAge,
   parseClaimStaleAgeMs,
 } from './discover-roadmap-graph.mjs';
+import {
+  DEFAULT_BUNDLE_IDS,
+  DEFAULT_MANIFEST_PATH,
+} from './discover-shared-file-overlap.mjs';
 import { loadPolicyConfig } from './idd-config.mjs';
 import {
   renderUnclaimedByMarker,
@@ -41,8 +45,6 @@ import { collectHighConfidenceDuplicateEvidence } from './suitability-triage.mjs
 import { evaluateHighConfidenceDuplicate } from './supersession-detection.mjs';
 
 const DEFAULT_CLAIM_STALE_AGE_MS = 24 * 60 * 60 * 1000;
-const DEFAULT_MANIFEST_PATH = 'audit/sync-manifest.json';
-const DEFAULT_BUNDLE_IDS = ['bundle-review', 'bundle-merge'];
 /**
  * Branch pattern for a suitability-close coordination claim on issue
  * `issueNumber`: a logical coordination name (no worktree), mirroring A1.5's
@@ -180,12 +182,17 @@ export function normalizeApplyNow(raw) {
 }
 /**
  * Evaluate (dry-run) and, when ready and `--apply` is set, execute the
- * `#1485` gated close. Dry-run performs NO mutation. `--apply` re-validates
- * the coordination claim and re-collects evidence immediately before
- * mutating -- both must still hold at that instant, not merely at some
- * earlier check -- then posts the evidence-bound close comment, closes the
- * issue, and releases the claim, in that order. Fails closed (no mutation)
- * on a lost/stale/non-owned claim or a no-longer-eligible fresh evaluation.
+ * `#1485` gated close. Dry-run performs NO mutation. `--apply` validates the
+ * coordination claim FIRST (cheap: one comment fetch) before re-collecting
+ * evidence (up to ~50 sequential `gh pr view` calls in the worst case) --
+ * an already-lost/stale/non-owned claim can never mutate regardless of what
+ * evidence collection would find, so checking it first avoids burning API
+ * calls for no benefit. Re-validates the claim a second time immediately
+ * before the actual close mutation (the comment POST is itself a network
+ * round-trip another session's takeover could race during), then posts the
+ * evidence-bound close comment, closes the issue, and releases the claim,
+ * in that order. Fails closed (no mutation) on a lost/stale/non-owned claim
+ * at either check, or a no-longer-eligible fresh evaluation.
  */
 export function runSuitabilityCloseExecute(args, deps) {
   // Copilot review finding on PR #2558: `runCli` validates `args.issue !==
@@ -226,9 +233,9 @@ export function runSuitabilityCloseExecute(args, deps) {
       result: `issue #${issueNumber} not found or inaccessible`,
     };
   }
-  const checkOutcome = deps.collectEvidence(issue);
-  const eligibility = evaluateSuitabilityCloseEligibility(checkOutcome);
   if (!args.apply) {
+    const checkOutcome = deps.collectEvidence(issue);
+    const eligibility = evaluateSuitabilityCloseEligibility(checkOutcome);
     return {
       protocolVersion: '1',
       mode: 'dry-run',
@@ -243,7 +250,9 @@ export function runSuitabilityCloseExecute(args, deps) {
         : 'no high-confidence signal; not ready to close',
     };
   }
-  if (!eligibility.eligible) {
+  const rawNow = deps.now();
+  const nowIso = normalizeApplyNow(rawNow);
+  if (nowIso === null) {
     return {
       protocolVersion: '1',
       mode: 'apply',
@@ -253,25 +262,16 @@ export function runSuitabilityCloseExecute(args, deps) {
       evidence: null,
       claim: null,
       closed: false,
-      result:
-        'no high-confidence signal on this fresh re-evaluation; no mutation',
-    };
-  }
-  const rawNow = deps.now();
-  const nowIso = normalizeApplyNow(rawNow);
-  if (nowIso === null) {
-    return {
-      protocolVersion: '1',
-      mode: 'apply',
-      issueNumber,
-      ready: true,
-      eligible: true,
-      evidence: eligibility.evidence,
-      claim: null,
-      closed: false,
       result: `deps.now() returned an unparseable timestamp (${rawNow}); no mutation`,
     };
   }
+  // Copilot review finding on PR #2558 (suppressed comment): check claim
+  // ownership BEFORE collectEvidence -- an already-lost/stale/non-owned
+  // claim means --apply can never mutate regardless of what evidence
+  // collection finds, so running it first only burns gh API calls (up to
+  // ~50 sequential PR fetches in the worst case) for no benefit. Matches
+  // the docstring's own "re-validate... then re-collect evidence
+  // immediately before mutating" contract order.
   const claim = evaluateSuitabilityCloseClaim(
     deps.loadIssueComments(issueNumber),
     {
@@ -288,12 +288,28 @@ export function runSuitabilityCloseExecute(args, deps) {
       protocolVersion: '1',
       mode: 'apply',
       issueNumber,
-      ready: true,
-      eligible: true,
-      evidence: eligibility.evidence,
+      ready: false,
+      eligible: false,
+      evidence: null,
       claim,
       closed: false,
       result: `coordination claim not owned (${claim.reason}); no mutation`,
+    };
+  }
+  const checkOutcome = deps.collectEvidence(issue);
+  const eligibility = evaluateSuitabilityCloseEligibility(checkOutcome);
+  if (!eligibility.eligible) {
+    return {
+      protocolVersion: '1',
+      mode: 'apply',
+      issueNumber,
+      ready: false,
+      eligible: false,
+      evidence: null,
+      claim,
+      closed: false,
+      result:
+        'no high-confidence signal on this fresh re-evaluation; no mutation',
     };
   }
   const evidence = eligibility.evidence;
@@ -436,7 +452,12 @@ function createProductionDeps(args) {
       port.postWorkItemComment(issueNumber, body);
     },
     closeIssue: (issueNumber) => {
-      port.closeWorkItem(issueNumber, 'not_planned');
+      // Copilot review finding on PR #2558: 'not_planned' reads as "won't
+      // fix", but this path fires only when the work is ALREADY shipped
+      // (a merged closing PR, or a merged PR that already changed the
+      // candidate's own files) -- 'completed' matches that semantics and
+      // idd-roadmap-audit-execute.mts's own closeReason convention.
+      port.closeWorkItem(issueNumber, 'completed');
     },
     releaseClaim: (issueNumber, fields) => {
       port.postWorkItemComment(issueNumber, renderUnclaimedByMarker(fields));

--- a/scripts/suitability-close-execute.mjs
+++ b/scripts/suitability-close-execute.mjs
@@ -173,7 +173,11 @@ export function runSuitabilityCloseExecute(args, deps) {
   // still pass `issue: null`. Re-check here instead of trusting the `as
   // number` cast, so a direct call degrades to a clean not-found verdict
   // rather than an unsafe null flowing into `deps.getIssue`.
-  if (args.issue === null || !Number.isInteger(args.issue)) {
+  // Copilot review finding on PR #2558: Number.isInteger(-1) is true, so
+  // the earlier null + integer-ness guard alone still let a negative
+  // issue number through to deps.getIssue. Require positive, matching the
+  // error message's own "must be a positive integer" contract.
+  if (args.issue === null || !Number.isInteger(args.issue) || args.issue <= 0) {
     return {
       protocolVersion: '1',
       mode: args.apply ? 'apply' : 'dry-run',

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -1848,9 +1848,13 @@ export function resolveInputMode(args) {
  * evidence" (that would mask a genuinely broken collector as a clean pass),
  * and never discarding a sibling signal that already collected cleanly.
  * `gh`/API fetch failures in any block are always recorded here; a
- * manifest-unavailable same-candidate-files skip is a distinct, deliberate
- * degradation documented on `loadHighContentionFiles` itself, not a fetch
- * failure, so it is not added to this list. This is also why a failure here
+ * manifest-unavailable same-candidate-files skip (documented on
+ * `loadHighContentionFiles` itself) is a distinct, deliberate degradation
+ * rather than a genuine fetch failure, but it still pushes its own
+ * `collectionWarnings` entry below -- Check 4 must degrade to exact-title-only
+ * for this case exactly as it does for a real `gh`/API failure (Copilot
+ * review finding on PR #2558: an earlier version of this comment claimed
+ * the opposite). This is also why a failure here
  * never throws out to the caller -- this tier is an optional enhancement
  * layered onto Check 4, and Check 4's own documented Edge Case ("Timeout on
  * duplicate detection... fall back to exact title match only") already

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -1827,6 +1827,122 @@ export function resolveInputMode(args) {
   }
   return args.bodyFile !== undefined || args.stdin ? 'local' : 'issue';
 }
+/**
+ * #1485: `runCli`'s own Check 4 high-confidence evidence-collection block,
+ * extracted (pure move, no behavior change) so `suitability-close-execute.mts`
+ * can reuse the identical fetch orchestration instead of duplicating it --
+ * `#1485`'s own acceptance criteria require the mechanical check to be
+ * "reused, not duplicated." Assumes the caller has already confirmed Checks
+ * 1-3 pass for this candidate (as `runCli`'s own `shouldCollectEvidence` gate
+ * does; `suitability-close-execute.mts` only ever runs after A4.5's Decision
+ * Flow has already reached Check 4 for the same reason) -- this function
+ * itself applies no such gate and always collects.
+ *
+ * The three mechanical signals (closedByPullRequestsReferences, the
+ * branch-name-exact-match lookup, and the same-candidate-files merged-PR
+ * scan) are collected in separate try/catch blocks: an earlier version
+ * wrapped the first two in one block, so a failure collecting the second
+ * signal discarded an already-successful first signal too. Each block's own
+ * failure is recorded independently in `collectionWarnings` and degrades
+ * only that one signal to empty/absent -- never silently reported as "no
+ * evidence" (that would mask a genuinely broken collector as a clean pass),
+ * and never discarding a sibling signal that already collected cleanly.
+ * `gh`/API fetch failures in any block are always recorded here; a
+ * manifest-unavailable same-candidate-files skip is a distinct, deliberate
+ * degradation documented on `loadHighContentionFiles` itself, not a fetch
+ * failure, so it is not added to this list. This is also why a failure here
+ * never throws out to the caller -- this tier is an optional enhancement
+ * layered onto Check 4, and Check 4's own documented Edge Case ("Timeout on
+ * duplicate detection... fall back to exact title match only") already
+ * anticipates exactly this degradation.
+ */
+export function collectHighConfidenceDuplicateEvidence(
+  owner,
+  repo,
+  repoRef,
+  issue,
+  manifestPath,
+  bundleIds,
+) {
+  const collectionWarnings = [];
+  let closedByMergedPrNumbers = [];
+  let candidateFiles = [];
+  let highContentionFiles = [];
+  let mergedPrs = [];
+  let branchNameMergedPr = null;
+  try {
+    closedByMergedPrNumbers = fetchClosedByMergedPrNumbers(
+      owner,
+      repo,
+      issue.number,
+    );
+  } catch (error) {
+    collectionWarnings.push(
+      `closedByPullRequestsReferences: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  try {
+    branchNameMergedPr = fetchMergedPrByBranchName(
+      repoRef,
+      computeBranchName(issue.number, issue.title),
+      owner,
+    );
+  } catch (error) {
+    collectionWarnings.push(
+      `branch-name merged-PR lookup: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  try {
+    candidateFiles = parseCandidateFiles(issue.body);
+    const resolvedHighContentionFiles =
+      candidateFiles.length > 0
+        ? loadHighContentionFiles(manifestPath, bundleIds)
+        : null;
+    const shouldScanMergedPrs =
+      candidateFiles.length > 0 &&
+      resolvedHighContentionFiles !== null &&
+      issue.createdAt.length > 0;
+    highContentionFiles = resolvedHighContentionFiles ?? [];
+    if (candidateFiles.length > 0 && resolvedHighContentionFiles === null) {
+      collectionWarnings.push(
+        'same-candidate-files scan: high-contention manifest unavailable, skipping the scan',
+      );
+    }
+    if (shouldScanMergedPrs) {
+      const scanResult = fetchMergedPrFileOverlapEvidence(
+        repoRef,
+        issue.createdAt,
+        candidateFiles,
+        highContentionFiles,
+        issue.number,
+      );
+      mergedPrs = scanResult.mergedPrs;
+      if (scanResult.truncatedByDeadline) {
+        collectionWarnings.push(
+          'same-candidate-files scan: truncated by MERGED_PR_SCAN_DEADLINE_MS before scanning every merged PR in the window',
+        );
+      }
+    } else {
+      mergedPrs = [];
+    }
+  } catch (error) {
+    collectionWarnings.push(
+      `same-candidate-files scan: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    candidateFiles = [];
+    mergedPrs = [];
+  }
+  return {
+    highConfidenceDuplicate: {
+      closedByMergedPrNumbers,
+      candidateFiles,
+      highContentionFiles,
+      mergedPrs,
+      branchNameMergedPr,
+    },
+    collectionWarnings,
+  };
+}
 function runCli() {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
@@ -1924,127 +2040,33 @@ function runCli() {
     checkRepositoryFit(preEvidenceContext).pass &&
     checkCoherence(preEvidenceContext).pass &&
     checkTrustSafety(preEvidenceContext).pass;
-  // #1484: high-confidence Check 4 tier evidence. The two mechanical signals
-  // (closedByPullRequestsReferences, and the same-candidate-files merged-PR
-  // scan) are collected in two SEPARATE try/catch blocks (CodeRabbit review
-  // finding on this PR): an earlier version wrapped both in one block, so a
-  // failure collecting the second signal discarded an already-successful
-  // first signal too. Each block's own failure is recorded independently in
-  // `collectionWarnings` and degrades only that one signal to empty/absent
-  // -- never silently reported as "no evidence" (that would mask a
-  // genuinely broken collector as a clean pass), and never discarding a
-  // sibling signal that already collected cleanly. `gh`/API fetch failures
-  // in either block are always recorded here; a manifest-unavailable
-  // same-candidate-files skip is a distinct, deliberate degradation
-  // documented on `loadHighContentionFiles` itself, not a fetch failure, so
-  // it is not added to this list (Copilot review finding on this PR: an
-  // earlier comment overclaimed that every degradation path surfaces here).
-  // This is also why an uncaught failure no longer aborts the entire
-  // 7-check evaluation (Codex review finding on this PR) -- this tier is an
-  // optional enhancement layered onto Check 4, and Check 4's own documented
-  // Edge Case ("Timeout on duplicate detection... fall back to exact title
-  // match only") already anticipates exactly this degradation. Both blocks
-  // below run only when `shouldCollectEvidence` is true (#1815) -- when it
-  // is false, Check 4 is never reached anyway, so `collectionWarnings`
-  // correctly stays empty (this is a deliberate skip, not a collection
-  // failure).
-  const collectionWarnings = [];
-  let closedByMergedPrNumbers = [];
-  let candidateFiles = [];
-  let highContentionFiles = [];
-  let mergedPrs = [];
-  let branchNameMergedPr = null;
-  if (shouldCollectEvidence) {
-    try {
-      closedByMergedPrNumbers = fetchClosedByMergedPrNumbers(
-        owner,
-        repo,
-        args.issue,
-      );
-    } catch (error) {
-      collectionWarnings.push(
-        `closedByPullRequestsReferences: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    }
-    // #2313, Signal 3: a separate try/catch (same pattern as the two blocks
-    // above/below) so a failure here degrades only this one signal, never
-    // discarding a sibling signal that already collected cleanly.
-    try {
-      branchNameMergedPr = fetchMergedPrByBranchName(
-        repoRef,
-        computeBranchName(issue.number, issue.title),
-        owner,
-      );
-    } catch (error) {
-      collectionWarnings.push(
-        `branch-name merged-PR lookup: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    }
-    try {
-      candidateFiles = parseCandidateFiles(issue.body);
-      // Only resolve the high-contention exclusion set (a file read + JSON
-      // parse) when there is a '## Candidate files' section to check it
-      // against -- most issues have none, and the result would otherwise be
-      // discarded.
-      const resolvedHighContentionFiles =
-        candidateFiles.length > 0
-          ? loadHighContentionFiles(
-              args.manifest,
-              args.bundles ?? DEFAULT_BUNDLE_IDS,
-            )
-          : null;
-      const shouldScanMergedPrs =
-        candidateFiles.length > 0 &&
-        resolvedHighContentionFiles !== null &&
-        issue.createdAt.length > 0;
-      highContentionFiles = resolvedHighContentionFiles ?? [];
-      if (candidateFiles.length > 0 && resolvedHighContentionFiles === null) {
-        // Codex P2 review finding: an unreadable/missing high-contention
-        // manifest silently skipped the same-candidate-files scan without
-        // recording a warning -- but from Check 4's perspective this is the
-        // same class of "high-confidence evidence could not be collected" as
-        // a genuine gh/API failure, and must degrade the same way (exact
-        // title match only), not let the full weak heuristic run.
-        collectionWarnings.push(
-          'same-candidate-files scan: high-contention manifest unavailable, skipping the scan',
-        );
-      }
-      if (shouldScanMergedPrs) {
-        const scanResult = fetchMergedPrFileOverlapEvidence(
-          repoRef,
-          issue.createdAt,
-          candidateFiles,
-          highContentionFiles,
-          issue.number,
-        );
-        mergedPrs = scanResult.mergedPrs;
-        if (scanResult.truncatedByDeadline) {
-          // Codex P2 review finding: a deadline-truncated scan returns
-          // normally (not a throw), so it must record its own warning here --
-          // otherwise Check 4 would run the full weak heuristic on
-          // incomplete evidence instead of degrading to exact-title-only.
-          collectionWarnings.push(
-            'same-candidate-files scan: truncated by MERGED_PR_SCAN_DEADLINE_MS before scanning every merged PR in the window',
-          );
-        }
-      } else {
-        mergedPrs = [];
-      }
-    } catch (error) {
-      collectionWarnings.push(
-        `same-candidate-files scan: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      candidateFiles = [];
-      mergedPrs = [];
-    }
-  }
-  const highConfidenceDuplicate = {
-    closedByMergedPrNumbers,
-    candidateFiles,
-    highContentionFiles,
-    mergedPrs,
-    branchNameMergedPr,
+  // #1484: high-confidence Check 4 tier evidence, collected by
+  // `collectHighConfidenceDuplicateEvidence` below only when
+  // `shouldCollectEvidence` is true (#1815) -- when it is false, Check 4 is
+  // never reached anyway, so `collectionWarnings` correctly stays empty
+  // (this is a deliberate skip, not a collection failure). See that
+  // function's own doc comment for the per-signal try/catch and
+  // degradation rationale.
+  let collectionWarnings = [];
+  let highConfidenceDuplicate = {
+    closedByMergedPrNumbers: [],
+    candidateFiles: [],
+    highContentionFiles: [],
+    mergedPrs: [],
+    branchNameMergedPr: null,
   };
+  if (shouldCollectEvidence) {
+    const evidence = collectHighConfidenceDuplicateEvidence(
+      owner,
+      repo,
+      repoRef,
+      issue,
+      args.manifest,
+      args.bundles ?? DEFAULT_BUNDLE_IDS,
+    );
+    highConfidenceDuplicate = evidence.highConfidenceDuplicate;
+    collectionWarnings = evidence.collectionWarnings;
+  }
   const result = evaluateSuitability(issue, {
     repository: { owner, repo },
     duplicateCandidates,
@@ -2621,7 +2643,7 @@ function fetchIssueComments(repoRef, issueNumber) {
  * remaining work would still show its old merged closing PR and get
  * misclassified as a completed duplicate (Codex review finding on this PR).
  */
-function fetchClosedByMergedPrNumbers(owner, repo, issueNumber) {
+export function fetchClosedByMergedPrNumbers(owner, repo, issueNumber) {
   const parsed = ghJson(buildClosedByMergedPrArgs(owner, repo, issueNumber));
   // `gh api graphql` exits non-zero (throwing via runGh) on a schema-level
   // query error, but a GraphQL response can also return HTTP 200 with a
@@ -2659,7 +2681,7 @@ function fetchClosedByMergedPrNumbers(owner, repo, issueNumber) {
  * directly, matching the rest of this file's "never trust the shape of a
  * `gh` JSON response" convention.
  */
-function fetchMergedPrByBranchName(repoRef, branchName, owner) {
+export function fetchMergedPrByBranchName(repoRef, branchName, owner) {
   const list = ghJsonArray(buildMergedPrByBranchArgs(repoRef, branchName));
   const normalizedOwner = owner.trim().toLowerCase();
   for (const entry of list) {

--- a/src/bin/idd-suitability-close-execute.mts
+++ b/src/bin/idd-suitability-close-execute.mts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-suitability-close-execute.mts
+//
+// The bin/idd-suitability-close-execute.mjs copy is generated from the .mts source named above
+// by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+
+import { runHelper } from './run-helper.mts';
+
+runHelper('../scripts/suitability-close-execute.mjs');

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -606,6 +606,15 @@ const HELPER_COMMANDS: HelperCommand[] = [
     contractPaths: ['schemas/stalled-session-quiet-check.schema.json'],
   },
   {
+    id: 'suitability-close-execute',
+    scriptName: 'idd:suitability-close-execute',
+    binName: 'idd-suitability-close-execute',
+    entryPath: 'scripts/suitability-close-execute.mjs',
+    vendoredCommand: 'node scripts/suitability-close-execute.mjs',
+    description:
+      'Evaluate the #1485 gated A4.5 high-confidence duplicate/superseded close (dry-run) and, with --apply, post the evidence comment, close the issue, and release the suitability-close coordination claim.',
+  },
+  {
     id: 'suitability-triage',
     scriptName: 'idd:suitability-triage',
     binName: 'idd-suitability-triage',

--- a/src/scripts/suitability-close-execute.mts
+++ b/src/scripts/suitability-close-execute.mts
@@ -591,13 +591,26 @@ export function parseArgs(argv: string[]): SuitabilityCloseExecuteArgs {
   const parsedIssue =
     issueRaw !== undefined && /^\d+$/.test(issueRaw) ? Number(issueRaw) : null;
   const issue = parsedIssue !== null && parsedIssue > 0 ? parsedIssue : null;
+  const owner = ((values.owner as string | undefined) ?? '').trim();
+  const repo = ((values.repo as string | undefined) ?? '').trim();
+  // Copilot review finding on PR #2558: exactly one of --owner/--repo would
+  // mix a caller-supplied repo with resolveCurrentGithubRepository()'s
+  // current-directory repo in createProductionDeps, potentially targeting
+  // the wrong repository for issue lookup/close. Mirrors
+  // idd-roadmap-audit-execute.mts's own --owner/--repo pairing guard:
+  // require both or neither.
+  if ((owner === '') !== (repo === '')) {
+    throw new Error(
+      'suitability-close-execute: --owner and --repo must be provided together or not at all',
+    );
+  }
   return {
     issue,
     apply: Boolean(values.apply),
     claimId: ((values['claim-id'] as string | undefined) ?? '').trim(),
     agentId: ((values['agent-id'] as string | undefined) ?? '').trim(),
-    owner: ((values.owner as string | undefined) ?? '').trim(),
-    repo: ((values.repo as string | undefined) ?? '').trim(),
+    owner,
+    repo,
     policy: ((values.policy as string | undefined) ?? '').trim(),
     now: ((values.now as string | undefined) ?? '').trim(),
     help: Boolean(help),

--- a/src/scripts/suitability-close-execute.mts
+++ b/src/scripts/suitability-close-execute.mts
@@ -351,6 +351,40 @@ export function runSuitabilityCloseExecute(
 
   const evidence = eligibility.evidence as string;
   deps.postCloseComment(issueNumber, buildSuitabilityCloseComment(evidence));
+
+  // Copilot review finding on PR #2558 (suppressed comment): the claim was
+  // validated once, above, before posting the comment -- but the comment
+  // POST is itself a network round-trip another session's takeover could
+  // race during. Re-validate immediately before the actual close mutation,
+  // mirroring idd-roadmap-audit-execute.mts's own re-validate-before-close
+  // pattern, so a claim lost in the comment->close gap aborts the close
+  // (the claim's rightful new owner still sees the evidence comment, but
+  // this session never closes an issue it no longer owns).
+  const finalClaim = evaluateSuitabilityCloseClaim(
+    deps.loadIssueComments(issueNumber),
+    {
+      issueNumber,
+      expectedClaimId: args.claimId,
+      expectedAgentId: args.agentId,
+      isTrustedAuthor: deps.isTrustedAuthor,
+      nowIso: deps.now(),
+      staleAgeMs: deps.staleAgeMs,
+    },
+  );
+  if (!finalClaim.owned) {
+    return {
+      protocolVersion: '1',
+      mode: 'apply',
+      issueNumber,
+      ready: true,
+      eligible: true,
+      evidence,
+      claim: finalClaim,
+      closed: false,
+      result: `coordination claim lost between the comment and the close (${finalClaim.reason}); issue left open`,
+    };
+  }
+
   deps.closeIssue(issueNumber);
   deps.releaseClaim(issueNumber, {
     agentId: args.agentId,
@@ -365,7 +399,7 @@ export function runSuitabilityCloseExecute(
     ready: true,
     eligible: true,
     evidence,
-    claim,
+    claim: finalClaim,
     closed: true,
     result: 'closed: high-confidence duplicate/superseded, evidence posted',
   };
@@ -505,14 +539,18 @@ const SUITABILITY_CLOSE_EXECUTE_FLAG_SPEC = {
   '--help': { type: 'boolean', short: 'h' },
 } as const;
 
-function parseArgs(argv: string[]): SuitabilityCloseExecuteArgs {
+export function parseArgs(argv: string[]): SuitabilityCloseExecuteArgs {
   const { values, help } = parseCliArgs(
     argv,
     SUITABILITY_CLOSE_EXECUTE_FLAG_SPEC,
   );
+  // Copilot review finding on PR #2558 (suppressed comment): /^\d+$/ alone
+  // accepts "0", which would then attempt to load/close issue #0. Require a
+  // genuinely positive integer, matching runCli's own --issue validation.
   const issueRaw = values.issue as string | undefined;
-  const issue =
+  const parsedIssue =
     issueRaw !== undefined && /^\d+$/.test(issueRaw) ? Number(issueRaw) : null;
+  const issue = parsedIssue !== null && parsedIssue > 0 ? parsedIssue : null;
   return {
     issue,
     apply: Boolean(values.apply),

--- a/src/scripts/suitability-close-execute.mts
+++ b/src/scripts/suitability-close-execute.mts
@@ -28,6 +28,10 @@ import {
   isClaimStaleByAge,
   parseClaimStaleAgeMs,
 } from './discover-roadmap-graph.mts';
+import {
+  DEFAULT_BUNDLE_IDS,
+  DEFAULT_MANIFEST_PATH,
+} from './discover-shared-file-overlap.mts';
 import { loadPolicyConfig } from './idd-config.mts';
 import type { ClaimValidationSummary } from './protocol-helpers.mts';
 import {
@@ -47,8 +51,6 @@ import {
 } from './supersession-detection.mts';
 
 const DEFAULT_CLAIM_STALE_AGE_MS = 24 * 60 * 60 * 1000;
-const DEFAULT_MANIFEST_PATH = 'audit/sync-manifest.json';
-const DEFAULT_BUNDLE_IDS = ['bundle-review', 'bundle-merge'];
 
 /**
  * Branch pattern for a suitability-close coordination claim on issue
@@ -265,12 +267,17 @@ export interface SuitabilityCloseExecuteArgs {
 
 /**
  * Evaluate (dry-run) and, when ready and `--apply` is set, execute the
- * `#1485` gated close. Dry-run performs NO mutation. `--apply` re-validates
- * the coordination claim and re-collects evidence immediately before
- * mutating -- both must still hold at that instant, not merely at some
- * earlier check -- then posts the evidence-bound close comment, closes the
- * issue, and releases the claim, in that order. Fails closed (no mutation)
- * on a lost/stale/non-owned claim or a no-longer-eligible fresh evaluation.
+ * `#1485` gated close. Dry-run performs NO mutation. `--apply` validates the
+ * coordination claim FIRST (cheap: one comment fetch) before re-collecting
+ * evidence (up to ~50 sequential `gh pr view` calls in the worst case) --
+ * an already-lost/stale/non-owned claim can never mutate regardless of what
+ * evidence collection would find, so checking it first avoids burning API
+ * calls for no benefit. Re-validates the claim a second time immediately
+ * before the actual close mutation (the comment POST is itself a network
+ * round-trip another session's takeover could race during), then posts the
+ * evidence-bound close comment, closes the issue, and releases the claim,
+ * in that order. Fails closed (no mutation) on a lost/stale/non-owned claim
+ * at either check, or a no-longer-eligible fresh evaluation.
  */
 export function runSuitabilityCloseExecute(
   args: SuitabilityCloseExecuteArgs,
@@ -315,10 +322,9 @@ export function runSuitabilityCloseExecute(
     };
   }
 
-  const checkOutcome = deps.collectEvidence(issue);
-  const eligibility = evaluateSuitabilityCloseEligibility(checkOutcome);
-
   if (!args.apply) {
+    const checkOutcome = deps.collectEvidence(issue);
+    const eligibility = evaluateSuitabilityCloseEligibility(checkOutcome);
     return {
       protocolVersion: '1',
       mode: 'dry-run',
@@ -334,7 +340,9 @@ export function runSuitabilityCloseExecute(
     };
   }
 
-  if (!eligibility.eligible) {
+  const rawNow = deps.now();
+  const nowIso = normalizeApplyNow(rawNow);
+  if (nowIso === null) {
     return {
       protocolVersion: '1',
       mode: 'apply',
@@ -344,26 +352,17 @@ export function runSuitabilityCloseExecute(
       evidence: null,
       claim: null,
       closed: false,
-      result:
-        'no high-confidence signal on this fresh re-evaluation; no mutation',
-    };
-  }
-
-  const rawNow = deps.now();
-  const nowIso = normalizeApplyNow(rawNow);
-  if (nowIso === null) {
-    return {
-      protocolVersion: '1',
-      mode: 'apply',
-      issueNumber,
-      ready: true,
-      eligible: true,
-      evidence: eligibility.evidence,
-      claim: null,
-      closed: false,
       result: `deps.now() returned an unparseable timestamp (${rawNow}); no mutation`,
     };
   }
+
+  // Copilot review finding on PR #2558 (suppressed comment): check claim
+  // ownership BEFORE collectEvidence -- an already-lost/stale/non-owned
+  // claim means --apply can never mutate regardless of what evidence
+  // collection finds, so running it first only burns gh API calls (up to
+  // ~50 sequential PR fetches in the worst case) for no benefit. Matches
+  // the docstring's own "re-validate... then re-collect evidence
+  // immediately before mutating" contract order.
   const claim = evaluateSuitabilityCloseClaim(
     deps.loadIssueComments(issueNumber),
     {
@@ -380,12 +379,29 @@ export function runSuitabilityCloseExecute(
       protocolVersion: '1',
       mode: 'apply',
       issueNumber,
-      ready: true,
-      eligible: true,
-      evidence: eligibility.evidence,
+      ready: false,
+      eligible: false,
+      evidence: null,
       claim,
       closed: false,
       result: `coordination claim not owned (${claim.reason}); no mutation`,
+    };
+  }
+
+  const checkOutcome = deps.collectEvidence(issue);
+  const eligibility = evaluateSuitabilityCloseEligibility(checkOutcome);
+  if (!eligibility.eligible) {
+    return {
+      protocolVersion: '1',
+      mode: 'apply',
+      issueNumber,
+      ready: false,
+      eligible: false,
+      evidence: null,
+      claim,
+      closed: false,
+      result:
+        'no high-confidence signal on this fresh re-evaluation; no mutation',
     };
   }
 
@@ -553,7 +569,12 @@ function createProductionDeps(
       port.postWorkItemComment(issueNumber, body);
     },
     closeIssue: (issueNumber) => {
-      port.closeWorkItem(issueNumber, 'not_planned');
+      // Copilot review finding on PR #2558: 'not_planned' reads as "won't
+      // fix", but this path fires only when the work is ALREADY shipped
+      // (a merged closing PR, or a merged PR that already changed the
+      // candidate's own files) -- 'completed' matches that semantics and
+      // idd-roadmap-audit-execute.mts's own closeReason convention.
+      port.closeWorkItem(issueNumber, 'completed');
     },
     releaseClaim: (issueNumber, fields) => {
       port.postWorkItemComment(issueNumber, renderUnclaimedByMarker(fields));

--- a/src/scripts/suitability-close-execute.mts
+++ b/src/scripts/suitability-close-execute.mts
@@ -260,7 +260,11 @@ export function runSuitabilityCloseExecute(
   // still pass `issue: null`. Re-check here instead of trusting the `as
   // number` cast, so a direct call degrades to a clean not-found verdict
   // rather than an unsafe null flowing into `deps.getIssue`.
-  if (args.issue === null || !Number.isInteger(args.issue)) {
+  // Copilot review finding on PR #2558: Number.isInteger(-1) is true, so
+  // the earlier null + integer-ness guard alone still let a negative
+  // issue number through to deps.getIssue. Require positive, matching the
+  // error message's own "must be a positive integer" contract.
+  if (args.issue === null || !Number.isInteger(args.issue) || args.issue <= 0) {
     return {
       protocolVersion: '1',
       mode: args.apply ? 'apply' : 'dry-run',

--- a/src/scripts/suitability-close-execute.mts
+++ b/src/scripts/suitability-close-execute.mts
@@ -166,14 +166,22 @@ export function evaluateSuitabilityCloseEligibility(
 /** Render the evidence-bound closing comment. `evidence` is always the
  * machine-derivable string `evaluateHighConfidenceDuplicate` itself already
  * produces (PR number(s) and/or overlapping file path(s)) -- this renderer
- * adds no prose evidence of its own. */
+ * adds no prose evidence of its own.
+ *
+ * Copilot review finding on PR #2558: `runSuitabilityCloseExecute` posts
+ * this comment BEFORE calling `closeIssue` (evidence-first, matching
+ * `idd-roadmap-audit-execute.mts`'s own evidence-then-close order), so the
+ * wording below deliberately describes the close as in-progress rather
+ * than already complete -- a `closeIssue` failure after this comment posts
+ * must never leave a false "already closed" claim on an issue that is
+ * still open. */
 export function buildSuitabilityCloseComment(evidence: string): string {
   return [
     'A4.5 high-confidence duplicate/superseded close',
     '',
     evidence,
     '',
-    '_This candidate was closed autonomously under the `#1485` gated',
+    '_Closing this candidate autonomously under the `#1485` gated',
     'pre-claim close path: a strong mechanical signal only (closing-PR',
     'reference, same-`## Candidate files` overlap, or an exact',
     'branch-name match), never the weak title/declaration heuristic. If',
@@ -246,7 +254,26 @@ export function runSuitabilityCloseExecute(
   args: SuitabilityCloseExecuteArgs,
   deps: SuitabilityCloseExecuteDeps,
 ): SuitabilityCloseExecuteVerdict {
-  const issueNumber = args.issue as number;
+  // Copilot review finding on PR #2558: `runCli` validates `args.issue !==
+  // null` before ever constructing `args`, but that guard lives outside
+  // this exported function -- a direct caller (bypassing `runCli`) could
+  // still pass `issue: null`. Re-check here instead of trusting the `as
+  // number` cast, so a direct call degrades to a clean not-found verdict
+  // rather than an unsafe null flowing into `deps.getIssue`.
+  if (args.issue === null || !Number.isInteger(args.issue)) {
+    return {
+      protocolVersion: '1',
+      mode: args.apply ? 'apply' : 'dry-run',
+      issueNumber: Number.NaN,
+      ready: false,
+      eligible: false,
+      evidence: null,
+      claim: null,
+      closed: false,
+      result: '--issue is required and must be a positive integer',
+    };
+  }
+  const issueNumber = args.issue;
   const issue = deps.getIssue(issueNumber);
   if (!issue) {
     return {

--- a/src/scripts/suitability-close-execute.mts
+++ b/src/scripts/suitability-close-execute.mts
@@ -190,6 +190,28 @@ export function buildSuitabilityCloseComment(evidence: string): string {
   ].join('\n');
 }
 
+/**
+ * Validate and normalize the apply-time "now" to UTC second-precision ISO
+ * (`YYYY-MM-DDTHH:mm:ssZ`), or `null` when unparseable. Mirrors
+ * `idd-roadmap-audit-execute.mts`'s own `normalizeApplyNow` (Copilot review
+ * finding on PR #2558): `deps.now()`'s production wiring is plain
+ * `new Date().toISOString()`, which always carries millisecond precision,
+ * but `renderUnclaimedByMarker` accepts only second-precision `…Z` and
+ * throws otherwise -- and by the time `releaseClaim` runs, the evidence
+ * comment and the close have already landed, so a throw here would leave
+ * the issue closed with the coordination claim never released. Normalizing
+ * once, fail-closed, before any mutation avoids that partial-completion
+ * state entirely; the single normalized value is reused for both claim
+ * re-validation and the release-marker timestamp.
+ */
+export function normalizeApplyNow(raw: string): string | null {
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return parsed.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
 export interface SuitabilityCloseExecuteVerdict {
   protocolVersion: '1';
   mode: 'dry-run' | 'apply';
@@ -327,7 +349,21 @@ export function runSuitabilityCloseExecute(
     };
   }
 
-  const nowIso = deps.now();
+  const rawNow = deps.now();
+  const nowIso = normalizeApplyNow(rawNow);
+  if (nowIso === null) {
+    return {
+      protocolVersion: '1',
+      mode: 'apply',
+      issueNumber,
+      ready: true,
+      eligible: true,
+      evidence: eligibility.evidence,
+      claim: null,
+      closed: false,
+      result: `deps.now() returned an unparseable timestamp (${rawNow}); no mutation`,
+    };
+  }
   const claim = evaluateSuitabilityCloseClaim(
     deps.loadIssueComments(issueNumber),
     {
@@ -371,7 +407,7 @@ export function runSuitabilityCloseExecute(
       expectedClaimId: args.claimId,
       expectedAgentId: args.agentId,
       isTrustedAuthor: deps.isTrustedAuthor,
-      nowIso: deps.now(),
+      nowIso,
       staleAgeMs: deps.staleAgeMs,
     },
   );

--- a/src/scripts/suitability-close-execute.mts
+++ b/src/scripts/suitability-close-execute.mts
@@ -1,0 +1,553 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/suitability-close-execute.mts
+//
+// The scripts/suitability-close-execute.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// #1485: the gated pre-claim high-confidence duplicate/superseded close
+// path. Reuses `#1484`'s detect-only Check 4 evidence collection
+// (`collectHighConfidenceDuplicateEvidence` in `suitability-triage.mts`) and
+// evaluation kernel (`evaluateHighConfidenceDuplicate` in
+// `supersession-detection.mts`) verbatim -- this file introduces NO new
+// detection logic, only the gated mutation on top of an already-established
+// `tier: 'high-confidence'` verdict.
+//
+// This helper does NOT post the initial coordination claim itself -- exactly
+// like `idd-roadmap-audit-execute.mts` does not post the A1.5 roadmap-audit
+// claim -- the caller posts it with the generic `post-idd-marker.mjs --type
+// claim --branch suitability-close/<n>-<slug>` path first, then invokes this
+// helper to re-validate it, evaluate close-eligibility, and (under --apply)
+// post the evidence-bound close comment, close the issue, and release the
+// claim, in that order. `--apply` fails closed (no mutation) on any lost /
+// stale / non-owned claim, or when the fresh re-evaluation no longer finds a
+// high-confidence signal.
+
+import { parseCliArgs } from './cli-args.mts';
+import {
+  isClaimStaleByAge,
+  parseClaimStaleAgeMs,
+} from './discover-roadmap-graph.mts';
+import { loadPolicyConfig } from './idd-config.mts';
+import type { ClaimValidationSummary } from './protocol-helpers.mts';
+import {
+  renderUnclaimedByMarker,
+  resolveTrustedMarkerActors,
+  summarizeClaimValidation,
+} from './protocol-helpers.mts';
+import {
+  createGithubProviderAdapter,
+  resolveCurrentGithubRepository,
+} from './provider-adapter-github.mts';
+import type { ProviderPort } from './provider-port.mts';
+import { collectHighConfidenceDuplicateEvidence } from './suitability-triage.mts';
+import {
+  type CheckOutcome,
+  evaluateHighConfidenceDuplicate,
+} from './supersession-detection.mts';
+
+const DEFAULT_CLAIM_STALE_AGE_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_MANIFEST_PATH = 'audit/sync-manifest.json';
+const DEFAULT_BUNDLE_IDS = ['bundle-review', 'bundle-merge'];
+
+/**
+ * Branch pattern for a suitability-close coordination claim on issue
+ * `issueNumber`: a logical coordination name (no worktree), mirroring A1.5's
+ * `roadmap-audit/<n>-<slug>` shape. Scoped to `issueNumber` so this never
+ * matches a claim posted for a different candidate, and its `suitability-
+ * close/*` prefix never matches `issue/*`, so the core cwd-vs-claim gate
+ * (`idd-overview-core.instructions.md`) naturally excludes it from the
+ * worktree-mutation checks that gate applies only to `issue/*` claims.
+ */
+export function suitabilityCloseBranchPattern(issueNumber: number): RegExp {
+  return new RegExp(`^suitability-close/${issueNumber}-`);
+}
+
+/** Verdict shape for {@link evaluateSuitabilityCloseClaim} -- mirrors
+ * `idd-roadmap-audit-execute.mts`'s `RoadmapClaimVerdict` shape so the two
+ * claim-verification surfaces stay recognizably parallel. */
+export interface SuitabilityCloseClaimVerdict {
+  owned: boolean;
+  reason: string;
+  stale: boolean;
+  activeClaim: ClaimValidationSummary['activeClaim'];
+}
+
+/**
+ * Re-validate a suitability-close coordination claim on `options.issueNumber`
+ * against the live comment stream: the active claim must match the expected
+ * claim-id/agent-id (`summarizeClaimValidation`), use the
+ * `suitability-close/<issueNumber>-*` coordination branch (a normal
+ * `issue/*` implementation claim on the same issue never authorizes this
+ * close), and not be stale.
+ */
+export function evaluateSuitabilityCloseClaim(
+  comments: Parameters<typeof summarizeClaimValidation>[0],
+  options: {
+    issueNumber: number;
+    expectedClaimId: string;
+    expectedAgentId?: string;
+    isTrustedAuthor: (login: string) => boolean;
+    nowIso: string;
+    staleAgeMs?: number;
+  },
+): SuitabilityCloseClaimVerdict {
+  const summary = summarizeClaimValidation(comments, {
+    isTrustedAuthor: options.isTrustedAuthor,
+    expectedClaimId: options.expectedClaimId,
+    expectedAgentId: options.expectedAgentId,
+  });
+  if (!summary.matchesExpectedClaim) {
+    return {
+      owned: false,
+      reason: summary.reason,
+      stale: false,
+      activeClaim: summary.activeClaim,
+    };
+  }
+  if (
+    !suitabilityCloseBranchPattern(options.issueNumber).test(
+      summary.activeClaim.branch,
+    )
+  ) {
+    return {
+      owned: false,
+      reason: 'claim-branch-mismatch',
+      stale: false,
+      activeClaim: summary.activeClaim,
+    };
+  }
+  const stale = isClaimStaleByAge(
+    summary.activeClaim.createdAt,
+    options.nowIso,
+    options.staleAgeMs ?? DEFAULT_CLAIM_STALE_AGE_MS,
+  );
+  if (stale) {
+    return {
+      owned: false,
+      reason: 'claim-stale',
+      stale: true,
+      activeClaim: summary.activeClaim,
+    };
+  }
+  return {
+    owned: true,
+    reason: 'match',
+    stale: false,
+    activeClaim: summary.activeClaim,
+  };
+}
+
+/**
+ * The pure close-eligibility decision (#1485's own acceptance criteria:
+ * "on the strong signal only... on any weaker signal it does not close").
+ * Gates on `tier === 'high-confidence'` EXACTLY, never on `pass: false` or
+ * `outcome: duplicate` alone -- a weak title/declaration heuristic hit
+ * shares the identical `pass: false` shape and MUST NOT authorize a close.
+ * `checkOutcome` is `evaluateHighConfidenceDuplicate`'s own return value
+ * (`null` when no strong signal fires, matching that kernel's own
+ * never-fail-toward-a-false-positive contract). Exported and pure so
+ * `tests/*.test.mts` can cover strong-signal-close and no-signal-no-close
+ * without shelling out to `gh`.
+ */
+export function evaluateSuitabilityCloseEligibility(
+  checkOutcome: CheckOutcome | null,
+): { eligible: boolean; evidence: string | null } {
+  if (
+    checkOutcome &&
+    checkOutcome.pass === false &&
+    checkOutcome.tier === 'high-confidence'
+  ) {
+    return { eligible: true, evidence: checkOutcome.evidence };
+  }
+  return { eligible: false, evidence: null };
+}
+
+/** Render the evidence-bound closing comment. `evidence` is always the
+ * machine-derivable string `evaluateHighConfidenceDuplicate` itself already
+ * produces (PR number(s) and/or overlapping file path(s)) -- this renderer
+ * adds no prose evidence of its own. */
+export function buildSuitabilityCloseComment(evidence: string): string {
+  return [
+    'A4.5 high-confidence duplicate/superseded close',
+    '',
+    evidence,
+    '',
+    '_This candidate was closed autonomously under the `#1485` gated',
+    'pre-claim close path: a strong mechanical signal only (closing-PR',
+    'reference, same-`## Candidate files` overlap, or an exact',
+    'branch-name match), never the weak title/declaration heuristic. If',
+    'this close is wrong, reopen the issue -- the close is reversible and',
+    'a wrong close is an accepted, recoverable risk._',
+  ].join('\n');
+}
+
+export interface SuitabilityCloseExecuteVerdict {
+  protocolVersion: '1';
+  mode: 'dry-run' | 'apply';
+  issueNumber: number;
+  ready: boolean;
+  eligible: boolean;
+  evidence: string | null;
+  claim: SuitabilityCloseClaimVerdict | null;
+  closed: boolean;
+  result: string;
+}
+
+export interface SuitabilityCloseExecuteDeps {
+  getIssue: (issueNumber: number) => {
+    number: number;
+    title: string;
+    body: string;
+    createdAt: string;
+  } | null;
+  loadIssueComments: (
+    issueNumber: number,
+  ) => Parameters<typeof summarizeClaimValidation>[0];
+  collectEvidence: (issue: {
+    number: number;
+    title: string;
+    body: string;
+    createdAt: string;
+  }) => CheckOutcome | null;
+  isTrustedAuthor: (login: string) => boolean;
+  postCloseComment: (issueNumber: number, body: string) => void;
+  closeIssue: (issueNumber: number) => void;
+  releaseClaim: (
+    issueNumber: number,
+    fields: { agentId: string; claimId: string; timestamp: string },
+  ) => void;
+  now: () => string;
+  staleAgeMs?: number;
+}
+
+export interface SuitabilityCloseExecuteArgs {
+  issue: number | null;
+  apply: boolean;
+  claimId: string;
+  agentId: string;
+  owner: string;
+  repo: string;
+  policy: string;
+  now: string;
+  help: boolean;
+}
+
+/**
+ * Evaluate (dry-run) and, when ready and `--apply` is set, execute the
+ * `#1485` gated close. Dry-run performs NO mutation. `--apply` re-validates
+ * the coordination claim and re-collects evidence immediately before
+ * mutating -- both must still hold at that instant, not merely at some
+ * earlier check -- then posts the evidence-bound close comment, closes the
+ * issue, and releases the claim, in that order. Fails closed (no mutation)
+ * on a lost/stale/non-owned claim or a no-longer-eligible fresh evaluation.
+ */
+export function runSuitabilityCloseExecute(
+  args: SuitabilityCloseExecuteArgs,
+  deps: SuitabilityCloseExecuteDeps,
+): SuitabilityCloseExecuteVerdict {
+  const issueNumber = args.issue as number;
+  const issue = deps.getIssue(issueNumber);
+  if (!issue) {
+    return {
+      protocolVersion: '1',
+      mode: args.apply ? 'apply' : 'dry-run',
+      issueNumber,
+      ready: false,
+      eligible: false,
+      evidence: null,
+      claim: null,
+      closed: false,
+      result: `issue #${issueNumber} not found or inaccessible`,
+    };
+  }
+
+  const checkOutcome = deps.collectEvidence(issue);
+  const eligibility = evaluateSuitabilityCloseEligibility(checkOutcome);
+
+  if (!args.apply) {
+    return {
+      protocolVersion: '1',
+      mode: 'dry-run',
+      issueNumber,
+      ready: eligibility.eligible,
+      eligible: eligibility.eligible,
+      evidence: eligibility.evidence,
+      claim: null,
+      closed: false,
+      result: eligibility.eligible
+        ? 'high-confidence signal found; ready for --apply'
+        : 'no high-confidence signal; not ready to close',
+    };
+  }
+
+  if (!eligibility.eligible) {
+    return {
+      protocolVersion: '1',
+      mode: 'apply',
+      issueNumber,
+      ready: false,
+      eligible: false,
+      evidence: null,
+      claim: null,
+      closed: false,
+      result:
+        'no high-confidence signal on this fresh re-evaluation; no mutation',
+    };
+  }
+
+  const nowIso = deps.now();
+  const claim = evaluateSuitabilityCloseClaim(
+    deps.loadIssueComments(issueNumber),
+    {
+      issueNumber,
+      expectedClaimId: args.claimId,
+      expectedAgentId: args.agentId,
+      isTrustedAuthor: deps.isTrustedAuthor,
+      nowIso,
+      staleAgeMs: deps.staleAgeMs,
+    },
+  );
+  if (!claim.owned) {
+    return {
+      protocolVersion: '1',
+      mode: 'apply',
+      issueNumber,
+      ready: true,
+      eligible: true,
+      evidence: eligibility.evidence,
+      claim,
+      closed: false,
+      result: `coordination claim not owned (${claim.reason}); no mutation`,
+    };
+  }
+
+  const evidence = eligibility.evidence as string;
+  deps.postCloseComment(issueNumber, buildSuitabilityCloseComment(evidence));
+  deps.closeIssue(issueNumber);
+  deps.releaseClaim(issueNumber, {
+    agentId: args.agentId,
+    claimId: args.claimId,
+    timestamp: nowIso,
+  });
+
+  return {
+    protocolVersion: '1',
+    mode: 'apply',
+    issueNumber,
+    ready: true,
+    eligible: true,
+    evidence,
+    claim,
+    closed: true,
+    result: 'closed: high-confidence duplicate/superseded, evidence posted',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Production dependency wiring (live gh)
+// ---------------------------------------------------------------------------
+
+function loadIssueComments(
+  port: ProviderPort,
+  issueNumber: number,
+): { body: string; createdAt: string; author: { login: string } }[] {
+  return port.listWorkItemComments(issueNumber).map((comment) => ({
+    body: comment.body,
+    createdAt: comment.createdAt,
+    author: { login: comment.authorLogin },
+  }));
+}
+
+function buildTrustedAuthorPredicate({
+  owner,
+  viewerLogin,
+  rawConfig,
+}: {
+  owner: string;
+  viewerLogin: string;
+  rawConfig: { trustedMarkerActors?: unknown } | null;
+}): (login: string) => boolean {
+  const { actors } = resolveTrustedMarkerActors({
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+    config: rawConfig,
+  });
+  const trusted = new Set(
+    [owner, viewerLogin, ...actors]
+      .filter(Boolean)
+      .map((login) => login.trim().toLowerCase()),
+  );
+  return (login) =>
+    trusted.has(
+      String(login ?? '')
+        .trim()
+        .toLowerCase(),
+    );
+}
+
+function loadPolicy(policyPath: string): unknown {
+  if (!policyPath) {
+    return null;
+  }
+  try {
+    return loadPolicyConfig(policyPath);
+  } catch {
+    return null;
+  }
+}
+
+function createProductionDeps(
+  args: SuitabilityCloseExecuteArgs,
+): SuitabilityCloseExecuteDeps {
+  const currentRepo =
+    args.owner && args.repo ? null : resolveCurrentGithubRepository();
+  const owner = args.owner || currentRepo?.owner || '';
+  const repo = args.repo || currentRepo?.repo || '';
+  const port = createGithubProviderAdapter(owner, repo);
+  const rawConfig = loadPolicy(args.policy);
+  const { viewerLogin } = port.resolveViewerLoginSafe();
+  const isTrustedAuthor = buildTrustedAuthorPredicate({
+    owner,
+    viewerLogin,
+    rawConfig: rawConfig as { trustedMarkerActors?: unknown } | null,
+  });
+  const staleAgeMs =
+    parseClaimStaleAgeMs(
+      (rawConfig as { claimTiming?: { staleAge?: unknown } } | null)
+        ?.claimTiming?.staleAge,
+    ) ?? DEFAULT_CLAIM_STALE_AGE_MS;
+  const repoRef = `${owner}/${repo}`;
+
+  return {
+    getIssue: (issueNumber) => {
+      const item = port.getWorkItem(issueNumber);
+      if (!item) {
+        return null;
+      }
+      return {
+        number: item.number,
+        title: item.title,
+        body: item.body,
+        createdAt: item.createdAt ?? '',
+      };
+    },
+    loadIssueComments: (issueNumber) => loadIssueComments(port, issueNumber),
+    collectEvidence: (issue) => {
+      const { highConfidenceDuplicate } =
+        collectHighConfidenceDuplicateEvidence(
+          owner,
+          repo,
+          repoRef,
+          issue,
+          DEFAULT_MANIFEST_PATH,
+          DEFAULT_BUNDLE_IDS,
+        );
+      return evaluateHighConfidenceDuplicate(
+        highConfidenceDuplicate,
+        issue.number,
+      );
+    },
+    isTrustedAuthor,
+    postCloseComment: (issueNumber, body) => {
+      port.postWorkItemComment(issueNumber, body);
+    },
+    closeIssue: (issueNumber) => {
+      port.closeWorkItem(issueNumber, 'not_planned');
+    },
+    releaseClaim: (issueNumber, fields) => {
+      port.postWorkItemComment(issueNumber, renderUnclaimedByMarker(fields));
+    },
+    now: () => args.now || new Date().toISOString(),
+    staleAgeMs,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CLI glue
+// ---------------------------------------------------------------------------
+
+const SUITABILITY_CLOSE_EXECUTE_FLAG_SPEC = {
+  '--issue': { type: 'string' },
+  '--apply': { type: 'boolean', default: false },
+  '--claim-id': { type: 'string' },
+  '--agent-id': { type: 'string' },
+  '--owner': { type: 'string' },
+  '--repo': { type: 'string' },
+  '--policy': { type: 'string' },
+  '--now': { type: 'string' },
+  '--help': { type: 'boolean', short: 'h' },
+} as const;
+
+function parseArgs(argv: string[]): SuitabilityCloseExecuteArgs {
+  const { values, help } = parseCliArgs(
+    argv,
+    SUITABILITY_CLOSE_EXECUTE_FLAG_SPEC,
+  );
+  const issueRaw = values.issue as string | undefined;
+  const issue =
+    issueRaw !== undefined && /^\d+$/.test(issueRaw) ? Number(issueRaw) : null;
+  return {
+    issue,
+    apply: Boolean(values.apply),
+    claimId: ((values['claim-id'] as string | undefined) ?? '').trim(),
+    agentId: ((values['agent-id'] as string | undefined) ?? '').trim(),
+    owner: ((values.owner as string | undefined) ?? '').trim(),
+    repo: ((values.repo as string | undefined) ?? '').trim(),
+    policy: ((values.policy as string | undefined) ?? '').trim(),
+    now: ((values.now as string | undefined) ?? '').trim(),
+    help: Boolean(help),
+  };
+}
+
+function printHelp(): void {
+  process.stdout.write(`
+Usage:
+  node scripts/suitability-close-execute.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--policy <path>] [--now <ISO8601>]
+  node scripts/suitability-close-execute.mjs --issue <number> --claim-id <claim-id> --agent-id <agent-id> [--owner <owner>] [--repo <repo>] [--policy <path>] [--now <ISO8601>] [--apply]
+
+  #1485: the gated pre-claim high-confidence duplicate/superseded close.
+  Default (no --apply): dry-run. Evaluates Check 4's high-confidence tier
+  (reusing #1484's detection kernel verbatim) and prints { ready, eligible,
+  evidence } without mutating.
+
+  --apply: requires --claim-id and --agent-id (the already-posted
+  suitability-close/<issue>-<slug> coordination claim -- this helper does
+  NOT post that claim itself). Re-validates the claim and re-collects
+  evidence immediately before mutating; posts the evidence-bound close
+  comment, closes the issue, and releases the claim, in that order. Fails
+  closed (exit 1, no mutation) on any lost/stale/non-owned claim or a
+  no-longer-eligible fresh evaluation.
+
+  Never fires on the weak title/declaration heuristic -- only a
+  tier: 'high-confidence' verdict from evaluateHighConfidenceDuplicate.
+`);
+}
+
+function runCli(): void {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (args.issue === null) {
+    throw new Error('--issue is required and must be a positive integer');
+  }
+  if (args.apply && (!args.claimId || !args.agentId)) {
+    throw new Error('--apply requires --claim-id and --agent-id');
+  }
+
+  const deps = createProductionDeps(args);
+  const verdict = runSuitabilityCloseExecute(args, deps);
+  process.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
+  const success = args.apply ? verdict.closed : verdict.ready;
+  process.exit(success ? 0 : 1);
+}
+
+if (import.meta.main) {
+  try {
+    runCli();
+  } catch (error: unknown) {
+    process.stderr.write(`Error: ${(error as Error).message}\n`);
+    process.exit(1);
+  }
+}

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -2051,6 +2051,130 @@ export function resolveInputMode(
   return args.bodyFile !== undefined || args.stdin ? 'local' : 'issue';
 }
 
+/**
+ * #1485: `runCli`'s own Check 4 high-confidence evidence-collection block,
+ * extracted (pure move, no behavior change) so `suitability-close-execute.mts`
+ * can reuse the identical fetch orchestration instead of duplicating it --
+ * `#1485`'s own acceptance criteria require the mechanical check to be
+ * "reused, not duplicated." Assumes the caller has already confirmed Checks
+ * 1-3 pass for this candidate (as `runCli`'s own `shouldCollectEvidence` gate
+ * does; `suitability-close-execute.mts` only ever runs after A4.5's Decision
+ * Flow has already reached Check 4 for the same reason) -- this function
+ * itself applies no such gate and always collects.
+ *
+ * The three mechanical signals (closedByPullRequestsReferences, the
+ * branch-name-exact-match lookup, and the same-candidate-files merged-PR
+ * scan) are collected in separate try/catch blocks: an earlier version
+ * wrapped the first two in one block, so a failure collecting the second
+ * signal discarded an already-successful first signal too. Each block's own
+ * failure is recorded independently in `collectionWarnings` and degrades
+ * only that one signal to empty/absent -- never silently reported as "no
+ * evidence" (that would mask a genuinely broken collector as a clean pass),
+ * and never discarding a sibling signal that already collected cleanly.
+ * `gh`/API fetch failures in any block are always recorded here; a
+ * manifest-unavailable same-candidate-files skip is a distinct, deliberate
+ * degradation documented on `loadHighContentionFiles` itself, not a fetch
+ * failure, so it is not added to this list. This is also why a failure here
+ * never throws out to the caller -- this tier is an optional enhancement
+ * layered onto Check 4, and Check 4's own documented Edge Case ("Timeout on
+ * duplicate detection... fall back to exact title match only") already
+ * anticipates exactly this degradation.
+ */
+export function collectHighConfidenceDuplicateEvidence(
+  owner: string,
+  repo: string,
+  repoRef: string,
+  issue: { number: number; title: string; body: string; createdAt: string },
+  manifestPath: string,
+  bundleIds: string[],
+): {
+  highConfidenceDuplicate: HighConfidenceDuplicateInput;
+  collectionWarnings: string[];
+} {
+  const collectionWarnings: string[] = [];
+  let closedByMergedPrNumbers: number[] = [];
+  let candidateFiles: string[] = [];
+  let highContentionFiles: string[] = [];
+  let mergedPrs: HighConfidenceMergedPr[] = [];
+  let branchNameMergedPr: { number: number; mergedAt: string } | null = null;
+
+  try {
+    closedByMergedPrNumbers = fetchClosedByMergedPrNumbers(
+      owner,
+      repo,
+      issue.number,
+    );
+  } catch (error) {
+    collectionWarnings.push(
+      `closedByPullRequestsReferences: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  try {
+    branchNameMergedPr = fetchMergedPrByBranchName(
+      repoRef,
+      computeBranchName(issue.number, issue.title),
+      owner,
+    );
+  } catch (error) {
+    collectionWarnings.push(
+      `branch-name merged-PR lookup: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  try {
+    candidateFiles = parseCandidateFiles(issue.body);
+    const resolvedHighContentionFiles =
+      candidateFiles.length > 0
+        ? loadHighContentionFiles(manifestPath, bundleIds)
+        : null;
+    const shouldScanMergedPrs =
+      candidateFiles.length > 0 &&
+      resolvedHighContentionFiles !== null &&
+      issue.createdAt.length > 0;
+    highContentionFiles = resolvedHighContentionFiles ?? [];
+    if (candidateFiles.length > 0 && resolvedHighContentionFiles === null) {
+      collectionWarnings.push(
+        'same-candidate-files scan: high-contention manifest unavailable, skipping the scan',
+      );
+    }
+    if (shouldScanMergedPrs) {
+      const scanResult = fetchMergedPrFileOverlapEvidence(
+        repoRef,
+        issue.createdAt,
+        candidateFiles,
+        highContentionFiles,
+        issue.number,
+      );
+      mergedPrs = scanResult.mergedPrs;
+      if (scanResult.truncatedByDeadline) {
+        collectionWarnings.push(
+          'same-candidate-files scan: truncated by MERGED_PR_SCAN_DEADLINE_MS before scanning every merged PR in the window',
+        );
+      }
+    } else {
+      mergedPrs = [];
+    }
+  } catch (error) {
+    collectionWarnings.push(
+      `same-candidate-files scan: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    candidateFiles = [];
+    mergedPrs = [];
+  }
+
+  return {
+    highConfidenceDuplicate: {
+      closedByMergedPrNumbers,
+      candidateFiles,
+      highContentionFiles,
+      mergedPrs,
+      branchNameMergedPr,
+    },
+    collectionWarnings,
+  };
+}
+
 function runCli(): void {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
@@ -2155,132 +2279,34 @@ function runCli(): void {
     checkCoherence(preEvidenceContext).pass &&
     checkTrustSafety(preEvidenceContext).pass;
 
-  // #1484: high-confidence Check 4 tier evidence. The two mechanical signals
-  // (closedByPullRequestsReferences, and the same-candidate-files merged-PR
-  // scan) are collected in two SEPARATE try/catch blocks (CodeRabbit review
-  // finding on this PR): an earlier version wrapped both in one block, so a
-  // failure collecting the second signal discarded an already-successful
-  // first signal too. Each block's own failure is recorded independently in
-  // `collectionWarnings` and degrades only that one signal to empty/absent
-  // -- never silently reported as "no evidence" (that would mask a
-  // genuinely broken collector as a clean pass), and never discarding a
-  // sibling signal that already collected cleanly. `gh`/API fetch failures
-  // in either block are always recorded here; a manifest-unavailable
-  // same-candidate-files skip is a distinct, deliberate degradation
-  // documented on `loadHighContentionFiles` itself, not a fetch failure, so
-  // it is not added to this list (Copilot review finding on this PR: an
-  // earlier comment overclaimed that every degradation path surfaces here).
-  // This is also why an uncaught failure no longer aborts the entire
-  // 7-check evaluation (Codex review finding on this PR) -- this tier is an
-  // optional enhancement layered onto Check 4, and Check 4's own documented
-  // Edge Case ("Timeout on duplicate detection... fall back to exact title
-  // match only") already anticipates exactly this degradation. Both blocks
-  // below run only when `shouldCollectEvidence` is true (#1815) -- when it
-  // is false, Check 4 is never reached anyway, so `collectionWarnings`
-  // correctly stays empty (this is a deliberate skip, not a collection
-  // failure).
-  const collectionWarnings: string[] = [];
-  let closedByMergedPrNumbers: number[] = [];
-  let candidateFiles: string[] = [];
-  let highContentionFiles: string[] = [];
-  let mergedPrs: HighConfidenceMergedPr[] = [];
-  let branchNameMergedPr: { number: number; mergedAt: string } | null = null;
+  // #1484: high-confidence Check 4 tier evidence, collected by
+  // `collectHighConfidenceDuplicateEvidence` below only when
+  // `shouldCollectEvidence` is true (#1815) -- when it is false, Check 4 is
+  // never reached anyway, so `collectionWarnings` correctly stays empty
+  // (this is a deliberate skip, not a collection failure). See that
+  // function's own doc comment for the per-signal try/catch and
+  // degradation rationale.
+  let collectionWarnings: string[] = [];
+  let highConfidenceDuplicate: SuitabilityOptions['highConfidenceDuplicate'] = {
+    closedByMergedPrNumbers: [],
+    candidateFiles: [],
+    highContentionFiles: [],
+    mergedPrs: [],
+    branchNameMergedPr: null,
+  };
 
   if (shouldCollectEvidence) {
-    try {
-      closedByMergedPrNumbers = fetchClosedByMergedPrNumbers(
-        owner,
-        repo,
-        args.issue,
-      );
-    } catch (error) {
-      collectionWarnings.push(
-        `closedByPullRequestsReferences: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    }
-
-    // #2313, Signal 3: a separate try/catch (same pattern as the two blocks
-    // above/below) so a failure here degrades only this one signal, never
-    // discarding a sibling signal that already collected cleanly.
-    try {
-      branchNameMergedPr = fetchMergedPrByBranchName(
-        repoRef,
-        computeBranchName(issue.number, issue.title),
-        owner,
-      );
-    } catch (error) {
-      collectionWarnings.push(
-        `branch-name merged-PR lookup: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    }
-
-    try {
-      candidateFiles = parseCandidateFiles(issue.body);
-      // Only resolve the high-contention exclusion set (a file read + JSON
-      // parse) when there is a '## Candidate files' section to check it
-      // against -- most issues have none, and the result would otherwise be
-      // discarded.
-      const resolvedHighContentionFiles =
-        candidateFiles.length > 0
-          ? loadHighContentionFiles(
-              args.manifest,
-              args.bundles ?? DEFAULT_BUNDLE_IDS,
-            )
-          : null;
-      const shouldScanMergedPrs =
-        candidateFiles.length > 0 &&
-        resolvedHighContentionFiles !== null &&
-        issue.createdAt.length > 0;
-      highContentionFiles = resolvedHighContentionFiles ?? [];
-      if (candidateFiles.length > 0 && resolvedHighContentionFiles === null) {
-        // Codex P2 review finding: an unreadable/missing high-contention
-        // manifest silently skipped the same-candidate-files scan without
-        // recording a warning -- but from Check 4's perspective this is the
-        // same class of "high-confidence evidence could not be collected" as
-        // a genuine gh/API failure, and must degrade the same way (exact
-        // title match only), not let the full weak heuristic run.
-        collectionWarnings.push(
-          'same-candidate-files scan: high-contention manifest unavailable, skipping the scan',
-        );
-      }
-      if (shouldScanMergedPrs) {
-        const scanResult = fetchMergedPrFileOverlapEvidence(
-          repoRef,
-          issue.createdAt,
-          candidateFiles,
-          highContentionFiles,
-          issue.number,
-        );
-        mergedPrs = scanResult.mergedPrs;
-        if (scanResult.truncatedByDeadline) {
-          // Codex P2 review finding: a deadline-truncated scan returns
-          // normally (not a throw), so it must record its own warning here --
-          // otherwise Check 4 would run the full weak heuristic on
-          // incomplete evidence instead of degrading to exact-title-only.
-          collectionWarnings.push(
-            'same-candidate-files scan: truncated by MERGED_PR_SCAN_DEADLINE_MS before scanning every merged PR in the window',
-          );
-        }
-      } else {
-        mergedPrs = [];
-      }
-    } catch (error) {
-      collectionWarnings.push(
-        `same-candidate-files scan: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      candidateFiles = [];
-      mergedPrs = [];
-    }
+    const evidence = collectHighConfidenceDuplicateEvidence(
+      owner,
+      repo,
+      repoRef,
+      issue,
+      args.manifest,
+      args.bundles ?? DEFAULT_BUNDLE_IDS,
+    );
+    highConfidenceDuplicate = evidence.highConfidenceDuplicate;
+    collectionWarnings = evidence.collectionWarnings;
   }
-
-  const highConfidenceDuplicate: SuitabilityOptions['highConfidenceDuplicate'] =
-    {
-      closedByMergedPrNumbers,
-      candidateFiles,
-      highContentionFiles,
-      mergedPrs,
-      branchNameMergedPr,
-    };
 
   const result = evaluateSuitability(issue, {
     repository: { owner, repo },
@@ -2962,7 +2988,7 @@ function fetchIssueComments(
  * remaining work would still show its old merged closing PR and get
  * misclassified as a completed duplicate (Codex review finding on this PR).
  */
-function fetchClosedByMergedPrNumbers(
+export function fetchClosedByMergedPrNumbers(
   owner: string,
   repo: string,
   issueNumber: number,
@@ -3019,7 +3045,7 @@ function fetchClosedByMergedPrNumbers(
  * directly, matching the rest of this file's "never trust the shape of a
  * `gh` JSON response" convention.
  */
-function fetchMergedPrByBranchName(
+export function fetchMergedPrByBranchName(
   repoRef: string,
   branchName: string,
   owner: string,

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -2072,9 +2072,13 @@ export function resolveInputMode(
  * evidence" (that would mask a genuinely broken collector as a clean pass),
  * and never discarding a sibling signal that already collected cleanly.
  * `gh`/API fetch failures in any block are always recorded here; a
- * manifest-unavailable same-candidate-files skip is a distinct, deliberate
- * degradation documented on `loadHighContentionFiles` itself, not a fetch
- * failure, so it is not added to this list. This is also why a failure here
+ * manifest-unavailable same-candidate-files skip (documented on
+ * `loadHighContentionFiles` itself) is a distinct, deliberate degradation
+ * rather than a genuine fetch failure, but it still pushes its own
+ * `collectionWarnings` entry below -- Check 4 must degrade to exact-title-only
+ * for this case exactly as it does for a real `gh`/API failure (Copilot
+ * review finding on PR #2558: an earlier version of this comment claimed
+ * the opposite). This is also why a failure here
  * never throws out to the caller -- this tier is an optional enhancement
  * layered onto Check 4, and Check 4's own documented Edge Case ("Timeout on
  * duplicate detection... fall back to exact title match only") already

--- a/tests/help-text-flags.test.mts
+++ b/tests/help-text-flags.test.mts
@@ -205,6 +205,7 @@ const COVERED_HELPERS = [
   'review-disposition-verify',
   'select-desynced-index',
   'stalled-session-quiet-check',
+  'suitability-close-execute',
   'suitability-triage',
   'verify-install-deps',
   'verify-workshop-integrity',

--- a/tests/suitability-close-execute.test.mts
+++ b/tests/suitability-close-execute.test.mts
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import { renderClaimedByMarker } from '../src/scripts/protocol-helpers.mts';
+import {
+  renderClaimedByMarker,
+  renderUnclaimedByMarker,
+} from '../src/scripts/protocol-helpers.mts';
 import {
   buildSuitabilityCloseComment,
   evaluateSuitabilityCloseClaim,
@@ -239,7 +242,16 @@ function makeDeps(
   const calls = {
     closed: [] as number[],
     comments: [] as { issue: number; body: string }[],
-    released: [] as { issue: number; agentId: string; claimId: string }[],
+    // Copilot review finding on PR #2558: the mock previously dropped
+    // `timestamp`, so no test could actually assert on the
+    // normalized-to-second-precision value runSuitabilityCloseExecute
+    // forwards to releaseClaim -- capture it too.
+    released: [] as {
+      issue: number;
+      agentId: string;
+      claimId: string;
+      timestamp: string;
+    }[],
   };
   const deps: SuitabilityCloseExecuteDeps = {
     getIssue: () => ISSUE_SHAPE,
@@ -257,12 +269,13 @@ function makeDeps(
     },
     releaseClaim: (
       issueNumber: number,
-      fields: { agentId: string; claimId: string },
+      fields: { agentId: string; claimId: string; timestamp: string },
     ) => {
       calls.released.push({
         issue: issueNumber,
         agentId: fields.agentId,
         claimId: fields.claimId,
+        timestamp: fields.timestamp,
       });
     },
     now: () => '2026-06-26T01:00:00Z',
@@ -312,7 +325,12 @@ test('--apply closes, posts the evidence-bound comment, and releases the claim w
   assert.equal(calls.comments[0]?.issue, ISSUE);
   assert.match(calls.comments[0]?.body ?? '', /High-confidence duplicate/);
   assert.deepEqual(calls.released, [
-    { issue: ISSUE, agentId: AGENT_ID, claimId: CLAIM_ID },
+    {
+      issue: ISSUE,
+      agentId: AGENT_ID,
+      claimId: CLAIM_ID,
+      timestamp: '2026-06-26T01:00:00Z',
+    },
   ]);
 });
 
@@ -463,16 +481,18 @@ test("--apply normalizes deps.now()'s millisecond-precision output before it eve
   const verdict = runSuitabilityCloseExecute(baseArgs({ apply: true }), deps);
   assert.equal(verdict.closed, true);
   assert.equal(calls.released[0]?.issue, ISSUE);
-  // renderUnclaimedByMarker itself throws on anything but second-precision
-  // `…Z` -- exercising it here (not just asserting the released-timestamp
-  // shape) proves the fix actually prevents the production throw.
+  // Copilot review finding on PR #2558: assert on the timestamp that
+  // ACTUALLY flowed into releaseClaim (not a hard-coded literal), then feed
+  // that exact value through the real renderUnclaimedByMarker -- which
+  // throws on anything but second-precision `…Z` -- so this test proves the
+  // fix on the real code path, not merely that some second-precision string
+  // happens not to throw.
+  assert.equal(calls.released[0]?.timestamp, '2026-06-26T00:05:42Z');
   assert.doesNotThrow(() =>
-    renderClaimedByMarker({
-      agentId: AGENT_ID,
-      claimId: CLAIM_ID,
-      supersedes: 'none',
-      timestamp: '2026-09-03T15:44:42Z',
-      branch: CLAIM_BRANCH,
+    renderUnclaimedByMarker({
+      agentId: calls.released[0]?.agentId,
+      claimId: calls.released[0]?.claimId,
+      timestamp: calls.released[0]?.timestamp,
     }),
   );
 });

--- a/tests/suitability-close-execute.test.mts
+++ b/tests/suitability-close-execute.test.mts
@@ -358,6 +358,18 @@ test('--apply fails closed (no mutation) when the coordination claim is not owne
   assert.deepEqual(calls.released, []);
 });
 
+test('--apply checks claim ownership BEFORE collecting evidence, so a lost claim never burns the evidence-collection API calls (Copilot review, PR #2558)', () => {
+  const { deps } = makeDeps({ claimComments: [] });
+  let collectEvidenceCalls = 0;
+  deps.collectEvidence = () => {
+    collectEvidenceCalls += 1;
+    return HIGH_CONFIDENCE_OUTCOME;
+  };
+  const verdict = runSuitabilityCloseExecute(baseArgs({ apply: true }), deps);
+  assert.equal(verdict.closed, false);
+  assert.equal(collectEvidenceCalls, 0);
+});
+
 test('--apply fails closed (no mutation) when the active claim is a normal issue/* implementation claim', () => {
   const { deps, calls } = makeDeps({
     claimComments: [claimComment({ branch: `issue/${ISSUE}-some-task` })],

--- a/tests/suitability-close-execute.test.mts
+++ b/tests/suitability-close-execute.test.mts
@@ -391,6 +391,18 @@ test('a direct call bypassing runCli with issue: null degrades to a clean not-re
   assert.deepEqual(calls.released, []);
 });
 
+test('a direct call with a negative issue number is also rejected, not just null (Copilot review, PR #2558)', () => {
+  const { deps, calls } = makeDeps();
+  const verdict = runSuitabilityCloseExecute(
+    baseArgs({ issue: -1, apply: true }),
+    deps,
+  );
+  assert.equal(verdict.ready, false);
+  assert.equal(verdict.closed, false);
+  assert.match(verdict.result, /--issue is required/);
+  assert.deepEqual(calls.closed, []);
+});
+
 // ---------------------------------------------------------------------------
 // parseArgs (pure)
 // ---------------------------------------------------------------------------

--- a/tests/suitability-close-execute.test.mts
+++ b/tests/suitability-close-execute.test.mts
@@ -353,3 +353,17 @@ test('a missing issue reports a not-found result without mutating', () => {
   assert.match(verdict.result, /not found or inaccessible/);
   assert.deepEqual(calls.closed, []);
 });
+
+test('a direct call bypassing runCli with issue: null degrades to a clean not-ready verdict, never an unsafe cast (Copilot review, PR #2558)', () => {
+  const { deps, calls } = makeDeps();
+  const verdict = runSuitabilityCloseExecute(
+    baseArgs({ issue: null, apply: true }),
+    deps,
+  );
+  assert.equal(verdict.ready, false);
+  assert.equal(verdict.closed, false);
+  assert.match(verdict.result, /--issue is required/);
+  assert.deepEqual(calls.closed, []);
+  assert.deepEqual(calls.comments, []);
+  assert.deepEqual(calls.released, []);
+});

--- a/tests/suitability-close-execute.test.mts
+++ b/tests/suitability-close-execute.test.mts
@@ -6,6 +6,7 @@ import {
   buildSuitabilityCloseComment,
   evaluateSuitabilityCloseClaim,
   evaluateSuitabilityCloseEligibility,
+  normalizeApplyNow,
   parseArgs,
   runSuitabilityCloseExecute,
   type SuitabilityCloseExecuteArgs,
@@ -412,4 +413,67 @@ test('parseArgs rejects "0" for --issue, not just non-digit input (Copilot revie
   assert.equal(parseArgs(['--issue', 'abc']).issue, null);
   assert.equal(parseArgs(['--issue', '-1']).issue, null);
   assert.equal(parseArgs(['--issue', '2222']).issue, 2222);
+});
+
+// ---------------------------------------------------------------------------
+// normalizeApplyNow (pure)
+// ---------------------------------------------------------------------------
+
+test('normalizeApplyNow strips the millisecond fraction Date#toISOString() always emits (Copilot review, PR #2558)', () => {
+  assert.equal(
+    normalizeApplyNow('2026-09-03T15:44:42.719Z'),
+    '2026-09-03T15:44:42Z',
+  );
+  // Already second-precision: unchanged.
+  assert.equal(
+    normalizeApplyNow('2026-09-03T15:44:42Z'),
+    '2026-09-03T15:44:42Z',
+  );
+  // A zone offset is normalized to UTC too (matches idd-roadmap-audit-execute.mts).
+  assert.equal(
+    normalizeApplyNow('2026-09-03T15:44:42.000+09:00'),
+    '2026-09-03T06:44:42Z',
+  );
+});
+
+test('normalizeApplyNow fails closed (null) on an unparseable value', () => {
+  assert.equal(normalizeApplyNow('not-a-date'), null);
+  assert.equal(normalizeApplyNow(''), null);
+});
+
+test("--apply normalizes deps.now()'s millisecond-precision output before it ever reaches releaseClaim, so renderUnclaimedByMarker never throws (Copilot review, PR #2558)", () => {
+  const { deps, calls } = makeDeps();
+  // A few minutes after the mock claim's createdAt (2026-06-26T00:00:00Z) --
+  // well within the default 24h stale window, unlike baseArgs's own
+  // '2026-06-26T01:00:00Z' `now` field, which this test overrides via
+  // deps.now() (the production code path this bug actually lives in).
+  deps.now = () => '2026-06-26T00:05:42.719Z';
+  const verdict = runSuitabilityCloseExecute(baseArgs({ apply: true }), deps);
+  assert.equal(verdict.closed, true);
+  assert.equal(calls.released[0]?.issue, ISSUE);
+  // renderUnclaimedByMarker itself throws on anything but second-precision
+  // `…Z` -- exercising it here (not just asserting the released-timestamp
+  // shape) proves the fix actually prevents the production throw.
+  assert.doesNotThrow(() =>
+    renderClaimedByMarker({
+      agentId: AGENT_ID,
+      claimId: CLAIM_ID,
+      supersedes: 'none',
+      timestamp: '2026-09-03T15:44:42Z',
+      branch: CLAIM_BRANCH,
+    }),
+  );
+});
+
+test('--apply fails closed (no mutation at all) when deps.now() returns an unparseable value', () => {
+  const { deps, calls } = makeDeps();
+  deps.now = () => 'not-a-date';
+  const verdict = runSuitabilityCloseExecute(baseArgs({ apply: true }), deps);
+  assert.equal(verdict.closed, false);
+  assert.match(verdict.result, /unparseable timestamp/);
+  assert.deepEqual(calls.closed, []);
+  // The comment was NOT yet posted either -- the now-validation runs before
+  // the first mutation of any kind.
+  assert.deepEqual(calls.comments, []);
+  assert.deepEqual(calls.released, []);
 });

--- a/tests/suitability-close-execute.test.mts
+++ b/tests/suitability-close-execute.test.mts
@@ -477,3 +477,27 @@ test('--apply fails closed (no mutation at all) when deps.now() returns an unpar
   assert.deepEqual(calls.comments, []);
   assert.deepEqual(calls.released, []);
 });
+
+test('parseArgs requires --owner and --repo together, not exactly one (Copilot review, PR #2558)', () => {
+  assert.throws(
+    () => parseArgs(['--issue', '2222', '--owner', 'kurone-kito']),
+    /--owner and --repo must be provided together/,
+  );
+  assert.throws(
+    () => parseArgs(['--issue', '2222', '--repo', 'idd-skill']),
+    /--owner and --repo must be provided together/,
+  );
+  // Neither: fine (falls back to the current-directory repo).
+  assert.doesNotThrow(() => parseArgs(['--issue', '2222']));
+  // Both: fine.
+  const args = parseArgs([
+    '--issue',
+    '2222',
+    '--owner',
+    'kurone-kito',
+    '--repo',
+    'idd-skill',
+  ]);
+  assert.equal(args.owner, 'kurone-kito');
+  assert.equal(args.repo, 'idd-skill');
+});

--- a/tests/suitability-close-execute.test.mts
+++ b/tests/suitability-close-execute.test.mts
@@ -1,0 +1,355 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { renderClaimedByMarker } from '../src/scripts/protocol-helpers.mts';
+import {
+  buildSuitabilityCloseComment,
+  evaluateSuitabilityCloseClaim,
+  evaluateSuitabilityCloseEligibility,
+  runSuitabilityCloseExecute,
+  type SuitabilityCloseExecuteArgs,
+  type SuitabilityCloseExecuteDeps,
+  suitabilityCloseBranchPattern,
+} from '../src/scripts/suitability-close-execute.mts';
+import type { CheckOutcome } from '../src/scripts/supersession-detection.mts';
+
+const ISSUE = 2222;
+const CLAIM_ID = 'claim-20260626T000000Z-2222';
+const AGENT_ID = 'claude-test';
+const CLAIM_BRANCH = `suitability-close/${ISSUE}-some-slug`;
+
+function claimComment(
+  overrides: { claimId?: string; agentId?: string; branch?: string } = {},
+) {
+  return {
+    body: renderClaimedByMarker({
+      agentId: overrides.agentId ?? AGENT_ID,
+      claimId: overrides.claimId ?? CLAIM_ID,
+      supersedes: 'none',
+      timestamp: '2026-06-26T00:00:00Z',
+      branch: overrides.branch ?? CLAIM_BRANCH,
+    }),
+    createdAt: '2026-06-26T00:00:00Z',
+    author: { login: 'kurone-kito' },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// suitabilityCloseBranchPattern (pure)
+// ---------------------------------------------------------------------------
+
+test('suitabilityCloseBranchPattern matches only this issue number under the coordination prefix', () => {
+  const pattern = suitabilityCloseBranchPattern(ISSUE);
+  assert.equal(pattern.test(`suitability-close/${ISSUE}-some-slug`), true);
+  assert.equal(pattern.test(`suitability-close/${ISSUE}-`), true);
+  // A different issue number never matches, even with the same prefix.
+  assert.equal(pattern.test(`suitability-close/${ISSUE}9-some-slug`), false);
+  assert.equal(pattern.test(`suitability-close/${ISSUE + 1}-some-slug`), false);
+  // A normal implementation claim branch never matches.
+  assert.equal(pattern.test(`issue/${ISSUE}-some-slug`), false);
+  // A roadmap-audit coordination branch never matches either.
+  assert.equal(pattern.test(`roadmap-audit/${ISSUE}-some-slug`), false);
+});
+
+// ---------------------------------------------------------------------------
+// evaluateSuitabilityCloseEligibility (pure)
+// ---------------------------------------------------------------------------
+
+test('a high-confidence tier fail is eligible, carrying its evidence verbatim', () => {
+  const outcome: CheckOutcome = {
+    pass: false,
+    evidence: 'High-confidence duplicate: merged PR #123.',
+    tier: 'high-confidence',
+  };
+  const result = evaluateSuitabilityCloseEligibility(outcome);
+  assert.equal(result.eligible, true);
+  assert.equal(result.evidence, outcome.evidence);
+});
+
+test('a weak-tier fail is never eligible, even though it shares pass: false', () => {
+  const outcome: CheckOutcome = {
+    pass: false,
+    evidence: 'Exact-title duplicate found: #456',
+    tier: 'weak',
+  };
+  const result = evaluateSuitabilityCloseEligibility(outcome);
+  assert.equal(result.eligible, false);
+  assert.equal(result.evidence, null);
+});
+
+test('a pass carries no tier and is never eligible', () => {
+  const outcome: CheckOutcome = {
+    pass: true,
+    evidence: 'No duplicate candidate matched.',
+  };
+  assert.equal(evaluateSuitabilityCloseEligibility(outcome).eligible, false);
+});
+
+test("no signal at all (null, matching evaluateHighConfidenceDuplicate's own contract) is never eligible", () => {
+  assert.equal(evaluateSuitabilityCloseEligibility(null).eligible, false);
+});
+
+// ---------------------------------------------------------------------------
+// evaluateSuitabilityCloseClaim (pure)
+// ---------------------------------------------------------------------------
+
+test('a present, matching, fresh, suitability-close-branch claim is owned', () => {
+  const verdict = evaluateSuitabilityCloseClaim([claimComment()], {
+    issueNumber: ISSUE,
+    expectedClaimId: CLAIM_ID,
+    expectedAgentId: AGENT_ID,
+    isTrustedAuthor: () => true,
+    nowIso: '2026-06-26T01:00:00Z',
+  });
+  assert.equal(verdict.owned, true);
+  assert.equal(verdict.reason, 'match');
+});
+
+test('a missing or mismatched claim is not owned', () => {
+  const missing = evaluateSuitabilityCloseClaim([], {
+    issueNumber: ISSUE,
+    expectedClaimId: CLAIM_ID,
+    isTrustedAuthor: () => true,
+    nowIso: '2026-06-26T01:00:00Z',
+  });
+  assert.equal(missing.owned, false);
+  assert.equal(missing.reason, 'missing-active-claim');
+
+  const mismatch = evaluateSuitabilityCloseClaim(
+    [claimComment({ claimId: 'other' })],
+    {
+      issueNumber: ISSUE,
+      expectedClaimId: CLAIM_ID,
+      isTrustedAuthor: () => true,
+      nowIso: '2026-06-26T01:00:00Z',
+    },
+  );
+  assert.equal(mismatch.owned, false);
+  assert.equal(mismatch.reason, 'claim-id-mismatch');
+});
+
+test('a normal issue/* implementation claim on the same issue does NOT authorize a close', () => {
+  const executionClaim = claimComment({ branch: `issue/${ISSUE}-some-task` });
+  const verdict = evaluateSuitabilityCloseClaim([executionClaim], {
+    issueNumber: ISSUE,
+    expectedClaimId: CLAIM_ID,
+    isTrustedAuthor: () => true,
+    nowIso: '2026-06-26T01:00:00Z',
+  });
+  assert.equal(verdict.owned, false);
+  assert.equal(verdict.reason, 'claim-branch-mismatch');
+});
+
+test('a suitability-close claim posted for a DIFFERENT issue number does not authorize this one', () => {
+  const otherIssueClaim = claimComment({
+    branch: `suitability-close/${ISSUE + 1}-some-slug`,
+  });
+  const verdict = evaluateSuitabilityCloseClaim([otherIssueClaim], {
+    issueNumber: ISSUE,
+    expectedClaimId: CLAIM_ID,
+    isTrustedAuthor: () => true,
+    nowIso: '2026-06-26T01:00:00Z',
+  });
+  assert.equal(verdict.owned, false);
+  assert.equal(verdict.reason, 'claim-branch-mismatch');
+});
+
+test('staleness honors the configured claim stale age', () => {
+  const comment = [claimComment()]; // createdAt 2026-06-26T00:00:00Z
+  const oneHourLater = '2026-06-26T01:00:00Z';
+
+  const shortened = evaluateSuitabilityCloseClaim(comment, {
+    issueNumber: ISSUE,
+    expectedClaimId: CLAIM_ID,
+    isTrustedAuthor: () => true,
+    nowIso: oneHourLater,
+    staleAgeMs: 30 * 60 * 1000,
+  });
+  assert.equal(shortened.owned, false);
+  assert.equal(shortened.reason, 'claim-stale');
+
+  const lengthened = evaluateSuitabilityCloseClaim(comment, {
+    issueNumber: ISSUE,
+    expectedClaimId: CLAIM_ID,
+    isTrustedAuthor: () => true,
+    nowIso: oneHourLater,
+    staleAgeMs: 48 * 60 * 60 * 1000,
+  });
+  assert.equal(lengthened.owned, true);
+});
+
+// ---------------------------------------------------------------------------
+// buildSuitabilityCloseComment (pure)
+// ---------------------------------------------------------------------------
+
+test('the close comment carries the evidence string verbatim and the #1485 reversal-posture note', () => {
+  const body = buildSuitabilityCloseComment(
+    'High-confidence duplicate: merged PR #123 (merged 2026-06-01T00:00:00Z).',
+  );
+  assert.match(body, /^A4\.5 high-confidence duplicate\/superseded close/);
+  assert.match(
+    body,
+    /High-confidence duplicate: merged PR #123 \(merged 2026-06-01T00:00:00Z\)\./,
+  );
+  assert.match(body, /reopen the issue/);
+});
+
+// ---------------------------------------------------------------------------
+// runSuitabilityCloseExecute (deps-injected orchestration)
+// ---------------------------------------------------------------------------
+
+const ISSUE_SHAPE = {
+  number: ISSUE,
+  title: 'some candidate issue',
+  body: '',
+  createdAt: '2026-06-01T00:00:00Z',
+};
+
+const HIGH_CONFIDENCE_OUTCOME: CheckOutcome = {
+  pass: false,
+  evidence: 'High-confidence duplicate: merged PR #123.',
+  tier: 'high-confidence',
+};
+
+function baseArgs(
+  overrides: Partial<SuitabilityCloseExecuteArgs> = {},
+): SuitabilityCloseExecuteArgs {
+  return {
+    issue: ISSUE,
+    apply: false,
+    claimId: CLAIM_ID,
+    agentId: AGENT_ID,
+    owner: 'kurone-kito',
+    repo: 'idd-skill',
+    policy: '',
+    now: '2026-06-26T01:00:00Z',
+    help: false,
+    ...overrides,
+  };
+}
+
+function makeDeps(
+  overrides: {
+    checkOutcome?: CheckOutcome | null;
+    claimComments?: ReturnType<typeof claimComment>[];
+  } = {},
+) {
+  const calls = {
+    closed: [] as number[],
+    comments: [] as { issue: number; body: string }[],
+    released: [] as { issue: number; agentId: string; claimId: string }[],
+  };
+  const deps: SuitabilityCloseExecuteDeps = {
+    getIssue: () => ISSUE_SHAPE,
+    loadIssueComments: () => overrides.claimComments ?? [claimComment()],
+    collectEvidence: () =>
+      overrides.checkOutcome === undefined
+        ? HIGH_CONFIDENCE_OUTCOME
+        : overrides.checkOutcome,
+    isTrustedAuthor: () => true,
+    postCloseComment: (issueNumber: number, body: string) => {
+      calls.comments.push({ issue: issueNumber, body });
+    },
+    closeIssue: (issueNumber: number) => {
+      calls.closed.push(issueNumber);
+    },
+    releaseClaim: (
+      issueNumber: number,
+      fields: { agentId: string; claimId: string },
+    ) => {
+      calls.released.push({
+        issue: issueNumber,
+        agentId: fields.agentId,
+        claimId: fields.claimId,
+      });
+    },
+    now: () => '2026-06-26T01:00:00Z',
+  };
+  return { deps, calls };
+}
+
+test('dry-run reports ready: true on a high-confidence signal, without mutating', () => {
+  const { deps, calls } = makeDeps();
+  const verdict = runSuitabilityCloseExecute(baseArgs({ apply: false }), deps);
+  assert.equal(verdict.mode, 'dry-run');
+  assert.equal(verdict.ready, true);
+  assert.equal(verdict.eligible, true);
+  assert.equal(verdict.evidence, HIGH_CONFIDENCE_OUTCOME.evidence);
+  assert.equal(verdict.closed, false);
+  assert.deepEqual(calls.closed, []);
+  assert.deepEqual(calls.comments, []);
+  assert.deepEqual(calls.released, []);
+});
+
+test('dry-run reports ready: false when no high-confidence signal fires', () => {
+  const { deps } = makeDeps({ checkOutcome: null });
+  const verdict = runSuitabilityCloseExecute(baseArgs({ apply: false }), deps);
+  assert.equal(verdict.ready, false);
+  assert.equal(verdict.eligible, false);
+});
+
+test('dry-run reports ready: false on a weak-tier fail (never authorizes a close)', () => {
+  const { deps } = makeDeps({
+    checkOutcome: {
+      pass: false,
+      evidence: 'Exact-title duplicate found: #456',
+      tier: 'weak',
+    },
+  });
+  const verdict = runSuitabilityCloseExecute(baseArgs({ apply: false }), deps);
+  assert.equal(verdict.ready, false);
+});
+
+test('--apply closes, posts the evidence-bound comment, and releases the claim when owned + eligible', () => {
+  const { deps, calls } = makeDeps();
+  const verdict = runSuitabilityCloseExecute(baseArgs({ apply: true }), deps);
+  assert.equal(verdict.mode, 'apply');
+  assert.equal(verdict.closed, true);
+  assert.deepEqual(calls.closed, [ISSUE]);
+  assert.equal(calls.comments.length, 1);
+  assert.equal(calls.comments[0]?.issue, ISSUE);
+  assert.match(calls.comments[0]?.body ?? '', /High-confidence duplicate/);
+  assert.deepEqual(calls.released, [
+    { issue: ISSUE, agentId: AGENT_ID, claimId: CLAIM_ID },
+  ]);
+});
+
+test('--apply fails closed (no mutation) when the fresh re-evaluation no longer finds a signal', () => {
+  const { deps, calls } = makeDeps({ checkOutcome: null });
+  const verdict = runSuitabilityCloseExecute(baseArgs({ apply: true }), deps);
+  assert.equal(verdict.closed, false);
+  assert.deepEqual(calls.closed, []);
+  assert.deepEqual(calls.comments, []);
+  assert.deepEqual(calls.released, []);
+});
+
+test('--apply fails closed (no mutation) when the coordination claim is not owned', () => {
+  const { deps, calls } = makeDeps({ claimComments: [] });
+  const verdict = runSuitabilityCloseExecute(baseArgs({ apply: true }), deps);
+  assert.equal(verdict.closed, false);
+  assert.equal(verdict.claim?.owned, false);
+  assert.equal(verdict.claim?.reason, 'missing-active-claim');
+  assert.deepEqual(calls.closed, []);
+  assert.deepEqual(calls.comments, []);
+  assert.deepEqual(calls.released, []);
+});
+
+test('--apply fails closed (no mutation) when the active claim is a normal issue/* implementation claim', () => {
+  const { deps, calls } = makeDeps({
+    claimComments: [claimComment({ branch: `issue/${ISSUE}-some-task` })],
+  });
+  const verdict = runSuitabilityCloseExecute(baseArgs({ apply: true }), deps);
+  assert.equal(verdict.closed, false);
+  assert.equal(verdict.claim?.reason, 'claim-branch-mismatch');
+  assert.deepEqual(calls.closed, []);
+});
+
+test('a missing issue reports a not-found result without mutating', () => {
+  const { deps, calls } = makeDeps();
+  deps.getIssue = () => null;
+  const verdict = runSuitabilityCloseExecute(baseArgs({ apply: true }), deps);
+  assert.equal(verdict.ready, false);
+  assert.equal(verdict.closed, false);
+  assert.match(verdict.result, /not found or inaccessible/);
+  assert.deepEqual(calls.closed, []);
+});

--- a/tests/suitability-close-execute.test.mts
+++ b/tests/suitability-close-execute.test.mts
@@ -6,6 +6,7 @@ import {
   buildSuitabilityCloseComment,
   evaluateSuitabilityCloseClaim,
   evaluateSuitabilityCloseEligibility,
+  parseArgs,
   runSuitabilityCloseExecute,
   type SuitabilityCloseExecuteArgs,
   type SuitabilityCloseExecuteDeps,
@@ -314,6 +315,28 @@ test('--apply closes, posts the evidence-bound comment, and releases the claim w
   ]);
 });
 
+test('--apply re-validates the claim immediately before closeIssue and aborts the close (not the comment) if it was lost in that gap (Copilot review, PR #2558)', () => {
+  const { deps, calls } = makeDeps();
+  let loadCount = 0;
+  deps.loadIssueComments = () => {
+    loadCount += 1;
+    // First call (before posting the comment): owned. Second call (the
+    // final re-validation immediately before closeIssue): taken over.
+    return loadCount === 1 ? [claimComment()] : [];
+  };
+  const verdict = runSuitabilityCloseExecute(baseArgs({ apply: true }), deps);
+  assert.equal(loadCount, 2);
+  assert.equal(verdict.closed, false);
+  assert.equal(verdict.claim?.owned, false);
+  assert.equal(verdict.claim?.reason, 'missing-active-claim');
+  assert.match(verdict.result, /comment and the close/);
+  // The evidence comment was already posted (informing whoever now owns
+  // the claim), but the close and release never ran.
+  assert.equal(calls.comments.length, 1);
+  assert.deepEqual(calls.closed, []);
+  assert.deepEqual(calls.released, []);
+});
+
 test('--apply fails closed (no mutation) when the fresh re-evaluation no longer finds a signal', () => {
   const { deps, calls } = makeDeps({ checkOutcome: null });
   const verdict = runSuitabilityCloseExecute(baseArgs({ apply: true }), deps);
@@ -366,4 +389,15 @@ test('a direct call bypassing runCli with issue: null degrades to a clean not-re
   assert.deepEqual(calls.closed, []);
   assert.deepEqual(calls.comments, []);
   assert.deepEqual(calls.released, []);
+});
+
+// ---------------------------------------------------------------------------
+// parseArgs (pure)
+// ---------------------------------------------------------------------------
+
+test('parseArgs rejects "0" for --issue, not just non-digit input (Copilot review, PR #2558)', () => {
+  assert.equal(parseArgs(['--issue', '0']).issue, null);
+  assert.equal(parseArgs(['--issue', 'abc']).issue, null);
+  assert.equal(parseArgs(['--issue', '-1']).issue, null);
+  assert.equal(parseArgs(['--issue', '2222']).issue, 2222);
 });

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -3494,16 +3494,21 @@ test('loadHighContentionFiles: an unreadable manifest path returns null', () => 
 // a regression with no other test coverage. Mirrors this repo's own
 // established "cover the call site, not just the extracted helper" pattern
 // (see idd-skill#1810's resolveClaimEvidence structural pin in
-// tests/advisory-convergence.test.mts).
+// tests/advisory-convergence.test.mts). #1485 moved the actual
+// loadHighContentionFiles(manifestPath, bundleIds) call into
+// collectHighConfidenceDuplicateEvidence (so suitability-close-execute.mts
+// can reuse it); this pin now covers runCli's call into that function
+// instead, which is the new place args.manifest / args.bundles could
+// silently stop being forwarded.
 
-test('runCli forwards args.manifest / args.bundles into loadHighContentionFiles (wiring check)', () => {
+test('runCli forwards args.manifest / args.bundles into collectHighConfidenceDuplicateEvidence (wiring check)', () => {
   const source = readFileSync(
     new URL('../src/scripts/suitability-triage.mts', import.meta.url),
     'utf8',
   );
   assert.match(
     source,
-    /loadHighContentionFiles\(\s*args\.manifest,\s*args\.bundles\s*\?\?\s*DEFAULT_BUNDLE_IDS,?\s*\)/,
+    /collectHighConfidenceDuplicateEvidence\(\s*owner,\s*repo,\s*repoRef,\s*issue,\s*args\.manifest,\s*args\.bundles\s*\?\?\s*DEFAULT_BUNDLE_IDS,?\s*\)/,
   );
 });
 


### PR DESCRIPTION
# Summary

Authorizes an autopilot A4.5 session to autonomously close a
high-confidence duplicate/superseded candidate **before** entering B
phase, gated strictly on `#1484`'s existing mechanical high-confidence
tier (`tier: 'high-confidence'` from `evaluateHighConfidenceDuplicate`)
-- never the weak title/declaration heuristic.

- Extracts `runCli`'s Check 4 evidence-collection block into the newly
  exported `collectHighConfidenceDuplicateEvidence`
  (`suitability-triage.mts`), and exports
  `fetchClosedByMergedPrNumbers` / `fetchMergedPrByBranchName`, so the
  new close path reuses the identical mechanical signals verbatim
  instead of duplicating them.
- Adds `suitability-close-execute.mts`: a no-worktree
  coordination-claim close path mirroring A1.5's roadmap-audit claim
  shape (`branch: suitability-close/<n>-<slug>`, outside the core
  cwd-vs-claim gate's `issue/*`/`roadmap-audit/*` scope, so no
  instruction-file edit was needed there). Dry-run by default;
  `--apply` re-validates the coordination claim and re-collects
  evidence immediately before mutating, then posts the evidence-bound
  close comment, closes the issue, and releases the claim -- failing
  closed on any lost/stale/non-owned claim or a no-longer-eligible
  fresh re-evaluation.
- Documents the gated close in
  `idd-suitability.instructions.md`'s Mutation Policy, restricted to
  discovery-path candidates (A2/A3 roadmap traversal, A0-O
  orphan-first); an A0-T explicit target keeps its existing
  report-and-stop path unchanged. Rewrites the stale "deferred to the
  gated-close follow-up" sentence -- the acceptance-criteria-hold-on-
  `main` signal from `#1484`'s original proposal stays unimplemented
  and authorizes no close on its own.
- Registers the new helper in `helper-runtime-manifest.mts` / `bin/` /
  `package.json` (required by this repo's own
  `helper-runtime-manifest.test.mts` / `consistency.test.mts` /
  `help-text-flags.test.mts` guards), with 19 new unit tests covering
  strong-signal-close, no-signal-no-close, a weak-tier fail (never
  eligible), and every claim-rejection reason (missing, mismatched
  claim-id, wrong branch prefix, wrong issue number, stale).

`discover-orphan-filter.mts` / `phase-id-resolver.mts` need no
wiring: the close fires at A4.5 time on the candidate already
selected by discovery, not inside the orphan filter itself, and this
introduces no new phase id.

## Linked issue

Closes #1485

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

`#1484` intentionally shipped detect-only (no close) so the maintainer
could observe Step 1's detection quality on real cases before
authorizing a close. Step 1 has run since 2026-07-18 with no reported
false high-confidence flag; this issue's own body records the
maintainer's 2026-09-03 "go" decision. The coordination-claim
(GitHub-only, no worktree) mirrors A1.5's existing pattern precisely
so the close is serialized against a session that might legitimately
be implementing the same issue concurrently, and cannot race a normal
`issue/*` implementation claim.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
