### PR TITLE
fix(build): resolve tsc/biome bin entries instead of PATH lookup

### DIFF
--- a/scripts/build-ts.mjs
+++ b/scripts/build-ts.mjs
@@ -28,9 +28,46 @@
 // Invoked via `pnpm run build`, so node_modules/.bin (tsc, biome) is on
 // PATH. Uses only node: builtins to stay compatible with the repository's
 // bare-node boundary.
+//
+// tsc/biome are invoked by resolving their package's own `bin` entry and
+// running it directly through `process.execPath`, rather than by
+// `execFileSync('tsc' | 'biome', ...)`. On Windows, node_modules/.bin/tsc
+// and node_modules/.bin/biome are `.CMD`/`.ps1` shims, not directly
+// executable files, and `execFileSync`/`spawnSync` without `shell: true`
+// skip `PATHEXT` resolution, so the plain-name form fails with ENOENT there
+// even though the shim is genuinely on PATH. Adding `shell: true` fixes
+// that, but reintroduces a Windows `cmd.exe` command-line length cap
+// (~8191 characters) that the Biome call below can exceed once the
+// emitted-file list grows — resolving the real JS entry point sidesteps
+// both: no PATH/PATHEXT lookup, and no shell to cap the command line. Every
+// platform's own `.bin` shim (`.CMD` on Windows, the POSIX shebang script
+// elsewhere) ultimately runs the exact same resolved script through node,
+// so this reproduces their behavior identically instead of bypassing it.
 import { execFileSync } from 'node:child_process';
 import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
 
+const require = createRequire(import.meta.url);
+/**
+ * Resolve an installed package's own `bin` entry to an absolute script
+ * path, bypassing the node_modules/.bin platform shim entirely. See the
+ * file header for why this replaces a plain `execFileSync('tsc' | 'biome', ...)`
+ * call.
+ */
+function resolveBinScript(packageName, binName) {
+  const packageJsonPath = require.resolve(`${packageName}/package.json`);
+  const { bin } = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+  const relativePath = typeof bin === 'string' ? bin : bin?.[binName];
+  if (!relativePath) {
+    throw new Error(
+      `${packageName}: package.json has no "${binName}" bin entry`,
+    );
+  }
+  return join(dirname(packageJsonPath), relativePath);
+}
+const TSC_BIN = resolveBinScript('typescript', 'tsc');
+const BIOME_BIN = resolveBinScript('@biomejs/biome', 'biome');
 const EMITTED_PREFIX = 'TSFILE: ';
 // The provenance header every emitted artifact carries; a helper with no
 // `.mts` source of its own would not. Kept identical to the
