### PR TITLE
docs(idd): note REST id to node_id conversion beside --subject-ids

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -490,13 +490,15 @@ no-ops).
 
 ### Hide displaced claim chain on takeover
 
-When the verified new claim was posted with `supersedes: <prior-id>`
-(stale takeover or forced-handoff recovery — **not** legacy migration,
-which always uses `supersedes: none`), minimize the displaced claim's
-marker chain on the issue as `OUTDATED` once this session has recorded
-its own verified `{claim-id}`. Find every trusted `claimed-by` /
-`unclaimed-by` / heartbeat comment whose embedded `{claim-id}` equals
-`<prior-id>` and call:
+When the verified new claim used `supersedes: <prior-id>` (stale
+takeover or forced-handoff recovery — **not** legacy migration, which
+always uses `supersedes: none`), minimize the displaced claim's marker
+chain as `OUTDATED` once this session's own `{claim-id}` is verified.
+Find every trusted `claimed-by`/`unclaimed-by`/heartbeat comment whose
+`{claim-id}` equals `<prior-id>` and call:
+
+`--subject-ids` takes a node id, not a REST id — see the
+[conversion note](idd-review-snapshot.instructions.md).
 
 ```sh
 node scripts/minimize-superseded-markers.mjs \
@@ -508,14 +510,11 @@ node scripts/minimize-superseded-markers.mjs \
 
 Skip this step entirely if:
 
-- the new claim has `supersedes: none` (fresh claim — there is no
-  displaced chain to hide);
-- the takeover claim was not verified (do not hide the prior chain
-  until the successor is observable as the active claim);
-- the candidate set is empty (no trusted markers carry the prior
-  `{claim-id}`);
-- the helper is unavailable. Subsequent F4 cleanup still picks up
-  any missed candidates.
+- `supersedes: none` (fresh claim, no displaced chain to hide);
+- the takeover claim was not yet verified (wait until the successor
+  is the observable active claim);
+- the candidate set is empty (no trusted markers carry `<prior-id>`);
+- the helper is unavailable (F4 cleanup catches missed candidates).
 
 **Do not** hide a same-`{claim-id}` heartbeat chain from a normal
 heartbeat post; heartbeats refresh the stale clock but do not

--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -497,8 +497,8 @@ chain as `OUTDATED` once this session's own `{claim-id}` is verified.
 Find every trusted `claimed-by`/`unclaimed-by`/heartbeat comment whose
 `{claim-id}` equals `<prior-id>` and call:
 
-`--subject-ids` takes a node id, not a REST id — see the
-[conversion note](idd-review-snapshot.instructions.md).
+`--subject-ids` takes a GraphQL node id, not a REST numeric
+id — see the [conversion note](idd-review-snapshot.instructions.md).
 
 ```sh
 node scripts/minimize-superseded-markers.mjs \

--- a/.github/instructions/idd-review-snapshot.instructions.md
+++ b/.github/instructions/idd-review-snapshot.instructions.md
@@ -168,12 +168,12 @@ ignore them and rerun E1 under the successor claim.
 **Hide superseded same-claim watermarks.** After the new watermark is
 verified on GitHub, minimize every strictly older trusted **same-claim**
 `review-watermark`/`review-baseline` comment as `OUTDATED` (cuts F4
-backlog and review-page noise). Find candidate subject IDs (trusted
-same-claim watermarks older than the new one), then call:
+backlog and review-page noise). Find candidate subject IDs (older
+trusted same-claim watermarks), then call:
 
-`--subject-ids` needs a node id, not a REST id; convert with
-`gh api repos/{owner}/{repo}/issues/comments/{comment_id} -q
-'.node_id'` (other kinds: see `--help`).
+`--subject-ids` needs a GraphQL node id, not a REST numeric id;
+convert with `gh api repos/{owner}/{repo}/issues/comments/{comment_id}
+-q '.node_id'` (other kinds: `--help` below).
 
 ```sh
 node scripts/minimize-superseded-markers.mjs \

--- a/.github/instructions/idd-review-snapshot.instructions.md
+++ b/.github/instructions/idd-review-snapshot.instructions.md
@@ -171,6 +171,10 @@ verified on GitHub, minimize every strictly older trusted **same-claim**
 backlog and review-page noise). Find candidate subject IDs (trusted
 same-claim watermarks older than the new one), then call:
 
+`--subject-ids` needs a node id, not a REST id; convert with
+`gh api repos/{owner}/{repo}/issues/comments/{comment_id} -q
+'.node_id'` (other kinds: see `--help`).
+
 ```sh
 node scripts/minimize-superseded-markers.mjs \
   --subject-ids "<id1>,<id2>,..." \

