### PR TITLE
fix(tests): parametrize resolveUserGlobalConfigPath's roots per platform

### DIFF
--- a/tests/idd-config.test.mts
+++ b/tests/idd-config.test.mts
@@ -244,24 +244,35 @@ test('loadPolicyConfig default path: throws (not silently absent) on a permissio
   });
 });
 
+// `isQualifiedConfigRoot` (src/scripts/idd-config.mts) requires a
+// Windows-native absolute root (a drive letter or a UNC `\\` prefix) on
+// win32, and a POSIX absolute root (leading `/`, not `//`) otherwise --
+// so the accepted XDG/HOME roots below must be platform-native for the
+// tests to actually exercise that acceptance path rather than its
+// rejection path.
+const XDG_CONFIG_HOME_ROOT =
+  platform === 'win32' ? 'C:\\xdg-config' : '/xdg-config';
+const HOME_ROOT =
+  platform === 'win32' ? 'C:\\Users\\operator' : '/home/operator';
+
 test('resolveUserGlobalConfigPath prefers XDG_CONFIG_HOME over HOME (#2257)', () => {
   assert.equal(
     resolveUserGlobalConfigPath({
       env: {
-        XDG_CONFIG_HOME: '/xdg-config',
-        HOME: '/home/operator',
+        XDG_CONFIG_HOME: XDG_CONFIG_HOME_ROOT,
+        HOME: HOME_ROOT,
       },
     }),
-    join('/xdg-config', 'idd-skill', 'config.json'),
+    join(XDG_CONFIG_HOME_ROOT, 'idd-skill', 'config.json'),
   );
 });
 
 test('resolveUserGlobalConfigPath falls back to HOME/.config when XDG_CONFIG_HOME is empty (#2257)', () => {
   assert.equal(
     resolveUserGlobalConfigPath({
-      env: { XDG_CONFIG_HOME: '  ', HOME: '/home/operator' },
+      env: { XDG_CONFIG_HOME: '  ', HOME: HOME_ROOT },
     }),
-    join('/home/operator', '.config', 'idd-skill', 'config.json'),
+    join(HOME_ROOT, '.config', 'idd-skill', 'config.json'),
   );
 });
 
@@ -272,9 +283,9 @@ test('resolveUserGlobalConfigPath does not consult process.env when env is injec
 test('resolveUserGlobalConfigPath ignores a relative XDG_CONFIG_HOME and requires an absolute HOME (#2257)', () => {
   assert.equal(
     resolveUserGlobalConfigPath({
-      env: { XDG_CONFIG_HOME: 'config', HOME: '/home/operator' },
+      env: { XDG_CONFIG_HOME: 'config', HOME: HOME_ROOT },
     }),
-    join('/home/operator', '.config', 'idd-skill', 'config.json'),
+    join(HOME_ROOT, '.config', 'idd-skill', 'config.json'),
   );
   assert.equal(
     resolveUserGlobalConfigPath({
@@ -287,9 +298,9 @@ test('resolveUserGlobalConfigPath ignores a relative XDG_CONFIG_HOME and require
 test('resolveUserGlobalConfigPath rejects a Windows current-drive root such as \\config (#2257)', () => {
   assert.equal(
     resolveUserGlobalConfigPath({
-      env: { XDG_CONFIG_HOME: '\\config', HOME: '/home/operator' },
+      env: { XDG_CONFIG_HOME: '\\config', HOME: HOME_ROOT },
     }),
-    join('/home/operator', '.config', 'idd-skill', 'config.json'),
+    join(HOME_ROOT, '.config', 'idd-skill', 'config.json'),
   );
   assert.equal(
     resolveUserGlobalConfigPath({


### PR DESCRIPTION
# Summary

Four tests in `tests/idd-config.test.mts` failed on native Windows.
`resolveUserGlobalConfigPath`'s `isQualifiedConfigRoot` helper in
`src/scripts/idd-config.mts` already has a correct platform gate:
win32 requires a drive letter or UNC prefix, POSIX requires a leading
`/` (not `//`). The tests hard-coded POSIX-style mock values
(`/xdg-config`, `/home/operator`) with no platform branching, so
`isQualifiedConfigRoot` correctly rejected them on Windows and the
function fell through to `undefined` where every test expected a
resolved path.

Add two module-level platform-aware constants,
`XDG_CONFIG_HOME_ROOT` and `HOME_ROOT` (`C:\xdg-config` /
`C:\Users\operator` on win32, the original `/xdg-config` /
`/home/operator` on POSIX), used in place of the hard-coded literals
in the four failing tests. The two rejection-only assertions in the
same tests (a relative `XDG_CONFIG_HOME`, the literal `\config`
current-drive-relative root) are unchanged, since both are genuinely
rejected on both platforms by `isQualifiedConfigRoot`'s own logic --
only the accepted-path expected values needed to vary per platform.
This follows two adjacent tests in the same file
(`ignores a Windows drive root on POSIX`, `documents that POSIX slash
roots are Unix-only`) that already branch on `process.platform` for
the same reason. `src/scripts/idd-config.mts` itself is untouched.

## Linked issue

Closes #2582

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Validated on native Windows: `node --test tests/idd-config.test.mts`
-- 45 tests, 42 pass, 3 skip, 0 fail; all four previously-failing
tests now pass. Full suite: 4985 pass, 6 fail (all pre-existing and
unrelated -- 5 in `evaluateLocalCoordinationState`/worktree-path
fixtures already tracked and fixed upstream as #2576's merged PR
#2593 in a later commit than this branch's base, 1 in
`applyImportPlan` tracked as #2577), 7 skipped (pre-existing,
unrelated).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (see Background/rationale above)
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (no docs touched by this change)
- [x] `node scripts/idd-doctor.mjs`

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJ2EuubG4Ynv5zPVYURFvu
