### PR TITLE
fix(review-triage): capture CodeRabbit's embedded findings

### DIFF
--- a/.github/instructions/idd-review-snapshot.instructions.md
+++ b/.github/instructions/idd-review-snapshot.instructions.md
@@ -204,7 +204,14 @@ regardless of maintainer response).
 
 **Review bodies** where the reviewer's latest state is
 `CHANGES_REQUESTED` — exclude reviews already replied to and
-re-review-requested in a previous E13/E14 pass.
+re-review-requested in a previous E13/E14 pass. **Embedded-finding
+gap (helper-first, optional):** a `COMMENTED`-state review can still
+carry a file/line-cited finding with no thread of its own, in an
+older collapsible body format some bots use (e.g. CodeRabbit's
+"Nitpick comments" / "Outside diff range comments") — an
+`extractEmbeddedFindings`-style helper (see
+`docs/idd-design-rationale.md`) detects this; add one PATH B item per
+uncovered finding.
 
 **Regular comments** where the last speaker isn't any IDD agent and no
 reply from **you** exists after that comment's timestamp — exclude

--- a/.github/instructions/idd-review-snapshot.instructions.md
+++ b/.github/instructions/idd-review-snapshot.instructions.md
@@ -208,10 +208,10 @@ re-review-requested in a previous E13/E14 pass. **Embedded-finding
 gap (helper-first, optional):** a `COMMENTED`-state review can still
 carry a file/line-cited finding with no thread of its own, in an
 older collapsible body format some bots use (e.g. CodeRabbit's
-"Nitpick comments" / "Outside diff range comments") — an
-`extractEmbeddedFindings`-style helper (see
-`docs/idd-design-rationale.md`) detects this; add one PATH B item per
-uncovered finding.
+"Nitpick comments" / "Outside diff range comments") — a helper that
+parses the embedded findings and compares against the threaded-comment
+count (see `docs/idd-design-rationale.md`) detects this; add one
+PATH B item per uncovered finding.
 
 **Regular comments** where the last speaker isn't any IDD agent and no
 reply from **you** exists after that comment's timestamp — exclude

--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -500,6 +500,49 @@ running E14's Primary advisory bot procedure at the now-stable HEAD
 whenever the last non-empty snapshot this episode zeroed out on a
 completed-review PATH B disposition, before proceeding to F1.
 
+### An advisory bot's embedded-but-unthreaded findings: mirror the detection scope, not the gate scope
+
+`#2197`'s live 30-day sweep (337 merged PRs) found a `coderabbitai[bot]`
+review in the older "🧹 Nitpick comments" / "⚠️ Outside diff range
+comments" collapsible-body format can carry a specific, file/line-cited
+finding with **zero** corresponding threaded review comment — e.g. PR
+`#1897` review `4863787336` (zero threaded comments on that PR at
+all) and PR `#1871` review `4860403155` (a Major finding, only
+unrelated Copilot threads present). E1 Step 3's "Review bodies" rule
+only pulls
+a review into `ReviewItems_snapshot` when its state is
+`CHANGES_REQUESTED`; every sampled review here was `COMMENTED`
+(CodeRabbit's own state for a nitpick/outside-diff finding), so the
+whole review body — not just the embedded finding — was invisible to
+E1, and E4-E8 never Accepted or Rejected it (#2559).
+
+This is CodeRabbit's analogue of Copilot's already-solved
+`suppressedCount` gap (#1880, `advisory-convergence.mts`): a finding
+that exists in a bot's review but has no GitHub thread of its own.
+Unlike Copilot's, CodeRabbit is a non-gating PATH B advisory bot here
+— the fix mirrors #1880's _detection pattern_ (parse the embedded
+findings, compare against threaded-comment count) but not its
+_gate-enforcement scope_: an uncovered finding becomes an ordinary
+PATH B `ReviewItems_snapshot` entry, not a new merge-blocking check.
+
+`extractCodeRabbitEmbeddedFindings` / `countUncoveredCodeRabbitEmbeddedFindings`
+(`protocol-helpers.mts`) do the parsing: scoped section-by-section
+(heading to next heading), then file-grouping by file-grouping, then
+finding-header-line by finding-header-line — not a full HTML/Markdown
+parser, since CodeRabbit's own nested `<details>` structure has no
+documented grammar to parse against. One sharp edge found while
+building the severity-word regex: `\bTrivial\b` never matches inside
+`_Trivial_` (CodeRabbit wraps each metadata segment in markdown
+italics) — regex `\b` treats `_` as a word character, so there is no
+boundary between the closing `_` and the preceding letter. Dropping
+the trailing `\b` (there is no real ambiguity risk in this
+already-scoped metadata segment) fixed it.
+
+Newer-format CodeRabbit reviews (`Actionable comments posted: N`,
+individually threaded) carry neither collapsible-section heading, so
+this parser naturally returns no findings for them — no separate
+format-detection branch needed.
+
 ## Advisory wait
 
 ### AW3-S vs AW3-R: why two recovery paths

--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -502,10 +502,11 @@ completed-review PATH B disposition, before proceeding to F1.
 
 ### An advisory bot's embedded-but-unthreaded findings: mirror the detection scope, not the gate scope
 
-`#2197`'s live 30-day sweep (337 merged PRs) found a `coderabbitai[bot]`
-review in the older "🧹 Nitpick comments" / "⚠️ Outside diff range
-comments" collapsible-body format can carry a specific, file/line-cited
-finding with **zero** corresponding threaded review comment — e.g. PR
+`#2197`'s live 30-day sweep (337 merged PRs, observed 2026-09-03) found
+a `coderabbitai[bot]` review in the older "🧹 Nitpick comments" /
+"⚠️ Outside diff range comments" collapsible-body format can carry a
+specific, file/line-cited finding with **zero** corresponding threaded
+review comment — e.g. PR
 `#1897` review `4863787336` (zero threaded comments on that PR at
 all) and PR `#1871` review `4860403155` (a Major finding, only
 unrelated Copilot threads present). E1 Step 3's "Review bodies" rule

--- a/idd-template/.github/instructions/idd-review-snapshot.instructions.md
+++ b/idd-template/.github/instructions/idd-review-snapshot.instructions.md
@@ -203,10 +203,10 @@ re-review-requested in a previous E13/E14 pass. **Embedded-finding
 gap (helper-first, optional):** a `COMMENTED`-state review can still
 carry a file/line-cited finding with no thread of its own, in an
 older collapsible body format some bots use (e.g. CodeRabbit's
-"Nitpick comments" / "Outside diff range comments") — an
-`extractEmbeddedFindings`-style helper (see
-`docs/idd-design-rationale.md`) detects this; add one PATH B item per
-uncovered finding.
+"Nitpick comments" / "Outside diff range comments") — a helper that
+parses the embedded findings and compares against the threaded-comment
+count (see `docs/idd-design-rationale.md`) detects this; add one
+PATH B item per uncovered finding.
 
 **Regular comments** where the last speaker isn't any IDD agent and no
 reply from **you** exists after that comment's timestamp — exclude

--- a/idd-template/.github/instructions/idd-review-snapshot.instructions.md
+++ b/idd-template/.github/instructions/idd-review-snapshot.instructions.md
@@ -199,7 +199,14 @@ regardless of maintainer response).
 
 **Review bodies** where the reviewer's latest state is
 `CHANGES_REQUESTED` — exclude reviews already replied to and
