### PR TITLE
fix(pre-merge-readiness): resolve every policy gate from a trusted ref

### DIFF
--- a/scripts/advisory-wait-policy.mjs
+++ b/scripts/advisory-wait-policy.mjs
@@ -71,6 +71,20 @@ export const ADVISORY_CAP_EXHAUSTED_ROUTES = new Set([
   'hold',
 ]);
 const POLICY_SCHEMA = loadJson('schemas/policy.schema.json');
+/**
+ * True when `config`'s `advisoryWait` section passes {@link POLICY_SCHEMA}
+ * validation (or the section is absent) -- the same gate every `read*`
+ * wrapper below applies to a freshly-parsed file before calling its
+ * `resolve*` sibling. Exported so a caller that already holds a parsed
+ * config from a source other than a local file (`pre-merge-readiness.mts`'s
+ * trusted-ref read, #2373) can apply the identical validate-or-default rule
+ * instead of duplicating this schema check.
+ */
+export function advisoryWaitSectionIsValid(config) {
+  return (
+    validateConfigSection(config, POLICY_SCHEMA, 'advisoryWait').length === 0
+  );
+}
 export function readAdvisoryWaitPolicy(path = '.github/idd/config.json') {
   try {
     const config = JSON.parse(readFileSync(path, 'utf8'));

--- a/scripts/idd-config.mjs
+++ b/scripts/idd-config.mjs
@@ -32,6 +32,8 @@
 // residual up knowingly.
 import { readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
+import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mjs';
+import { deriveGhHttpStatus } from './gh-http-status.mjs';
 import {
   inspectCritiqueLoopDelegateLayer,
   resolveEffectiveCritiqueLoopDelegate,
@@ -53,6 +55,95 @@ export function loadIddConfig() {
 }
 /** Default `.github/idd/config.json` path, relative to the process cwd. */
 export const DEFAULT_POLICY_CONFIG_PATH = '.github/idd/config.json';
+/**
+ * Build the `gh api` argv that reads `.github/idd/config.json` for
+ * `owner/repo` **at `ref`** via the Contents API, narrowed to `.content`
+ * (base64). `--method GET` is required alongside the `-f ref=...` field:
+ * `gh api` defaults to POST as soon as any `-f` value is present, and the
+ * Contents API only accepts GET -- an unqualified `-f ref=...` here 404s on
+ * every call (confirmed empirically), which {@link loadTrustedIddConfig}'s
+ * own catch block would otherwise silently treat as "config genuinely
+ * absent, use defaults" instead of surfacing the real problem.
+ */
+export function buildIddConfigContentsArgs(owner, repo, ref) {
+  return [
+    'api',
+    `repos/${owner}/${repo}/contents/.github/idd/config.json`,
+    '--method',
+    'GET',
+    '-f',
+    `ref=${ref}`,
+    '--jq',
+    '.content',
+  ];
+}
+/**
+ * Fetch and parse `.github/idd/config.json` for `owner/repo` **at a trusted
+ * `ref`** -- a repository's default branch, or a PR's base branch -- via
+ * the Contents API, instead of a local worktree read. Generalized from
+ * `rerun-advisory-convergence.mts`'s original `loadRemoteIddConfig` (#1434)
+ * so every caller that needs this trust boundary (that file's bot-identity
+ * diagnosis, and `pre-merge-readiness.mts`'s policy-gate resolution, #2373)
+ * shares one fetch-and-classify implementation instead of near-identical
+ * copies.
+ *
+ * `ref` must be a value the PR under evaluation cannot itself steer --
+ * never a PR's own `headSha`, never a local working-tree read. A PR that
+ * could edit the ref this function reads from could edit its own
+ * `.github/idd/config.json` to disguise a bot-triggered run as non-bot, loosen
+ * `ciWait.rerunPolicy`, widen `trustedMarkerActors`, or otherwise weaken any
+ * policy-driven gate that resolves through this function.
+ *
+ * Returns `null` -- falls back to the same documented defaults
+ * {@link loadIddConfig} does for a missing local file -- **only** on a
+ * confirmed 404 (`ref` genuinely has no config committed). Any other
+ * failure -- a permission error, a transient Contents API failure, or
+ * malformed content -- means this function cannot confirm whether `ref`
+ * configures a non-default policy, so silently substituting defaults could
+ * misclassify what the trusted ref actually governs. That ambiguity throws
+ * instead of guessing, rather than proceeding on unconfirmed policy.
+ *
+ * `fetchEncodedConfig` is injectable (default: a real `gh api` call via
+ * {@link ghText}) so a caller like `collectPreMergeReadiness` can pass a
+ * fake in tests without spawning a `gh` process, mirroring
+ * `idd-merge-execute.mts`'s `resolveRemoteSoloCodeownerAdminFallbackMode`.
+ */
+export function loadTrustedIddConfig(
+  owner,
+  repo,
+  ref,
+  fetchEncodedConfig = (fetchOwner, fetchRepo, fetchRef) =>
+    ghText(
+      buildIddConfigContentsArgs(fetchOwner, fetchRepo, fetchRef),
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    ),
+) {
+  try {
+    const encoded = fetchEncodedConfig(owner, repo, ref);
+    const decoded = Buffer.from(encoded.replace(/\n/g, ''), 'base64').toString(
+      'utf8',
+    );
+    const parsed = JSON.parse(decoded);
+    // A syntactically-valid top-level scalar/array/`null` (`JSON.parse('null')`
+    // succeeds) would otherwise masquerade as this function's own "absent"
+    // sentinel -- the same fail-open gap #1776 fixed for loadPolicyConfig's
+    // local-file read, reopened here via a trusted-ref fetch instead.
+    if (!isPlainObject(parsed)) {
+      throw new Error(
+        `expected a JSON object at the top level, got ${describeJsonValueKind(parsed)}`,
+      );
+    }
+    return parsed;
+  } catch (error) {
+    if (deriveGhHttpStatus(error) === 404) {
+      return null;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `cannot confirm .github/idd/config.json for ${owner}/${repo}@${ref}: this trusted-ref read requires the file to be readable or genuinely absent (404) at this ref, not merely unreadable -- ${message}`,
+    );
+  }
+}
 /**
  * Read and parse a policy config file for the nine `--policy`/`--config`
  * aware helpers (#1721), converging the read-and-parse failure semantics

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -4,30 +4,26 @@
 // The scripts/pre-merge-readiness.mjs copy is generated from the .mts
 // source named above by `pnpm run build`. Edit the .mts source, never the
 // generated .mjs. See docs/typescript-sources.md.
-import { readFileSync } from 'node:fs';
 import {
+  advisoryWaitSectionIsValid,
   DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
-  readAdvisoryConvergenceDeadlineMinutes,
-  readAdvisoryPrimaryBotLogin,
-  readAdvisoryRecoveryCycleCap,
-  readAdvisorySecondaryBotLogin,
-  readAdvisorySecondaryQuietWindowMinutes,
-  readAdvisoryTerminalWindowMinutes,
-  readAdvisoryWaitPolicy,
+  resolveAdvisoryConvergenceDeadlineMinutes,
+  resolveAdvisoryPrimaryBotLogin,
+  resolveAdvisoryRecoveryCycleCap,
+  resolveAdvisorySecondaryBotLogin,
+  resolveAdvisorySecondaryQuietWindowMinutes,
+  resolveAdvisoryTerminalWindowMinutes,
+  resolveAdvisoryWaitPolicy,
 } from './advisory-wait-policy.mjs';
 import { buildCopilotRecoverySummary } from './advisory-wait-state.mjs';
 import { parseCliArgs } from './cli-args.mjs';
-import {
-  isAuthorizedForcedHandoffActor,
-  readForcedHandoffAuthorityPolicy,
-  readForcedHandoffMode,
-} from './collaborator-permission.mjs';
+import { isAuthorizedForcedHandoffActor } from './collaborator-permission.mjs';
 import {
   normalizeAuthorityEvidence,
   resolveCollaboratorAuthority,
 } from './external-check-waiver.mjs';
 import { deriveGhHttpStatus } from './gh-http-status.mjs';
-import { loadIddConfig } from './idd-config.mjs';
+import { loadTrustedIddConfig } from './idd-config.mjs';
 import {
   inspectDevelopmentBranch,
   normalizePolicyConfig,
@@ -189,6 +185,7 @@ const PRE_MERGE_READINESS_FLAG_SPEC = {
 export function collectPreMergeReadiness(
   argv,
   createPort = createGithubProviderAdapter,
+  loadTrustedConfig = loadTrustedIddConfig,
 ) {
   const args = parseArgs(argv);
   // --help used to exit from inside the parseArgs token loop; relocated
@@ -212,19 +209,6 @@ export function collectPreMergeReadiness(
   const port = createPort(owner, repo);
   const viewerLogin = port.resolveViewerLoginSafe().viewerLogin;
   const viewerAppSlug = port.resolveViewerAppSlugSafe().appSlug.toLowerCase();
-  const iddConfig = loadIddConfig();
-  const { actors: configuredTrustedActors, source: trustedMarkerActorsSource } =
-    resolveTrustedMarkerActors({
-      flagValue: args.trustedMarkerLogins,
-      envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
-      config: iddConfig,
-    });
-  const { logins: advisoryBotLogins, source: advisoryBotLoginsSource } =
-    resolveAdvisoryBotLogins({
-      flagValue: args.advisoryBotLogins,
-      envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
-      config: iddConfig,
-    });
   // #1513: `mergeable`/`mergeStateStatus` are part of this same richest
   // single `pr view` call (no extra network round-trip) so the branch-
   // currency gate below can pair a live `BEHIND` state with the up-to-date-
@@ -247,10 +231,60 @@ export function collectPreMergeReadiness(
       );
     }
   }
+  // #2373: EVERY config-driven gate below resolves `.github/idd/config.json`
+  // from this ONE trusted-ref read, never a local worktree read -- the F3
+  // merge-gate helper normally runs from the claimed PR's own worktree
+  // (B1 creates it from the PR's branch), so a local read would return the
+  // PR branch's own possibly-edited copy of its policy file, letting a PR
+  // widen its own trustedMarkerActors, loosen a ciGate setting, or disguise
+  // its developmentBranchTarget check against itself. `baseRefName` -- the
+  // PR's base branch -- is the trust boundary; when a PR context cannot
+  // supply one (defensive only, `--pr` is required so this is normally
+  // non-empty), this falls back to the repository's live default branch,
+  // matching `developmentBranchTarget`'s own `liveDefaultBranch` fallback
+  // below. `--pr <number>` is a required argument on every path, including
+  // `--claimless` (checked above) -- confirmed no call site of this file
+  // (nor `idd-doctor.mts`, whose own `readTrustEmptyProtectionReads` is a
+  // distinct, root-scoped local reader unrelated to this one) invokes
+  // `collectPreMergeReadiness` without `--pr`, so this fallback is
+  // defensive-only, not a documented "no PR at all" entry point.
+  const trustedConfigRef =
+    baseRefName || port.getRepositoryDefaultBranch(owner, repo);
+  if (!trustedConfigRef) {
+    throw new Error(
+      `cannot resolve a trusted ref for .github/idd/config.json: PR #${args.prNumber} has no baseRefName and the repository's live default branch could not be determined`,
+    );
+  }
+  const iddConfig = loadTrustedConfig(owner, repo, trustedConfigRef);
+  // Schema-validated once here, matching every `advisoryWait.*` resolver's
+  // own individual `read*` wrapper (advisory-wait-policy.mts) validating
+  // before it resolves -- an invalid `advisoryWait` section falls back to
+  // schema defaults for the WHOLE section rather than leaving a malformed
+  // field to whichever resolver reads it next.
+  const advisoryWaitConfig = advisoryWaitSectionIsValid(iddConfig)
+    ? iddConfig
+    : {};
+  const { actors: configuredTrustedActors, source: trustedMarkerActorsSource } =
+    resolveTrustedMarkerActors({
+      flagValue: args.trustedMarkerLogins,
+      envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+      config: iddConfig,
+    });
+  const { logins: advisoryBotLogins, source: advisoryBotLoginsSource } =
+    resolveAdvisoryBotLogins({
+      flagValue: args.advisoryBotLogins,
+      envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
+      config: iddConfig,
+    });
   // #2272: fail-closed development-branch invariant. Only reads the live
   // repository default branch when the policy is silent (`'absent'`) --
   // a configured or malformed value never needs it, so a repo with an
-  // explicit `developmentBranch` never pays this extra `gh api` call.
+  // explicit `developmentBranch` never pays this extra `gh api` call. Kept
+  // as its own lazy `getRepositoryDefaultBranch` call rather than reusing
+  // `trustedConfigRef` above: that value is eagerly resolved for every PR
+  // (`baseRefName` is normally non-empty), so merging the two would pay
+  // this call unconditionally instead of only on the rare-in-practice
+  // policy-silent path.
   const developmentBranchInspection = inspectDevelopmentBranch(iddConfig);
   const liveDefaultBranch =
     developmentBranchInspection.status === 'absent'
@@ -274,7 +308,7 @@ export function collectPreMergeReadiness(
   const checks = (snapshot.statusCheckRollup ?? []).map(
     normalizeStatusCheckRollupEntry,
   );
-  const trustEmptyProtectionReads = readTrustEmptyProtectionReads();
+  const trustEmptyProtectionReads = readTrustEmptyProtectionReads(iddConfig);
   const branchRulesRead = fetchGovernanceJson(
     `repos/${owner}/${repo}/rules/branches/${encodedBaseRefName}`,
     true,
@@ -367,7 +401,7 @@ export function collectPreMergeReadiness(
     viewerLogin,
     branchProtection,
   );
-  const collaboratorTrustEnabled = readCollaboratorTrustEnabled();
+  const collaboratorTrustEnabled = readCollaboratorTrustEnabled(iddConfig);
   const trustedMarkerLogins = normalizeTrustedMarkerLogins([
     viewerLogin,
     ...configuredTrustedActors,
@@ -384,10 +418,11 @@ export function collectPreMergeReadiness(
     trustedMarkerLogins,
     operationalComments: [...comments, ...claimComments],
   });
-  const advisoryWaitPolicy = readAdvisoryWaitPolicy();
-  const primaryBotLogin = readAdvisoryPrimaryBotLogin();
-  const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
-  const forcedHandoffEnabled = readForcedHandoffMode() === 'human-gated';
+  const advisoryWaitPolicy = resolveAdvisoryWaitPolicy(advisoryWaitConfig);
+  const primaryBotLogin = resolveAdvisoryPrimaryBotLogin(advisoryWaitConfig);
+  const forcedHandoffPolicy = normalizePolicyConfig(iddConfig).forcedHandoff;
+  const forcedHandoffAuthorityPolicy = forcedHandoffPolicy.authorityPolicy;
+  const forcedHandoffEnabled = forcedHandoffPolicy.mode === 'human-gated';
   // The PR's first-commit time backs the Part B forced-handoff rule (#1058):
   // a legitimate issue-only handoff that predates the PR is honored even
   // against a PR-backed claim. This allowance is applied on the merge side
@@ -408,11 +443,13 @@ export function collectPreMergeReadiness(
     }
   }
   const forcedHandoffPermissionCache = new Map();
-  const waivableCheckSelectors = readWaivableCheckSelectors();
-  const externalCheckWaiverMaxValidity = readExternalCheckWaiverMaxValidity();
-  const externalCheckWaiverMode = readExternalCheckWaiverMode();
-  const trustSourcePinnedRequiredChecks = readTrustSourcePinnedRequiredChecks();
-  const staleAgeMs = readClaimStaleAgeMs();
+  const waivableCheckSelectors = readWaivableCheckSelectors(iddConfig);
+  const externalCheckWaiverMaxValidity =
+    readExternalCheckWaiverMaxValidity(iddConfig);
+  const externalCheckWaiverMode = readExternalCheckWaiverMode(iddConfig);
+  const trustSourcePinnedRequiredChecks =
+    readTrustSourcePinnedRequiredChecks(iddConfig);
+  const staleAgeMs = readClaimStaleAgeMs(iddConfig);
   const now = args.now || new Date().toISOString().replace('.000Z', 'Z');
   const normalizedComments = comments.map(normalizeComment);
   const normalizedReviews = reviews.map(normalizeReview);
@@ -433,9 +470,11 @@ export function collectPreMergeReadiness(
     headCommittedAt: advisoryConvergenceHeadCommittedAt,
   } = fetchReviewsAndHeadCommit(owner, repo, args.prNumber, port);
   const advisoryConvergenceDeadlineMinutes =
-    readAdvisoryConvergenceDeadlineMinutes();
-  const secondaryQuietWindowMinutes = readAdvisorySecondaryQuietWindowMinutes();
-  const secondaryBotLogin = readAdvisorySecondaryBotLogin();
+    resolveAdvisoryConvergenceDeadlineMinutes(advisoryWaitConfig);
+  const secondaryQuietWindowMinutes =
+    resolveAdvisorySecondaryQuietWindowMinutes(advisoryWaitConfig);
+  const secondaryBotLogin =
+    resolveAdvisorySecondaryBotLogin(advisoryWaitConfig);
   // #1570: precompute the `#1572` terminal Copilot-unavailability verdict
   // here (the CLI/orchestration layer) rather than inside
   // `buildPreMergeReadinessSummary` (protocol-helpers.mts), which cannot
@@ -484,8 +523,9 @@ export function collectPreMergeReadiness(
       trustedMarkerLogins,
       claimId: args.expectedClaimId,
       agentId: args.expectedAgentId,
-      recoveryCycleCap: readAdvisoryRecoveryCycleCap(),
-      terminalWindowMinutes: readAdvisoryTerminalWindowMinutes(),
+      recoveryCycleCap: resolveAdvisoryRecoveryCycleCap(advisoryWaitConfig),
+      terminalWindowMinutes:
+        resolveAdvisoryTerminalWindowMinutes(advisoryWaitConfig),
     },
   );
   const copilotUnavailable = copilotRecovery.state === 'COPILOT_UNAVAILABLE';
@@ -494,6 +534,7 @@ export function collectPreMergeReadiness(
       port,
       owner,
       repo,
+      iddConfig,
       copilotUnavailable,
       waivableCheckSelectors,
       now,
@@ -1115,64 +1156,44 @@ function splitCsv(value) {
     .map((token) => token.trim())
     .filter(Boolean);
 }
-function isTruthy(value) {
-  return /^(1|true|yes)$/i.test(String(value ?? '').trim());
-}
-function readCollaboratorTrustEnabled() {
-  try {
-    return resolveCollaboratorMarkerTrust(
-      JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
-      process.env.IDD_TRUST_COLLABORATOR_MARKERS,
-    );
-  } catch {
-    // Fall through to env-var fallback.
-  }
-  return isTruthy(process.env.IDD_TRUST_COLLABORATOR_MARKERS);
+// #2373: takes the already-resolved trusted-ref config (see
+// `collectPreMergeReadiness`'s own `iddConfig` resolution) instead of
+// reading `.github/idd/config.json` locally -- `normalizePolicyConfig`/
+// `resolveCollaboratorMarkerTrust` already treat `null` (and a malformed
+// shape within a valid object) as "unconfigured", so no try/catch is
+// needed here now that the fetch itself owns the fail-closed contract.
+function readCollaboratorTrustEnabled(iddConfig) {
+  return resolveCollaboratorMarkerTrust(
+    iddConfig,
+    process.env.IDD_TRUST_COLLABORATOR_MARKERS,
+  );
 }
 // Configured waivable external-check selectors (`ciGate.externalChecks.
 // waivable`). The F2 gate only lets a valid waiver fold a check into
-// `requiredChecksPassing` when that check sits on this surface; an absent or
-// unreadable config yields an empty list (nothing waivable).
-function readWaivableCheckSelectors() {
-  try {
-    return [
-      ...normalizePolicyConfig(
-        JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
-      ).ciGate.externalChecks.waivable,
-    ];
-  } catch {
-    return [];
-  }
+// `requiredChecksPassing` when that check sits on this surface; an absent
+// config yields an empty list (nothing waivable).
+function readWaivableCheckSelectors(iddConfig) {
+  return [...normalizePolicyConfig(iddConfig).ciGate.externalChecks.waivable];
 }
 // Configured external-check waiver validity window (`ciGate.
 // externalCheckWaivers.maxValidity`). The consume side re-enforces it so a
 // waiver whose `expiresAt - createdAt` outlives the policy window cannot count
-// as valid. `normalizePolicyConfig` already defaults this to `PT24H`; an absent
-// or unreadable config falls back to the same authoring default.
-function readExternalCheckWaiverMaxValidity() {
-  try {
-    return normalizePolicyConfig(
-      JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
-    ).ciGate.externalCheckWaivers.maxValidity;
-  } catch {
-    return 'PT24H';
-  }
+// as valid. `normalizePolicyConfig` already defaults this to `PT24H`; an
+// absent config falls back to the same authoring default.
+function readExternalCheckWaiverMaxValidity(iddConfig) {
+  return normalizePolicyConfig(iddConfig).ciGate.externalCheckWaivers
+    .maxValidity;
 }
 // Configured external-check waiver mode (`ciGate.externalCheckWaivers.mode`,
 // #2046). `mode` gates the WHOLE waiver mechanism independent of the
-// `waivable` selector list -- an absent or unreadable config falls back to
+// `waivable` selector list -- an absent config falls back to
 // `normalizePolicyConfig`'s own schema default (`disabled`), the fail-closed
-// choice: an unreadable config can never make this check wrongly report an
-// otherwise-valid waiver as covered when the real required check would not
-// honor it, mirroring `advisory-convergence.mts`'s own fail-closed guard.
-function readExternalCheckWaiverMode() {
-  try {
-    return normalizePolicyConfig(
-      JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
-    ).ciGate.externalCheckWaivers.mode;
-  } catch {
-    return 'disabled';
-  }
+// choice: an unconfigured repository can never make this check wrongly
+// report an otherwise-valid waiver as covered when the real required check
+// would not honor it, mirroring `advisory-convergence.mts`'s own
+// fail-closed guard.
+function readExternalCheckWaiverMode(iddConfig) {
+  return normalizePolicyConfig(iddConfig).ciGate.externalCheckWaivers.mode;
 }
 // #2353 (Codex review on PR #2370, second follow-up): a declaration's own
 // `startedAt` is generated before the `--declare --apply` interactive
@@ -1227,15 +1248,14 @@ function resolveAdvisoryConvergenceOutageRelief({
   port,
   owner,
   repo,
+  iddConfig,
   copilotUnavailable,
   waivableCheckSelectors,
   now,
 }) {
   const notRelieved = { relieved: false, since: '' };
   try {
-    const policy = normalizePolicyConfig(
-      JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
-    );
+    const policy = normalizePolicyConfig(iddConfig);
     if (policy.ciGate.externalCheckWaivers.mode !== 'maintainer-authorized') {
       return notRelieved;
     }
@@ -1283,28 +1303,25 @@ function resolveAdvisoryConvergenceOutageRelief({
 }
 // Configured claim-staleness window (`claimTiming.staleAge`, #1310), parsed
 // to milliseconds so the write-gate claim resolver honors it instead of the
-// hardcoded 24h `isStaleAt` default. Reuses the shared `loadIddConfig`
-// loader (already imported by this file) instead of a per-helper
-// `readFileSync + JSON.parse` copy; `loadIddConfig` already fails safe to
-// `null` and `normalizePolicyConfig(null)` already defaults to `PT24H`, so
-// no separate try/catch is needed here. An absent, unreadable, or
-// unparseable config falls back to the shared `DEFAULT_STALE_AGE_MS`
-// (protocol-helpers.mts) rather than a second local 24h literal, so
-// behavior is unchanged for repos on the default and there is exactly one
-// hardcoded-24h source of truth.
-function readClaimStaleAgeMs() {
-  const staleAge = normalizePolicyConfig(loadIddConfig()).claimTiming.staleAge;
+// hardcoded 24h `isStaleAt` default. Takes the caller's already-resolved
+// trusted-ref config (#2373) instead of its own `.github/idd/config.json`
+// read; `normalizePolicyConfig(null)` already defaults to `PT24H`, so no
+// try/catch is needed here. An absent or unparseable value falls back to
+// the shared `DEFAULT_STALE_AGE_MS` (protocol-helpers.mts) rather than a
+// second local 24h literal, so behavior is unchanged for repos on the
+// default and there is exactly one hardcoded-24h source of truth.
+function readClaimStaleAgeMs(iddConfig) {
+  const staleAge = normalizePolicyConfig(iddConfig).claimTiming.staleAge;
   return parseIsoDurationToMs(staleAge) ?? DEFAULT_STALE_AGE_MS;
 }
 // Configured governance-read trust opt-in (`ciGate.trustEmptyProtectionReads`,
-// #1377). Reuses the shared `loadIddConfig` loader (already imported by this
-// file); an absent, unreadable, or unparseable config fails safe to the
-// `false` default via `normalizePolicyConfig(null)`, matching
-// `readClaimStaleAgeMs`'s pattern above.
-function readTrustEmptyProtectionReads() {
+// #1377). Takes the caller's already-resolved trusted-ref config (#2373);
+// an absent or unparseable config fails safe to the `false` default via
+// `normalizePolicyConfig(null)`, matching `readClaimStaleAgeMs`'s pattern
+// above.
+function readTrustEmptyProtectionReads(iddConfig) {
   return (
-    normalizePolicyConfig(loadIddConfig()).ciGate.trustEmptyProtectionReads ===
-    true
+    normalizePolicyConfig(iddConfig).ciGate.trustEmptyProtectionReads === true
   );
 }
 // Configured source-pinned required-check trust opt-in
@@ -1312,10 +1329,10 @@ function readTrustEmptyProtectionReads() {
 // `readTrustEmptyProtectionReads` above; see `summarizeRequiredChecks`'s
 // (protocol-helpers.mts) doc comment on the option of the same name for the
 // full rationale.
-function readTrustSourcePinnedRequiredChecks() {
+function readTrustSourcePinnedRequiredChecks(iddConfig) {
   return (
-    normalizePolicyConfig(loadIddConfig()).ciGate
-      .trustSourcePinnedRequiredChecks === true
+    normalizePolicyConfig(iddConfig).ciGate.trustSourcePinnedRequiredChecks ===
+    true
   );
 }
 /**

--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -134,7 +134,7 @@ import {
 } from './ci-wait-policy.mjs';
 import { parseCanonicalIntegerOrNull, parseCliArgs } from './cli-args.mjs';
 import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mjs';
-import { deriveGhHttpStatus } from './gh-http-status.mjs';
+import { loadTrustedIddConfig } from './idd-config.mjs';
 import { isValidIsoTimestamp } from './marker-helpers.mjs';
 import {
   advisoryBotIdentityToken,
@@ -1481,10 +1481,11 @@ function fetchCheckRunsForRef(owner, repo, ref, checkName) {
   return parsePaginatedGhNdjson(raw);
 }
 /**
- * Fetch and parse `.github/idd/config.json` for `owner/repo` **at `ref`**
- * via the Contents API. Used unconditionally -- both a same-repo and a
- * true cross-repository invocation -- rather than a local `readFileSync`
- * fallback for the same-repo case (`loadIddConfig`, idd-config.mts).
+ * `.github/idd/config.json` for `owner/repo` **at `ref`**, fetched via
+ * {@link loadTrustedIddConfig} (idd-config.mts) -- generalized there from
+ * this file's original private implementation (#1434) so
+ * `pre-merge-readiness.mts` shares the same fetch-and-classify contract
+ * instead of a second, near-identical `gh api contents` call (#2373).
  *
  * `ref` must be the repository's TRUSTED default branch (see
  * {@link resolveDefaultBranch}), never `prHeadSha` and never a local
@@ -1502,60 +1503,8 @@ function fetchCheckRunsForRef(owner, repo, ref, checkName) {
  * actually governed those runs (#1434 review, Codex P2, second
  * occurrence -- reverts this file's own prior "always prHeadSha" fix,
  * which solved the "unpinned ref" bug but pinned the wrong ref).
- *
- * `--method GET` is required alongside the `-f ref=...` field, for the
- * same reason `buildCheckRunsForRefArgs` above needs it: `gh api` defaults
- * to POST as soon as any `-f` value is present, and the Contents API only
- * accepts GET -- an unqualified `-f ref=...` here would 404 on every call
- * (confirmed empirically), which this function's own catch block would
- * silently treat as "config genuinely absent, use defaults" instead of
- * surfacing the real problem.
- *
- * Returns `null` -- falls back to documented defaults, same as a missing
- * local file -- **only** on a confirmed 404 (`ref` genuinely has no
- * config committed, the same "absent" state `loadIddConfig` treats as
- * "use defaults" locally). Any other failure -- a permission error, a
- * transient Contents API failure, or malformed content -- means this
- * helper cannot confirm whether `ref` configures a non-default bot
- * identity, so silently substituting defaults could misclassify a
- * bot-triggered run there as rerun-eligible. Per this repo's own
- * fail-closed default (`idd-overview-core.instructions.md`), that
- * ambiguity throws instead of guessing, rejecting the diagnosis outright
- * rather than proceeding on unconfirmed bot identity (#1434 review, Codex
- * P2).
  */
-export function buildIddConfigContentsArgs(owner, repo, ref) {
-  return [
-    'api',
-    `repos/${owner}/${repo}/contents/.github/idd/config.json`,
-    '--method',
-    'GET',
-    '-f',
-    `ref=${ref}`,
-    '--jq',
-    '.content',
-  ];
-}
-function loadRemoteIddConfig(owner, repo, ref) {
-  try {
-    const encoded = ghText(
-      buildIddConfigContentsArgs(owner, repo, ref),
-      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
-    );
-    const decoded = Buffer.from(encoded.replace(/\n/g, ''), 'base64').toString(
-      'utf8',
-    );
-    return JSON.parse(decoded);
-  } catch (error) {
-    if (deriveGhHttpStatus(error) === 404) {
-      return null;
-    }
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(
-      `cannot confirm .github/idd/config.json for ${owner}/${repo}@${ref}: bot-identity resolution for this diagnosis requires this file to be readable or genuinely absent (404) at this ref, not merely unreadable -- ${message}`,
-    );
-  }
-}
+const loadRemoteIddConfig = loadTrustedIddConfig;
 /**
  * Resolve `owner/repo`'s default branch via the Repository API -- the
  * `ref` {@link loadRemoteIddConfig} must read `.github/idd/config.json`

--- a/src/scripts/advisory-wait-policy.mts
+++ b/src/scripts/advisory-wait-policy.mts
@@ -75,6 +75,21 @@ export const ADVISORY_CAP_EXHAUSTED_ROUTES = new Set([
 ]);
 const POLICY_SCHEMA = loadJson('schemas/policy.schema.json');
 
+/**
+ * True when `config`'s `advisoryWait` section passes {@link POLICY_SCHEMA}
+ * validation (or the section is absent) -- the same gate every `read*`
+ * wrapper below applies to a freshly-parsed file before calling its
+ * `resolve*` sibling. Exported so a caller that already holds a parsed
+ * config from a source other than a local file (`pre-merge-readiness.mts`'s
+ * trusted-ref read, #2373) can apply the identical validate-or-default rule
+ * instead of duplicating this schema check.
+ */
+export function advisoryWaitSectionIsValid(config: unknown): boolean {
+  return (
+    validateConfigSection(config, POLICY_SCHEMA, 'advisoryWait').length === 0
+  );
+}
+
 interface AdvisoryWaitPolicy {
   requestCap: number;
   pendingWindowMinutes: number;

--- a/src/scripts/idd-config.mts
+++ b/src/scripts/idd-config.mts
@@ -34,6 +34,8 @@
 import { readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 
+import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mts';
+import { deriveGhHttpStatus } from './gh-http-status.mts';
 import {
   type EffectiveCritiqueLoopDelegate,
   inspectCritiqueLoopDelegateLayer,
@@ -73,6 +75,105 @@ export function loadIddConfig(): IddConfig | null {
 
 /** Default `.github/idd/config.json` path, relative to the process cwd. */
 export const DEFAULT_POLICY_CONFIG_PATH = '.github/idd/config.json';
+
+/**
+ * Build the `gh api` argv that reads `.github/idd/config.json` for
+ * `owner/repo` **at `ref`** via the Contents API, narrowed to `.content`
+ * (base64). `--method GET` is required alongside the `-f ref=...` field:
+ * `gh api` defaults to POST as soon as any `-f` value is present, and the
+ * Contents API only accepts GET -- an unqualified `-f ref=...` here 404s on
+ * every call (confirmed empirically), which {@link loadTrustedIddConfig}'s
+ * own catch block would otherwise silently treat as "config genuinely
+ * absent, use defaults" instead of surfacing the real problem.
+ */
+export function buildIddConfigContentsArgs(
+  owner: string,
+  repo: string,
+  ref: string,
+): string[] {
+  return [
+    'api',
+    `repos/${owner}/${repo}/contents/.github/idd/config.json`,
+    '--method',
+    'GET',
+    '-f',
+    `ref=${ref}`,
+    '--jq',
+    '.content',
+  ];
+}
+
+/**
+ * Fetch and parse `.github/idd/config.json` for `owner/repo` **at a trusted
+ * `ref`** -- a repository's default branch, or a PR's base branch -- via
+ * the Contents API, instead of a local worktree read. Generalized from
+ * `rerun-advisory-convergence.mts`'s original `loadRemoteIddConfig` (#1434)
+ * so every caller that needs this trust boundary (that file's bot-identity
+ * diagnosis, and `pre-merge-readiness.mts`'s policy-gate resolution, #2373)
+ * shares one fetch-and-classify implementation instead of near-identical
+ * copies.
+ *
+ * `ref` must be a value the PR under evaluation cannot itself steer --
+ * never a PR's own `headSha`, never a local working-tree read. A PR that
+ * could edit the ref this function reads from could edit its own
+ * `.github/idd/config.json` to disguise a bot-triggered run as non-bot, loosen
+ * `ciWait.rerunPolicy`, widen `trustedMarkerActors`, or otherwise weaken any
+ * policy-driven gate that resolves through this function.
+ *
+ * Returns `null` -- falls back to the same documented defaults
+ * {@link loadIddConfig} does for a missing local file -- **only** on a
+ * confirmed 404 (`ref` genuinely has no config committed). Any other
+ * failure -- a permission error, a transient Contents API failure, or
+ * malformed content -- means this function cannot confirm whether `ref`
+ * configures a non-default policy, so silently substituting defaults could
+ * misclassify what the trusted ref actually governs. That ambiguity throws
+ * instead of guessing, rather than proceeding on unconfirmed policy.
+ *
+ * `fetchEncodedConfig` is injectable (default: a real `gh api` call via
+ * {@link ghText}) so a caller like `collectPreMergeReadiness` can pass a
+ * fake in tests without spawning a `gh` process, mirroring
+ * `idd-merge-execute.mts`'s `resolveRemoteSoloCodeownerAdminFallbackMode`.
+ */
+export function loadTrustedIddConfig(
+  owner: string,
+  repo: string,
+  ref: string,
+  fetchEncodedConfig: (owner: string, repo: string, ref: string) => string = (
+    fetchOwner,
+    fetchRepo,
+    fetchRef,
+  ) =>
+    ghText(
+      buildIddConfigContentsArgs(fetchOwner, fetchRepo, fetchRef),
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    ),
+): IddConfig | null {
+  try {
+    const encoded = fetchEncodedConfig(owner, repo, ref);
+    const decoded = Buffer.from(encoded.replace(/\n/g, ''), 'base64').toString(
+      'utf8',
+    );
+    const parsed: unknown = JSON.parse(decoded);
+    // A syntactically-valid top-level scalar/array/`null` (`JSON.parse('null')`
+    // succeeds) would otherwise masquerade as this function's own "absent"
+    // sentinel -- the same fail-open gap #1776 fixed for loadPolicyConfig's
+    // local-file read, reopened here via a trusted-ref fetch instead.
+    if (!isPlainObject(parsed)) {
+      throw new Error(
+        `expected a JSON object at the top level, got ${describeJsonValueKind(parsed)}`,
+      );
+    }
+    return parsed as IddConfig;
+  } catch (error) {
+    if (deriveGhHttpStatus(error) === 404) {
+      return null;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `cannot confirm .github/idd/config.json for ${owner}/${repo}@${ref}: this trusted-ref read requires the file to be readable or genuinely absent (404) at this ref, not merely unreadable -- ${message}`,
+    );
+  }
+}
 
 /** Result of {@link loadPolicyConfig}. */
 export interface PolicyConfigLoad {

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -5,33 +5,28 @@
 // source named above by `pnpm run build`. Edit the .mts source, never the
 // generated .mjs. See docs/typescript-sources.md.
 
-import { readFileSync } from 'node:fs';
-
 import {
+  advisoryWaitSectionIsValid,
   DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
-  readAdvisoryConvergenceDeadlineMinutes,
-  readAdvisoryPrimaryBotLogin,
-  readAdvisoryRecoveryCycleCap,
-  readAdvisorySecondaryBotLogin,
-  readAdvisorySecondaryQuietWindowMinutes,
-  readAdvisoryTerminalWindowMinutes,
-  readAdvisoryWaitPolicy,
+  resolveAdvisoryConvergenceDeadlineMinutes,
+  resolveAdvisoryPrimaryBotLogin,
+  resolveAdvisoryRecoveryCycleCap,
+  resolveAdvisorySecondaryBotLogin,
+  resolveAdvisorySecondaryQuietWindowMinutes,
+  resolveAdvisoryTerminalWindowMinutes,
+  resolveAdvisoryWaitPolicy,
 } from './advisory-wait-policy.mts';
 import { buildCopilotRecoverySummary } from './advisory-wait-state.mts';
 import { parseCliArgs } from './cli-args.mts';
 import type { CollaboratorPermissionCache } from './collaborator-permission.mts';
-import {
-  isAuthorizedForcedHandoffActor,
-  readForcedHandoffAuthorityPolicy,
-  readForcedHandoffMode,
-} from './collaborator-permission.mts';
+import { isAuthorizedForcedHandoffActor } from './collaborator-permission.mts';
 import {
   type AuthorityEvidence,
   normalizeAuthorityEvidence,
   resolveCollaboratorAuthority,
 } from './external-check-waiver.mts';
 import { deriveGhHttpStatus } from './gh-http-status.mts';
-import { loadIddConfig } from './idd-config.mts';
+import { type IddConfig, loadTrustedIddConfig } from './idd-config.mts';
 import {
   inspectDevelopmentBranch,
   normalizePolicyConfig,
@@ -376,6 +371,11 @@ export function collectPreMergeReadiness(
     owner: string,
     repo: string,
   ) => ProviderPort = createGithubProviderAdapter,
+  loadTrustedConfig: (
+    owner: string,
+    repo: string,
+    ref: string,
+  ) => IddConfig | null = loadTrustedIddConfig,
 ): PreMergeReadinessReport {
   const args = parseArgs(argv);
   // --help used to exit from inside the parseArgs token loop; relocated
@@ -400,19 +400,6 @@ export function collectPreMergeReadiness(
   const port = createPort(owner, repo);
   const viewerLogin = port.resolveViewerLoginSafe().viewerLogin;
   const viewerAppSlug = port.resolveViewerAppSlugSafe().appSlug.toLowerCase();
-  const iddConfig = loadIddConfig();
-  const { actors: configuredTrustedActors, source: trustedMarkerActorsSource } =
-    resolveTrustedMarkerActors({
-      flagValue: args.trustedMarkerLogins,
-      envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
-      config: iddConfig,
-    });
-  const { logins: advisoryBotLogins, source: advisoryBotLoginsSource } =
-    resolveAdvisoryBotLogins({
-      flagValue: args.advisoryBotLogins,
-      envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
-      config: iddConfig,
-    });
 
   // #1513: `mergeable`/`mergeStateStatus` are part of this same richest
   // single `pr view` call (no extra network round-trip) so the branch-
@@ -436,10 +423,63 @@ export function collectPreMergeReadiness(
       );
     }
   }
+
+  // #2373: EVERY config-driven gate below resolves `.github/idd/config.json`
+  // from this ONE trusted-ref read, never a local worktree read -- the F3
+  // merge-gate helper normally runs from the claimed PR's own worktree
+  // (B1 creates it from the PR's branch), so a local read would return the
+  // PR branch's own possibly-edited copy of its policy file, letting a PR
+  // widen its own trustedMarkerActors, loosen a ciGate setting, or disguise
+  // its developmentBranchTarget check against itself. `baseRefName` -- the
+  // PR's base branch -- is the trust boundary; when a PR context cannot
+  // supply one (defensive only, `--pr` is required so this is normally
+  // non-empty), this falls back to the repository's live default branch,
+  // matching `developmentBranchTarget`'s own `liveDefaultBranch` fallback
+  // below. `--pr <number>` is a required argument on every path, including
+  // `--claimless` (checked above) -- confirmed no call site of this file
+  // (nor `idd-doctor.mts`, whose own `readTrustEmptyProtectionReads` is a
+  // distinct, root-scoped local reader unrelated to this one) invokes
+  // `collectPreMergeReadiness` without `--pr`, so this fallback is
+  // defensive-only, not a documented "no PR at all" entry point.
+  const trustedConfigRef =
+    baseRefName || port.getRepositoryDefaultBranch(owner, repo);
+  if (!trustedConfigRef) {
+    throw new Error(
+      `cannot resolve a trusted ref for .github/idd/config.json: PR #${args.prNumber} has no baseRefName and the repository's live default branch could not be determined`,
+    );
+  }
+  const iddConfig = loadTrustedConfig(owner, repo, trustedConfigRef);
+  // Schema-validated once here, matching every `advisoryWait.*` resolver's
+  // own individual `read*` wrapper (advisory-wait-policy.mts) validating
+  // before it resolves -- an invalid `advisoryWait` section falls back to
+  // schema defaults for the WHOLE section rather than leaving a malformed
+  // field to whichever resolver reads it next.
+  const advisoryWaitConfig = advisoryWaitSectionIsValid(iddConfig)
+    ? iddConfig
+    : {};
+
+  const { actors: configuredTrustedActors, source: trustedMarkerActorsSource } =
+    resolveTrustedMarkerActors({
+      flagValue: args.trustedMarkerLogins,
+      envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+      config: iddConfig,
+    });
+  const { logins: advisoryBotLogins, source: advisoryBotLoginsSource } =
+    resolveAdvisoryBotLogins({
+      flagValue: args.advisoryBotLogins,
+      envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
+      config: iddConfig,
+    });
+
   // #2272: fail-closed development-branch invariant. Only reads the live
   // repository default branch when the policy is silent (`'absent'`) --
   // a configured or malformed value never needs it, so a repo with an
-  // explicit `developmentBranch` never pays this extra `gh api` call.
+  // explicit `developmentBranch` never pays this extra `gh api` call. Kept
+  // as its own lazy `getRepositoryDefaultBranch` call rather than reusing
+  // `trustedConfigRef` above: that value is eagerly resolved for every PR
+  // (`baseRefName` is normally non-empty), so merging the two would pay
+  // this call unconditionally instead of only on the rare-in-practice
+  // policy-silent path.
   const developmentBranchInspection = inspectDevelopmentBranch(iddConfig);
   const liveDefaultBranch =
     developmentBranchInspection.status === 'absent'
@@ -464,7 +504,7 @@ export function collectPreMergeReadiness(
   const checks = (
     (snapshot.statusCheckRollup as StatusCheckRollupPayload[] | null) ?? []
   ).map(normalizeStatusCheckRollupEntry);
-  const trustEmptyProtectionReads = readTrustEmptyProtectionReads();
+  const trustEmptyProtectionReads = readTrustEmptyProtectionReads(iddConfig);
   const branchRulesRead = fetchGovernanceJson<BranchRulePayload[]>(
     `repos/${owner}/${repo}/rules/branches/${encodedBaseRefName}`,
     true,
@@ -564,7 +604,7 @@ export function collectPreMergeReadiness(
     branchProtection,
   );
 
-  const collaboratorTrustEnabled = readCollaboratorTrustEnabled();
+  const collaboratorTrustEnabled = readCollaboratorTrustEnabled(iddConfig);
   const trustedMarkerLogins = normalizeTrustedMarkerLogins([
     viewerLogin,
     ...configuredTrustedActors,
@@ -581,10 +621,11 @@ export function collectPreMergeReadiness(
     trustedMarkerLogins,
     operationalComments: [...comments, ...claimComments],
   });
-  const advisoryWaitPolicy = readAdvisoryWaitPolicy();
-  const primaryBotLogin = readAdvisoryPrimaryBotLogin();
-  const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
-  const forcedHandoffEnabled = readForcedHandoffMode() === 'human-gated';
+  const advisoryWaitPolicy = resolveAdvisoryWaitPolicy(advisoryWaitConfig);
+  const primaryBotLogin = resolveAdvisoryPrimaryBotLogin(advisoryWaitConfig);
+  const forcedHandoffPolicy = normalizePolicyConfig(iddConfig).forcedHandoff;
+  const forcedHandoffAuthorityPolicy = forcedHandoffPolicy.authorityPolicy;
+  const forcedHandoffEnabled = forcedHandoffPolicy.mode === 'human-gated';
   // The PR's first-commit time backs the Part B forced-handoff rule (#1058):
   // a legitimate issue-only handoff that predates the PR is honored even
   // against a PR-backed claim. This allowance is applied on the merge side
@@ -607,11 +648,13 @@ export function collectPreMergeReadiness(
     }
   }
   const forcedHandoffPermissionCache: CollaboratorPermissionCache = new Map();
-  const waivableCheckSelectors = readWaivableCheckSelectors();
-  const externalCheckWaiverMaxValidity = readExternalCheckWaiverMaxValidity();
-  const externalCheckWaiverMode = readExternalCheckWaiverMode();
-  const trustSourcePinnedRequiredChecks = readTrustSourcePinnedRequiredChecks();
-  const staleAgeMs = readClaimStaleAgeMs();
+  const waivableCheckSelectors = readWaivableCheckSelectors(iddConfig);
+  const externalCheckWaiverMaxValidity =
+    readExternalCheckWaiverMaxValidity(iddConfig);
+  const externalCheckWaiverMode = readExternalCheckWaiverMode(iddConfig);
+  const trustSourcePinnedRequiredChecks =
+    readTrustSourcePinnedRequiredChecks(iddConfig);
+  const staleAgeMs = readClaimStaleAgeMs(iddConfig);
   const now = args.now || new Date().toISOString().replace('.000Z', 'Z');
   const normalizedComments = comments.map(normalizeComment);
   const normalizedReviews = reviews.map(normalizeReview);
@@ -633,9 +676,11 @@ export function collectPreMergeReadiness(
     headCommittedAt: advisoryConvergenceHeadCommittedAt,
   } = fetchReviewsAndHeadCommit(owner, repo, args.prNumber, port);
   const advisoryConvergenceDeadlineMinutes =
-    readAdvisoryConvergenceDeadlineMinutes();
-  const secondaryQuietWindowMinutes = readAdvisorySecondaryQuietWindowMinutes();
-  const secondaryBotLogin = readAdvisorySecondaryBotLogin();
+    resolveAdvisoryConvergenceDeadlineMinutes(advisoryWaitConfig);
+  const secondaryQuietWindowMinutes =
+    resolveAdvisorySecondaryQuietWindowMinutes(advisoryWaitConfig);
+  const secondaryBotLogin =
+    resolveAdvisorySecondaryBotLogin(advisoryWaitConfig);
 
   // #1570: precompute the `#1572` terminal Copilot-unavailability verdict
   // here (the CLI/orchestration layer) rather than inside
@@ -685,8 +730,9 @@ export function collectPreMergeReadiness(
       trustedMarkerLogins,
       claimId: args.expectedClaimId,
       agentId: args.expectedAgentId,
-      recoveryCycleCap: readAdvisoryRecoveryCycleCap(),
-      terminalWindowMinutes: readAdvisoryTerminalWindowMinutes(),
+      recoveryCycleCap: resolveAdvisoryRecoveryCycleCap(advisoryWaitConfig),
+      terminalWindowMinutes:
+        resolveAdvisoryTerminalWindowMinutes(advisoryWaitConfig),
     },
   );
   const copilotUnavailable = copilotRecovery.state === 'COPILOT_UNAVAILABLE';
@@ -695,6 +741,7 @@ export function collectPreMergeReadiness(
       port,
       owner,
       repo,
+      iddConfig,
       copilotUnavailable,
       waivableCheckSelectors,
       now,
@@ -1393,71 +1440,52 @@ function splitCsv(value: unknown): string[] {
     .filter(Boolean);
 }
 
-function isTruthy(value: unknown): boolean {
-  return /^(1|true|yes)$/i.test(String(value ?? '').trim());
-}
-
-function readCollaboratorTrustEnabled(): boolean {
-  try {
-    return resolveCollaboratorMarkerTrust(
-      JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
-      process.env.IDD_TRUST_COLLABORATOR_MARKERS,
-    );
-  } catch {
-    // Fall through to env-var fallback.
-  }
-  return isTruthy(process.env.IDD_TRUST_COLLABORATOR_MARKERS);
+// #2373: takes the already-resolved trusted-ref config (see
+// `collectPreMergeReadiness`'s own `iddConfig` resolution) instead of
+// reading `.github/idd/config.json` locally -- `normalizePolicyConfig`/
+// `resolveCollaboratorMarkerTrust` already treat `null` (and a malformed
+// shape within a valid object) as "unconfigured", so no try/catch is
+// needed here now that the fetch itself owns the fail-closed contract.
+function readCollaboratorTrustEnabled(iddConfig: IddConfig | null): boolean {
+  return resolveCollaboratorMarkerTrust(
+    iddConfig,
+    process.env.IDD_TRUST_COLLABORATOR_MARKERS,
+  );
 }
 
 // Configured waivable external-check selectors (`ciGate.externalChecks.
 // waivable`). The F2 gate only lets a valid waiver fold a check into
-// `requiredChecksPassing` when that check sits on this surface; an absent or
-// unreadable config yields an empty list (nothing waivable).
-function readWaivableCheckSelectors(): {
+// `requiredChecksPassing` when that check sits on this surface; an absent
+// config yields an empty list (nothing waivable).
+function readWaivableCheckSelectors(iddConfig: IddConfig | null): {
   selector?: unknown;
   matchMode?: unknown;
 }[] {
-  try {
-    return [
-      ...normalizePolicyConfig(
-        JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
-      ).ciGate.externalChecks.waivable,
-    ];
-  } catch {
-    return [];
-  }
+  return [...normalizePolicyConfig(iddConfig).ciGate.externalChecks.waivable];
 }
 
 // Configured external-check waiver validity window (`ciGate.
 // externalCheckWaivers.maxValidity`). The consume side re-enforces it so a
 // waiver whose `expiresAt - createdAt` outlives the policy window cannot count
-// as valid. `normalizePolicyConfig` already defaults this to `PT24H`; an absent
-// or unreadable config falls back to the same authoring default.
-function readExternalCheckWaiverMaxValidity(): string {
-  try {
-    return normalizePolicyConfig(
-      JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
-    ).ciGate.externalCheckWaivers.maxValidity;
-  } catch {
-    return 'PT24H';
-  }
+// as valid. `normalizePolicyConfig` already defaults this to `PT24H`; an
+// absent config falls back to the same authoring default.
+function readExternalCheckWaiverMaxValidity(
+  iddConfig: IddConfig | null,
+): string {
+  return normalizePolicyConfig(iddConfig).ciGate.externalCheckWaivers
+    .maxValidity;
 }
 
 // Configured external-check waiver mode (`ciGate.externalCheckWaivers.mode`,
 // #2046). `mode` gates the WHOLE waiver mechanism independent of the
-// `waivable` selector list -- an absent or unreadable config falls back to
+// `waivable` selector list -- an absent config falls back to
 // `normalizePolicyConfig`'s own schema default (`disabled`), the fail-closed
-// choice: an unreadable config can never make this check wrongly report an
-// otherwise-valid waiver as covered when the real required check would not
-// honor it, mirroring `advisory-convergence.mts`'s own fail-closed guard.
-function readExternalCheckWaiverMode(): string {
-  try {
-    return normalizePolicyConfig(
-      JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
-    ).ciGate.externalCheckWaivers.mode;
-  } catch {
-    return 'disabled';
-  }
+// choice: an unconfigured repository can never make this check wrongly
+// report an otherwise-valid waiver as covered when the real required check
+// would not honor it, mirroring `advisory-convergence.mts`'s own
+// fail-closed guard.
+function readExternalCheckWaiverMode(iddConfig: IddConfig | null): string {
+  return normalizePolicyConfig(iddConfig).ciGate.externalCheckWaivers.mode;
 }
 
 // #2353 (Codex review on PR #2370, second follow-up): a declaration's own
@@ -1516,6 +1544,7 @@ function resolveAdvisoryConvergenceOutageRelief({
   port,
   owner,
   repo,
+  iddConfig,
   copilotUnavailable,
   waivableCheckSelectors,
   now,
@@ -1523,15 +1552,14 @@ function resolveAdvisoryConvergenceOutageRelief({
   port: ProviderPort;
   owner: string;
   repo: string;
+  iddConfig: IddConfig | null;
   copilotUnavailable: boolean;
   waivableCheckSelectors: { selector?: unknown; matchMode?: unknown }[];
   now: string;
 }): { relieved: boolean; since: string } {
   const notRelieved = { relieved: false, since: '' };
   try {
-    const policy = normalizePolicyConfig(
-      JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
-    );
+    const policy = normalizePolicyConfig(iddConfig);
     if (policy.ciGate.externalCheckWaivers.mode !== 'maintainer-authorized') {
       return notRelieved;
     }
@@ -1580,29 +1608,26 @@ function resolveAdvisoryConvergenceOutageRelief({
 
 // Configured claim-staleness window (`claimTiming.staleAge`, #1310), parsed
 // to milliseconds so the write-gate claim resolver honors it instead of the
-// hardcoded 24h `isStaleAt` default. Reuses the shared `loadIddConfig`
-// loader (already imported by this file) instead of a per-helper
-// `readFileSync + JSON.parse` copy; `loadIddConfig` already fails safe to
-// `null` and `normalizePolicyConfig(null)` already defaults to `PT24H`, so
-// no separate try/catch is needed here. An absent, unreadable, or
-// unparseable config falls back to the shared `DEFAULT_STALE_AGE_MS`
-// (protocol-helpers.mts) rather than a second local 24h literal, so
-// behavior is unchanged for repos on the default and there is exactly one
-// hardcoded-24h source of truth.
-function readClaimStaleAgeMs(): number {
-  const staleAge = normalizePolicyConfig(loadIddConfig()).claimTiming.staleAge;
+// hardcoded 24h `isStaleAt` default. Takes the caller's already-resolved
+// trusted-ref config (#2373) instead of its own `.github/idd/config.json`
+// read; `normalizePolicyConfig(null)` already defaults to `PT24H`, so no
+// try/catch is needed here. An absent or unparseable value falls back to
+// the shared `DEFAULT_STALE_AGE_MS` (protocol-helpers.mts) rather than a
+// second local 24h literal, so behavior is unchanged for repos on the
+// default and there is exactly one hardcoded-24h source of truth.
+function readClaimStaleAgeMs(iddConfig: IddConfig | null): number {
+  const staleAge = normalizePolicyConfig(iddConfig).claimTiming.staleAge;
   return parseIsoDurationToMs(staleAge) ?? DEFAULT_STALE_AGE_MS;
 }
 
 // Configured governance-read trust opt-in (`ciGate.trustEmptyProtectionReads`,
-// #1377). Reuses the shared `loadIddConfig` loader (already imported by this
-// file); an absent, unreadable, or unparseable config fails safe to the
-// `false` default via `normalizePolicyConfig(null)`, matching
-// `readClaimStaleAgeMs`'s pattern above.
-function readTrustEmptyProtectionReads(): boolean {
+// #1377). Takes the caller's already-resolved trusted-ref config (#2373);
+// an absent or unparseable config fails safe to the `false` default via
+// `normalizePolicyConfig(null)`, matching `readClaimStaleAgeMs`'s pattern
+// above.
+function readTrustEmptyProtectionReads(iddConfig: IddConfig | null): boolean {
   return (
-    normalizePolicyConfig(loadIddConfig()).ciGate.trustEmptyProtectionReads ===
-    true
+    normalizePolicyConfig(iddConfig).ciGate.trustEmptyProtectionReads === true
   );
 }
 
@@ -1611,10 +1636,12 @@ function readTrustEmptyProtectionReads(): boolean {
 // `readTrustEmptyProtectionReads` above; see `summarizeRequiredChecks`'s
 // (protocol-helpers.mts) doc comment on the option of the same name for the
 // full rationale.
-function readTrustSourcePinnedRequiredChecks(): boolean {
+function readTrustSourcePinnedRequiredChecks(
+  iddConfig: IddConfig | null,
+): boolean {
   return (
-    normalizePolicyConfig(loadIddConfig()).ciGate
-      .trustSourcePinnedRequiredChecks === true
+    normalizePolicyConfig(iddConfig).ciGate.trustSourcePinnedRequiredChecks ===
+    true
   );
 }
 

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -135,8 +135,8 @@ import {
 } from './ci-wait-policy.mts';
 import { parseCanonicalIntegerOrNull, parseCliArgs } from './cli-args.mts';
 import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mts';
-import { deriveGhHttpStatus } from './gh-http-status.mts';
 import type { IddConfig } from './idd-config.mts';
+import { loadTrustedIddConfig } from './idd-config.mts';
 import { isValidIsoTimestamp } from './marker-helpers.mts';
 import {
   advisoryBotIdentityToken,
@@ -1986,10 +1986,11 @@ function fetchCheckRunsForRef(
 }
 
 /**
- * Fetch and parse `.github/idd/config.json` for `owner/repo` **at `ref`**
- * via the Contents API. Used unconditionally -- both a same-repo and a
- * true cross-repository invocation -- rather than a local `readFileSync`
- * fallback for the same-repo case (`loadIddConfig`, idd-config.mts).
+ * `.github/idd/config.json` for `owner/repo` **at `ref`**, fetched via
+ * {@link loadTrustedIddConfig} (idd-config.mts) -- generalized there from
+ * this file's original private implementation (#1434) so
+ * `pre-merge-readiness.mts` shares the same fetch-and-classify contract
+ * instead of a second, near-identical `gh api contents` call (#2373).
  *
  * `ref` must be the repository's TRUSTED default branch (see
  * {@link resolveDefaultBranch}), never `prHeadSha` and never a local
@@ -2007,69 +2008,8 @@ function fetchCheckRunsForRef(
  * actually governed those runs (#1434 review, Codex P2, second
  * occurrence -- reverts this file's own prior "always prHeadSha" fix,
  * which solved the "unpinned ref" bug but pinned the wrong ref).
- *
- * `--method GET` is required alongside the `-f ref=...` field, for the
- * same reason `buildCheckRunsForRefArgs` above needs it: `gh api` defaults
- * to POST as soon as any `-f` value is present, and the Contents API only
- * accepts GET -- an unqualified `-f ref=...` here would 404 on every call
- * (confirmed empirically), which this function's own catch block would
- * silently treat as "config genuinely absent, use defaults" instead of
- * surfacing the real problem.
- *
- * Returns `null` -- falls back to documented defaults, same as a missing
- * local file -- **only** on a confirmed 404 (`ref` genuinely has no
- * config committed, the same "absent" state `loadIddConfig` treats as
- * "use defaults" locally). Any other failure -- a permission error, a
- * transient Contents API failure, or malformed content -- means this
- * helper cannot confirm whether `ref` configures a non-default bot
- * identity, so silently substituting defaults could misclassify a
- * bot-triggered run there as rerun-eligible. Per this repo's own
- * fail-closed default (`idd-overview-core.instructions.md`), that
- * ambiguity throws instead of guessing, rejecting the diagnosis outright
- * rather than proceeding on unconfirmed bot identity (#1434 review, Codex
- * P2).
  */
-export function buildIddConfigContentsArgs(
-  owner: string,
-  repo: string,
-  ref: string,
-): string[] {
-  return [
-    'api',
-    `repos/${owner}/${repo}/contents/.github/idd/config.json`,
-    '--method',
-    'GET',
-    '-f',
-    `ref=${ref}`,
-    '--jq',
-    '.content',
-  ];
-}
-
-function loadRemoteIddConfig(
-  owner: string,
-  repo: string,
-  ref: string,
-): IddConfig | null {
-  try {
-    const encoded = ghText(
-      buildIddConfigContentsArgs(owner, repo, ref),
-      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
-    );
-    const decoded = Buffer.from(encoded.replace(/\n/g, ''), 'base64').toString(
-      'utf8',
-    );
-    return JSON.parse(decoded) as IddConfig;
-  } catch (error) {
-    if (deriveGhHttpStatus(error) === 404) {
-      return null;
-    }
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(
-      `cannot confirm .github/idd/config.json for ${owner}/${repo}@${ref}: bot-identity resolution for this diagnosis requires this file to be readable or genuinely absent (404) at this ref, not merely unreadable -- ${message}`,
-    );
-  }
-}
+const loadRemoteIddConfig = loadTrustedIddConfig;
 
 /**
  * Resolve `owner/repo`'s default branch via the Repository API -- the

--- a/tests/idd-config.test.mts
+++ b/tests/idd-config.test.mts
@@ -6,12 +6,28 @@ import { platform } from 'node:process';
 import { test } from 'node:test';
 
 import {
+  buildIddConfigContentsArgs,
   loadIddConfig,
   loadPolicyConfig,
+  loadTrustedIddConfig,
   loadUserGlobalPolicyDocument,
   resolveEffectiveCritiqueLoopDelegateFromEnv,
   resolveUserGlobalConfigPath,
 } from '../src/scripts/idd-config.mts';
+
+const HEAD = '1111111111111111111111111111111111111111';
+
+function toEncodedConfig(config: unknown): string {
+  return Buffer.from(JSON.stringify(config), 'utf8').toString('base64');
+}
+
+function syntheticNotFoundError(): Error & { stderr?: string } {
+  const notFound = new Error('Not Found (HTTP 404)') as Error & {
+    stderr?: string;
+  };
+  notFound.stderr = 'Not Found (HTTP 404)';
+  return notFound;
+}
 
 // Every scenario runs inside its own freshly `mkdtempSync`-created sandbox
 // (never the real repo cwd), mirroring the sandboxing already used by
@@ -505,4 +521,118 @@ test('resolveEffectiveCritiqueLoopDelegateFromEnv fails closed on a malformed re
     source: 'repository-local',
     reason: 'invalid-repository-local-delegate',
   });
+});
+
+// --- buildIddConfigContentsArgs (regression: #1434 review, Codex P2; moved
+// from tests/rerun-advisory-convergence.test.mts by #2373) --------------
+//
+// This pure args-builder accepts whatever `ref` its caller passes. Both
+// current production callers pin `ref` to a TRUSTED value the PR under
+// evaluation cannot itself steer -- `rerun-advisory-convergence.mts` pins
+// it to the repository's default branch, `pre-merge-readiness.mts` (#2373)
+// pins it to the PR's base branch (falling back to the default branch) --
+// never the PR's own head SHA; see loadTrustedIddConfig's own doc comment
+// for the full rationale. `--method GET` is required alongside `-f
+// ref=...`: `gh api` defaults to POST as soon as any `-f` value is
+// present, and the Contents API only accepts GET -- confirmed empirically
+// that an unqualified `-f ref=...` 404s on every call, which
+// loadTrustedIddConfig's own catch block would otherwise silently treat as
+// "config genuinely absent, use defaults".
+
+test('buildIddConfigContentsArgs includes --method GET and pins -f ref to the given ref value', () => {
+  const args = buildIddConfigContentsArgs('kurone-kito', 'idd-skill', HEAD);
+  assert.deepEqual(args, [
+    'api',
+    'repos/kurone-kito/idd-skill/contents/.github/idd/config.json',
+    '--method',
+    'GET',
+    '-f',
+    `ref=${HEAD}`,
+    '--jq',
+    '.content',
+  ]);
+});
+
+test('buildIddConfigContentsArgs places --method immediately before GET (gh api requires the value to follow its flag)', () => {
+  const args = buildIddConfigContentsArgs('o', 'r', HEAD);
+  const methodIndex = args.indexOf('--method');
+  assert.notEqual(methodIndex, -1);
+  assert.equal(args[methodIndex + 1], 'GET');
+});
+
+// --- loadTrustedIddConfig (#2373) ---------------------------------------
+
+test('loadTrustedIddConfig decodes and parses a fetched base64 config', () => {
+  const config = loadTrustedIddConfig('kurone-kito', 'idd-skill', 'main', () =>
+    toEncodedConfig({ claimTiming: { staleAge: 'PT48H' } }),
+  );
+  assert.deepEqual(config, { claimTiming: { staleAge: 'PT48H' } });
+});
+
+test('loadTrustedIddConfig passes owner/repo/ref through to the injected fetch', () => {
+  const seen: { owner: string; repo: string; ref: string }[] = [];
+  loadTrustedIddConfig('o', 'r', 'feature-branch', (owner, repo, ref) => {
+    seen.push({ owner, repo, ref });
+    return toEncodedConfig({});
+  });
+  assert.deepEqual(seen, [{ owner: 'o', repo: 'r', ref: 'feature-branch' }]);
+});
+
+test('loadTrustedIddConfig returns null on a confirmed 404 (config absent at ref)', () => {
+  const config = loadTrustedIddConfig('o', 'r', 'main', () => {
+    throw syntheticNotFoundError();
+  });
+  assert.equal(config, null);
+});
+
+test('loadTrustedIddConfig rethrows (fail-closed) on a non-404 failure', () => {
+  assert.throws(
+    () =>
+      loadTrustedIddConfig('o', 'r', 'main', () => {
+        throw new Error('network timeout');
+      }),
+    /cannot confirm \.github\/idd\/config\.json for o\/r@main/,
+  );
+});
+
+test('loadTrustedIddConfig rethrows on malformed (non-JSON) fetched content', () => {
+  assert.throws(
+    () =>
+      loadTrustedIddConfig('o', 'r', 'main', () =>
+        Buffer.from('not json', 'utf8').toString('base64'),
+      ),
+    /cannot confirm \.github\/idd\/config\.json for o\/r@main/,
+  );
+});
+
+// Regression: mirrors loadPolicyConfig's own #1776 fix (JSON.parse('null')
+// succeeds without throwing, so a syntactically-valid top-level scalar/
+// array/null would otherwise masquerade as this function's own "absent"
+// (404) sentinel).
+
+test('loadTrustedIddConfig rethrows on a top-level JSON null instead of treating it as absent', () => {
+  assert.throws(
+    () => loadTrustedIddConfig('o', 'r', 'main', () => toEncodedConfig(null)),
+    /cannot confirm \.github\/idd\/config\.json for o\/r@main: .*expected a JSON object at the top level, got null/,
+  );
+});
+
+test('loadTrustedIddConfig rethrows on a top-level JSON array', () => {
+  assert.throws(
+    () => loadTrustedIddConfig('o', 'r', 'main', () => toEncodedConfig([])),
+    /expected a JSON object at the top level, got an array/,
+  );
+});
+
+// #2373 acceptance criterion: "an empty-but-fetched .content rethrows
+// rather than silently falling back to a permissive default" -- decoding
+// an empty string yields an empty JSON document, which JSON.parse rejects
+// (SyntaxError, no HTTP status text), so this already falls into the
+// non-404 rethrow path; this test names that criterion explicitly.
+
+test('loadTrustedIddConfig rethrows when the fetch returns empty content', () => {
+  assert.throws(
+    () => loadTrustedIddConfig('o', 'r', 'main', () => ''),
+    /cannot confirm \.github\/idd\/config\.json for o\/r@main/,
+  );
 });

--- a/tests/pre-merge-readiness-collection-smoke.test.mts
+++ b/tests/pre-merge-readiness-collection-smoke.test.mts
@@ -145,16 +145,20 @@ test('normalizeThread maps a ProviderPort review-thread node, including nested c
 // that differ in exactly one field (a review thread's `isResolved`), so a
 // normalizer or collection-wiring regression changes the final verdict.
 //
-// Run with `cwd: <empty temp dir>` (not REPO_ROOT): every policy read in
-// `collectPreMergeReadiness` (`loadIddConfig`, `readForcedHandoffMode`,
-// `readCollaboratorTrustEnabled`, etc.) resolves `.github/idd/config.json`
-// relative to `process.cwd()`, not the script's own location. An empty cwd
-// makes every one of those reads fail closed to schema defaults, which
-// keeps this fixture hermetic (independent of this repository's own live
-// config) and -- since `forcedHandoff.mode` defaults to `disabled` and
-// `collaboratorTrust` defaults to off -- skips the two gh calls that are
-// conditional on those policies, keeping the stub's call inventory to
-// exactly what a default-policy adopter repository would trigger.
+// Run with `cwd: <empty temp dir>` (not REPO_ROOT): every policy-driven
+// gate in `collectPreMergeReadiness` (#2373) resolves `.github/idd/
+// config.json` via a trusted-ref `gh api contents` read (the stub's own
+// `contents/.github/idd/config.json` handler below), never a local
+// worktree file -- an empty `cwd` merely keeps this fixture from
+// accidentally picking up a stray local file, it plays no role in config
+// resolution itself now. The stub's `contents/` catch-all 404s that read
+// by default (schema defaults, same "absent" fail-closed contract as a
+// missing local file used to have), which keeps this fixture hermetic
+// (independent of this repository's own live config) and -- since
+// `forcedHandoff.mode` defaults to `disabled` and `collaboratorTrust`
+// defaults to off -- skips the two gh calls that are conditional on those
+// policies, keeping the stub's call inventory to exactly what a
+// default-policy adopter repository would trigger.
 // ---------------------------------------------------------------------------
 
 const OWNER = 'o';
@@ -191,6 +195,7 @@ function buildStubGhScript(
   options: {
     closingIssuesReferences?: unknown[];
     failOnClaimComments?: boolean;
+    configJson?: string;
   } = {},
 ): string {
   const prView = {
@@ -334,6 +339,11 @@ if (a(0) === 'api' && a(1) === '${`repos/${REPO_REF}/issues/${CLAIM_ISSUE}/comme
 if (a(0) === 'api' && a(1) === 'graphql' && args.join(' ').includes('reviewThreads')) out(${JSON.stringify(JSON.stringify(reviewThreadsPayload))});
 if (a(0) === 'api' && a(1) === 'graphql' && args.join(' ').includes('committedDate')) out(${JSON.stringify(JSON.stringify(reviewsAndHeadCommitPayload))});
 if (a(0) === 'api' && a(1) === '${`repos/${REPO_REF}/pulls/${PR_NUMBER}/files`}') out(${JSON.stringify(ndjson(changedFiles))});
+${
+  options.configJson !== undefined
+    ? `if (a(0) === 'api' && a(1) === '${`repos/${REPO_REF}/contents/.github/idd/config.json`}') out(${JSON.stringify(Buffer.from(options.configJson, 'utf8').toString('base64'))});`
+    : ''
+}
 if (a(0) === 'api' && String(a(1)).startsWith('${`repos/${REPO_REF}/contents/`}')) notFound();
 process.stderr.write('unexpected gh invocation: ' + args.join(' ') + '\\n');
 process.exit(1);
@@ -348,14 +358,16 @@ function runPreMergeReadinessSmoke(
   const cwdRoot = mkdtempSync(join(tmpdir(), 'idd-pre-merge-readiness-cwd-'));
   try {
     const ghPath = join(tempRoot, 'gh');
-    writeFileSync(ghPath, buildStubGhScript(threadResolved));
+    // #2373: `configJson` is served from the stub's own
+    // `contents/.github/idd/config.json` GET response, not a local
+    // `cwdRoot` file -- `collectPreMergeReadiness` now resolves every
+    // policy-driven gate from a trusted-ref Contents API read, never the
+    // PR worktree's own copy.
+    writeFileSync(
+      ghPath,
+      buildStubGhScript(threadResolved, { configJson: options.configJson }),
+    );
     chmodSync(ghPath, 0o755);
-
-    if (options.configJson !== undefined) {
-      const configDir = join(cwdRoot, '.github', 'idd');
-      mkdirSync(configDir, { recursive: true });
-      writeFileSync(join(configDir, 'config.json'), options.configJson);
-    }
 
     const output = execFileSync(
       process.execPath,
@@ -717,6 +729,11 @@ test('collectPreMergeReadiness against a fake provider: unreadable CI governance
         '2026-08-01T00:00:00Z',
       ],
       () => port,
+      // #2373: this file's own "no gh process spawned" contract now also
+      // covers the trusted-ref config read -- stub it to "absent, use
+      // defaults" instead of letting the default loadTrustedIddConfig
+      // spawn a real gh process.
+      () => null,
     );
 
     const ciReport = report.ci as { protectionReadsUnreadable: boolean };
@@ -805,6 +822,9 @@ test('collectPreMergeReadiness against a fake provider: a required check reporti
         '2026-08-01T00:00:00Z',
       ],
       () => port,
+      // #2373: see the sibling "unreadable CI governance" test above for
+      // why this stub is needed to keep "no gh process spawned" true.
+      () => null,
     );
 
     const ciReport = report.ci as {
@@ -895,6 +915,13 @@ test('collectPreMergeReadiness against a fake provider: a matching CODEOWNER res
         '2026-08-01T00:00:00Z',
       ],
       () => port,
+      // #2373: this test strips PATH to force a live-adapter `gh` spawn
+      // to fail (for the CODEOWNER-permission assertion below); without
+      // this stub, the default `loadTrustedIddConfig` would ALSO attempt
+      // a real `gh` spawn for its own config read and throw before
+      // reaching the assertion under test. No fixture cares about config
+      // content here, so this always resolves to "absent, use defaults".
+      () => null,
     );
     const reviewerStates = report.reviewerStates as {
       codeownerSelfApproval: { codeownerEligibilityUnreadable: boolean };
@@ -916,6 +943,172 @@ test('collectPreMergeReadiness against a fake provider: a matching CODEOWNER res
 });
 
 // ---------------------------------------------------------------------------
+// #2373: collectPreMergeReadiness resolves every policy-driven gate from a
+// TRUSTED ref, never the PR branch's own worktree copy of
+// `.github/idd/config.json`. These four tests cover the issue's own
+// acceptance criteria end to end, via the `loadTrustedConfig` seam
+// (collectPreMergeReadiness's 3rd param) rather than a real `gh` process.
+// ---------------------------------------------------------------------------
+
+function buildMinimalFakePort(
+  overrides: {
+    baseRefName?: string;
+    repositoryDefaultBranch?: string | null;
+  } = {},
+) {
+  return createFakeProviderAdapter({
+    changeRequestReadinessSnapshots: {
+      42: {
+        headSha: 'a'.repeat(40),
+        baseRefName: overrides.baseRefName ?? 'main',
+        url: 'https://github.com/o/r/pull/42',
+        authorLogin: 'author-user',
+        reviewDecision: null,
+        statusCheckRollup: [],
+        mergeable: 'MERGEABLE',
+        mergeStateStatus: 'CLEAN',
+        closingIssuesReferences: [],
+      },
+    },
+    branchRules: { 'o/r/main': [] },
+    branchProtection: { 'o/r/main': {} },
+    reviewThreadsWithComments: { 42: [] },
+    reviewsWithHeadCommitDate: {
+      42: { reviews: [], headCommittedAt: '2026-07-31T23:00:00Z' },
+    },
+    repositoryDefaultBranch: overrides.repositoryDefaultBranch ?? 'main',
+  });
+}
+
+function withSandboxCwd<T>(run: () => T): T {
+  const cwdRoot = mkdtempSync(join(tmpdir(), 'idd-pre-merge-trusted-ref-'));
+  const originalCwd = process.cwd();
+  try {
+    process.chdir(cwdRoot);
+    return run();
+  } finally {
+    process.chdir(originalCwd);
+    rmSync(cwdRoot, { recursive: true, force: true });
+  }
+}
+
+test('collectPreMergeReadiness: a PR-branch-local .github/idd/config.json edit does not change developmentBranchTarget (or any other gate) -- only the injected trusted-ref config does', () => {
+  withSandboxCwd(() => {
+    const configDir = join(process.cwd(), '.github', 'idd');
+    mkdirSync(configDir, { recursive: true });
+    // Simulates the PR branch's own worktree copy, edited to widen its own
+    // developmentBranch check against itself -- this must have zero effect.
+    writeFileSync(
+      join(configDir, 'config.json'),
+      JSON.stringify({ developmentBranch: 'attacker-controlled-branch' }),
+    );
+
+    const port = buildMinimalFakePort();
+    const report = collectPreMergeReadiness(
+      [
+        '--pr',
+        '42',
+        '--claimless',
+        '--owner',
+        'o',
+        '--repo',
+        'r',
+        '--now',
+        '2026-08-01T00:00:00Z',
+      ],
+      () => port,
+      () => ({ developmentBranch: 'trusted-dev-branch' }),
+    );
+
+    const developmentBranchTarget = report.developmentBranchTarget as {
+      status: string;
+      branch?: string;
+    };
+    assert.equal(developmentBranchTarget.status, 'configured');
+    assert.equal(developmentBranchTarget.branch, 'trusted-dev-branch');
+  });
+});
+
+test('collectPreMergeReadiness: a confirmed 404 at the trusted ref falls back to documented defaults (developmentBranchTarget resolves to the live default branch)', () => {
+  const port = buildMinimalFakePort({ repositoryDefaultBranch: 'main' });
+  const report = collectPreMergeReadiness(
+    [
+      '--pr',
+      '42',
+      '--claimless',
+      '--owner',
+      'o',
+      '--repo',
+      'r',
+      '--now',
+      '2026-08-01T00:00:00Z',
+    ],
+    () => port,
+    // null == the same "confirmed absent" outcome loadTrustedIddConfig
+    // returns on a real 404.
+    () => null,
+  );
+  const developmentBranchTarget = report.developmentBranchTarget as {
+    status: string;
+    branch?: string;
+  };
+  assert.equal(developmentBranchTarget.status, 'default');
+  assert.equal(developmentBranchTarget.branch, 'main');
+});
+
+test('collectPreMergeReadiness: a non-404 trusted-ref fetch failure aborts the whole readiness collection instead of silently defaulting', () => {
+  const port = buildMinimalFakePort();
+  assert.throws(
+    () =>
+      collectPreMergeReadiness(
+        [
+          '--pr',
+          '42',
+          '--claimless',
+          '--owner',
+          'o',
+          '--repo',
+          'r',
+          '--now',
+          '2026-08-01T00:00:00Z',
+        ],
+        () => port,
+        () => {
+          throw new Error('transient Contents API failure');
+        },
+      ),
+    /transient Contents API failure/,
+  );
+});
+
+test('collectPreMergeReadiness: an empty baseRefName falls back to the repository live default branch as the trusted config ref', () => {
+  const port = buildMinimalFakePort({
+    baseRefName: '',
+    repositoryDefaultBranch: 'trunk',
+  });
+  const seenRefs: string[] = [];
+  collectPreMergeReadiness(
+    [
+      '--pr',
+      '42',
+      '--claimless',
+      '--owner',
+      'o',
+      '--repo',
+      'r',
+      '--now',
+      '2026-08-01T00:00:00Z',
+    ],
+    () => port,
+    (_owner, _repo, ref) => {
+      seenRefs.push(ref);
+      return null;
+    },
+  );
+  assert.deepEqual(seenRefs, ['trunk']);
+});
+
+// ---------------------------------------------------------------------------
 // #2544: secondaryQuietWindow settled-buffer end-to-end wiring. Proves
 // collectPreMergeReadiness's own readAdvisorySecondaryBotLogin() call
 // (pre-merge-readiness.mts) actually reaches buildPreMergeReadinessSummary
@@ -934,17 +1127,15 @@ function runSecondaryQuietWindowFixture(
   const originalCwd = process.cwd();
   try {
     process.chdir(cwdRoot);
-    const configDir = join(cwdRoot, '.github', 'idd');
-    mkdirSync(configDir, { recursive: true });
-    writeFileSync(
-      join(configDir, 'config.json'),
-      JSON.stringify({
-        advisoryWait: {
-          secondaryBotLogin: 'coderabbitai[bot]',
-          secondaryQuietWindow: 'PT1H',
-        },
-      }),
-    );
+    // #2373: fed via the injected loadTrustedConfig param below, not a
+    // local .github/idd/config.json write -- collectPreMergeReadiness no
+    // longer reads the PR worktree's own copy of this file.
+    const trustedConfig = {
+      advisoryWait: {
+        secondaryBotLogin: 'coderabbitai[bot]',
+        secondaryQuietWindow: 'PT1H',
+      },
+    };
 
     const port = createFakeProviderAdapter({
       changeRequestReadinessSnapshots: {
@@ -991,6 +1182,7 @@ function runSecondaryQuietWindowFixture(
         now,
       ],
       () => port,
+      () => trustedConfig,
     );
     return report.secondaryQuietWindow as {
       elapsed: boolean;

--- a/tests/rerun-advisory-convergence.test.mts
+++ b/tests/rerun-advisory-convergence.test.mts
@@ -4,7 +4,6 @@ import { test } from 'node:test';
 import {
   applyRerunPlan,
   buildCheckRunsForRefArgs,
-  buildIddConfigContentsArgs,
   buildRerunPlanTextSections,
   buildRunViewLogArgs,
   computeRerunPlan,
@@ -1961,46 +1960,9 @@ test('buildCheckRunsForRefArgs places --method immediately before GET (gh api re
   assert.equal(args[methodIndex + 1], 'GET');
 });
 
-// --- buildIddConfigContentsArgs (regression: #1434 review, Codex P2) ----
-//
-// This pure args-builder accepts whatever `ref` its caller passes; the
-// production caller (`collectFromGitHub`, via `loadRemoteIddConfig`)
-// pins it to `resolveDefaultBranch(owner, repo)` -- the repository's
-// TRUSTED default branch, matching the `idd-advisory-convergence`
-// workflow's own trusted checkout -- never the PR's own head SHA. Fetching
-// without pinning `ref` at all reads whichever ref `gh` defaults to,
-// which could as easily be the PR-authored config as the trusted one;
-// pinning to the PR's own head specifically would let a PR redefine its
-// own primaryBotLogin / advisoryBotLogins / ciWait.rerunPolicy to
-// influence its own classification and rerun recommendations (see
-// loadRemoteIddConfig's own doc comment for the full rationale). Same
-// `--method GET` hazard as buildCheckRunsForRefArgs above: `gh api`
-// defaults to POST as soon as any `-f` value is present, and the
-// Contents API only accepts GET -- confirmed empirically that an
-// unqualified `-f ref=...` 404s on every call, which loadRemoteIddConfig's
-// own catch block would otherwise silently treat as "config genuinely
-// absent, use defaults".
-
-test('buildIddConfigContentsArgs includes --method GET and pins -f ref to the given ref value', () => {
-  const args = buildIddConfigContentsArgs('kurone-kito', 'idd-skill', HEAD);
-  assert.deepEqual(args, [
-    'api',
-    'repos/kurone-kito/idd-skill/contents/.github/idd/config.json',
-    '--method',
-    'GET',
-    '-f',
-    `ref=${HEAD}`,
-    '--jq',
-    '.content',
-  ]);
-});
-
-test('buildIddConfigContentsArgs places --method immediately before GET (gh api requires the value to follow its flag)', () => {
-  const args = buildIddConfigContentsArgs('o', 'r', HEAD);
-  const methodIndex = args.indexOf('--method');
-  assert.notEqual(methodIndex, -1);
-  assert.equal(args[methodIndex + 1], 'GET');
-});
+// buildIddConfigContentsArgs now lives in idd-config.mts (#2373, shared
+// with pre-merge-readiness.mts) -- its own tests moved to
+// tests/idd-config.test.mts alongside it.
 
 // --- sanitizeRemoteConfig (regression: Codex P2, #1434 review) ----------
 //


### PR DESCRIPTION
## Summary

`pre-merge-readiness.mts` normally runs from the claimed PR's own worktree (B1 creates it from the PR's branch), so every read of `.github/idd/config.json` returned the PR branch's own possibly-edited copy of its policy file. A PR could therefore widen its own `trustedMarkerActors`, loosen a `ciGate` setting, or set `developmentBranch` to its own `baseRefName` so the `developmentBranchTarget` gate trivially "matches" — defeating each gate's purpose. Confirmed via `chatgpt-codex-connector[bot]` review (P1) on #2368; the flagged code was byte-identical to `origin/main`, confirming pre-existing #2272 design, not something #2273 introduced.

This fix covers *more* than the issue's `loadIddConfig()` framing: besides the shared `loadIddConfig()` call, 5 independent inline `readFileSync` copies and 9 transitively-imported `read*()` local reads (`advisory-wait-policy.mts` / `collaborator-permission.mts`) also resolved the same PR-branch-relative file. All of these now resolve from one trusted-ref fetch per run, routed through each module's own pure `resolve*`/`normalizePolicyConfig` sibling — with **zero changes** to `advisory-wait-policy.mts` or `collaborator-permission.mts` themselves, so their other 16 existing callers are unaffected.

## What changed

- `idd-config.mts`: new exported `loadTrustedIddConfig(owner, repo, ref, fetchEncodedConfig?)`, generalized from `rerun-advisory-convergence.mts`'s original private `loadRemoteIddConfig`/`buildIddConfigContentsArgs`. Fetches `.github/idd/config.json` via the Contents API at an explicit trusted `ref`, with an injectable fetch function (mirroring `idd-merge-execute.mts`'s `resolveRemoteSoloCodeownerAdminFallbackMode` pattern) so callers can test it without spawning `gh`.
- `rerun-advisory-convergence.mts`: its own `loadRemoteIddConfig` now delegates to the shared `loadTrustedIddConfig` instead of a near-identical private implementation. No behavior change for that file.
- `pre-merge-readiness.mts`: `collectPreMergeReadiness` gains a third injectable parameter, `loadTrustedConfig` (default: `loadTrustedIddConfig`), matching the existing `createPort` DI convention rather than a single monolithic port. Config is now resolved **once**, from the PR's `baseRefName` (falling back to the repository's live default branch when empty — defensive only; `--pr` is required on every call path, so `baseRefName` is normally non-empty). Every `read*()` helper that used to independently re-read the file now takes the already-resolved config as a parameter.
- `advisory-wait-policy.mts`: added one small exported predicate, `advisoryWaitSectionIsValid`, factoring out the schema-validation gate every `read*` wrapper in that file already applies before calling its `resolve*` sibling — so `pre-merge-readiness.mts` can apply the identical validate-or-default rule to its own already-fetched config instead of duplicating the schema check.

## Fail-closed contract

- A confirmed 404 (no config committed at the trusted ref) → `null` → the same distributed defaults `loadIddConfig()` already used for a missing local file.
- Any other fetch failure, or a syntactically-valid-but-non-object top-level JSON value (`null`, an array, a scalar — `JSON.parse` doesn't reject these) → throws, aborting the whole readiness collection. The non-object case mirrors `loadPolicyConfig`'s own #1776 fix for the exact same masquerade-as-absent gap, reopened here for a remote fetch.
- **Behavior change, by design**: a handful of local read helpers previously caught *any* error (missing file **or** malformed JSON) and silently fell back to a permissive default. Under the new contract, "missing" (404) and "unreadable/malformed" are no longer collapsed into one outcome — only a confirmed-absent config defaults; anything else now aborts the run. This is the fail-closed posture the issue asked for, applied uniformly across every gate this file resolves.

## Scope boundary

`advisory-wait-policy.mts` and `collaborator-permission.mts` still read `.github/idd/config.json` from a local path in their own `read*()` functions — but `pre-merge-readiness.mts` no longer calls those functions; it calls their pure `resolve*(config)` siblings (or, for `forcedHandoff.*`, `normalizePolicyConfig` directly) with the trusted-ref config. Those two modules' `read*()` local-file readers themselves are unchanged and still used by their other 7 and 9 callers respectively — none of which run from a PR's own worktree the way this file does, so they're out of scope here.

## Test plan

- [x] `pnpm run build` (regenerates `scripts/*.mjs`/`bin/*.mjs` from the edited `.mts` sources)
- [x] `node --test tests/*.test.mts` — all 4930 tests pass, including 4 new end-to-end `collectPreMergeReadiness` tests covering every acceptance criterion: a PR-branch-local config edit not affecting `developmentBranchTarget`, the 404-fallback-to-defaults path, the fetch-failure-rethrows path, and the empty-`baseRefName`-falls-back-to-live-default-branch path — plus new unit tests for `loadTrustedIddConfig` (404→null, ok→parsed, non-404→throws, top-level-null/array→throws, empty content→throws)
- [x] `pre-push-validate` (biome, dprint, markdownlint, cspell, `audit-docs.mjs --check`, `audit-code-span-wrap.mjs`, `agent-entry-mirror-sync.test.mts`, `build:check`, `idd-doctor.mjs`) — all pass; `idd-doctor.mjs` reports only pre-existing, unrelated warnings

Closes #2373

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CtcjhuuXDqQASYGXtJnmV3