--- a/docs/idd-advisory-wait-shell-fallback.md
+++ b/docs/idd-advisory-wait-shell-fallback.md
@@ -234,7 +234,7 @@ curl -X POST "https://api.github.com/repos/{owner}/{repo}/issues/{pr-number}/com
 
 `--subject-ids` needs a GraphQL node id, not a REST numeric id —
 convert first: `gh api repos/{owner}/{repo}/issues/comments/{comment_id}
--q '.node_id'` (other kinds: `minimize-superseded-markers.mjs --help`).
+-q '.node_id'` (other kinds: pass `--help` to the command below).
 
 ```sh
 # source repo / vendored-node profile:

--- a/docs/idd-advisory-wait-shell-fallback.md
+++ b/docs/idd-advisory-wait-shell-fallback.md
@@ -232,6 +232,10 @@ curl -X POST "https://api.github.com/repos/{owner}/{repo}/issues/{pr-number}/com
 
 ## AW3-H
 
+`--subject-ids` needs a GraphQL node id, not a REST numeric id —
+convert first: `gh api repos/{owner}/{repo}/issues/comments/{comment_id}
+-q '.node_id'` (other kinds: `minimize-superseded-markers.mjs --help`).
+
 ```sh
 # source repo / vendored-node profile:
 node scripts/minimize-superseded-markers.mjs \

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -485,13 +485,15 @@ no-ops).
 
 ### Hide displaced claim chain on takeover
 
-When the verified new claim was posted with `supersedes: <prior-id>`
-(stale takeover or forced-handoff recovery — **not** legacy migration,
-which always uses `supersedes: none`), minimize the displaced claim's
-marker chain on the issue as `OUTDATED` once this session has recorded
-its own verified `{claim-id}`. Find every trusted `claimed-by` /
-`unclaimed-by` / heartbeat comment whose embedded `{claim-id}` equals
-`<prior-id>` and call:
+When the verified new claim used `supersedes: <prior-id>` (stale
+takeover or forced-handoff recovery — **not** legacy migration, which
+always uses `supersedes: none`), minimize the displaced claim's marker
+chain as `OUTDATED` once this session's own `{claim-id}` is verified.
+Find every trusted `claimed-by`/`unclaimed-by`/heartbeat comment whose
+`{claim-id}` equals `<prior-id>` and call:
+
+`--subject-ids` takes a node id, not a REST id — see the
+[conversion note](idd-review-snapshot.instructions.md).
 
 ```sh
 node scripts/minimize-superseded-markers.mjs \
@@ -503,14 +505,11 @@ node scripts/minimize-superseded-markers.mjs \
 
 Skip this step entirely if:
 
-- the new claim has `supersedes: none` (fresh claim — there is no
-  displaced chain to hide);
-- the takeover claim was not verified (do not hide the prior chain
-  until the successor is observable as the active claim);
-- the candidate set is empty (no trusted markers carry the prior
-  `{claim-id}`);
-- the helper is unavailable. Subsequent F4 cleanup still picks up
-  any missed candidates.
+- `supersedes: none` (fresh claim, no displaced chain to hide);
+- the takeover claim was not yet verified (wait until the successor
+  is the observable active claim);
+- the candidate set is empty (no trusted markers carry `<prior-id>`);
+- the helper is unavailable (F4 cleanup catches missed candidates).
 
 **Do not** hide a same-`{claim-id}` heartbeat chain from a normal
 heartbeat post; heartbeats refresh the stale clock but do not

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -492,8 +492,8 @@ chain as `OUTDATED` once this session's own `{claim-id}` is verified.
 Find every trusted `claimed-by`/`unclaimed-by`/heartbeat comment whose
 `{claim-id}` equals `<prior-id>` and call:
 
-`--subject-ids` takes a node id, not a REST id — see the
-[conversion note](idd-review-snapshot.instructions.md).
+`--subject-ids` takes a GraphQL node id, not a REST numeric
+id — see the [conversion note](idd-review-snapshot.instructions.md).
 
 ```sh
 node scripts/minimize-superseded-markers.mjs \

--- a/idd-template/.github/instructions/idd-review-snapshot.instructions.md
+++ b/idd-template/.github/instructions/idd-review-snapshot.instructions.md
@@ -163,12 +163,12 @@ ignore them and rerun E1 under the successor claim.
 **Hide superseded same-claim watermarks.** After the new watermark is
 verified on GitHub, minimize every strictly older trusted **same-claim**
 `review-watermark`/`review-baseline` comment as `OUTDATED` (cuts F4
-backlog and review-page noise). Find candidate subject IDs (trusted
-same-claim watermarks older than the new one), then call:
+backlog and review-page noise). Find candidate subject IDs (older
+trusted same-claim watermarks), then call:
 
-`--subject-ids` needs a node id, not a REST id; convert with
-`gh api repos/{owner}/{repo}/issues/comments/{comment_id} -q
-'.node_id'` (other kinds: see `--help`).
+`--subject-ids` needs a GraphQL node id, not a REST numeric id;
+convert with `gh api repos/{owner}/{repo}/issues/comments/{comment_id}
+-q '.node_id'` (other kinds: `--help` below).
 
 ```sh
 node scripts/minimize-superseded-markers.mjs \

