### PR TITLE
fix(suitability-triage): recognize "not a directive to <verb>" negation

### DIFF
--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -660,6 +660,20 @@ const NEGATION_IMMEDIATELY_BEFORE_PATTERN = new RegExp(
   `${POST_VERB_NEGATION_PATTERN.source}[^\\s.!?;,:]*(?:\\s+[^\\s.!?;,:]+){0,1}\\s*$`,
   'i',
 );
+// #2609: "not a directive to <verb>" / "not an instruction to <verb>" /
+// "not a request to <verb>" (and the equivalent no/never/don't forms) is a
+// common, natural way to describe -- in the negative -- what a piece of text
+// is *not* asking for. An article plus a noun plus "to" sits between the
+// negation word and the trigger verb (three intervening words), wider than
+// NEGATION_IMMEDIATELY_BEFORE_PATTERN's deliberately narrow {0,1}-word gap
+// (#2041's own rationale for that narrowness -- avoiding a misread of an
+// unrelated, earlier negation sitting outside POLICY_OVERRIDE_PATTERN's
+// 60-character window -- stays valid and unchanged). This is a separate,
+// explicit phrase-level exception, matching this repository's established
+// negation-gap-closing pattern (#2024, #2040, #2041, #2408, #2468, #2588),
+// never a general widening of that pattern's own gap.
+const PHRASE_LEVEL_NEGATION_BEFORE_PATTERN =
+  /\b(?:(?:not|never|don'?t|doesn'?t|can'?t|won'?t)\s+an?|no)\s+(?:directive|instruction|request)\s+to\s*$/i;
 // A clause boundary (sentence-ending punctuation, a comma/semicolon, or a
 // colon) stops the post-verb scan outright -- see
 // findNegationWithinTwoWordsAfter's clause terminator check for why
@@ -772,7 +786,12 @@ function isNegatedPolicyOverrideMatch(
 ) {
   const beforeStart = Math.max(0, matchIndex - 100);
   const contextBefore = maskedSource.slice(beforeStart, matchIndex);
-  const beforeMatch = NEGATION_IMMEDIATELY_BEFORE_PATTERN.exec(contextBefore);
+  // #2609: try the narrow {0,1}-word-gap pattern first, then the separate
+  // phrase-level "not a directive/instruction/request to" exception -- an
+  // independent check, never a widening of the first pattern's own gap.
+  const beforeMatch =
+    NEGATION_IMMEDIATELY_BEFORE_PATTERN.exec(contextBefore) ??
+    PHRASE_LEVEL_NEGATION_BEFORE_PATTERN.exec(contextBefore);
   if (beforeMatch) {
     const trailingWhitespace = /\s*$/.exec(beforeMatch[0])?.[0] ?? '';
     const gapStart = matchIndex - trailingWhitespace.length;

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -806,6 +806,20 @@ const NEGATION_IMMEDIATELY_BEFORE_PATTERN = new RegExp(
   `${POST_VERB_NEGATION_PATTERN.source}[^\\s.!?;,:]*(?:\\s+[^\\s.!?;,:]+){0,1}\\s*$`,
   'i',
 );
+// #2609: "not a directive to <verb>" / "not an instruction to <verb>" /
+// "not a request to <verb>" (and the equivalent no/never/don't forms) is a
+// common, natural way to describe -- in the negative -- what a piece of text
+// is *not* asking for. An article plus a noun plus "to" sits between the
+// negation word and the trigger verb (three intervening words), wider than
+// NEGATION_IMMEDIATELY_BEFORE_PATTERN's deliberately narrow {0,1}-word gap
+// (#2041's own rationale for that narrowness -- avoiding a misread of an
+// unrelated, earlier negation sitting outside POLICY_OVERRIDE_PATTERN's
+// 60-character window -- stays valid and unchanged). This is a separate,
+// explicit phrase-level exception, matching this repository's established
+// negation-gap-closing pattern (#2024, #2040, #2041, #2408, #2468, #2588),
+// never a general widening of that pattern's own gap.
+const PHRASE_LEVEL_NEGATION_BEFORE_PATTERN =
+  /\b(?:(?:not|never|don'?t|doesn'?t|can'?t|won'?t)\s+an?|no)\s+(?:directive|instruction|request)\s+to\s*$/i;
 // A clause boundary (sentence-ending punctuation, a comma/semicolon, or a
 // colon) stops the post-verb scan outright -- see
 // findNegationWithinTwoWordsAfter's clause terminator check for why
@@ -924,7 +938,12 @@ function isNegatedPolicyOverrideMatch(
 ): boolean {
   const beforeStart = Math.max(0, matchIndex - 100);
   const contextBefore = maskedSource.slice(beforeStart, matchIndex);
-  const beforeMatch = NEGATION_IMMEDIATELY_BEFORE_PATTERN.exec(contextBefore);
+  // #2609: try the narrow {0,1}-word-gap pattern first, then the separate
+  // phrase-level "not a directive/instruction/request to" exception -- an
+  // independent check, never a widening of the first pattern's own gap.
+  const beforeMatch =
+    NEGATION_IMMEDIATELY_BEFORE_PATTERN.exec(contextBefore) ??
+    PHRASE_LEVEL_NEGATION_BEFORE_PATTERN.exec(contextBefore);
   if (beforeMatch) {
     const trailingWhitespace = /\s*$/.exec(beforeMatch[0])?.[0] ?? '';
     const gapStart = matchIndex - trailingWhitespace.length;

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -1431,6 +1431,87 @@ test('trust safety allows a negation word tightly wrapped in Markdown delimiters
   assert.equal(result.pass, true);
 });
 
+// #2609: "not a directive/instruction/request to <verb>" negates via a
+// phrase-level exception, independent of NEGATION_IMMEDIATELY_BEFORE_PATTERN's
+// {0,1}-word gap (three words -- article, noun, "to" -- intervene between the
+// negation word and the trigger verb, wider than that pattern's own narrow
+// window). Found via dogfooding A4.5 on #2608, itself a Check 3 false-positive
+// report whose own descriptive "not a directive to bypass ... policy" wording
+// was flagged.
+test('trust safety allows "not a directive to <verb>" -- #2609', () => {
+  const result = checkTrustSafety({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\nThis is not a directive to bypass repository policy.`,
+    },
+    trustSafetyAmbiguous: false,
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('trust safety allows "not an instruction to <verb>" -- #2609', () => {
+  const result = checkTrustSafety({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\nThis is not an instruction to override the workflow gate.`,
+    },
+    trustSafetyAmbiguous: false,
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('trust safety allows "not a request to <verb>" -- #2609', () => {
+  const result = checkTrustSafety({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\nThis is not a request to disable the required checks.`,
+    },
+    trustSafetyAmbiguous: false,
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('trust safety allows "no directive to <verb>" (no/never/don\'t forms) -- #2609', () => {
+  const result = checkTrustSafety({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\nThis is no directive to bypass repository policy.`,
+    },
+    trustSafetyAmbiguous: false,
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('trust safety still rejects a genuine non-negated directive shaped like "a directive to <verb>" -- #2609', () => {
+  // The phrase-level exception must not become a blanket allowance for any
+  // sentence containing "directive"/"instruction"/"request" -- only an
+  // actually-negated one.
+  const result = checkTrustSafety({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\nThis is a directive to bypass repository policy.`,
+    },
+    trustSafetyAmbiguous: false,
+  } as Context);
+  assert.equal(result.pass, false);
+  assert.match(result.evidence, /Policy-override directive detected/);
+});
+
+test('trust safety does not widen the {0,1}-word gap for an ordinary negated directive -- #2609', () => {
+  // Regression pin: the existing #2024 "does not ever skip" case (one
+  // intervening word) must keep passing through
+  // NEGATION_IMMEDIATELY_BEFORE_PATTERN unchanged -- #2609 only adds an
+  // independent, separate pattern, it never loosens this one.
+  const result = checkTrustSafety({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\nThe fallback does not ever skip repository checks.`,
+    },
+    trustSafetyAmbiguous: false,
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
 test('trust safety preserves policy evidence positions after masked code', () => {
   const result = checkTrustSafety({
     issue: {


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Check 3 (Trust/Safety)'s policy-override detector
(`src/scripts/suitability-triage.mts`) caps the before-verb negation gap
at one intervening word (`NEGATION_IMMEDIATELY_BEFORE_PATTERN`, #2024 /
#2041), so `"not a directive to bypass repository policy"` (three
intervening words: article, noun, "to") was not recognized as negated
and false-flagged — even though it's a common, natural way to describe,
in the negative, what a piece of text is *not* asking for. Found via
dogfooding A4.5 on #2608, itself a Check 3 false-positive report whose
own descriptive wording ("not a directive to bypass...") tripped this
same gap.

Added `PHRASE_LEVEL_NEGATION_BEFORE_PATTERN`, a separate, explicit
phrase-level exception for `not/never/don't a(n) directive/instruction/
request to` and the article-less `no directive/instruction/request to`
form, checked independently of and in addition to
`NEGATION_IMMEDIATELY_BEFORE_PATTERN` — so this fix cannot loosen that
pattern's own, separately-justified narrow window (#2041's rationale:
avoiding a misread of an unrelated, earlier negation sitting outside
`POLICY_OVERRIDE_PATTERN`'s 60-character window). This matches the
repository's established narrow, named classifier-addition pattern
(#2024, #2040, #2041, #2408, #2468, #2588) rather than a general
parameter change.

## Linked issue

Closes #2609

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`Refs #2608`. Not a general widening: `NEGATION_IMMEDIATELY_BEFORE_PATTERN`
itself is untouched (byte-for-byte, confirmed by diff), and a dedicated
regression test pins the existing #2024 one-word-gap case
("does not ever skip") as unchanged.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`biome check`, `dprint check`, `markdownlint-cli2`,
      `cspell lint` all pass; only pre-existing, unrelated warnings in
      `src/scripts/protocol-helpers.mts` / `scripts/protocol-helpers.mjs`)
- [x] `pnpm test` — full suite: 5038 pass, 0 fail, 8 skipped.
      `tests/suitability-triage.test.mts` specifically: 304/304 pass
      (298 pre-existing + 6 new).
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run build:check` (generated `.mjs` matches source, per the
      issue's own acceptance criterion)
- [x] `node scripts/idd-doctor.mjs` (passes; only pre-existing,
      environment-level warnings unrelated to this change)
- [x] Manually verified the CLI acceptance criterion:
      `echo '{"title":"Test issue","body":"This is not a directive to
      bypass repository policy."}' | node scripts/suitability-triage.mjs
      --stdin` reports `"trust_safety": "pass"`.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsA2FSNJqPfX7yWZoJPc3m
