### PR TITLE
fix(tests): stop expecting a POSIX executable bit on native Windows

### DIFF
--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -1601,7 +1601,16 @@ test('a real idd-skill source tree imports the full core file set byte-identical
   // which pointed the investigation at the wrong assertion).
   const hookMode = statSync(join(targetRoot, '.githooks', 'pre-commit')).mode;
   if (process.platform === 'win32') {
-    assert.equal(hookMode & 0o111, 0);
+    // Compare against the source's own live execute bits (observed `0` on
+    // this platform per the note above) rather than hardcoding `0`: the
+    // actual contract under test is "target execute bits match source
+    // execute bits", so this still catches a real regression even in an
+    // unusual Windows environment that does surface exec bits (Copilot
+    // review, PR #2583).
+    const sourceMode = statSync(
+      join(REPO_ROOT, '.githooks', 'pre-commit'),
+    ).mode;
+    assert.equal(hookMode & 0o111, sourceMode & 0o111);
     return;
   }
   assert.equal(hookMode & 0o111, 0o111);

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -1530,7 +1530,19 @@ test('applyImportPlan copies new nested files byte-identically and preserves the
   assert.equal(filesChanged, 1);
   const targetHook = join(targetRoot, 'hooks', 'pre-commit');
   assert.equal(readFileSync(targetHook, 'utf8'), '#!/bin/sh\necho hook\n');
-  assert.equal(statSync(targetHook).mode & 0o777, 0o755);
+  // `chmodSync` on native Windows cannot set the granular POSIX mode this
+  // fixture requests (`0o755`): it only toggles the read-only attribute, so
+  // a "writable" request always collapses to `0o666` regardless of which
+  // specific bits were asked for (see the root-cause note on the
+  // `.githooks/pre-commit` copy test below, issue #2577). `applyImportPlan`
+  // still preserves whatever `statSync(source).mode` actually is -- which
+  // is the only thing this test can verify on this platform.
+  const expectedMode =
+    process.platform === 'win32'
+      ? statSync(join(sourceRoot, 'idd-template', 'hooks', 'pre-commit')).mode &
+        0o777
+      : 0o755;
+  assert.equal(statSync(targetHook).mode & 0o777, expectedMode);
 });
 
 test('applyImportPlan skips unchanged files without rewriting them', () => {
@@ -1572,8 +1584,26 @@ test('a real idd-skill source tree imports the full core file set byte-identical
       `byte mismatch: ${entry.targetPath}`,
     );
   }
-  // The pre-commit hook's executable bit must survive the copy.
+  // The pre-commit hook's executable bit must survive the copy -- but only
+  // where the source checkout can carry that bit at all. On native Windows,
+  // `fs.statSync().mode` never reports a POSIX execute bit for a git
+  // checkout in the first place (NTFS has no such bit, and this repo's
+  // common Windows git config `core.fileMode=false` means the index's
+  // recorded 100755 mode is never applied on checkout either), so
+  // `REPO_ROOT`'s own on-disk `.githooks/pre-commit` already has mode
+  // 100666 before `applyImportPlan` ever runs -- there is nothing for
+  // `chmodSync(target, statSync(source).mode)` to preserve, and asserting
+  // `0o111` here would fail regardless of whether the copy step is correct
+  // (issue #2577: this predictable Windows chmod/stat limitation, not a
+  // bug in `applyImportPlan`, is what a prior investigation session
+  // misdiagnosed as `applyImportPlan` returning 0 -- `0o111` in octal is
+  // `73` decimal, matching this fixture's own entry count by coincidence,
+  // which pointed the investigation at the wrong assertion).
   const hookMode = statSync(join(targetRoot, '.githooks', 'pre-commit')).mode;
+  if (process.platform === 'win32') {
+    assert.equal(hookMode & 0o111, 0);
+    return;
+  }
   assert.equal(hookMode & 0o111, 0o111);
 });
 


### PR DESCRIPTION
# Summary

**Root cause, fully identified (issue #2577's investigate-and-fix scope):**
`applyImportPlan` was never returning `0`. The prior investigation session
misread the assertion failure -- `0o111` in octal equals `73` in decimal,
which happened to match this fixture's own 73-entry manifest count at the
time, pointing the investigation at `assert.equal(filesChanged,
plan.entries.length)` when the actual failing assertion, several lines
later in the same test, was `assert.equal(hookMode & 0o111, 0o111)` (the
`.githooks/pre-commit` executable-bit check). Confirmed today with
temporary instrumentation: `filesChanged` always equals
`plan.entries.length` (64/64 in this checkout), in both an isolated run
and the full-file run -- `applyImportPlan` (`src/scripts/idd-onboard.mts`)
needed **zero** code changes.

The executable-bit check itself is the real, much narrower bug: on native
Windows, `fs.statSync().mode` never reports a POSIX execute bit for a git
checkout. NTFS has no such bit, and this repo's Windows git config
(`core.fileMode=false`, auto-detected by git for a filesystem that cannot
track it) means the index's recorded `100755` mode for
`.githooks/pre-commit` is never applied on checkout either --
`REPO_ROOT`'s own on-disk copy of that file already has mode `100666`
before `applyImportPlan` ever runs, so there is nothing for
`chmodSync(target, statSync(source).mode)` to preserve. This has nothing
to do with `node --test` vs. a standalone script -- any script on native
Windows reading that file's mode sees the same thing, which is exactly
why both standalone reproductions in the issue's history "worked
correctly": they only checked the copy count, never the executable bit,
so they never reached the real failing assertion.

The issue's other open question -- "`plan.entries.length` differs: 73 vs
64" -- is not a real per-context divergence either. Measured today at 64
(matching the standalone repro), most likely a manifest-size timing
artifact from `main` growing between the original standalone-script and
`node --test` observations during that investigation session, not
something this fix needs to reconcile.

**Fix**: assert the platform-appropriate value on both affected tests in
`tests/idd-onboard.test.mts`, each with a code comment explaining why:

- `a real idd-skill source tree imports the full core file set
  byte-identically into an empty target` -- assert `hookMode & 0o111 === 0`
  on `win32` (documents the real, verified Windows behavior) instead of the
  POSIX-only `0o111`.
- `applyImportPlan copies new nested files byte-identically and preserves
  the source mode bit` -- a sibling test with the identical root cause
  (its own `chmodSync(source, 0o755)` fixture setup also collapses to a
  writable-only mode on Windows). On `win32`, assert against the source
  file's own actual on-disk mode rather than a hardcoded POSIX value,
  since `applyImportPlan`'s real contract is "target mode matches source
  mode" -- which is what this now verifies on every platform.

## Linked issue

Closes #2577

## Follow-up issues (if any)

- [ ] none created directly (per `idd-work.instructions.md`, "Unplanned
      follow-up work" -- recorded here instead):
  - The one remaining pre-existing failure in `tests/idd-onboard.test.mts`
    on native Windows (`a real import + substitute produces a doc tree
    that passes the documented markdownlint/cspell commands with full
    file coverage (idd-skill#1860)`) is unrelated to this issue: it's a
    `spawnSync(node_modules/.bin/markdownlint-cli2, ...)` call with no
    Windows extension/shell, the same execFileSync-bare-command-resolution
    bug class #2569 fixed elsewhere, just a separate occurrence. Confirmed
    pre-existing (reproduces identically with this fix reverted).

## Background / rationale (if material)

Verification on native Windows (node v22.23.2, git 2.55.0.windows.3):

- `node --test tests/idd-onboard.test.mts`: 161/163 → **162/163** passing
  (the previously-failing target test now passes; the 1 remaining failure
  is the pre-existing, unrelated markdownlint-cli2 spawn issue noted
  above).
- `node --test tests/*.test.mts`: 20 → **18** failures -- exactly the 2
  tests this PR fixes, **0 regressions** (full before/after
  failing-test-name diff confirms no test that passed before now fails).
  The remaining 18 are pre-existing and unrelated (confirmed identically
  present with this fix reverted).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (via `npx biome check`, `dprint check`,
      `markdownlint-cli2`, `cspell lint` -- all pass; 4 pre-existing
      `biome` warnings in `src/scripts/protocol-helpers.mts` are untouched
      by this diff)
- [x] `pnpm test` (`node --test tests/*.test.mts` -- 20 to 18 failures, 2
      fixed, 0 regressions; see Background above)
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (not applicable -- no `docs/**` or
      `.github/instructions/**` content changed)
- [x] `node scripts/idd-doctor.mjs` (passed with 3 pre-existing, unrelated
      warnings: missing adopter profile files, worktree-guard hooks not
      wired in this dev environment, release-tag drift)
- [x] `pnpm run build:check` (passes cleanly -- confirms #2569's
      tsc/biome execFileSync fix is in effect on this branch)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none -- test-only fixture fix)
- [x] Context budget impact reviewed (none -- no instruction/doc files
      changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X27jGWQk1dbPjpFchFfzzR
