### PR TITLE
docs(idd-review-fix): state agents must not poll the secondary advisory bot before F2

### DIFF
--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -23,9 +23,8 @@ swaps the single bot instead of gating every configured one).
 For non-Copilot bots, the load-bearing safety net for late-arriving
 findings is the **E1 activity-universe snapshot + `review-watermark`
 delta** (`idd-review-snapshot.instructions.md`), re-checked by the
-F2/F3 merge-readiness gate
-([`idd-pre-merge.instructions.md`](idd-pre-merge.instructions.md)),
-which forbids a bare CI-green merge without a fresh covering snapshot.
+F2/F3 merge-readiness gate (`idd-pre-merge.instructions.md`), which
+forbids a bare CI-green merge without a fresh covering snapshot.
 
 ## Fast path — common case
 
@@ -94,11 +93,9 @@ distributed defaults in `docs/policy-constants.md`: `REQUEST_CAP`,
 (default) — E14 skips to E15, F2/F3 hold; `hold` — E14, F2, and F3 all
 hold on `CAP_EXHAUSTED`.
 
-**Diagnostic note**: when every documented recovery route below fails
-identically and repeatedly, an organization-level Copilot review-quota
-outage (unrelated to this PR) is a plausible cause worth checking — for
-example via Copilot/GitHub status or an org admin surface — before
-continuing to retry the same recovery cycle.
+**Diagnostic note**: if every documented recovery route below fails
+identically and repeatedly, check for an org-level Copilot review-quota
+outage (e.g. via status page or an org admin surface) before retrying.
 
 ### Caller mapping
 
@@ -120,7 +117,9 @@ route, never satisfies the primary gate, posts no `advisory-wait`
 marker. A bot check alone never confirms review of current HEAD.
 Full trigger condition (`secondaryRequestNeeded`/`CAP_EXHAUSTED`/
 stalled `SATISFIED`) and request procedure:
-`idd-review-fix.instructions.md`'s E14 step 5.
+`idd-review-fix.instructions.md`'s E14 step 5 — never poll/wait for it
+there or at E1/E2; only F2's `secondary-quiet-window` blocker
+(`idd-pre-merge.instructions.md`) waits.
 
 ### F3-specific interpretation
 
@@ -474,7 +473,5 @@ current-HEAD recovery marker is posted. Waiting out either clock is
 therefore only a viable strategy once the diff has converged — no
 further pushes expected, independent of whether review itself has
 converged (the terminal-unavailable path exists precisely because it
-may never converge) — roadmap `#2318`'s field-evidence comment on pull
-request `#2325` recorded this repository's `PT9H` deadline override
-restarting four times across seven advisory review rounds, observed at
-229/540 minutes.
+may never converge) — see roadmap `#2318` (`#2325`: this repository's
+`PT9H` override restarted four times across seven rounds).

--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -118,7 +118,7 @@ marker. A bot check alone never confirms review of current HEAD.
 Full trigger condition (`secondaryRequestNeeded`/`CAP_EXHAUSTED`/
 stalled `SATISFIED`) and request procedure:
 `idd-review-fix.instructions.md`'s E14 step 5 — never poll/wait for it
-there or at E1/E2; only F2's `secondary-quiet-window` blocker
+there, E1, or E2; only F2's `secondary-quiet-window` blocker
 (`idd-pre-merge.instructions.md`) waits.
 
 ### F3-specific interpretation

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -339,7 +339,9 @@ login).
    gh-then-REST fallback as the primary, no `advisory-wait:` marker, and
    no change to the AW3 route. Its review is ordinary advisory input,
    returned by the E1 snapshot if it lands before merge; skipped when
-   unconfigured.
+   unconfigured. Never poll/wait for it here, E1, or E2; only F2's
+   `secondary-quiet-window` blocker (`idd-pre-merge.instructions.md`)
+   waits.
 
 Copilot and CI advisory bot comments are advisory; unanswered ones do
 not block merge.

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -113,7 +113,7 @@ marker. A bot check alone never confirms review of current HEAD.
 Full trigger condition (`secondaryRequestNeeded`/`CAP_EXHAUSTED`/
 stalled `SATISFIED`) and request procedure:
 `idd-review-fix.instructions.md`'s E14 step 5 — never poll/wait for it
-there or at E1/E2; only F2's `secondary-quiet-window` blocker
+there, E1, or E2; only F2's `secondary-quiet-window` blocker
 (`idd-pre-merge.instructions.md`) waits.
 
 ### F3-specific interpretation

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -18,9 +18,8 @@ swaps the single bot instead of gating every configured one).
 For non-Copilot bots, the load-bearing safety net for late-arriving
 findings is the **E1 activity-universe snapshot + `review-watermark`
 delta** (`idd-review-snapshot.instructions.md`), re-checked by the
-F2/F3 merge-readiness gate
-([`idd-pre-merge.instructions.md`](idd-pre-merge.instructions.md)),
-which forbids a bare CI-green merge without a fresh covering snapshot.
+F2/F3 merge-readiness gate (`idd-pre-merge.instructions.md`), which
+forbids a bare CI-green merge without a fresh covering snapshot.
 
 ## Fast path — common case
 
@@ -89,11 +88,9 @@ distributed defaults in `docs/policy-constants.md`: `REQUEST_CAP`,
 (default) — E14 skips to E15, F2/F3 hold; `hold` — E14, F2, and F3 all
 hold on `CAP_EXHAUSTED`.
 
-**Diagnostic note**: when every documented recovery route below fails
-identically and repeatedly, an organization-level Copilot review-quota
-outage (unrelated to this PR) is a plausible cause worth checking — for
-example via Copilot/GitHub status or an org admin surface — before
-continuing to retry the same recovery cycle.
+**Diagnostic note**: if every documented recovery route below fails
+identically and repeatedly, check for an org-level Copilot review-quota
+outage (e.g. via status page or an org admin surface) before retrying.
 
 ### Caller mapping
 
@@ -115,7 +112,9 @@ route, never satisfies the primary gate, posts no `advisory-wait`
 marker. A bot check alone never confirms review of current HEAD.
 Full trigger condition (`secondaryRequestNeeded`/`CAP_EXHAUSTED`/
 stalled `SATISFIED`) and request procedure:
-`idd-review-fix.instructions.md`'s E14 step 5.
+`idd-review-fix.instructions.md`'s E14 step 5 — never poll/wait for it
+there or at E1/E2; only F2's `secondary-quiet-window` blocker
+(`idd-pre-merge.instructions.md`) waits.
 
 ### F3-specific interpretation
 
@@ -469,7 +468,5 @@ current-HEAD recovery marker is posted. Waiting out either clock is
 therefore only a viable strategy once the diff has converged — no
 further pushes expected, independent of whether review itself has
 converged (the terminal-unavailable path exists precisely because it
-may never converge) — roadmap `#2318`'s field-evidence comment on pull
-request `#2325` recorded this repository's `PT9H` deadline override
-restarting four times across seven advisory review rounds, observed at
-229/540 minutes.
+may never converge) — see roadmap `#2318` (`#2325`: this repository's
+`PT9H` override restarted four times across seven rounds).

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -334,7 +334,9 @@ login).
    gh-then-REST fallback as the primary, no `advisory-wait:` marker, and
    no change to the AW3 route. Its review is ordinary advisory input,
    returned by the E1 snapshot if it lands before merge; skipped when
-   unconfigured.
+   unconfigured. Never poll/wait for it here, E1, or E2; only F2's
+   `secondary-quiet-window` blocker (`idd-pre-merge.instructions.md`)
+   waits.
 
 Copilot and CI advisory bot comments are advisory; unanswered ones do
 not block merge.


### PR DESCRIPTION
# Summary

An IDD agent session started an unbounded background poll loop waiting
for the secondary advisory bot's (e.g. CodeRabbit) review before
proceeding past E14, on two separate review rounds -- a real protocol
deviation, since the only authorized bounded wait for the secondary bot
lives at F2's `secondary-quiet-window` blocker. The prior wording
already implied this ("optional, non-gating", "if it lands before
merge") but never stated it as an explicit negative instruction.

Adds one explicit "never poll/wait for it here" sentence to
`idd-review-fix.instructions.md`'s E14 step 5 and
`idd-advisory-wait.instructions.md`'s secondary-bot supplement section,
both pointing to F2's `secondary-quiet-window` blocker as the one place
a bounded wait is authorized.

## Linked issue

Closes #2607

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

**Byte-budget constraint and how it was resolved.** Both edited files
already sat within ~1% of their `bundle-review` / `bundle-merge`
`context-ceiling-200k` budgets (`node scripts/audit-docs.mjs --check`).
Per `docs/policy-constants.md`'s near-ceiling guidance (prefer trimming
existing restatement over a ratchet bump once utilization is at or
above 95%) and the prior content-diet precedent (#2191), the two new
sentences are offset by trimming three genuinely redundant passages in
the same two files: a self-referencing Markdown link whose link text
duplicated its target, an over-verbose diagnostic-note aside, and a
citation's trailing detail (verified not referenced anywhere else in
the corpus). No rule, policy value, or citation reference was dropped
-- only wording tightened. An independent C1 critique subagent verified
this and confirmed `audit-docs.mjs --check` / `audit-code-span-wrap.mjs`
both pass.

**Known residual risk (flagged by the C1 critique, not fixed here):**
this change consumes the last of `bundle-review`'s remaining headroom --
it now sits at exactly its 98%-utilization ceiling with zero bytes to
spare. The **next** PR touching any of `bundle-review`'s seven member
files (`idd-advisory-wait`, `idd-ci`, `idd-overview-appendix`,
`idd-overview-core`, `idd-review-fix`, `idd-review-snapshot`,
`idd-review-triage`) will need to trim an equal or greater number of
bytes to pass `audit-docs.mjs --check`, even for a one-character
addition. This is disclosed here rather than fixed, since further
squeezing this PR's own two files for extra margin has diminishing
returns and a real risk of further degrading clarity; `bundle-merge` has
normal headroom (97.87%) and is unaffected.

**Deviation from the posted B2 plan (self-disclosed, per C1):** the
refined plan proposed a full Markdown link with anchor
(`` [F2 — Pre-merge condition check](idd-pre-merge.instructions.md#f2--pre-merge-condition-check) ``)
for the new F2 cross-reference. The actual implementation uses a bare
backtick-wrapped filename (`` `idd-pre-merge.instructions.md` ``)
instead, matching the dominant existing convention already used
elsewhere in both edited files (and in `idd-merge.instructions.md`,
`idd-review-triage.instructions.md`, `idd-merge-handoff.instructions.md`)
-- the plan's link+anchor form, borrowed from a different file
(`idd-ci.instructions.md`), turned out to be the outlier once the
corpus was checked, and the shorter form was also necessary to fit the
byte budget above.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (`node --test tests/*.test.mts`; 5040/5040)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed (see Background/rationale above --
      `bundle-review` now at its ceiling with zero headroom, disclosed
      as a known residual risk for the next touching PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzttxREebRkAnF4KwPd2GP
