### PR TITLE
fix(suitability-triage): Check 3 flags process.platform-style code mentions as policy-override

### DIFF
--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -1124,16 +1124,17 @@ function isNarrativeIddMention(rawSource, matchIndex) {
 // ASCII letters/`_`/`$` plus any Unicode letter (`\p{L}`, e.g.
 // `process.é`) -- real ECMAScript `IdentifierStart` also allows a small set
 // of other Unicode categories (Nl, and the two explicit code points
-// U+2118/U+212E) and a `\uXXXX`/`\u{X...}` escape sequence (e.g.
-// `process.env`, an escaped spelling of `process.env`). Both are
-// deliberately left unhandled here: a hand-typed Unicode escape sequence
-// naming a `process` property has no realistic occurrence in an issue
-// body's prose (unlike `#2399`'s bare `force-skip`, which the resolution
-// there rejected for a *shape ambiguity*, this is rejected for
-// *implausibility* -- pinned by its own regression test below so a later
-// change does not silently "fix" it without deliberate review, the same
-// convention `isOrdinaryHyphenatedCompoundToken`'s own accepted limit
-// follows).
+// U+2118/U+212E) and a `\uXXXX`/`\u{X...}` escape sequence, e.g. writing
+// out `process` then a literal backslash, `u`, and the four hex digits
+// `0065` before `nv` -- an escaped spelling of `process.env`, not that
+// literal text. Both are deliberately left unhandled here: a hand-typed
+// Unicode escape sequence naming a `process` property has no realistic
+// occurrence in an issue body's prose (unlike `#2399`'s bare `force-skip`,
+// which the resolution there rejected for a *shape ambiguity*, this is
+// rejected for *implausibility* -- pinned by its own regression test below
+// so a later change does not silently "fix" it without deliberate review,
+// the same convention `isOrdinaryHyphenatedCompoundToken`'s own accepted
+// limit follows).
 const CODE_IDENTIFIER_PROCESS_TOKEN_LENGTH = 'process'.length;
 const CODE_IDENTIFIER_PROCESS_PROPERTY_ACCESS_PATTERN = /^\.[\p{L}_$]/u;
 function isCodeIdentifierProcessMention(rawSource, matchIndex) {

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -1119,8 +1119,23 @@ function isNarrativeIddMention(rawSource, matchIndex) {
 // lacks (and it is also unreachable there regardless, since the masked
 // pass has already blanked a code-wrapped occurrence to spaces before this
 // classifier ever runs against it).
+//
+// CodeRabbit review (#2610): the identifier-start character class covers
+// ASCII letters/`_`/`$` plus any Unicode letter (`\p{L}`, e.g.
+// `process.é`) -- real ECMAScript `IdentifierStart` also allows a small set
+// of other Unicode categories (Nl, and the two explicit code points
+// U+2118/U+212E) and a `\uXXXX`/`\u{X...}` escape sequence (e.g.
+// `process.env`, an escaped spelling of `process.env`). Both are
+// deliberately left unhandled here: a hand-typed Unicode escape sequence
+// naming a `process` property has no realistic occurrence in an issue
+// body's prose (unlike `#2399`'s bare `force-skip`, which the resolution
+// there rejected for a *shape ambiguity*, this is rejected for
+// *implausibility* -- pinned by its own regression test below so a later
+// change does not silently "fix" it without deliberate review, the same
+// convention `isOrdinaryHyphenatedCompoundToken`'s own accepted limit
+// follows).
 const CODE_IDENTIFIER_PROCESS_TOKEN_LENGTH = 'process'.length;
-const CODE_IDENTIFIER_PROCESS_PROPERTY_ACCESS_PATTERN = /^\.[A-Za-z_$]/;
+const CODE_IDENTIFIER_PROCESS_PROPERTY_ACCESS_PATTERN = /^\.[\p{L}_$]/u;
 function isCodeIdentifierProcessMention(rawSource, matchIndex) {
   const token = rawSource
     .slice(matchIndex, matchIndex + CODE_IDENTIFIER_PROCESS_TOKEN_LENGTH)

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -875,11 +875,13 @@ function findGenuineNounMatch(
     // stays detectable even though the same bare, un-code-wrapped text in
     // prose is a deliberately accepted ordinary-compound exclusion. #2588:
     // the same code-range short-circuit applies to isNarrativeIddMention,
-    // for the same reason -- see that function's own comment.
+    // for the same reason -- see that function's own comment. #2608: same
+    // for isCodeIdentifierProcessMention.
     if (
       (getCodeRangeAt(absoluteIndex) ||
         (!isOrdinaryHyphenatedCompoundToken(rawSource, absoluteIndex) &&
-          !isNarrativeIddMention(rawSource, absoluteIndex))) &&
+          !isNarrativeIddMention(rawSource, absoluteIndex) &&
+          !isCodeIdentifierProcessMention(rawSource, absoluteIndex))) &&
       !(
         headingBoundary &&
         matchCrossesHeadingBoundary(
@@ -1082,6 +1084,53 @@ function isNarrativeIddMention(rawSource, matchIndex) {
     afterStart + NARRATIVE_IDD_LOOKAHEAD_CHARS,
   );
   return NARRATIVE_IDD_FOLLOWING_WORD_PATTERN.test(after);
+}
+// #2608: the bare `process` alternative matched a Node.js code identifier's
+// leading segment -- `process.platform`, `process.env`, `process.argv`,
+// `process.exit(` -- as ordinary prose about "the process" (a procedural
+// workflow), even when un-code-wrapped inside a sentence about
+// platform-detection or CLI-argument-handling code. Reproduced by
+// idd-skill#2608 itself: "Skip it on process.platform === 'win32' since NTFS
+// has no POSIX execute bit..." matched verb "Skip" against noun "process"
+// (the only listed noun in that window), with nothing nearby actually
+// attempting to change this checker's own behavior.
+//
+// This exclusion targets `process` only -- the other eight listed nouns
+// have no analogous Node.js-global shape, so this property-access exclusion
+// is not the distinguishing false-positive source #2608 reports for any of
+// them, and narrowing them the same way risks a new, unreviewed
+// false-negative surface with no matching repro.
+//
+// Unlike `isNarrativeIddMention`, this needs no article/following-word
+// heuristic: a genuine narrative directive ("bypass the process", "skip
+// this repository's process") never continues with a literal `.` followed
+// by an identifier-start character -- that exact shape is unambiguously a
+// JS property-access expression, never English prose, regardless of
+// surrounding context. So the true-positive case #2608 itself requires
+// stays detected unconditionally: "skip the review process for this PR"
+// has `process` followed by a space, not `.`, so this classifier never
+// excludes it.
+//
+// A code-wrapped `` `process.platform` `` is never passed to this
+// classifier -- its call site in `findGenuineNounMatch` already
+// short-circuits on `getCodeRangeAt` first, the same precedent
+// `isOrdinaryHyphenatedCompoundToken`/`isNarrativeIddMention` follow: being
+// wrapped in code at all is itself a distinguishing signal bare prose
+// lacks (and it is also unreachable there regardless, since the masked
+// pass has already blanked a code-wrapped occurrence to spaces before this
+// classifier ever runs against it).
+const CODE_IDENTIFIER_PROCESS_TOKEN_LENGTH = 'process'.length;
+const CODE_IDENTIFIER_PROCESS_PROPERTY_ACCESS_PATTERN = /^\.[A-Za-z_$]/;
+function isCodeIdentifierProcessMention(rawSource, matchIndex) {
+  const token = rawSource
+    .slice(matchIndex, matchIndex + CODE_IDENTIFIER_PROCESS_TOKEN_LENGTH)
+    .toLowerCase();
+  if (token !== 'process') {
+    return false;
+  }
+  const afterStart = matchIndex + CODE_IDENTIFIER_PROCESS_TOKEN_LENGTH;
+  const after = rawSource.slice(afterStart, afterStart + 2);
+  return CODE_IDENTIFIER_PROCESS_PROPERTY_ACCESS_PATTERN.test(after);
 }
 function findPolicyOverrideMatch(text, maskedText, getCodeRangeAt) {
   // #2408: POLICY_OVERRIDE_PATTERN's own greedy `[\s\S]{0,N}` backtracks

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -1028,11 +1028,13 @@ function findGenuineNounMatch(
     // stays detectable even though the same bare, un-code-wrapped text in
     // prose is a deliberately accepted ordinary-compound exclusion. #2588:
     // the same code-range short-circuit applies to isNarrativeIddMention,
-    // for the same reason -- see that function's own comment.
+    // for the same reason -- see that function's own comment. #2608: same
+    // for isCodeIdentifierProcessMention.
     if (
       (getCodeRangeAt(absoluteIndex) ||
         (!isOrdinaryHyphenatedCompoundToken(rawSource, absoluteIndex) &&
-          !isNarrativeIddMention(rawSource, absoluteIndex))) &&
+          !isNarrativeIddMention(rawSource, absoluteIndex) &&
+          !isCodeIdentifierProcessMention(rawSource, absoluteIndex))) &&
       !(
         headingBoundary &&
         matchCrossesHeadingBoundary(
@@ -1242,6 +1244,58 @@ function isNarrativeIddMention(rawSource: string, matchIndex: number): boolean {
     afterStart + NARRATIVE_IDD_LOOKAHEAD_CHARS,
   );
   return NARRATIVE_IDD_FOLLOWING_WORD_PATTERN.test(after);
+}
+
+// #2608: the bare `process` alternative matched a Node.js code identifier's
+// leading segment -- `process.platform`, `process.env`, `process.argv`,
+// `process.exit(` -- as ordinary prose about "the process" (a procedural
+// workflow), even when un-code-wrapped inside a sentence about
+// platform-detection or CLI-argument-handling code. Reproduced by
+// idd-skill#2608 itself: "Skip it on process.platform === 'win32' since NTFS
+// has no POSIX execute bit..." matched verb "Skip" against noun "process"
+// (the only listed noun in that window), with nothing nearby actually
+// attempting to change this checker's own behavior.
+//
+// This exclusion targets `process` only -- the other eight listed nouns
+// have no analogous Node.js-global shape, so this property-access exclusion
+// is not the distinguishing false-positive source #2608 reports for any of
+// them, and narrowing them the same way risks a new, unreviewed
+// false-negative surface with no matching repro.
+//
+// Unlike `isNarrativeIddMention`, this needs no article/following-word
+// heuristic: a genuine narrative directive ("bypass the process", "skip
+// this repository's process") never continues with a literal `.` followed
+// by an identifier-start character -- that exact shape is unambiguously a
+// JS property-access expression, never English prose, regardless of
+// surrounding context. So the true-positive case #2608 itself requires
+// stays detected unconditionally: "skip the review process for this PR"
+// has `process` followed by a space, not `.`, so this classifier never
+// excludes it.
+//
+// A code-wrapped `` `process.platform` `` is never passed to this
+// classifier -- its call site in `findGenuineNounMatch` already
+// short-circuits on `getCodeRangeAt` first, the same precedent
+// `isOrdinaryHyphenatedCompoundToken`/`isNarrativeIddMention` follow: being
+// wrapped in code at all is itself a distinguishing signal bare prose
+// lacks (and it is also unreachable there regardless, since the masked
+// pass has already blanked a code-wrapped occurrence to spaces before this
+// classifier ever runs against it).
+const CODE_IDENTIFIER_PROCESS_TOKEN_LENGTH = 'process'.length;
+const CODE_IDENTIFIER_PROCESS_PROPERTY_ACCESS_PATTERN = /^\.[A-Za-z_$]/;
+
+function isCodeIdentifierProcessMention(
+  rawSource: string,
+  matchIndex: number,
+): boolean {
+  const token = rawSource
+    .slice(matchIndex, matchIndex + CODE_IDENTIFIER_PROCESS_TOKEN_LENGTH)
+    .toLowerCase();
+  if (token !== 'process') {
+    return false;
+  }
+  const afterStart = matchIndex + CODE_IDENTIFIER_PROCESS_TOKEN_LENGTH;
+  const after = rawSource.slice(afterStart, afterStart + 2);
+  return CODE_IDENTIFIER_PROCESS_PROPERTY_ACCESS_PATTERN.test(after);
 }
 
 function findPolicyOverrideMatch(

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -1280,8 +1280,23 @@ function isNarrativeIddMention(rawSource: string, matchIndex: number): boolean {
 // lacks (and it is also unreachable there regardless, since the masked
 // pass has already blanked a code-wrapped occurrence to spaces before this
 // classifier ever runs against it).
+//
+// CodeRabbit review (#2610): the identifier-start character class covers
+// ASCII letters/`_`/`$` plus any Unicode letter (`\p{L}`, e.g.
+// `process.é`) -- real ECMAScript `IdentifierStart` also allows a small set
+// of other Unicode categories (Nl, and the two explicit code points
+// U+2118/U+212E) and a `\uXXXX`/`\u{X...}` escape sequence (e.g.
+// `process.env`, an escaped spelling of `process.env`). Both are
+// deliberately left unhandled here: a hand-typed Unicode escape sequence
+// naming a `process` property has no realistic occurrence in an issue
+// body's prose (unlike `#2399`'s bare `force-skip`, which the resolution
+// there rejected for a *shape ambiguity*, this is rejected for
+// *implausibility* -- pinned by its own regression test below so a later
+// change does not silently "fix" it without deliberate review, the same
+// convention `isOrdinaryHyphenatedCompoundToken`'s own accepted limit
+// follows).
 const CODE_IDENTIFIER_PROCESS_TOKEN_LENGTH = 'process'.length;
-const CODE_IDENTIFIER_PROCESS_PROPERTY_ACCESS_PATTERN = /^\.[A-Za-z_$]/;
+const CODE_IDENTIFIER_PROCESS_PROPERTY_ACCESS_PATTERN = /^\.[\p{L}_$]/u;
 
 function isCodeIdentifierProcessMention(
   rawSource: string,

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -1285,16 +1285,17 @@ function isNarrativeIddMention(rawSource: string, matchIndex: number): boolean {
 // ASCII letters/`_`/`$` plus any Unicode letter (`\p{L}`, e.g.
 // `process.é`) -- real ECMAScript `IdentifierStart` also allows a small set
 // of other Unicode categories (Nl, and the two explicit code points
-// U+2118/U+212E) and a `\uXXXX`/`\u{X...}` escape sequence (e.g.
-// `process.env`, an escaped spelling of `process.env`). Both are
-// deliberately left unhandled here: a hand-typed Unicode escape sequence
-// naming a `process` property has no realistic occurrence in an issue
-// body's prose (unlike `#2399`'s bare `force-skip`, which the resolution
-// there rejected for a *shape ambiguity*, this is rejected for
-// *implausibility* -- pinned by its own regression test below so a later
-// change does not silently "fix" it without deliberate review, the same
-// convention `isOrdinaryHyphenatedCompoundToken`'s own accepted limit
-// follows).
+// U+2118/U+212E) and a `\uXXXX`/`\u{X...}` escape sequence, e.g. writing
+// out `process` then a literal backslash, `u`, and the four hex digits
+// `0065` before `nv` -- an escaped spelling of `process.env`, not that
+// literal text. Both are deliberately left unhandled here: a hand-typed
+// Unicode escape sequence naming a `process` property has no realistic
+// occurrence in an issue body's prose (unlike `#2399`'s bare `force-skip`,
+// which the resolution there rejected for a *shape ambiguity*, this is
+// rejected for *implausibility* -- pinned by its own regression test below
+// so a later change does not silently "fix" it without deliberate review,
+// the same convention `isOrdinaryHyphenatedCompoundToken`'s own accepted
+// limit follows).
 const CODE_IDENTIFIER_PROCESS_TOKEN_LENGTH = 'process'.length;
 const CODE_IDENTIFIER_PROCESS_PROPERTY_ACCESS_PATTERN = /^\.[\p{L}_$]/u;
 

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -529,6 +529,39 @@ test('trust safety still rejects a genuine directive against the review process 
   assert.equal(result.pass, false);
 });
 
+test('trust safety ignores a Unicode-letter JS property access -- #2608 (CodeRabbit)', () => {
+  // CodeRabbit review (PR #2610): the identifier-start character class must
+  // accept a Unicode letter, not only ASCII, since `process.<unicodeLetter>`
+  // is just as unambiguously a JS property-access expression as the ASCII
+  // examples #2608 itself names.
+  const result = checkTrustSafety({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\nSkip process.é handling when unset.`,
+    },
+    trustSafetyAmbiguous: false,
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('trust safety still fails on a \\uXXXX-escaped property name -- #2608 (documented limit)', () => {
+  // Deliberately accepted limit -- see isCodeIdentifierProcessMention's own
+  // comment: a hand-typed `\uXXXX` escape sequence naming a `process`
+  // property has no realistic occurrence in an issue body's prose, so it is
+  // not recognized as a code identifier and stays detected. Pinned here so
+  // a later change does not silently alter this without deliberate review
+  // (the same convention isOrdinaryHyphenatedCompoundToken's own accepted
+  // limit follows).
+  const result = checkTrustSafety({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\nSkip process.\\u0065nv handling when unset.`,
+    },
+    trustSafetyAmbiguous: false,
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
 test('trust safety ignores a hyphenated compound noun ending in a policy-override verb -- #2399', () => {
   // #2218 wrapped only POLICY_OVERRIDE_NOUN_SOURCE in the hyphen-boundary
   // guard, leaving POLICY_OVERRIDE_VERB_SOURCE on a bare `\b`. A hyphen

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -492,6 +492,43 @@ test('trust safety still rejects the protocol name paired with another listed no
   assert.equal(result.pass, false);
 });
 
+test('trust safety ignores process.<property>-style code identifiers near a trigger verb -- #2608', () => {
+  // The exact reproduction from idd-skill#2608, plus the other three shapes
+  // its own acceptance criteria name explicitly: each is ordinary prose
+  // about platform-detection/CLI-argument-handling code, not a directive to
+  // bypass this repository's policy, workflow, or process.
+  for (const directive of [
+    "Skip it on process.platform === 'win32' since NTFS has no POSIX execute bit",
+    'Ignore process.env.CI in this branch',
+    'Bypass process.argv parsing here',
+    'Disable this call unless process.exit(1) already ran',
+  ]) {
+    const result = checkTrustSafety({
+      issue: {
+        ...BASE_ISSUE,
+        body: `${BASE_ISSUE.body}\n${directive}.`,
+      },
+      trustSafetyAmbiguous: false,
+    } as Context);
+    assert.equal(result.pass, true, directive);
+  }
+});
+
+test('trust safety still rejects a genuine directive against the review process -- #2608', () => {
+  // "process" here means a procedural workflow (the review process, the
+  // merge process), not the Node.js global -- isCodeIdentifierProcessMention
+  // must not exclude it, since it is never followed by a `.` plus an
+  // identifier-start character.
+  const result = checkTrustSafety({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\nSkip the review process for this PR.`,
+    },
+    trustSafetyAmbiguous: false,
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
 test('trust safety ignores a hyphenated compound noun ending in a policy-override verb -- #2399', () => {
   // #2218 wrapped only POLICY_OVERRIDE_NOUN_SOURCE in the hyphen-boundary
   // guard, leaving POLICY_OVERRIDE_VERB_SOURCE on a bare `\b`. A hyphen


### PR DESCRIPTION
# Summary

Check 3's `POLICY_OVERRIDE_NOUN_SOURCE` regex includes a bare
`process` alternative that matched a Node.js code identifier's
leading segment -- `process.platform`, `process.env`, `process.argv`,
`process.exit(` -- even when un-code-wrapped inside ordinary prose
about platform-detection or CLI-argument-handling code, not a
directive to bypass this repository's policy, workflow, or process.
Reproduced by the issue's own `--stdin` repro, which wrongly
hard-failed `trust_safety`.

Added `isCodeIdentifierProcessMention()`: excludes a `process` noun
match only when immediately followed by a literal `.` plus an
identifier-start character. That exact shape is unambiguously a JS
property-access expression and never occurs in the narrative
"the process"/"this repository's process" sense, so -- unlike `#2588`'s
`isNarrativeIddMention` -- no article/following-word heuristic is
needed; the shape alone is sufficient and unconditional. `skip the
review process for this PR` (the issue's own required true-positive
case) stays detected: `process` there is followed by a space, not `.`.

## Linked issue

Closes #2608

## Follow-up issues (if any)

- [ ] none created

## Background / rationale (if material)

Verified all required shapes directly via
`node scripts/suitability-triage.mjs --stdin` before writing the unit
tests:

- The issue's own repro (`process.platform === 'win32'`) -- `trust_safety`
  now `pass` (was `fail`).
- `process.env`, `process.argv`, `process.exit(` (the other three
  shapes the acceptance criteria name) -- all `pass`.
- `skip the review process for this PR` -- still `fail`, as required.

This repository was mid-flight on the closely related `#2589` (Check 7
fix) while this branch was created; picked up the merged result
(`d4965157`) as this branch's base and re-read the current
`src/scripts/suitability-triage.mts`/`src/scripts/markdown-code.mts`
fresh before implementing, rather than assuming stale line numbers or
structure from `#2588`'s own earlier work on this file.

Per the issue's own request, verified against the actual masking/
code-region pipeline rather than assuming a bolt-on regex tweak was
safe in isolation: confirmed a code-wrapped `` `process.platform` ``
is masked out entirely in `findPolicyOverrideMatch`'s masked-first
pass (via `maskMarkdownCodeRegionsPreservingPositions`), and the
raw-fallback pass's own `getCodeRangeAt` short-circuit already
excludes a wholly-code-wrapped match before this new classifier would
ever run against it -- the same precedent `isOrdinaryHyphenatedCompoundToken`/
`isNarrativeIddMention` already follow.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed (`scripts/suitability-triage.mjs`,
      generated from `src/scripts/suitability-triage.mts` by
      `pnpm run build`, per `docs/typescript-sources.md`)
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm run typecheck` (`tsc -p tsconfig.json` -- clean)
- [x] `pnpm run build:check` (regenerated `.mjs` committed alongside
      the `.mts` source; clean, no diff after commit)
- [x] `npx biome check` (both changed source files: clean)
- [x] `pnpm run test -- suitability-triage`
      (`node --test tests/suitability-triage.test.mts` -- 300/300
      pass, including all existing `#2218`/`#2399`/`#2588` regression
      coverage unchanged, plus 2 new tests for the 4-shape repro and
      the preserved true-positive case)
- [x] `pnpm test` (`node --test tests/*.test.mts`, full suite --
      5042 tests, 5034 pass, 0 fail, 8 skipped; 0 regressions)
- [x] `node scripts/audit-docs.mjs --check`

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none -- narrows an existing
      trust/safety false-positive; does not weaken detection of the
      genuine "bypass/disable the process" directive shape, per the
      regression test above)
- [x] Context budget impact reviewed (none -- no instruction/doc files
      changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X27jGWQk1dbPjpFchFfzzR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved policy-override detection to avoid treating JavaScript and Node.js references such as `process.env` or `process.platform` as directives.
  * Continued recognizing genuine policy directives, including code-wrapped matches and ordinary prose uses of “process.”

* **Tests**
  * Added coverage for common `process.*` references and legitimate directive scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->