### PR TITLE
fix(tests): windows-safe null device for git config fixtures

### DIFF
--- a/tests/claim-lock.test.mts
+++ b/tests/claim-lock.test.mts
@@ -26,6 +26,14 @@ const execFileAsync = promisify(execFile);
 const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
 const CLI_PATH = join(REPO_ROOT, 'scripts/claim-lock.mjs');
 
+// A git-config-file-safe null-device path. `node:os`'s `devNull` is the
+// Win32 device-namespace form (`\\.\nul`) on win32, which Git for Windows
+// cannot open as a GIT_CONFIG_GLOBAL/GIT_CONFIG_SYSTEM value (`fatal:
+// unable to access '//./nul': Invalid argument`); the bare `'NUL'` device
+// name is the form git itself accepts there. POSIX is unaffected -- devNull
+// there is already `/dev/null`. See kurone-kito/idd-skill#2570.
+const GIT_NULL_DEVICE = process.platform === 'win32' ? 'NUL' : devNull;
+
 // Fixture invariant mirrored from tests/worktree-guard-hook.test.mts: fixture
 // git processes must never read the ambient git environment or the
 // developer's config, and must never inherit GIT_DIR/GIT_WORK_TREE from a
@@ -42,8 +50,8 @@ function fixtureEnv(): NodeJS.ProcessEnv {
   delete env.GIT_WORK_TREE;
   delete env.GIT_COMMON_DIR;
   delete env.GIT_OBJECT_DIRECTORY;
-  env.GIT_CONFIG_GLOBAL = devNull;
-  env.GIT_CONFIG_SYSTEM = devNull;
+  env.GIT_CONFIG_GLOBAL = GIT_NULL_DEVICE;
+  env.GIT_CONFIG_SYSTEM = GIT_NULL_DEVICE;
   return env;
 }
 

--- a/tests/clone-lock.test.mts
+++ b/tests/clone-lock.test.mts
@@ -27,6 +27,14 @@ const execFileAsync = promisify(execFile);
 const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
 const CLI_PATH = join(REPO_ROOT, 'scripts/clone-lock.mjs');
 
+// A git-config-file-safe null-device path. `node:os`'s `devNull` is the
+// Win32 device-namespace form (`\\.\nul`) on win32, which Git for Windows
+// cannot open as a GIT_CONFIG_GLOBAL/GIT_CONFIG_SYSTEM value (`fatal:
+// unable to access '//./nul': Invalid argument`); the bare `'NUL'` device
+// name is the form git itself accepts there. POSIX is unaffected -- devNull
+// there is already `/dev/null`. See kurone-kito/idd-skill#2570.
+const GIT_NULL_DEVICE = process.platform === 'win32' ? 'NUL' : devNull;
+
 // Fixture invariant mirrored from tests/claim-lock.test.mts: fixture git
 // processes must never read the ambient git environment or the
 // developer's config.
@@ -42,8 +50,8 @@ function fixtureEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   delete env.GIT_WORK_TREE;
   delete env.GIT_COMMON_DIR;
   delete env.GIT_OBJECT_DIRECTORY;
-  env.GIT_CONFIG_GLOBAL = devNull;
-  env.GIT_CONFIG_SYSTEM = devNull;
+  env.GIT_CONFIG_GLOBAL = GIT_NULL_DEVICE;
+  env.GIT_CONFIG_SYSTEM = GIT_NULL_DEVICE;
   return env;
 }
 

--- a/tests/idd-roadmap-audit-execute.test.mts
+++ b/tests/idd-roadmap-audit-execute.test.mts
@@ -2040,6 +2040,14 @@ test('evaluateLocalCoordinationState evaluates EVERY matched worktree, not just 
 // evaluateLocalCoordinationState against REAL git fixtures (#2225, AC2-AC4)
 // ---------------------------------------------------------------------------
 
+// A git-config-file-safe null-device path. `node:os`'s `devNull` is the
+// Win32 device-namespace form (`\\.\nul`) on win32, which Git for Windows
+// cannot open as a GIT_CONFIG_GLOBAL/GIT_CONFIG_SYSTEM value (`fatal:
+// unable to access '//./nul': Invalid argument`); the bare `'NUL'` device
+// name is the form git itself accepts there. POSIX is unaffected -- devNull
+// there is already `/dev/null`. See kurone-kito/idd-skill#2570.
+const GIT_NULL_DEVICE = process.platform === 'win32' ? 'NUL' : devNull;
+
 // Fixture invariant mirrored from tests/worktree-guard-hook.test.mts and
 // tests/claim-lock.test.mts: fixture git processes must never read the
 // ambient git environment or the developer's config, so a signing-enabled
@@ -2057,8 +2065,8 @@ function fixtureEnv(): NodeJS.ProcessEnv {
   delete env.GIT_WORK_TREE;
   delete env.GIT_COMMON_DIR;
   delete env.GIT_OBJECT_DIRECTORY;
-  env.GIT_CONFIG_GLOBAL = devNull;
-  env.GIT_CONFIG_SYSTEM = devNull;
+  env.GIT_CONFIG_GLOBAL = GIT_NULL_DEVICE;
+  env.GIT_CONFIG_SYSTEM = GIT_NULL_DEVICE;
   return env;
 }
 

--- a/tests/test-utils.mts
+++ b/tests/test-utils.mts
@@ -14,6 +14,17 @@ import { fileURLToPath } from 'node:url';
 
 import type { ReviewThreadNode } from '../src/scripts/resolve-review-thread.mts';
 
+/**
+ * A git-config-file-safe null-device path. `node:os`'s `devNull` is the
+ * Win32 device-namespace form (`\\.\nul`) on win32, which Git for Windows
+ * cannot open as a `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM`/
+ * `GIT_CONFIG_VALUE_0` value (`fatal: unable to access '//./nul': Invalid
+ * argument`); the bare `'NUL'` device name is the form git itself accepts
+ * there. POSIX is unaffected -- `devNull` there is already `/dev/null`.
+ * See kurone-kito/idd-skill#2570.
+ */
+const GIT_NULL_DEVICE = process.platform === 'win32' ? 'NUL' : devNull;
+
 const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
 const SYNC_DOCS_SCRIPT = join(REPO_ROOT, 'scripts/sync-docs.mjs');
 // sync-docs.mjs imports the shared banner/helper module, which in turn imports
@@ -171,10 +182,11 @@ function writeScaffoldedFile(dir: string, rel: string, content: string): void {
  * of the temp fixture despite `cwd` being set correctly -- and every
  * ambient `GIT_CONFIG*` variable, replacing them with a fixed
  * `GIT_CONFIG_COUNT`/`KEY`/`VALUE` triple that pins `core.excludesFile`
- * to `os.devNull` (the platform null device, not necessarily the literal
- * path `/dev/null`) so an operator's personal global ignore file can
- * never drop fixture paths from `git ls-files --exclude-standard`. Other
- * `GIT_*` variables outside these two groups are left untouched. Shared
+ * to the platform null device (`GIT_NULL_DEVICE`, not necessarily
+ * `os.devNull` -- see its own doc comment) so an operator's personal
+ * global ignore file can never drop fixture paths from `git ls-files
+ * --exclude-standard`. Other `GIT_*` variables outside these two groups
+ * are left untouched. Shared
  * by every suite that scaffolds a git-backed fixture (originally local
  * to `audit-docs-file-sets.test.mts`; lifted out for `sync-docs.test.mts`
  * too per #1703, so the sanitization logic itself has one copy).
@@ -191,11 +203,11 @@ export function fixtureEnv(): NodeJS.ProcessEnv {
   delete env.GIT_WORK_TREE;
   delete env.GIT_COMMON_DIR;
   delete env.GIT_OBJECT_DIRECTORY;
-  env.GIT_CONFIG_GLOBAL = devNull;
-  env.GIT_CONFIG_SYSTEM = devNull;
+  env.GIT_CONFIG_GLOBAL = GIT_NULL_DEVICE;
+  env.GIT_CONFIG_SYSTEM = GIT_NULL_DEVICE;
   env.GIT_CONFIG_COUNT = '1';
   env.GIT_CONFIG_KEY_0 = 'core.excludesFile';
-  env.GIT_CONFIG_VALUE_0 = devNull;
+  env.GIT_CONFIG_VALUE_0 = GIT_NULL_DEVICE;
   return env;
 }
 

--- a/tests/worktree-guard-hook.test.mts
+++ b/tests/worktree-guard-hook.test.mts
@@ -13,6 +13,14 @@ const HOOKS_DIR = join(
   '.githooks',
 );
 
+// A git-config-file-safe null-device path. `node:os`'s `devNull` is the
+// Win32 device-namespace form (`\\.\nul`) on win32, which Git for Windows
+// cannot open as a GIT_CONFIG_GLOBAL/GIT_CONFIG_SYSTEM value (`fatal:
+// unable to access '//./nul': Invalid argument`); the bare `'NUL'` device
+// name is the form git itself accepts there. POSIX is unaffected -- devNull
+// there is already `/dev/null`. See kurone-kito/idd-skill#2570.
+const GIT_NULL_DEVICE = process.platform === 'win32' ? 'NUL' : devNull;
+
 // Fixture invariant: fixture git processes must never read the ambient
 // git environment or the developer's config. Hook runs export GIT_DIR /
 // GIT_INDEX_FILE (so an unsanitized fixture would mutate the HOST
@@ -33,8 +41,8 @@ function fixtureEnv() {
   delete env.GIT_WORK_TREE;
   delete env.GIT_COMMON_DIR;
   delete env.GIT_OBJECT_DIRECTORY;
-  env.GIT_CONFIG_GLOBAL = devNull;
-  env.GIT_CONFIG_SYSTEM = devNull;
+  env.GIT_CONFIG_GLOBAL = GIT_NULL_DEVICE;
+  env.GIT_CONFIG_SYSTEM = GIT_NULL_DEVICE;
   return env;
 }
 


### PR DESCRIPTION
# Summary

`node:os`'s `devNull` is the Win32 device-namespace form (`\\.\nul`) on
win32. Git for Windows cannot open that exact form when it is supplied
as a `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM`/`GIT_CONFIG_VALUE_0`
value (`fatal: unable to access '//./nul': Invalid argument`), so
almost every git-backed fixture test in `tests/test-utils.mts`,
`tests/worktree-guard-hook.test.mts`, `tests/claim-lock.test.mts`,
`tests/clone-lock.test.mts`, and `tests/idd-roadmap-audit-execute.test.mts`
failed on native Windows.

Each of those five files' own duplicated `fixtureEnv()` copy now
computes a small `process.platform === 'win32' ? 'NUL' : devNull`
-shaped `GIT_NULL_DEVICE` constant and uses it in place of the raw
`devNull` reference for those three env vars. POSIX behavior is
unchanged (`devNull` there is already `/dev/null`). The fix is
deliberately scoped to the null-device value only, per the issue's own
instruction not to force a broader `fixtureEnv()` dedupe.

`tests/branch-conflict-state.test.mts`, the sixth file the issue
names, was checked against both the issue's cited baseline commit
(`8a4177cb`) and current `main` via `grep`/`git log -p --all`. **Correction**
(Copilot review, #2574): this file *does* reference `GIT_CONFIG_GLOBAL`
(around `tests/branch-conflict-state.test.mts:481-506`), but only to point
it at a temporary signing-config fixture file for an unrelated GPG-signing
test — never at `os.devNull`, and it never defines its own `fixtureEnv()`.
The originally-posted wording ("no `GIT_CONFIG_GLOBAL` occurrence at all")
overclaimed; the precise claim is: no occurrence of `os.devNull`/
`fixtureEnv()`, and no `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` value ever
set to `devNull`. So it still needed no change for *this* issue's
null-device pattern — acceptance criterion 3 is satisfied on that precise
reading, not the looser one originally stated.

## Linked issue

Closes #2570

## Follow-up issues (if any)

- [ ] none created directly (per `idd-work.instructions.md`, "Unplanned
      follow-up work" -- recorded here instead):
  - Remaining native-Windows test failures after this fix cluster
    around `ghText`/`--gh-token` CLI plumbing, `pre-merge-readiness.mjs`
    CLI, `checkPostMergeCleanupBacklog` CLI, and
    `resolveUserGlobalConfigPath` -- these look plausibly in scope for
    #2571 ("PATH-stubbed gh CLI fixtures") rather than this issue.
  - `tests/idd-roadmap-audit-execute.test.mts`'s
    `evaluateLocalCoordinationState`/AC2-AC4 real-fixture suite has a
    small number of unrelated native-Windows failures, including a
    path-separator (`/` vs `\`) string-equality mismatch. Confirmed no
    `devNull` usage anywhere under `src/` (production code, not just
    tests, is unaffected) -- purely a test-expectation issue, out of
    this `fix(tests)` issue's scope.

## Background / rationale (if material)

Measured on native Windows (node v22.23.2, git 2.55.0.windows.3)
against current `main` (this branch's merge base, unmodified):
`node --test tests/*.test.mts` reports `# tests 4962, # pass 4781,
# fail 178`. With this fix applied: `# tests 4962, # pass 4847,
# fail 112` -- **66 tests fixed, 0 regressions** (full before/after
failing-test-name diff confirms no test that passed before now
fails). The remaining 112 failures reproduce identically with this
fix reverted, so they are unrelated to the `os.devNull` null-device
pattern this issue targets -- consistent with the issue's own
Background section, which attributes only "the large majority" of
the original 174 failures to this one root cause, not all of it.
Acceptance criterion 1 ("0 failures") is therefore not fully reached
by this change alone; see Follow-up issues above for where the
remainder plausibly belongs.

**On closing #2570 despite that gap** (Copilot review, #2574): the
issue's own Proposed change and Impact/root-cause analysis are fully
addressed -- every `os.devNull` occurrence this issue's own six-file
candidate list actually contains is fixed, with zero regressions. The
"0 failures" bullet encoded an assumption (fixing this one root cause
would reach zero) that this PR's own measurement disproves; the
issue's Background section itself only ever claimed the shared root
cause explains "the large majority" of the original 174, not all of
it. Re-opening #2570 to also chase the 112 unrelated, differently-caused
failures would misfile that work under this issue's now-completed,
narrowly-scoped root cause instead of the issues that actually own
each remaining cluster (see Follow-up issues above) -- so this PR
closes #2570 as its own scope is fully delivered, with the residual
explicitly disclosed and routed elsewhere rather than silently dropped.

`pnpm run build:check` also fails locally on native Windows, both on
this branch and on unmodified `main` (`spawnSync tsc ENOENT` --
`execFileSync('tsc', ...)` doesn't resolve the bare command on
Windows even though `node_modules/.bin/tsc.CMD` exists). This is
pre-existing, untouched by this diff, and matches the class of
problem #2569 targets -- not addressed here.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (via `npx biome check`, `dprint check`,
      `markdownlint-cli2`, `cspell lint` -- all pass; 4 pre-existing
      `biome` warnings in `src/scripts/protocol-helpers.mts` are
      untouched by this diff)
- [x] `pnpm test` (`node --test tests/*.test.mts` -- 178 to 112
      failures, 66 fixed, 0 regressions; see Background above)
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (not applicable -- no `docs/**` or
      `.github/instructions/**` content changed)
- [x] `node scripts/idd-doctor.mjs` (passed with 3 pre-existing,
      unrelated warnings: missing adopter profile files, worktree-guard
      hooks not wired in this dev environment, release-tag drift)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none -- test-only fixture fix)
- [x] Context budget impact reviewed (none -- no instruction/doc files
      changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X27jGWQk1dbPjpFchFfzzR

