### PR TITLE
docs(idd-discover): name A4 Step 2's floor-skip case in trigger (b)

### DIFF
--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -102,9 +102,10 @@ Read the **issue-scope** value from the Project commands table in
   roadmap path yields **no viable, startable, unclaimed candidate** —
   **trigger (a)** (zero candidates reach A3.5: A2 found none, or A3
   filtered them all), **trigger (b)** (candidates reach A3.5 but A4
-  Step 1 or Step 1.5 discards every one), or **trigger (c)** (A1 finds
-  no roadmap issues). A0-O runs **at most once** per Discover pass as
-  this fallback; once spent, a later A4 exhaustion reports and stops
+  Step 1, Step 1.5, or Step 2's floor skip discards every one), or
+  **trigger (c)** (A1 finds no roadmap issues). A0-O runs **at most
+  once** per Discover pass as this fallback; once spent, a later A4
+  exhaustion reports and stops
   (not an abort) without re-entering A0-O. A non-empty A3.5
   approval-needed bucket is not a true zero and never triggers this
   fallback. See

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -97,9 +97,10 @@ Read the **issue-scope** value from the Project commands table in
   roadmap path yields **no viable, startable, unclaimed candidate** —
   **trigger (a)** (zero candidates reach A3.5: A2 found none, or A3
   filtered them all), **trigger (b)** (candidates reach A3.5 but A4
-  Step 1 or Step 1.5 discards every one), or **trigger (c)** (A1 finds
-  no roadmap issues). A0-O runs **at most once** per Discover pass as
-  this fallback; once spent, a later A4 exhaustion reports and stops
+  Step 1, Step 1.5, or Step 2's floor skip discards every one), or
+  **trigger (c)** (A1 finds no roadmap issues). A0-O runs **at most
+  once** per Discover pass as this fallback; once spent, a later A4
+  exhaustion reports and stops
   (not an abort) without re-entering A0-O. A non-empty A3.5
   approval-needed bucket is not a true zero and never triggers this
   fallback. See


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

`idd-template/.github/instructions/idd-discover.instructions.md`'s
**A0 — Check issue-scope setting** section summarized trigger (b) (one
of three ways Discover falls back from the roadmap path to A0-O) as
naming only **A4 Step 1** and **Step 1.5**. It omitted **Step 2** — the
step that applies the autopilot-suitability floor and can discard every
surviving candidate on its own — even though that outcome is intended
to fall back to A0-O the same way Step 1/1.5 exhaustion does.

**Correction (found during this PR's own critique pass — see PR
comments):** the issue's original wording described this as "A4 Step
2 — Select's own exhaustion-exit routing" already folding the
floor-skip case into trigger (b). That's not quite accurate: the
quoted routing text is **Step 1's** own exhaustion-exit clause
(`idd-discover.instructions.md:483-490`), reused by reference from
Step 1.5 (`:529`). Step 2 itself has no equivalent clause of its own.
So this PR's A0 wording change reflects the *intended* design (per
the issue author, who is also this repo's maintainer) rather than an
already-fully-documented behavior — see Follow-up issues below for
the remaining gap this doesn't close.

Extended the trigger (b) parenthetical to name Step 2's floor skip
explicitly, phrased as "Step 2's floor skip" to match the existing
"A4 Step 2's floor rule" shorthand already used later in the same file
(A0-O's own Autopilot floor paragraph). Regenerated the mirrored
`.github/instructions/idd-discover.instructions.md` via
`node scripts/sync-docs.mjs --apply`. No other wording changed in
either file.

## Linked issue

Closes #2578

## Follow-up issues (if any)

- [ ] Recommended (not filed): A4 Step 2
      (`idd-template/.github/instructions/idd-discover.instructions.md:536-624`)
      still has no explicit exhaustion-exit clause of its own for the
      floor-skip-to-zero case, unlike Step 1.5 (which says "otherwise
      apply Step 1's exhaustion-exit routing above"). This PR's A0
      summary fix is correct and matches design intent, but a reader
      following Step 2 in isolation still can't confirm the A0-O
      fallback from Step 2's own text.
      `docs/idd-design-rationale.md:38-40,52` has the same narrower
      Step 1/Step 1.5-only framing and would need the same follow-up
      update.

## Background / rationale (if material)

The initial straightforward extension ("Step 1, Step 1.5, or Step 2's
autopilot-floor skip discards every one)") pushed
`idd-template/.github/instructions/idd-discover.instructions.md` 3
bytes over its 33000-byte `instruction-size-budgets` phase limit
(`node scripts/audit-docs.mjs --check`). Reworded to the terser
"Step 2's floor skip" (mirroring the file's own existing "A4 Step 2's
floor rule" shorthand a few lines below in A0-O) to stay under budget
with margin (32993 bytes) without losing meaning.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`biome check`, `dprint check`, `markdownlint-cli2`,
      `cspell lint` all pass; only pre-existing, unrelated warnings in
      `src/scripts/protocol-helpers.mts` / `scripts/protocol-helpers.mjs`)
- [x] `pnpm test` (`node --test tests/agent-entry-mirror-sync.test.mts`
      passes 6/6; no test targets this instructions file specifically)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (equivalent: `node scripts/sync-docs.mjs
      --apply` regenerated the mirror with zero further drift)
- [x] `node scripts/idd-doctor.mjs` (passes; only pre-existing,
      environment-level warnings unrelated to this change)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed (byte-budget failure caught and
      fixed — see Background above)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsA2FSNJqPfX7yWZoJPc3m


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The roadmap-first fallback now activates when all candidates are skipped by the autopilot suitability criteria during the final discovery step.
  * Existing limits and stop behavior for fallback activation remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
