### PR TITLE
fix(idd-roadmap-audit): normalize git-path joins on native Windows

### DIFF
--- a/scripts/idd-roadmap-audit-execute.mjs
+++ b/scripts/idd-roadmap-audit-execute.mjs
@@ -18,11 +18,6 @@
 // work is NEVER closed.
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
-import {
-  isAbsolute,
-  join as joinPath,
-  resolve as resolvePath,
-} from 'node:path';
 import { parseCliArgs } from './cli-args.mjs';
 import {
   buildIssueLoader,
@@ -662,6 +657,35 @@ export function findWorktreeEntryForBranch(entries, branchName) {
   return findWorktreeEntriesForBranch(entries, branchName)[0] ?? null;
 }
 /**
+ * True for a POSIX absolute path (`/...`), a Windows drive-absolute path
+ * (`C:/...` or `C:\...`), or a Windows UNC path (`\\server\share`) (#2576).
+ */
+function isGitPathAbsolute(value) {
+  return /^(\/|[A-Za-z]:[\\/]|\\\\)/.test(value);
+}
+/**
+ * Join a git-porcelain-derived worktree path with a (possibly relative)
+ * `git rev-parse --git-path` output, using forward slashes throughout
+ * (#2576). `git worktree list --porcelain` and `git rev-parse --git-path`
+ * both always report forward-slash paths, even on native Windows, so
+ * building the combined path this way — instead of through the platform's
+ * native `path.resolve`/`path.join` (which reformat to backslash and, for a
+ * root-relative but drive-letter-less input, silently guess a drive letter
+ * from `process.cwd()`, corrupting the result) — stays functionally correct
+ * on disk (Windows' filesystem APIs, and Node's `fs` module, accept
+ * forward-slash paths interchangeably with backslash ones) and consistent
+ * with whatever git itself reported for the same location. `relative` may
+ * itself already be absolute (git-path output sometimes is); in that case
+ * it is returned unchanged, `worktreePath` is not consulted at all.
+ */
+function joinGitPath(worktreePath, relative) {
+  if (isGitPathAbsolute(relative)) {
+    return relative;
+  }
+  const base = worktreePath.replace(/[\\/]+$/, '');
+  return `${base}/${relative}`;
+}
+/**
  * True when a rebase sequencer directory exists for `worktreePath` (#2225,
  * AC4), resolved via `git -C <worktreePath> rev-parse --git-path <name>`
  * rather than a hardcoded `.git/rebase-merge` / `.git/rebase-apply` path. A
@@ -680,9 +704,7 @@ function hasInProgressRebase(worktreePath, resolveGitPath, pathExists) {
     if (resolved.length === 0) {
       continue;
     }
-    const absolute = isAbsolute(resolved)
-      ? resolved
-      : resolvePath(worktreePath, resolved);
+    const absolute = joinGitPath(worktreePath, resolved);
     if (pathExists(absolute)) {
       return true;
     }
@@ -710,13 +732,11 @@ function resolveDetachedRebaseBranch(worktreePath, inputs) {
     if (resolved.length === 0) {
       continue;
     }
-    const absolute = isAbsolute(resolved)
-      ? resolved
-      : resolvePath(worktreePath, resolved);
+    const absolute = joinGitPath(worktreePath, resolved);
     if (!inputs.pathExists(absolute)) {
       continue;
     }
-    const headName = inputs.readFile(joinPath(absolute, 'head-name'));
+    const headName = inputs.readFile(joinGitPath(absolute, 'head-name'));
     if (headName && headName.trim().length > 0) {
       return branchNameFromRef(headName.trim());
     }

--- a/src/scripts/idd-roadmap-audit-execute.mts
+++ b/src/scripts/idd-roadmap-audit-execute.mts
@@ -19,11 +19,6 @@
 
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
-import {
-  isAbsolute,
-  join as joinPath,
-  resolve as resolvePath,
-} from 'node:path';
 
 import { parseCliArgs } from './cli-args.mts';
 import {
@@ -881,6 +876,37 @@ export function findWorktreeEntryForBranch(
 }
 
 /**
+ * True for a POSIX absolute path (`/...`), a Windows drive-absolute path
+ * (`C:/...` or `C:\...`), or a Windows UNC path (`\\server\share`) (#2576).
+ */
+function isGitPathAbsolute(value: string): boolean {
+  return /^(\/|[A-Za-z]:[\\/]|\\\\)/.test(value);
+}
+
+/**
+ * Join a git-porcelain-derived worktree path with a (possibly relative)
+ * `git rev-parse --git-path` output, using forward slashes throughout
+ * (#2576). `git worktree list --porcelain` and `git rev-parse --git-path`
+ * both always report forward-slash paths, even on native Windows, so
+ * building the combined path this way — instead of through the platform's
+ * native `path.resolve`/`path.join` (which reformat to backslash and, for a
+ * root-relative but drive-letter-less input, silently guess a drive letter
+ * from `process.cwd()`, corrupting the result) — stays functionally correct
+ * on disk (Windows' filesystem APIs, and Node's `fs` module, accept
+ * forward-slash paths interchangeably with backslash ones) and consistent
+ * with whatever git itself reported for the same location. `relative` may
+ * itself already be absolute (git-path output sometimes is); in that case
+ * it is returned unchanged, `worktreePath` is not consulted at all.
+ */
+function joinGitPath(worktreePath: string, relative: string): string {
+  if (isGitPathAbsolute(relative)) {
+    return relative;
+  }
+  const base = worktreePath.replace(/[\\/]+$/, '');
+  return `${base}/${relative}`;
+}
+
+/**
  * True when a rebase sequencer directory exists for `worktreePath` (#2225,
  * AC4), resolved via `git -C <worktreePath> rev-parse --git-path <name>`
  * rather than a hardcoded `.git/rebase-merge` / `.git/rebase-apply` path. A
@@ -906,9 +932,7 @@ function hasInProgressRebase(
     if (resolved.length === 0) {
       continue;
     }
-    const absolute = isAbsolute(resolved)
-      ? resolved
-      : resolvePath(worktreePath, resolved);
+    const absolute = joinGitPath(worktreePath, resolved);
     if (pathExists(absolute)) {
       return true;
     }
@@ -990,13 +1014,11 @@ function resolveDetachedRebaseBranch(
     if (resolved.length === 0) {
       continue;
     }
-    const absolute = isAbsolute(resolved)
-      ? resolved
-      : resolvePath(worktreePath, resolved);
+    const absolute = joinGitPath(worktreePath, resolved);
     if (!inputs.pathExists(absolute)) {
       continue;
     }
-    const headName = inputs.readFile(joinPath(absolute, 'head-name'));
+    const headName = inputs.readFile(joinGitPath(absolute, 'head-name'));
     if (headName && headName.trim().length > 0) {
       return branchNameFromRef(headName.trim());
     }

--- a/tests/idd-roadmap-audit-execute.test.mts
+++ b/tests/idd-roadmap-audit-execute.test.mts
@@ -2091,6 +2091,17 @@ function fixtureGitOut(cwd: string, args: string[]): string {
  */
 const realLocalInputs = createLocalCoordinationInputs;
 
+// `git worktree list --porcelain` always reports forward-slash paths, even
+// on native Windows (#2576), while `mkdtempSync`/`path.join` below compute
+// this test's own "expected" path with the platform's native separator
+// (backslash on win32). Both name the identical filesystem location, so
+// normalize the native-separator side before comparing against a value that
+// came from -- or through -- parsed porcelain output. A no-op on POSIX,
+// where the native separator already matches porcelain's.
+function toGitPorcelainPath(nativePath: string): string {
+  return nativePath.replaceAll('\\', '/');
+}
+
 function setupPrimaryRepo(): string {
   const primary = mkdtempSync(join(tmpdir(), 'idd-roadmap-local-'));
   fixtureGit(primary, ['init', '-b', 'main']);
@@ -2161,7 +2172,10 @@ test('AC3 real fixture: a detached worktree is correctly detected via porcelain 
       '-z',
     ]);
     const entries = parseWorktreeListPorcelain(porcelain);
-    const detachedEntry = entries.find((entry) => entry.path === detached);
+    const detachedPorcelainPath = toGitPorcelainPath(detached);
+    const detachedEntry = entries.find(
+      (entry) => entry.path === detachedPorcelainPath,
+    );
     assert.equal(detachedEntry?.detached, true);
     assert.equal(detachedEntry?.branchRef, null);
 
@@ -2171,7 +2185,7 @@ test('AC3 real fixture: a detached worktree is correctly detected via porcelain 
       'roadmap-audit/995-slug',
       realLocalInputs(primary),
     );
-    assert.deepEqual(verdict.detachedWorktreePaths, [detached]);
+    assert.deepEqual(verdict.detachedWorktreePaths, [detachedPorcelainPath]);
   } finally {
     try {
       fixtureGit(primary, ['worktree', 'remove', '--force', detached]);
@@ -2351,7 +2365,17 @@ test('real fixture: a dirty submodule reports present-broken even under diff.ign
   }
 });
 
