### PR TITLE
fix(suitability-triage): accept substantive AC checklists without a keyword

### DIFF
--- a/scripts/markdown-code.mjs
+++ b/scripts/markdown-code.mjs
@@ -974,7 +974,14 @@ function parseFencedLine(
 function isValidFenceOpener(fence) {
   return fence.marker[0] !== '`' || !fence.info.includes('`');
 }
-function findFencedCodeRanges(text) {
+/**
+ * Fenced code block ranges only (no inline spans, no indented code). Unlike
+ * {@link findMarkdownCodeRanges}, this lets a caller mask example Markdown
+ * syntax inside a fence (a quoted heading or bullet) while leaving inline
+ * code spans intact for a scan that still needs them (e.g. suitability-triage
+ * Check 7's `hasSubstantiveBullet`, #2589).
+ */
+export function findFencedCodeRanges(text) {
   const ranges = [];
   let fence = null;
   const listTracker = createListContentIndentTrackerState();

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -17,6 +17,7 @@ import {
 import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mjs';
 import { loadPolicyConfig } from './idd-config.mjs';
 import {
+  findFencedCodeRanges,
   findMarkdownCodeRanges,
   getMarkdownCodeRange,
   maskMarkdownCodeRegionsPreservingPositions,
@@ -553,6 +554,18 @@ const ACCEPTANCE_CRITERIA_PATTERN = /^#+\s*Acceptance\s+Criteria\s*$/im;
 // previously-documented "TODO/FIXME" gap being broader than described.
 // Testing the anchored pattern against the raw content directly, rather
 // than a hand-split lead token, closes the whole class at once.
+//
+// Accepted limitation (E2 critique subagent, #2589 round 6): a real
+// identifier that starts with one of these reserved words, has no dotted
+// extension, and is glued directly to structural punctuation -- e.g.
+// "`WIP-tracker/config`" -- is misclassified as a placeholder and the bullet
+// fails, even though it names a concrete path. Widening the pattern to admit
+// this would re-admit "TODO-later" / "TODO/FIXME" (rounds 3-4's fixed gap):
+// both shapes are "placeholder word + one structural delimiter + word",
+// indistinguishable without a real identifier dictionary. A false negative
+// here costs less than reopening a false positive already fixed twice, and
+// the realistic case (a dotted extension) is already rescued by
+// BARE_DOTTED_FILENAME_PATTERN below.
 const PLACEHOLDER_LEAD_PATTERN =
   /^(?:TODO|TBD|N\/A|NA|XXX|FIXME|WIP|PENDING|PLACEHOLDER|NONE|ASAP)(?:[^a-zA-Z0-9]|$)/i;
 const CODE_SPAN_STRUCTURE_PATTERN = /[/._:-]/;
@@ -587,7 +600,16 @@ function extractListItemLines(section) {
     .join('\n');
 }
 function hasSubstantiveBullet(text) {
-  for (const match of text.matchAll(/`([^`]+)`/g)) {
+  // `text` is `extractListItemLines()`'s output: one list-item line per
+  // line, already joined by '\n' from lines that may not be adjacent in the
+  // original section. `[^`]` matching a newline let an unmatched backtick on
+  // one bullet pair across that artificial join with an unmatched backtick
+  // on a later bullet, manufacturing a fake code span from two unrelated
+  // placeholder bullets (e.g. "- [ ] TODO `" + "- [ ] TBD `") -- excluding
+  // `\n` from the span keeps a match within a single line, matching how a
+  // real inline code span can never cross a list item's own block boundary
+  // here (E2 critique subagent, #2589 round 6).
+  for (const match of text.matchAll(/`([^`\n]+)`/g)) {
     const content = (match[1] ?? '').trim();
     if (
       content.length > 0 &&
@@ -1776,13 +1798,31 @@ export function checkVerifiability(context) {
     /\btests?\b|\bverification\b|\bvalidate\b|\blint\b|\bci\b/i.test(body);
   // Check for substantive objective criteria, not just empty headings
   let hasObjectiveCriteria = false;
-  // Check for "Acceptance Criteria" with substantive content after it
-  const acceptanceCriteriaMatch = body.match(ACCEPTANCE_CRITERIA_PATTERN);
+  // Check for "Acceptance Criteria" with substantive content after it. A
+  // fenced code block quoting example Markdown syntax (an illustrative
+  // bullet, or a heading-like line meant only as sample output) must not
+  // leak into this scan either way -- as a fake substantive bullet, or as a
+  // fake section-boundary heading that truncates the section before a real
+  // bullet after the fence. Mask fence content only (not inline code spans,
+  // which hasSubstantiveBullet below still needs) over the whole body before
+  // any slicing, so a fence that opens inside the eventual 500-char window
+  // and closes outside it is still fully masked (E2 critique subagent,
+  // #2589 round 6). Masking preserves character positions, so every offset
+  // computed below stays valid against the original body.
+  const fenceMaskedBody = maskMarkdownCodeRegionsPreservingPositions(
+    body,
+    findFencedCodeRanges(body),
+  );
+  const acceptanceCriteriaMatch = fenceMaskedBody.match(
+    ACCEPTANCE_CRITERIA_PATTERN,
+  );
   if (acceptanceCriteriaMatch) {
     const indexAfter =
       (acceptanceCriteriaMatch.index ?? 0) +
       (acceptanceCriteriaMatch[0]?.length ?? 0);
-    const contentAfter = body.slice(indexAfter, indexAfter + 500).trim();
+    const contentAfter = fenceMaskedBody
+      .slice(indexAfter, indexAfter + 500)
+      .trim();
     // Bound the AC section at the next heading so a trailing sibling
     // section (e.g. this repo's own "## Candidate files" convention, which
     // is itself a bullet list of paths) never leaks substance or an

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -532,7 +532,30 @@ const ACCEPTANCE_CRITERIA_PATTERN = /^#+\s*Acceptance\s+Criteria\s*$/im;
 // conjunction like "and/or" or "read/write" with no real path underneath --
 // a real file path in this repo's AC bullets is either backticked or ends
 // in a dotted extension, both already covered below.
-const SUBSTANTIVE_BULLET_PATTERN = /`[^`]+`|\b[\w-]{2,}\.[a-zA-Z]{1,5}\b/;
+//
+// Copilot review (PR #2602) flagged that treating ANY inline-code span as
+// substantive lets a backticked placeholder ("- [ ] `TODO`", "- [ ] `N/A`")
+// wrongly pass. A code span now also needs a structural signal of being a
+// real path/command/identifier (a slash, dot, underscore, hyphen, or
+// internal whitespace) and must not be an exact match against a short,
+// closed placeholder-token list.
+const PLACEHOLDER_TOKEN_PATTERN =
+  /^(?:TODO|TBD|N\/A|NA|XXX|FIXME|WIP|PENDING|PLACEHOLDER|NONE|ASAP)$/i;
+const CODE_SPAN_STRUCTURE_PATTERN = /[/._-]|\s/;
+const BARE_DOTTED_FILENAME_PATTERN = /\b[\w-]{2,}\.[a-zA-Z]{1,5}\b/;
+function hasSubstantiveBullet(text) {
+  for (const match of text.matchAll(/`([^`]+)`/g)) {
+    const content = (match[1] ?? '').trim();
+    if (
+      content.length > 0 &&
+      CODE_SPAN_STRUCTURE_PATTERN.test(content) &&
+      !PLACEHOLDER_TOKEN_PATTERN.test(content)
+    ) {
+      return true;
+    }
+  }
+  return BARE_DOTTED_FILENAME_PATTERN.test(text);
+}
 // A heading line such as "## Decision (resolved 2026-06-27)" records that a
 // human has already ruled on the issue's open question (see Check 7). The
 // negative lookahead rejects only a still-open *phrase* that directly negates
@@ -1726,12 +1749,12 @@ export function checkVerifiability(context) {
         ? contentAfter
         : contentAfter.slice(0, nextHeadingIndex);
     // Require either a list (starting with - or *) or numbered content. A
-    // substantive bullet (SUBSTANTIVE_BULLET_PATTERN) satisfies this on its
-    // own; an outcome-signal keyword remains a fallback for a list that
-    // names no concrete file, command, or artifact (#2589).
+    // substantive bullet (hasSubstantiveBullet) satisfies this on its own;
+    // an outcome-signal keyword remains a fallback for a list that names
+    // no concrete file, command, or artifact (#2589).
     if (/^[-*]\s+/.test(listSection) || /^\d+\.\s+/.test(listSection)) {
       hasObjectiveCriteria =
-        SUBSTANTIVE_BULLET_PATTERN.test(listSection) ||
+        hasSubstantiveBullet(listSection) ||
         OUTCOME_SIGNAL_PATTERN.test(listSection);
     }
   }

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -556,9 +556,35 @@ const ACCEPTANCE_CRITERIA_PATTERN = /^#+\s*Acceptance\s+Criteria\s*$/im;
 const PLACEHOLDER_LEAD_PATTERN =
   /^(?:TODO|TBD|N\/A|NA|XXX|FIXME|WIP|PENDING|PLACEHOLDER|NONE|ASAP)(?:[^a-zA-Z0-9]|$)/i;
 const CODE_SPAN_STRUCTURE_PATTERN = /[/._:-]/;
+// CodeRabbit review (PR #2602): a code span needs actual alphanumeric
+// content, not just a structural delimiter -- "- [ ] `-`" or "- [ ] `.`"
+// otherwise names nothing while still satisfying
+// CODE_SPAN_STRUCTURE_PATTERN.
+const CODE_SPAN_ALNUM_PATTERN = /[a-zA-Z0-9]/;
 const BARE_DOTTED_FILENAME_PATTERN = /\b[\w-]{2,}\.[a-zA-Z]{1,5}\b/;
+// CodeRabbit review (PR #2602): an ATX heading may carry up to three
+// leading spaces per CommonMark, so the AC-section boundary below must
+// tolerate that indentation or an indented sibling heading (e.g. this
+// repo's own "   ## Candidate files", however it happens to be indented)
+// would not stop the section.
+const NEXT_HEADING_PATTERN = /\n {0,3}#{1,6}\s/;
+// CodeRabbit review (PR #2602): scanning the whole AC section's raw text
+// -- rather than just its list-item lines -- let a placeholder bullet
+// ("- [ ] TODO") followed by unrelated, non-list prose containing a
+// substantive-looking code span or outcome-signal keyword wrongly pass.
+// Only lines that are themselves list-item markers (a wrapped/lazy
+// continuation line is intentionally excluded too, since it cannot be
+// told apart from unrelated trailing prose without full Markdown
+// paragraph parsing) are considered for either check.
+const LIST_ITEM_LINE_PATTERN = /^\s*(?:[-*]|\d+\.)\s+/;
 function looksLikePlaceholder(content) {
   return PLACEHOLDER_LEAD_PATTERN.test(content);
+}
+function extractListItemLines(section) {
+  return section
+    .split('\n')
+    .filter((line) => LIST_ITEM_LINE_PATTERN.test(line))
+    .join('\n');
 }
 function hasSubstantiveBullet(text) {
   for (const match of text.matchAll(/`([^`]+)`/g)) {
@@ -566,6 +592,7 @@ function hasSubstantiveBullet(text) {
     if (
       content.length > 0 &&
       CODE_SPAN_STRUCTURE_PATTERN.test(content) &&
+      CODE_SPAN_ALNUM_PATTERN.test(content) &&
       !looksLikePlaceholder(content)
     ) {
       return true;
@@ -1760,7 +1787,7 @@ export function checkVerifiability(context) {
     // section (e.g. this repo's own "## Candidate files" convention, which
     // is itself a bullet list of paths) never leaks substance or an
     // outcome-signal keyword into a genuinely placeholder AC list (#2589).
-    const nextHeadingIndex = contentAfter.search(/\n#{1,6}\s/);
+    const nextHeadingIndex = contentAfter.search(NEXT_HEADING_PATTERN);
     const listSection =
       nextHeadingIndex === -1
         ? contentAfter
@@ -1768,11 +1795,15 @@ export function checkVerifiability(context) {
     // Require either a list (starting with - or *) or numbered content. A
     // substantive bullet (hasSubstantiveBullet) satisfies this on its own;
     // an outcome-signal keyword remains a fallback for a list that names
-    // no concrete file, command, or artifact (#2589).
+    // no concrete file, command, or artifact (#2589). Both checks scan
+    // only the section's own list-item lines, not its full raw text, so a
+    // placeholder bullet followed by unrelated non-list prose can't
+    // borrow that prose's substance or keywords (#2589 CodeRabbit review).
     if (/^[-*]\s+/.test(listSection) || /^\d+\.\s+/.test(listSection)) {
+      const listItemsOnly = extractListItemLines(listSection);
       hasObjectiveCriteria =
-        hasSubstantiveBullet(listSection) ||
-        OUTCOME_SIGNAL_PATTERN.test(listSection);
+        hasSubstantiveBullet(listItemsOnly) ||
+        OUTCOME_SIGNAL_PATTERN.test(listItemsOnly);
     }
   }
   // Alternative: check for numbered steps with outcome signals or checklists

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -533,23 +533,32 @@ const ACCEPTANCE_CRITERIA_PATTERN = /^#+\s*Acceptance\s+Criteria\s*$/im;
 // a real file path in this repo's AC bullets is either backticked or ends
 // in a dotted extension, both already covered below.
 //
-// Copilot review (PR #2602) flagged that treating ANY inline-code span as
-// substantive lets a backticked placeholder ("- [ ] `TODO`", "- [ ] `N/A`")
-// wrongly pass. A code span now also needs a structural signal of being a
-// real path/command/identifier (a slash, dot, underscore, hyphen, or
-// internal whitespace) and must not be an exact match against a short,
-// closed placeholder-token list.
+// Copilot review (PR #2602) flagged, across two passes, that treating ANY
+// inline-code span as substantive lets a backticked placeholder --
+// "- [ ] `TODO`", "- [ ] `N/A`", "- [ ] `TODO later`" -- wrongly pass. A
+// code span now needs a structural signal of being a real
+// path/command/identifier (a slash, dot, underscore, colon, or hyphen)
+// AND its leading token (split on whitespace, colon, or hyphen -- not
+// slash, so a slash-joined token like "N/A" itself stays intact) must not
+// exactly match a short, closed placeholder-token list. Checking only the
+// lead token (not the whole span) catches a trailing-punctuation or
+// trailing-word variant ("TODO-later", "TODO: fix", "N/A yet") without
+// having to enumerate every such phrase.
 const PLACEHOLDER_TOKEN_PATTERN =
   /^(?:TODO|TBD|N\/A|NA|XXX|FIXME|WIP|PENDING|PLACEHOLDER|NONE|ASAP)$/i;
-const CODE_SPAN_STRUCTURE_PATTERN = /[/._-]|\s/;
+const CODE_SPAN_STRUCTURE_PATTERN = /[/._:-]/;
 const BARE_DOTTED_FILENAME_PATTERN = /\b[\w-]{2,}\.[a-zA-Z]{1,5}\b/;
+function looksLikePlaceholder(content) {
+  const leadToken = content.split(/[\s:-]+/)[0] ?? '';
+  return PLACEHOLDER_TOKEN_PATTERN.test(leadToken);
+}
 function hasSubstantiveBullet(text) {
   for (const match of text.matchAll(/`([^`]+)`/g)) {
     const content = (match[1] ?? '').trim();
     if (
       content.length > 0 &&
       CODE_SPAN_STRUCTURE_PATTERN.test(content) &&
-      !PLACEHOLDER_TOKEN_PATTERN.test(content)
+      !looksLikePlaceholder(content)
     ) {
       return true;
     }

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -521,6 +521,18 @@ function isEnumeratedParentheticalEntry(body, matchIndex, matchLength) {
   return otherEntries.length > 0 && otherEntries.every(looksLikeLabelEntry);
 }
 const ACCEPTANCE_CRITERIA_PATTERN = /^#+\s*Acceptance\s+Criteria\s*$/im;
+// #2589: a bullet under "## Acceptance Criteria" that names something
+// concrete -- an inline-code span (covers a quoted file path, command, or
+// identifier) or a bare dotted filename -- is substantive on its own,
+// independent of OUTCOME_SIGNAL_PATTERN's closed English vocabulary. Check 5
+// (actionability) already accepts the same checklist as actionable; this
+// keeps Check 7 from re-gating it behind a keyword spot-check the
+// checklist's own content already satisfies. Deliberately has no bare
+// slash-path alternative: `\bfoo\/bar\b` alone also matches an ordinary
+// conjunction like "and/or" or "read/write" with no real path underneath --
+// a real file path in this repo's AC bullets is either backticked or ends
+// in a dotted extension, both already covered below.
+const SUBSTANTIVE_BULLET_PATTERN = /`[^`]+`|\b[\w-]{2,}\.[a-zA-Z]{1,5}\b/;
 // A heading line such as "## Decision (resolved 2026-06-27)" records that a
 // human has already ruled on the issue's open question (see Check 7). The
 // negative lookahead rejects only a still-open *phrase* that directly negates
@@ -1704,12 +1716,23 @@ export function checkVerifiability(context) {
       (acceptanceCriteriaMatch.index ?? 0) +
       (acceptanceCriteriaMatch[0]?.length ?? 0);
     const contentAfter = body.slice(indexAfter, indexAfter + 500).trim();
-    // Require either a list (starting with - or *) or numbered content with outcome signals
-    if (/^[-*]\s+/.test(contentAfter) || /^\d+\.\s+/.test(contentAfter)) {
-      const hasOutcomeSignals = OUTCOME_SIGNAL_PATTERN.test(contentAfter);
-      if (hasOutcomeSignals) {
-        hasObjectiveCriteria = true;
-      }
+    // Bound the AC section at the next heading so a trailing sibling
+    // section (e.g. this repo's own "## Candidate files" convention, which
+    // is itself a bullet list of paths) never leaks substance or an
+    // outcome-signal keyword into a genuinely placeholder AC list (#2589).
+    const nextHeadingIndex = contentAfter.search(/\n#{1,6}\s/);
+    const listSection =
+      nextHeadingIndex === -1
+        ? contentAfter
+        : contentAfter.slice(0, nextHeadingIndex);
+    // Require either a list (starting with - or *) or numbered content. A
+    // substantive bullet (SUBSTANTIVE_BULLET_PATTERN) satisfies this on its
+    // own; an outcome-signal keyword remains a fallback for a list that
+    // names no concrete file, command, or artifact (#2589).
+    if (/^[-*]\s+/.test(listSection) || /^\d+\.\s+/.test(listSection)) {
+      hasObjectiveCriteria =
+        SUBSTANTIVE_BULLET_PATTERN.test(listSection) ||
+        OUTCOME_SIGNAL_PATTERN.test(listSection);
     }
   }
   // Alternative: check for numbered steps with outcome signals or checklists

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -533,24 +533,32 @@ const ACCEPTANCE_CRITERIA_PATTERN = /^#+\s*Acceptance\s+Criteria\s*$/im;
 // a real file path in this repo's AC bullets is either backticked or ends
 // in a dotted extension, both already covered below.
 //
-// Copilot review (PR #2602) flagged, across two passes, that treating ANY
-// inline-code span as substantive lets a backticked placeholder --
+// Copilot review (PR #2602) flagged, across multiple passes, that treating
+// ANY inline-code span as substantive lets a backticked placeholder --
 // "- [ ] `TODO`", "- [ ] `N/A`", "- [ ] `TODO later`" -- wrongly pass. A
 // code span now needs a structural signal of being a real
 // path/command/identifier (a slash, dot, underscore, colon, or hyphen)
-// AND its leading token (split on whitespace, colon, or hyphen -- not
-// slash, so a slash-joined token like "N/A" itself stays intact) must not
-// exactly match a short, closed placeholder-token list. Checking only the
-// lead token (not the whole span) catches a trailing-punctuation or
-// trailing-word variant ("TODO-later", "TODO: fix", "N/A yet") without
-// having to enumerate every such phrase.
-const PLACEHOLDER_TOKEN_PATTERN =
-  /^(?:TODO|TBD|N\/A|NA|XXX|FIXME|WIP|PENDING|PLACEHOLDER|NONE|ASAP)$/i;
+// AND must not merely *lead with* a short, closed placeholder token.
+// PLACEHOLDER_LEAD_PATTERN is anchored at the start and requires the
+// placeholder word to be immediately followed by a non-alphanumeric
+// character or the end of the string, so it matches the bare token
+// ("TODO"), a trailing punctuation glue of any kind ("TODO.", "TODO_",
+// "TODO-later", "TODO: fix", "TODO/FIXME") and a trailing word ("N/A
+// yet"), without matching a real identifier that merely starts with the
+// same letters ("NASA", "nonexistent-file.txt"). An earlier revision
+// tried to reconstruct this via a whitespace/colon/hyphen split of the
+// span's lead token, which covered the punctuation marks it split on but
+// missed a placeholder glued directly to a period, underscore, or slash
+// -- an E2 critique subagent caught "TODO.", "TODO_", and the
+// previously-documented "TODO/FIXME" gap being broader than described.
+// Testing the anchored pattern against the raw content directly, rather
+// than a hand-split lead token, closes the whole class at once.
+const PLACEHOLDER_LEAD_PATTERN =
+  /^(?:TODO|TBD|N\/A|NA|XXX|FIXME|WIP|PENDING|PLACEHOLDER|NONE|ASAP)(?:[^a-zA-Z0-9]|$)/i;
 const CODE_SPAN_STRUCTURE_PATTERN = /[/._:-]/;
 const BARE_DOTTED_FILENAME_PATTERN = /\b[\w-]{2,}\.[a-zA-Z]{1,5}\b/;
 function looksLikePlaceholder(content) {
-  const leadToken = content.split(/[\s:-]+/)[0] ?? '';
-  return PLACEHOLDER_TOKEN_PATTERN.test(leadToken);
+  return PLACEHOLDER_LEAD_PATTERN.test(content);
 }
 function hasSubstantiveBullet(text) {
   for (const match of text.matchAll(/`([^`]+)`/g)) {

--- a/src/scripts/markdown-code.mts
+++ b/src/scripts/markdown-code.mts
@@ -1130,7 +1130,14 @@ function isValidFenceOpener(fence: FencedLine): boolean {
   return fence.marker[0] !== '`' || !fence.info.includes('`');
 }
 
-function findFencedCodeRanges(text: string): MarkdownCodeRange[] {
+/**
+ * Fenced code block ranges only (no inline spans, no indented code). Unlike
+ * {@link findMarkdownCodeRanges}, this lets a caller mask example Markdown
+ * syntax inside a fence (a quoted heading or bullet) while leaving inline
+ * code spans intact for a scan that still needs them (e.g. suitability-triage
+ * Check 7's `hasSubstantiveBullet`, #2589).
+ */
+export function findFencedCodeRanges(text: string): MarkdownCodeRange[] {
   const ranges: MarkdownCodeRange[] = [];
   let fence: {
     char: string;

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -697,10 +697,37 @@ const ACCEPTANCE_CRITERIA_PATTERN = /^#+\s*Acceptance\s+Criteria\s*$/im;
 const PLACEHOLDER_LEAD_PATTERN =
   /^(?:TODO|TBD|N\/A|NA|XXX|FIXME|WIP|PENDING|PLACEHOLDER|NONE|ASAP)(?:[^a-zA-Z0-9]|$)/i;
 const CODE_SPAN_STRUCTURE_PATTERN = /[/._:-]/;
+// CodeRabbit review (PR #2602): a code span needs actual alphanumeric
+// content, not just a structural delimiter -- "- [ ] `-`" or "- [ ] `.`"
+// otherwise names nothing while still satisfying
+// CODE_SPAN_STRUCTURE_PATTERN.
+const CODE_SPAN_ALNUM_PATTERN = /[a-zA-Z0-9]/;
 const BARE_DOTTED_FILENAME_PATTERN = /\b[\w-]{2,}\.[a-zA-Z]{1,5}\b/;
+// CodeRabbit review (PR #2602): an ATX heading may carry up to three
+// leading spaces per CommonMark, so the AC-section boundary below must
+// tolerate that indentation or an indented sibling heading (e.g. this
+// repo's own "   ## Candidate files", however it happens to be indented)
+// would not stop the section.
+const NEXT_HEADING_PATTERN = /\n {0,3}#{1,6}\s/;
+// CodeRabbit review (PR #2602): scanning the whole AC section's raw text
+// -- rather than just its list-item lines -- let a placeholder bullet
+// ("- [ ] TODO") followed by unrelated, non-list prose containing a
+// substantive-looking code span or outcome-signal keyword wrongly pass.
+// Only lines that are themselves list-item markers (a wrapped/lazy
+// continuation line is intentionally excluded too, since it cannot be
+// told apart from unrelated trailing prose without full Markdown
+// paragraph parsing) are considered for either check.
+const LIST_ITEM_LINE_PATTERN = /^\s*(?:[-*]|\d+\.)\s+/;
 
 function looksLikePlaceholder(content: string): boolean {
   return PLACEHOLDER_LEAD_PATTERN.test(content);
+}
+
+function extractListItemLines(section: string): string {
+  return section
+    .split('\n')
+    .filter((line) => LIST_ITEM_LINE_PATTERN.test(line))
+    .join('\n');
 }
 
 function hasSubstantiveBullet(text: string): boolean {
@@ -709,6 +736,7 @@ function hasSubstantiveBullet(text: string): boolean {
     if (
       content.length > 0 &&
       CODE_SPAN_STRUCTURE_PATTERN.test(content) &&
+      CODE_SPAN_ALNUM_PATTERN.test(content) &&
       !looksLikePlaceholder(content)
     ) {
       return true;
@@ -1974,7 +2002,7 @@ export function checkVerifiability(context: Context): CheckOutcome {
     // section (e.g. this repo's own "## Candidate files" convention, which
     // is itself a bullet list of paths) never leaks substance or an
     // outcome-signal keyword into a genuinely placeholder AC list (#2589).
-    const nextHeadingIndex = contentAfter.search(/\n#{1,6}\s/);
+    const nextHeadingIndex = contentAfter.search(NEXT_HEADING_PATTERN);
     const listSection =
       nextHeadingIndex === -1
         ? contentAfter
@@ -1982,11 +2010,15 @@ export function checkVerifiability(context: Context): CheckOutcome {
     // Require either a list (starting with - or *) or numbered content. A
     // substantive bullet (hasSubstantiveBullet) satisfies this on its own;
     // an outcome-signal keyword remains a fallback for a list that names
-    // no concrete file, command, or artifact (#2589).
+    // no concrete file, command, or artifact (#2589). Both checks scan
+    // only the section's own list-item lines, not its full raw text, so a
+    // placeholder bullet followed by unrelated non-list prose can't
+    // borrow that prose's substance or keywords (#2589 CodeRabbit review).
     if (/^[-*]\s+/.test(listSection) || /^\d+\.\s+/.test(listSection)) {
+      const listItemsOnly = extractListItemLines(listSection);
       hasObjectiveCriteria =
-        hasSubstantiveBullet(listSection) ||
-        OUTCOME_SIGNAL_PATTERN.test(listSection);
+        hasSubstantiveBullet(listItemsOnly) ||
+        OUTCOME_SIGNAL_PATTERN.test(listItemsOnly);
     }
   }
 

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -674,25 +674,33 @@ const ACCEPTANCE_CRITERIA_PATTERN = /^#+\s*Acceptance\s+Criteria\s*$/im;
 // a real file path in this repo's AC bullets is either backticked or ends
 // in a dotted extension, both already covered below.
 //
-// Copilot review (PR #2602) flagged, across two passes, that treating ANY
-// inline-code span as substantive lets a backticked placeholder --
+// Copilot review (PR #2602) flagged, across multiple passes, that treating
+// ANY inline-code span as substantive lets a backticked placeholder --
 // "- [ ] `TODO`", "- [ ] `N/A`", "- [ ] `TODO later`" -- wrongly pass. A
 // code span now needs a structural signal of being a real
 // path/command/identifier (a slash, dot, underscore, colon, or hyphen)
-// AND its leading token (split on whitespace, colon, or hyphen -- not
-// slash, so a slash-joined token like "N/A" itself stays intact) must not
-// exactly match a short, closed placeholder-token list. Checking only the
-// lead token (not the whole span) catches a trailing-punctuation or
-// trailing-word variant ("TODO-later", "TODO: fix", "N/A yet") without
-// having to enumerate every such phrase.
-const PLACEHOLDER_TOKEN_PATTERN =
-  /^(?:TODO|TBD|N\/A|NA|XXX|FIXME|WIP|PENDING|PLACEHOLDER|NONE|ASAP)$/i;
+// AND must not merely *lead with* a short, closed placeholder token.
+// PLACEHOLDER_LEAD_PATTERN is anchored at the start and requires the
+// placeholder word to be immediately followed by a non-alphanumeric
+// character or the end of the string, so it matches the bare token
+// ("TODO"), a trailing punctuation glue of any kind ("TODO.", "TODO_",
+// "TODO-later", "TODO: fix", "TODO/FIXME") and a trailing word ("N/A
+// yet"), without matching a real identifier that merely starts with the
+// same letters ("NASA", "nonexistent-file.txt"). An earlier revision
+// tried to reconstruct this via a whitespace/colon/hyphen split of the
+// span's lead token, which covered the punctuation marks it split on but
+// missed a placeholder glued directly to a period, underscore, or slash
+// -- an E2 critique subagent caught "TODO.", "TODO_", and the
+// previously-documented "TODO/FIXME" gap being broader than described.
+// Testing the anchored pattern against the raw content directly, rather
+// than a hand-split lead token, closes the whole class at once.
+const PLACEHOLDER_LEAD_PATTERN =
+  /^(?:TODO|TBD|N\/A|NA|XXX|FIXME|WIP|PENDING|PLACEHOLDER|NONE|ASAP)(?:[^a-zA-Z0-9]|$)/i;
 const CODE_SPAN_STRUCTURE_PATTERN = /[/._:-]/;
 const BARE_DOTTED_FILENAME_PATTERN = /\b[\w-]{2,}\.[a-zA-Z]{1,5}\b/;
 
 function looksLikePlaceholder(content: string): boolean {
-  const leadToken = content.split(/[\s:-]+/)[0] ?? '';
-  return PLACEHOLDER_TOKEN_PATTERN.test(leadToken);
+  return PLACEHOLDER_LEAD_PATTERN.test(content);
 }
 
 function hasSubstantiveBullet(text: string): boolean {

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -674,16 +674,26 @@ const ACCEPTANCE_CRITERIA_PATTERN = /^#+\s*Acceptance\s+Criteria\s*$/im;
 // a real file path in this repo's AC bullets is either backticked or ends
 // in a dotted extension, both already covered below.
 //
-// Copilot review (PR #2602) flagged that treating ANY inline-code span as
-// substantive lets a backticked placeholder ("- [ ] `TODO`", "- [ ] `N/A`")
-// wrongly pass. A code span now also needs a structural signal of being a
-// real path/command/identifier (a slash, dot, underscore, hyphen, or
-// internal whitespace) and must not be an exact match against a short,
-// closed placeholder-token list.
+// Copilot review (PR #2602) flagged, across two passes, that treating ANY
+// inline-code span as substantive lets a backticked placeholder --
+// "- [ ] `TODO`", "- [ ] `N/A`", "- [ ] `TODO later`" -- wrongly pass. A
+// code span now needs a structural signal of being a real
+// path/command/identifier (a slash, dot, underscore, colon, or hyphen)
+// AND its leading token (split on whitespace, colon, or hyphen -- not
+// slash, so a slash-joined token like "N/A" itself stays intact) must not
+// exactly match a short, closed placeholder-token list. Checking only the
+// lead token (not the whole span) catches a trailing-punctuation or
+// trailing-word variant ("TODO-later", "TODO: fix", "N/A yet") without
+// having to enumerate every such phrase.
 const PLACEHOLDER_TOKEN_PATTERN =
   /^(?:TODO|TBD|N\/A|NA|XXX|FIXME|WIP|PENDING|PLACEHOLDER|NONE|ASAP)$/i;
-const CODE_SPAN_STRUCTURE_PATTERN = /[/._-]|\s/;
+const CODE_SPAN_STRUCTURE_PATTERN = /[/._:-]/;
 const BARE_DOTTED_FILENAME_PATTERN = /\b[\w-]{2,}\.[a-zA-Z]{1,5}\b/;
+
+function looksLikePlaceholder(content: string): boolean {
+  const leadToken = content.split(/[\s:-]+/)[0] ?? '';
+  return PLACEHOLDER_TOKEN_PATTERN.test(leadToken);
+}
 
 function hasSubstantiveBullet(text: string): boolean {
   for (const match of text.matchAll(/`([^`]+)`/g)) {
@@ -691,7 +701,7 @@ function hasSubstantiveBullet(text: string): boolean {
     if (
       content.length > 0 &&
       CODE_SPAN_STRUCTURE_PATTERN.test(content) &&
-      !PLACEHOLDER_TOKEN_PATTERN.test(content)
+      !looksLikePlaceholder(content)
     ) {
       return true;
     }

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -673,7 +673,31 @@ const ACCEPTANCE_CRITERIA_PATTERN = /^#+\s*Acceptance\s+Criteria\s*$/im;
 // conjunction like "and/or" or "read/write" with no real path underneath --
 // a real file path in this repo's AC bullets is either backticked or ends
 // in a dotted extension, both already covered below.
-const SUBSTANTIVE_BULLET_PATTERN = /`[^`]+`|\b[\w-]{2,}\.[a-zA-Z]{1,5}\b/;
+//
+// Copilot review (PR #2602) flagged that treating ANY inline-code span as
+// substantive lets a backticked placeholder ("- [ ] `TODO`", "- [ ] `N/A`")
+// wrongly pass. A code span now also needs a structural signal of being a
+// real path/command/identifier (a slash, dot, underscore, hyphen, or
+// internal whitespace) and must not be an exact match against a short,
+// closed placeholder-token list.
+const PLACEHOLDER_TOKEN_PATTERN =
+  /^(?:TODO|TBD|N\/A|NA|XXX|FIXME|WIP|PENDING|PLACEHOLDER|NONE|ASAP)$/i;
+const CODE_SPAN_STRUCTURE_PATTERN = /[/._-]|\s/;
+const BARE_DOTTED_FILENAME_PATTERN = /\b[\w-]{2,}\.[a-zA-Z]{1,5}\b/;
+
+function hasSubstantiveBullet(text: string): boolean {
+  for (const match of text.matchAll(/`([^`]+)`/g)) {
+    const content = (match[1] ?? '').trim();
+    if (
+      content.length > 0 &&
+      CODE_SPAN_STRUCTURE_PATTERN.test(content) &&
+      !PLACEHOLDER_TOKEN_PATTERN.test(content)
+    ) {
+      return true;
+    }
+  }
+  return BARE_DOTTED_FILENAME_PATTERN.test(text);
+}
 // A heading line such as "## Decision (resolved 2026-06-27)" records that a
 // human has already ruled on the issue's open question (see Check 7). The
 // negative lookahead rejects only a still-open *phrase* that directly negates
@@ -1938,12 +1962,12 @@ export function checkVerifiability(context: Context): CheckOutcome {
         ? contentAfter
         : contentAfter.slice(0, nextHeadingIndex);
     // Require either a list (starting with - or *) or numbered content. A
-    // substantive bullet (SUBSTANTIVE_BULLET_PATTERN) satisfies this on its
-    // own; an outcome-signal keyword remains a fallback for a list that
-    // names no concrete file, command, or artifact (#2589).
+    // substantive bullet (hasSubstantiveBullet) satisfies this on its own;
+    // an outcome-signal keyword remains a fallback for a list that names
+    // no concrete file, command, or artifact (#2589).
     if (/^[-*]\s+/.test(listSection) || /^\d+\.\s+/.test(listSection)) {
       hasObjectiveCriteria =
-        SUBSTANTIVE_BULLET_PATTERN.test(listSection) ||
+        hasSubstantiveBullet(listSection) ||
         OUTCOME_SIGNAL_PATTERN.test(listSection);
     }
   }

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -19,6 +19,7 @@ import {
 import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mts';
 import { loadPolicyConfig } from './idd-config.mts';
 import {
+  findFencedCodeRanges,
   findMarkdownCodeRanges,
   getMarkdownCodeRange,
   type MarkdownCodeRange,
@@ -694,6 +695,18 @@ const ACCEPTANCE_CRITERIA_PATTERN = /^#+\s*Acceptance\s+Criteria\s*$/im;
 // previously-documented "TODO/FIXME" gap being broader than described.
 // Testing the anchored pattern against the raw content directly, rather
 // than a hand-split lead token, closes the whole class at once.
+//
+// Accepted limitation (E2 critique subagent, #2589 round 6): a real
+// identifier that starts with one of these reserved words, has no dotted
+// extension, and is glued directly to structural punctuation -- e.g.
+// "`WIP-tracker/config`" -- is misclassified as a placeholder and the bullet
+// fails, even though it names a concrete path. Widening the pattern to admit
+// this would re-admit "TODO-later" / "TODO/FIXME" (rounds 3-4's fixed gap):
+// both shapes are "placeholder word + one structural delimiter + word",
+// indistinguishable without a real identifier dictionary. A false negative
+// here costs less than reopening a false positive already fixed twice, and
+// the realistic case (a dotted extension) is already rescued by
+// BARE_DOTTED_FILENAME_PATTERN below.
 const PLACEHOLDER_LEAD_PATTERN =
   /^(?:TODO|TBD|N\/A|NA|XXX|FIXME|WIP|PENDING|PLACEHOLDER|NONE|ASAP)(?:[^a-zA-Z0-9]|$)/i;
 const CODE_SPAN_STRUCTURE_PATTERN = /[/._:-]/;
@@ -731,7 +744,16 @@ function extractListItemLines(section: string): string {
 }
 
 function hasSubstantiveBullet(text: string): boolean {
-  for (const match of text.matchAll(/`([^`]+)`/g)) {
+  // `text` is `extractListItemLines()`'s output: one list-item line per
+  // line, already joined by '\n' from lines that may not be adjacent in the
+  // original section. `[^`]` matching a newline let an unmatched backtick on
+  // one bullet pair across that artificial join with an unmatched backtick
+  // on a later bullet, manufacturing a fake code span from two unrelated
+  // placeholder bullets (e.g. "- [ ] TODO `" + "- [ ] TBD `") -- excluding
+  // `\n` from the span keeps a match within a single line, matching how a
+  // real inline code span can never cross a list item's own block boundary
+  // here (E2 critique subagent, #2589 round 6).
+  for (const match of text.matchAll(/`([^`\n]+)`/g)) {
     const content = (match[1] ?? '').trim();
     if (
       content.length > 0 &&
@@ -1991,13 +2013,31 @@ export function checkVerifiability(context: Context): CheckOutcome {
   // Check for substantive objective criteria, not just empty headings
   let hasObjectiveCriteria = false;
 
-  // Check for "Acceptance Criteria" with substantive content after it
-  const acceptanceCriteriaMatch = body.match(ACCEPTANCE_CRITERIA_PATTERN);
+  // Check for "Acceptance Criteria" with substantive content after it. A
+  // fenced code block quoting example Markdown syntax (an illustrative
+  // bullet, or a heading-like line meant only as sample output) must not
+  // leak into this scan either way -- as a fake substantive bullet, or as a
+  // fake section-boundary heading that truncates the section before a real
+  // bullet after the fence. Mask fence content only (not inline code spans,
+  // which hasSubstantiveBullet below still needs) over the whole body before
+  // any slicing, so a fence that opens inside the eventual 500-char window
+  // and closes outside it is still fully masked (E2 critique subagent,
+  // #2589 round 6). Masking preserves character positions, so every offset
+  // computed below stays valid against the original body.
+  const fenceMaskedBody = maskMarkdownCodeRegionsPreservingPositions(
+    body,
+    findFencedCodeRanges(body),
+  );
+  const acceptanceCriteriaMatch = fenceMaskedBody.match(
+    ACCEPTANCE_CRITERIA_PATTERN,
+  );
   if (acceptanceCriteriaMatch) {
     const indexAfter =
       (acceptanceCriteriaMatch.index ?? 0) +
       (acceptanceCriteriaMatch[0]?.length ?? 0);
-    const contentAfter = body.slice(indexAfter, indexAfter + 500).trim();
+    const contentAfter = fenceMaskedBody
+      .slice(indexAfter, indexAfter + 500)
+      .trim();
     // Bound the AC section at the next heading so a trailing sibling
     // section (e.g. this repo's own "## Candidate files" convention, which
     // is itself a bullet list of paths) never leaks substance or an

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -662,6 +662,18 @@ function isEnumeratedParentheticalEntry(
   return otherEntries.length > 0 && otherEntries.every(looksLikeLabelEntry);
 }
 const ACCEPTANCE_CRITERIA_PATTERN = /^#+\s*Acceptance\s+Criteria\s*$/im;
+// #2589: a bullet under "## Acceptance Criteria" that names something
+// concrete -- an inline-code span (covers a quoted file path, command, or
+// identifier) or a bare dotted filename -- is substantive on its own,
+// independent of OUTCOME_SIGNAL_PATTERN's closed English vocabulary. Check 5
+// (actionability) already accepts the same checklist as actionable; this
+// keeps Check 7 from re-gating it behind a keyword spot-check the
+// checklist's own content already satisfies. Deliberately has no bare
+// slash-path alternative: `\bfoo\/bar\b` alone also matches an ordinary
+// conjunction like "and/or" or "read/write" with no real path underneath --
+// a real file path in this repo's AC bullets is either backticked or ends
+// in a dotted extension, both already covered below.
+const SUBSTANTIVE_BULLET_PATTERN = /`[^`]+`|\b[\w-]{2,}\.[a-zA-Z]{1,5}\b/;
 // A heading line such as "## Decision (resolved 2026-06-27)" records that a
 // human has already ruled on the issue's open question (see Check 7). The
 // negative lookahead rejects only a still-open *phrase* that directly negates
@@ -1916,12 +1928,23 @@ export function checkVerifiability(context: Context): CheckOutcome {
       (acceptanceCriteriaMatch.index ?? 0) +
       (acceptanceCriteriaMatch[0]?.length ?? 0);
     const contentAfter = body.slice(indexAfter, indexAfter + 500).trim();
-    // Require either a list (starting with - or *) or numbered content with outcome signals
-    if (/^[-*]\s+/.test(contentAfter) || /^\d+\.\s+/.test(contentAfter)) {
-      const hasOutcomeSignals = OUTCOME_SIGNAL_PATTERN.test(contentAfter);
-      if (hasOutcomeSignals) {
-        hasObjectiveCriteria = true;
-      }
+    // Bound the AC section at the next heading so a trailing sibling
+    // section (e.g. this repo's own "## Candidate files" convention, which
+    // is itself a bullet list of paths) never leaks substance or an
+    // outcome-signal keyword into a genuinely placeholder AC list (#2589).
+    const nextHeadingIndex = contentAfter.search(/\n#{1,6}\s/);
+    const listSection =
+      nextHeadingIndex === -1
+        ? contentAfter
+        : contentAfter.slice(0, nextHeadingIndex);
+    // Require either a list (starting with - or *) or numbered content. A
+    // substantive bullet (SUBSTANTIVE_BULLET_PATTERN) satisfies this on its
+    // own; an outcome-signal keyword remains a fallback for a list that
+    // names no concrete file, command, or artifact (#2589).
+    if (/^[-*]\s+/.test(listSection) || /^\d+\.\s+/.test(listSection)) {
+      hasObjectiveCriteria =
+        SUBSTANTIVE_BULLET_PATTERN.test(listSection) ||
+        OUTCOME_SIGNAL_PATTERN.test(listSection);
     }
   }
 

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2672,6 +2672,65 @@ test('verifiability still accepts a bare dotted identifier with no leading place
   assert.equal(result.pass, true);
 });
 
+test('verifiability rejects a placeholder glued directly to punctuation with no separator (#2589 round 4, E2 critique)', () => {
+  // An E2 critique subagent caught that round 3's split-on-whitespace/
+  // colon/hyphen lead-token check never split on a period, underscore, or
+  // slash, so a placeholder glued directly to one of those -- with no
+  // separating character at all -- still supplied its own structural
+  // signal while evading the exact-match stoplist: "- [ ] `TODO.`",
+  // "- [ ] `TODO_`", and the previously-documented "TODO/FIXME" gap (shown
+  // here to be broader than described: any slash-glued suffix, not just a
+  // second placeholder word). PLACEHOLDER_LEAD_PATTERN's anchored,
+  // non-alphanumeric-or-end lookahead closes all of these in one rule.
+  for (const placeholder of [
+    'TODO.',
+    'TODO..',
+    'TODO_',
+    'N/A.',
+    'NA.',
+    'TBD.',
+    'FIXME.',
+    'TODO/FIXME',
+    'TODO/details forthcoming',
+  ]) {
+    const result = checkVerifiability({
+      issue: {
+        ...BASE_ISSUE,
+        body: `## Acceptance criteria\n- [ ] \`${placeholder}\`\n`,
+      },
+    } as Context);
+    assert.equal(
+      result.pass,
+      false,
+      `expected fail for backticked "${placeholder}"`,
+    );
+  }
+});
+
+test('verifiability does not mistake a real identifier that merely starts with a placeholder word (#2589 round 4)', () => {
+  // True-positive guard for the anchored pattern: a real path/identifier
+  // whose letters happen to start with a placeholder word, but continue
+  // with more alphanumeric characters rather than ending or hitting
+  // punctuation, must not be misclassified as a placeholder.
+  for (const identifier of [
+    'NASA-report.txt',
+    'nonexistent-file.txt',
+    'WIPExample.md',
+  ]) {
+    const result = checkVerifiability({
+      issue: {
+        ...BASE_ISSUE,
+        body: `## Acceptance criteria\n- [ ] \`${identifier}\` is updated\n`,
+      },
+    } as Context);
+    assert.equal(
+      result.pass,
+      true,
+      `expected pass for backticked "${identifier}"`,
+    );
+  }
+});
+
 test('verifiability keyword fallback still fails with no Acceptance Criteria section (#2589)', () => {
   // Unrelated to the AC-heading path above: a body with no AC section at all
   // still relies solely on hasVerificationChannel / the other keyword

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2550,6 +2550,87 @@ test('verifiability still fails a bullet list with no outcome-signal word at all
   assert.equal(result.pass, false);
 });
 
+test('verifiability accepts a structured AC checklist with no outcome-signal keyword (#2589)', () => {
+  // Check 7's "substantive AC" path used to require an OUTCOME_SIGNAL_PATTERN
+  // keyword even when a genuine, structured checklist was already present --
+  // disagreeing with Check 5, which already accepts the same list as
+  // actionable. A bullet naming a concrete file path (in backticks) now
+  // satisfies the check on its own, with no outcome-signal word anywhere.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `## Acceptance criteria
+- [ ] \`docs/example.md\`'s pointer section reflects the confirmed owner
+      and storage kind, with the open TODO callout removed.
+- [ ] No confidential grant content appears anywhere in the updated
+      page.
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('verifiability still fails an Acceptance Criteria section with only a placeholder bullet (#2589)', () => {
+  // A checklist under the heading naming no path, command, or artifact --
+  // and no outcome-signal keyword -- must still fail; the widened
+  // substantive-bullet path is not a blanket "any list passes" gate.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `## Acceptance Criteria
+- [ ] TODO
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
+test('verifiability keyword fallback still fails with no Acceptance Criteria section (#2589)', () => {
+  // Unrelated to the AC-heading path above: a body with no AC section at all
+  // still relies solely on hasVerificationChannel / the other keyword
+  // fallbacks, unchanged by the substantive-bullet addition.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: 'Update the onboarding doc with the new steps for new contributors.',
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
+test('verifiability rejects an ordinary conjunction as a substantive bullet (#2589 review)', () => {
+  // SUBSTANTIVE_BULLET_PATTERN must not treat a bare slash as a path on its
+  // own -- "and/or" has a slash but names no file, command, or artifact.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `## Acceptance criteria
+- [ ] Update and/or remove the callout
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
+test('verifiability does not let a trailing "## Candidate files" list leak substance into a placeholder AC (#2589 review)', () => {
+  // This repo's own issue template puts "## Candidate files" (a bullet list
+  // of paths) directly after "## Acceptance Criteria". Without bounding the
+  // AC section at the next heading, that trailing list's paths would leak
+  // substance into a genuinely placeholder AC bullet above it.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `## Acceptance criteria
+- [ ] TODO
+
+## Candidate files
+- src/scripts/foo.mts
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
 test('coherence allows TODO mentions when the issue is otherwise concrete', () => {
   const result = checkCoherence({
     issue: {

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2605,6 +2605,73 @@ test('verifiability rejects a backtick-wrapped placeholder as a substantive bull
   }
 });
 
+test('verifiability rejects a backtick-wrapped multi-word placeholder (#2589 Copilot review, round 2)', () => {
+  // A second Copilot pass on the first fix: CODE_SPAN_STRUCTURE_PATTERN
+  // originally counted internal whitespace as a structural signal, so a
+  // multi-word placeholder phrase -- "- [ ] `TODO later`", "- [ ] `TBD
+  // soon`" -- slipped past PLACEHOLDER_TOKEN_PATTERN's single-token exact
+  // match and wrongly passed. Whitespace alone no longer counts.
+  for (const placeholder of ['TODO later', 'TBD soon']) {
+    const result = checkVerifiability({
+      issue: {
+        ...BASE_ISSUE,
+        body: `## Acceptance criteria\n- [ ] \`${placeholder}\`\n`,
+      },
+    } as Context);
+    assert.equal(
+      result.pass,
+      false,
+      `expected fail for backticked "${placeholder}"`,
+    );
+  }
+});
+
+test('verifiability accepts a multi-word command with colon/slash punctuation (#2589 Copilot review, round 2)', () => {
+  // Guards the other direction: a genuine multi-word command still passes
+  // once whitespace is no longer a qualifying signal on its own, as long
+  // as it carries the punctuation a real command/path normally has.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: '## Acceptance criteria\n- [ ] `pnpm run lint:minimum` passes\n',
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('verifiability rejects a placeholder token glued to trailing punctuation or words (#2589 round 3, pre-submission probe)', () => {
+  // Adversarial self-probe before this fix's third round-trip: a
+  // placeholder whose lead token is followed by a hyphen, colon, or
+  // trailing word (rather than sitting alone, as in round 2's fix) must
+  // still fail -- only the span's structural punctuation should ever
+  // change, never the placeholder classification of its lead token.
+  for (const placeholder of ['TODO-later', 'TODO: fix', 'N/A yet']) {
+    const result = checkVerifiability({
+      issue: {
+        ...BASE_ISSUE,
+        body: `## Acceptance criteria\n- [ ] \`${placeholder}\`\n`,
+      },
+    } as Context);
+    assert.equal(
+      result.pass,
+      false,
+      `expected fail for backticked "${placeholder}"`,
+    );
+  }
+});
+
+test('verifiability still accepts a bare dotted identifier with no leading placeholder word (#2589 round 3)', () => {
+  // True-positive guard for the same lead-token check: an ordinary dotted
+  // identifier/filename with no placeholder lead word must keep passing.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: '## Acceptance criteria\n- [ ] `foo.bar` is updated\n',
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
 test('verifiability keyword fallback still fails with no Acceptance Criteria section (#2589)', () => {
   // Unrelated to the AC-heading path above: a body with no AC section at all
   // still relies solely on hasVerificationChannel / the other keyword
@@ -2619,8 +2686,8 @@ test('verifiability keyword fallback still fails with no Acceptance Criteria sec
 });
 
 test('verifiability accepts a bare dotted filename with no backticks or keyword (#2589 review)', () => {
-  // Exercises SUBSTANTIVE_BULLET_PATTERN's second alternative in isolation
-  // (every other new test hits the pattern only via a backtick-wrapped
+  // Exercises hasSubstantiveBullet()'s BARE_DOTTED_FILENAME_PATTERN branch
+  // in isolation (every other new test hits it only via a backtick-wrapped
   // path): a plain, unquoted filename token is substantive on its own.
   const result = checkVerifiability({
     issue: {
@@ -2634,7 +2701,7 @@ test('verifiability accepts a bare dotted filename with no backticks or keyword 
 });
 
 test('verifiability rejects an ordinary conjunction as a substantive bullet (#2589 review)', () => {
-  // SUBSTANTIVE_BULLET_PATTERN must not treat a bare slash as a path on its
+  // hasSubstantiveBullet() must not treat a bare slash as a path on its
   // own -- "and/or" has a slash but names no file, command, or artifact.
   const result = checkVerifiability({
     issue: {

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2609,7 +2609,7 @@ test('verifiability rejects a backtick-wrapped multi-word placeholder (#2589 Cop
   // A second Copilot pass on the first fix: CODE_SPAN_STRUCTURE_PATTERN
   // originally counted internal whitespace as a structural signal, so a
   // multi-word placeholder phrase -- "- [ ] `TODO later`", "- [ ] `TBD
-  // soon`" -- slipped past PLACEHOLDER_TOKEN_PATTERN's single-token exact
+  // soon`" -- slipped past the placeholder check's single-token exact
   // match and wrongly passed. Whitespace alone no longer counts.
   for (const placeholder of ['TODO later', 'TBD soon']) {
     const result = checkVerifiability({

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2901,6 +2901,23 @@ test('verifiability does not let a heading-like line inside a fence truncate the
   assert.equal(result.pass, true);
 });
 
+test('verifiability accepts an isolated multi-word command with no whole-body verification/outcome keyword (#2589 round 6, E2 critique)', () => {
+  // An E2 critique subagent found that the existing round-2 multi-word
+  // command test ("`pnpm run lint:minimum` passes") is over-determined:
+  // "lint" alone satisfies hasVerificationChannel and "passes" alone
+  // satisfies OUTCOME_SIGNAL_PATTERN against the whole body, so that test
+  // would still pass even if hasSubstantiveBullet's multi-word handling
+  // were broken. This body avoids every hasVerificationChannel and
+  // OUTCOME_SIGNAL_PATTERN word, isolating hasSubstantiveBullet itself.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: '## Acceptance criteria\n- [ ] `pnpm run build:all` is green\n',
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
 test('verifiability accepted limitation: a placeholder-led identifier glued to punctuation with no dotted rescue still fails (#2589 round 6, E2 critique)', () => {
   // An E2 critique subagent found that PLACEHOLDER_LEAD_PATTERN's anchored
   // match rejects a REAL identifier that happens to start with a reserved

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2598,6 +2598,21 @@ test('verifiability keyword fallback still fails with no Acceptance Criteria sec
   assert.equal(result.pass, false);
 });
 
+test('verifiability accepts a bare dotted filename with no backticks or keyword (#2589 review)', () => {
+  // Exercises SUBSTANTIVE_BULLET_PATTERN's second alternative in isolation
+  // (every other new test hits the pattern only via a backtick-wrapped
+  // path): a plain, unquoted filename token is substantive on its own.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `## Acceptance criteria
+- [ ] update the version pin in config.json
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
 test('verifiability rejects an ordinary conjunction as a substantive bullet (#2589 review)', () => {
   // SUBSTANTIVE_BULLET_PATTERN must not treat a bare slash as a path on its
   // own -- "and/or" has a slash but names no file, command, or artifact.

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2731,6 +2731,56 @@ test('verifiability does not mistake a real identifier that merely starts with a
   }
 });
 
+test('verifiability rejects a punctuation-only code span as substantive (#2589 round 5, CodeRabbit review)', () => {
+  // CodeRabbit review on PR #2602: CODE_SPAN_STRUCTURE_PATTERN only checks
+  // for the *presence* of a structural delimiter, so a code span
+  // containing nothing but that delimiter -- "- [ ] `-`", "- [ ] `.`" --
+  // wrongly passed even though it names no path, command, or artifact.
+  for (const span of ['-', '.', '/', ':', '_']) {
+    const result = checkVerifiability({
+      issue: {
+        ...BASE_ISSUE,
+        body: `## Acceptance criteria\n- [ ] \`${span}\`\n`,
+      },
+    } as Context);
+    assert.equal(result.pass, false, `expected fail for backticked "${span}"`);
+  }
+});
+
+test('verifiability bounds the Acceptance Criteria section at an indented heading (#2589 round 5, CodeRabbit review)', () => {
+  // CodeRabbit review on PR #2602: CommonMark permits up to three leading
+  // spaces before an ATX heading, so an indented "   ## Candidate files"
+  // sibling section wasn't recognized as a boundary and its paths leaked
+  // substance into a placeholder-only Acceptance Criteria bullet above it.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `## Acceptance criteria
+- [ ] TODO
+
+   ## Candidate files
+- src/example.mts
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
+test('verifiability restricts substance/keyword matching to list-item lines only (#2589 round 5, CodeRabbit review)', () => {
+  // CodeRabbit review on PR #2602: hasSubstantiveBullet (and the
+  // outcome-signal keyword fallback) scanned the whole Acceptance
+  // Criteria section's raw text, not just its list-item lines, so a
+  // placeholder bullet followed by unrelated, non-list prose could
+  // borrow that prose's substantive code span or outcome-signal keyword.
+  const substanceLeak = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: '## Acceptance criteria\n- [ ] TODO\nSee `src/example.mts` for context.\n',
+    },
+  } as Context);
+  assert.equal(substanceLeak.pass, false);
+});
+
 test('verifiability keyword fallback still fails with no Acceptance Criteria section (#2589)', () => {
   // Unrelated to the AC-heading path above: a body with no AC section at all
   // still relies solely on hasVerificationChannel / the other keyword

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2842,6 +2842,85 @@ test('verifiability does not let a trailing "## Candidate files" list leak subst
   assert.equal(result.pass, false);
 });
 
+test('verifiability rejects two placeholder bullets whose unmatched backticks pair across lines (#2589 round 6, E2 critique)', () => {
+  // An E2 critique subagent found that hasSubstantiveBullet's code-span scan
+  // ran over the whole list-item-lines text at once, and `[^`]` also
+  // matches '\n' -- so two unrelated bullets each carrying one *unmatched*
+  // backtick got paired across the '\n' extractListItemLines() joins them
+  // with, manufacturing a fake code span ("- [ ] TBD") that wrongly
+  // satisfied the structure/alnum/non-placeholder check. Neither bullet is
+  // substantive on its own; the match must not cross a line.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: '## Acceptance Criteria\n- [ ] TODO `\n- [ ] TBD `\n',
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
+test('verifiability does not let a fenced example bullet leak substance into a placeholder AC (#2589 round 6, E2 critique)', () => {
+  // An E2 critique subagent found that the Acceptance Criteria scan had no
+  // fence-awareness: an illustrative bullet inside a fenced example (quoting
+  // Markdown syntax, not a real criterion) was scanned as if it were a real
+  // list item and wrongly supplied substance for a placeholder bullet above
+  // it.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `## Acceptance Criteria
+- [ ] TODO
+
+Example of the file layout we are discussing:
+\`\`\`
+- \`src/real/path.mts\` exists
+\`\`\`
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
+test('verifiability does not let a heading-like line inside a fence truncate the Acceptance Criteria section (#2589 round 6, E2 critique)', () => {
+  // Mirror image of the fence-leak above: a fenced block containing a line
+  // that merely resembles an ATX heading was previously matched by
+  // NEXT_HEADING_PATTERN as a real section boundary, truncating the section
+  // before a genuine substantive bullet that follows the fence.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `## Acceptance Criteria
+- [ ] Set up the fixture, see example:
+\`\`\`
+## fake heading inside a fence
+\`\`\`
+- [ ] \`src/real.mts\` exists
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('verifiability accepted limitation: a placeholder-led identifier glued to punctuation with no dotted rescue still fails (#2589 round 6, E2 critique)', () => {
+  // An E2 critique subagent found that PLACEHOLDER_LEAD_PATTERN's anchored
+  // match rejects a REAL identifier that happens to start with a reserved
+  // word, carries no dotted extension (so BARE_DOTTED_FILENAME_PATTERN
+  // can't rescue it), and is glued directly to structural punctuation --
+  // e.g. "WIP-tracker/config". This is a deliberate accepted trade-off, not
+  // a bug: widening the pattern to admit it would also re-admit
+  // "TODO-later" / "TODO/FIXME" (rounds 3-4's fixed false-positive gap),
+  // which is structurally identical ("placeholder word + one delimiter +
+  // word"). Pinned here so a future round doesn't re-litigate this as a
+  // regression.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: '## Acceptance criteria\n- [ ] `WIP-tracker/config` is updated\n',
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
 test('coherence allows TODO mentions when the issue is otherwise concrete', () => {
   const result = checkCoherence({
     issue: {

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2585,6 +2585,26 @@ test('verifiability still fails an Acceptance Criteria section with only a place
   assert.equal(result.pass, false);
 });
 
+test('verifiability rejects a backtick-wrapped placeholder as a substantive bullet (#2589 Copilot review)', () => {
+  // Copilot review on PR #2602: the backtick alternative originally treated
+  // ANY inline-code span as substantive, so a placeholder token wrapped in
+  // backticks -- "- [ ] `TODO`" or "- [ ] `N/A`" -- wrongly passed even
+  // though it names no concrete file, command, or artifact.
+  for (const placeholder of ['TODO', 'N/A', 'TBD', 'tbd']) {
+    const result = checkVerifiability({
+      issue: {
+        ...BASE_ISSUE,
+        body: `## Acceptance criteria\n- [ ] \`${placeholder}\`\n`,
+      },
+    } as Context);
+    assert.equal(
+      result.pass,
+      false,
+      `expected fail for backticked "${placeholder}"`,
+    );
+  }
+});
+
 test('verifiability keyword fallback still fails with no Acceptance Criteria section (#2589)', () => {
   // Unrelated to the AC-heading path above: a body with no AC section at all
   // still relies solely on hasVerificationChannel / the other keyword


### PR DESCRIPTION
# Summary

`checkVerifiability` (Check 7) in `suitability-triage.mts` required an
`OUTCOME_SIGNAL_PATTERN` keyword to appear inside a `## Acceptance
Criteria` section even when that section already held a genuine,
structured Markdown checklist — disagreeing with Check 5
(actionability), which already accepted the same list as actionable.

A bullet under the `## Acceptance Criteria` heading is now treated as
substantive on its own when `hasSubstantiveBullet()` finds an
inline-code span with both a real structural signal (a slash, dot,
underscore, colon, or hyphen) and actual alphanumeric content, and a
leading token that doesn't match `PLACEHOLDER_LEAD_PATTERN`, or a bare
dotted filename, with the existing outcome-signal keyword kept as a
fallback for a list with neither. The AC section is bounded at the next
Markdown heading — including one indented up to three spaces, per
CommonMark — so a trailing sibling section (this repo's own
`## Candidate files` convention) can't leak substance into a
placeholder AC bullet above it. Both the substantive-bullet check and
the outcome-signal fallback are scoped strictly to the section's own
list-item lines, so ordinary prose inside the section (including a
lazy-continuation line) can't supply a keyword or a code span the list
items themselves don't have. A fenced code block inside the section is
masked before any of this runs, so an illustrative bullet or
heading-like line quoted only as an example can neither supply fake
substance nor falsely truncate the section — and the code-span scan
itself no longer lets an unmatched backtick on one bullet pair across
lines with an unmatched backtick on another.

## Linked issue

Closes #2589

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

This PR went through seven review rounds — three from Copilot, two from
an internal E2 critique subagent, one PR-body reconciliation (no code
change), and one from CodeRabbit — each finding a genuine false-positive
gap in the substantive-bullet heuristic (or a stale description of it),
fixed with a regression test per round:

1. A bare slash-path alternative also matched an ordinary conjunction
   (`and/or`, `N/A`, `6/30`) — dropped in favor of backtick spans +
   bare dotted filenames, and the AC section was bounded at the next
   heading so a trailing `## Candidate files` list couldn't leak
   substance into a placeholder bullet above it.
2. The backtick alternative treated *any* code span as substantive, so
   a placeholder wrapped in backticks (`` `TODO` ``, `` `N/A` ``)
   wrongly passed — fixed by requiring a structural signal inside the
   span plus a placeholder-token exclusion.
3. Internal whitespace counted as a structural signal, so a
   *multi-word* backticked placeholder (`` `TODO later` ``) still slipped
   past a single-token exact match — fixed by dropping whitespace as a
   signal and checking only the span's leading token (adding a colon
   to the signal set for npm-script names like
   `` `pnpm run lint:minimum` ``).
4. An E2 critique subagent found that round 3's lead-token split never
   split on a period, underscore, or slash, so a placeholder glued
   directly to one of those (`` `TODO.` ``, `` `TODO_` ``) still passed,
   and the "TODO/FIXME" case documented as an accepted limitation
   turned out to be a broader gap (any slash-glued suffix). Fixed by
   replacing the split-then-exact-match approach with a single pattern
   (`PLACEHOLDER_LEAD_PATTERN`) anchored at the start of the raw
   content: a placeholder word must be immediately followed by a
   non-alphanumeric character or the end of the string. Verified
   against a 34-case adversarial matrix (every prior round's cases plus
   the newly-found ones) before adding tests, with zero mismatches —
   this also closes the "TODO/FIXME" gap with no special-casing, while
   still correctly passing a real identifier that merely starts with
   the same letters (`` `NASA-report.txt` ``, `` `nonexistent-file.txt` ``).
5. Copilot flagged that this PR body's own "known accepted limitation"
   text (about the pre-round-4 `` `TODO/FIXME` `` gap) was stale once
   round 4 landed — no code change, just this body being reconciled
   with the code it describes.
6. CodeRabbit found three genuine gaps in the round-4 heuristic: a
   punctuation-only backtick span (e.g. `` `/` `` alone, no alphanumeric
   content) still counted as substantive; `NEXT_HEADING_PATTERN` didn't
   recognize a sibling heading indented up to three spaces (still a
   valid ATX heading per CommonMark), so it failed to bound the AC
   section there; and a non-list-item prose line inside the AC section
   (including a lazy-continuation line) could still supply a code span
   or outcome-signal keyword the list items themselves lacked. Fixed by
   adding `CODE_SPAN_ALNUM_PATTERN`, making `NEXT_HEADING_PATTERN`
   indentation-tolerant, and adding `extractListItemLines()` to scope
   both checks to the section's own list-item lines.
7. A second internal E2 critique subagent (round 6's fixes had no prior
   critique pass of their own) found three more gaps, each empirically
   confirmed to regress against the pre-PR build: (a) the code-span
   scan's `` [^`]+ `` also matched a newline, so two unrelated
   placeholder bullets each carrying one *unmatched* backtick got paired
   across the line join `extractListItemLines()` introduces, faking a
   substantive span out of two placeholders; (b) a fenced example
   bullet was read as a real list item, leaking substance into a
   placeholder bullet above it; (c) the mirror bug — a heading-like line
   inside a fence falsely bounded the section, hiding a genuine bullet
   after the fence. Fixed by excluding a newline from the code-span
   match and by masking fence content (not inline spans) over the whole
   body before any slicing, reusing `markdown-code.mts`'s existing
   position-preserving mask with a newly-exported fence-only range
   finder. The same pass also found and pinned (no code change) that a
   real identifier starting with a reserved placeholder word, with no
   dotted extension, glued directly to punctuation — e.g.
   `` `WIP-tracker/config` `` — is misclassified as a placeholder;
   documented as an accepted trade-off below rather than fixed, since
   widening the pattern to admit it would re-admit round 3-4's
   `TODO-later` / `TODO/FIXME` false-positive gap (structurally
   identical: placeholder word + one delimiter + word).

A separate, pre-existing whole-body fallback path (`hasNumSteps` /
`hasChecklist` in `checkVerifiability`, untouched by this diff) shares
the same "prose can supply the missing signal" bug class as finding 3
above, but no reviewer flagged it and it sits outside this issue's
scope — left as-is rather than fixed opportunistically.

**Known accepted limitation**: `` `WIP-tracker/config` `` (a real
identifier starting with a reserved placeholder word, no dotted
extension, glued directly to a slash) fails Check 7's substantive-bullet
check — see finding 7 above for why this is intentional rather than a
bug to fix.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (`node --test tests/*.test.mts`; suitability-triage
      suite at 296/296, `cli-entry-smoke` TDZ guard at 21/21, full repo
      suite at 5021/5021)
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (no docs/instructions touched)
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Acceptance Criteria checks to recognize substantive file names, paths, commands, and identifiers—even when outcome-related keywords are absent.
  - Prevented placeholder examples, ordinary conjunctions, and content from later sections from being incorrectly treated as valid criteria.
  - Preserved existing keyword-based validation behavior while improving accuracy for structured checklists.

- **Tests**
  - Added coverage for valid structured criteria, placeholder rejection, dotted identifiers, commands, and section boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


