### PR TITLE
fix(tests): make the fake install command cross-platform

### DIFF
--- a/tests/verify-install-deps.test.mts
+++ b/tests/verify-install-deps.test.mts
@@ -48,23 +48,32 @@ const CLI_ENTRY = join(
 const KEY_BINARY = 'node_modules/.bin/tsc';
 
 /**
- * A shell one-liner (run via `sh -c`, same as the tool's own runInstallCommand)
- * that counts its own invocations via CALL_LOG and, once `calls` reaches
- * `hitOnAttempt`, creates KEY_BINARY. `exitNonZeroBefore` optionally makes
- * every call before that attempt exit 1, to simulate a hard install failure.
+ * A `node -e` one-liner (run via the platform shell, same as the tool's own
+ * runInstallCommand) that counts its own invocations via CALL_LOG and, once
+ * `calls` reaches `hitOnAttempt`, creates KEY_BINARY. `exitNonZeroBefore`
+ * optionally makes every call before that attempt exit 1, to simulate a hard
+ * install failure. Using `node -e` instead of POSIX shell syntax (`[ -f ... ]`,
+ * `wc -l`, `mkdir -p`) means the same generated string works whether
+ * `execFileSync(installCommand, [], { shell: true })` invokes `/bin/sh`
+ * (POSIX) or `cmd.exe` (Windows) -- the script body uses only single-quoted
+ * JS string literals and no `$`/`%...%` shell-expansion syntax, so the whole
+ * `-e` argument can be safely double-quoted for either shell.
  */
 function fakeInstallCommand(
   hitOnAttempt: number,
   exitNonZeroBefore = false,
 ): string {
-  return [
-    'calls=0',
-    '[ -f "$CALL_LOG" ] && calls=$(wc -l < "$CALL_LOG" | tr -d \' \')',
-    'echo x >> "$CALL_LOG"',
-    'calls=$((calls + 1))',
-    `if [ "$calls" -ge ${hitOnAttempt} ]; then mkdir -p node_modules/.bin && touch ${KEY_BINARY}; exit 0; fi`,
-    exitNonZeroBefore ? 'exit 1' : 'exit 0',
+  const script = [
+    "const fs = require('fs')",
+    'const p = process.env.CALL_LOG',
+    'let calls = 0',
+    "try { calls = fs.readFileSync(p, 'utf8').split('\\n').filter(Boolean).length } catch {}",
+    'calls += 1',
+    "fs.appendFileSync(p, 'x\\n')",
+    `if (calls >= ${hitOnAttempt}) { fs.mkdirSync('node_modules/.bin', { recursive: true }); fs.writeFileSync('${KEY_BINARY}', ''); process.exit(0) }`,
+    exitNonZeroBefore ? 'process.exit(1)' : 'process.exit(0)',
   ].join('; ');
+  return `node -e "${script}"`;
 }
 
 interface CliRun {


### PR DESCRIPTION
# Summary

Four CLI-integration tests in `tests/verify-install-deps.test.mts`
failed on native Windows. The tests' `fakeInstallCommand` helper
generated a POSIX shell one-liner (`[ -f ... ]`, `wc -l`, `mkdir -p`),
but the production `runInstallCommand` it mirrors correctly invokes
the configured install command via `execFileSync(installCommand, [],
{ shell: true })` -- Node's platform shell, `cmd.exe` on Windows, not a
hard-coded `/bin/sh`. `cmd.exe` doesn't understand the POSIX syntax,
so the fake command failed there regardless of what production code
does. `src/scripts/verify-install-deps.mts` is unaffected -- this is a
test-only fix.

Rewrite `fakeInstallCommand` as a `node -e "<script>"` one-liner
instead: the script uses only single-quoted JS string literals and no
`$`-shell-expansion or `%...%`-shaped text, so the same generated
string works identically whether `shell: true` invokes `/bin/sh` or
`cmd.exe`. Verified directly via `execFileSync(cmd, [], { shell: true
})` on this Windows machine, for both the plain-success path and the
`exitNonZeroBefore` retry path, before touching the test file itself.
The helper's full behavior contract (`CALL_LOG`-based invocation
counting, creating `KEY_BINARY` at the configured attempt, optional
non-zero exit before that attempt) is unchanged -- no test assertion
needed to change, only the generated command string.

## Linked issue

Closes #2581

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Validated on native Windows: all four previously-failing tests now
pass under `node --test tests/verify-install-deps.test.mts` (10/10).
Full suite: 4981 pass, 10 fail (all pre-existing and unrelated -- 4 in
`resolveUserGlobalConfigPath`, 5 in `evaluateLocalCoordinationState`/
worktree-path fixtures already tracked as #2576, 1 in `applyImportPlan`
partially tracked as #2577), 7 skipped (pre-existing, unrelated to
this change).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (see Background/rationale above)
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (no docs touched by this change)
- [x] `node scripts/idd-doctor.mjs`

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJ2EuubG4Ynv5zPVYURFvu