--- a/idd-template/.github/instructions/idd-review-snapshot.instructions.md
+++ b/idd-template/.github/instructions/idd-review-snapshot.instructions.md
@@ -166,6 +166,10 @@ verified on GitHub, minimize every strictly older trusted **same-claim**
 backlog and review-page noise). Find candidate subject IDs (trusted
 same-claim watermarks older than the new one), then call:
 
+`--subject-ids` needs a node id, not a REST id; convert with
+`gh api repos/{owner}/{repo}/issues/comments/{comment_id} -q
+'.node_id'` (other kinds: see `--help`).
+
 ```sh
 node scripts/minimize-superseded-markers.mjs \
   --subject-ids "<id1>,<id2>,..." \

--- a/idd-template/docs/idd-advisory-wait-shell-fallback.md
+++ b/idd-template/docs/idd-advisory-wait-shell-fallback.md
@@ -234,7 +234,7 @@ curl -X POST "https://api.github.com/repos/{owner}/{repo}/issues/{pr-number}/com
 
 `--subject-ids` needs a GraphQL node id, not a REST numeric id —
 convert first: `gh api repos/{owner}/{repo}/issues/comments/{comment_id}
--q '.node_id'` (other kinds: `minimize-superseded-markers.mjs --help`).
+-q '.node_id'` (other kinds: pass `--help` to the command below).
 
 ```sh
 # source repo / vendored-node profile:

--- a/idd-template/docs/idd-advisory-wait-shell-fallback.md
+++ b/idd-template/docs/idd-advisory-wait-shell-fallback.md
@@ -232,6 +232,10 @@ curl -X POST "https://api.github.com/repos/{owner}/{repo}/issues/{pr-number}/com
 
 ## AW3-H
 
+`--subject-ids` needs a GraphQL node id, not a REST numeric id —
+convert first: `gh api repos/{owner}/{repo}/issues/comments/{comment_id}
+-q '.node_id'` (other kinds: `minimize-superseded-markers.mjs --help`).
+
 ```sh
 # source repo / vendored-node profile:
 node scripts/minimize-superseded-markers.mjs \


### PR DESCRIPTION
## Summary

- Adds a one-line note beside each of the three `--subject-ids` worked
  examples for `minimize-superseded-markers.mjs`, naming the
  REST-id-to-`node_id` conversion (`gh api .../issues/comments -q
  '.node_id'` for the issue-comment case) so an agent doesn't have to
  hit the failure once and rediscover it by hand.
- `idd-review-snapshot.instructions.md`'s "Hide superseded same-claim
  watermarks" step and `docs/idd-advisory-wait-shell-fallback.md`'s
  AW3-H section quote the exact command.
- `idd-claim.instructions.md`'s "Hide displaced claim chain on
  takeover" step links back to the review-snapshot note instead,
  since `idd-claim.instructions.md` had only ~5 bytes of headroom
  under its 33000-byte instruction-size budget. Fitting the note
  required losslessly tightening the adjacent intro paragraph and
  skip-list in the same section.

## Notes for reviewers

- `docs/idd-advisory-wait-shell-fallback.md` is a third `idd-template/`
  exact-mode mirror pair the issue's own candidate-files list omitted;
  `sync-docs.mjs`'s own error output caught it. Edited the
  `idd-template/` source, as required.
- An independent C1 critique pass flagged the `idd-claim` cross-
  reference as not literally a markdown link (Medium) — fixed by
  making it a real `[conversion note](idd-review-snapshot.instructions.md)`
  link, byte-neutral against the budget.
- Local `pnpm run lint:minimum` on this Windows machine intermittently
  shows unrelated pre-existing test failures in `tests/idd-config.test.mts`
  (Windows path-resolution, tracked separately) and
  `tests/idd-onboard.test.mts`; neither test file references any of
  the 3 files this PR touches. This branch is rebased onto the latest
  `main` (which includes #2598/#2599, fixing related Windows-native
  test issues). `pre-push-validate` (biome, dprint, markdownlint,
  cspell, `audit-docs.mjs --check`, `audit-code-span-wrap.mjs`,
  `agent-entry-mirror-sync.test.mts`, `build:check`, `idd-doctor.mjs`)
  passes cleanly. CI is the authoritative signal for the full suite.

## Test plan

- [x] `node scripts/sync-docs.mjs --apply` reports no diff beyond the
      intended edit
- [x] `node scripts/audit-docs.mjs --check` passes
- [x] `node scripts/audit-code-span-wrap.mjs` finds no mid-token wraps
- [x] `pre-push-validate` command set passes
- [ ] CI green

Closes #2591

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCsJWegXKTXMsNCE7DHxDM
