### PR TITLE
fix(marker-helpers): truncate fractional-second timestamps

### DIFF
--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -1620,9 +1620,11 @@ export function isValidIsoTimestamp(value) {
 // --- Apply-time "now" normalization (#2568) ---
 //
 // `renderUnclaimedByMarker` and the other operational-marker renderers above
-// accept only second-precision `…Z` timestamps and throw otherwise, but a
-// production `now` (`new Date().toISOString()`) always carries millisecond
-// precision. These two were independently re-implemented four times across
+// accept a second-precision `…Z` timestamp, or a well-formed sub-second `…Z`
+// value truncated down to one (#2592) -- but throw on anything else (an
+// offset form, or an otherwise malformed value). A production `now`
+// (`new Date().toISOString()`) always carries millisecond precision. These
+// two were independently re-implemented four times across
 // `idd-roadmap-audit-execute.mts`, `suitability-close-execute.mts`,
 // `provider-outage-park.mts`, and `provider-outage-declaration.mts` before
 // being consolidated here as the one canonical, tested implementation every
@@ -1641,10 +1643,11 @@ export function toSecondPrecisionIso(date) {
  * gate a mutation on this value (claim staleness, release markers) must fail
  * closed on `null` BEFORE any mutation: an unparseable value would
  * mis-evaluate staleness (`NaN` comparisons read as not-stale), and an
- * offset / sub-second form (e.g. `…+09:00`) would otherwise reach
- * `renderUnclaimedByMarker` -- which accepts only second-precision `…Z` --
- * and throw AFTER other side effects (an evidence comment, a close) had
- * already landed. Normalizing through `toISOString()` also converts any
+ * offset form (e.g. `…+09:00`) would otherwise reach
+ * `renderUnclaimedByMarker` -- which throws on anything but a (possibly
+ * sub-second, per #2592) `…Z` value -- and throw AFTER other side effects
+ * (an evidence comment, a close) had already landed. Normalizing through
+ * `toISOString()` also converts any
  * zone offset to UTC, so the single normalized value is safe for both the
  * staleness checks and the release marker.
  */

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -1577,12 +1577,21 @@ function normalizeIsoTimestamp(value) {
   }
   return trimmed;
 }
-function normalizeSecondPrecisionIsoTimestamp(value) {
+export function normalizeSecondPrecisionIsoTimestamp(value) {
   const timestamp = normalizeIsoTimestamp(value);
-  if (!timestamp || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(timestamp)) {
+  if (!timestamp) {
     return '';
   }
-  return timestamp;
+  // Truncate a well-formed fractional-second timestamp (e.g. the millisecond
+  // precision `Date#toISOString()` always emits) down to second precision
+  // instead of rejecting it outright -- reusing the same canonical
+  // truncation `toSecondPrecisionIso` already applies for apply-time "now"
+  // values (see the comment below), rather than re-deriving it here.
+  const truncated = toSecondPrecisionIso(new Date(timestamp));
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(truncated)) {
+    return '';
+  }
+  return truncated;
 }
 function normalizeContextScope(value) {
   if (typeof value !== 'string') {

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -2070,12 +2070,21 @@ function normalizeIsoTimestamp(value: unknown): string {
   return trimmed;
 }
 
-function normalizeSecondPrecisionIsoTimestamp(value: unknown): string {
+export function normalizeSecondPrecisionIsoTimestamp(value: unknown): string {
   const timestamp = normalizeIsoTimestamp(value);
-  if (!timestamp || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(timestamp)) {
+  if (!timestamp) {
     return '';
   }
-  return timestamp;
+  // Truncate a well-formed fractional-second timestamp (e.g. the millisecond
+  // precision `Date#toISOString()` always emits) down to second precision
+  // instead of rejecting it outright -- reusing the same canonical
+  // truncation `toSecondPrecisionIso` already applies for apply-time "now"
+  // values (see the comment below), rather than re-deriving it here.
+  const truncated = toSecondPrecisionIso(new Date(timestamp));
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(truncated)) {
+    return '';
+  }
+  return truncated;
 }
 
 function normalizeContextScope(value: unknown): string {

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -2118,9 +2118,11 @@ export function isValidIsoTimestamp(value: unknown): value is string {
 // --- Apply-time "now" normalization (#2568) ---
 //
 // `renderUnclaimedByMarker` and the other operational-marker renderers above
-// accept only second-precision `…Z` timestamps and throw otherwise, but a
-// production `now` (`new Date().toISOString()`) always carries millisecond
-// precision. These two were independently re-implemented four times across
+// accept a second-precision `…Z` timestamp, or a well-formed sub-second `…Z`
+// value truncated down to one (#2592) -- but throw on anything else (an
+// offset form, or an otherwise malformed value). A production `now`
+// (`new Date().toISOString()`) always carries millisecond precision. These
+// two were independently re-implemented four times across
 // `idd-roadmap-audit-execute.mts`, `suitability-close-execute.mts`,
 // `provider-outage-park.mts`, and `provider-outage-declaration.mts` before
 // being consolidated here as the one canonical, tested implementation every
@@ -2141,10 +2143,11 @@ export function toSecondPrecisionIso(date: Date): string {
  * gate a mutation on this value (claim staleness, release markers) must fail
  * closed on `null` BEFORE any mutation: an unparseable value would
  * mis-evaluate staleness (`NaN` comparisons read as not-stale), and an
- * offset / sub-second form (e.g. `…+09:00`) would otherwise reach
- * `renderUnclaimedByMarker` -- which accepts only second-precision `…Z` --
- * and throw AFTER other side effects (an evidence comment, a close) had
- * already landed. Normalizing through `toISOString()` also converts any
+ * offset form (e.g. `…+09:00`) would otherwise reach
+ * `renderUnclaimedByMarker` -- which throws on anything but a (possibly
+ * sub-second, per #2592) `…Z` value -- and throw AFTER other side effects
+ * (an evidence comment, a close) had already landed. Normalizing through
+ * `toISOString()` also converts any
  * zone offset to UTC, so the single normalized value is safe for both the
  * staleness checks and the release marker.
  */

--- a/tests/emit-marker.test.mts
+++ b/tests/emit-marker.test.mts
@@ -156,6 +156,24 @@ test('round-trip: rendered claim and watermark bodies satisfy their own parsers'
   );
 });
 
+test('renderClaimedByMarker truncates a millisecond-precision timestamp instead of rejecting it (#2592)', () => {
+  // A raw Date#toISOString() value -- the idiomatic way to obtain "now" --
+  // always carries millisecond precision, and the claimed-by body/parser
+  // only accept second precision.
+  const claimBody = renderClaimedByMarker({
+    agentId: 'claude-1cab217a',
+    claimId: 'abc123',
+    supersedes: 'none',
+    timestamp: '2026-06-17T09:47:08.219Z',
+    branch: 'issue/901-add-foo',
+  });
+  assert.match(claimBody, /2026-06-17T09:47:08Z/);
+  assert.ok(
+    parseClaimComment(claimBody, '2026-06-17T09:47:08Z'),
+    'truncated claimed-by must still round-trip',
+  );
+});
+
 test('renderers reject payloads that would not round-trip', () => {
   // blank required tokens
   assert.throws(() =>
@@ -166,12 +184,14 @@ test('renderers reject payloads that would not round-trip', () => {
       branch: 'b',
     }),
   );
-  // fractional-second timestamp (claim parser requires second precision)
+  // non-UTC-offset timestamp (#2592: still not a valid ISO8601 UTC value --
+  // a fractional-second `…Z` timestamp is truncated and accepted instead of
+  // rejected as of #2592; see marker-helpers-timestamp.test.mts)
   assert.throws(() =>
     renderClaimedByMarker({
       agentId: 'a',
       claimId: 'c',
-      timestamp: '2026-06-17T09:47:08.123Z',
+      timestamp: '2026-06-17T09:47:08.123+09:00',
       branch: 'b',
     }),
   );

--- a/tests/forced-handoff-marker.test.mts
+++ b/tests/forced-handoff-marker.test.mts
@@ -484,12 +484,24 @@ test('forced handoff requires an exact old-agent match before transferring owner
   assert.deepEqual(next, activeClaim);
 });
 
-test('forced handoff rejects fractional-second timestamps', () => {
+test('forced handoff truncates a millisecond-precision timestamp instead of rejecting it (#2592)', () => {
+  const body = renderForcedHandoffComment({
+    ...payload,
+    timestamp: '2026-05-12T11:00:00.123Z',
+  });
+  const parsed = parseForcedHandoffComment(body, '2026-05-12T11:00:05Z');
+  assert.deepEqual(parsed, {
+    ...payload,
+    createdAt: '2026-05-12T11:00:05Z',
+  });
+});
+
+test('forced handoff rejects a non-UTC-offset timestamp', () => {
   assert.throws(
     () =>
       renderForcedHandoffComment({
         ...payload,
-        timestamp: '2026-05-12T11:00:00.123Z',
+        timestamp: '2026-05-12T11:00:00.123+09:00',
       }),
     /invalid forced handoff payload/,
   );

--- a/tests/marker-helpers-timestamp.test.mts
+++ b/tests/marker-helpers-timestamp.test.mts
@@ -4,6 +4,7 @@ import { test } from 'node:test';
 import {
   isValidIsoTimestamp,
   normalizeApplyNow,
+  normalizeSecondPrecisionIsoTimestamp,
   toSecondPrecisionIso,
 } from '../src/scripts/marker-helpers.mts';
 
@@ -61,4 +62,49 @@ test('normalizeApplyNow normalizes a non-UTC-offset input to UTC', () => {
 test('normalizeApplyNow fails closed (null) on an unparseable value', () => {
   assert.equal(normalizeApplyNow('not-a-date'), null);
   assert.equal(normalizeApplyNow(''), null);
+});
+
+// ---------------------------------------------------------------------------
+// normalizeSecondPrecisionIsoTimestamp (#2592) -- gates 18 operational-marker
+// constructors (claimed-by, unclaimed-by, activation-nonce, advisory-wait,
+// advisory-wait-recovery, advisory-reroll, review-ack, copilot-unavailable,
+// and the outage-park marker fields), all reachable from
+// post-idd-marker.mts's --timestamp flag. It previously rejected any
+// fractional-second value outright instead of truncating it, even though
+// Date#toISOString() -- the idiomatic way to obtain "now" -- always emits
+// millisecond precision.
+// ---------------------------------------------------------------------------
+
+test('normalizeSecondPrecisionIsoTimestamp truncates a millisecond-precision toISOString() value instead of rejecting it', () => {
+  assert.equal(
+    normalizeSecondPrecisionIsoTimestamp('2026-09-04T09:25:43.219Z'),
+    '2026-09-04T09:25:43Z',
+  );
+  // A real Date#toISOString() call always carries millisecond precision.
+  const now = new Date('2026-09-04T09:25:43.219Z');
+  assert.equal(
+    normalizeSecondPrecisionIsoTimestamp(now.toISOString()),
+    '2026-09-04T09:25:43Z',
+  );
+});
+
+test('normalizeSecondPrecisionIsoTimestamp leaves an already-second-precision value unchanged', () => {
+  assert.equal(
+    normalizeSecondPrecisionIsoTimestamp('2026-09-04T09:25:43Z'),
+    '2026-09-04T09:25:43Z',
+  );
+});
+
+test('normalizeSecondPrecisionIsoTimestamp still rejects a non-UTC-offset timestamp', () => {
+  assert.equal(
+    normalizeSecondPrecisionIsoTimestamp('2026-09-04T09:25:43.219+09:00'),
+    '',
+  );
+});
+
+test('normalizeSecondPrecisionIsoTimestamp still rejects a genuinely malformed value', () => {
+  assert.equal(normalizeSecondPrecisionIsoTimestamp('not-a-timestamp'), '');
+  assert.equal(normalizeSecondPrecisionIsoTimestamp(''), '');
+  assert.equal(normalizeSecondPrecisionIsoTimestamp(undefined), '');
+  assert.equal(normalizeSecondPrecisionIsoTimestamp(123), '');
 });

--- a/tests/provider-outage-declaration.test.mts
+++ b/tests/provider-outage-declaration.test.mts
@@ -92,27 +92,55 @@ test('renderProviderOutageDeclarationComment / parseProviderOutageDeclarationCom
   assert.equal(parsed?.createdAt, '2026-09-01T05:00:01Z');
 });
 
-test('renderProviderOutageDeclarationComment rejects a millisecond-precision timestamp (#2320 review)', () => {
+test('renderProviderOutageDeclarationComment truncates a millisecond-precision timestamp instead of rejecting it (#2592)', () => {
+  const body = renderProviderOutageDeclarationComment({
+    actor: 'kurone-kito',
+    service: 'idd-advisory-convergence',
+    startedAt: '2026-09-01T05:00:00.123Z',
+    expiresAt: '2026-09-02T05:00:00Z',
+  });
+  const parsed = parseProviderOutageDeclarationComment(
+    body,
+    '2026-09-01T05:00:01Z',
+  );
+  assert.equal(parsed?.startedAt, '2026-09-01T05:00:00Z');
+});
+
+test('renderProviderOutageDeclarationComment rejects a non-UTC-offset timestamp', () => {
   assert.throws(
     () =>
       renderProviderOutageDeclarationComment({
         actor: 'kurone-kito',
         service: 'idd-advisory-convergence',
-        startedAt: '2026-09-01T05:00:00.123Z',
+        startedAt: '2026-09-01T05:00:00.123+09:00',
         expiresAt: '2026-09-02T05:00:00Z',
       }),
     /invalid provider outage declaration payload/,
   );
 });
 
-test('renderProviderOutageAdvancedComment rejects a millisecond-precision timestamp (#2320 review)', () => {
+test('renderProviderOutageAdvancedComment truncates a millisecond-precision timestamp instead of rejecting it (#2592)', () => {
+  const body = renderProviderOutageAdvancedComment({
+    actor: 'kurone-kito',
+    prNumber: 2345,
+    headSha: 'a'.repeat(40),
+    declaredAt: '2026-09-01T05:00:00.000Z',
+  });
+  const parsed = parseProviderOutageAdvancedComment(
+    body,
+    '2026-09-01T05:00:01Z',
+  );
+  assert.equal(parsed?.declaredAt, '2026-09-01T05:00:00Z');
+});
+
+test('renderProviderOutageAdvancedComment rejects a non-UTC-offset timestamp', () => {
   assert.throws(
     () =>
       renderProviderOutageAdvancedComment({
         actor: 'kurone-kito',
         prNumber: 2345,
         headSha: 'a'.repeat(40),
-        declaredAt: '2026-09-01T05:00:00.000Z',
+        declaredAt: '2026-09-01T05:00:00.123+09:00',
       }),
     /invalid provider outage advancement payload/,
   );


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

`normalizeSecondPrecisionIsoTimestamp` (`src/scripts/marker-helpers.mts`)
required an exact `YYYY-MM-DDTHH:mm:ssZ` match and rejected any
fractional-seconds component outright. This gates 18 operational-marker
constructors in the same file (`claimed-by`, `unclaimed-by`,
`activation-nonce`, `advisory-wait`, `advisory-wait-recovery`,
`advisory-reroll`, `review-ack`, `copilot-unavailable`, `forced-handoff`,
and the provider-outage declaration/advancement/park marker fields), all
reachable from `post-idd-marker.mts`'s `--timestamp` flag.
`Date.prototype.toISOString()` — the idiomatic way to obtain "now" in
JavaScript — always emits millisecond precision, so a raw `new
Date().toISOString()` value threw an `invalid ... marker payload` error
instead of being accepted, forcing every caller to pre-strip milliseconds
by hand.

Truncate a well-formed fractional-second timestamp down to second
precision before applying the strict match, reusing the already-exported
`toSecondPrecisionIso` helper (`#2568`) rather than re-deriving a fourth
truncation implementation in the same file. Exported
`normalizeSecondPrecisionIsoTimestamp` itself so it can be tested
directly, matching this file's other exported timestamp helpers
(`isValidIsoTimestamp`, `toSecondPrecisionIso`, `normalizeApplyNow`).

Updated three pre-existing tests (`emit-marker`, `forced-handoff-marker`,
`provider-outage-declaration`) that asserted the old reject-on-
fractional-seconds behavior — each now asserts truncate-and-accept
instead, with a replacement non-UTC-offset case covering the path that's
still correctly rejected. Added a new suite to
`marker-helpers-timestamp.test.mts` covering
`normalizeSecondPrecisionIsoTimestamp` directly: truncation of a
millisecond-precision value, an already-second-precision value passing
through unchanged, and continued rejection of a non-UTC-offset or
otherwise malformed value.

## Linked issue

Closes #2592

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`Refs #2586`. Not a duplicate of `#2247` (closed) — that issue only
addressed the *missing*-field error text; it never touched the
second-precision acceptance rule.

`protocol-helpers.mts` (imported by `post-idd-marker.mts` and
`emit-marker.mts`) is a pure re-export barrel (`export * from
'./marker-helpers.mts'`), and every one of the 18 gated renderers calls
`normalizeSecondPrecisionIsoTimestamp` directly on its `timestamp` field —
so this single fix in the one canonical function propagates to every call
site and to the CLI `--timestamp` boundary automatically; no separate
CLI-level change was needed.

**Correction (found during this PR's own E2 critique pass — see PR
comments):** several of those 18 call sites are on the *parse* side
(e.g. `parseProviderOutageDeclarationComment`,
`parseProviderOutageAdvancedComment`, `parseProviderOutageParkComment`,
`normalizeForcedHandoffPayload`'s `timestamp`/`createdAt` fields), not
just local render-time construction — an externally-authored marker
comment carrying a fractional-second timestamp in `started:`/`expires:`/
`declared:`/`parked:`/JSON `timestamp` previously failed to parse
(`null`) and now parses successfully with the value truncated. Not a
trust/safety concern (author-login trust-filtering elsewhere in the
pipeline still gates whether a parsed marker is treated as
authoritative), but worth naming explicitly rather than leaving it
implied by "every one of the 18 gated renderers."

A follow-up commit also fixed stale same-file JSDoc (the "Apply-time
'now' normalization" header comment and `normalizeApplyNow`'s own
doc) that still described the pre-fix reject-on-fractional-seconds
behavior — the E2 critique caught that the new code comment pointed
readers at prose that now contradicted the fix. No code change, docs
only.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`biome check`, `dprint check`, `markdownlint-cli2`,
      `cspell lint` all pass; only pre-existing, unrelated warnings in
      `src/scripts/protocol-helpers.mts` / `scripts/protocol-helpers.mjs`)
- [x] `pnpm test` — full suite: 4995 pass, 5 fail (all 5 pre-existing and
      unrelated: 4x `resolveUserGlobalConfigPath` `#2257` — already being
      fixed in the separately-claimed `#2582` — plus 1x doc-tree `#1860`;
      neither touches `marker-helpers.mts` or timestamp handling).
      Targeted re-runs after every change: `marker-helpers-timestamp`,
      `emit-marker`, `forced-handoff-marker`, `provider-outage-declaration`,
      `provider-outage-park`, `claim-lifecycle`, `claim-parser`,
      `post-idd-marker`, `marker-helpers-facade` — 233/233 pass.
- [x] `node scripts/audit-docs.mjs --check`
- [x] `node scripts/idd-doctor.mjs` (passes; only pre-existing,
      environment-level warnings unrelated to this change)
- [x] Manually verified the CLI boundary:
      `node scripts/post-idd-marker.mjs --type claim --target issue <n>
      --agent-id <id> --claim-id <id> --supersedes none --timestamp
      "$(node -e 'console.log(new Date().toISOString())')" --branch <b>`
      (a raw, millisecond-precision `toISOString()` value) succeeds
      without pre-stripping milliseconds — used this exact pattern to
      post this repository's own IDD claim/activation-nonce markers for
      this issue.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsA2FSNJqPfX7yWZoJPc3m

