### PR TITLE
feat(rerun-advisory-convergence): auto-rerun budget-held #1806 siblings

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -2010,15 +2010,31 @@ to post it is the consuming track's job.
   `runAttempt` already exhausted the `"rerun-once"` budget, withholds the
   corresponding plan entries with an explanatory `rerunPolicyHoldNotice`
   instead of silently omitting them
+- Also reports a `liveCoverageRecoveryPlan` (kurone-kito/idd-skill#2549):
+  a narrow, separately-bounded exception for an instance that is
+  BOTH the live-coverage-recovery case above AND itself
+  `rerun-budget-held` (its own `runAttempt` already exhausted the
+  `"rerun-once"` budget) AND has a sibling instance for the same check
+  that already classifies `pass` -- proof the rollup is otherwise
+  already resolved, so rerunning this one is bounded cleanup of a
+  redundant stale sibling on an already-covered HEAD, never a second
+  automated rerun-budget grant. Every other `rerun-budget-held`
+  instance (including the waiver-rebind case below) keeps the
+  unconditional withholding unchanged; each promoted instance's
+  original hold reason is named both in the plan document
+  (`originalHoldReason`) and in the `--apply` summary
 - Without `--apply`, it never calls `gh run rerun` (or any other mutating
   command) itself. Pass `--apply` (#1766) to execute the printed plan:
-  it reruns each rerun-eligible instance in order (recovery-refresh first
-  when one applies), waits for each to reach a genuinely new completed
-  attempt (polled via the actions/runs API, not `gh run watch`, to avoid
-  racing a just-issued rerun's stale pre-rerun status) before starting
-  the next, and stops early once the recomputed plan is fully resolved --
+  it reruns each rerun-eligible instance in order (recovery-refresh
+  first, then the sequential plan, then `liveCoverageRecoveryPlan`
+  last), waits for each to reach a genuinely new completed attempt
+  (polled via the actions/runs API, not `gh run watch`, to avoid racing
+  a just-issued rerun's stale pre-rerun status) before starting the
+  next, and stops early once the recomputed plan is fully resolved --
   a `bot-gated-skip`, `awaiting-fresh-review`, or rerun-budget-held
-  instance is never rerun
+  instance is never rerun outside the narrow `liveCoverageRecoveryPlan`
+  exception just above, and the same `MAX_APPLY_RERUNS` safety bound
+  covers all three plan sections together, not a second loop
 - `--check-name <name>` (#1935) overrides the check-run name searched for
   and reported, defaulting to `idd-advisory-convergence` when omitted
   (byte-identical output to before this flag existed). Use it when the
@@ -2038,7 +2054,12 @@ to post it is the consuming track's job.
 instance (see above) -- that withholding is correct and load-bearing
 on its own, and this section does not change it: the script keeps
 withholding these instances from its own plan, and gains no
-`--override-budget` flag or equivalent. A specific combination sits
+`--override-budget` flag or equivalent. `liveCoverageRecoveryPlan`
+above (#2549) is a separate, much narrower automated exception (a
+live-coverage-recovered instance with an already-passing sibling
+proving the rollup is otherwise resolved) -- it does not apply to the
+waiver-rebind case below, which still requires this manual procedure.
+A specific combination sits
 outside what the withholding alone can resolve: an
 `idd-advisory-convergence` instance already went `rerun-budget-held`
 from a genuinely-failed attempt, and only afterward does a maintainer

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -2010,15 +2010,31 @@ to post it is the consuming track's job.
   `runAttempt` already exhausted the `"rerun-once"` budget, withholds the
   corresponding plan entries with an explanatory `rerunPolicyHoldNotice`
   instead of silently omitting them
+- Also reports a `liveCoverageRecoveryPlan` (kurone-kito/idd-skill#2549):
+  a narrow, separately-bounded exception for an instance that is
+  BOTH the live-coverage-recovery case above AND itself
+  `rerun-budget-held` (its own `runAttempt` already exhausted the
+  `"rerun-once"` budget) AND has a sibling instance for the same check
+  that already classifies `pass` -- proof the rollup is otherwise
+  already resolved, so rerunning this one is bounded cleanup of a
+  redundant stale sibling on an already-covered HEAD, never a second
+  automated rerun-budget grant. Every other `rerun-budget-held`
+  instance (including the waiver-rebind case below) keeps the
+  unconditional withholding unchanged; each promoted instance's
+  original hold reason is named both in the plan document
+  (`originalHoldReason`) and in the `--apply` summary
 - Without `--apply`, it never calls `gh run rerun` (or any other mutating
   command) itself. Pass `--apply` (#1766) to execute the printed plan:
-  it reruns each rerun-eligible instance in order (recovery-refresh first
-  when one applies), waits for each to reach a genuinely new completed
-  attempt (polled via the actions/runs API, not `gh run watch`, to avoid
-  racing a just-issued rerun's stale pre-rerun status) before starting
-  the next, and stops early once the recomputed plan is fully resolved --
+  it reruns each rerun-eligible instance in order (recovery-refresh
+  first, then the sequential plan, then `liveCoverageRecoveryPlan`
+  last), waits for each to reach a genuinely new completed attempt
+  (polled via the actions/runs API, not `gh run watch`, to avoid racing
+  a just-issued rerun's stale pre-rerun status) before starting the
+  next, and stops early once the recomputed plan is fully resolved --
   a `bot-gated-skip`, `awaiting-fresh-review`, or rerun-budget-held
-  instance is never rerun
+  instance is never rerun outside the narrow `liveCoverageRecoveryPlan`
+  exception just above, and the same `MAX_APPLY_RERUNS` safety bound
+  covers all three plan sections together, not a second loop
 - `--check-name <name>` (#1935) overrides the check-run name searched for
   and reported, defaulting to `idd-advisory-convergence` when omitted
   (byte-identical output to before this flag existed). Use it when the
@@ -2038,7 +2054,12 @@ to post it is the consuming track's job.
 instance (see above) -- that withholding is correct and load-bearing
 on its own, and this section does not change it: the script keeps
 withholding these instances from its own plan, and gains no
-`--override-budget` flag or equivalent. A specific combination sits
+`--override-budget` flag or equivalent. `liveCoverageRecoveryPlan`
+above (#2549) is a separate, much narrower automated exception (a
+live-coverage-recovered instance with an already-passing sibling
+proving the rollup is otherwise resolved) -- it does not apply to the
+waiver-rebind case below, which still requires this manual procedure.
+A specific combination sits
 outside what the withholding alone can resolve: an
 `idd-advisory-convergence` instance already went `rerun-budget-held`
 from a genuinely-failed attempt, and only afterward does a maintainer

--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -238,7 +238,7 @@ const RECOVERY_REFRESH_CAVEAT =
 // instance with no passing sibling) keeps today's manual-decision
 // behavior unchanged.
 const LIVE_COVERAGE_RECOVERY_CAVEAT =
-  "Per idd-ci.instructions.md Rerun mechanics (#2549): each instance below was previously withheld by its own exhausted rerun-once budget, but its live-coverage-recovery classification (#1806) combined with an already-PASSING sibling instance for this check proves the rollup is otherwise resolved -- rerunning it here is bounded cleanup of a redundant stale sibling, not a second automated rerun-budget grant. Every other rerun-budget-held instance keeps today's manual-decision behavior unchanged.";
+  "Per docs/idd-helper-scripts.md (#2549): each instance below was previously withheld by its own exhausted rerun-once budget, but its live-coverage-recovery classification (#1806) combined with an already-PASSING sibling instance for this check proves the rollup is otherwise resolved -- rerunning it here is bounded cleanup of a redundant stale sibling, not a second automated rerun-budget grant. Every other rerun-budget-held instance keeps today's manual-decision behavior unchanged.";
 /**
  * Compute the deterministic rerun-plan verdict from already-fetched and
  * already-enriched check-run instances. Pure (no I/O), so it is directly

--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -228,6 +228,17 @@ const PLAN_CAVEAT =
 // the technical gating condition, which holds regardless (#1752).
 const RECOVERY_REFRESH_CAVEAT =
   'At least one check-run is bot-gated-skip and at least one already-PASSING non-bot pull_request-family instance exists for this SHA. Per idd-ci.instructions.md Rerun mechanics, rerunning that already-passing instance (not the bot-gated one) is the documented way to force a fresh non-bot-triggered evaluation and clear a required-check rollup pinned to the stale bot-gated state -- the instance itself does not need to change its outcome.';
+// #2549: each entry below was previously withheld from `plan` by its own
+// exhausted rerun-once budget, but its live-coverage-recovery
+// classification (#1806) combined with an already-PASSING sibling
+// instance for this check proves the rollup is otherwise resolved --
+// rerunning it here is bounded cleanup of a redundant stale sibling, not a
+// second automated rerun-budget grant. Every OTHER rerun-budget-held
+// instance (including the waiver-rebind case, and a live-coverage-recovery
+// instance with no passing sibling) keeps today's manual-decision
+// behavior unchanged.
+const LIVE_COVERAGE_RECOVERY_CAVEAT =
+  "Per idd-ci.instructions.md Rerun mechanics (#2549): each instance below was previously withheld by its own exhausted rerun-once budget, but its live-coverage-recovery classification (#1806) combined with an already-PASSING sibling instance for this check proves the rollup is otherwise resolved -- rerunning it here is bounded cleanup of a redundant stale sibling, not a second automated rerun-budget grant. Every other rerun-budget-held instance keeps today's manual-decision behavior unchanged.";
 /**
  * Compute the deterministic rerun-plan verdict from already-fetched and
  * already-enriched check-run instances. Pure (no I/O), so it is directly
@@ -298,6 +309,64 @@ export function computeRerunPlan(input, options) {
       eligibleDecisions.get(instance.checkRunId)?.action === 'rerun',
   );
   const plan = buildOrderedPlan(reRunningEligibleInstances, owner, repo);
+  // #2549: narrow, separately-bounded exception to rule 1 below --
+  // documented in full on {@link RerunAdvisoryConvergencePlan.liveCoverageRecoveryPlan}.
+  // ALL four conditions gate this promotion; failing any one leaves the
+  // instance held exactly as before #2549 (rule 1 still applies to it):
+  //   1. `rerunPolicy === 'rerun-once'` -- a `"hold"` policy withholds this
+  //      exception too, like every other rerun.
+  //   2. `instance.isLiveCoverageRecovery === true` -- the EXACT #1806
+  //      reclassification (classifyInstance step 7's second return), never
+  //      any other rerun-budget-held cause (e.g. the waiver-rebind case).
+  //   3. `decision.reason === 'rerun-budget-exhausted'` -- a CONFIRMED spent
+  //      budget. `'run-attempt-unknown'` (an unconfirmed one) does not
+  //      qualify: this exception only cleans up a proven-redundant sibling,
+  //      never guesses one is safe.
+  //   4. A sibling instance (same check, i.e. elsewhere in `instances`) is
+  //      already `classification === 'pass'` -- proof the rollup is
+  //      otherwise already resolved, so THIS instance's own outcome no
+  //      longer decides it. Any triggering actor counts (including a bot):
+  //      rollup-resolution does not care who triggered the passing sibling
+  //      -- unlike `selectRecoveryRefreshCandidates`, which excludes a
+  //      bot-triggered passing instance for a DIFFERENT reason (that
+  //      mechanism specifically needs a fresh NON-bot-triggered
+  //      evaluation; this one only needs proof the rollup is settled).
+  const liveCoverageRecoveryHeldInstances =
+    rerunPolicy === 'rerun-once'
+      ? eligibleInstances.filter((instance) => {
+          if (instance.isLiveCoverageRecovery !== true) return false;
+          const decision = eligibleDecisions.get(instance.checkRunId);
+          if (
+            decision?.action !== 'hold' ||
+            decision.reason !== 'rerun-budget-exhausted'
+          ) {
+            return false;
+          }
+          return instances.some(
+            (other) =>
+              other.checkRunId !== instance.checkRunId &&
+              other.classification === 'pass',
+          );
+        })
+      : [];
+  const liveCoverageRecoveryHeldCheckRunIds = new Set(
+    liveCoverageRecoveryHeldInstances.map((instance) => instance.checkRunId),
+  );
+  const liveCoverageRecoveryPlan = buildOrderedPlan(
+    liveCoverageRecoveryHeldInstances,
+    owner,
+    repo,
+  ).map((command) => ({
+    ...command,
+    originalHoldReason: command.checkRunIds
+      .map((checkRunId) => {
+        const source = liveCoverageRecoveryHeldInstances.find(
+          (instance) => instance.checkRunId === checkRunId,
+        );
+        return `check-run ${checkRunId} was withheld as rerun-budget-exhausted; ${source?.reason ?? 'live-coverage recovery (#1806)'}`;
+      })
+      .join('; '),
+  }));
   const recoveryRefreshCandidates = selectRecoveryRefreshCandidates(
     instances,
     classifyOptions,
@@ -334,20 +403,34 @@ export function computeRerunPlan(input, options) {
   // (classified `rerun-eligible` instead of `awaiting-fresh-review` --
   // see `classifyInstance`'s awaiting-fresh-review step) enters `eligibleInstances`
   // like any other rerun-eligible instance. If ITS OWN `runAttempt` already
-  // exhausted the rerun-once budget, rule 1 above applies to it exactly the
-  // same way it already applies to any other budget-held eligible instance:
+  // exhausted the rerun-once budget, rule 1 above applies to it the same
+  // way it already applies to any other budget-held eligible instance:
   // `anyEligibleHeld` becomes `true` and `recoveryRefreshPlan` is withheld
   // for the WHOLE rollup, even when a separate, still-genuinely-stuck
   // `bot-gated-skip` sibling exists. This is not a #1806-specific carve-out
   // -- #1806 only widens which instances CAN reach `eligibleInstances` in
   // the first place; rule 1's own boundary (a human must look at a
   // budget-exhausted eligible instance rather than have the tool silently
-  // route around it via a different instance's rerun) applies uniformly
-  // once an instance is there, regardless of how it got classified
-  // `rerun-eligible`. See the "budget-exhausted recovered instance" test.
+  // route around it via a different instance's rerun) applies once an
+  // instance is there, regardless of how it got classified
+  // `rerun-eligible` -- UNLESS the narrow #2549 exception immediately
+  // below promotes it. See the "run-attempt-unknown live-coverage
+  // instance still suppresses recoveryRefreshPlan" test for the case
+  // this rule still governs post-#2549.
+  //
+  // #2549 exception: an instance already promoted into
+  // `liveCoverageRecoveryPlan` above is excluded from this check -- it is
+  // being HANDLED (its own narrow, separately-bounded rerun is queued),
+  // not silently held, so it must not suppress `recoveryRefreshPlan` for
+  // the rest of the rollup. A live-coverage-recovery instance that failed
+  // the promotion's passing-sibling precondition is NOT in
+  // `liveCoverageRecoveryHeldCheckRunIds` and therefore still counts here
+  // exactly as before #2549 -- this exclusion narrows only for the exact
+  // instances #2549 actually reruns, never wider.
   const anyEligibleHeld = eligibleInstances.some(
     (instance) =>
-      eligibleDecisions.get(instance.checkRunId)?.action !== 'rerun',
+      eligibleDecisions.get(instance.checkRunId)?.action !== 'rerun' &&
+      !liveCoverageRecoveryHeldCheckRunIds.has(instance.checkRunId),
   );
   const everyReRunningEligibleIsBotTriggered = reRunningEligibleInstances.every(
     (instance) => isBotTriggered(instance, classifyOptions),
@@ -372,8 +455,14 @@ export function computeRerunPlan(input, options) {
         repo,
       )
     : [];
-  const heldEligibleCount = [...eligibleDecisions.values()].filter(
-    (decision) => decision.action === 'hold',
+  // #2549: an instance promoted into `liveCoverageRecoveryPlan` is being
+  // handled (a bounded rerun is queued for it), not withheld -- excluded
+  // here so `rerunPolicyHoldNotice` never claims a maintainer must
+  // manually decide about an instance the plan is already acting on.
+  const heldEligibleCount = [...eligibleDecisions.entries()].filter(
+    ([checkRunId, decision]) =>
+      decision.action === 'hold' &&
+      !liveCoverageRecoveryHeldCheckRunIds.has(checkRunId),
   ).length;
   const heldRefreshCount = [...refreshDecisions.values()].filter(
     (decision) => decision.action === 'hold',
@@ -386,9 +475,13 @@ export function computeRerunPlan(input, options) {
   // so the notice never claims a budget is "already used" when it was
   // actually just never confirmed.
   const allHeldReasons = new Set(
-    [...eligibleDecisions.values(), ...refreshDecisions.values()]
-      .filter((decision) => decision.action === 'hold')
-      .map((decision) => decision.reason),
+    [...eligibleDecisions.entries(), ...refreshDecisions.entries()]
+      .filter(
+        ([checkRunId, decision]) =>
+          decision.action === 'hold' &&
+          !liveCoverageRecoveryHeldCheckRunIds.has(checkRunId),
+      )
+      .map(([, decision]) => decision.reason),
   );
   const rerunPolicyHoldNotice =
     totalHeldCount === 0
@@ -399,9 +492,10 @@ export function computeRerunPlan(input, options) {
   const budgetHeldCheckRunIds = new Set(
     [...eligibleDecisions.entries(), ...refreshDecisions.entries()]
       .filter(
-        ([, decision]) =>
-          decision.reason === 'rerun-budget-exhausted' ||
-          decision.reason === 'run-attempt-unknown',
+        ([checkRunId, decision]) =>
+          (decision.reason === 'rerun-budget-exhausted' ||
+            decision.reason === 'run-attempt-unknown') &&
+          !liveCoverageRecoveryHeldCheckRunIds.has(checkRunId),
       )
       .map(([checkRunId]) => checkRunId),
   );
@@ -442,6 +536,9 @@ export function computeRerunPlan(input, options) {
     recoveryRefreshPlan,
     recoveryRefreshCaveat:
       recoveryRefreshPlan.length > 0 ? RECOVERY_REFRESH_CAVEAT : '',
+    liveCoverageRecoveryPlan,
+    liveCoverageRecoveryCaveat:
+      liveCoverageRecoveryPlan.length > 0 ? LIVE_COVERAGE_RECOVERY_CAVEAT : '',
     rerunPolicy,
     rerunPolicyHoldNotice,
   };
@@ -685,6 +782,7 @@ function classifyInstance(instance, options) {
       ...instance,
       classification: 'rerun-eligible',
       reason: `advisory-convergence verdict historically reported "${matched}", but a live check now confirms the current HEAD is covered by a fresh review; the historical hold is stale -- safe to rerun (live-coverage recovery, #1806)`,
+      isLiveCoverageRecovery: true,
     };
   }
   // 8. Non-pass, terminal, resolved, pull_request-family -- safe to rerun.
@@ -1225,6 +1323,20 @@ export function buildRerunPlanTextSections(plan) {
       ].join('\n'),
     );
   }
+  if (plan.liveCoverageRecoveryPlan.length > 0) {
+    sections.push(
+      [
+        'Live-coverage-recovery cleanup available (#2549) -- bounded rerun of budget-held sibling(s) now provably redundant; run after the sections above:',
+        ...plan.liveCoverageRecoveryPlan.map((entry, index) =>
+          entry.originalHoldReason
+            ? `  ${index + 1}. ${entry.command}\n     originally held: ${entry.originalHoldReason}`
+            : `  ${index + 1}. ${entry.command}`,
+        ),
+        '',
+        plan.liveCoverageRecoveryCaveat,
+      ].join('\n'),
+    );
+  }
   return sections;
 }
 function printHelp() {
@@ -1254,9 +1366,21 @@ exactly as "planCaveat" already documents. Prefers the recovery-refresh
 plan first when one exists, matching idd-ci.instructions.md's documented
 recovery order. After each rerun, the plan is recomputed from fresh
 evidence and the loop stops early as soon as it resolves (no
-rerun-eligible or recovery-refresh instance remains) instead of running
-the rest of the original plan. A final summary of what ran and whether
-the target state resolved is printed to stderr.
+rerun-eligible, recovery-refresh, or live-coverage-recovery instance
+remains) instead of running the rest of the original plan. A final
+summary of what ran and whether the target state resolved is printed to
+stderr.
+
+One narrow, bounded exception to "never rerun-budget-held" (#2549): an
+instance held ONLY because its own rerun-once budget is exhausted, whose
+classification is specifically the #1806 live-coverage-recovery case, and
+for which a sibling instance for the same check already shows "pass" --
+proof the rollup is otherwise already resolved -- is rerun as bounded
+cleanup of that redundant stale sibling, after the plan and
+recovery-refresh sections above. Every other rerun-budget-held instance
+(including the waiver-rebind case) still requires a maintainer's manual
+decision, unchanged. Stays within the same rerun budget documented below
+-- this is not a second or unbounded loop.
 
 --owner and --repo must be given together (to inspect a PR outside the
 current checkout) or omitted together (to auto-detect the current
@@ -1323,25 +1447,41 @@ const MAX_APPLY_RERUNS = 20;
  * Prefers `recoveryRefreshPlan`'s next entry over `plan`'s whenever both
  * are non-empty, matching {@link describeRecoveryRefreshHeader}'s
  * documented recovery order (try the recovery-refresh rerun first; only
- * fall back to the sequential plan if it does not clear the rollup).
+ * fall back to the sequential plan if it does not clear the rollup); a
+ * `liveCoverageRecoveryPlan` (#2549) entry is only picked once BOTH of
+ * those are exhausted -- it is bounded cleanup of an already-provably-
+ * redundant sibling, never a substitute for either mechanism above.
  * `bot-gated-skip`, `awaiting-fresh-review`, and rerun-budget-held
- * instances are never candidates here: neither `plan` nor
- * `recoveryRefreshPlan` ever contains them (see {@link computeRerunPlan}),
- * so this loop cannot reach them regardless of `deps.recomputePlan`'s
- * output (#1775 keeps uncovered-HEAD failures out of both plans).
+ * instances are never candidates here (except the narrow #2549 subset
+ * promoted into `liveCoverageRecoveryPlan`): neither `plan` nor
+ * `recoveryRefreshPlan` ever contains any other one of them (see {@link
+ * computeRerunPlan}), so this loop cannot reach them regardless of
+ * `deps.recomputePlan`'s output (#1775 keeps uncovered-HEAD failures out
+ * of both plans).
  */
 export function applyRerunPlan(initialPlan, deps) {
   const executed = [];
   let plan = initialPlan;
   for (let attempt = 0; attempt < MAX_APPLY_RERUNS; attempt += 1) {
     const fromRefresh = plan.recoveryRefreshPlan[0];
-    const next = fromRefresh ?? plan.plan[0];
+    const fromPlan = plan.plan[0];
+    const fromLiveCoverageRecovery = plan.liveCoverageRecoveryPlan[0];
+    const next = fromRefresh ?? fromPlan ?? fromLiveCoverageRecovery;
     if (!next) {
       return { executed, finalPlan: plan, resolved: true };
     }
-    const section = fromRefresh ? 'recoveryRefreshPlan' : 'plan';
+    const section = fromRefresh
+      ? 'recoveryRefreshPlan'
+      : fromPlan
+        ? 'plan'
+        : 'liveCoverageRecoveryPlan';
     deps.rerunAndWait(next);
-    executed.push({ runId: next.runId, command: next.command, section });
+    executed.push({
+      runId: next.runId,
+      command: next.command,
+      section,
+      originalHoldReason: next.originalHoldReason,
+    });
     plan = deps.recomputePlan();
   }
   return { executed, finalPlan: plan, resolved: false };
@@ -1357,6 +1497,9 @@ export function formatApplySummary(result) {
   const lines = [`--apply: executed ${result.executed.length} rerun(s).`];
   for (const [index, entry] of result.executed.entries()) {
     lines.push(`  ${index + 1}. [${entry.section}] ${entry.command}`);
+    if (entry.originalHoldReason) {
+      lines.push(`     originally held: ${entry.originalHoldReason}`);
+    }
   }
   lines.push(
     result.resolved
@@ -2070,6 +2213,7 @@ if (import.meta.main) {
     } else if (
       plan.plan.length === 0 &&
       plan.recoveryRefreshPlan.length === 0 &&
+      plan.liveCoverageRecoveryPlan.length === 0 &&
       !plan.rerunPolicyHoldNotice
     ) {
       // Genuinely nothing to report at all.

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -492,7 +492,7 @@ const RECOVERY_REFRESH_CAVEAT =
 // instance with no passing sibling) keeps today's manual-decision
 // behavior unchanged.
 const LIVE_COVERAGE_RECOVERY_CAVEAT =
-  "Per idd-ci.instructions.md Rerun mechanics (#2549): each instance below was previously withheld by its own exhausted rerun-once budget, but its live-coverage-recovery classification (#1806) combined with an already-PASSING sibling instance for this check proves the rollup is otherwise resolved -- rerunning it here is bounded cleanup of a redundant stale sibling, not a second automated rerun-budget grant. Every other rerun-budget-held instance keeps today's manual-decision behavior unchanged.";
+  "Per docs/idd-helper-scripts.md (#2549): each instance below was previously withheld by its own exhausted rerun-once budget, but its live-coverage-recovery classification (#1806) combined with an already-PASSING sibling instance for this check proves the rollup is otherwise resolved -- rerunning it here is bounded cleanup of a redundant stale sibling, not a second automated rerun-budget grant. Every other rerun-budget-held instance keeps today's manual-decision behavior unchanged.";
 
 /** Pure inputs to {@link computeRerunPlan} (already fetched; this function
  * performs no I/O). */

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -293,6 +293,14 @@ export interface RerunPlanRawInstance {
 export interface RerunPlanClassifiedInstance extends RerunPlanRawInstance {
   classification: RerunPlanClassification;
   reason: string;
+  /** `true` only for the exact #1806 live-coverage-recovery reclassification
+   * in `classifyInstance` step 7 (a historical uncovered-HEAD/never-reviewed
+   * hold recovered to `rerun-eligible` by a live signal) -- never set by any
+   * other classification path, including the ordinary non-held
+   * `rerun-eligible` step 8 case. Lets {@link computeRerunPlan} identify the
+   * narrow #2549 promotion candidates by a structured flag instead of
+   * re-parsing `reason`'s prose. Omitted (not `false`) everywhere else. */
+  isLiveCoverageRecovery?: boolean;
 }
 
 /**
@@ -315,7 +323,12 @@ export interface RerunPlanFinalizedInstance
    * classification, or a `"hold"` policy withholding everything). Lets a
    * caller see WHY an otherwise `rerun-eligible` (or recovery-refresh
    * candidate) instance is absent from its plan without re-deriving the
-   * budget decision itself. Always `false` for every other instance. */
+   * budget decision itself. `false` for every other instance, INCLUDING
+   * (#2549) a budget-exhausted instance the narrow live-coverage-recovery
+   * exception promoted into
+   * {@link RerunAdvisoryConvergencePlan.liveCoverageRecoveryPlan} -- it is
+   * no longer absent from every plan (its own bounded rerun IS queued
+   * there), so this flag would mislead if left `true` for it. */
   rerunBudgetHeld: boolean;
 }
 
@@ -330,6 +343,13 @@ export interface RerunPlanCommand {
    * instances, or `''` if none is known. Drives the ordering; kept in the
    * output for transparency. */
   startedAt: string;
+  /** Set only for {@link RerunAdvisoryConvergencePlan.liveCoverageRecoveryPlan}
+   * entries (#2549): per contributing check-run id, the reason it had
+   * been withheld before (`rerun-budget-exhausted`) plus the
+   * live-coverage-recovery classification (#1806) that makes rerunning it
+   * here bounded cleanup rather than a fresh rerun-budget grant. Undefined
+   * for `plan` / `recoveryRefreshPlan` entries. */
+  originalHoldReason?: string;
 }
 
 /** Full JSON document printed by this CLI. */
@@ -356,7 +376,11 @@ export interface RerunAdvisoryConvergencePlan {
      * already counted within `rerunEligible` (or within `pass`, for a
      * refresh candidate); this is the quick-scan aggregate of the same
      * signal as each instance's own
-     * {@link RerunPlanFinalizedInstance.rerunBudgetHeld} flag. */
+     * {@link RerunPlanFinalizedInstance.rerunBudgetHeld} flag. Excludes
+     * (#2549) an instance the narrow live-coverage-recovery exception
+     * promoted into `liveCoverageRecoveryPlan` -- it is being handled,
+     * not withheld, matching `rerunBudgetHeld`'s own per-instance
+     * exclusion. */
     rerunBudgetHeld: number;
     total: number;
   };
@@ -376,7 +400,11 @@ export interface RerunAdvisoryConvergencePlan {
    * of it), or a genuinely rerun-eligible instance was excluded from
    * `plan` purely by rerun-budget exhaustion (#1434 review, Codex P1 --
    * recovery-refresh must never become a loophole around that instance's
-   * own "one rerun, then a human reviews it" boundary). A bot-triggered
+   * own "one rerun, then a human reviews it" boundary) -- UNLESS (#2549)
+   * that excluded instance was itself promoted into
+   * `liveCoverageRecoveryPlan` below: once its own bounded rerun is
+   * queued there, it is being handled rather than routed around, so it no
+   * longer suppresses this field. A bot-triggered
    * rerun-eligible instance in `plan` (e.g. a `CANCELLED`-conclusion
    * sibling, #1745) does NOT by itself suppress this field: rerunning it
    * preserves its original triggering actor, so it does not supply the
@@ -394,6 +422,33 @@ export interface RerunAdvisoryConvergencePlan {
   /** Guidance for `recoveryRefreshPlan`, printed only when it is
    * non-empty. */
   recoveryRefreshCaveat: string;
+  /**
+   * Bounded #2549 promotion: rerun-eligible instances that would otherwise
+   * be excluded from `plan` by rule 1's `anyEligibleHeld` boundary (their
+   * own rerun-once budget is exhausted), but qualify for a narrow,
+   * separately-bounded exception -- ALL of: the instance's
+   * {@link RerunPlanClassifiedInstance.isLiveCoverageRecovery} flag is
+   * `true` (the exact #1806 live-coverage-recovery classification, not any
+   * other rerun-budget-held cause such as the waiver-rebind case), its own
+   * hold reason is specifically `'rerun-budget-exhausted'` (a spent
+   * budget -- `'run-attempt-unknown'`, an unconfirmed one, does NOT
+   * qualify and stays held), the resolved `rerunPolicy` is `'rerun-once'`
+   * (a `'hold'` policy withholds this too, like everything else), and at
+   * least one OTHER instance for this check already classifies `'pass'`
+   * (proof the rollup is otherwise already resolved, so rerunning this one
+   * is cleanup of a redundant stale sibling on an already-covered HEAD --
+   * not a general second rerun-budget grant the rest of rule 1 still
+   * forbids). These instances no longer count toward `anyEligibleHeld`
+   * (they are being handled, not held) but a live-coverage-recovery
+   * instance that fails the passing-sibling precondition still does,
+   * unchanged. Executed by {@link applyRerunPlan} under the same
+   * {@link MAX_APPLY_RERUNS} bound as `plan` and `recoveryRefreshPlan`,
+   * after both are exhausted -- no separate loop.
+   */
+  liveCoverageRecoveryPlan: RerunPlanCommand[];
+  /** Guidance for `liveCoverageRecoveryPlan`, printed only when it is
+   * non-empty. */
+  liveCoverageRecoveryCaveat: string;
   /** The resolved `ciWait.rerunPolicy` this plan honored (`"rerun-once"`
    * or `"hold"`), matching the same policy `idd-ci.instructions.md`
    * §Rerun mechanics already makes the advisory-convergence recovery
@@ -426,6 +481,18 @@ const PLAN_CAVEAT =
 // the technical gating condition, which holds regardless (#1752).
 const RECOVERY_REFRESH_CAVEAT =
   'At least one check-run is bot-gated-skip and at least one already-PASSING non-bot pull_request-family instance exists for this SHA. Per idd-ci.instructions.md Rerun mechanics, rerunning that already-passing instance (not the bot-gated one) is the documented way to force a fresh non-bot-triggered evaluation and clear a required-check rollup pinned to the stale bot-gated state -- the instance itself does not need to change its outcome.';
+
+// #2549: each entry below was previously withheld from `plan` by its own
+// exhausted rerun-once budget, but its live-coverage-recovery
+// classification (#1806) combined with an already-PASSING sibling
+// instance for this check proves the rollup is otherwise resolved --
+// rerunning it here is bounded cleanup of a redundant stale sibling, not a
+// second automated rerun-budget grant. Every OTHER rerun-budget-held
+// instance (including the waiver-rebind case, and a live-coverage-recovery
+// instance with no passing sibling) keeps today's manual-decision
+// behavior unchanged.
+const LIVE_COVERAGE_RECOVERY_CAVEAT =
+  "Per idd-ci.instructions.md Rerun mechanics (#2549): each instance below was previously withheld by its own exhausted rerun-once budget, but its live-coverage-recovery classification (#1806) combined with an already-PASSING sibling instance for this check proves the rollup is otherwise resolved -- rerunning it here is bounded cleanup of a redundant stale sibling, not a second automated rerun-budget grant. Every other rerun-budget-held instance keeps today's manual-decision behavior unchanged.";
 
 /** Pure inputs to {@link computeRerunPlan} (already fetched; this function
  * performs no I/O). */
@@ -554,6 +621,65 @@ export function computeRerunPlan(
   );
   const plan = buildOrderedPlan(reRunningEligibleInstances, owner, repo);
 
+  // #2549: narrow, separately-bounded exception to rule 1 below --
+  // documented in full on {@link RerunAdvisoryConvergencePlan.liveCoverageRecoveryPlan}.
+  // ALL four conditions gate this promotion; failing any one leaves the
+  // instance held exactly as before #2549 (rule 1 still applies to it):
+  //   1. `rerunPolicy === 'rerun-once'` -- a `"hold"` policy withholds this
+  //      exception too, like every other rerun.
+  //   2. `instance.isLiveCoverageRecovery === true` -- the EXACT #1806
+  //      reclassification (classifyInstance step 7's second return), never
+  //      any other rerun-budget-held cause (e.g. the waiver-rebind case).
+  //   3. `decision.reason === 'rerun-budget-exhausted'` -- a CONFIRMED spent
+  //      budget. `'run-attempt-unknown'` (an unconfirmed one) does not
+  //      qualify: this exception only cleans up a proven-redundant sibling,
+  //      never guesses one is safe.
+  //   4. A sibling instance (same check, i.e. elsewhere in `instances`) is
+  //      already `classification === 'pass'` -- proof the rollup is
+  //      otherwise already resolved, so THIS instance's own outcome no
+  //      longer decides it. Any triggering actor counts (including a bot):
+  //      rollup-resolution does not care who triggered the passing sibling
+  //      -- unlike `selectRecoveryRefreshCandidates`, which excludes a
+  //      bot-triggered passing instance for a DIFFERENT reason (that
+  //      mechanism specifically needs a fresh NON-bot-triggered
+  //      evaluation; this one only needs proof the rollup is settled).
+  const liveCoverageRecoveryHeldInstances =
+    rerunPolicy === 'rerun-once'
+      ? eligibleInstances.filter((instance) => {
+          if (instance.isLiveCoverageRecovery !== true) return false;
+          const decision = eligibleDecisions.get(instance.checkRunId);
+          if (
+            decision?.action !== 'hold' ||
+            decision.reason !== 'rerun-budget-exhausted'
+          ) {
+            return false;
+          }
+          return instances.some(
+            (other) =>
+              other.checkRunId !== instance.checkRunId &&
+              other.classification === 'pass',
+          );
+        })
+      : [];
+  const liveCoverageRecoveryHeldCheckRunIds = new Set(
+    liveCoverageRecoveryHeldInstances.map((instance) => instance.checkRunId),
+  );
+  const liveCoverageRecoveryPlan = buildOrderedPlan(
+    liveCoverageRecoveryHeldInstances,
+    owner,
+    repo,
+  ).map((command) => ({
+    ...command,
+    originalHoldReason: command.checkRunIds
+      .map((checkRunId) => {
+        const source = liveCoverageRecoveryHeldInstances.find(
+          (instance) => instance.checkRunId === checkRunId,
+        );
+        return `check-run ${checkRunId} was withheld as rerun-budget-exhausted; ${source?.reason ?? 'live-coverage recovery (#1806)'}`;
+      })
+      .join('; '),
+  }));
+
   const recoveryRefreshCandidates = selectRecoveryRefreshCandidates(
     instances,
     classifyOptions,
@@ -590,20 +716,34 @@ export function computeRerunPlan(
   // (classified `rerun-eligible` instead of `awaiting-fresh-review` --
   // see `classifyInstance`'s awaiting-fresh-review step) enters `eligibleInstances`
   // like any other rerun-eligible instance. If ITS OWN `runAttempt` already
-  // exhausted the rerun-once budget, rule 1 above applies to it exactly the
-  // same way it already applies to any other budget-held eligible instance:
+  // exhausted the rerun-once budget, rule 1 above applies to it the same
+  // way it already applies to any other budget-held eligible instance:
   // `anyEligibleHeld` becomes `true` and `recoveryRefreshPlan` is withheld
   // for the WHOLE rollup, even when a separate, still-genuinely-stuck
   // `bot-gated-skip` sibling exists. This is not a #1806-specific carve-out
   // -- #1806 only widens which instances CAN reach `eligibleInstances` in
   // the first place; rule 1's own boundary (a human must look at a
   // budget-exhausted eligible instance rather than have the tool silently
-  // route around it via a different instance's rerun) applies uniformly
-  // once an instance is there, regardless of how it got classified
-  // `rerun-eligible`. See the "budget-exhausted recovered instance" test.
+  // route around it via a different instance's rerun) applies once an
+  // instance is there, regardless of how it got classified
+  // `rerun-eligible` -- UNLESS the narrow #2549 exception immediately
+  // below promotes it. See the "run-attempt-unknown live-coverage
+  // instance still suppresses recoveryRefreshPlan" test for the case
+  // this rule still governs post-#2549.
+  //
+  // #2549 exception: an instance already promoted into
+  // `liveCoverageRecoveryPlan` above is excluded from this check -- it is
+  // being HANDLED (its own narrow, separately-bounded rerun is queued),
+  // not silently held, so it must not suppress `recoveryRefreshPlan` for
+  // the rest of the rollup. A live-coverage-recovery instance that failed
+  // the promotion's passing-sibling precondition is NOT in
+  // `liveCoverageRecoveryHeldCheckRunIds` and therefore still counts here
+  // exactly as before #2549 -- this exclusion narrows only for the exact
+  // instances #2549 actually reruns, never wider.
   const anyEligibleHeld = eligibleInstances.some(
     (instance) =>
-      eligibleDecisions.get(instance.checkRunId)?.action !== 'rerun',
+      eligibleDecisions.get(instance.checkRunId)?.action !== 'rerun' &&
+      !liveCoverageRecoveryHeldCheckRunIds.has(instance.checkRunId),
   );
   const everyReRunningEligibleIsBotTriggered = reRunningEligibleInstances.every(
     (instance) => isBotTriggered(instance, classifyOptions),
@@ -632,8 +772,14 @@ export function computeRerunPlan(
       )
     : [];
 
-  const heldEligibleCount = [...eligibleDecisions.values()].filter(
-    (decision) => decision.action === 'hold',
+  // #2549: an instance promoted into `liveCoverageRecoveryPlan` is being
+  // handled (a bounded rerun is queued for it), not withheld -- excluded
+  // here so `rerunPolicyHoldNotice` never claims a maintainer must
+  // manually decide about an instance the plan is already acting on.
+  const heldEligibleCount = [...eligibleDecisions.entries()].filter(
+    ([checkRunId, decision]) =>
+      decision.action === 'hold' &&
+      !liveCoverageRecoveryHeldCheckRunIds.has(checkRunId),
   ).length;
   const heldRefreshCount = [...refreshDecisions.values()].filter(
     (decision) => decision.action === 'hold',
@@ -646,9 +792,13 @@ export function computeRerunPlan(
   // so the notice never claims a budget is "already used" when it was
   // actually just never confirmed.
   const allHeldReasons = new Set(
-    [...eligibleDecisions.values(), ...refreshDecisions.values()]
-      .filter((decision) => decision.action === 'hold')
-      .map((decision) => decision.reason),
+    [...eligibleDecisions.entries(), ...refreshDecisions.entries()]
+      .filter(
+        ([checkRunId, decision]) =>
+          decision.action === 'hold' &&
+          !liveCoverageRecoveryHeldCheckRunIds.has(checkRunId),
+      )
+      .map(([, decision]) => decision.reason),
   );
   const rerunPolicyHoldNotice =
     totalHeldCount === 0
@@ -660,9 +810,10 @@ export function computeRerunPlan(
   const budgetHeldCheckRunIds = new Set(
     [...eligibleDecisions.entries(), ...refreshDecisions.entries()]
       .filter(
-        ([, decision]) =>
-          decision.reason === 'rerun-budget-exhausted' ||
-          decision.reason === 'run-attempt-unknown',
+        ([checkRunId, decision]) =>
+          (decision.reason === 'rerun-budget-exhausted' ||
+            decision.reason === 'run-attempt-unknown') &&
+          !liveCoverageRecoveryHeldCheckRunIds.has(checkRunId),
       )
       .map(([checkRunId]) => checkRunId),
   );
@@ -705,6 +856,9 @@ export function computeRerunPlan(
     recoveryRefreshPlan,
     recoveryRefreshCaveat:
       recoveryRefreshPlan.length > 0 ? RECOVERY_REFRESH_CAVEAT : '',
+    liveCoverageRecoveryPlan,
+    liveCoverageRecoveryCaveat:
+      liveCoverageRecoveryPlan.length > 0 ? LIVE_COVERAGE_RECOVERY_CAVEAT : '',
     rerunPolicy,
     rerunPolicyHoldNotice,
   };
@@ -979,6 +1133,7 @@ function classifyInstance(
       ...instance,
       classification: 'rerun-eligible',
       reason: `advisory-convergence verdict historically reported "${matched}", but a live check now confirms the current HEAD is covered by a fresh review; the historical hold is stale -- safe to rerun (live-coverage recovery, #1806)`,
+      isLiveCoverageRecovery: true,
     };
   }
 
@@ -1599,6 +1754,20 @@ export function buildRerunPlanTextSections(
       ].join('\n'),
     );
   }
+  if (plan.liveCoverageRecoveryPlan.length > 0) {
+    sections.push(
+      [
+        'Live-coverage-recovery cleanup available (#2549) -- bounded rerun of budget-held sibling(s) now provably redundant; run after the sections above:',
+        ...plan.liveCoverageRecoveryPlan.map((entry, index) =>
+          entry.originalHoldReason
+            ? `  ${index + 1}. ${entry.command}\n     originally held: ${entry.originalHoldReason}`
+            : `  ${index + 1}. ${entry.command}`,
+        ),
+        '',
+        plan.liveCoverageRecoveryCaveat,
+      ].join('\n'),
+    );
+  }
   return sections;
 }
 
@@ -1629,9 +1798,21 @@ exactly as "planCaveat" already documents. Prefers the recovery-refresh
 plan first when one exists, matching idd-ci.instructions.md's documented
 recovery order. After each rerun, the plan is recomputed from fresh
 evidence and the loop stops early as soon as it resolves (no
-rerun-eligible or recovery-refresh instance remains) instead of running
-the rest of the original plan. A final summary of what ran and whether
-the target state resolved is printed to stderr.
+rerun-eligible, recovery-refresh, or live-coverage-recovery instance
+remains) instead of running the rest of the original plan. A final
+summary of what ran and whether the target state resolved is printed to
+stderr.
+
+One narrow, bounded exception to "never rerun-budget-held" (#2549): an
+instance held ONLY because its own rerun-once budget is exhausted, whose
+classification is specifically the #1806 live-coverage-recovery case, and
+for which a sibling instance for the same check already shows "pass" --
+proof the rollup is otherwise already resolved -- is rerun as bounded
+cleanup of that redundant stale sibling, after the plan and
+recovery-refresh sections above. Every other rerun-budget-held instance
+(including the waiver-rebind case) still requires a maintainer's manual
+decision, unchanged. Stays within the same rerun budget documented below
+-- this is not a second or unbounded loop.
 
 --owner and --repo must be given together (to inspect a PR outside the
 current checkout) or omitted together (to auto-detect the current
@@ -1714,8 +1895,14 @@ export interface RerunApplyExecutedEntry {
   command: string;
   /** Which plan section this entry came from -- `recoveryRefreshPlan` is
    * preferred first when both are non-empty, matching {@link
-   * describeRecoveryRefreshHeader}'s documented recovery order. */
-  section: 'plan' | 'recoveryRefreshPlan';
+   * describeRecoveryRefreshHeader}'s documented recovery order;
+   * `liveCoverageRecoveryPlan` (#2549) is only ever picked once both
+   * `recoveryRefreshPlan` and `plan` are exhausted. */
+  section: 'plan' | 'recoveryRefreshPlan' | 'liveCoverageRecoveryPlan';
+  /** Carried over from {@link RerunPlanCommand.originalHoldReason} for a
+   * `liveCoverageRecoveryPlan` entry (#2549) -- undefined for every other
+   * section, matching the source field. */
+  originalHoldReason?: string;
 }
 
 /** Result of {@link applyRerunPlan}. */
@@ -1725,8 +1912,9 @@ export interface RerunApplyResult {
    * nothing was ever executed). */
   finalPlan: RerunAdvisoryConvergencePlan;
   /** `true` when the loop stopped because recomputing found nothing left
-   * to rerun (both `plan` and `recoveryRefreshPlan` empty) -- the "target
-   * state resolved" signal from #1766's acceptance criteria, expressed as
+   * to rerun (`plan`, `recoveryRefreshPlan`, and `liveCoverageRecoveryPlan`
+   * all empty) -- the "target state resolved" signal from #1766's
+   * acceptance criteria, expressed as
    * this helper's own check-name rollup state (an alternative the issue
    * explicitly allows in place of a separate `mergeStateStatus` fetch,
    * and one this helper already has every input to compute without a new
@@ -1761,12 +1949,17 @@ export interface RerunApplyDeps {
  * Prefers `recoveryRefreshPlan`'s next entry over `plan`'s whenever both
  * are non-empty, matching {@link describeRecoveryRefreshHeader}'s
  * documented recovery order (try the recovery-refresh rerun first; only
- * fall back to the sequential plan if it does not clear the rollup).
+ * fall back to the sequential plan if it does not clear the rollup); a
+ * `liveCoverageRecoveryPlan` (#2549) entry is only picked once BOTH of
+ * those are exhausted -- it is bounded cleanup of an already-provably-
+ * redundant sibling, never a substitute for either mechanism above.
  * `bot-gated-skip`, `awaiting-fresh-review`, and rerun-budget-held
- * instances are never candidates here: neither `plan` nor
- * `recoveryRefreshPlan` ever contains them (see {@link computeRerunPlan}),
- * so this loop cannot reach them regardless of `deps.recomputePlan`'s
- * output (#1775 keeps uncovered-HEAD failures out of both plans).
+ * instances are never candidates here (except the narrow #2549 subset
+ * promoted into `liveCoverageRecoveryPlan`): neither `plan` nor
+ * `recoveryRefreshPlan` ever contains any other one of them (see {@link
+ * computeRerunPlan}), so this loop cannot reach them regardless of
+ * `deps.recomputePlan`'s output (#1775 keeps uncovered-HEAD failures out
+ * of both plans).
  */
 export function applyRerunPlan(
   initialPlan: RerunAdvisoryConvergencePlan,
@@ -1777,15 +1970,24 @@ export function applyRerunPlan(
 
   for (let attempt = 0; attempt < MAX_APPLY_RERUNS; attempt += 1) {
     const fromRefresh = plan.recoveryRefreshPlan[0];
-    const next = fromRefresh ?? plan.plan[0];
+    const fromPlan = plan.plan[0];
+    const fromLiveCoverageRecovery = plan.liveCoverageRecoveryPlan[0];
+    const next = fromRefresh ?? fromPlan ?? fromLiveCoverageRecovery;
     if (!next) {
       return { executed, finalPlan: plan, resolved: true };
     }
     const section: RerunApplyExecutedEntry['section'] = fromRefresh
       ? 'recoveryRefreshPlan'
-      : 'plan';
+      : fromPlan
+        ? 'plan'
+        : 'liveCoverageRecoveryPlan';
     deps.rerunAndWait(next);
-    executed.push({ runId: next.runId, command: next.command, section });
+    executed.push({
+      runId: next.runId,
+      command: next.command,
+      section,
+      originalHoldReason: next.originalHoldReason,
+    });
     plan = deps.recomputePlan();
   }
 
@@ -1803,6 +2005,9 @@ export function formatApplySummary(result: RerunApplyResult): string {
   const lines = [`--apply: executed ${result.executed.length} rerun(s).`];
   for (const [index, entry] of result.executed.entries()) {
     lines.push(`  ${index + 1}. [${entry.section}] ${entry.command}`);
+    if (entry.originalHoldReason) {
+      lines.push(`     originally held: ${entry.originalHoldReason}`);
+    }
   }
   lines.push(
     result.resolved
@@ -2629,6 +2834,7 @@ if (import.meta.main) {
     } else if (
       plan.plan.length === 0 &&
       plan.recoveryRefreshPlan.length === 0 &&
+      plan.liveCoverageRecoveryPlan.length === 0 &&
       !plan.rerunPolicyHoldNotice
     ) {
       // Genuinely nothing to report at all.

--- a/tests/rerun-advisory-convergence.test.mts
+++ b/tests/rerun-advisory-convergence.test.mts
@@ -1054,7 +1054,18 @@ test('does not offer a recovery-refresh plan when a genuine rerun-eligible insta
 // instance came from the #1806 recovery path rather than an ordinary
 // terminal failure. This locks in that the widened classification path does
 // not accidentally create a second, looser rule.
-test('#1806: a budget-exhausted live-coverage-recovered instance still suppresses recovery-refresh (rule 1 applies uniformly)', () => {
+// Pre-#2549, this exact fixture (a budget-exhausted #1806-recovered
+// instance coexisting with a bot-gated sibling AND an already-passing
+// sibling) pinned that rule 1 suppresses recoveryRefreshPlan uniformly,
+// with no exception. #2549 narrowly changes precisely this combination:
+// the SAME passing sibling that makes recoveryRefreshPlan's own
+// precondition true also proves the rollup is otherwise already resolved,
+// so `recovered` is promoted into `liveCoverageRecoveryPlan` instead of
+// staying a silent hold -- and, promoted, it no longer suppresses
+// recoveryRefreshPlan for the separate `gated` problem either. See the
+// "run-attempt-unknown" and "no passing sibling" tests below for the
+// cases rule 1 still governs unchanged.
+test('#2549: a budget-exhausted live-coverage-recovered instance with a passing sibling promotes to liveCoverageRecoveryPlan and stops suppressing recovery-refresh', () => {
   const plan = computeRerunPlan(
     baseInput({
       instances: [
@@ -1080,16 +1091,287 @@ test('#1806: a budget-exhausted live-coverage-recovered instance still suppresse
     }),
     baseOptions({ headCoverageSatisfied: true }),
   );
-  // The recovered instance itself is classified rerun-eligible...
   const recovered = plan.instances.find((i) => i.checkRunId === 'recovered');
   assert.equal(recovered?.classification, 'rerun-eligible');
-  // ...but its own budget-exhaustion withholds it from `plan`...
-  assert.equal(recovered?.rerunBudgetHeld, true);
+  assert.equal(recovered?.isLiveCoverageRecovery, true);
+  // No longer reported as budget-held: it is being handled via
+  // liveCoverageRecoveryPlan, not silently withheld.
+  assert.equal(recovered?.rerunBudgetHeld, false);
   assert.equal(plan.plan.length, 0);
-  // ...and, per rule 1, that held-but-eligible instance suppresses
-  // recoveryRefreshPlan for the whole rollup, same as the pre-#1806 case.
+  assert.deepEqual(
+    plan.liveCoverageRecoveryPlan.map((entry) => entry.runId),
+    ['7003'],
+  );
+  assert.match(
+    plan.liveCoverageRecoveryPlan[0]?.originalHoldReason ?? '',
+    /rerun-budget-exhausted/,
+  );
+  assert.match(
+    plan.liveCoverageRecoveryPlan[0]?.originalHoldReason ?? '',
+    /recovered/,
+  );
+  assert.notEqual(plan.liveCoverageRecoveryCaveat, '');
+  // The `recovered` promotion no longer suppresses recoveryRefreshPlan --
+  // the separate `gated`/`passing` pairing still qualifies for it.
+  assert.deepEqual(
+    plan.recoveryRefreshPlan.map((entry) => entry.runId),
+    ['7002'],
+  );
+  assert.equal(plan.rerunPolicyHoldNotice, '');
+});
+
+// The non-vacuous regression guard for rule 1 post-#2549: an unconfirmed
+// budget ('run-attempt-unknown', `runAttempt: null`) is NOT a spent one,
+// so it must not qualify for the #2549 promotion even though every other
+// precondition (live-coverage-recovery classification, a passing sibling,
+// a bot-gated sibling, rerunPolicy rerun-once) is met -- rule 1 still
+// suppresses recoveryRefreshPlan here exactly as before #2549.
+test('#2549: a run-attempt-unknown live-coverage-recovered instance is NOT promoted and still suppresses recovery-refresh', () => {
+  const plan = computeRerunPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          checkRunId: 'gated',
+          runId: '7001',
+          conclusion: 'action_required',
+        }),
+        baseInstance({
+          checkRunId: 'passing',
+          runId: '7002',
+          conclusion: 'success',
+          startedAt: '2026-07-16T11:00:00Z',
+        }),
+        baseInstance({
+          checkRunId: 'recovered',
+          runId: '7003',
+          conclusion: 'failure',
+          runAttempt: null,
+          verdictReasons: [UNCOVERED_HEAD_HISTORICAL_REASON],
+        }),
+      ],
+    }),
+    baseOptions({ headCoverageSatisfied: true }),
+  );
+  const recovered = plan.instances.find((i) => i.checkRunId === 'recovered');
+  assert.equal(recovered?.isLiveCoverageRecovery, true);
+  assert.equal(recovered?.rerunBudgetHeld, true);
+  assert.deepEqual(plan.liveCoverageRecoveryPlan, []);
   assert.deepEqual(plan.recoveryRefreshPlan, []);
   assert.notEqual(plan.rerunPolicyHoldNotice, '');
+});
+
+// A live-coverage-recovered instance with NO passing sibling anywhere in
+// the batch never satisfies the #2549 promotion's "rollup otherwise
+// resolved" precondition, regardless of `anyEligibleHeld` -- it stays
+// held exactly as before #2549.
+test('#2549: a budget-exhausted live-coverage-recovered instance with no passing sibling is NOT promoted', () => {
+  const plan = computeRerunPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          checkRunId: 'recovered',
+          runId: '7003',
+          conclusion: 'failure',
+          runAttempt: 2,
+          verdictReasons: [UNCOVERED_HEAD_HISTORICAL_REASON],
+        }),
+      ],
+    }),
+    baseOptions({ headCoverageSatisfied: true }),
+  );
+  const recovered = plan.instances.find((i) => i.checkRunId === 'recovered');
+  assert.equal(recovered?.isLiveCoverageRecovery, true);
+  assert.equal(recovered?.rerunBudgetHeld, true);
+  assert.deepEqual(plan.liveCoverageRecoveryPlan, []);
+  assert.notEqual(plan.rerunPolicyHoldNotice, '');
+});
+
+// A repository that opted out of ALL automatic reruns (`ciWait.rerunPolicy:
+// "hold"`) must not get the #2549 exception either -- every other
+// rerun-budget-held path already withholds under "hold", and this one
+// must too.
+test('#2549: rerunPolicy "hold" withholds the live-coverage-recovery promotion too', () => {
+  const plan = computeRerunPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          checkRunId: 'passing',
+          runId: '7002',
+          conclusion: 'success',
+        }),
+        baseInstance({
+          checkRunId: 'recovered',
+          runId: '7003',
+          conclusion: 'failure',
+          runAttempt: 2,
+          verdictReasons: [UNCOVERED_HEAD_HISTORICAL_REASON],
+        }),
+      ],
+    }),
+    baseOptions({ headCoverageSatisfied: true, rerunPolicy: 'hold' }),
+  );
+  assert.deepEqual(plan.liveCoverageRecoveryPlan, []);
+  assert.equal(plan.rerunPolicy, 'hold');
+});
+
+// An ordinary rerun-eligible instance whose budget is exhausted, but
+// which was NEVER reclassified via #1806 live-coverage recovery (e.g. the
+// waiver-rebind case, or simply a plain non-passing conclusion that used
+// its rerun already) is a wholly different `rerun-budget-held` cause and
+// must keep today's manual-decision behavior unchanged -- the #2549
+// exception is scoped exactly to the live-coverage-recovery
+// classification, never wider.
+test('#2549: an ordinary (non-live-coverage-recovery) budget-exhausted instance is NOT promoted, even with a passing sibling', () => {
+  const plan = computeRerunPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          checkRunId: 'passing',
+          runId: '7002',
+          conclusion: 'success',
+        }),
+        baseInstance({
+          checkRunId: 'ordinary-held',
+          runId: '7003',
+          conclusion: 'failure',
+          runAttempt: 2,
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  const ordinaryHeld = plan.instances.find(
+    (i) => i.checkRunId === 'ordinary-held',
+  );
+  assert.equal(ordinaryHeld?.classification, 'rerun-eligible');
+  assert.equal(ordinaryHeld?.isLiveCoverageRecovery, undefined);
+  assert.equal(ordinaryHeld?.rerunBudgetHeld, true);
+  assert.deepEqual(plan.liveCoverageRecoveryPlan, []);
+  assert.notEqual(plan.rerunPolicyHoldNotice, '');
+});
+
+test('#2549: applyRerunPlan executes a liveCoverageRecoveryPlan entry only after plan and recoveryRefreshPlan are exhausted, carrying originalHoldReason', () => {
+  const initialPlan = computeRerunPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          checkRunId: 'gated',
+          runId: '7001',
+          conclusion: 'action_required',
+        }),
+        baseInstance({
+          checkRunId: 'passing',
+          runId: '7002',
+          conclusion: 'success',
+        }),
+        baseInstance({
+          checkRunId: 'recovered',
+          runId: '7003',
+          conclusion: 'failure',
+          runAttempt: 2,
+          verdictReasons: [UNCOVERED_HEAD_HISTORICAL_REASON],
+        }),
+      ],
+    }),
+    baseOptions({ headCoverageSatisfied: true }),
+  );
+  assert.deepEqual(initialPlan.plan, []);
+  assert.equal(initialPlan.recoveryRefreshPlan.length, 1);
+  assert.equal(initialPlan.liveCoverageRecoveryPlan.length, 1);
+
+  const resolvedPlan = computeRerunPlan(
+    baseInput({ instances: [] }),
+    baseOptions({ headCoverageSatisfied: true }),
+  );
+  const rerunAndWaitCalls: string[] = [];
+  const recomputeQueue = [
+    // After rerunning the recovery-refresh entry, still nothing left in
+    // `plan`, but the live-coverage-recovery entry is still outstanding.
+    { ...initialPlan, plan: [], recoveryRefreshPlan: [] },
+    // After rerunning the liveCoverageRecoveryPlan entry, everything
+    // resolves.
+    resolvedPlan,
+  ];
+  const result = applyRerunPlan(initialPlan, {
+    rerunAndWait: (command) => {
+      rerunAndWaitCalls.push(command.runId);
+    },
+    recomputePlan: () => recomputeQueue.shift() ?? resolvedPlan,
+  });
+
+  assert.deepEqual(rerunAndWaitCalls, ['7002', '7003']);
+  assert.deepEqual(
+    result.executed.map((entry) => entry.section),
+    ['recoveryRefreshPlan', 'liveCoverageRecoveryPlan'],
+  );
+  const liveCoverageEntry = result.executed.find(
+    (entry) => entry.section === 'liveCoverageRecoveryPlan',
+  );
+  assert.match(liveCoverageEntry?.originalHoldReason ?? '', /recovered/);
+  assert.equal(result.resolved, true);
+  assert.match(formatApplySummary(result), /originally held/);
+});
+
+// Issue #2549 acceptance criterion: MAX_APPLY_RERUNS still bounds the
+// total reruns in one --apply call even when MULTIPLE
+// live-coverage-recovery-held siblings exist and qualify for promotion --
+// this is not a second, larger, or unbounded loop layered on top of the
+// existing safety bound.
+test('#2549: MAX_APPLY_RERUNS still bounds a run with multiple liveCoverageRecoveryPlan siblings', () => {
+  const instances = [
+    baseInstance({
+      checkRunId: 'passing',
+      runId: '9000',
+      conclusion: 'success',
+    }),
+    baseInstance({
+      checkRunId: 'recovered-a',
+      runId: '9001',
+      conclusion: 'failure',
+      runAttempt: 2,
+      verdictReasons: [UNCOVERED_HEAD_HISTORICAL_REASON],
+    }),
+    baseInstance({
+      checkRunId: 'recovered-b',
+      runId: '9002',
+      conclusion: 'failure',
+      runAttempt: 2,
+      verdictReasons: [UNCOVERED_HEAD_HISTORICAL_REASON],
+    }),
+    baseInstance({
+      checkRunId: 'recovered-c',
+      runId: '9003',
+      conclusion: 'failure',
+      runAttempt: 2,
+      verdictReasons: [UNCOVERED_HEAD_HISTORICAL_REASON],
+    }),
+  ];
+  const initialPlan = computeRerunPlan(
+    baseInput({ instances }),
+    baseOptions({ headCoverageSatisfied: true }),
+  );
+  assert.equal(initialPlan.liveCoverageRecoveryPlan.length, 3);
+
+  let calls = 0;
+  // recomputePlan always hands back the SAME never-resolving plan, so
+  // the loop cannot terminate early via `resolved` -- only
+  // MAX_APPLY_RERUNS itself can stop it, exactly as the pre-existing
+  // "stops after its safety bound" test exercises for `plan`.
+  const result = applyRerunPlan(initialPlan, {
+    rerunAndWait: () => {
+      calls += 1;
+    },
+    recomputePlan: () => initialPlan,
+  });
+
+  assert.equal(result.resolved, false);
+  assert.equal(calls, 20);
+  assert.equal(result.executed.length, 20);
+  assert.ok(
+    result.executed.every(
+      (entry) => entry.section === 'liveCoverageRecoveryPlan',
+    ),
+  );
 });
 
 // Regression (#1745 Codex review on this same PR, P2): a bot-triggered


### PR DESCRIPTION
## Summary

`rerun-advisory-convergence.mjs --apply` permanently excluded a
`rerun-budget-held` `idd-advisory-convergence` instance from its plan --
even when the tool's own `#1806` live-coverage-recovery classification
had already proved a fresh review covers current HEAD. This forced a
manual, unscripted `gh run rerun <run-id>` on every such straggler; two
independent sessions rediscovered and self-authorized the same
escalation (PR `#2540`/issue `#2466`, and `#2411`/PR `#2437`), with no
human review of the exception -- the exact gap `#2103` closed for the
waiver-rebind case, left open here.

This adds a narrow, separately-bounded `liveCoverageRecoveryPlan`. An
instance promotes into it **only** when ALL of:

- its hold reason is specifically `rerun-budget-exhausted` (a
  CONFIRMED spent budget -- `run-attempt-unknown`, an unconfirmed one,
  does not qualify)
- its classification is the *exact* `#1806` live-coverage-recovery
  match (`isLiveCoverageRecovery === true`), never any other
  `rerun-budget-held` cause such as the waiver-rebind case
- the resolved `rerunPolicy` is `rerun-once` (a `hold` policy withholds
  this too, like everything else)
- a sibling instance for the same check already classifies `pass` --
  proof the rollup is otherwise already resolved, so rerunning this one
  is bounded cleanup of a redundant stale sibling, not a general second
  rerun-budget grant

Every other `rerun-budget-held` instance keeps today's manual-decision
behavior unchanged. `applyRerunPlan` executes the new section only
after `plan` and `recoveryRefreshPlan` are exhausted, under the exact
same `MAX_APPLY_RERUNS` bound (no second or unbounded loop), and the
`--apply` summary names each promoted instance's original hold reason
via a new `originalHoldReason` field.

Promoted instances also stop counting toward rule 1's `anyEligibleHeld`
check (they are being handled, not silently held) -- a
live-coverage-recovery instance that fails the passing-sibling
precondition still counts exactly as before, and the pre-existing
"ordinary budget-held instance suppresses recovery-refresh" regression
test (unrelated to `#1806`) is untouched and still passes.

## Design-tension note (recompute self-limiting)

After `--apply` reruns a promoted instance, the recomputed plan could in
principle re-promote it if the fresh attempt again reported an
uncovered-HEAD hold while the live signal still says covered. In
practice this self-limits: the fresh attempt's `verdictReasons` come
from the new job log, which either passes or fails with non-stale
markers, so `isLiveCoverageRecovery` will not re-fire on it. The
existing `MAX_APPLY_RERUNS` bound also caps the pathological case
regardless.

## Byte-budget note

`.github/instructions/idd-ci.instructions.md` was intentionally left
unchanged -- `node scripts/audit-docs.mjs --check` reports
`bundle-review` at 97.54% and `bundle-merge` at 98.00% utilization
against the 98% hard-fail threshold, with no headroom for even a terse
addition there without a compensating trim. Per the issue's own
escape hatch ("only if it fits the current byte budget"), the new
behavior is documented in `docs/idd-helper-scripts.md` (and its
`idd-template/` canonical source) instead, alongside the existing
`#2103` "Manual recovery: budget-held instance after a waiver rebind"
section, with an explicit cross-reference explaining the two are
distinct, non-overlapping cases.

## Test plan

- [x] `node --experimental-strip-types --test tests/rerun-advisory-convergence.test.mts` -- 156 pass, including 7 new `#2549` tests (promotion + passing sibling, run-attempt-unknown non-promotion, no-passing-sibling non-promotion, `rerunPolicy: hold` non-promotion, ordinary non-live-coverage-recovery non-promotion, `applyRerunPlan` execution order + `originalHoldReason`, `MAX_APPLY_RERUNS` bound with multiple siblings)
- [x] `pnpm run test:scripts` -- 4953 pass
- [x] `pnpm run typecheck` -- clean
- [x] `pnpm run build` -- `.mjs` regenerated from `.mts`, committed
- [x] `node scripts/sync-docs.mjs --apply` -- `docs/idd-helper-scripts.md` regenerated from the `idd-template/` canonical source
- [x] `node scripts/audit-docs.mjs --check` -- passed, no new bundle-budget notices
- [x] `npx biome check && npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress && node scripts/audit-code-span-wrap.mjs && node --test tests/agent-entry-mirror-sync.test.mts && node scripts/idd-doctor.mjs` -- pre-push-validate chain passed (idd-doctor's 3 warnings are pre-existing environment-level, unrelated to this change)

Closes #2549

🤖 Generated with [Claude Code](https://claude.com/claude-code)