-re-review-requested in a previous E13/E14 pass.
+re-review-requested in a previous E13/E14 pass. **Embedded-finding
+gap (helper-first, optional):** a `COMMENTED`-state review can still
+carry a file/line-cited finding with no thread of its own, in an
+older collapsible body format some bots use (e.g. CodeRabbit's
+"Nitpick comments" / "Outside diff range comments") — an
+`extractEmbeddedFindings`-style helper (see
+`docs/idd-design-rationale.md`) detects this; add one PATH B item per
+uncovered finding.
 
 **Regular comments** where the last speaker isn't any IDD agent and no
 reply from **you** exists after that comment's timestamp — exclude

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -502,8 +502,9 @@ disposition, before proceeding to F1.
 A review bot can embed a specific, file/line-cited finding inside its
 review body's prose (an older collapsible-section format, e.g.
 CodeRabbit's "Nitpick comments" / "Outside diff range comments") with
-**no** corresponding threaded review comment of its own
-(kurone-kito/idd-skill#2197's live sweep, kurone-kito/idd-skill#2559).
+**no** corresponding threaded review comment of its own (observed
+2026-09-03, kurone-kito/idd-skill#2197's live sweep,
+kurone-kito/idd-skill#2559).
 Because E1 Step 3's "Review bodies" rule only pulls a review into
 `ReviewItems_snapshot` when its state is `CHANGES_REQUESTED`, and this
 bot-review-state pattern reports `COMMENTED` instead, the whole review

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -497,6 +497,37 @@ Primary advisory bot procedure at the now-stable HEAD whenever the last
 non-empty snapshot this episode zeroed out on a completed-review PATH B
 disposition, before proceeding to F1.
 
+### An advisory bot's embedded-but-unthreaded findings: mirror the detection scope, not the gate scope
+
+A review bot can embed a specific, file/line-cited finding inside its
+review body's prose (an older collapsible-section format, e.g.
+CodeRabbit's "Nitpick comments" / "Outside diff range comments") with
+**no** corresponding threaded review comment of its own
+(kurone-kito/idd-skill#2197's live sweep, kurone-kito/idd-skill#2559).
+Because E1 Step 3's "Review bodies" rule only pulls a review into
+`ReviewItems_snapshot` when its state is `CHANGES_REQUESTED`, and this
+bot-review-state pattern reports `COMMENTED` instead, the whole review
+body — not just the embedded finding — was invisible to E1, and E4-E8
+never Accepted or Rejected it.
+
+This is the same class of gap Copilot's `suppressedCount` handling
+already closes (kurone-kito/idd-skill#1880,
+`advisory-convergence.mts`): a finding that exists in a bot's review
+but has no GitHub thread of its own. For a non-gating PATH B advisory
+bot, mirror kurone-kito/idd-skill#1880's _detection pattern_ (parse
+the embedded findings, compare against threaded-comment count) but
+not its _gate-enforcement scope_: an uncovered finding becomes an
+ordinary PATH B
+`ReviewItems_snapshot` entry, not a new merge-blocking check.
+
+One sharp regex edge worth recording: matching a severity word like
+"Trivial" against a markdown-italic-wrapped segment (`_Trivial_`) with
+`\bTrivial\b` never matches — regex `\b` treats `_` as a word
+character, so there is no boundary between the closing `_` and the
+preceding letter. Drop the trailing `\b` rather than trying to work
+around it with lookarounds, when the surrounding text is already
+narrowly scoped enough that the ambiguity risk is negligible.
+
 ## Advisory wait
 
 ### AW3-S vs AW3-R: why two recovery paths

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -522,8 +522,14 @@ const CODERABBIT_EMBEDDED_FILE_HEADING_RE =
 // or line range, a colon, then 1-3 pipe-separated italic metadata segments
 // (category, severity, effort -- CodeRabbit does not document this shape
 // itself; it is inferred from every review body sampled for #2197/#2559).
+// Deliberately confined to same-line whitespace (`[ \t]`, never `\s`, which
+// includes newlines) in both the per-segment content and the separator
+// between segments: an earlier `\s`-based version could absorb an entirely
+// separate later `_italic_` phrase from the finding's own prose into this
+// same metadata capture once a blank line intervened, corrupting the
+// severity/title boundary (Copilot review, PR #2563).
 const CODERABBIT_EMBEDDED_FINDING_HEADER_RE =
-  /`(\d+(?:-\d+)?)`:\s*((?:_[^_]*_\s*\|?\s*)+)/g;
+  /`(\d+(?:-\d+)?)`:[ \t]*((?:_[^_\n]*_[ \t]*\|?[ \t]*)+)/g;
 // No `\b` before/after the word: each segment is markdown-italic-wrapped
 // (`_..._`), and `_` is itself a `\w` character, so a trailing `\b` would
 // never match immediately before the closing underscore.
@@ -577,11 +583,23 @@ function extractCodeRabbitEmbeddedFindingsFromSection(section) {
     const start = fileHeadings[i].index + fileHeadings[i][0].length;
     const end = fileHeadings[i + 1]?.index ?? section.length;
     const zone = section.slice(start, end);
-    for (const header of zone.matchAll(CODERABBIT_EMBEDDED_FINDING_HEADER_RE)) {
+    // Collected up front (not iterated via a live matchAll) so each
+    // finding's own title search below can be bounded by the NEXT
+    // finding's header position -- searching the zone's unbounded
+    // remainder let a finding with no bold title of its own "steal" a
+    // later finding's title instead of reporting an empty description
+    // (Copilot review, PR #2563).
+    const headers = [...zone.matchAll(CODERABBIT_EMBEDDED_FINDING_HEADER_RE)];
+    for (let j = 0; j < headers.length; j += 1) {
+      const header = headers[j];
       const lineRange = header[1];
       const severityMatch = header[2].match(CODERABBIT_SEVERITY_WORD_RE);
-      const rest = zone.slice(header.index + header[0].length);
-      const titleMatch = rest.match(CODERABBIT_EMBEDDED_FINDING_TITLE_RE);
+      const contentStart = header.index + header[0].length;
+      const contentEnd = headers[j + 1]?.index ?? zone.length;
+      const findingContent = zone.slice(contentStart, contentEnd);
+      const titleMatch = findingContent.match(
+        CODERABBIT_EMBEDDED_FINDING_TITLE_RE,
+      );
       findings.push({
         file,
         lineRange,

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -503,6 +503,110 @@ const CODERABBIT_SKIP_REVIEW_MARKER_RE = new RegExp(
   escapeRegExp(CODERABBIT_SKIP_REVIEW_MARKER),
   'i',
 );
+// Matches the two section headings this older CodeRabbit format nests
+// per-file findings under (kurone-kito/idd-skill#2197, kurone-kito/idd-skill#2559): a review whose finding has no
+// threaded comment of its own. A newer-format review ("Actionable comments
+// posted: N", individually threaded) never emits either heading, so this
+// gate alone already satisfies the "newer format stays unaffected"
+// acceptance criterion.
+const CODERABBIT_EMBEDDED_SECTION_HEADING_RE =
+  /<summary>(?:🧹 Nitpick comments|⚠️ Outside diff range comments) \(\d+\)<\/summary>/g;
+// A per-file grouping inside one of the sections above: `<summary>{file}
+// (N)</summary>`, where `file` is required to look like a real path (a `.`
+// extension or a `/` separator) so this never matches an unrelated
+// `<summary>` heading that also carries a parenthesized count -- e.g. the
+// review's own "📒 Files selected for processing (N)" section.
+const CODERABBIT_EMBEDDED_FILE_HEADING_RE =
+  /<summary>([^<]*[./][^<]*?) \(\d+\)<\/summary>/g;
+// One finding's header line inside a file grouping: a backtick-quoted line
+// or line range, a colon, then 1-3 pipe-separated italic metadata segments
+// (category, severity, effort -- CodeRabbit does not document this shape
+// itself; it is inferred from every review body sampled for #2197/#2559).
+const CODERABBIT_EMBEDDED_FINDING_HEADER_RE =
+  /`(\d+(?:-\d+)?)`:\s*((?:_[^_]*_\s*\|?\s*)+)/g;
+// No `\b` before/after the word: each segment is markdown-italic-wrapped
+// (`_..._`), and `_` is itself a `\w` character, so a trailing `\b` would
+// never match immediately before the closing underscore.
+const CODERABBIT_SEVERITY_WORD_RE = /(Trivial|Minor|Major|Critical)/i;
+/** Bold title line (`**...**`) directly introducing a finding's prose. */
+const CODERABBIT_EMBEDDED_FINDING_TITLE_RE = /\*\*(.+?)\*\*/;
+/**
+ * Extract each finding embedded in a CodeRabbit review body's older
+ * "🧹 Nitpick comments" / "⚠️ Outside diff range comments" collapsible
+ * format (#2197, #2559) -- a specific, file/line-cited finding that this
+ * format never gives its own threaded review comment, unlike CodeRabbit's
+ * newer per-comment format. Returns `[]` when `body` carries neither
+ * section heading (including every newer-format review) or is not a
+ * string.
+ *
+ * Best-effort, not a full HTML/Markdown parser: scoped to one section at a
+ * time by heading-to-next-heading text slicing, then one file grouping at a
+ * time the same way, then one finding header line at a time within that
+ * slice. A finding whose bold title cannot be found before the next
+ * boundary still contributes an entry with `description: ''` rather than
+ * being silently dropped -- an uncovered finding this parser cannot
+ * describe is still an uncovered finding.
+ */
+export function extractCodeRabbitEmbeddedFindings(body) {
+  if (typeof body !== 'string' || body.length === 0) {
+    return [];
+  }
+  const sectionHeadings = [
+    ...body.matchAll(CODERABBIT_EMBEDDED_SECTION_HEADING_RE),
+  ];
+  if (sectionHeadings.length === 0) {
+    return [];
+  }
+  const findings = [];
+  for (let i = 0; i < sectionHeadings.length; i += 1) {
+    const start = sectionHeadings[i].index + sectionHeadings[i][0].length;
+    const end = sectionHeadings[i + 1]?.index ?? body.length;
+    findings.push(
+      ...extractCodeRabbitEmbeddedFindingsFromSection(body.slice(start, end)),
+    );
+  }
+  return findings;
+}
+function extractCodeRabbitEmbeddedFindingsFromSection(section) {
+  const fileHeadings = [
+    ...section.matchAll(CODERABBIT_EMBEDDED_FILE_HEADING_RE),
+  ];
+  const findings = [];
+  for (let i = 0; i < fileHeadings.length; i += 1) {
+    const file = fileHeadings[i][1].trim();
+    const start = fileHeadings[i].index + fileHeadings[i][0].length;
+    const end = fileHeadings[i + 1]?.index ?? section.length;
+    const zone = section.slice(start, end);
+    for (const header of zone.matchAll(CODERABBIT_EMBEDDED_FINDING_HEADER_RE)) {
+      const lineRange = header[1];
+      const severityMatch = header[2].match(CODERABBIT_SEVERITY_WORD_RE);
+      const rest = zone.slice(header.index + header[0].length);
+      const titleMatch = rest.match(CODERABBIT_EMBEDDED_FINDING_TITLE_RE);
+      findings.push({
+        file,
+        lineRange,
+        severity: severityMatch ? severityMatch[0] : null,
+        description: titleMatch ? titleMatch[1].trim() : '',
+      });
+    }
+  }
+  return findings;
+}
+/**
+ * Compare {@link extractCodeRabbitEmbeddedFindings}'s count for `body`
+ * against `threadedCommentCount` -- the number of `coderabbitai[bot]`
+ * threaded review comments already present for this review/PR -- so a
+ * caller gets the uncovered-finding gap (#2559) without re-deriving the
+ * comparison. Never negative: a review whose threaded comments already
+ * meet or exceed its embedded-finding count reports `0`.
+ */
+export function countUncoveredCodeRabbitEmbeddedFindings(
+  body,
+  threadedCommentCount,
+) {
+  const embeddedFindingCount = extractCodeRabbitEmbeddedFindings(body).length;
+  return Math.max(0, embeddedFindingCount - threadedCommentCount);
+}
 export function classifyRegularBotComment(
   comment,
   comments,

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -512,12 +512,27 @@ const CODERABBIT_SKIP_REVIEW_MARKER_RE = new RegExp(
 const CODERABBIT_EMBEDDED_SECTION_HEADING_RE =
   /<summary>(?:🧹 Nitpick comments|⚠️ Outside diff range comments) \(\d+\)<\/summary>/g;
 // A per-file grouping inside one of the sections above: `<summary>{file}
-// (N)</summary>`, where `file` is required to look like a real path (a `.`
-// extension or a `/` separator) so this never matches an unrelated
-// `<summary>` heading that also carries a parenthesized count -- e.g. the
-// review's own "📒 Files selected for processing (N)" section.
+// (N)</summary>`. Accepts an extensionless, separator-less filename (e.g.
+// `Dockerfile`, `Makefile`, `LICENSE`) -- an earlier version required a
+// `.` extension or `/` separator to avoid matching an unrelated
+// `<summary>` heading that also carries a parenthesized count, e.g. the
+// review's own "📒 Files selected for processing (N)" section, but that
+// also dropped every finding for a real extensionless file (Copilot
+// review, PR #2563). The real defense against that unrelated heading is
+// {@link CODERABBIT_EMBEDDED_SECTION_END_RE} bounding the section's own
+// span below, not this pattern.
 const CODERABBIT_EMBEDDED_FILE_HEADING_RE =
-  /<summary>([^<]*[./][^<]*?) \(\d+\)<\/summary>/g;
+  /<summary>([^<]+?) \(\d+\)<\/summary>/g;
+// Marks the natural end of a Nitpick/Outside-diff section's own content in
+// every review body sampled for #2197/#2559: CodeRabbit always follows the
+// per-file findings with this footer before any unrelated section (e.g.
+// "ℹ️ Review info" > "📒 Files selected for processing"). Bounding the
+// section span here -- not just at the next same-kind section heading --
+// keeps the relaxed file-heading pattern above from matching a later,
+// unrelated `<summary>{text} (N)</summary>` several sections down (Copilot
+// review, PR #2563).
+const CODERABBIT_EMBEDDED_SECTION_END_RE =
+  /<summary>🤖 Prompt for all review comments with AI agents<\/summary>/;
 // One finding's header line inside a file grouping: a backtick-quoted line
 // or line range, a colon, then 1-3 pipe-separated italic metadata segments
 // (category, severity, effort -- CodeRabbit does not document this shape
@@ -566,7 +581,14 @@ export function extractCodeRabbitEmbeddedFindings(body) {
   const findings = [];
   for (let i = 0; i < sectionHeadings.length; i += 1) {
     const start = sectionHeadings[i].index + sectionHeadings[i][0].length;
-    const end = sectionHeadings[i + 1]?.index ?? body.length;
+    const nextSectionStart = sectionHeadings[i + 1]?.index ?? body.length;
+    const footerMatch = body
+      .slice(start, nextSectionStart)
+      .match(CODERABBIT_EMBEDDED_SECTION_END_RE);
+    const end =
+      footerMatch?.index !== undefined
+        ? start + footerMatch.index
+        : nextSectionStart;
     findings.push(
       ...extractCodeRabbitEmbeddedFindingsFromSection(body.slice(start, end)),
     );

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1152,8 +1152,14 @@ const CODERABBIT_EMBEDDED_FILE_HEADING_RE =
 // or line range, a colon, then 1-3 pipe-separated italic metadata segments
 // (category, severity, effort -- CodeRabbit does not document this shape
 // itself; it is inferred from every review body sampled for #2197/#2559).
+// Deliberately confined to same-line whitespace (`[ \t]`, never `\s`, which
+// includes newlines) in both the per-segment content and the separator
+// between segments: an earlier `\s`-based version could absorb an entirely
+// separate later `_italic_` phrase from the finding's own prose into this
+// same metadata capture once a blank line intervened, corrupting the
+// severity/title boundary (Copilot review, PR #2563).
 const CODERABBIT_EMBEDDED_FINDING_HEADER_RE =
-  /`(\d+(?:-\d+)?)`:\s*((?:_[^_]*_\s*\|?\s*)+)/g;
+  /`(\d+(?:-\d+)?)`:[ \t]*((?:_[^_\n]*_[ \t]*\|?[ \t]*)+)/g;
 
 // No `\b` before/after the word: each segment is markdown-italic-wrapped
 // (`_..._`), and `_` is itself a `\w` character, so a trailing `\b` would
@@ -1215,11 +1221,23 @@ function extractCodeRabbitEmbeddedFindingsFromSection(
     const start = fileHeadings[i].index + fileHeadings[i][0].length;
     const end = fileHeadings[i + 1]?.index ?? section.length;
     const zone = section.slice(start, end);
-    for (const header of zone.matchAll(CODERABBIT_EMBEDDED_FINDING_HEADER_RE)) {
+    // Collected up front (not iterated via a live matchAll) so each
+    // finding's own title search below can be bounded by the NEXT
+    // finding's header position -- searching the zone's unbounded
+    // remainder let a finding with no bold title of its own "steal" a
+    // later finding's title instead of reporting an empty description
+    // (Copilot review, PR #2563).
+    const headers = [...zone.matchAll(CODERABBIT_EMBEDDED_FINDING_HEADER_RE)];
+    for (let j = 0; j < headers.length; j += 1) {
+      const header = headers[j];
       const lineRange = header[1];
       const severityMatch = header[2].match(CODERABBIT_SEVERITY_WORD_RE);
-      const rest = zone.slice(header.index + header[0].length);
-      const titleMatch = rest.match(CODERABBIT_EMBEDDED_FINDING_TITLE_RE);
+      const contentStart = header.index + header[0].length;
+      const contentEnd = headers[j + 1]?.index ?? zone.length;
+      const findingContent = zone.slice(contentStart, contentEnd);
+      const titleMatch = findingContent.match(
+        CODERABBIT_EMBEDDED_FINDING_TITLE_RE,
+      );
       findings.push({
         file,
         lineRange,

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1141,12 +1141,28 @@ const CODERABBIT_EMBEDDED_SECTION_HEADING_RE =
   /<summary>(?:🧹 Nitpick comments|⚠️ Outside diff range comments) \(\d+\)<\/summary>/g;
 
 // A per-file grouping inside one of the sections above: `<summary>{file}
-// (N)</summary>`, where `file` is required to look like a real path (a `.`
-// extension or a `/` separator) so this never matches an unrelated
-// `<summary>` heading that also carries a parenthesized count -- e.g. the
-// review's own "📒 Files selected for processing (N)" section.
+// (N)</summary>`. Accepts an extensionless, separator-less filename (e.g.
+// `Dockerfile`, `Makefile`, `LICENSE`) -- an earlier version required a
+// `.` extension or `/` separator to avoid matching an unrelated
+// `<summary>` heading that also carries a parenthesized count, e.g. the
+// review's own "📒 Files selected for processing (N)" section, but that
+// also dropped every finding for a real extensionless file (Copilot
+// review, PR #2563). The real defense against that unrelated heading is
+// {@link CODERABBIT_EMBEDDED_SECTION_END_RE} bounding the section's own
+// span below, not this pattern.
 const CODERABBIT_EMBEDDED_FILE_HEADING_RE =
-  /<summary>([^<]*[./][^<]*?) \(\d+\)<\/summary>/g;
+  /<summary>([^<]+?) \(\d+\)<\/summary>/g;
+
+// Marks the natural end of a Nitpick/Outside-diff section's own content in
+// every review body sampled for #2197/#2559: CodeRabbit always follows the
+// per-file findings with this footer before any unrelated section (e.g.
+// "ℹ️ Review info" > "📒 Files selected for processing"). Bounding the
+// section span here -- not just at the next same-kind section heading --
+// keeps the relaxed file-heading pattern above from matching a later,
+// unrelated `<summary>{text} (N)</summary>` several sections down (Copilot
+// review, PR #2563).
+const CODERABBIT_EMBEDDED_SECTION_END_RE =
+  /<summary>🤖 Prompt for all review comments with AI agents<\/summary>/;
 
 // One finding's header line inside a file grouping: a backtick-quoted line
 // or line range, a colon, then 1-3 pipe-separated italic metadata segments
@@ -1201,7 +1217,14 @@ export function extractCodeRabbitEmbeddedFindings(
   const findings: CodeRabbitEmbeddedFinding[] = [];
   for (let i = 0; i < sectionHeadings.length; i += 1) {
     const start = sectionHeadings[i].index + sectionHeadings[i][0].length;
-    const end = sectionHeadings[i + 1]?.index ?? body.length;
+    const nextSectionStart = sectionHeadings[i + 1]?.index ?? body.length;
+    const footerMatch = body
+      .slice(start, nextSectionStart)
+      .match(CODERABBIT_EMBEDDED_SECTION_END_RE);
+    const end =
+      footerMatch?.index !== undefined
+        ? start + footerMatch.index
+        : nextSectionStart;
     findings.push(
       ...extractCodeRabbitEmbeddedFindingsFromSection(body.slice(start, end)),
     );

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1119,6 +1119,134 @@ const CODERABBIT_SKIP_REVIEW_MARKER_RE = new RegExp(
   'i',
 );
 
+/**
+ * One finding embedded in a CodeRabbit review body's older "🧹 Nitpick
+ * comments" / "⚠️ Outside diff range comments" collapsible-section format
+ * (#2559), extracted by {@link extractCodeRabbitEmbeddedFindings}.
+ */
+export interface CodeRabbitEmbeddedFinding {
+  file: string;
+  lineRange: string;
+  severity: string | null;
+  description: string;
+}
+
+// Matches the two section headings this older CodeRabbit format nests
+// per-file findings under (kurone-kito/idd-skill#2197, kurone-kito/idd-skill#2559): a review whose finding has no
+// threaded comment of its own. A newer-format review ("Actionable comments
+// posted: N", individually threaded) never emits either heading, so this
+// gate alone already satisfies the "newer format stays unaffected"
+// acceptance criterion.
+const CODERABBIT_EMBEDDED_SECTION_HEADING_RE =
+  /<summary>(?:🧹 Nitpick comments|⚠️ Outside diff range comments) \(\d+\)<\/summary>/g;
+
+// A per-file grouping inside one of the sections above: `<summary>{file}
+// (N)</summary>`, where `file` is required to look like a real path (a `.`
+// extension or a `/` separator) so this never matches an unrelated
+// `<summary>` heading that also carries a parenthesized count -- e.g. the
+// review's own "📒 Files selected for processing (N)" section.
+const CODERABBIT_EMBEDDED_FILE_HEADING_RE =
+  /<summary>([^<]*[./][^<]*?) \(\d+\)<\/summary>/g;
+
+// One finding's header line inside a file grouping: a backtick-quoted line
+// or line range, a colon, then 1-3 pipe-separated italic metadata segments
+// (category, severity, effort -- CodeRabbit does not document this shape
+// itself; it is inferred from every review body sampled for #2197/#2559).
+const CODERABBIT_EMBEDDED_FINDING_HEADER_RE =
+  /`(\d+(?:-\d+)?)`:\s*((?:_[^_]*_\s*\|?\s*)+)/g;
+
+// No `\b` before/after the word: each segment is markdown-italic-wrapped
+// (`_..._`), and `_` is itself a `\w` character, so a trailing `\b` would
+// never match immediately before the closing underscore.
+const CODERABBIT_SEVERITY_WORD_RE = /(Trivial|Minor|Major|Critical)/i;
+
+/** Bold title line (`**...**`) directly introducing a finding's prose. */
+const CODERABBIT_EMBEDDED_FINDING_TITLE_RE = /\*\*(.+?)\*\*/;
+
+/**
+ * Extract each finding embedded in a CodeRabbit review body's older
+ * "🧹 Nitpick comments" / "⚠️ Outside diff range comments" collapsible
+ * format (#2197, #2559) -- a specific, file/line-cited finding that this
+ * format never gives its own threaded review comment, unlike CodeRabbit's
+ * newer per-comment format. Returns `[]` when `body` carries neither
+ * section heading (including every newer-format review) or is not a
+ * string.
+ *
+ * Best-effort, not a full HTML/Markdown parser: scoped to one section at a
+ * time by heading-to-next-heading text slicing, then one file grouping at a
+ * time the same way, then one finding header line at a time within that
+ * slice. A finding whose bold title cannot be found before the next
+ * boundary still contributes an entry with `description: ''` rather than
+ * being silently dropped -- an uncovered finding this parser cannot
+ * describe is still an uncovered finding.
+ */
+export function extractCodeRabbitEmbeddedFindings(
+  body: unknown,
+): CodeRabbitEmbeddedFinding[] {
+  if (typeof body !== 'string' || body.length === 0) {
+    return [];
+  }
+  const sectionHeadings = [
+    ...body.matchAll(CODERABBIT_EMBEDDED_SECTION_HEADING_RE),
+  ];
+  if (sectionHeadings.length === 0) {
+    return [];
+  }
+  const findings: CodeRabbitEmbeddedFinding[] = [];
+  for (let i = 0; i < sectionHeadings.length; i += 1) {
+    const start = sectionHeadings[i].index + sectionHeadings[i][0].length;
+    const end = sectionHeadings[i + 1]?.index ?? body.length;
+    findings.push(
+      ...extractCodeRabbitEmbeddedFindingsFromSection(body.slice(start, end)),
+    );
+  }
+  return findings;
+}
+
+function extractCodeRabbitEmbeddedFindingsFromSection(
+  section: string,
+): CodeRabbitEmbeddedFinding[] {
+  const fileHeadings = [
+    ...section.matchAll(CODERABBIT_EMBEDDED_FILE_HEADING_RE),
+  ];
+  const findings: CodeRabbitEmbeddedFinding[] = [];
+  for (let i = 0; i < fileHeadings.length; i += 1) {
+    const file = fileHeadings[i][1].trim();
+    const start = fileHeadings[i].index + fileHeadings[i][0].length;
+    const end = fileHeadings[i + 1]?.index ?? section.length;
+    const zone = section.slice(start, end);
+    for (const header of zone.matchAll(CODERABBIT_EMBEDDED_FINDING_HEADER_RE)) {
+      const lineRange = header[1];
+      const severityMatch = header[2].match(CODERABBIT_SEVERITY_WORD_RE);
+      const rest = zone.slice(header.index + header[0].length);
+      const titleMatch = rest.match(CODERABBIT_EMBEDDED_FINDING_TITLE_RE);
+      findings.push({
+        file,
+        lineRange,
+        severity: severityMatch ? severityMatch[0] : null,
+        description: titleMatch ? titleMatch[1].trim() : '',
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Compare {@link extractCodeRabbitEmbeddedFindings}'s count for `body`
+ * against `threadedCommentCount` -- the number of `coderabbitai[bot]`
+ * threaded review comments already present for this review/PR -- so a
+ * caller gets the uncovered-finding gap (#2559) without re-deriving the
+ * comparison. Never negative: a review whose threaded comments already
+ * meet or exceed its embedded-finding count reports `0`.
+ */
+export function countUncoveredCodeRabbitEmbeddedFindings(
+  body: unknown,
+  threadedCommentCount: number,
+): number {
+  const embeddedFindingCount = extractCodeRabbitEmbeddedFindings(body).length;
+  return Math.max(0, embeddedFindingCount - threadedCommentCount);
+}
+
 export function classifyRegularBotComment(
   comment: CommentLike,
   comments: CommentLike[],

--- a/tests/protocol-helpers-coderabbit-embedded-findings.test.mts
+++ b/tests/protocol-helpers-coderabbit-embedded-findings.test.mts
@@ -212,6 +212,81 @@ no bold title here, just prose
   ]);
 });
 
+// Regression (Copilot review, PR #2563): when a title-less finding is
+// followed by another finding that DOES have a bold title, the title-less
+// finding must report an empty description of its own -- not "steal" the
+// later finding's title by an unbounded search into the rest of the zone.
+test("extractCodeRabbitEmbeddedFindings: a title-less finding does not steal a later finding's bold title in the same file grouping", () => {
+  const body = `
+<details>
+<summary>🧹 Nitpick comments (2)</summary><blockquote>
+
+<details>
+<summary>src/a.mts (2)</summary><blockquote>
+
+\`10\`: _cat_ | _eff_
+
+no bold title for this first finding
+
+<!-- cr-comment:v1:aaa -->
+
+\`20\`: _cat_ | _eff_
+
+**Second finding title.**
+
+more prose
+
+<!-- cr-comment:v1:bbb -->
+
+</blockquote></details>
+
+</blockquote></details>
+`;
+  assert.deepEqual(extractCodeRabbitEmbeddedFindings(body), [
+    { file: 'src/a.mts', lineRange: '10', severity: null, description: '' },
+    {
+      file: 'src/a.mts',
+      lineRange: '20',
+      severity: null,
+      description: 'Second finding title.',
+    },
+  ]);
+});
+
+// Regression (Copilot review, PR #2563): a metadata line's own italic
+// segments must not absorb a later, separate `_italic_` phrase from the
+// finding's prose once a blank line intervenes -- that would corrupt the
+// severity/title boundary by treating unrelated prose as more metadata.
+test('extractCodeRabbitEmbeddedFindings: a later italic phrase in the finding prose is not absorbed into the metadata segment', () => {
+  const body = `
+<details>
+<summary>🧹 Nitpick comments (1)</summary><blockquote>
+
+<details>
+<summary>src/b.mts (1)</summary><blockquote>
+
+\`10\`: _cat_ | _🔵 Trivial_
+
+_Emphasized lead-in prose._ Then the real description follows.
+
+**Real Title Here.**
+
+<!-- cr-comment:v1:ccc -->
+
+</blockquote></details>
+
+</blockquote></details>
+`;
+  assert.deepEqual(extractCodeRabbitEmbeddedFindings(body), [
+    {
+      file: 'src/b.mts',
+      lineRange: '10',
+      severity: 'Trivial',
+      description: 'Real Title Here.',
+    },
+  ]);
+});
+
 // --- countUncoveredCodeRabbitEmbeddedFindings ---------------------------
 
 test('countUncoveredCodeRabbitEmbeddedFindings: PR #1897 -- 1 embedded finding, 0 threaded comments -> 1 uncovered', () => {

--- a/tests/protocol-helpers-coderabbit-embedded-findings.test.mts
+++ b/tests/protocol-helpers-coderabbit-embedded-findings.test.mts
@@ -183,6 +183,61 @@ prose
   ]);
 });
 
+// Regression (Copilot review, PR #2563): an extensionless, separator-less
+// filename (Dockerfile, Makefile, LICENSE, ...) must not be dropped, and
+// the later, unrelated "📒 Files selected for processing (N)" heading
+// (which the relaxed file-heading pattern could otherwise also match)
+// must stay excluded once the section's own footer bounds the scan.
+test('extractCodeRabbitEmbeddedFindings: an extensionless filename (Dockerfile) is not dropped, and the later "Files selected for processing" heading is not mistaken for a file grouping', () => {
+  const body = `
+<details>
+<summary>🧹 Nitpick comments (1)</summary><blockquote>
+
+<details>
+<summary>Dockerfile (1)</summary><blockquote>
+
+\`5\`: _cat_ | _eff_
+
+**A finding in the Dockerfile.**
+
+<!-- cr-comment:v1:aaa -->
+
+</blockquote></details>
+
+</blockquote></details>
+
+<details>
+<summary>🤖 Prompt for all review comments with AI agents</summary>
+
+\`\`\`
+Nitpick comments in Dockerfile.
+\`\`\`
+
+</details>
+
+<details>
+<summary>ℹ️ Review info</summary>
+
+<details>
+<summary>📒 Files selected for processing (2)</summary>
+
+* Dockerfile
+* src/other.mts
+
+</details>
+
+</details>
+`;
+  assert.deepEqual(extractCodeRabbitEmbeddedFindings(body), [
+    {
+      file: 'Dockerfile',
+      lineRange: '5',
+      severity: null,
+      description: 'A finding in the Dockerfile.',
+    },
+  ]);
+});
+
 test('extractCodeRabbitEmbeddedFindings: returns [] for a non-string body', () => {
   assert.deepEqual(extractCodeRabbitEmbeddedFindings(null), []);
   assert.deepEqual(extractCodeRabbitEmbeddedFindings(undefined), []);

--- a/tests/protocol-helpers-coderabbit-embedded-findings.test.mts
+++ b/tests/protocol-helpers-coderabbit-embedded-findings.test.mts
@@ -1,0 +1,270 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  countUncoveredCodeRabbitEmbeddedFindings,
+  extractCodeRabbitEmbeddedFindings,
+} from '../src/scripts/protocol-helpers.mts';
+
+// Verbatim review bodies captured live for #2197's 30-day sweep, re-cited
+// by #2559 as the canonical fixtures for this parser. Both PRs had zero
+// coderabbitai[bot]-authored threaded review comments, so both findings
+// were genuinely invisible to E1's CHANGES_REQUESTED-only snapshot rule.
+
+// PR #1897, review 4863787336: one Nitpick finding.
+const PR_1897_REVIEW_4863787336 = `
+
+<details>
+<summary>🧹 Nitpick comments (1)</summary><blockquote>
+
+<details>
+<summary>src/scripts/markdown-code.mts (1)</summary><blockquote>
+
+\`399-407\`: _📐 Maintainability & Code Quality_ | _🔵 Trivial_ | _⚡ Quick win_
+
+**Extract the repeated block-start predicate.**
+
+The same four-way test (\`isMarkdownBlockStart\`, \`MARKDOWN_HTML_BLOCK_START_PATTERN\`, \`MARKDOWN_CUSTOM_HTML_BLOCK_START_PATTERN\`, valid fence opener) now appears three times: here, in \`openingIsParagraph\` (Lines 462-466), and in the main loop (Lines 491-495). A shared helper keeps the three sites in sync when the set of recognized block starts changes.
+
+<details>
+<summary>♻️ Proposed helper</summary>
+
+\`\`\`diff
++function startsMarkdownBlock(content: string, raw: string): boolean {
++  return true;
++}
+\`\`\`
+
+</details>
+
+<!-- cr-comment:v1:2db3b7119b3fcf0ccf6d0499 -->
+
+</blockquote></details>
+
+</blockquote></details>
+
+<details>
+<summary>🤖 Prompt for all review comments with AI agents</summary>
+
+\`\`\`
+Nitpick comments:
+In \`@src/scripts/markdown-code.mts\`:
+- Around line 399-407: Extract the repeated four-condition block-start check.
+\`\`\`
+
+</details>
+`;
+
+// PR #1871, review 4860403155: one Outside-diff-range finding, wrapped in
+// a "> [!CAUTION]" blockquote prefix on every line (GitHub still renders
+// the nested HTML; this parser must tolerate that prefix unchanged, since
+// it operates on raw body text, not per-line stripped text).
+const PR_1871_REVIEW_4860403155 = `
+
+> [!CAUTION]
+> Some comments are outside the diff and can't be posted inline due to platform limitations.
+>
+> <details>
+> <summary>⚠️ Outside diff range comments (1)</summary><blockquote>
+>
+> <details>
+> <summary>schemas/pre-merge-readiness.schema.json (1)</summary><blockquote>
+>
+> \`1057-1073\`: _🗄️ Data Integrity & Integration_ | _🟠 Major_ | _⚡ Quick win_
+>
+> **Add the activation-nonce reason to the schema.**
+>
+> \`summarizeClaimValidation\` emits \`activation-nonce-mismatch\` when \`expectedNonce\` is supplied and does not match the trusted active claim winner. Keep the description as-is and add \`activation-nonce-mismatch\` to \`claim.reason.enum\`; otherwise pre-merge readiness output can fail against the schema.
+>
+> <!-- cr-comment:v1:02fd1e1eb9747e87b84ca74d -->
+>
+> </blockquote></details>
+>
+> </blockquote></details>
+
+<details>
+<summary>🤖 Prompt for all review comments with AI agents</summary>
+
+\`\`\`
+Outside diff comments:
+In \`@schemas/pre-merge-readiness.schema.json\`:
+- Around line 1057-1073: Update the claim.reason enum.
+\`\`\`
+
+</details>
+`;
+
+// A newer-format CodeRabbit review: individually threaded comments, no
+// "Nitpick comments" / "Outside diff range comments" collapsible section
+// at all. Must stay unaffected (#2559's own explicit non-goal).
+const NEWER_FORMAT_REVIEW = `**Actionable comments posted: 2**
+
+<details>
+<summary>♻️ Duplicate comments (1)</summary>
+
+Some prior-round comment, already threaded individually.
+
+</details>
+`;
+
+test('extractCodeRabbitEmbeddedFindings: PR #1897 review 4863787336 -- 1 embedded finding, real fixture body', () => {
+  const findings = extractCodeRabbitEmbeddedFindings(PR_1897_REVIEW_4863787336);
+  assert.deepEqual(findings, [
+    {
+      file: 'src/scripts/markdown-code.mts',
+      lineRange: '399-407',
+      severity: 'Trivial',
+      description: 'Extract the repeated block-start predicate.',
+    },
+  ]);
+});
+
+test('extractCodeRabbitEmbeddedFindings: PR #1871 review 4860403155 -- 1 embedded finding under a blockquote-wrapped Outside-diff section, real fixture body', () => {
+  const findings = extractCodeRabbitEmbeddedFindings(PR_1871_REVIEW_4860403155);
+  assert.deepEqual(findings, [
+    {
+      file: 'schemas/pre-merge-readiness.schema.json',
+      lineRange: '1057-1073',
+      severity: 'Major',
+      description: 'Add the activation-nonce reason to the schema.',
+    },
+  ]);
+});
+
+test('extractCodeRabbitEmbeddedFindings: a newer-format review (Actionable comments posted, no Nitpick/Outside-diff section) extracts nothing', () => {
+  assert.deepEqual(extractCodeRabbitEmbeddedFindings(NEWER_FORMAT_REVIEW), []);
+});
+
+test('extractCodeRabbitEmbeddedFindings: multiple files each with their own finding inside one section', () => {
+  const body = `
+<details>
+<summary>🧹 Nitpick comments (2)</summary><blockquote>
+
+<details>
+<summary>src/a.mts (1)</summary><blockquote>
+
+\`10-12\`: _cat_ | _🔵 Trivial_ | _eff_
+
+**First finding.**
+
+prose
+
+<!-- cr-comment:v1:aaa -->
+
+</blockquote></details>
+
+<details>
+<summary>src/b.mts (1)</summary><blockquote>
+
+\`20\`: _cat_ | _🟡 Minor_ | _eff_
+
+**Second finding.**
+
+prose
+
+<!-- cr-comment:v1:bbb -->
+
+</blockquote></details>
+
+</blockquote></details>
+`;
+  assert.deepEqual(extractCodeRabbitEmbeddedFindings(body), [
+    {
+      file: 'src/a.mts',
+      lineRange: '10-12',
+      severity: 'Trivial',
+      description: 'First finding.',
+    },
+    {
+      file: 'src/b.mts',
+      lineRange: '20',
+      severity: 'Minor',
+      description: 'Second finding.',
+    },
+  ]);
+});
+
+test('extractCodeRabbitEmbeddedFindings: returns [] for a non-string body', () => {
+  assert.deepEqual(extractCodeRabbitEmbeddedFindings(null), []);
+  assert.deepEqual(extractCodeRabbitEmbeddedFindings(undefined), []);
+  assert.deepEqual(extractCodeRabbitEmbeddedFindings(42), []);
+});
+
+test('extractCodeRabbitEmbeddedFindings: a finding whose bold title is missing still contributes an entry, with an empty description', () => {
+  const body = `
+<details>
+<summary>🧹 Nitpick comments (1)</summary><blockquote>
+
+<details>
+<summary>src/a.mts (1)</summary><blockquote>
+
+\`5\`: _cat_ | _eff_
+
+no bold title here, just prose
+
+<!-- cr-comment:v1:ccc -->
+
+</blockquote></details>
+
+</blockquote></details>
+`;
+  assert.deepEqual(extractCodeRabbitEmbeddedFindings(body), [
+    { file: 'src/a.mts', lineRange: '5', severity: null, description: '' },
+  ]);
+});
+
+// --- countUncoveredCodeRabbitEmbeddedFindings ---------------------------
+
+test('countUncoveredCodeRabbitEmbeddedFindings: PR #1897 -- 1 embedded finding, 0 threaded comments -> 1 uncovered', () => {
+  assert.equal(
+    countUncoveredCodeRabbitEmbeddedFindings(PR_1897_REVIEW_4863787336, 0),
+    1,
+  );
+});
+
+test('countUncoveredCodeRabbitEmbeddedFindings: PR #1871 -- 1 embedded finding, 0 matching coderabbitai[bot] threads -> 1 uncovered', () => {
+  assert.equal(
+    countUncoveredCodeRabbitEmbeddedFindings(PR_1871_REVIEW_4860403155, 0),
+    1,
+  );
+});
+
+test('countUncoveredCodeRabbitEmbeddedFindings: a newer-format review with matching threads reports 0 uncovered (unaffected)', () => {
+  assert.equal(
+    countUncoveredCodeRabbitEmbeddedFindings(NEWER_FORMAT_REVIEW, 2),
+    0,
+  );
+});
+
+test('countUncoveredCodeRabbitEmbeddedFindings: N embedded findings with N matching threads reports 0 uncovered (the count comparison, not just presence/absence)', () => {
+  const body = `
+<details>
+<summary>🧹 Nitpick comments (2)</summary><blockquote>
+
+<details>
+<summary>src/a.mts (1)</summary><blockquote>
+
+\`10\`: _cat_ | _🔵 Trivial_ | _eff_
+
+**First finding.**
+
+<!-- cr-comment:v1:aaa -->
+
+</blockquote></details>
+
+<details>
+<summary>src/b.mts (1)</summary><blockquote>
+
+\`20\`: _cat_ | _🟡 Minor_ | _eff_
+
+**Second finding.**
+
+<!-- cr-comment:v1:bbb -->
+
+</blockquote></details>
+
+</blockquote></details>
+`;
+  assert.equal(countUncoveredCodeRabbitEmbeddedFindings(body, 2), 0);
+  // Fewer threads than findings still reports the gap, not just non-zero.
+  assert.equal(countUncoveredCodeRabbitEmbeddedFindings(body, 1), 1);
+});


### PR DESCRIPTION
## Summary

`#2197`'s live 30-day sweep of 337 merged PRs found a `coderabbitai[bot]` review in the older "🧹 Nitpick comments" / "⚠️ Outside diff range comments" collapsible-body format can carry a specific, file/line-cited finding with **zero** corresponding threaded review comment — e.g. PR #1897 review `4863787336` (zero threaded comments on that PR at all) and PR #1871 review `4860403155` (a Major finding, only unrelated Copilot threads present).

`idd-review-snapshot.instructions.md` E1 Step 3's "Review bodies" rule only pulls a review into `ReviewItems_snapshot` when its state is `CHANGES_REQUESTED`. Every review in this sweep was `COMMENTED` (CodeRabbit's own review state for a nitpick/outside-diff finding), so E1 never captured the review body at all — not just the embedded finding, the entire review object was invisible to the snapshot, and E4-E8 triage never Accepted or Rejected it.

This mirrors Copilot's already-solved `suppressedCount` gap (`#1880`, `advisory-convergence.mts`) — a finding that exists in a bot's review but has no GitHub thread of its own. Unlike Copilot's gate, CodeRabbit is a non-gating PATH B advisory bot in this repository, so this fix mirrors `#1880`'s *detection pattern*, not its *gate-enforcement scope*: an uncovered finding becomes an ordinary PATH B `ReviewItems_snapshot` entry, no new triage category.

## What changed

- `protocol-helpers.mts`: new `extractCodeRabbitEmbeddedFindings(body)` and `countUncoveredCodeRabbitEmbeddedFindings(body, threadedCommentCount)`. The parser is scoped section-by-section (heading to next heading), then file-grouping by file-grouping, then finding-header-line by finding-header-line — not a full HTML/Markdown parser, since CodeRabbit's nested `<details>` structure has no documented grammar. Newer-format reviews (`Actionable comments posted: N`) carry neither collapsible-section heading, so they naturally extract zero findings — no separate format-detection branch needed.
- `idd-review-snapshot.instructions.md` E1 Step 3: a minimal, helper-first pointer (`bundle-review` is at ~97.5% of its 138000-byte ceiling, per the issue's own caution — there was no headroom for verbose prose).
- `docs/idd-design-rationale.md` / `idd-template/docs/idd-design-rationale.md`: the fuller rationale, including the two real fixture PRs and a regex gotcha worth recording — `\bTrivial\b` never matches inside CodeRabbit's `_Trivial_` (markdown italics), since regex `\b` treats `_` as a word character, so there's no boundary between the closing `_` and the preceding letter. Dropped the trailing `\b`.

## Test plan

- [x] `pnpm run build`
- [x] `node --test tests/*.test.mts` — all 4970 tests pass, including 10 new tests in `tests/protocol-helpers-coderabbit-embedded-findings.test.mts`: both real fixture bodies (PR #1897 review `4863787336`, PR #1871 review `4860403155`), a newer-format review (0 findings), multi-file/multi-finding extraction, non-string-body handling, a finding with no bold title (still contributes an entry with `description: ''`), and the count-comparison acceptance criteria (N findings + 0/N/fewer-than-N matching threads)
- [x] `pre-push-validate` (biome, dprint, markdownlint, cspell, `audit-docs.mjs --check`, `audit-code-span-wrap.mjs`, `agent-entry-mirror-sync.test.mts`, `build:check`) — all pass; live-rechecked the `bundle-review` byte budget before and after editing (97.54% → 97.84%, still under the 138000-byte ceiling)
- [x] Copilot's own gate (`advisory-convergence.mts`, `review-clause.mts`) untouched

Closes #2559

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CtcjhuuXDqQASYGXtJnmV3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Review snapshots now capture file- and line-specific findings embedded in older advisory review summaries when no matching discussion thread exists.
  - Embedded findings include location, severity, and title details and are recorded as standard review items.

- **Documentation**
  - Added guidance explaining embedded-finding detection, review-item handling, severity parsing, and compatibility with newer review formats.

- **Tests**
  - Added coverage for supported review formats, malformed content, multiple findings, missing titles, and thread-count handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->