-test('real fixture: a worktree path with trailing whitespace is matched correctly, not silently trimmed away (review finding, #2225)', () => {
+test('real fixture: a worktree path with trailing whitespace is matched correctly, not silently trimmed away (review finding, #2225)', {
+  // Windows itself refuses to create a directory whose name ends in a
+  // space (`git worktree add` there fails with "could not create leading
+  // directories ... Invalid argument") -- an OS-level constraint, not a
+  // bug in this repository's code, so this regression cannot be exercised
+  // as a real git fixture on native Windows (#2576). POSIX has no such
+  // restriction and keeps running the real-fixture coverage unchanged.
+  skip:
+    process.platform === 'win32' &&
+    'Windows cannot create a directory with a trailing space in its name',
+}, () => {
   const primary = setupPrimaryRepo();
   // A trailing space in the directory name: `-z`'s exact field boundary
   // preserves it, and the parser must not strip it back off.
@@ -2372,7 +2396,7 @@ test('real fixture: a worktree path with trailing whitespace is matched correctl
       realLocalInputs(primary),
     );
     assert.equal(verdict.presence, 'present-broken');
-    assert.equal(verdict.path, worktree);
+    assert.equal(verdict.path, toGitPorcelainPath(worktree));
     assert.deepEqual(verdict.brokenReasons, ['uncommitted content present']);
   } finally {
     try {
@@ -2454,7 +2478,7 @@ test('real fixture: local git shell-outs ignore ambient GIT_* overrides and neve
         createLocalCoordinationInputs(primary),
       );
       assert.equal(verdict.presence, 'present-clean');
-      assert.equal(verdict.path, worktree);
+      assert.equal(verdict.path, toGitPorcelainPath(worktree));
       assert.equal(verdict.unreadable, false);
     } finally {
       for (const [key, value] of saved) {

--- a/tests/idd-roadmap-audit-execute.test.mts
+++ b/tests/idd-roadmap-audit-execute.test.mts
@@ -1860,6 +1860,33 @@ test('evaluateLocalCoordinationState resolves a RELATIVE --git-path output again
   assert.deepEqual(verdict.brokenReasons, ['rebase in progress']);
 });
 
+test('evaluateLocalCoordinationState resolves a RELATIVE --git-path output against a Windows drive-absolute worktree path without corrupting the drive letter or separators (#2576)', () => {
+  // A real worktree path always carries a drive letter on native Windows
+  // (unlike the plain `/repo/wt` fixture above), so this specifically
+  // exercises `isGitPathAbsolute`'s drive-letter branch and demonstrates
+  // that `joinGitPath` never re-guesses a drive letter the way
+  // `path.resolve('C:/repo/wt', '.git/rebase-merge')` would if the input
+  // lacked one -- it also never reformats the forward-slash join to
+  // backslash, matching git's own porcelain convention.
+  const verdict = evaluateLocalCoordinationState(
+    'roadmap-audit/995-slug',
+    localInputs({
+      listWorktrees: () =>
+        OK(
+          toZ(
+            'worktree C:/repo/wt\nHEAD abc123\nbranch refs/heads/roadmap-audit/995-slug\n',
+          ),
+        ),
+      statusPorcelain: () => OK(''),
+      resolveGitPath: (_worktreePath, name) =>
+        name === 'rebase-merge' ? OK('.git/rebase-merge\n') : FAIL('none'),
+      pathExists: (path) => path === 'C:/repo/wt/.git/rebase-merge',
+    }),
+  );
+  assert.equal(verdict.presence, 'present-broken');
+  assert.deepEqual(verdict.brokenReasons, ['rebase in progress']);
+});
+
 test('evaluateLocalCoordinationState reports locked directly from porcelain without probing status or rebase', () => {
   const calls = { status: 0, gitPath: 0 };
   const verdict = evaluateLocalCoordinationState(

--- a/tests/idd-roadmap-audit-execute.test.mts
+++ b/tests/idd-roadmap-audit-execute.test.mts
@@ -1862,12 +1862,15 @@ test('evaluateLocalCoordinationState resolves a RELATIVE --git-path output again
 
 test('evaluateLocalCoordinationState resolves a RELATIVE --git-path output against a Windows drive-absolute worktree path without corrupting the drive letter or separators (#2576)', () => {
   // A real worktree path always carries a drive letter on native Windows
-  // (unlike the plain `/repo/wt` fixture above), so this specifically
-  // exercises `isGitPathAbsolute`'s drive-letter branch and demonstrates
-  // that `joinGitPath` never re-guesses a drive letter the way
-  // `path.resolve('C:/repo/wt', '.git/rebase-merge')` would if the input
-  // lacked one -- it also never reformats the forward-slash join to
-  // backslash, matching git's own porcelain convention.
+  // (unlike the plain `/repo/wt` fixture above). `resolveGitPath`'s output
+  // here is still RELATIVE (`isGitPathAbsolute` is false for it, same as the
+  // `/repo/wt` case above), so this exercises `joinGitPath`'s
+  // string-concatenation branch with a drive-absolute BASE: it demonstrates
+  // that base is preserved verbatim (no re-guessing a drive letter the way
+  // `path.resolve('C:/repo/wt', '.git/rebase-merge')` would need to if the
+  // base lacked one, and no reformatting to backslash). It does NOT exercise
+  // `isGitPathAbsolute` returning true for a drive-letter path -- see the
+  // next test for that.
   const verdict = evaluateLocalCoordinationState(
     'roadmap-audit/995-slug',
     localInputs({
@@ -1881,6 +1884,37 @@ test('evaluateLocalCoordinationState resolves a RELATIVE --git-path output again
       resolveGitPath: (_worktreePath, name) =>
         name === 'rebase-merge' ? OK('.git/rebase-merge\n') : FAIL('none'),
       pathExists: (path) => path === 'C:/repo/wt/.git/rebase-merge',
+    }),
+  );
+  assert.equal(verdict.presence, 'present-broken');
+  assert.deepEqual(verdict.brokenReasons, ['rebase in progress']);
+});
+
+test('evaluateLocalCoordinationState treats an ABSOLUTE Windows drive-letter --git-path output as already-absolute, without double-joining it onto the worktree path (#2576)', () => {
+  // Real `git rev-parse --git-path` output on native Windows is itself
+  // drive-absolute (confirmed empirically against a real linked worktree:
+  // e.g. `C:/Users/.../primary/.git/worktrees/wt/rebase-merge`) -- this is
+  // the common real-world case, not the relative one above. This exercises
+  // `isGitPathAbsolute`'s `[A-Za-z]:[\\/]` regex branch directly: if it ever
+  // failed to recognize a drive-letter path as absolute, `joinGitPath` would
+  // wrongly concatenate the worktree path onto it (producing something like
+  // `C:/repo/wt/C:/repo/.git/worktrees/wt/rebase-merge`), which `pathExists`
+  // would never find -- silently reporting no rebase in progress.
+  const verdict = evaluateLocalCoordinationState(
+    'roadmap-audit/995-slug',
+    localInputs({
+      listWorktrees: () =>
+        OK(
+          toZ(
+            'worktree C:/repo/wt\nHEAD abc123\nbranch refs/heads/roadmap-audit/995-slug\n',
+          ),
+        ),
+      statusPorcelain: () => OK(''),
+      resolveGitPath: (_worktreePath, name) =>
+        name === 'rebase-merge'
+          ? OK('C:/repo/.git/worktrees/wt/rebase-merge\n')
+          : FAIL('none'),
+      pathExists: (path) => path === 'C:/repo/.git/worktrees/wt/rebase-merge',
     }),
   );
   assert.equal(verdict.presence, 'present-broken');


### PR DESCRIPTION
# Summary

`evaluateLocalCoordinationState` gates whether an autonomous
roadmap-audit mutation may proceed, by inspecting local `git worktree`
state for a leftover dirty/broken worktree. On native Windows it
mismatched path separators: `git worktree list --porcelain` always
reports forward-slash paths, while Node's native
`path.resolve`/`path.join` reformat to backslash and, for a
drive-letter-less root-relative input, silently guess a drive letter
from `process.cwd()` — corrupting the result rather than merely
re-separating it. This caused 5 of 110 tests in
`tests/idd-roadmap-audit-execute.test.mts` to fail on native Windows.

Fix: add a small `joinGitPath`/`isGitPathAbsolute` helper that
combines a worktree path with a (possibly relative)
`git rev-parse --git-path` output using forward slashes throughout,
used at the two internal call sites that perform this combination
(`hasInProgressRebase`, `resolveDetachedRebaseBranch`). Windows'
filesystem APIs accept forward-slash paths interchangeably with
backslash ones, so this stays correct on disk while matching git's
own porcelain convention. `evaluateLocalCoordinationState`'s returned
`path`/`detachedWorktreePaths` fields were already an untouched
passthrough of git's own output and needed no change.

Two of the five originally-failing tests needed no test-file changes
at all — their existing hardcoded fixture literals already described
the git-canonical forward-slash form the fix now produces. The other
three (two real-git-fixture tests, one platform constraint) needed
test-side adjustments — see commit messages for detail.

A three-round self-review (C1 critique) caught that the first
follow-up test I added didn't actually exercise the code path it
claimed to (its `resolveGitPath` mock stayed relative, so
`isGitPathAbsolute` never saw a drive-letter argument) — a second
follow-up commit added the correct test and confirmed, by empirically
querying a real linked worktree on this machine, that
`git rev-parse --git-path` output is itself drive-absolute on native
Windows (the common case, not an edge case).

No other function in `idd-roadmap-audit-execute.mts` was touched, per
the issue's own scope constraint.

## Linked issue

Closes #2576

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`hasInProgressRebase`/`resolveDetachedRebaseBranch` are private
helpers reached only through `evaluateLocalCoordinationState`'s own
call graph (confirmed via grep — no other caller). The relative
`--git-path`-output branch these functions defend against appears to
be a defensive/legacy path: on this machine's git, `--git-path`
always returns an absolute path for a linked worktree. The fix
handles both shapes correctly regardless.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`biome check`, `dprint check`, `markdownlint-cli2`, `cspell lint`)
- [x] `pnpm test` (`node --test tests/idd-roadmap-audit-execute.test.mts`: 112 pass, 0 fail, 1 skipped by design on win32; full suite otherwise unchanged from the pre-existing baseline)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (n/a — no docs changed; `audit-docs.mjs --check` covers sync drift)
- [x] `node scripts/idd-doctor.mjs` (if applicable) — passed, only pre-existing unrelated warnings
- [x] `pnpm run typecheck`, `pnpm run build:check` (no drift, `.mjs` mirror regenerated and committed)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none — test/source fix only)
- [x] Context budget impact reviewed (none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCsJWegXKTXMsNCE7DHxDM
