### PR TITLE
feat(idd-doctor): warn on rulesets-only repos missing trust flag

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -101,7 +101,7 @@ export function runDoctor({
     report,
   );
   checkWorkshopExampleRepoBackLink(root, { requireGithub }, report);
-  checkGithubReadiness(root, requireGithub, report);
+  checkGithubReadiness(root, requireGithub, strict, report);
   checkAutopilotSuitabilityConsistency(
     root,
     { requireGithub, markerPrefix },
@@ -3138,7 +3138,7 @@ function checkWorkshopExampleRepoBackLink(root, options, report) {
     );
   }
 }
-function checkGithubReadiness(root, requireGithub, report) {
+function checkGithubReadiness(root, requireGithub, strict, report) {
   const repoView = runCommand(
     'gh',
     ['repo', 'view', '--json', 'owner,name,defaultBranchRef,url'],
@@ -3217,6 +3217,18 @@ function checkGithubReadiness(root, requireGithub, report) {
     }
     return;
   }
+  if (isRulesetsOnlyTrustGap(branchRulesRead, branchProtectionRead)) {
+    const message = formatRulesetsOnlyTrustGapWarning(owner, repo, branch);
+    if (strict) {
+      report.errors.push(message);
+    } else {
+      report.warnings.push(message);
+    }
+    // Deliberately falls through to evaluateBranchProtectionFindings below
+    // (unlike the isBranchProtectionUnreadable branch above, which returns):
+    // the Rulesets read still succeeded, so the required-checks and
+    // review-policy findings it powers remain accurate and worth reporting.
+  }
   const findings = evaluateBranchProtectionFindings(
     branchRulesRead.value,
     branchProtectionRead.value,
@@ -3266,6 +3278,59 @@ export function isBranchProtectionUnreadable(
   branchProtectionRead,
 ) {
   return branchRulesRead.unreadable && branchProtectionRead.unreadable;
+}
+/**
+ * Whether `checkGithubReadiness` should warn (or, under `--strict`, error)
+ * that the F2/F3 merge gate will still fail closed on the first merge
+ * attempt despite `idd-doctor` itself reporting clean -- distinct from, and
+ * strictly narrower than, {@link isBranchProtectionUnreadable} above (this
+ * predicate never changes that function's own leniency; idd-skill#2587).
+ *
+ * `true` only when the Rulesets read succeeded with at least one rule AND
+ * the classic read is unreadable:
+ *
+ * - `branchRulesRead.value.length > 0` after a successful
+ *   (`unreadable: false`) `rules/branches/{branch}` read means at least one
+ *   rule is currently **enforcing** on the branch -- GitHub's REST API
+ *   reference for this endpoint states verbatim: "Rules in rulesets with
+ *   'evaluate' or 'disabled' enforcement statuses are not returned." A
+ *   non-empty result therefore never needs a separate enforcement-status
+ *   field (this codebase's `BranchRuleLike` carries none).
+ * - `branchProtectionRead.unreadable` can only be `true` here because
+ *   `checkGithubReadiness` passes the *same* `ciGate.trustEmptyProtectionReads`
+ *   value into both governance reads, and {@link fetchGovernanceJson}
+ *   (`pre-merge-readiness.mts`) sets `unreadable: true` on a read only for a
+ *   genuine `404` when that trust flag is not `true` -- any other thrown
+ *   status re-throws and is caught by `checkGithubReadiness`'s own outer
+ *   `try`/`catch` before this predicate ever runs. So this condition being
+ *   `true` already implies `ciGate.trustEmptyProtectionReads` is not `true`,
+ *   with no separate trust parameter needed.
+ *
+ * Pure and dependency-free, mirroring {@link isBranchProtectionUnreadable}'s
+ * own rationale, so the rulesets-only / both-readable / neither-readable /
+ * no-rulesets-protection matrix is directly testable without mocking `gh`.
+ */
+export function isRulesetsOnlyTrustGap(branchRulesRead, branchProtectionRead) {
+  return (
+    !branchRulesRead.unreadable &&
+    branchRulesRead.value.length > 0 &&
+    branchProtectionRead.unreadable
+  );
+}
+/**
+ * Render {@link isRulesetsOnlyTrustGap}'s warning/error text. Extracted as
+ * its own function so the exact wording -- naming
+ * `ciGate.trustEmptyProtectionReads` and the F2/F3 fail-closed consequence,
+ * per idd-skill#2587's acceptance criteria -- is directly unit-testable
+ * without re-deriving it from a full `checkGithubReadiness` run.
+ */
+export function formatRulesetsOnlyTrustGapWarning(owner, repo, branch) {
+  return (
+    `branch protection on ${owner}/${repo}:${branch} is enforced only via GitHub Rulesets ` +
+    `(the classic branches/${branch}/protection read 404s); the F2/F3 merge gate will still ` +
+    `fail closed on the first merge attempt unless ciGate.trustEmptyProtectionReads: true is ` +
+    `set in .github/idd/config.json`
+  );
 }
 /**
  * Combine a classic `branches/{branch}/protection` read with a GitHub
@@ -3612,7 +3677,7 @@ options:
   --repo-root <path>                       repository root to inspect (default: cwd)
   --json                                   print JSON report
   --require-github                         treat GitHub API check failures as errors
-  --strict                                 treat a primary-worktree implementation-branch HEAD as an error (also enabled by worktreeGuard.enabled in config)
+  --strict                                 treat a primary-worktree implementation-branch HEAD as an error (also enabled by worktreeGuard.enabled in config); also treats a rulesets-only branch-protection trust gap (see ciGate.trustEmptyProtectionReads) as an error instead of a warning
   --cleanup-backlog-window-days <N>        merged-PR window for the cleanup backlog check (default: 14)
   --cleanup-backlog-warn-threshold <N>     backlog count above which the check warns (default: 2)
   --cleanup-backlog-bootstrap-cutoff <YYYY-MM-DD|ISO8601Z> label a flagged merged PR "(bootstrap-era)" in the report when it merged before this UTC date/timestamp, instead of a genuine claim-marker-missing gap (default: none -- every flagged PR reports the same way)

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -3326,10 +3326,12 @@ export function isRulesetsOnlyTrustGap(branchRulesRead, branchProtectionRead) {
  */
 export function formatRulesetsOnlyTrustGapWarning(owner, repo, branch) {
   return (
-    `branch protection on ${owner}/${repo}:${branch} is enforced only via GitHub Rulesets ` +
-    `(the classic branches/${branch}/protection read 404s); the F2/F3 merge gate will still ` +
-    `fail closed on the first merge attempt unless ciGate.trustEmptyProtectionReads: true is ` +
-    `set in .github/idd/config.json`
+    `branch protection on ${owner}/${repo}:${branch}: the classic branches/${branch}/protection ` +
+    `read returned 404 (this endpoint also 404s when the token lacks permission to read it, not ` +
+    `only when nothing is configured there) while the Rulesets read (rules/branches/${branch}) ` +
+    `already confirms at least one enforcing rule; either way, the F2/F3 merge gate will still ` +
+    `fail closed on the first merge attempt unless ciGate.trustEmptyProtectionReads: true is set ` +
+    `in .github/idd/config.json`
   );
 }
 /**

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -3331,23 +3331,26 @@ export function isRulesetsOnlyTrustGap(branchRulesRead, branchProtectionRead) {
  * unencoded, matching {@link isBranchProtectionUnreadable}'s own message
  * convention (Copilot review, idd-skill#2587 PR #2600).
  *
- * Names the token-permission cause as the safer remedy when it applies,
- * rather than implying `ciGate.trustEmptyProtectionReads` is the only fix
- * regardless of cause -- blindly setting that flag over a genuine
- * permission gap would trust a read that should actually be fixed at the
- * token-scope level (same tradeoff `fetchGovernanceJson`'s own doc comment
- * describes).
+ * States the two possible remedies as conditional on cause, rather than
+ * implying `ciGate.trustEmptyProtectionReads` is required "either way" --
+ * when the 404 is permission-masked, fixing the token's permissions makes
+ * the classic read succeed and no trust flag is needed at all; only when
+ * the 404 is genuine (classic protection truly isn't configured) does the
+ * trust flag apply. Blindly setting it over a genuine permission gap would
+ * trust a read that should actually be fixed at the token-scope level
+ * (same tradeoff `fetchGovernanceJson`'s own doc comment describes;
+ * Copilot review, idd-skill#2587 PR #2600).
  */
 export function formatRulesetsOnlyTrustGapWarning(owner, repo, branch) {
   const encodedBranch = encodeURIComponent(branch);
   return (
     `branch protection on ${owner}/${repo}:${branch}: the classic branches/${encodedBranch}/protection ` +
-    `read returned 404 (this endpoint also 404s when the token lacks permission to read it, not ` +
-    `only when nothing is configured there -- if that's the cause here, fixing the token's ` +
-    `permissions is the safer remedy) while the Rulesets read (rules/branches/${encodedBranch}) ` +
-    `already confirms at least one enforcing rule; either way, until the cause is resolved the ` +
-    `F2/F3 merge gate will still fail closed on the first merge attempt unless ` +
-    `ciGate.trustEmptyProtectionReads: true is set in .github/idd/config.json`
+    `read returned 404, while the Rulesets read (rules/branches/${encodedBranch}) already confirms at ` +
+    `least one enforcing rule. A 404 here can mean either (1) the token lacks permission to read the ` +
+    `classic endpoint -- fix the token's permissions, the safer remedy, and no config change is ` +
+    `needed, or (2) classic protection genuinely isn't configured (Rulesets-only) -- if so, set ` +
+    `ciGate.trustEmptyProtectionReads: true in .github/idd/config.json. Until whichever cause is ` +
+    `resolved, the F2/F3 merge gate will still fail closed on the first merge attempt`
   );
 }
 /**

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -3323,15 +3323,31 @@ export function isRulesetsOnlyTrustGap(branchRulesRead, branchProtectionRead) {
  * `ciGate.trustEmptyProtectionReads` and the F2/F3 fail-closed consequence,
  * per idd-skill#2587's acceptance criteria -- is directly unit-testable
  * without re-deriving it from a full `checkGithubReadiness` run.
+ *
+ * The endpoint path fragments URL-encode `branch` (matching
+ * `checkGithubReadiness`'s own `encodeURIComponent(branch)` call, since a
+ * branch name can contain `/`) so the printed path reflects the actual API
+ * call; the human-readable `owner/repo:branch` identifier prefix stays
+ * unencoded, matching {@link isBranchProtectionUnreadable}'s own message
+ * convention (Copilot review, idd-skill#2587 PR #2600).
+ *
+ * Names the token-permission cause as the safer remedy when it applies,
+ * rather than implying `ciGate.trustEmptyProtectionReads` is the only fix
+ * regardless of cause -- blindly setting that flag over a genuine
+ * permission gap would trust a read that should actually be fixed at the
+ * token-scope level (same tradeoff `fetchGovernanceJson`'s own doc comment
+ * describes).
  */
 export function formatRulesetsOnlyTrustGapWarning(owner, repo, branch) {
+  const encodedBranch = encodeURIComponent(branch);
   return (
-    `branch protection on ${owner}/${repo}:${branch}: the classic branches/${branch}/protection ` +
+    `branch protection on ${owner}/${repo}:${branch}: the classic branches/${encodedBranch}/protection ` +
     `read returned 404 (this endpoint also 404s when the token lacks permission to read it, not ` +
-    `only when nothing is configured there) while the Rulesets read (rules/branches/${branch}) ` +
-    `already confirms at least one enforcing rule; either way, the F2/F3 merge gate will still ` +
-    `fail closed on the first merge attempt unless ciGate.trustEmptyProtectionReads: true is set ` +
-    `in .github/idd/config.json`
+    `only when nothing is configured there -- if that's the cause here, fixing the token's ` +
+    `permissions is the safer remedy) while the Rulesets read (rules/branches/${encodedBranch}) ` +
+    `already confirms at least one enforcing rule; either way, until the cause is resolved the ` +
+    `F2/F3 merge gate will still fail closed on the first merge attempt unless ` +
+    `ciGate.trustEmptyProtectionReads: true is set in .github/idd/config.json`
   );
 }
 /**

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -3817,19 +3817,35 @@ export function isRulesetsOnlyTrustGap(
  * `ciGate.trustEmptyProtectionReads` and the F2/F3 fail-closed consequence,
  * per idd-skill#2587's acceptance criteria -- is directly unit-testable
  * without re-deriving it from a full `checkGithubReadiness` run.
+ *
+ * The endpoint path fragments URL-encode `branch` (matching
+ * `checkGithubReadiness`'s own `encodeURIComponent(branch)` call, since a
+ * branch name can contain `/`) so the printed path reflects the actual API
+ * call; the human-readable `owner/repo:branch` identifier prefix stays
+ * unencoded, matching {@link isBranchProtectionUnreadable}'s own message
+ * convention (Copilot review, idd-skill#2587 PR #2600).
+ *
+ * Names the token-permission cause as the safer remedy when it applies,
+ * rather than implying `ciGate.trustEmptyProtectionReads` is the only fix
+ * regardless of cause -- blindly setting that flag over a genuine
+ * permission gap would trust a read that should actually be fixed at the
+ * token-scope level (same tradeoff `fetchGovernanceJson`'s own doc comment
+ * describes).
  */
 export function formatRulesetsOnlyTrustGapWarning(
   owner: string,
   repo: string,
   branch: string,
 ): string {
+  const encodedBranch = encodeURIComponent(branch);
   return (
-    `branch protection on ${owner}/${repo}:${branch}: the classic branches/${branch}/protection ` +
+    `branch protection on ${owner}/${repo}:${branch}: the classic branches/${encodedBranch}/protection ` +
     `read returned 404 (this endpoint also 404s when the token lacks permission to read it, not ` +
-    `only when nothing is configured there) while the Rulesets read (rules/branches/${branch}) ` +
-    `already confirms at least one enforcing rule; either way, the F2/F3 merge gate will still ` +
-    `fail closed on the first merge attempt unless ciGate.trustEmptyProtectionReads: true is set ` +
-    `in .github/idd/config.json`
+    `only when nothing is configured there -- if that's the cause here, fixing the token's ` +
+    `permissions is the safer remedy) while the Rulesets read (rules/branches/${encodedBranch}) ` +
+    `already confirms at least one enforcing rule; either way, until the cause is resolved the ` +
+    `F2/F3 merge gate will still fail closed on the first merge attempt unless ` +
+    `ciGate.trustEmptyProtectionReads: true is set in .github/idd/config.json`
   );
 }
 

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -3825,12 +3825,15 @@ export function isRulesetsOnlyTrustGap(
  * unencoded, matching {@link isBranchProtectionUnreadable}'s own message
  * convention (Copilot review, idd-skill#2587 PR #2600).
  *
- * Names the token-permission cause as the safer remedy when it applies,
- * rather than implying `ciGate.trustEmptyProtectionReads` is the only fix
- * regardless of cause -- blindly setting that flag over a genuine
- * permission gap would trust a read that should actually be fixed at the
- * token-scope level (same tradeoff `fetchGovernanceJson`'s own doc comment
- * describes).
+ * States the two possible remedies as conditional on cause, rather than
+ * implying `ciGate.trustEmptyProtectionReads` is required "either way" --
+ * when the 404 is permission-masked, fixing the token's permissions makes
+ * the classic read succeed and no trust flag is needed at all; only when
+ * the 404 is genuine (classic protection truly isn't configured) does the
+ * trust flag apply. Blindly setting it over a genuine permission gap would
+ * trust a read that should actually be fixed at the token-scope level
+ * (same tradeoff `fetchGovernanceJson`'s own doc comment describes;
+ * Copilot review, idd-skill#2587 PR #2600).
  */
 export function formatRulesetsOnlyTrustGapWarning(
   owner: string,
@@ -3840,12 +3843,12 @@ export function formatRulesetsOnlyTrustGapWarning(
   const encodedBranch = encodeURIComponent(branch);
   return (
     `branch protection on ${owner}/${repo}:${branch}: the classic branches/${encodedBranch}/protection ` +
-    `read returned 404 (this endpoint also 404s when the token lacks permission to read it, not ` +
-    `only when nothing is configured there -- if that's the cause here, fixing the token's ` +
-    `permissions is the safer remedy) while the Rulesets read (rules/branches/${encodedBranch}) ` +
-    `already confirms at least one enforcing rule; either way, until the cause is resolved the ` +
-    `F2/F3 merge gate will still fail closed on the first merge attempt unless ` +
-    `ciGate.trustEmptyProtectionReads: true is set in .github/idd/config.json`
+    `read returned 404, while the Rulesets read (rules/branches/${encodedBranch}) already confirms at ` +
+    `least one enforcing rule. A 404 here can mean either (1) the token lacks permission to read the ` +
+    `classic endpoint -- fix the token's permissions, the safer remedy, and no config change is ` +
+    `needed, or (2) classic protection genuinely isn't configured (Rulesets-only) -- if so, set ` +
+    `ciGate.trustEmptyProtectionReads: true in .github/idd/config.json. Until whichever cause is ` +
+    `resolved, the F2/F3 merge gate will still fail closed on the first merge attempt`
   );
 }
 

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -3824,10 +3824,12 @@ export function formatRulesetsOnlyTrustGapWarning(
   branch: string,
 ): string {
   return (
-    `branch protection on ${owner}/${repo}:${branch} is enforced only via GitHub Rulesets ` +
-    `(the classic branches/${branch}/protection read 404s); the F2/F3 merge gate will still ` +
-    `fail closed on the first merge attempt unless ciGate.trustEmptyProtectionReads: true is ` +
-    `set in .github/idd/config.json`
+    `branch protection on ${owner}/${repo}:${branch}: the classic branches/${branch}/protection ` +
+    `read returned 404 (this endpoint also 404s when the token lacks permission to read it, not ` +
+    `only when nothing is configured there) while the Rulesets read (rules/branches/${branch}) ` +
+    `already confirms at least one enforcing rule; either way, the F2/F3 merge gate will still ` +
+    `fail closed on the first merge attempt unless ciGate.trustEmptyProtectionReads: true is set ` +
+    `in .github/idd/config.json`
   );
 }
 

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -176,7 +176,7 @@ export function runDoctor({
     report,
   );
   checkWorkshopExampleRepoBackLink(root, { requireGithub }, report);
-  checkGithubReadiness(root, requireGithub, report);
+  checkGithubReadiness(root, requireGithub, strict, report);
   checkAutopilotSuitabilityConsistency(
     root,
     { requireGithub, markerPrefix },
@@ -3579,6 +3579,7 @@ function checkWorkshopExampleRepoBackLink(
 function checkGithubReadiness(
   root: string,
   requireGithub: boolean | undefined,
+  strict: boolean | undefined,
   report: DoctorReport,
 ) {
   const repoView = runCommand(
@@ -3669,6 +3670,19 @@ function checkGithubReadiness(
     return;
   }
 
+  if (isRulesetsOnlyTrustGap(branchRulesRead, branchProtectionRead)) {
+    const message = formatRulesetsOnlyTrustGapWarning(owner, repo, branch);
+    if (strict) {
+      report.errors.push(message);
+    } else {
+      report.warnings.push(message);
+    }
+    // Deliberately falls through to evaluateBranchProtectionFindings below
+    // (unlike the isBranchProtectionUnreadable branch above, which returns):
+    // the Rulesets read still succeeded, so the required-checks and
+    // review-policy findings it powers remain accurate and worth reporting.
+  }
+
   const findings = evaluateBranchProtectionFindings(
     branchRulesRead.value,
     branchProtectionRead.value,
@@ -3753,6 +3767,68 @@ export function isBranchProtectionUnreadable(
   branchProtectionRead: { unreadable: boolean },
 ): boolean {
   return branchRulesRead.unreadable && branchProtectionRead.unreadable;
+}
+
+/**
+ * Whether `checkGithubReadiness` should warn (or, under `--strict`, error)
+ * that the F2/F3 merge gate will still fail closed on the first merge
+ * attempt despite `idd-doctor` itself reporting clean -- distinct from, and
+ * strictly narrower than, {@link isBranchProtectionUnreadable} above (this
+ * predicate never changes that function's own leniency; idd-skill#2587).
+ *
+ * `true` only when the Rulesets read succeeded with at least one rule AND
+ * the classic read is unreadable:
+ *
+ * - `branchRulesRead.value.length > 0` after a successful
+ *   (`unreadable: false`) `rules/branches/{branch}` read means at least one
+ *   rule is currently **enforcing** on the branch -- GitHub's REST API
+ *   reference for this endpoint states verbatim: "Rules in rulesets with
+ *   'evaluate' or 'disabled' enforcement statuses are not returned." A
+ *   non-empty result therefore never needs a separate enforcement-status
+ *   field (this codebase's `BranchRuleLike` carries none).
+ * - `branchProtectionRead.unreadable` can only be `true` here because
+ *   `checkGithubReadiness` passes the *same* `ciGate.trustEmptyProtectionReads`
+ *   value into both governance reads, and {@link fetchGovernanceJson}
+ *   (`pre-merge-readiness.mts`) sets `unreadable: true` on a read only for a
+ *   genuine `404` when that trust flag is not `true` -- any other thrown
+ *   status re-throws and is caught by `checkGithubReadiness`'s own outer
+ *   `try`/`catch` before this predicate ever runs. So this condition being
+ *   `true` already implies `ciGate.trustEmptyProtectionReads` is not `true`,
+ *   with no separate trust parameter needed.
+ *
+ * Pure and dependency-free, mirroring {@link isBranchProtectionUnreadable}'s
+ * own rationale, so the rulesets-only / both-readable / neither-readable /
+ * no-rulesets-protection matrix is directly testable without mocking `gh`.
+ */
+export function isRulesetsOnlyTrustGap(
+  branchRulesRead: { value: unknown[]; unreadable: boolean },
+  branchProtectionRead: { unreadable: boolean },
+): boolean {
+  return (
+    !branchRulesRead.unreadable &&
+    branchRulesRead.value.length > 0 &&
+    branchProtectionRead.unreadable
+  );
+}
+
+/**
+ * Render {@link isRulesetsOnlyTrustGap}'s warning/error text. Extracted as
+ * its own function so the exact wording -- naming
+ * `ciGate.trustEmptyProtectionReads` and the F2/F3 fail-closed consequence,
+ * per idd-skill#2587's acceptance criteria -- is directly unit-testable
+ * without re-deriving it from a full `checkGithubReadiness` run.
+ */
+export function formatRulesetsOnlyTrustGapWarning(
+  owner: string,
+  repo: string,
+  branch: string,
+): string {
+  return (
+    `branch protection on ${owner}/${repo}:${branch} is enforced only via GitHub Rulesets ` +
+    `(the classic branches/${branch}/protection read 404s); the F2/F3 merge gate will still ` +
+    `fail closed on the first merge attempt unless ciGate.trustEmptyProtectionReads: true is ` +
+    `set in .github/idd/config.json`
+  );
 }
 
 /** Findings the branch-protection check reports for the doctor output. */
@@ -4157,7 +4233,7 @@ options:
   --repo-root <path>                       repository root to inspect (default: cwd)
   --json                                   print JSON report
   --require-github                         treat GitHub API check failures as errors
-  --strict                                 treat a primary-worktree implementation-branch HEAD as an error (also enabled by worktreeGuard.enabled in config)
+  --strict                                 treat a primary-worktree implementation-branch HEAD as an error (also enabled by worktreeGuard.enabled in config); also treats a rulesets-only branch-protection trust gap (see ciGate.trustEmptyProtectionReads) as an error instead of a warning
   --cleanup-backlog-window-days <N>        merged-PR window for the cleanup backlog check (default: 14)
   --cleanup-backlog-warn-threshold <N>     backlog count above which the check warns (default: 2)
   --cleanup-backlog-bootstrap-cutoff <YYYY-MM-DD|ISO8601Z> label a flagged merged PR "(bootstrap-era)" in the report when it merged before this UTC date/timestamp, instead of a genuine claim-marker-missing gap (default: none -- every flagged PR reports the same way)

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -50,12 +50,14 @@ import {
   formatCleanupBacklogRemediation,
   formatCleanupBacklogScanPreamble,
   formatCleanupBacklogScanProgress,
+  formatRulesetsOnlyTrustGapWarning,
   hookChainsToGithooksScript,
   hookHasCrlfLineEndings,
   hookWiresWorktreeGuard,
   isBranchProtectionUnreadable,
   isGithubBackLinkHost,
   isIddManagedPlaceholderScanPath,
+  isRulesetsOnlyTrustGap,
   parseIsoDurationToHours,
   parseLockfileImporterVersion,
   parsePrimaryWorktreePath,
@@ -4148,6 +4150,77 @@ test('isBranchProtectionUnreadable is true only when both reads are unreadable',
     isBranchProtectionUnreadable({ unreadable: true }, { unreadable: true }),
     true,
   );
+});
+
+// idd-skill#2587: isRulesetsOnlyTrustGap warns (or, under --strict, errors)
+// when a repository's branch protection is enforced only via GitHub
+// Rulesets and ciGate.trustEmptyProtectionReads is not set -- the F2/F3
+// merge gate still fails closed on the first merge attempt in that case,
+// even though isBranchProtectionUnreadable (above) reports no problem.
+test('isRulesetsOnlyTrustGap is true for a rulesets-only repository with trust unset', () => {
+  assert.equal(
+    isRulesetsOnlyTrustGap(
+      { value: [{ type: 'required_status_checks' }], unreadable: false },
+      { unreadable: true },
+    ),
+    true,
+  );
+});
+
+test('isRulesetsOnlyTrustGap is false for a rulesets-only repository once trust is set (classic 404 trusted as empty)', () => {
+  // ciGate.trustEmptyProtectionReads: true makes fetchGovernanceJson trust
+  // the classic endpoint's 404 as genuinely empty, so branchProtectionRead
+  // arrives with unreadable: false -- simulated directly here rather than
+  // through a live config read, matching this predicate's pure, dependency
+  // -free contract.
+  assert.equal(
+    isRulesetsOnlyTrustGap(
+      { value: [{ type: 'required_status_checks' }], unreadable: false },
+      { unreadable: false },
+    ),
+    false,
+  );
+});
+
+test('isRulesetsOnlyTrustGap is false when both reads succeed (protection configured via both mechanisms)', () => {
+  assert.equal(
+    isRulesetsOnlyTrustGap(
+      { value: [{ type: 'required_status_checks' }], unreadable: false },
+      { unreadable: false },
+    ),
+    false,
+  );
+});
+
+test('isRulesetsOnlyTrustGap is false when neither read succeeds (isBranchProtectionUnreadable already covers this case)', () => {
+  assert.equal(
+    isRulesetsOnlyTrustGap(
+      { value: [], unreadable: true },
+      { unreadable: true },
+    ),
+    false,
+  );
+});
+
+test('isRulesetsOnlyTrustGap is false when the repository has no Rulesets protection at all (empty rules array)', () => {
+  assert.equal(
+    isRulesetsOnlyTrustGap(
+      { value: [], unreadable: false },
+      { unreadable: true },
+    ),
+    false,
+  );
+});
+
+test('formatRulesetsOnlyTrustGapWarning names ciGate.trustEmptyProtectionReads and the F2/F3 fail-closed consequence', () => {
+  const message = formatRulesetsOnlyTrustGapWarning(
+    'kurone-kito',
+    'setup.kito',
+    'master',
+  );
+  assert.match(message, /ciGate\.trustEmptyProtectionReads/);
+  assert.match(message, /F2\/F3/);
+  assert.match(message, /kurone-kito\/setup\.kito:master/);
 });
 
 test('readTrustEmptyProtectionReads is false when .github/idd/config.json is absent, lacks ciGate, or is malformed (idd-skill#2010)', () => {

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -4160,7 +4160,7 @@ test('isBranchProtectionUnreadable is true only when both reads are unreadable',
 // reports no problem. A 404 on the classic read can also be
 // permission-masked rather than proof the repository is Rulesets-only;
 // see formatRulesetsOnlyTrustGapWarning's own doc comment for that nuance.
-test('isRulesetsOnlyTrustGap is true for a rulesets-only repository with trust unset', () => {
+test('isRulesetsOnlyTrustGap is true when the Rulesets read has an enforcing rule, the classic read is unreadable, and trust is unset', () => {
   assert.equal(
     isRulesetsOnlyTrustGap(
       { value: [{ type: 'required_status_checks' }], unreadable: false },
@@ -4170,7 +4170,7 @@ test('isRulesetsOnlyTrustGap is true for a rulesets-only repository with trust u
   );
 });
 
-test('isRulesetsOnlyTrustGap is false for a rulesets-only repository once trust is set (classic 404 trusted as empty)', () => {
+test('isRulesetsOnlyTrustGap is false once trust is set, even with an enforcing Rulesets rule present (classic 404 trusted as empty)', () => {
   // ciGate.trustEmptyProtectionReads: true makes fetchGovernanceJson trust
   // the classic endpoint's 404 as genuinely empty, so branchProtectionRead
   // arrives with unreadable: false -- simulated directly here rather than

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -4202,7 +4202,7 @@ test('isRulesetsOnlyTrustGap is false when neither read succeeds (isBranchProtec
   );
 });
 
-test('isRulesetsOnlyTrustGap is false when the repository has no Rulesets protection at all (empty rules array)', () => {
+test('isRulesetsOnlyTrustGap is false when no Rulesets rule is enforcing on the branch (empty rules array -- covers both "no rulesets configured" and "rulesets exist but none currently enforce")', () => {
   assert.equal(
     isRulesetsOnlyTrustGap(
       { value: [], unreadable: false },

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -4223,6 +4223,29 @@ test('formatRulesetsOnlyTrustGapWarning names ciGate.trustEmptyProtectionReads a
   assert.match(message, /example-owner\/example-repo:master/);
 });
 
+test('formatRulesetsOnlyTrustGapWarning names the token-permission cause as the safer remedy, not just the trust flag', () => {
+  const message = formatRulesetsOnlyTrustGapWarning(
+    'example-owner',
+    'example-repo',
+    'master',
+  );
+  assert.match(message, /lacks permission/);
+  assert.match(message, /fixing the token's permissions is the safer remedy/);
+});
+
+test("formatRulesetsOnlyTrustGapWarning URL-encodes the branch name in endpoint path fragments, matching checkGithubReadiness's own encodeURIComponent(branch) call", () => {
+  const message = formatRulesetsOnlyTrustGapWarning(
+    'example-owner',
+    'example-repo',
+    'release/1.0',
+  );
+  assert.match(message, /branches\/release%2F1\.0\/protection/);
+  assert.match(message, /rules\/branches\/release%2F1\.0/);
+  // The human-readable identifier prefix stays unencoded, matching
+  // isBranchProtectionUnreadable's own message convention.
+  assert.match(message, /example-owner\/example-repo:release\/1\.0/);
+});
+
 test('readTrustEmptyProtectionReads is false when .github/idd/config.json is absent, lacks ciGate, or is malformed (idd-skill#2010)', () => {
   const dir = mkdtempSync(
     join(tmpdir(), 'idd-doctor-trust-empty-protection-reads-'),

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -4226,14 +4226,16 @@ test('formatRulesetsOnlyTrustGapWarning names ciGate.trustEmptyProtectionReads a
   assert.match(message, /example-owner\/example-repo:master/);
 });
 
-test('formatRulesetsOnlyTrustGapWarning names the token-permission cause as the safer remedy, not just the trust flag', () => {
+test('formatRulesetsOnlyTrustGapWarning states the two remedies as conditional on cause, not the trust flag "either way"', () => {
   const message = formatRulesetsOnlyTrustGapWarning(
     'example-owner',
     'example-repo',
     'master',
   );
   assert.match(message, /lacks permission/);
-  assert.match(message, /fixing the token's permissions is the safer remedy/);
+  assert.match(message, /fix the token's permissions, the safer remedy/);
+  assert.match(message, /no config change is\s+needed/);
+  assert.doesNotMatch(message, /either way/);
 });
 
 test("formatRulesetsOnlyTrustGapWarning URL-encodes the branch name in endpoint path fragments, matching checkGithubReadiness's own encodeURIComponent(branch) call", () => {

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -4214,13 +4214,13 @@ test('isRulesetsOnlyTrustGap is false when the repository has no Rulesets protec
 
 test('formatRulesetsOnlyTrustGapWarning names ciGate.trustEmptyProtectionReads and the F2/F3 fail-closed consequence', () => {
   const message = formatRulesetsOnlyTrustGapWarning(
-    'kurone-kito',
-    'setup.kito',
+    'example-owner',
+    'example-repo',
     'master',
   );
   assert.match(message, /ciGate\.trustEmptyProtectionReads/);
   assert.match(message, /F2\/F3/);
-  assert.match(message, /kurone-kito\/setup\.kito:master/);
+  assert.match(message, /example-owner\/example-repo:master/);
 });
 
 test('readTrustEmptyProtectionReads is false when .github/idd/config.json is absent, lacks ciGate, or is malformed (idd-skill#2010)', () => {

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -4171,8 +4171,8 @@ test('isRulesetsOnlyTrustGap is false for a rulesets-only repository once trust 
   // ciGate.trustEmptyProtectionReads: true makes fetchGovernanceJson trust
   // the classic endpoint's 404 as genuinely empty, so branchProtectionRead
   // arrives with unreadable: false -- simulated directly here rather than
-  // through a live config read, matching this predicate's pure, dependency
-  // -free contract.
+  // through a live config read, matching this predicate's pure,
+  // dependency-free contract.
   assert.equal(
     isRulesetsOnlyTrustGap(
       { value: [{ type: 'required_status_checks' }], unreadable: false },
@@ -4182,10 +4182,10 @@ test('isRulesetsOnlyTrustGap is false for a rulesets-only repository once trust 
   );
 });
 
-test('isRulesetsOnlyTrustGap is false when both reads succeed (protection configured via both mechanisms)', () => {
+test('isRulesetsOnlyTrustGap is false for classic-only protection (no enforcing Rulesets rules, classic read succeeds)', () => {
   assert.equal(
     isRulesetsOnlyTrustGap(
-      { value: [{ type: 'required_status_checks' }], unreadable: false },
+      { value: [], unreadable: false },
       { unreadable: false },
     ),
     false,

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -4153,10 +4153,13 @@ test('isBranchProtectionUnreadable is true only when both reads are unreadable',
 });
 
 // idd-skill#2587: isRulesetsOnlyTrustGap warns (or, under --strict, errors)
-// when a repository's branch protection is enforced only via GitHub
-// Rulesets and ciGate.trustEmptyProtectionReads is not set -- the F2/F3
-// merge gate still fails closed on the first merge attempt in that case,
-// even though isBranchProtectionUnreadable (above) reports no problem.
+// when the Rulesets read observes at least one enforcing rule while the
+// classic protection read is unreadable and ciGate.trustEmptyProtectionReads
+// is not set -- the F2/F3 merge gate still fails closed on the first merge
+// attempt in that case, even though isBranchProtectionUnreadable (above)
+// reports no problem. A 404 on the classic read can also be
+// permission-masked rather than proof the repository is Rulesets-only;
+// see formatRulesetsOnlyTrustGapWarning's own doc comment for that nuance.
 test('isRulesetsOnlyTrustGap is true for a rulesets-only repository with trust unset', () => {
   assert.equal(
     isRulesetsOnlyTrustGap(


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

`idd-doctor` now warns (or, under `--strict`, errors) when a
repository's branch protection is enforced only via GitHub Rulesets:
the Rulesets read (`rules/branches/{branch}`) succeeds with at least
one enforcing rule, the classic `branches/{branch}/protection` read
genuinely 404s, and `ciGate.trustEmptyProtectionReads` is not `true`.
Previously `idd-doctor` reported a clean bill of health in exactly
this case (per `isBranchProtectionUnreadable`'s intentional #2010
leniency, left unchanged here), even though the F2/F3 merge gate
still fails closed on the first merge attempt without that config
key, since `pre-merge-readiness.mts` ORs both governance reads'
`unreadable` flags unconditionally.

Adds two pure, exported functions next to `isBranchProtectionUnreadable`
in `src/scripts/idd-doctor.mts`:

- `isRulesetsOnlyTrustGap` — the predicate, derivable purely from both
  governance reads' outcomes (no separate trust-flag parameter needed:
  `checkGithubReadiness` passes the same `trustEmptyProtectionReads`
  value into both reads, so `branchProtectionRead.unreadable === true`
  already implies the trust flag is not `true`).
- `formatRulesetsOnlyTrustGapWarning` — the message text, extracted so
  its exact wording (naming `ciGate.trustEmptyProtectionReads` and the
  F2/F3 fail-closed consequence) is independently unit-tested rather
  than only the boolean predicate.

Wired into `checkGithubReadiness` with a fall-through (not an early
`return`, unlike the sibling `isBranchProtectionUnreadable` branch): the
Rulesets read still succeeded, so the required-checks/review-policy
findings below it remain accurate and worth reporting. `--strict` is
threaded through to promote the warning to an error, and the CLI help
text documents the new `--strict` behavior as its own clause, separate
from the existing worktree-guard one it shares the flag with.

## Linked issue

Closes #2587

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

As described in the linked issue: on a repository whose branch
protection is implemented entirely via a GitHub Ruleset, with no
classic branch-protection rule configured, `idd-doctor` reported clean
while the first autonomous PR still failed closed at F2 until
`ciGate.trustEmptyProtectionReads: true` was set by hand. This closes
that reactive-discovery gap by surfacing the config requirement
proactively during `idd-doctor`.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (ran as `pnpm run lint:minimum`)
- [x] `pnpm test` (`pnpm run test`, 5006 passed)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McMFNCbk3CYbCSjyvuDd4z


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub readiness checks now detect when branch protection is enforced through Rulesets but classic protection details cannot be read.
  * The CLI reports this condition as a warning by default and as an error when `--strict` is enabled.
  * CLI help now documents the additional strict-mode behavior.

* **Bug Fixes**
  * Readiness checks continue evaluating available branch-protection findings even when one protection source is unavailable.

* **Tests**
  * Added coverage for trusted, unreadable, empty, and non-enforcing protection configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->