### PR TITLE
docs(idd-pre-merge): carve out third-party bot skip-review notices in F2 review-currency

### DIFF
--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -89,12 +89,11 @@ workflow to E1 instead of merging over it.
 (directly, or via the documented merge-gate helper reference), pass
 `--nonce {nonce}` — this session's own locally-recorded activation-nonce
 from claim time (`idd-claim.instructions.md`'s activation-nonce format) —
-alongside `--claim-id`. This extends `idd-claim.instructions.md`'s
-Claim-verification-step-5 nonce collision check to the merge-time
-write-gate too (Resume-phase cold recovery is a distinct, not-yet-wired
-case — see the "Scope for #1522" note under
-[rationale](../../docs/idd-design-rationale.md#activation-nonce-why-a-separate-marker-and-what-stays-deferred)
-and kurone-kito/idd-skill#1529). Omitting `--nonce` silently skips the
+alongside `--claim-id`, extending Claim-verification-step-5's nonce
+collision check to this merge-time write-gate (Resume-phase cold
+recovery stays a distinct, not-yet-wired case — see
+[rationale](../../docs/idd-design-rationale.md#activation-nonce-why-a-separate-marker-and-what-stays-deferred),
+kurone-kito/idd-skill#1529). Omitting `--nonce` silently skips the
 merge-time comparison rather than failing closed, so pass it whenever a
 nonce was recorded for the active claim.
 
@@ -117,12 +116,10 @@ nonce was recorded for the active claim.
   When helper runtime is enabled, prefer the documented merge-gate
   helper reference in
   [`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#stable-helper-evidence-outputs)
-  to collect this evidence, consuming `reviewCurrency` (including
-  `comparisonRoute`), `threads`, `unrepliedComments`, `reviewerStates`,
-  `advisoryWait`, `ci`, `claim`, and optional `dispositionEvidence`.
-  Helpers remain read-only evidence collectors: if execution fails,
-  output is invalid JSON, required sections are missing, or live GitHub
-  state disagrees with it, discard helper output and fetch the activity
+  to collect this evidence (the fields listed at that anchor). Helpers
+  remain read-only evidence collectors: if execution fails, output is
+  invalid JSON, required sections are missing, or live GitHub state
+  disagrees with it, discard helper output and fetch the activity
   universe snapshot (same scope as E1 Step 1) plus current CI state for
   the HEAD SHA directly — the instruction rules remain canonical. Return
   to E1 if **any** of the following is true:
@@ -165,6 +162,13 @@ nonce was recorded for the active claim.
   procedural or status comments of that kind, or both, refresh the
   watermark directly instead; every other F2 trigger and gate is
   unaffected.
+
+  Third-party advisory bot skip-review carve-out: the same applies to
+  a third-party advisory bot's own skip-review or no-action notice
+  posted after the watermark — when helper evidence shows it carries
+  no reviewer finding or actionable content, a return-to-E1 triggered
+  solely by that notice refreshes the watermark directly instead; a
+  mixed-cause trigger still returns to E1 normally.
 - **Advisory bot wait** (restart-safe enforcement): schedule a wake, or
   background only if the topology-safety condition holds (confirmed to
   route completion back to this turn) — otherwise wait synchronously:
@@ -233,9 +237,9 @@ nonce was recorded for the active claim.
     on a vacuous green.
 
   **External-check waivers**: When `pre-merge-readiness` reports a check
-  as `coveredByWaiver: true`, a trusted maintainer authorized skipping
-  it under the current head SHA and active claim. Treat it as passing
-  for F2/F3 routing **only when**:
+  `coveredByWaiver: true`, a trusted maintainer authorized skipping it
+  for the current head SHA and claim. Treat it as passing for F2/F3
+  routing **only when**:
   - `waiverEvidence.valid` is non-empty for that check's selector
   - The waiver actor is a trusted marker login
   - The waiver `headSha` matches the current PR HEAD
@@ -246,40 +250,38 @@ nonce was recorded for the active claim.
   threads, unreplied comments, required reviews, disposition evidence,
   or claim ownership. Non-empty `waiverEvidence.wrongHead`, `wrongClaim`,
   `unauthorized`, `expired`, or `malformed` are suspicious context, never
-  valid permissions. A waiver posted before its own effectiveness
-  precondition is met is valid but inert until then — see
+  valid permissions. A waiver posted before its effectiveness
+  precondition is met stays valid but inert until then — see
   `idd-pr-submit.instructions.md`'s D4 for the mechanical check.
 
   **Local validation evidence** (#2323): `pre-merge-readiness`'s
   `localValidationEvidence` field reports whether HEAD-pinned local
   evidence exists for an active `ciGate` outage
-  ([`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#local-validation-evidence-helper)).
-  It is informational only — never treat it as a passing check or a
-  waiver: an unavailable required check stays a CI-gate blocker exactly
-  as above regardless of this field. With required checks unavailable,
-  merges queue; restoring the platform check rollup is an out-of-band
-  privileged operation outside this loop.
+  ([`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#local-validation-evidence-helper))
+  — informational only, never a passing check or waiver: an
+  unavailable required check stays a CI-gate blocker regardless. With
+  required checks unavailable, merges queue until the platform check
+  rollup is restored (an out-of-band privileged operation).
 - **Required reviews**: required approvals count is satisfied and all
-  CODEOWNER approvals are obtained. If helper evidence includes
-  `reviewerStates.codeownerSelfApproval`, include that diagnostic
-  whenever its `status` is `deadlock` or `possible_deadlock` (see the
-  [field contract](../../docs/idd-helper-scripts.md#merge-gate-evidence))
-  — evidence only, never permission to bypass this gate. If approvals
-  are absent but no open actionable review items exist
-  (`ReviewItems_snapshot` empty), do **not** route to E1 — request
-  CODEOWNER/required reviewers directly (if not already requested),
-  post a hold comment, and stop. Return to E1 only when actual review
-  threads or comments exist (→ `idd-review-snapshot.instructions.md`).
+  CODEOWNER approvals are obtained. When helper evidence's
+  `reviewerStates.codeownerSelfApproval` `status` is `deadlock` or
+  `possible_deadlock`, include it as diagnostic evidence only ([field contract](../../docs/idd-helper-scripts.md#merge-gate-evidence)),
+  never permission to bypass this gate. If approvals are absent but no
+  open actionable review items exist (`ReviewItems_snapshot` empty), do
+  **not** route to E1 — request CODEOWNER/required reviewers directly
+  (if not already requested), post a hold comment, and stop. Return to
+  E1 only when actual review threads or comments exist (→
+  `idd-review-snapshot.instructions.md`).
 - **No `CHANGES_REQUESTED`** (human/required/CODEOWNER reviewers only):
   no such reviewer's latest state is `CHANGES_REQUESTED` (→ if not yet
   addressed, return to review triage; if addressed and re-review
-  requested, wait up to 30 min, then post a hold comment and stop if
-  still no response). Advisory bot reviewers (Copilot, CI bots) are
-  exempt — their `CHANGES_REQUESTED` does not block merge once the
-  advisory wait window completes.
-- **Unresolved threads = 0** (backlog gate, orthogonal to the currency
-  check above): no unresolved review threads remain, excluding
-  **awaiting-reviewer threads**. Classify each unresolved thread:
+  requested, wait up to 30 min, then post a hold comment and stop if no
+  response). Advisory bot reviewers (Copilot, CI bots) are exempt —
+  their `CHANGES_REQUESTED` does not block merge once the advisory wait
+  window completes.
+- **Unresolved threads = 0** (backlog gate): no unresolved review
+  threads remain, excluding **awaiting-reviewer threads**. Classify
+  each unresolved thread:
 
   | Condition                                                                                                       | Classification              |
   | --------------------------------------------------------------------------------------------------------------- | --------------------------- |
@@ -307,8 +309,7 @@ nonce was recorded for the active claim.
 - **Unreplied comments = 0**: no regular comment from a non-IDD-agent
   lacks a subsequent IDD-agent comment — "subsequent" meaning any
   IDD-agent regular comment posted at a strictly later timestamp (→
-  return to review triage). Mirrors E1's regular-comment filter for
-  non-advisory discussion. Copilot and CI advisory bot comments are
+  return to review triage). Copilot and CI advisory bot comments are
   handled earlier in the PATH B triage flow (E4-E7) and excluded here.
 - **Advisory convergence** (exit-code obligation for Copilot-authored
   review threads, not a judgment call): run `node

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -84,12 +84,11 @@ workflow to E1 instead of merging over it.
 (directly, or via the documented merge-gate helper reference), pass
 `--nonce {nonce}` — this session's own locally-recorded activation-nonce
 from claim time (`idd-claim.instructions.md`'s activation-nonce format) —
-alongside `--claim-id`. This extends `idd-claim.instructions.md`'s
-Claim-verification-step-5 nonce collision check to the merge-time
-write-gate too (Resume-phase cold recovery is a distinct, not-yet-wired
-case — see the "Scope for #1522" note under
-[rationale](../../docs/idd-design-rationale.md#activation-nonce-why-a-separate-marker-and-what-stays-deferred)
-and kurone-kito/idd-skill#1529). Omitting `--nonce` silently skips the
+alongside `--claim-id`, extending Claim-verification-step-5's nonce
+collision check to this merge-time write-gate (Resume-phase cold
+recovery stays a distinct, not-yet-wired case — see
+[rationale](../../docs/idd-design-rationale.md#activation-nonce-why-a-separate-marker-and-what-stays-deferred),
+kurone-kito/idd-skill#1529). Omitting `--nonce` silently skips the
 merge-time comparison rather than failing closed, so pass it whenever a
 nonce was recorded for the active claim.
 
@@ -112,12 +111,10 @@ nonce was recorded for the active claim.
   When helper runtime is enabled, prefer the documented merge-gate
   helper reference in
   [`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#stable-helper-evidence-outputs)
-  to collect this evidence, consuming `reviewCurrency` (including
-  `comparisonRoute`), `threads`, `unrepliedComments`, `reviewerStates`,
-  `advisoryWait`, `ci`, `claim`, and optional `dispositionEvidence`.
-  Helpers remain read-only evidence collectors: if execution fails,
-  output is invalid JSON, required sections are missing, or live GitHub
-  state disagrees with it, discard helper output and fetch the activity
+  to collect this evidence (the fields listed at that anchor). Helpers
+  remain read-only evidence collectors: if execution fails, output is
+  invalid JSON, required sections are missing, or live GitHub state
+  disagrees with it, discard helper output and fetch the activity
   universe snapshot (same scope as E1 Step 1) plus current CI state for
   the HEAD SHA directly — the instruction rules remain canonical. Return
   to E1 if **any** of the following is true:
@@ -160,6 +157,13 @@ nonce was recorded for the active claim.
   procedural or status comments of that kind, or both, refresh the
   watermark directly instead; every other F2 trigger and gate is
   unaffected.
+
+  Third-party advisory bot skip-review carve-out: the same applies to
+  a third-party advisory bot's own skip-review or no-action notice
+  posted after the watermark — when helper evidence shows it carries
+  no reviewer finding or actionable content, a return-to-E1 triggered
+  solely by that notice refreshes the watermark directly instead; a
+  mixed-cause trigger still returns to E1 normally.
 - **Advisory bot wait** (restart-safe enforcement): schedule a wake, or
   background only if the topology-safety condition holds (confirmed to
   route completion back to this turn) — otherwise wait synchronously:
@@ -228,9 +232,9 @@ nonce was recorded for the active claim.
     on a vacuous green.
 
   **External-check waivers**: When `pre-merge-readiness` reports a check
-  as `coveredByWaiver: true`, a trusted maintainer authorized skipping
-  it under the current head SHA and active claim. Treat it as passing
-  for F2/F3 routing **only when**:
+  `coveredByWaiver: true`, a trusted maintainer authorized skipping it
+  for the current head SHA and claim. Treat it as passing for F2/F3
+  routing **only when**:
   - `waiverEvidence.valid` is non-empty for that check's selector
   - The waiver actor is a trusted marker login
   - The waiver `headSha` matches the current PR HEAD
@@ -241,40 +245,38 @@ nonce was recorded for the active claim.
   threads, unreplied comments, required reviews, disposition evidence,
   or claim ownership. Non-empty `waiverEvidence.wrongHead`, `wrongClaim`,
   `unauthorized`, `expired`, or `malformed` are suspicious context, never
-  valid permissions. A waiver posted before its own effectiveness
-  precondition is met is valid but inert until then — see
+  valid permissions. A waiver posted before its effectiveness
+  precondition is met stays valid but inert until then — see
   `idd-pr-submit.instructions.md`'s D4 for the mechanical check.
 
   **Local validation evidence** (#2323): `pre-merge-readiness`'s
   `localValidationEvidence` field reports whether HEAD-pinned local
   evidence exists for an active `ciGate` outage
-  ([`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#local-validation-evidence-helper)).
-  It is informational only — never treat it as a passing check or a
-  waiver: an unavailable required check stays a CI-gate blocker exactly
-  as above regardless of this field. With required checks unavailable,
-  merges queue; restoring the platform check rollup is an out-of-band
-  privileged operation outside this loop.
+  ([`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#local-validation-evidence-helper))
+  — informational only, never a passing check or waiver: an
+  unavailable required check stays a CI-gate blocker regardless. With
+  required checks unavailable, merges queue until the platform check
+  rollup is restored (an out-of-band privileged operation).
 - **Required reviews**: required approvals count is satisfied and all
-  CODEOWNER approvals are obtained. If helper evidence includes
-  `reviewerStates.codeownerSelfApproval`, include that diagnostic
-  whenever its `status` is `deadlock` or `possible_deadlock` (see the
-  [field contract](../../docs/idd-helper-scripts.md#merge-gate-evidence))
-  — evidence only, never permission to bypass this gate. If approvals
-  are absent but no open actionable review items exist
-  (`ReviewItems_snapshot` empty), do **not** route to E1 — request
-  CODEOWNER/required reviewers directly (if not already requested),
-  post a hold comment, and stop. Return to E1 only when actual review
-  threads or comments exist (→ `idd-review-snapshot.instructions.md`).
+  CODEOWNER approvals are obtained. When helper evidence's
+  `reviewerStates.codeownerSelfApproval` `status` is `deadlock` or
+  `possible_deadlock`, include it as diagnostic evidence only ([field contract](../../docs/idd-helper-scripts.md#merge-gate-evidence)),
+  never permission to bypass this gate. If approvals are absent but no
+  open actionable review items exist (`ReviewItems_snapshot` empty), do
+  **not** route to E1 — request CODEOWNER/required reviewers directly
+  (if not already requested), post a hold comment, and stop. Return to
+  E1 only when actual review threads or comments exist (→
+  `idd-review-snapshot.instructions.md`).
 - **No `CHANGES_REQUESTED`** (human/required/CODEOWNER reviewers only):
   no such reviewer's latest state is `CHANGES_REQUESTED` (→ if not yet
   addressed, return to review triage; if addressed and re-review
-  requested, wait up to 30 min, then post a hold comment and stop if
-  still no response). Advisory bot reviewers (Copilot, CI bots) are
-  exempt — their `CHANGES_REQUESTED` does not block merge once the
-  advisory wait window completes.
-- **Unresolved threads = 0** (backlog gate, orthogonal to the currency
-  check above): no unresolved review threads remain, excluding
-  **awaiting-reviewer threads**. Classify each unresolved thread:
+  requested, wait up to 30 min, then post a hold comment and stop if no
+  response). Advisory bot reviewers (Copilot, CI bots) are exempt —
+  their `CHANGES_REQUESTED` does not block merge once the advisory wait
+  window completes.
+- **Unresolved threads = 0** (backlog gate): no unresolved review
+  threads remain, excluding **awaiting-reviewer threads**. Classify
+  each unresolved thread:
 
   | Condition                                                                                                       | Classification              |
   | --------------------------------------------------------------------------------------------------------------- | --------------------------- |
@@ -302,8 +304,7 @@ nonce was recorded for the active claim.
 - **Unreplied comments = 0**: no regular comment from a non-IDD-agent
   lacks a subsequent IDD-agent comment — "subsequent" meaning any
   IDD-agent regular comment posted at a strictly later timestamp (→
-  return to review triage). Mirrors E1's regular-comment filter for
-  non-advisory discussion. Copilot and CI advisory bot comments are
+  return to review triage). Copilot and CI advisory bot comments are
   handled earlier in the PATH B triage flow (E4-E7) and excluded here.
 - **Advisory convergence** (exit-code obligation for Copilot-authored
   review threads, not a judgment call): run `node

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -1480,6 +1480,42 @@ test('pre-merge F2 own-agent-comment carve-out covers procedural/status comments
   }
 });
 
+test('pre-merge F2 carves out third-party advisory bot skip-review notices from review-currency staleness (idd-skill#2590)', () => {
+  const preMerge = readFileSync(
+    new URL(
+      '../.github/instructions/idd-pre-merge.instructions.md',
+      import.meta.url,
+    ),
+    'utf8',
+  );
+  const templatePreMerge = readFileSync(
+    new URL(
+      '../idd-template/.github/instructions/idd-pre-merge.instructions.md',
+      import.meta.url,
+    ),
+    'utf8',
+  );
+
+  for (const text of [preMerge, templatePreMerge]) {
+    // \s+ between words tolerates a Markdown reflow (dprint) that moves a
+    // wrap point mid-phrase without changing the semantic content.
+    assert.match(
+      text,
+      /third-party\s+advisory\s+bot's\s+own\s+skip-review\s+or\s+no-action\s+notice/,
+    );
+    // Guards the carve-out's no-finding condition: it only covers a
+    // notice that carries no reviewer finding or actionable content.
+    assert.match(text, /no\s+reviewer\s+finding\s+or\s+actionable\s+content/);
+    // Guards against silently swallowing a mixed-cause trigger: the
+    // refresh-instead sentence must still be gated on "solely".
+    assert.match(text, /triggered\s+solely\s+by\s+that\s+notice/);
+    assert.match(
+      text,
+      /mixed-cause\s+trigger\s+still\s+returns\s+to\s+E1\s+normally/,
+    );
+  }
+});
+
 test('recursive roadmap audit guidance stays aligned across instruction and docs surfaces', () => {
   const audit = readFileSync(ROADMAP_AUDIT_PATH, 'utf8');
   const workflow = readFileSync(WORKFLOW_PATH, 'utf8');


### PR DESCRIPTION
# Summary

Extends `idd-pre-merge.instructions.md`'s F2 review-currency check with
a carve-out for a third-party advisory bot's own skip-review/no-action
notice landing after the E1 watermark. Previously such a notice — for
example a CodeRabbit or Codex skip-review notification — forced a full
return-to-E1 even though it carries no reviewer finding of its own,
because the existing carve-out (`#1811`) was scoped to own-agent
comments only. The new carve-out mirrors that wording: when helper
evidence shows the notice carries no reviewer finding or actionable
content, and it is the *sole* cause of staleness, refresh the
watermark directly instead of a full return to E1. A mixed-cause
trigger still returns to E1 normally.

`idd-template/`'s canonical copy and the `.github/instructions/` mirror
are both updated (`node scripts/sync-docs.mjs --apply` produces no
further diff), and a `tests/consistency.test.mts` regression test
guards the new wording in both surfaces, mirroring `#1811`'s own test
shape.

**Context-budget note**: `bundle-merge` was already at 98.00%
utilization (effectively zero headroom) against its 122,000-byte
`limitBytes` before this change. Per `docs/policy-constants.md`'s
documented near-ceiling exception, the new paragraph is offset by
trimming several already-verbose, non-gate-critical passages elsewhere
in the same file (helper-evidence field enumeration already documented
at its linked anchor, the Local-validation-evidence bullet, a redundant
cross-reference aside, and similar prose tightening) rather than
raising the bundle's `limitBytes` ratchet. None of the trims touch the
`#1811` own-agent-comment carve-out's wording, the CI-completedAt
trigger, or any gate's pass/fail condition list — confirmed by the
existing `#1811` regression test still passing unmodified.
`bundle-merge` sits at 97.97% after this change (`node
scripts/audit-docs.mjs --check` passes).

## Linked issue

Closes #2590

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

See the issue body for the full background: the existing structural
ack-only carve-out doesn't cover this case either, since it requires a
disposition to already exist to acknowledge, and a skip-review notice
can land in the E1-to-F2 window before any disposition exists yet.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
