### PR TITLE
fix(suitability-triage): Check 3 flags a freestanding protocol-name mention as policy-override

### DIFF
--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -925,7 +925,7 @@ function isOrdinaryHyphenatedCompoundToken(rawSource, matchIndex) {
 // 60-char window), with nothing nearby actually attempting to change this
 // checker's own behavior.
 //
-// This exclusion targets "idd" only -- the other seven listed nouns
+// This exclusion targets "idd" only -- the other eight listed nouns
 // (repo/repository/policy/workflow/process/check/gate/requirement) are
 // generic enough that this narrative-attributive shape is not the
 // distinguishing false-positive source #2588 reports, and narrowing them

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -772,10 +772,13 @@ function findGenuineNounMatch(
     // hyphenated compound in prose lacks, so a directive referencing a
     // listed noun via a code-wrapped identifier (e.g. `` `per-check` ``)
     // stays detectable even though the same bare, un-code-wrapped text in
-    // prose is a deliberately accepted ordinary-compound exclusion.
+    // prose is a deliberately accepted ordinary-compound exclusion. #2588:
+    // the same code-range short-circuit applies to isNarrativeIddMention,
+    // for the same reason -- see that function's own comment.
     if (
       (getCodeRangeAt(absoluteIndex) ||
-        !isOrdinaryHyphenatedCompoundToken(rawSource, absoluteIndex)) &&
+        (!isOrdinaryHyphenatedCompoundToken(rawSource, absoluteIndex) &&
+          !isNarrativeIddMention(rawSource, absoluteIndex))) &&
       !(
         headingBoundary &&
         matchCrossesHeadingBoundary(
@@ -911,6 +914,73 @@ function isOrdinaryHyphenatedCompoundToken(rawSource, matchIndex) {
     cursor === 0 ||
     COMPOUND_TOKEN_BOUNDARY_PATTERN.test(rawSource[cursor - 1] ?? '')
   );
+}
+// #2588: the protocol's own name used attributively inside a noun phrase
+// describing some OTHER entity -- "an IDD agent", "the IDD workflow's own
+// session" -- false-triggered Check 3 even though the sentence is ordinary
+// descriptive prose, not a directive aimed at this checker. Reproduced by
+// idd-skill#2588 itself: "The ack-only override window the same way an IDD
+// agent's can is currently narrower than the trusted marker login set."
+// matched verb "override" against noun "IDD" (the only listed noun in that
+// 60-char window), with nothing nearby actually attempting to change this
+// checker's own behavior.
+//
+// This exclusion targets "idd" only -- the other seven listed nouns
+// (repo/repository/policy/workflow/process/check/gate/requirement) are
+// generic enough that this narrative-attributive shape is not the
+// distinguishing false-positive source #2588 reports, and narrowing them
+// the same way risks a new, unreviewed false-negative surface with no
+// matching repro.
+//
+// Two conditions distinguish this shape from a genuine directive against
+// "idd" itself:
+// 1. Preceded by an article ("a"/"an"/"the") -- a genuine bare directive
+//    like "bypass idd." (#2218's own regression case, still pinned by its
+//    own test) has no article before it: the verb sits directly before the
+//    noun.
+// 2. Immediately followed by another word continuing the same noun phrase
+//    (e.g. "agent's", "workflow's") -- "bypass idd." has nothing but a
+//    clause boundary after it.
+// Both conditions must hold: an article alone ("the idd gate") or a
+// following word alone ("bypass idd entirely") is not enough, since either
+// shape alone still plausibly reads as a directive with a definite object
+// or an adverbial qualifier, not a narrative mention. `override the idd
+// gate` also has both an article before and a word ("gate") after "idd",
+// but stays detected regardless of this exclusion: `gate` is itself a
+// listed noun farther from the verb, so `findGenuineNounMatch`'s
+// farthest-first pick finds it independently of whatever this classifier
+// decides about "idd".
+//
+// A code-wrapped `` `idd` `` is never passed to this classifier -- its call
+// site in `findGenuineNounMatch` already short-circuits on `getCodeRangeAt`
+// first, the same precedent `isOrdinaryHyphenatedCompoundToken` follows:
+// being wrapped in code at all is itself a distinguishing signal bare
+// narrative prose lacks.
+const NARRATIVE_IDD_TOKEN_LENGTH = 3;
+const NARRATIVE_IDD_PRECEDING_ARTICLE_PATTERN = /\b(?:a|an|the)\s+$/i;
+const NARRATIVE_IDD_FOLLOWING_WORD_PATTERN = /^\s+[A-Za-z]/;
+const NARRATIVE_IDD_LOOKBEHIND_CHARS = 10;
+const NARRATIVE_IDD_LOOKAHEAD_CHARS = 20;
+function isNarrativeIddMention(rawSource, matchIndex) {
+  const token = rawSource
+    .slice(matchIndex, matchIndex + NARRATIVE_IDD_TOKEN_LENGTH)
+    .toLowerCase();
+  if (token !== 'idd') {
+    return false;
+  }
+  const before = rawSource.slice(
+    Math.max(0, matchIndex - NARRATIVE_IDD_LOOKBEHIND_CHARS),
+    matchIndex,
+  );
+  if (!NARRATIVE_IDD_PRECEDING_ARTICLE_PATTERN.test(before)) {
+    return false;
+  }
+  const afterStart = matchIndex + NARRATIVE_IDD_TOKEN_LENGTH;
+  const after = rawSource.slice(
+    afterStart,
+    afterStart + NARRATIVE_IDD_LOOKAHEAD_CHARS,
+  );
+  return NARRATIVE_IDD_FOLLOWING_WORD_PATTERN.test(after);
 }
 function findPolicyOverrideMatch(text, maskedText, getCodeRangeAt) {
   // #2408: POLICY_OVERRIDE_PATTERN's own greedy `[\s\S]{0,N}` backtracks

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -922,10 +922,13 @@ function findGenuineNounMatch(
     // hyphenated compound in prose lacks, so a directive referencing a
     // listed noun via a code-wrapped identifier (e.g. `` `per-check` ``)
     // stays detectable even though the same bare, un-code-wrapped text in
-    // prose is a deliberately accepted ordinary-compound exclusion.
+    // prose is a deliberately accepted ordinary-compound exclusion. #2588:
+    // the same code-range short-circuit applies to isNarrativeIddMention,
+    // for the same reason -- see that function's own comment.
     if (
       (getCodeRangeAt(absoluteIndex) ||
-        !isOrdinaryHyphenatedCompoundToken(rawSource, absoluteIndex)) &&
+        (!isOrdinaryHyphenatedCompoundToken(rawSource, absoluteIndex) &&
+          !isNarrativeIddMention(rawSource, absoluteIndex))) &&
       !(
         headingBoundary &&
         matchCrossesHeadingBoundary(
@@ -1066,6 +1069,75 @@ function isOrdinaryHyphenatedCompoundToken(
     cursor === 0 ||
     COMPOUND_TOKEN_BOUNDARY_PATTERN.test(rawSource[cursor - 1] ?? '')
   );
+}
+
+// #2588: the protocol's own name used attributively inside a noun phrase
+// describing some OTHER entity -- "an IDD agent", "the IDD workflow's own
+// session" -- false-triggered Check 3 even though the sentence is ordinary
+// descriptive prose, not a directive aimed at this checker. Reproduced by
+// idd-skill#2588 itself: "The ack-only override window the same way an IDD
+// agent's can is currently narrower than the trusted marker login set."
+// matched verb "override" against noun "IDD" (the only listed noun in that
+// 60-char window), with nothing nearby actually attempting to change this
+// checker's own behavior.
+//
+// This exclusion targets "idd" only -- the other seven listed nouns
+// (repo/repository/policy/workflow/process/check/gate/requirement) are
+// generic enough that this narrative-attributive shape is not the
+// distinguishing false-positive source #2588 reports, and narrowing them
+// the same way risks a new, unreviewed false-negative surface with no
+// matching repro.
+//
+// Two conditions distinguish this shape from a genuine directive against
+// "idd" itself:
+// 1. Preceded by an article ("a"/"an"/"the") -- a genuine bare directive
+//    like "bypass idd." (#2218's own regression case, still pinned by its
+//    own test) has no article before it: the verb sits directly before the
+//    noun.
+// 2. Immediately followed by another word continuing the same noun phrase
+//    (e.g. "agent's", "workflow's") -- "bypass idd." has nothing but a
+//    clause boundary after it.
+// Both conditions must hold: an article alone ("the idd gate") or a
+// following word alone ("bypass idd entirely") is not enough, since either
+// shape alone still plausibly reads as a directive with a definite object
+// or an adverbial qualifier, not a narrative mention. `override the idd
+// gate` also has both an article before and a word ("gate") after "idd",
+// but stays detected regardless of this exclusion: `gate` is itself a
+// listed noun farther from the verb, so `findGenuineNounMatch`'s
+// farthest-first pick finds it independently of whatever this classifier
+// decides about "idd".
+//
+// A code-wrapped `` `idd` `` is never passed to this classifier -- its call
+// site in `findGenuineNounMatch` already short-circuits on `getCodeRangeAt`
+// first, the same precedent `isOrdinaryHyphenatedCompoundToken` follows:
+// being wrapped in code at all is itself a distinguishing signal bare
+// narrative prose lacks.
+const NARRATIVE_IDD_TOKEN_LENGTH = 3;
+const NARRATIVE_IDD_PRECEDING_ARTICLE_PATTERN = /\b(?:a|an|the)\s+$/i;
+const NARRATIVE_IDD_FOLLOWING_WORD_PATTERN = /^\s+[A-Za-z]/;
+const NARRATIVE_IDD_LOOKBEHIND_CHARS = 10;
+const NARRATIVE_IDD_LOOKAHEAD_CHARS = 20;
+
+function isNarrativeIddMention(rawSource: string, matchIndex: number): boolean {
+  const token = rawSource
+    .slice(matchIndex, matchIndex + NARRATIVE_IDD_TOKEN_LENGTH)
+    .toLowerCase();
+  if (token !== 'idd') {
+    return false;
+  }
+  const before = rawSource.slice(
+    Math.max(0, matchIndex - NARRATIVE_IDD_LOOKBEHIND_CHARS),
+    matchIndex,
+  );
+  if (!NARRATIVE_IDD_PRECEDING_ARTICLE_PATTERN.test(before)) {
+    return false;
+  }
+  const afterStart = matchIndex + NARRATIVE_IDD_TOKEN_LENGTH;
+  const after = rawSource.slice(
+    afterStart,
+    afterStart + NARRATIVE_IDD_LOOKAHEAD_CHARS,
+  );
+  return NARRATIVE_IDD_FOLLOWING_WORD_PATTERN.test(after);
 }
 
 function findPolicyOverrideMatch(

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -1081,7 +1081,7 @@ function isOrdinaryHyphenatedCompoundToken(
 // 60-char window), with nothing nearby actually attempting to change this
 // checker's own behavior.
 //
-// This exclusion targets "idd" only -- the other seven listed nouns
+// This exclusion targets "idd" only -- the other eight listed nouns
 // (repo/repository/policy/workflow/process/check/gate/requirement) are
 // generic enough that this narrative-attributive shape is not the
 // distinguishing false-positive source #2588 reports, and narrowing them

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -461,6 +461,37 @@ test('trust safety ignores any policy-override noun in the same hyphenated file-
   assert.equal(result.pass, true);
 });
 
+test('trust safety ignores the protocol name used attributively in ordinary narrative prose -- #2588', () => {
+  // The exact reproduction from idd-skill#2588: "idd" is the only listed
+  // noun in the verb's window, but it modifies a different entity ("an IDD
+  // agent's [own limit]") rather than standing as the verb's own direct
+  // object -- ordinary descriptive prose, not a directive aimed at this
+  // checker.
+  const result = checkTrustSafety({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\nThe ack-only override window the same way an IDD agent's can is currently narrower than the trusted marker login set.`,
+    },
+    trustSafetyAmbiguous: false,
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('trust safety still rejects the protocol name paired with another listed noun -- #2588', () => {
+  // "gate" is itself a listed, more specific noun farther from the verb
+  // than "idd" -- findGenuineNounMatch's farthest-first pick finds it
+  // independently of whether "idd" is excluded as a narrative mention, so
+  // this stays detected regardless.
+  const result = checkTrustSafety({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\nSomeone might try to override the idd gate on this repository.`,
+    },
+    trustSafetyAmbiguous: false,
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
 test('trust safety ignores a hyphenated compound noun ending in a policy-override verb -- #2399', () => {
   // #2218 wrapped only POLICY_OVERRIDE_NOUN_SOURCE in the hyphen-boundary
   // guard, leaving POLICY_OVERRIDE_VERB_SOURCE on a bare `\b`. A hyphen


### PR DESCRIPTION
# Summary

Check 3's `POLICY_OVERRIDE_NOUN_SOURCE` regex includes a bare `idd`
alternative that matched the protocol's own name in ordinary
descriptive prose ("an IDD agent's...", "the IDD workflow's own
session"), not just a genuine directive aimed at this checker.
Reproduced by the issue's own repro sentence, which describes the
ack-only override window using the protocol's own name and wrongly
hard-failed `trust_safety`, treating an otherwise-startable issue as
`invalid` at A4.5.

Added `isNarrativeIddMention()`: excludes an `idd` noun match from
Check 3's detection only when **both** conditions hold:

1. Immediately preceded by an article (`a`/`an`/`the`).
2. Immediately followed by another word continuing the same noun
   phrase (not a clause boundary).

A bare, article-free `idd` (`#2218`'s own regression case, e.g.
`bypass idd.`) still matches -- no article precedes it. `override the
idd gate` also stays detected regardless of this exclusion: `gate` is
itself a listed, more specific noun farther from the verb than `idd`,
so `findGenuineNounMatch`'s farthest-first pick finds it independently
of whatever this classifier decides about `idd`.

## Linked issue

Closes #2588

## Follow-up issues (if any)

- [ ] none created

## Background / rationale (if material)

Verified all three shapes directly via `node scripts/suitability-triage.mjs --stdin`
before writing the unit tests:

- The issue's own repro sentence -- `trust_safety` now `pass` (was
  `fail`).
- `` `override the idd gate` `` -- `trust_safety` still `fail`.
- `` `bypass idd.` `` (`#2218`'s bare case) -- `trust_safety` still
  `fail`.

Two considered alternatives, both rejected because they break
`#2218`'s own pinned regression test (`"trust safety still rejects a
freestanding policy-override use of the marker prefix -- #2218"`,
asserting `bypass idd.` must still fail):

- Drop the bare `idd` alternative entirely from
  `POLICY_OVERRIDE_NOUN_SOURCE`.
- Require `idd` to sit adjacent to another listed noun unconditionally
  (with no article-based distinction).

Both would also stop detecting `bypass idd.` (no other listed noun
nearby), since neither has any signal to tell that case apart from the
narrative false positive. The two-condition classifier above is the
narrowest rule that separates them: an article-plus-following-word
shape only appears in the narrative case among the known repro/
regression inputs.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed (`scripts/suitability-triage.mjs`,
      generated from `src/scripts/suitability-triage.mts` by
      `pnpm run build`, per `docs/typescript-sources.md`)
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm run typecheck` (`tsc -p tsconfig.json` -- clean)
- [x] `pnpm run build:check` (regenerated `.mjs` committed alongside
      the `.mts` source; clean, no diff after commit)
- [x] `npx biome check` (both changed source files: clean)
- [x] `pnpm run test -- suitability-triage`
      (`node --test tests/suitability-triage.test.mts` -- 277/277
      pass, including all existing `#2218`/`#2399` regression tests
      unchanged, plus 2 new tests for the repro/still-detected cases)
- [x] `pnpm test` (`node --test tests/*.test.mts`, full suite --
      5002 tests, 4994 pass, 0 fail, 8 skipped; 0 regressions)
- [x] `node scripts/audit-docs.mjs --check`

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none -- narrows an existing
      trust/safety false-positive; does not weaken detection of any
      known genuine directive shape, per the regression tests above)
- [x] Context budget impact reviewed (none -- no instruction/doc files
      changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X27jGWQk1dbPjpFchFfzzR
