### PR TITLE
chore(idd-config): widen pre-push-validate to the full test suite

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -23,7 +23,7 @@
   "commands": {
     "install-deps": "node scripts/verify-install-deps.mjs --key-binary node_modules/.bin/tsc --install-command \"pnpm install --frozen-lockfile\"",
     "fix-validate": "npx biome check --write && npx dprint fmt \"**/*.md\" && npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\"",
-    "pre-push-validate": "npx biome check && npx dprint check \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress && node scripts/audit-docs.mjs --check && node scripts/audit-code-span-wrap.mjs && node --test tests/agent-entry-mirror-sync.test.mts && pnpm run build:check && node scripts/idd-doctor.mjs",
+    "pre-push-validate": "npx biome check && npx dprint check \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress && node scripts/audit-docs.mjs --check && node scripts/audit-code-span-wrap.mjs && node --test tests/*.test.mts && pnpm run build:check && node scripts/idd-doctor.mjs",
     "post-fix-validate": "npx biome check --write && npx dprint fmt \"**/*.md\" && npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress && node scripts/audit-docs.mjs --check && node scripts/audit-code-span-wrap.mjs"
   },
   "helperRuntime": {

--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -267,7 +267,7 @@ enabled and default approval actors to
 | Name | Commands |
 | --- | --- |
 | **fix-validate** | `npx biome check --write && npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"` |
-| **pre-push-validate** | `npx biome check && npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress && node scripts/audit-docs.mjs --check && node scripts/audit-code-span-wrap.mjs && node --test tests/agent-entry-mirror-sync.test.mts && pnpm run build:check && node scripts/idd-doctor.mjs` |
+| **pre-push-validate** | `npx biome check && npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress && node scripts/audit-docs.mjs --check && node scripts/audit-code-span-wrap.mjs && node --test tests/*.test.mts && pnpm run build:check && node scripts/idd-doctor.mjs` |
 | **post-fix-validate** | `npx biome check --write && npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress && node scripts/audit-docs.mjs --check && node scripts/audit-code-span-wrap.mjs` |
 | **install-deps** | `node scripts/verify-install-deps.mjs --key-binary node_modules/.bin/tsc --install-command "pnpm install --frozen-lockfile"` |
 | **issue-scope** | `roadmap-first` |

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -569,7 +569,7 @@
         },
         {
           "from": "| **pre-push-validate** | `{{PRE_PUSH_VALIDATE_COMMANDS}}` |",
-          "to": "| **pre-push-validate** | `npx biome check && npx dprint check \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress && node scripts/audit-docs.mjs --check && node scripts/audit-code-span-wrap.mjs && node --test tests/agent-entry-mirror-sync.test.mts && pnpm run build:check && node scripts/idd-doctor.mjs` |"
+          "to": "| **pre-push-validate** | `npx biome check && npx dprint check \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress && node scripts/audit-docs.mjs --check && node scripts/audit-code-span-wrap.mjs && node --test tests/*.test.mts && pnpm run build:check && node scripts/idd-doctor.mjs` |"
         },
         {
           "from": "| **post-fix-validate** | `{{POST_FIX_VALIDATE_COMMANDS}}` |",


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Widens `.github/idd/config.json`'s `commands.pre-push-validate` from a
single narrow test file (`node --test tests/agent-entry-mirror-sync.test.mts`)
to the full suite (`node --test tests/*.test.mts`), matching CI's
required `pnpm run lint:minimum` scope. A clean local run of the full
suite completes in ~18s (5040 tests, 0 failures), so there is no
performance case for the narrow scope.

## Linked issue

Closes #2611

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

This restores an acceptance criterion from #1007 (closed) that
pre-push validation keep full local/CI coverage parity — without it, a
mirror-sync-style regression (like #2410) can pass locally and only
fail in CI. #2449 narrowly addressed the #2410 regression by adding
just the one affected test file, and deliberately deferred the
full-suite widening pending a timing re-verification; #2611's issue
body records that re-verification (18.04s wall-clock, 5040 tests).

**Scope note beyond the issue's own candidate files**: this PR also
updates `audit/sync-manifest.json`, which is not listed in #2611's
`## Candidate files` section. `scripts/sync-docs.mjs`'s
`applyReplacements` does a literal, hardcoded `from`/`to` string
substitution sourced from this manifest when regenerating
`.github/instructions/idd-overview-core.instructions.md` — it does not
re-derive the substitution text from `.github/idd/config.json` at apply
time. Without updating the manifest's matching `to` text too,
`sync-docs.mjs --apply` would have kept emitting the old narrow-scope
command in the generated doc table even after `config.json` changed,
which `audit-docs.mjs --check`'s config/doc drift check would then have
correctly flagged. This was found and self-critiqued during planning
(see the issue's B2 plan comment) before implementation, not added in
response to review feedback.

`idd-template/.github/idd/config.json`'s
`{{PRE_PUSH_VALIDATE_COMMANDS}}` placeholder is intentionally
untouched — that is the adopter-customized template value, out of
scope for this source-repo command definition (same boundary #2449
already drew).

## IDD impact

- [x] Instruction files changed (generated mirror only —
      `.github/instructions/idd-overview-core.instructions.md`,
      regenerated via `sync-docs.mjs --apply`, not hand-edited)
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

Also verified per the issue's own acceptance criteria: a deliberate
regression introduced in `tests/branch-name.test.mts` (a file other
than `agent-entry-mirror-sync.test.mts`) made the widened
`pre-push-validate` fail as expected, then was reverted before
committing.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
