### PR TITLE
fix(tests): skip chmodSync-based fault injection tests on Windows

### DIFF
--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -1479,7 +1479,17 @@ test('worktreeGuardWiredAt: a directory merely ending in "_" is not treated as t
 // Review feedback (PR #1969, chatgpt-codex-connector P1): git silently
 // skips a hook file that exists but lacks the executable bit, so an
 // existence-only check is not sufficient evidence that git would invoke it.
-test('worktreeGuardWiredAt: a present but non-executable active hook file reads as unwired', () => {
+//
+// Skipped on Windows (#2580): `worktreeGuardWiredAt` checks executability
+// via `accessSync(path, fsConstants.X_OK)`, and Windows has no POSIX
+// execute-permission bit for `accessSync` to detect the absence of --
+// verified empirically, `chmodSync(f, 0o644)` never makes `X_OK` fail
+// there, so this test's fault precondition can't be constructed on
+// Windows at all. POSIX/Linux CI stays the authoritative coverage for
+// this POSIX-permission-semantics check, unaffected by this skip.
+test('worktreeGuardWiredAt: a present but non-executable active hook file reads as unwired', {
+  skip: process.platform === 'win32',
+}, () => {
   const dir = mkdtempSync(join(tmpdir(), 'idd-guard-chain-non-executable-'));
   try {
     writeFixtureFile(

--- a/tests/token-cost-adapter-codex.test.mts
+++ b/tests/token-cost-adapter-codex.test.mts
@@ -181,7 +181,17 @@ test('scanCodexSessions skips a malformed session that fails to harvest, keeping
   assert.equal(results[0].sample.vendorSessionId, 'sess-basic-0001');
 });
 
-test('scanCodexSessions skips an unreadable file, keeping the rest', () => {
+// Skipped on Windows (#2580): `chmodSync(file, 0o000)` doesn't block a
+// subsequent `readFileSync` there -- verified empirically, Windows' own
+// read-only attribute (the closest analogue chmodSync can set) blocks
+// writes only, never reads, and an explicit `icacls ... /deny` ACE
+// doesn't block the read either for an administrator-class account
+// (the common case for CI runners too). POSIX/Linux CI stays the
+// authoritative coverage for this POSIX-permission-semantics check,
+// unaffected by this skip.
+test('scanCodexSessions skips an unreadable file, keeping the rest', {
+  skip: process.platform === 'win32',
+}, () => {
   const sandbox = mkdtempSync(
     join(tmpdir(), 'idd-token-cost-adapter-codex-test-'),
   );

--- a/tests/token-cost-adapter-grok.test.mts
+++ b/tests/token-cost-adapter-grok.test.mts
@@ -389,7 +389,17 @@ test('scanGrokSessions skips a malformed session that fails to harvest, keeping 
   assert.equal(results[0].sample.vendorSessionId, 'grok-basic-0001');
 });
 
-test('scanGrokSessions skips an unreadable updates.jsonl, keeping the rest', () => {
+// Skipped on Windows (#2580): `chmodSync(file, 0o000)` doesn't block a
+// subsequent `readFileSync` there -- verified empirically, Windows' own
+// read-only attribute (the closest analogue chmodSync can set) blocks
+// writes only, never reads, and an explicit `icacls ... /deny` ACE
+// doesn't block the read either for an administrator-class account
+// (the common case for CI runners too). POSIX/Linux CI stays the
+// authoritative coverage for this POSIX-permission-semantics check,
+// unaffected by this skip.
+test('scanGrokSessions skips an unreadable updates.jsonl, keeping the rest', {
+  skip: process.platform === 'win32',
+}, () => {
   const sandbox = mkdtempSync(
     join(tmpdir(), 'idd-token-cost-adapter-grok-test-'),
   );

--- a/tests/token-cost-event.test.mts
+++ b/tests/token-cost-event.test.mts
@@ -348,7 +348,16 @@ test('CLI --strict rejects an unknown --stage and writes nothing', () => {
   }
 });
 
-test('CLI default (non-strict) mode exits 0 with a warning when --out is on a read-only path', () => {
+// Skipped on Windows (#2580): `chmodSync(dir, 0o500)` doesn't block a
+// subsequent `mkdirSync` inside that directory there -- verified
+// empirically, Windows' own read-only attribute on a directory doesn't
+// propagate to block creating files/subdirectories inside it the way a
+// POSIX write-permission removal does. POSIX/Linux CI stays the
+// authoritative coverage for this POSIX-permission-semantics check,
+// unaffected by this skip.
+test('CLI default (non-strict) mode exits 0 with a warning when --out is on a read-only path', {
+  skip: process.platform === 'win32',
+}, () => {
   const dir = tempDir();
   try {
     const readonlyDir = join(dir, 'readonly');


### PR DESCRIPTION
# Summary

Four tests use `chmodSync` to remove a POSIX permission bit
(executable or writable) as a fault-injection precondition, then
assert the production code detects the resulting broken state. On
native Windows none of these faults can actually be constructed this
way, so every assertion failed there. Confirmed empirically on this
machine (each probed directly with a small standalone script before
touching any test):

- `accessSync(path, X_OK)` unconditionally succeeds regardless of
  `chmodSync(path, 0o644)` -- Windows has no POSIX execute-permission
  bit for `X_OK` to detect the absence of.
- `chmodSync(path, 0o000)` does not block a subsequent `readFileSync`
  -- Windows' read-only attribute blocks writes only, never reads. An
  explicit `icacls /deny Everyone:(R,W)` ACE listed first in the DACL
  doesn't block the read either, for an administrator-class account
  (the common case for CI runners too).
- `chmodSync(dir, 0o500)` does not block `mkdirSync` inside that
  directory -- the read-only attribute on a Windows folder doesn't
  propagate to block writes inside it.

Since no reachable Windows-side equivalent exists for any of these
four, each test is now skipped on `win32` via `node:test`'s
`{ skip: ... }` option, with a comment citing the specific empirical
finding. All four production code paths were already correct -- this
is a test-only change. POSIX/Linux CI stays the authoritative,
unaffected coverage.

This refines the linked issue's own speculated fix ("find a
cross-platform mechanism") -- that turned out not to be reachable for
any of the four sites once actually tested, as documented in the B2
plan comment on the issue.

## Linked issue

Closes #2580

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Validated on native Windows: all four previously-failing tests now
report `SKIP` (not silently passing or vanishing) under
`node --test`. Full suite: 4975 pass, 16 fail (all pre-existing and
unrelated -- 5 in `evaluateLocalCoordinationState`/worktree-path
fixtures already tracked as #2576, 3 in `applyImportPlan` already
tracked as #2577, 4 in `verify-install-deps` CLI tests, 4 in
`resolveUserGlobalConfigPath` -- the latter two not yet filed as of
this PR), 7 skipped (4 from this change plus 3 pre-existing).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (see Background/rationale above)
- [x] `node scripts/audit-docs.mjs --check` (no docs touched)
- [ ] `pnpm run docs:sync:check` (no docs touched by this change)
- [x] `node scripts/idd-doctor.mjs`

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJ2EuubG4Ynv5zPVYURFvu
