### PR TITLE
fix(tests): markdownlint-cli2/cspell node_modules/.bin spawnSync calls ENOENT on native Windows

### DIFF
--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -3332,16 +3332,19 @@ test('the ONBOARDING.md CLI-assisted onboarding section anchors its --import fil
 // Resolve markdownlint-cli2/cspell by their own package.json `bin` entry and
 // run them directly through `process.execPath`, rather than by
 // `spawnSync('.../node_modules/.bin/markdownlint-cli2' | '.../cspell', ...)`.
-// On native Windows, `node_modules/.bin/markdownlint-cli2` and
-// `node_modules/.bin/cspell` are POSIX shell shims; the executable form
-// Windows actually resolves for a bare command is `.CMD` (or `.ps1`) via
-// `PATHEXT`. `spawnSync`/`execFileSync` without `shell: true` never apply
-// `PATHEXT` resolution, so invoking the bare `.bin` path fails with `ENOENT`
-// there even though the shim is genuinely on PATH -- the same root cause
+// `MARKDOWNLINT_BIN`/`CSPELL_BIN` were always absolute paths, not bare
+// commands relying on a PATH search -- but on native Windows,
+// `node_modules/.bin/markdownlint-cli2` and `node_modules/.bin/cspell` are
+// POSIX shell shims with no recognized Windows-executable extension, so
+// Windows still can't launch that exact file. `shell: true` alone fixes
+// it (verified: it makes `cmd.exe` apply its own `PATHEXT`-based extension
+// dispatch to that same absolute path, finding `<name>.CMD`), but
+// `spawnSync`/`execFileSync` without `shell: true` never invoke a shell at
+// all, so no extension dispatch of any kind happens -- the same root cause
 // #2569 fixed for tsc/biome in `src/scripts/build-ts.mts`'s
 // `resolveBinScript`. Resolving the package's real JS entry point and
-// running it through `process.execPath` sidesteps PATH/`PATHEXT` lookup
-// entirely, so it behaves identically on every platform.
+// running it through `process.execPath` sidesteps the shell (and its
+// PATHEXT dispatch) entirely, so it behaves identically on every platform.
 //
 // Unlike `typescript`/`@biomejs/biome`, both `markdownlint-cli2` and
 // `cspell` declare a package.json `exports` map with no `./package.json`
@@ -3349,12 +3352,11 @@ test('the ONBOARDING.md CLI-assisted onboarding section anchors its --import fil
 // (`require.resolve`) throws `ERR_PACKAGE_PATH_NOT_EXPORTED` for either --
 // this reads `node_modules/<packageName>/package.json` directly instead.
 //
-// Returns `undefined` only when `package.json` itself is absent -- the
-// expected bare-node lane case (see the block comment above) where the
-// package genuinely isn't installed. A `package.json` that IS present but
-// has no matching `bin` entry is an unexpected packaging/fixture problem,
-// not a "not installed" state, so that case throws instead of silently
-// returning `undefined` and letting the caller mistake it for a skip.
+// Throws when `package.json` is present but has no matching `bin` entry,
+// or when the `bin` entry points at a script that doesn't actually exist
+// (a partial/corrupted install) -- either is an unexpected packaging/
+// fixture problem, not a "not installed" state, so it should fail loudly
+// here rather than let the caller silently treat it as a skip.
 function resolveBinScript(packageName: string, binName: string): string {
   const packageJsonPath = join(
     REPO_ROOT,
@@ -3371,10 +3373,18 @@ function resolveBinScript(packageName: string, binName: string): string {
       `${packageName}: package.json has no "${binName}" bin entry`,
     );
   }
-  return join(dirname(packageJsonPath), relativePath);
+  const scriptPath = join(dirname(packageJsonPath), relativePath);
+  if (!existsSync(scriptPath)) {
+    throw new Error(
+      `${packageName}: bin entry "${binName}" points at a missing file: ${scriptPath}`,
+    );
+  }
+  return scriptPath;
 }
 
-/** `resolveBinScript`, but `undefined` when the package isn't installed at all. */
+// `resolveBinScript`, but returns `undefined` instead of throwing when
+// `package.json` itself is absent -- the expected bare-node lane case (see
+// the block comment above) where the package genuinely isn't installed.
 function tryResolveBinScript(
   packageName: string,
   binName: string,
@@ -3395,11 +3405,9 @@ const MARKDOWNLINT_BIN = tryResolveBinScript(
   'markdownlint-cli2',
 );
 const CSPELL_BIN = tryResolveBinScript('cspell', 'cspell');
-const LINT_BINARIES_INSTALLED =
-  MARKDOWNLINT_BIN !== undefined && CSPELL_BIN !== undefined;
 
 test('a real import + substitute produces a doc tree that passes the documented markdownlint/cspell commands with full file coverage (idd-skill#1860)', (t) => {
-  if (!LINT_BINARIES_INSTALLED || !MARKDOWNLINT_BIN || !CSPELL_BIN) {
+  if (!MARKDOWNLINT_BIN || !CSPELL_BIN) {
     // Expected on the bare-node lane (lint.yml), which runs this suite with
     // no package-manager install by design -- see the block comment above.
     t.skip('markdownlint-cli2/cspell are not installed in this environment');

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -3329,18 +3329,57 @@ test('the ONBOARDING.md CLI-assisted onboarding section anchors its --import fil
 // binaries it needs are not installed, instead of failing that lane.
 // ---------------------------------------------------------------------------
 
-const MARKDOWNLINT_BIN = join(
-  REPO_ROOT,
-  'node_modules',
-  '.bin',
+// Resolve markdownlint-cli2/cspell by their own package.json `bin` entry and
+// run them directly through `process.execPath`, rather than by
+// `spawnSync('.../node_modules/.bin/markdownlint-cli2' | '.../cspell', ...)`.
+// On native Windows, `node_modules/.bin/markdownlint-cli2` and
+// `node_modules/.bin/cspell` are POSIX shell shims; the executable form
+// Windows actually resolves for a bare command is `.CMD` (or `.ps1`) via
+// `PATHEXT`. `spawnSync`/`execFileSync` without `shell: true` never apply
+// `PATHEXT` resolution, so invoking the bare `.bin` path fails with `ENOENT`
+// there even though the shim is genuinely on PATH -- the same root cause
+// #2569 fixed for tsc/biome in `src/scripts/build-ts.mts`'s
+// `resolveBinScript`. Resolving the package's real JS entry point and
+// running it through `process.execPath` sidesteps PATH/`PATHEXT` lookup
+// entirely, so it behaves identically on every platform.
+//
+// Unlike `typescript`/`@biomejs/biome`, both `markdownlint-cli2` and
+// `cspell` declare a package.json `exports` map with no `./package.json`
+// subpath, so `require.resolve(`${packageName}/package.json`)` throws
+// `ERR_PACKAGE_PATH_NOT_EXPORTED` for either -- this reads `node_modules/
+// <packageName>/package.json` directly instead of through `require.resolve`.
+function resolveBinScript(
+  packageName: string,
+  binName: string,
+): string | undefined {
+  const packageJsonPath = join(
+    REPO_ROOT,
+    'node_modules',
+    packageName,
+    'package.json',
+  );
+  if (!existsSync(packageJsonPath)) {
+    return undefined;
+  }
+  const { bin } = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
+    bin?: string | Record<string, string>;
+  };
+  const relativePath = typeof bin === 'string' ? bin : bin?.[binName];
+  return relativePath === undefined
+    ? undefined
+    : join(dirname(packageJsonPath), relativePath);
+}
+
+const MARKDOWNLINT_BIN = resolveBinScript(
+  'markdownlint-cli2',
   'markdownlint-cli2',
 );
-const CSPELL_BIN = join(REPO_ROOT, 'node_modules', '.bin', 'cspell');
+const CSPELL_BIN = resolveBinScript('cspell', 'cspell');
 const LINT_BINARIES_INSTALLED =
-  existsSync(MARKDOWNLINT_BIN) && existsSync(CSPELL_BIN);
+  MARKDOWNLINT_BIN !== undefined && CSPELL_BIN !== undefined;
 
 test('a real import + substitute produces a doc tree that passes the documented markdownlint/cspell commands with full file coverage (idd-skill#1860)', (t) => {
-  if (!LINT_BINARIES_INSTALLED) {
+  if (!LINT_BINARIES_INSTALLED || !MARKDOWNLINT_BIN || !CSPELL_BIN) {
     // Expected on the bare-node lane (lint.yml), which runs this suite with
     // no package-manager install by design -- see the block comment above.
     t.skip('markdownlint-cli2/cspell are not installed in this environment');
@@ -3381,20 +3420,28 @@ test('a real import + substitute produces a doc tree that passes the documented 
   assert.equal(substituted.verdict.written, true);
   assert.deepEqual(substituted.verdict.residue, []);
 
-  const markdownlintResult = spawnSync(MARKDOWNLINT_BIN, ['**/*.md'], {
-    cwd: targetRoot,
-    encoding: 'utf8',
-  });
+  const markdownlintResult = spawnSync(
+    process.execPath,
+    [MARKDOWNLINT_BIN, '**/*.md'],
+    {
+      cwd: targetRoot,
+      encoding: 'utf8',
+    },
+  );
   assert.equal(
     markdownlintResult.status,
     0,
     `markdownlint-cli2 findings against the imported docs:\n${markdownlintResult.stdout}${markdownlintResult.stderr}`,
   );
 
-  const cspellResult = spawnSync(CSPELL_BIN, ['lint', '**', '--no-progress'], {
-    cwd: targetRoot,
-    encoding: 'utf8',
-  });
+  const cspellResult = spawnSync(
+    process.execPath,
+    [CSPELL_BIN, 'lint', '**', '--no-progress'],
+    {
+      cwd: targetRoot,
+      encoding: 'utf8',
+    },
+  );
   assert.equal(
     cspellResult.status,
     0,

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -3345,10 +3345,37 @@ test('the ONBOARDING.md CLI-assisted onboarding section anchors its --import fil
 //
 // Unlike `typescript`/`@biomejs/biome`, both `markdownlint-cli2` and
 // `cspell` declare a package.json `exports` map with no `./package.json`
-// subpath, so `require.resolve(`${packageName}/package.json`)` throws
-// `ERR_PACKAGE_PATH_NOT_EXPORTED` for either -- this reads `node_modules/
-// <packageName>/package.json` directly instead of through `require.resolve`.
-function resolveBinScript(
+// subpath, so resolving that subpath through Node's own package resolver
+// (`require.resolve`) throws `ERR_PACKAGE_PATH_NOT_EXPORTED` for either --
+// this reads `node_modules/<packageName>/package.json` directly instead.
+//
+// Returns `undefined` only when `package.json` itself is absent -- the
+// expected bare-node lane case (see the block comment above) where the
+// package genuinely isn't installed. A `package.json` that IS present but
+// has no matching `bin` entry is an unexpected packaging/fixture problem,
+// not a "not installed" state, so that case throws instead of silently
+// returning `undefined` and letting the caller mistake it for a skip.
+function resolveBinScript(packageName: string, binName: string): string {
+  const packageJsonPath = join(
+    REPO_ROOT,
+    'node_modules',
+    packageName,
+    'package.json',
+  );
+  const { bin } = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
+    bin?: string | Record<string, string>;
+  };
+  const relativePath = typeof bin === 'string' ? bin : bin?.[binName];
+  if (relativePath === undefined) {
+    throw new Error(
+      `${packageName}: package.json has no "${binName}" bin entry`,
+    );
+  }
+  return join(dirname(packageJsonPath), relativePath);
+}
+
+/** `resolveBinScript`, but `undefined` when the package isn't installed at all. */
+function tryResolveBinScript(
   packageName: string,
   binName: string,
 ): string | undefined {
@@ -3358,23 +3385,16 @@ function resolveBinScript(
     packageName,
     'package.json',
   );
-  if (!existsSync(packageJsonPath)) {
-    return undefined;
-  }
-  const { bin } = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
-    bin?: string | Record<string, string>;
-  };
-  const relativePath = typeof bin === 'string' ? bin : bin?.[binName];
-  return relativePath === undefined
-    ? undefined
-    : join(dirname(packageJsonPath), relativePath);
+  return existsSync(packageJsonPath)
+    ? resolveBinScript(packageName, binName)
+    : undefined;
 }
 
-const MARKDOWNLINT_BIN = resolveBinScript(
+const MARKDOWNLINT_BIN = tryResolveBinScript(
   'markdownlint-cli2',
   'markdownlint-cli2',
 );
-const CSPELL_BIN = resolveBinScript('cspell', 'cspell');
+const CSPELL_BIN = tryResolveBinScript('cspell', 'cspell');
 const LINT_BINARIES_INSTALLED =
   MARKDOWNLINT_BIN !== undefined && CSPELL_BIN !== undefined;
 


### PR DESCRIPTION
# Summary

`node_modules/.bin/markdownlint-cli2` and `node_modules/.bin/cspell`
are POSIX shell shims on Windows; the executable form Windows
actually resolves for a bare command is `.CMD` (or `.ps1`) via
`PATHEXT`. `spawnSync` without `shell: true` never applies `PATHEXT`
resolution, so `tests/idd-onboard.test.mts`'s
`"a real import + substitute produces a doc tree that passes the
documented markdownlint/cspell commands with full file coverage
(idd-skill#1860)"` test failed with `ENOENT` before either linter
ever ran -- the same root-cause class already fixed for `tsc`/`biome`
in `#2569`.

Both `MARKDOWNLINT_BIN`/`CSPELL_BIN` are now resolved through each
package's own `package.json` `bin` entry and invoked directly via
`process.execPath`, matching `#2569`'s `resolveBinScript` pattern in
`src/scripts/build-ts.mts` (`shell: true` was the other option
flagged in the issue; went with this one for consistency with the
already-reviewed `#2569` pattern and to avoid introducing a shell
interpretation layer at all).

One difference from `#2569`'s pattern, called out in the new
`resolveBinScript`'s doc comment: unlike `typescript`/`@biomejs/biome`,
both `markdownlint-cli2` and `cspell` declare a `package.json`
`exports` map with no `./package.json` subpath, so
`require.resolve(`${packageName}/package.json`)` throws
`ERR_PACKAGE_PATH_NOT_EXPORTED` for either package (confirmed by
direct reproduction). This helper reads
`node_modules/<packageName>/package.json` directly instead.

## Linked issue

Closes #2585

## Follow-up issues (if any)

- [ ] none created

## Background / rationale (if material)

Reproduced standalone before the fix, no test framework involved:

```js
const { spawnSync } = require('node:child_process');
const { join } = require('node:path');
const bin = join(process.cwd(), 'node_modules', '.bin', 'markdownlint-cli2');
console.log(spawnSync(bin, ['--version'], { encoding: 'utf8' }));
// { status: null, error: Error: spawnSync .../markdownlint-cli2 ENOENT, code: 'ENOENT' }
```

Same for `cspell`.

Before/after, native Windows (node v22.23.2), this branch's merge base
(`6822d6e9`):

- `node --test tests/idd-onboard.test.mts` (163 tests): before this
  fix, `162` pass / `1` fail (the target test, `ENOENT`); after,
  `163` pass / `0` fail.
- `node --test tests/*.test.mts` (full suite, `4998` tests) after this
  fix: `4978` pass / `13` fail / `7` skipped. The 13 remaining
  failures are pre-existing and unrelated to this change --
  `resolveUserGlobalConfigPath` (`#2582`), `evaluateLocalCoordinationState`
  (`#2576`), and the `verify-install-deps` CLI retry tests (`#2581`),
  each already tracked and owned by another in-flight session. `0`
  regressions from this diff.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm run typecheck` (`tsc -p tsconfig.json` -- clean)
- [x] `pnpm run build:check` (clean, no diff; 2 pre-existing unrelated
      `biome` warnings in `src/scripts/protocol-helpers.mts` untouched
      by this diff)
- [x] `npx biome check` (this file: clean)
- [x] `pnpm test` (`node --test tests/*.test.mts` -- see Background
      above: 1 test fixed, 0 regressions)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `node scripts/verify-workshop-integrity.mjs --format table`
      (`0` issues)
- [x] `cspell lint "**" --no-progress` (`0` issues)
- [x] `markdownlint-cli2 "**/*.md"` (`0` issues)
- [ ] `pnpm run docs:sync:check` (not applicable -- no `docs/**` or
      `.github/instructions/**` content changed)
- [x] `node scripts/idd-doctor.mjs` (passed; pre-existing unrelated
      release-tag/adopter-profile notices only)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none -- test-only fixture fix)
- [x] Context budget impact reviewed (none -- no instruction/doc files
      changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X27jGWQk1dbPjpFchFfzzR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved documentation-lint test reliability across platforms by invoking linting tools through their resolved JavaScript entry points.
  * Tests now skip only when the required linting packages are unavailable and report failures when installed packages are missing expected executable entries.
  * Updated lint commands to use the resolved tool entry points directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->