@@ -112,8 +149,8 @@ function syncGitattributes() {
 /** Emit the .mjs artifacts with tsc, then Biome-normalize only the emitted set. */
 function build() {
   const tscOutput = execFileSync(
-    'tsc',
-    ['-p', 'tsconfig.build.json', '--listEmittedFiles'],
+    process.execPath,
+    [TSC_BIN, '-p', 'tsconfig.build.json', '--listEmittedFiles'],
     { encoding: 'utf8' },
   );
   const emittedFiles = tscOutput
@@ -122,9 +159,11 @@ function build() {
     .map((line) => line.slice(EMITTED_PREFIX.length).trim())
     .filter((file) => file.endsWith('.mjs'));
   if (emittedFiles.length > 0) {
-    execFileSync('biome', ['check', '--write', ...emittedFiles], {
-      stdio: 'inherit',
-    });
+    execFileSync(
+      process.execPath,
+      [BIOME_BIN, 'check', '--write', ...emittedFiles],
+      { stdio: 'inherit' },
+    );
   }
 }
 if (import.meta.main) {

--- a/scripts/build-ts.mjs
+++ b/scripts/build-ts.mjs
@@ -43,6 +43,13 @@
 // platform's own `.bin` shim (`.CMD` on Windows, the POSIX shebang script
 // elsewhere) ultimately runs the exact same resolved script through node,
 // so this reproduces their behavior identically instead of bypassing it.
+//
+// resolveBinScript() below must stay called from inside build(), never at
+// module top-level: tests/build-ts.test.mts imports this module for the
+// dependency-free rewriteGitattributesBlock() below, and lint.yml's
+// toolless bare-node CI lane runs that test with NO package-manager
+// install at all (no node_modules), so merely importing this file must
+// not require `typescript`/`@biomejs/biome` to be resolvable.
 import { execFileSync } from 'node:child_process';
 import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
@@ -53,7 +60,7 @@ const require = createRequire(import.meta.url);
  * Resolve an installed package's own `bin` entry to an absolute script
  * path, bypassing the node_modules/.bin platform shim entirely. See the
  * file header for why this replaces a plain `execFileSync('tsc' | 'biome', ...)`
- * call.
+ * call, and why every call to this function must stay inside build().
  */
 function resolveBinScript(packageName, binName) {
   const packageJsonPath = require.resolve(`${packageName}/package.json`);
@@ -66,8 +73,6 @@ function resolveBinScript(packageName, binName) {
   }
   return join(dirname(packageJsonPath), relativePath);
 }
-const TSC_BIN = resolveBinScript('typescript', 'tsc');
-const BIOME_BIN = resolveBinScript('@biomejs/biome', 'biome');
 const EMITTED_PREFIX = 'TSFILE: ';
 // The provenance header every emitted artifact carries; a helper with no
 // `.mts` source of its own would not. Kept identical to the
@@ -150,7 +155,12 @@ function syncGitattributes() {
 function build() {
   const tscOutput = execFileSync(
     process.execPath,
-    [TSC_BIN, '-p', 'tsconfig.build.json', '--listEmittedFiles'],
+    [
+      resolveBinScript('typescript', 'tsc'),
+      '-p',
+      'tsconfig.build.json',
+      '--listEmittedFiles',
+    ],
     { encoding: 'utf8' },
   );
   const emittedFiles = tscOutput
@@ -161,7 +171,12 @@ function build() {
   if (emittedFiles.length > 0) {
     execFileSync(
       process.execPath,
-      [BIOME_BIN, 'check', '--write', ...emittedFiles],
+      [
+        resolveBinScript('@biomejs/biome', 'biome'),
+        'check',
+        '--write',
+        ...emittedFiles,
+      ],
       { stdio: 'inherit' },
     );
   }

--- a/src/scripts/build-ts.mts
+++ b/src/scripts/build-ts.mts
@@ -28,9 +28,51 @@
 // Invoked via `pnpm run build`, so node_modules/.bin (tsc, biome) is on
 // PATH. Uses only node: builtins to stay compatible with the repository's
 // bare-node boundary.
+//
+// tsc/biome are invoked by resolving their package's own `bin` entry and
+// running it directly through `process.execPath`, rather than by
+// `execFileSync('tsc' | 'biome', ...)`. On Windows, node_modules/.bin/tsc
+// and node_modules/.bin/biome are `.CMD`/`.ps1` shims, not directly
+// executable files, and `execFileSync`/`spawnSync` without `shell: true`
+// skip `PATHEXT` resolution, so the plain-name form fails with ENOENT there
+// even though the shim is genuinely on PATH. Adding `shell: true` fixes
+// that, but reintroduces a Windows `cmd.exe` command-line length cap
+// (~8191 characters) that the Biome call below can exceed once the
+// emitted-file list grows — resolving the real JS entry point sidesteps
+// both: no PATH/PATHEXT lookup, and no shell to cap the command line. Every
+// platform's own `.bin` shim (`.CMD` on Windows, the POSIX shebang script
+// elsewhere) ultimately runs the exact same resolved script through node,
+// so this reproduces their behavior identically instead of bypassing it.
 
 import { execFileSync } from 'node:child_process';
 import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+
+const require = createRequire(import.meta.url);
+
+/**
+ * Resolve an installed package's own `bin` entry to an absolute script
+ * path, bypassing the node_modules/.bin platform shim entirely. See the
+ * file header for why this replaces a plain `execFileSync('tsc' | 'biome', ...)`
+ * call.
+ */
+function resolveBinScript(packageName: string, binName: string): string {
+  const packageJsonPath = require.resolve(`${packageName}/package.json`);
+  const { bin } = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
+    bin?: string | Record<string, string>;
+  };
+  const relativePath = typeof bin === 'string' ? bin : bin?.[binName];
+  if (!relativePath) {
+    throw new Error(
+      `${packageName}: package.json has no "${binName}" bin entry`,
+    );
+  }
+  return join(dirname(packageJsonPath), relativePath);
+}
+
+const TSC_BIN = resolveBinScript('typescript', 'tsc');
+const BIOME_BIN = resolveBinScript('@biomejs/biome', 'biome');
 
 const EMITTED_PREFIX = 'TSFILE: ';
 
@@ -123,8 +165,8 @@ function syncGitattributes(): void {
 /** Emit the .mjs artifacts with tsc, then Biome-normalize only the emitted set. */
 function build(): void {
   const tscOutput: string = execFileSync(
-    'tsc',
-    ['-p', 'tsconfig.build.json', '--listEmittedFiles'],
+    process.execPath,
+    [TSC_BIN, '-p', 'tsconfig.build.json', '--listEmittedFiles'],
     { encoding: 'utf8' },
   );
 
@@ -135,9 +177,11 @@ function build(): void {
     .filter((file) => file.endsWith('.mjs'));
 
   if (emittedFiles.length > 0) {
-    execFileSync('biome', ['check', '--write', ...emittedFiles], {
-      stdio: 'inherit',
-    });
+    execFileSync(
+      process.execPath,
+      [BIOME_BIN, 'check', '--write', ...emittedFiles],
+      { stdio: 'inherit' },
+    );
   }
 }
 

--- a/src/scripts/build-ts.mts
+++ b/src/scripts/build-ts.mts
@@ -43,6 +43,13 @@
 // platform's own `.bin` shim (`.CMD` on Windows, the POSIX shebang script
 // elsewhere) ultimately runs the exact same resolved script through node,
 // so this reproduces their behavior identically instead of bypassing it.
+//
+// resolveBinScript() below must stay called from inside build(), never at
+// module top-level: tests/build-ts.test.mts imports this module for the
+// dependency-free rewriteGitattributesBlock() below, and lint.yml's
+// toolless bare-node CI lane runs that test with NO package-manager
+// install at all (no node_modules), so merely importing this file must
+// not require `typescript`/`@biomejs/biome` to be resolvable.
 
 import { execFileSync } from 'node:child_process';
 import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
@@ -55,7 +62,7 @@ const require = createRequire(import.meta.url);
  * Resolve an installed package's own `bin` entry to an absolute script
  * path, bypassing the node_modules/.bin platform shim entirely. See the
  * file header for why this replaces a plain `execFileSync('tsc' | 'biome', ...)`
- * call.
+ * call, and why every call to this function must stay inside build().
  */
 function resolveBinScript(packageName: string, binName: string): string {
   const packageJsonPath = require.resolve(`${packageName}/package.json`);
@@ -70,9 +77,6 @@ function resolveBinScript(packageName: string, binName: string): string {
   }
   return join(dirname(packageJsonPath), relativePath);
 }
-
-const TSC_BIN = resolveBinScript('typescript', 'tsc');
-const BIOME_BIN = resolveBinScript('@biomejs/biome', 'biome');
 
 const EMITTED_PREFIX = 'TSFILE: ';
 
@@ -166,7 +170,12 @@ function syncGitattributes(): void {
 function build(): void {
   const tscOutput: string = execFileSync(
     process.execPath,
-    [TSC_BIN, '-p', 'tsconfig.build.json', '--listEmittedFiles'],
+    [
+      resolveBinScript('typescript', 'tsc'),
+      '-p',
+      'tsconfig.build.json',
+      '--listEmittedFiles',
+    ],
     { encoding: 'utf8' },
   );
 
@@ -179,7 +188,12 @@ function build(): void {
   if (emittedFiles.length > 0) {
     execFileSync(
       process.execPath,
-      [BIOME_BIN, 'check', '--write', ...emittedFiles],
+      [
+        resolveBinScript('@biomejs/biome', 'biome'),
+        'check',
+        '--write',
+        ...emittedFiles,
+      ],
       { stdio: 'inherit' },
     );
   }


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

`src/scripts/build-ts.mts` called `execFileSync('tsc', ...)` and
`execFileSync('biome', ...)` without `shell: true`. On native Windows,
`node_modules/.bin/tsc` and `node_modules/.bin/biome` are `.CMD`/`.ps1`
shims, not directly-executable files, and `execFileSync`/`spawnSync`
without `shell: true` skip `PATHEXT` resolution — so both calls failed
with `ENOENT` even though `node_modules/.bin` was correctly on `PATH`.
This made `pnpm run build` (and everything that depends on it: `lint`,
`lint:minimum`, `build:check`) unusable from a native-Windows checkout.

`shell: true` was tried first but empirically breaks the `biome` call:
on Windows it runs through `cmd.exe`, which caps a command line at
~8191 characters, and the emitted-file list can exceed that ("The
command line is too long"). Instead, both call sites now resolve their
package's own `bin` entry (`typescript` → `bin/tsc`, `@biomejs/biome` →
`bin/biome`) via the package's own `package.json`, and invoke the
resolved script directly through `process.execPath` — no PATH/PATHEXT
lookup, no shell, no command-line cap, while reproducing exactly what
each platform's own `.bin` shim already does under the hood (confirmed
by inspecting the actual `.CMD` / POSIX shebang shim contents).

`scripts/build-ts.mjs` (generated from `src/scripts/build-ts.mts` by
`pnpm run build`) was hand-patched with the equivalent fix first, to
bootstrap a native-Windows `pnpm run build`, then regenerated for real
via `pnpm run build` once the build was runnable again;
`pnpm run build:check` confirms zero drift after committing.

No other `execFileSync`/`spawnSync` call site in `src/scripts/*.mts`
was touched — every other call targets `git`/`gh`, real native `.exe`
binaries on Windows, unaffected by this bug class.

## Linked issue

Closes #2569

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Reproduced on Windows 11, node v22.23.2, pnpm 11.21.0 (see issue #2569
for the exact repro and isolated `spawnSync` confirmation). This is
this repository's first native-Windows verification pass of its own
contributor-facing dev tooling (build/lint/test) — distinct from the
`idd-template/` adopter-distributed surface #2072 already swept.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`biome check`, `dprint check`, `markdownlint-cli2`,
      `cspell lint` all pass on the changed files; two pre-existing
      unrelated warnings in `src/scripts/protocol-helpers.mts` /
      `scripts/protocol-helpers.mjs`, untouched by this diff)
- [x] `pnpm test` (`tests/build-ts.test.mts` 5/5 pass; the full
      `node --test tests/*.test.mts` run has 178 pre-existing failures
      unrelated to this diff — Windows-specific git-subprocess-mocking
      issues in unrelated test files, reproducing identically on `main`;
      none touch `build-ts`)
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (not applicable — no docs/instructions
      files changed)
- [x] `node scripts/idd-doctor.mjs` (passes; only pre-existing,
      environment-level warnings unrelated to this change)

Additionally verified directly on native Windows (the acceptance
criteria from #2569):

- [x] `pnpm run build` exits `0` (previously failed with
      `spawnSync tsc ENOENT`)
- [x] `pnpm run build:check` exits `0` with no drift

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

---

An independent C1 critique pass (general-purpose subagent, per
`idd-overview-appendix.instructions.md`) found no High or Medium
severity issues; three Low-severity, non-blocking notes were reviewed
and rejected as out of scope for this fix. See the plan/critique
summary comment on #2569 for detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsA2FSNJqPfX7yWZoJPc3m
