### PR TITLE
docs(idd-work): define B1/F4 path inside a host-isolated worktree

### DIFF
--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -215,9 +215,10 @@ directory on every later command — see
 If this agent's own execution environment is already a host-isolated
 worktree from the harness or orchestrator, the "primary worktree"
 concept above does not apply — there is no separate worktree to manage
-or return to. Skip Worktree creation; run install-deps and verify HEAD
-is on the claimed `issue/<number>-<slug>` branch as the substitute for
-the B1 self-check.
+or return to. Skip Worktree creation; run **install-deps** and verify
+`git rev-parse --abbrev-ref HEAD` returns the claimed
+`issue/<number>-<slug>` branch as the substitute for the B1
+self-check.
 
 At F4, skip the primary-worktree fetch/switch/merge and `git worktree
 remove` steps — this session cannot remove its own checkout. Let the

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -212,18 +212,18 @@ directory on every later command — see
 
 ### Already inside a host-isolated worktree
 
-If this agent's own execution environment is already a host-isolated
-worktree from the harness or orchestrator, the "primary worktree"
-concept above does not apply — there is no separate worktree to manage
-or return to. Skip Worktree creation; run **install-deps** and verify
+If this agent's own environment is already a host-isolated worktree
+from the harness or orchestrator, "primary worktree" above does not
+apply: there is no separate worktree to manage or return to. Skip
+Worktree creation; run **install-deps** and verify
 `git rev-parse --abbrev-ref HEAD` returns the claimed
 `issue/<number>-<slug>` branch as the substitute for the B1
-self-check.
+self-check. On a mismatch, post a hold note and stop for the harness
+or orchestrator — never remove or recreate this checkout.
 
 At F4, skip the primary-worktree fetch/switch/merge and `git worktree
-remove` steps — this session cannot remove its own checkout. Let the
-harness reclaim it instead, and still complete every other F4 step
-(issue close, digest, comment cleanup).
+remove` steps; let the harness reclaim it and finish the rest (issue
+close, digest, comment cleanup).
 
 ## B2 — Create and refine plan
 

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -210,6 +210,20 @@ installed but not active` diagnostic, re-verify the current working
 directory on every later command — see
 [rationale](../../docs/idd-design-rationale.md#worktrunk-cwd-caveat).
 
+### Already inside a host-isolated worktree
+
+If this agent's own execution environment is already a host-isolated
+worktree from the harness or orchestrator, the "primary worktree"
+concept above does not apply — there is no separate worktree to manage
+or return to. Skip Worktree creation; run install-deps and verify HEAD
+is on the claimed `issue/<number>-<slug>` branch as the substitute for
+the B1 self-check.
+
+At F4, skip the primary-worktree fetch/switch/merge and `git worktree
+remove` steps — this session cannot remove its own checkout. Let the
+harness reclaim it instead, and still complete every other F4 step
+(issue close, digest, comment cleanup).
+
 ## B2 — Create and refine plan
 
 ### B2.0 — Supersession re-check (before planning)

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -207,18 +207,18 @@ directory on every later command — see
 
 ### Already inside a host-isolated worktree
 
-If this agent's own execution environment is already a host-isolated
-worktree from the harness or orchestrator, the "primary worktree"
-concept above does not apply — there is no separate worktree to manage
-or return to. Skip Worktree creation; run **install-deps** and verify
+If this agent's own environment is already a host-isolated worktree
+from the harness or orchestrator, "primary worktree" above does not
+apply: there is no separate worktree to manage or return to. Skip
+Worktree creation; run **install-deps** and verify
 `git rev-parse --abbrev-ref HEAD` returns the claimed
 `issue/<number>-<slug>` branch as the substitute for the B1
-self-check.
+self-check. On a mismatch, post a hold note and stop for the harness
+or orchestrator — never remove or recreate this checkout.
 
 At F4, skip the primary-worktree fetch/switch/merge and `git worktree
-remove` steps — this session cannot remove its own checkout. Let the
-harness reclaim it instead, and still complete every other F4 step
-(issue close, digest, comment cleanup).
+remove` steps; let the harness reclaim it and finish the rest (issue
+close, digest, comment cleanup).
 
 ## B2 — Create and refine plan
 

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -205,6 +205,20 @@ installed but not active` diagnostic, re-verify the current working
 directory on every later command — see
 [rationale](../../docs/idd-design-rationale.md#worktrunk-cwd-caveat).
 
+### Already inside a host-isolated worktree
+
+If this agent's own execution environment is already a host-isolated
+worktree from the harness or orchestrator, the "primary worktree"
+concept above does not apply — there is no separate worktree to manage
+or return to. Skip Worktree creation; run install-deps and verify HEAD
+is on the claimed `issue/<number>-<slug>` branch as the substitute for
+the B1 self-check.
+
+At F4, skip the primary-worktree fetch/switch/merge and `git worktree
+remove` steps — this session cannot remove its own checkout. Let the
+harness reclaim it instead, and still complete every other F4 step
+(issue close, digest, comment cleanup).
+
 ## B2 — Create and refine plan
 
 ### B2.0 — Supersession re-check (before planning)

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -210,9 +210,10 @@ directory on every later command — see
 If this agent's own execution environment is already a host-isolated
 worktree from the harness or orchestrator, the "primary worktree"
 concept above does not apply — there is no separate worktree to manage
-or return to. Skip Worktree creation; run install-deps and verify HEAD
-is on the claimed `issue/<number>-<slug>` branch as the substitute for
-the B1 self-check.
+or return to. Skip Worktree creation; run **install-deps** and verify
+`git rev-parse --abbrev-ref HEAD` returns the claimed
+`issue/<number>-<slug>` branch as the substitute for the B1
+self-check.
 
 At F4, skip the primary-worktree fetch/switch/merge and `git worktree
 remove` steps — this session cannot remove its own checkout. Let the


### PR DESCRIPTION
## Summary

`idd-work.instructions.md` already names Agent-tool-style `isolation:
worktree` execution as a harness-native worktree tool option, but B1's
sibling-worktree convention and F4's local cleanup steps both assume
the agent starts from, and can return to, a "primary worktree" it
directly manages. An agent that is itself already running inside a
host-isolated worktree (distinct from the sibling worktrees B1
creates) has no such primary worktree to return to, and cannot remove
its own worktree during F4 cleanup. Several sessions on another
repository hit this repeatedly and needed manual orchestrator
intervention (`git worktree remove --force`) to recover.

- Adds an explicit "Already inside a host-isolated worktree" alternate
  path at the end of B1: skip sibling-worktree creation, run
  install-deps, and substitute a claimed-branch HEAD check for the B1
  self-check (the same wrong-branch-claim risk `idd-claim.instructions.md`
  already guards against elsewhere).
- States the F4 alternate explicitly: skip the primary-worktree-only
  fetch/switch/merge and `git worktree remove` steps -- this session
  cannot remove its own checkout -- while still completing the rest of
  F4 (issue close, digest, comment cleanup) from the current
  environment. F4 itself lives in `idd-merge.instructions.md`; per this
  issue's own candidate-files scope, only `idd-work.instructions.md` is
  edited, and this section is the cross-referenced definition F4's
  existing "from the primary worktree" language now has an explicit
  exception for.
- Scope note: `.github/instructions/lite/idd-work-lite.instructions.md`
  (a separate, self-contained lite bundle) is intentionally left
  untouched -- it is not in this issue's candidate-files list or
  acceptance criteria.

`bundle-work`'s byte budget was at zero headroom when this issue was
originally held (#2232 comment history); #2377's resolution raised
`limitBytes` from 45000 to 49500, and this change lands at 97.80%
utilization (within the 98% error threshold, verified via
`node scripts/audit-docs.mjs --check`).

## Test plan

- [x] `node scripts/audit-docs.mjs --check` -- documentation audit
      passed, `bundle-work` at 97.80% (notice only, below the 98%
      error threshold)
- [x] `pnpm exec dprint check` on both the source and generated file
- [x] `pnpm exec markdownlint-cli2` on both files -- 0 issues
- [x] `pnpm exec cspell lint` on both files -- 0 issues
- [x] `node scripts/audit-code-span-wrap.mjs` -- no mid-token wraps
- [x] `node --test tests/consistency.test.mts tests/context-ceiling.test.mts`
      -- 111/111 passing

Closes #2232

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Smou8PbTPvD32SMHkfvEia

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for agents operating within host-isolated worktrees.
  * Clarified setup, dependency installation, branch verification, and cleanup steps for this environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->