### PR TITLE
fix(audit-pr-cleanup): extend F2/F3's ack-only-post-disposition carve-out to F4

### DIFF
--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -17,6 +17,7 @@ import { combineOwnerRepoFlags, ghText } from './gh-exec.mjs';
 import { resolveCollaboratorMarkerTrust } from './policy-helpers.mjs';
 import {
   classifyRegularBotComment,
+  classifyThreadAckOnlyPostDisposition,
   hasFreshDisposition,
   indexLatestGatingReviewsByAuthor,
   indexThreadsByReview,
@@ -24,6 +25,7 @@ import {
   isKnownReviewBot,
   normalizeTrustedMarkerLogins,
   operationalMarkerPrefix,
+  resolveAdvisoryBotLogins,
   summarizeClaimValidation,
   unionTrustedMarkerActorSources,
   unsafeTextReason,
@@ -52,6 +54,7 @@ const trustedMarkerAuthorCache = new Map();
 const collaboratorPermissionCache = new Map();
 let cachedConfiguredTrustedMarkerActorSources = null;
 let cachedCurrentViewerLogin = null;
+let cachedConfiguredAdvisoryBotLogins = null;
 /** Default bound on whole-pass apply retries (#2011). */
 const DEFAULT_APPLY_RETRY_MAX_ATTEMPTS = 3;
 /** Base backoff (ms) before each rescan; linear-ish with jitter, matching
@@ -469,6 +472,8 @@ async function buildReport(owner, repo, prNumber, options = {}) {
   ]);
   const threadIndex = indexThreadsByReview(threads, {
     isDispositionAuthor: makeIddDispositionAuthorPredicate(iddAgentLogins),
+    iddAgentLogins,
+    advisoryBotLogins: configuredAdvisoryBotLogins(),
   });
   const latestGatingReviews = indexLatestGatingReviewsByAuthor(reviews);
   const report = {
@@ -702,7 +707,8 @@ function evaluateReviewComments(thread, pr, latestGatingReviews, report) {
     evaluateReviewComment(comment, thread, pr, latestGatingReviews, report);
   }
 }
-function evaluateReviewComment(
+/** Exported for direct unit testing (#2618); not part of the CLI surface. */
+export function evaluateReviewComment(
   comment,
   thread,
   pr,
@@ -765,7 +771,11 @@ function evaluateReviewComment(
       isDispositionAuthor: makeIddDispositionAuthorPredicate(
         report.trustedMarkerActors,
       ),
-    })
+    }) &&
+    !classifyThreadAckOnlyPostDisposition(thread, {
+      iddAgentLogins: report.trustedMarkerActors,
+      advisoryBotLogins: configuredAdvisoryBotLogins(),
+    }).ackOnlyPostDisposition
   ) {
     addSkipped(
       report,
@@ -1292,6 +1302,24 @@ function configuredTrustedMarkerActorSources() {
 }
 function configuredTrustedMarkerAuthors() {
   return configuredTrustedMarkerActorSources().actors;
+}
+// #2618: this repository's configured advisory-bot logins, feeding the
+// ack-only-post-disposition carve-out (`classifyThreadAckOnlyPostDisposition`)
+// so F4 recognizes the same courtesy-ack shape F2/F3 already does.
+function configuredAdvisoryBotLogins() {
+  if (cachedConfiguredAdvisoryBotLogins) {
+    return cachedConfiguredAdvisoryBotLogins;
+  }
+  let config = null;
+  try {
+    config = JSON.parse(readFileSync('.github/idd/config.json', 'utf8'));
+  } catch {
+    config = null;
+  }
+  cachedConfiguredAdvisoryBotLogins = resolveAdvisoryBotLogins({
+    config,
+  }).logins;
+  return cachedConfiguredAdvisoryBotLogins;
 }
 function trustCollaboratorMarkers() {
   try {

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -1317,6 +1317,7 @@ function configuredAdvisoryBotLogins() {
     config = null;
   }
   cachedConfiguredAdvisoryBotLogins = resolveAdvisoryBotLogins({
+    envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
     config,
   }).logins;
   return cachedConfiguredAdvisoryBotLogins;

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -474,6 +474,7 @@ async function buildReport(owner, repo, prNumber, options = {}) {
     isDispositionAuthor: makeIddDispositionAuthorPredicate(iddAgentLogins),
     iddAgentLogins,
     advisoryBotLogins: configuredAdvisoryBotLogins(),
+    prAuthorLogin: pr.author?.login,
   });
   const latestGatingReviews = indexLatestGatingReviewsByAuthor(reviews);
   const report = {
@@ -775,6 +776,7 @@ export function evaluateReviewComment(
     !classifyThreadAckOnlyPostDisposition(thread, {
       iddAgentLogins: report.trustedMarkerActors,
       advisoryBotLogins: configuredAdvisoryBotLogins(),
+      prAuthorLogin: pr.author?.login,
     }).ackOnlyPostDisposition
   ) {
     addSkipped(
@@ -815,6 +817,7 @@ function fetchPullRequest(owner, repo, number, options = {}) {
         number
         url
         merged
+        author { login }
       }
     }
   }`;

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -755,7 +755,11 @@ export function indexThreadsByReview(threads, options = {}) {
       if (
         !hasFreshDisposition(thread, {
           isDispositionAuthor: options.isDispositionAuthor,
-        })
+        }) &&
+        !classifyThreadAckOnlyPostDisposition(thread, {
+          iddAgentLogins: options.iddAgentLogins,
+          advisoryBotLogins: options.advisoryBotLogins,
+        }).ackOnlyPostDisposition
       ) {
         current.missingDisposition += 1;
       }
@@ -2632,8 +2636,8 @@ export function buildActivitySnapshotSummary(
   // `**Rejected**` re-post once a maintainer agrees an
   // `**Awaiting maintainer decision**` item needs no action -- a disposition
   // is a disposition regardless of which of the two terminal shapes it took.
-  // `summarizeDispositionEvidenceForGate`'s `classifyThreadAckOnlyPostDisposition`
-  // already recognizes both, but ONLY as a reply on a resolved review thread
+  // `classifyThreadAckOnlyPostDisposition` already recognizes both, but ONLY
+  // as a reply on a resolved review thread
   // (the marker's own contract, `isRejectionConfirmedDisposition`'s doc
   // comment above). `filteredComments` below are plain top-level PR
   // comments with no thread/resolved concept at all, so they must keep
@@ -3173,6 +3177,136 @@ function isIddOriginatedThreadReply(comment, options) {
     isDispositionComment({ body }) || isRejectionConfirmedDisposition({ body })
   );
 }
+// #978 advisory-only diagnostic, extracted from `summarizeDispositionEvidenceForGate`
+// (#2618) so both the F2/F3 merge gate and F4's `audit-pr-cleanup` disposition
+// checks share one implementation. A blocking resolved thread is
+// "ack-only-post-disposition" when a thread-local IDD disposition exists and
+// EVERY external comment newer than the disposition (and, when
+// `snapshotBoundaryAt` is supplied, also newer than that boundary) is an
+// advisory-bot, non-disposition courtesy ack. `snapshotBoundaryAt` is
+// optional: F2/F3 passes the review-snapshot watermark so only feedback that
+// re-blocks the gate counts; F4 has no such watermark and omits it, so every
+// post-disposition external comment counts. Fails closed (false) without a
+// thread-local disposition or for an unresolved thread, and never changes
+// any caller's route by itself.
+//
+// #1313: also computes the narrower `inPlaceEditOnly` sibling signal in the
+// same pass (it needs the identical `threadDispositionAt` /
+// `postDispositionBlockingFeedback` groundwork, so folding it into one
+// function avoids recomputing that twice). `inPlaceEditOnly` additionally
+// requires every qualifying comment to be an in-place edit of content that
+// already existed at-or-before the disposition (its own `createdAt` is not
+// newer than the disposition, and its `updatedAt` is strictly newer than its
+// own `createdAt`) rather than a brand-new post-disposition comment.
+// Deliberately advisory-only, like its sibling: GitHub's API exposes no
+// revision diff for an edited comment, so this helper cannot tell a
+// cosmetic append from a substantive change to the finding.
+export function classifyThreadAckOnlyPostDisposition(thread, options = {}) {
+  const none = { ackOnlyPostDisposition: false, inPlaceEditOnly: false };
+  if (!thread.isResolved) {
+    return none;
+  }
+  const snapshotBoundaryAt = isValidIsoTimestamp(options.snapshotBoundaryAt)
+    ? String(options.snapshotBoundaryAt)
+    : null;
+  const iddAgentLogins = new Set(
+    normalizeTrustedMarkerLogins(options.iddAgentLogins ?? []),
+  );
+  const advisoryBotLogins = new Set(
+    normalizeTrustedMarkerLogins(options.advisoryBotLogins ?? []),
+  );
+  const prAuthorLogin = String(options.prAuthorLogin ?? '')
+    .trim()
+    .toLowerCase();
+  // #2014: an advisory bot can never anchor "a disposition exists" -- see
+  // `summarizeDispositionEvidenceForGate`'s identical subtraction (this
+  // file, "An advisory bot can never anchor..."). Scoped to only this
+  // anchor set; callers' own `iddAgentLogins` stay unsubtracted everywhere
+  // else, since each reacts differently (fail-open vs. fail-closed) to a
+  // global change.
+  const ackAnchorAuthorLogins = new Set(
+    [...iddAgentLogins].filter(
+      (login) => !isConfiguredAdvisoryBotLogin(login, advisoryBotLogins),
+    ),
+  );
+  const nodes = thread.comments?.nodes ?? [];
+  // Recognize the same dispositions `hasFreshDisposition` accepts on a
+  // resolved thread (the gate that already decided this thread blocks): a
+  // `**Accepted**`/`**Rejected**` marker OR the terminal
+  // `**Rejection confirmed by maintainer**` marker, anchored by effective
+  // activity (`updatedAt`-preferring) so an edited disposition is dated
+  // consistently. The thread is already known resolved here.
+  const threadDispositionAt = maxIsoTimestamp(
+    nodes
+      .filter(
+        (comment) =>
+          ackAnchorAuthorLogins.has(
+            String(comment.author?.login ?? '')
+              .trim()
+              .toLowerCase(),
+          ) &&
+          (isDispositionComment({ body: String(comment.body ?? '') }) ||
+            isRejectionConfirmedDisposition({
+              body: String(comment.body ?? ''),
+            })),
+      )
+      .map((comment) => effectiveThreadCommentActivityAt(comment))
+      .filter(isValidIsoTimestamp),
+  );
+  if (!threadDispositionAt) {
+    return none;
+  }
+  // The blocking activity is external feedback newer than the thread
+  // disposition (so already-dispositioned feedback predating the ack does
+  // not disqualify the signal) and, when a snapshot boundary is supplied,
+  // also newer than it (so it actually re-blocks that gate). Without a
+  // boundary, every post-disposition external comment counts.
+  const postDispositionBlockingFeedback = nodes.filter((comment) => {
+    const authorLogin = String(comment.author?.login ?? '')
+      .trim()
+      .toLowerCase();
+    if (
+      !authorLogin ||
+      iddAgentLogins.has(authorLogin) ||
+      authorLogin === prAuthorLogin
+    ) {
+      return false;
+    }
+    const activityAt = effectiveThreadCommentActivityAt(comment);
+    return (
+      isValidIsoTimestamp(activityAt) &&
+      (!snapshotBoundaryAt ||
+        compareIsoTimestamps(activityAt, snapshotBoundaryAt) > 0) &&
+      compareIsoTimestamps(activityAt, threadDispositionAt) > 0
+    );
+  });
+  if (postDispositionBlockingFeedback.length === 0) {
+    return none;
+  }
+  // Each remaining item must be a pure advisory-bot courtesy ack: an
+  // advisory-bot author whose body is neither a `**Accepted**`/`**Rejected**`
+  // marker nor the terminal `**Rejection confirmed by maintainer**` marker.
+  const ackOnlyPostDisposition = postDispositionBlockingFeedback.every(
+    (comment) =>
+      isConfiguredAdvisoryBotLogin(comment.author?.login, advisoryBotLogins) &&
+      !isDispositionComment({ body: String(comment.body ?? '') }) &&
+      !isRejectionConfirmedDisposition({ body: String(comment.body ?? '') }),
+  );
+  if (!ackOnlyPostDisposition) {
+    return none;
+  }
+  const inPlaceEditOnly = postDispositionBlockingFeedback.every((comment) => {
+    const createdAt = String(comment.createdAt ?? '');
+    const updatedAt = String(comment.updatedAt ?? '');
+    return (
+      isValidIsoTimestamp(createdAt) &&
+      compareIsoTimestamps(createdAt, threadDispositionAt) <= 0 &&
+      isValidIsoTimestamp(updatedAt) &&
+      compareIsoTimestamps(updatedAt, createdAt) > 0
+    );
+  });
+  return { ackOnlyPostDisposition, inPlaceEditOnly };
+}
 export function summarizeDispositionEvidenceForGate(
   { comments = [], threads = [] },
   options = {},
@@ -3202,29 +3336,6 @@ export function summarizeDispositionEvidenceForGate(
   ).trim();
   const markerPrefix =
     explicitMarkerPrefix || configuredMarkerPrefix || undefined;
-  // #2014: An advisory bot can never anchor "dispositions exist", mirroring
-  // `buildActivitySnapshotSummary`'s identical `dispositionAuthorLogins`
-  // subtraction above (this file, "An advisory bot can never anchor..."
-  // comment) -- its own `**Accepted**`/`**Rejected**`-shaped reply must not
-  // open the post-disposition window that classifies a later advisory-bot
-  // reply as ack-only. Scoped to ONLY `classifyThreadAckOnlyPostDisposition`'s
-  // own anchor below -- the raw `iddAgentLogins` set is used unchanged
-  // everywhere else in this function (`hasFreshDisposition`,
-  // `outstandingComments`, the generic `dispositionComments` 1:1 pool), per
-  // the "Pre-merge gate invariants" comment above `summarizeDispositionEvidenceForGate`:
-  // each of those reacts differently (fail-open vs. fail-closed) to a global
-  // change, so this subtraction must stay local to the ack-only diagnostic.
-  // Excludes via `isConfiguredAdvisoryBotLogin`, not a plain `Set.has`, so a
-  // `[bot]`-suffix mismatch between the two configured login sets (e.g.
-  // `iddAgentLogins` storing GitHub's `dual-bot[bot]` author-login form
-  // while `advisoryBotLogins` stores the supported suffixless `dual-bot`
-  // form) still excludes the shared login -- the same normalized identity
-  // every other advisory-bot recognition in this file already uses.
-  const ackAnchorAuthorLogins = new Set(
-    [...iddAgentLogins].filter(
-      (login) => !isConfiguredAdvisoryBotLogin(login, advisoryBotLogins),
-    ),
-  );
   const normalizedComments = comments
     .map((comment, inputIndex) => ({
       id: String(comment.id ?? ''),
@@ -3594,116 +3705,6 @@ export function summarizeDispositionEvidenceForGate(
             : {}),
     };
   });
-  // #978 advisory-only diagnostic: a blocking resolved thread is
-  // "ack-only-post-disposition" when a thread-local IDD disposition exists and
-  // EVERY external comment newer than BOTH the snapshot boundary (so it re-blocks
-  // the gate) AND the disposition is an advisory-bot, non-disposition courtesy
-  // ack. Reuses the review-currency carve-out's recognition shape (advisory-bot
-  // predicate driven by `advisoryBotLogins`, no hard-coded logins;
-  // post-disposition ack). Fails closed (false) without a snapshot boundary,
-  // without a thread-local disposition, or for unresolved threads, and never
-  // changes the gate route.
-  //
-  // #1313: also computes the narrower `inPlaceEditOnly` sibling signal in the
-  // same pass (it needs the identical `threadDispositionAt` /
-  // `postDispositionBlockingFeedback` groundwork, so folding it into one
-  // function avoids recomputing that twice). `inPlaceEditOnly` additionally
-  // requires every qualifying comment to be an in-place edit of content that
-  // already existed at-or-before the disposition (its own `createdAt` is not
-  // newer than the disposition, and its `updatedAt` is strictly newer than
-  // its own `createdAt`) rather than a brand-new post-disposition comment --
-  // the #1313 report's exact scenario (a bot editing its own
-  // already-dispositioned finding in place, e.g. to append a cosmetic
-  // "addressed" badge). Deliberately advisory-only, like its sibling:
-  // GitHub's API exposes no revision diff for an edited comment, so this
-  // helper cannot tell a cosmetic append from a substantive change to the
-  // finding -- an agent that wants to act on this signal must still read the
-  // comment's current body before treating the block as safe to override.
-  const classifyThreadAckOnlyPostDisposition = (thread) => {
-    const none = { ackOnlyPostDisposition: false, inPlaceEditOnly: false };
-    if (!thread.isResolved || !snapshotBoundaryAt) {
-      return none;
-    }
-    const nodes = thread.comments?.nodes ?? [];
-    // Recognize the same dispositions `hasFreshDisposition` accepts on a
-    // resolved thread (the gate that already decided this thread blocks): a
-    // `**Accepted**`/`**Rejected**` marker OR the terminal
-    // `**Rejection confirmed by maintainer**` marker, anchored by effective
-    // activity (`updatedAt`-preferring) so an edited disposition is dated
-    // consistently. The thread is already known resolved here.
-    const threadDispositionAt = maxIsoTimestamp(
-      nodes
-        .filter(
-          (comment) =>
-            ackAnchorAuthorLogins.has(
-              String(comment.author?.login ?? '')
-                .trim()
-                .toLowerCase(),
-            ) &&
-            (isDispositionComment({ body: String(comment.body ?? '') }) ||
-              isRejectionConfirmedDisposition({
-                body: String(comment.body ?? ''),
-              })),
-        )
-        .map((comment) => effectiveThreadCommentActivityAt(comment))
-        .filter(isValidIsoTimestamp),
-    );
-    if (!threadDispositionAt) {
-      return none;
-    }
-    // The blocking activity is external feedback newer than BOTH the snapshot
-    // boundary (so it actually re-blocks the gate) AND the thread disposition
-    // (so already-dispositioned feedback predating the ack does not disqualify
-    // the signal). When the disposition lands after the boundary, the
-    // post-disposition bound is what isolates the genuine ack.
-    const postDispositionBlockingFeedback = nodes.filter((comment) => {
-      const authorLogin = String(comment.author?.login ?? '')
-        .trim()
-        .toLowerCase();
-      if (
-        !authorLogin ||
-        iddAgentLogins.has(authorLogin) ||
-        authorLogin === prAuthorLogin
-      ) {
-        return false;
-      }
-      const activityAt = effectiveThreadCommentActivityAt(comment);
-      return (
-        isValidIsoTimestamp(activityAt) &&
-        compareIsoTimestamps(activityAt, snapshotBoundaryAt) > 0 &&
-        compareIsoTimestamps(activityAt, threadDispositionAt) > 0
-      );
-    });
-    if (postDispositionBlockingFeedback.length === 0) {
-      return none;
-    }
-    // Each remaining item must be a pure advisory-bot courtesy ack: an
-    // advisory-bot author whose body is neither a `**Accepted**`/`**Rejected**`
-    // marker nor the terminal `**Rejection confirmed by maintainer**` marker.
-    const ackOnlyPostDisposition = postDispositionBlockingFeedback.every(
-      (comment) =>
-        isConfiguredAdvisoryBotLogin(
-          comment.author?.login,
-          advisoryBotLogins,
-        ) &&
-        !isDispositionComment({ body: String(comment.body ?? '') }) &&
-        !isRejectionConfirmedDisposition({ body: String(comment.body ?? '') }),
-    );
-    if (!ackOnlyPostDisposition) {
-      return none;
-    }
-    const inPlaceEditOnly = postDispositionBlockingFeedback.every((comment) => {
-      const createdAt = String(comment.createdAt ?? '');
-      const updatedAt = String(comment.updatedAt ?? '');
-      return (
-        isValidIsoTimestamp(createdAt) &&
-        compareIsoTimestamps(createdAt, threadDispositionAt) <= 0 &&
-        isValidIsoTimestamp(updatedAt) &&
-        compareIsoTimestamps(updatedAt, createdAt) > 0
-      );
-    });
-    return { ackOnlyPostDisposition, inPlaceEditOnly };
-  };
   const missingThreads = (threads ?? [])
     .map((thread, index) => {
       const commentsInThread = thread.comments?.nodes ?? [];
@@ -3798,7 +3799,12 @@ export function summarizeDispositionEvidenceForGate(
           return null;
         }
       }
-      const classification = classifyThreadAckOnlyPostDisposition(thread);
+      const classification = classifyThreadAckOnlyPostDisposition(thread, {
+        iddAgentLogins: options.iddAgentLogins,
+        advisoryBotLogins: options.advisoryBotLogins,
+        prAuthorLogin: options.prAuthorLogin,
+        snapshotBoundaryAt: options.snapshotBoundaryAt,
+      });
       return {
         id: String(thread.id ?? '') || `thread-${index + 1}`,
         isResolved: Boolean(thread.isResolved),

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -759,6 +759,7 @@ export function indexThreadsByReview(threads, options = {}) {
         !classifyThreadAckOnlyPostDisposition(thread, {
           iddAgentLogins: options.iddAgentLogins,
           advisoryBotLogins: options.advisoryBotLogins,
+          prAuthorLogin: options.prAuthorLogin,
         }).ackOnlyPostDisposition
       ) {
         current.missingDisposition += 1;

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -3221,9 +3221,9 @@ export function classifyThreadAckOnlyPostDisposition(thread, options = {}) {
   // #2014: an advisory bot can never anchor "a disposition exists" -- see
   // `summarizeDispositionEvidenceForGate`'s identical subtraction (this
   // file, "An advisory bot can never anchor..."). Scoped to only this
-  // anchor set; callers' own `iddAgentLogins` stay unsubtracted everywhere
-  // else, since each reacts differently (fail-open vs. fail-closed) to a
-  // global change.
+  // anchor set; the raw `iddAgentLogins` set above stays unchanged
+  // everywhere else, since each caller reacts differently (fail-open vs.
+  // fail-closed) to a global change.
   const ackAnchorAuthorLogins = new Set(
     [...iddAgentLogins].filter(
       (login) => !isConfiguredAdvisoryBotLogin(login, advisoryBotLogins),

--- a/src/scripts/audit-pr-cleanup.mts
+++ b/src/scripts/audit-pr-cleanup.mts
@@ -91,6 +91,7 @@ interface PullRequestNode {
   number?: number | null;
   url: string;
   merged: boolean;
+  author?: GqlAuthorPayload | null;
 }
 
 /** Minimized-comment node returned by the minimizeComment mutation. */
@@ -716,6 +717,7 @@ async function buildReport(
     isDispositionAuthor: makeIddDispositionAuthorPredicate(iddAgentLogins),
     iddAgentLogins,
     advisoryBotLogins: configuredAdvisoryBotLogins(),
+    prAuthorLogin: pr.author?.login,
   });
   const latestGatingReviews = indexLatestGatingReviewsByAuthor(reviews);
 
@@ -1082,6 +1084,7 @@ export function evaluateReviewComment(
     !classifyThreadAckOnlyPostDisposition(thread, {
       iddAgentLogins: report.trustedMarkerActors,
       advisoryBotLogins: configuredAdvisoryBotLogins(),
+      prAuthorLogin: pr.author?.login,
     }).ackOnlyPostDisposition
   ) {
     addSkipped(
@@ -1139,6 +1142,7 @@ function fetchPullRequest(
         number
         url
         merged
+        author { login }
       }
     }
   }`;

--- a/src/scripts/audit-pr-cleanup.mts
+++ b/src/scripts/audit-pr-cleanup.mts
@@ -21,6 +21,7 @@ import { resolveCollaboratorMarkerTrust } from './policy-helpers.mts';
 import type { ClaimValidationSummary } from './protocol-helpers.mts';
 import {
   classifyRegularBotComment,
+  classifyThreadAckOnlyPostDisposition,
   hasFreshDisposition,
   indexLatestGatingReviewsByAuthor,
   indexThreadsByReview,
@@ -28,6 +29,7 @@ import {
   isKnownReviewBot,
   normalizeTrustedMarkerLogins,
   operationalMarkerPrefix,
+  resolveAdvisoryBotLogins,
   summarizeClaimValidation,
   unionTrustedMarkerActorSources,
   unsafeTextReason,
@@ -241,6 +243,7 @@ let cachedConfiguredTrustedMarkerActorSources: {
   sources: string[];
 } | null = null;
 let cachedCurrentViewerLogin: string | null = null;
+let cachedConfiguredAdvisoryBotLogins: string[] | null = null;
 
 /** Default bound on whole-pass apply retries (#2011). */
 const DEFAULT_APPLY_RETRY_MAX_ATTEMPTS = 3;
@@ -711,6 +714,8 @@ async function buildReport(
   ]);
   const threadIndex = indexThreadsByReview(threads, {
     isDispositionAuthor: makeIddDispositionAuthorPredicate(iddAgentLogins),
+    iddAgentLogins,
+    advisoryBotLogins: configuredAdvisoryBotLogins(),
   });
   const latestGatingReviews = indexLatestGatingReviewsByAuthor(reviews);
 
@@ -1000,7 +1005,8 @@ function evaluateReviewComments(
   }
 }
 
-function evaluateReviewComment(
+/** Exported for direct unit testing (#2618); not part of the CLI surface. */
+export function evaluateReviewComment(
   comment: ThreadCommentNode,
   thread: ReviewThreadNode,
   pr: PullRequestNode,
@@ -1072,7 +1078,11 @@ function evaluateReviewComment(
       isDispositionAuthor: makeIddDispositionAuthorPredicate(
         report.trustedMarkerActors,
       ),
-    })
+    }) &&
+    !classifyThreadAckOnlyPostDisposition(thread, {
+      iddAgentLogins: report.trustedMarkerActors,
+      advisoryBotLogins: configuredAdvisoryBotLogins(),
+    }).ackOnlyPostDisposition
   ) {
     addSkipped(
       report,
@@ -1790,6 +1800,27 @@ function configuredTrustedMarkerActorSources(): {
 
 function configuredTrustedMarkerAuthors(): Set<string> {
   return configuredTrustedMarkerActorSources().actors;
+}
+
+// #2618: this repository's configured advisory-bot logins, feeding the
+// ack-only-post-disposition carve-out (`classifyThreadAckOnlyPostDisposition`)
+// so F4 recognizes the same courtesy-ack shape F2/F3 already does.
+function configuredAdvisoryBotLogins(): string[] {
+  if (cachedConfiguredAdvisoryBotLogins) {
+    return cachedConfiguredAdvisoryBotLogins;
+  }
+  let config: { advisoryBotLogins?: unknown } | null = null;
+  try {
+    config = JSON.parse(readFileSync('.github/idd/config.json', 'utf8')) as {
+      advisoryBotLogins?: unknown;
+    };
+  } catch {
+    config = null;
+  }
+  cachedConfiguredAdvisoryBotLogins = resolveAdvisoryBotLogins({
+    config,
+  }).logins;
+  return cachedConfiguredAdvisoryBotLogins;
 }
 
 function trustCollaboratorMarkers(): boolean {

--- a/src/scripts/audit-pr-cleanup.mts
+++ b/src/scripts/audit-pr-cleanup.mts
@@ -1818,6 +1818,7 @@ function configuredAdvisoryBotLogins(): string[] {
     config = null;
   }
   cachedConfiguredAdvisoryBotLogins = resolveAdvisoryBotLogins({
+    envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
     config,
   }).logins;
   return cachedConfiguredAdvisoryBotLogins;

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1385,7 +1385,16 @@ export function indexLatestGatingReviewsByAuthor(reviews: ReviewLike[]) {
 
 export function indexThreadsByReview(
   threads: ThreadLike[],
-  options: { isDispositionAuthor?: (login: string) => boolean } = {},
+  options: {
+    isDispositionAuthor?: (login: string) => boolean;
+    // #2618: F4's ack-only-post-disposition carve-out, matching F2/F3's
+    // `summarizeDispositionEvidenceForGate` (`classifyThreadAckOnlyPostDisposition`).
+    // Both are optional: omitting either keeps the pre-#2618 behavior
+    // exactly (a thread without a fresh disposition always counts as
+    // missing).
+    iddAgentLogins?: unknown[] | null;
+    advisoryBotLogins?: unknown[] | null;
+  } = {},
 ) {
   const index = new Map<
     string,
@@ -1420,7 +1429,11 @@ export function indexThreadsByReview(
       if (
         !hasFreshDisposition(thread, {
           isDispositionAuthor: options.isDispositionAuthor,
-        })
+        }) &&
+        !classifyThreadAckOnlyPostDisposition(thread, {
+          iddAgentLogins: options.iddAgentLogins,
+          advisoryBotLogins: options.advisoryBotLogins,
+        }).ackOnlyPostDisposition
       ) {
         current.missingDisposition += 1;
       }
@@ -3578,8 +3591,8 @@ export function buildActivitySnapshotSummary(
   // `**Rejected**` re-post once a maintainer agrees an
   // `**Awaiting maintainer decision**` item needs no action -- a disposition
   // is a disposition regardless of which of the two terminal shapes it took.
-  // `summarizeDispositionEvidenceForGate`'s `classifyThreadAckOnlyPostDisposition`
-  // already recognizes both, but ONLY as a reply on a resolved review thread
+  // `classifyThreadAckOnlyPostDisposition` already recognizes both, but ONLY
+  // as a reply on a resolved review thread
   // (the marker's own contract, `isRejectionConfirmedDisposition`'s doc
   // comment above). `filteredComments` below are plain top-level PR
   // comments with no thread/resolved concept at all, so they must keep
@@ -4183,6 +4196,145 @@ function isIddOriginatedThreadReply(
   );
 }
 
+// #978 advisory-only diagnostic, extracted from `summarizeDispositionEvidenceForGate`
+// (#2618) so both the F2/F3 merge gate and F4's `audit-pr-cleanup` disposition
+// checks share one implementation. A blocking resolved thread is
+// "ack-only-post-disposition" when a thread-local IDD disposition exists and
+// EVERY external comment newer than the disposition (and, when
+// `snapshotBoundaryAt` is supplied, also newer than that boundary) is an
+// advisory-bot, non-disposition courtesy ack. `snapshotBoundaryAt` is
+// optional: F2/F3 passes the review-snapshot watermark so only feedback that
+// re-blocks the gate counts; F4 has no such watermark and omits it, so every
+// post-disposition external comment counts. Fails closed (false) without a
+// thread-local disposition or for an unresolved thread, and never changes
+// any caller's route by itself.
+//
+// #1313: also computes the narrower `inPlaceEditOnly` sibling signal in the
+// same pass (it needs the identical `threadDispositionAt` /
+// `postDispositionBlockingFeedback` groundwork, so folding it into one
+// function avoids recomputing that twice). `inPlaceEditOnly` additionally
+// requires every qualifying comment to be an in-place edit of content that
+// already existed at-or-before the disposition (its own `createdAt` is not
+// newer than the disposition, and its `updatedAt` is strictly newer than its
+// own `createdAt`) rather than a brand-new post-disposition comment.
+// Deliberately advisory-only, like its sibling: GitHub's API exposes no
+// revision diff for an edited comment, so this helper cannot tell a
+// cosmetic append from a substantive change to the finding.
+export function classifyThreadAckOnlyPostDisposition(
+  thread: ThreadLike,
+  options: {
+    iddAgentLogins?: unknown[] | null;
+    advisoryBotLogins?: unknown[] | null;
+    prAuthorLogin?: string | null;
+    snapshotBoundaryAt?: string | null;
+  } = {},
+): { ackOnlyPostDisposition: boolean; inPlaceEditOnly: boolean } {
+  const none = { ackOnlyPostDisposition: false, inPlaceEditOnly: false };
+  if (!thread.isResolved) {
+    return none;
+  }
+  const snapshotBoundaryAt = isValidIsoTimestamp(options.snapshotBoundaryAt)
+    ? String(options.snapshotBoundaryAt)
+    : null;
+  const iddAgentLogins = new Set(
+    normalizeTrustedMarkerLogins(options.iddAgentLogins ?? []),
+  );
+  const advisoryBotLogins = new Set(
+    normalizeTrustedMarkerLogins(options.advisoryBotLogins ?? []),
+  );
+  const prAuthorLogin = String(options.prAuthorLogin ?? '')
+    .trim()
+    .toLowerCase();
+  // #2014: an advisory bot can never anchor "a disposition exists" -- see
+  // `summarizeDispositionEvidenceForGate`'s identical subtraction (this
+  // file, "An advisory bot can never anchor..."). Scoped to only this
+  // anchor set; callers' own `iddAgentLogins` stay unsubtracted everywhere
+  // else, since each reacts differently (fail-open vs. fail-closed) to a
+  // global change.
+  const ackAnchorAuthorLogins = new Set(
+    [...iddAgentLogins].filter(
+      (login) => !isConfiguredAdvisoryBotLogin(login, advisoryBotLogins),
+    ),
+  );
+  const nodes = thread.comments?.nodes ?? [];
+  // Recognize the same dispositions `hasFreshDisposition` accepts on a
+  // resolved thread (the gate that already decided this thread blocks): a
+  // `**Accepted**`/`**Rejected**` marker OR the terminal
+  // `**Rejection confirmed by maintainer**` marker, anchored by effective
+  // activity (`updatedAt`-preferring) so an edited disposition is dated
+  // consistently. The thread is already known resolved here.
+  const threadDispositionAt = maxIsoTimestamp(
+    nodes
+      .filter(
+        (comment) =>
+          ackAnchorAuthorLogins.has(
+            String(comment.author?.login ?? '')
+              .trim()
+              .toLowerCase(),
+          ) &&
+          (isDispositionComment({ body: String(comment.body ?? '') }) ||
+            isRejectionConfirmedDisposition({
+              body: String(comment.body ?? ''),
+            })),
+      )
+      .map((comment) => effectiveThreadCommentActivityAt(comment))
+      .filter(isValidIsoTimestamp),
+  );
+  if (!threadDispositionAt) {
+    return none;
+  }
+  // The blocking activity is external feedback newer than the thread
+  // disposition (so already-dispositioned feedback predating the ack does
+  // not disqualify the signal) and, when a snapshot boundary is supplied,
+  // also newer than it (so it actually re-blocks that gate). Without a
+  // boundary, every post-disposition external comment counts.
+  const postDispositionBlockingFeedback = nodes.filter((comment) => {
+    const authorLogin = String(comment.author?.login ?? '')
+      .trim()
+      .toLowerCase();
+    if (
+      !authorLogin ||
+      iddAgentLogins.has(authorLogin) ||
+      authorLogin === prAuthorLogin
+    ) {
+      return false;
+    }
+    const activityAt = effectiveThreadCommentActivityAt(comment);
+    return (
+      isValidIsoTimestamp(activityAt) &&
+      (!snapshotBoundaryAt ||
+        compareIsoTimestamps(activityAt, snapshotBoundaryAt) > 0) &&
+      compareIsoTimestamps(activityAt, threadDispositionAt) > 0
+    );
+  });
+  if (postDispositionBlockingFeedback.length === 0) {
+    return none;
+  }
+  // Each remaining item must be a pure advisory-bot courtesy ack: an
+  // advisory-bot author whose body is neither a `**Accepted**`/`**Rejected**`
+  // marker nor the terminal `**Rejection confirmed by maintainer**` marker.
+  const ackOnlyPostDisposition = postDispositionBlockingFeedback.every(
+    (comment) =>
+      isConfiguredAdvisoryBotLogin(comment.author?.login, advisoryBotLogins) &&
+      !isDispositionComment({ body: String(comment.body ?? '') }) &&
+      !isRejectionConfirmedDisposition({ body: String(comment.body ?? '') }),
+  );
+  if (!ackOnlyPostDisposition) {
+    return none;
+  }
+  const inPlaceEditOnly = postDispositionBlockingFeedback.every((comment) => {
+    const createdAt = String(comment.createdAt ?? '');
+    const updatedAt = String(comment.updatedAt ?? '');
+    return (
+      isValidIsoTimestamp(createdAt) &&
+      compareIsoTimestamps(createdAt, threadDispositionAt) <= 0 &&
+      isValidIsoTimestamp(updatedAt) &&
+      compareIsoTimestamps(updatedAt, createdAt) > 0
+    );
+  });
+  return { ackOnlyPostDisposition, inPlaceEditOnly };
+}
+
 export function summarizeDispositionEvidenceForGate(
   {
     comments = [],
@@ -4222,29 +4374,6 @@ export function summarizeDispositionEvidenceForGate(
   ).trim();
   const markerPrefix =
     explicitMarkerPrefix || configuredMarkerPrefix || undefined;
-  // #2014: An advisory bot can never anchor "dispositions exist", mirroring
-  // `buildActivitySnapshotSummary`'s identical `dispositionAuthorLogins`
-  // subtraction above (this file, "An advisory bot can never anchor..."
-  // comment) -- its own `**Accepted**`/`**Rejected**`-shaped reply must not
-  // open the post-disposition window that classifies a later advisory-bot
-  // reply as ack-only. Scoped to ONLY `classifyThreadAckOnlyPostDisposition`'s
-  // own anchor below -- the raw `iddAgentLogins` set is used unchanged
-  // everywhere else in this function (`hasFreshDisposition`,
-  // `outstandingComments`, the generic `dispositionComments` 1:1 pool), per
-  // the "Pre-merge gate invariants" comment above `summarizeDispositionEvidenceForGate`:
-  // each of those reacts differently (fail-open vs. fail-closed) to a global
-  // change, so this subtraction must stay local to the ack-only diagnostic.
-  // Excludes via `isConfiguredAdvisoryBotLogin`, not a plain `Set.has`, so a
-  // `[bot]`-suffix mismatch between the two configured login sets (e.g.
-  // `iddAgentLogins` storing GitHub's `dual-bot[bot]` author-login form
-  // while `advisoryBotLogins` stores the supported suffixless `dual-bot`
-  // form) still excludes the shared login -- the same normalized identity
-  // every other advisory-bot recognition in this file already uses.
-  const ackAnchorAuthorLogins = new Set(
-    [...iddAgentLogins].filter(
-      (login) => !isConfiguredAdvisoryBotLogin(login, advisoryBotLogins),
-    ),
-  );
 
   const normalizedComments = comments
     .map((comment, inputIndex) => ({
@@ -4624,119 +4753,6 @@ export function summarizeDispositionEvidenceForGate(
     };
   });
 
-  // #978 advisory-only diagnostic: a blocking resolved thread is
-  // "ack-only-post-disposition" when a thread-local IDD disposition exists and
-  // EVERY external comment newer than BOTH the snapshot boundary (so it re-blocks
-  // the gate) AND the disposition is an advisory-bot, non-disposition courtesy
-  // ack. Reuses the review-currency carve-out's recognition shape (advisory-bot
-  // predicate driven by `advisoryBotLogins`, no hard-coded logins;
-  // post-disposition ack). Fails closed (false) without a snapshot boundary,
-  // without a thread-local disposition, or for unresolved threads, and never
-  // changes the gate route.
-  //
-  // #1313: also computes the narrower `inPlaceEditOnly` sibling signal in the
-  // same pass (it needs the identical `threadDispositionAt` /
-  // `postDispositionBlockingFeedback` groundwork, so folding it into one
-  // function avoids recomputing that twice). `inPlaceEditOnly` additionally
-  // requires every qualifying comment to be an in-place edit of content that
-  // already existed at-or-before the disposition (its own `createdAt` is not
-  // newer than the disposition, and its `updatedAt` is strictly newer than
-  // its own `createdAt`) rather than a brand-new post-disposition comment --
-  // the #1313 report's exact scenario (a bot editing its own
-  // already-dispositioned finding in place, e.g. to append a cosmetic
-  // "addressed" badge). Deliberately advisory-only, like its sibling:
-  // GitHub's API exposes no revision diff for an edited comment, so this
-  // helper cannot tell a cosmetic append from a substantive change to the
-  // finding -- an agent that wants to act on this signal must still read the
-  // comment's current body before treating the block as safe to override.
-  const classifyThreadAckOnlyPostDisposition = (
-    thread: ThreadLike,
-  ): { ackOnlyPostDisposition: boolean; inPlaceEditOnly: boolean } => {
-    const none = { ackOnlyPostDisposition: false, inPlaceEditOnly: false };
-    if (!thread.isResolved || !snapshotBoundaryAt) {
-      return none;
-    }
-    const nodes = thread.comments?.nodes ?? [];
-    // Recognize the same dispositions `hasFreshDisposition` accepts on a
-    // resolved thread (the gate that already decided this thread blocks): a
-    // `**Accepted**`/`**Rejected**` marker OR the terminal
-    // `**Rejection confirmed by maintainer**` marker, anchored by effective
-    // activity (`updatedAt`-preferring) so an edited disposition is dated
-    // consistently. The thread is already known resolved here.
-    const threadDispositionAt = maxIsoTimestamp(
-      nodes
-        .filter(
-          (comment) =>
-            ackAnchorAuthorLogins.has(
-              String(comment.author?.login ?? '')
-                .trim()
-                .toLowerCase(),
-            ) &&
-            (isDispositionComment({ body: String(comment.body ?? '') }) ||
-              isRejectionConfirmedDisposition({
-                body: String(comment.body ?? ''),
-              })),
-        )
-        .map((comment) => effectiveThreadCommentActivityAt(comment))
-        .filter(isValidIsoTimestamp),
-    );
-    if (!threadDispositionAt) {
-      return none;
-    }
-    // The blocking activity is external feedback newer than BOTH the snapshot
-    // boundary (so it actually re-blocks the gate) AND the thread disposition
-    // (so already-dispositioned feedback predating the ack does not disqualify
-    // the signal). When the disposition lands after the boundary, the
-    // post-disposition bound is what isolates the genuine ack.
-    const postDispositionBlockingFeedback = nodes.filter((comment) => {
-      const authorLogin = String(comment.author?.login ?? '')
-        .trim()
-        .toLowerCase();
-      if (
-        !authorLogin ||
-        iddAgentLogins.has(authorLogin) ||
-        authorLogin === prAuthorLogin
-      ) {
-        return false;
-      }
-      const activityAt = effectiveThreadCommentActivityAt(comment);
-      return (
-        isValidIsoTimestamp(activityAt) &&
-        compareIsoTimestamps(activityAt, snapshotBoundaryAt) > 0 &&
-        compareIsoTimestamps(activityAt, threadDispositionAt) > 0
-      );
-    });
-    if (postDispositionBlockingFeedback.length === 0) {
-      return none;
-    }
-    // Each remaining item must be a pure advisory-bot courtesy ack: an
-    // advisory-bot author whose body is neither a `**Accepted**`/`**Rejected**`
-    // marker nor the terminal `**Rejection confirmed by maintainer**` marker.
-    const ackOnlyPostDisposition = postDispositionBlockingFeedback.every(
-      (comment) =>
-        isConfiguredAdvisoryBotLogin(
-          comment.author?.login,
-          advisoryBotLogins,
-        ) &&
-        !isDispositionComment({ body: String(comment.body ?? '') }) &&
-        !isRejectionConfirmedDisposition({ body: String(comment.body ?? '') }),
-    );
-    if (!ackOnlyPostDisposition) {
-      return none;
-    }
-    const inPlaceEditOnly = postDispositionBlockingFeedback.every((comment) => {
-      const createdAt = String(comment.createdAt ?? '');
-      const updatedAt = String(comment.updatedAt ?? '');
-      return (
-        isValidIsoTimestamp(createdAt) &&
-        compareIsoTimestamps(createdAt, threadDispositionAt) <= 0 &&
-        isValidIsoTimestamp(updatedAt) &&
-        compareIsoTimestamps(updatedAt, createdAt) > 0
-      );
-    });
-    return { ackOnlyPostDisposition, inPlaceEditOnly };
-  };
-
   const missingThreads = (threads ?? [])
     .map((thread, index) => {
       const commentsInThread = thread.comments?.nodes ?? [];
@@ -4831,7 +4847,12 @@ export function summarizeDispositionEvidenceForGate(
           return null;
         }
       }
-      const classification = classifyThreadAckOnlyPostDisposition(thread);
+      const classification = classifyThreadAckOnlyPostDisposition(thread, {
+        iddAgentLogins: options.iddAgentLogins,
+        advisoryBotLogins: options.advisoryBotLogins,
+        prAuthorLogin: options.prAuthorLogin,
+        snapshotBoundaryAt: options.snapshotBoundaryAt,
+      });
       return {
         id: String(thread.id ?? '') || `thread-${index + 1}`,
         isResolved: Boolean(thread.isResolved),

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -4248,9 +4248,9 @@ export function classifyThreadAckOnlyPostDisposition(
   // #2014: an advisory bot can never anchor "a disposition exists" -- see
   // `summarizeDispositionEvidenceForGate`'s identical subtraction (this
   // file, "An advisory bot can never anchor..."). Scoped to only this
-  // anchor set; callers' own `iddAgentLogins` stay unsubtracted everywhere
-  // else, since each reacts differently (fail-open vs. fail-closed) to a
-  // global change.
+  // anchor set; the raw `iddAgentLogins` set above stays unchanged
+  // everywhere else, since each caller reacts differently (fail-open vs.
+  // fail-closed) to a global change.
   const ackAnchorAuthorLogins = new Set(
     [...iddAgentLogins].filter(
       (login) => !isConfiguredAdvisoryBotLogin(login, advisoryBotLogins),

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1394,6 +1394,7 @@ export function indexThreadsByReview(
     // missing).
     iddAgentLogins?: unknown[] | null;
     advisoryBotLogins?: unknown[] | null;
+    prAuthorLogin?: string | null;
   } = {},
 ) {
   const index = new Map<
@@ -1433,6 +1434,7 @@ export function indexThreadsByReview(
         !classifyThreadAckOnlyPostDisposition(thread, {
           iddAgentLogins: options.iddAgentLogins,
           advisoryBotLogins: options.advisoryBotLogins,
+          prAuthorLogin: options.prAuthorLogin,
         }).ackOnlyPostDisposition
       ) {
         current.missingDisposition += 1;

--- a/tests/audit-pr-cleanup.test.mts
+++ b/tests/audit-pr-cleanup.test.mts
@@ -4,12 +4,15 @@ import { test } from 'node:test';
 import type {
   CleanupArgs,
   CleanupAuditReport,
+  ReviewThreadNode,
 } from '../src/scripts/audit-pr-cleanup.mts';
 import {
   assertBatchApplyClaimScope,
+  evaluateReviewComment,
   fetchReviewThreads,
   parsePrNumbers,
 } from '../src/scripts/audit-pr-cleanup.mts';
+import { indexLatestGatingReviewsByAuthor } from '../src/scripts/protocol-helpers.mts';
 import { stubExecutable } from './test-utils.mts';
 
 // Importing the CLI module directly is only possible now that its top-level
@@ -663,5 +666,86 @@ test('fetchReviewThreads fails loudly on hasNextPage:true with a missing endCurs
         fetchReviewThreads('o', 'r', 1, { throwOnError: true }),
       ),
     /hasNextPage without endCursor/,
+  );
+});
+
+// #2618: `evaluateReviewComment`'s ack-only-post-disposition carve-out,
+// mirroring F2/F3's `classifyThreadAckOnlyPostDisposition`. This repository's
+// own `.github/idd/config.json` configures `coderabbitai[bot]` as an
+// advisory bot, which these tests rely on (no mocking needed).
+const mergedPr = { number: 1, url: 'https://pr', merged: true };
+const noGatingReviews = indexLatestGatingReviewsByAuthor([]);
+
+test('evaluateReviewComment reports a candidate for an ack-only-after-disposition thread (#2618)', () => {
+  const disposition = {
+    id: 'EC-1',
+    url: 'https://pr#EC-1',
+    author: { login: 'idd-bot' },
+    body: '**Accepted** — done.',
+    createdAt: '2026-05-12T00:00:00Z',
+    viewerCanMinimize: true,
+    isMinimized: false,
+  };
+  const comment = {
+    id: 'EC-2',
+    url: 'https://pr#EC-2',
+    author: { login: 'coderabbitai[bot]' },
+    body: 'Thanks for confirming!',
+    createdAt: '2026-05-12T00:01:00Z',
+    viewerCanMinimize: true,
+    isMinimized: false,
+  };
+  const thread: ReviewThreadNode = {
+    id: 'THREAD-EVAL-ACK',
+    isResolved: true,
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [disposition, comment],
+    },
+  };
+  const report = createAuditReport({ trustedMarkerActors: ['idd-bot'] });
+
+  evaluateReviewComment(comment, thread, mergedPr, noGatingReviews, report);
+
+  assert.equal(report.skipped.length, 0);
+  assert.equal(report.candidates.length, 1);
+  assert.equal(report.candidates[0]?.subjectId, 'EC-2');
+});
+
+test('evaluateReviewComment still skips a genuinely missing disposition (#2618)', () => {
+  const humanFeedback = {
+    id: 'EM-1',
+    url: 'https://pr#EM-1',
+    author: { login: 'reviewer-a' },
+    body: 'please fix this',
+    createdAt: '2026-05-12T00:00:00Z',
+    viewerCanMinimize: true,
+    isMinimized: false,
+  };
+  const comment = {
+    id: 'EM-2',
+    url: 'https://pr#EM-2',
+    author: { login: 'coderabbitai[bot]' },
+    body: 'Thanks for confirming!',
+    createdAt: '2026-05-12T00:01:00Z',
+    viewerCanMinimize: true,
+    isMinimized: false,
+  };
+  const thread: ReviewThreadNode = {
+    id: 'THREAD-EVAL-MISSING',
+    isResolved: true,
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [humanFeedback, comment],
+    },
+  };
+  const report = createAuditReport({ trustedMarkerActors: ['idd-bot'] });
+
+  evaluateReviewComment(comment, thread, mergedPr, noGatingReviews, report);
+
+  assert.equal(report.candidates.length, 0);
+  assert.equal(
+    report.skipped[0]?.skipReason,
+    'review thread is missing an IDD accept/reject disposition',
   );
 });

--- a/tests/audit-pr-cleanup.test.mts
+++ b/tests/audit-pr-cleanup.test.mts
@@ -749,3 +749,53 @@ test('evaluateReviewComment still skips a genuinely missing disposition (#2618)'
     'review thread is missing an IDD accept/reject disposition',
   );
 });
+
+test('evaluateReviewComment excludes the PR author from ack-only blocking feedback (#2618, Codex P2)', () => {
+  // The PR author's own post-disposition reply must not count as blocking
+  // feedback -- mirroring F2/F3's `prAuthorLogin` exclusion -- so a
+  // trailing advisory-bot courtesy ack after it still classifies as
+  // ack-only.
+  const prWithAuthor = { ...mergedPr, author: { login: 'pr-author' } };
+  const disposition = {
+    id: 'PA-1',
+    url: 'https://pr#PA-1',
+    author: { login: 'idd-bot' },
+    body: '**Accepted** — done.',
+    createdAt: '2026-05-12T00:00:00Z',
+    viewerCanMinimize: true,
+    isMinimized: false,
+  };
+  const authorReply = {
+    id: 'PA-2',
+    url: 'https://pr#PA-2',
+    author: { login: 'pr-author' },
+    body: 'thanks!',
+    createdAt: '2026-05-12T00:01:00Z',
+    viewerCanMinimize: true,
+    isMinimized: false,
+  };
+  const comment = {
+    id: 'PA-3',
+    url: 'https://pr#PA-3',
+    author: { login: 'coderabbitai[bot]' },
+    body: 'Thanks for confirming!',
+    createdAt: '2026-05-12T00:02:00Z',
+    viewerCanMinimize: true,
+    isMinimized: false,
+  };
+  const thread: ReviewThreadNode = {
+    id: 'THREAD-EVAL-PR-AUTHOR',
+    isResolved: true,
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [disposition, authorReply, comment],
+    },
+  };
+  const report = createAuditReport({ trustedMarkerActors: ['idd-bot'] });
+
+  evaluateReviewComment(comment, thread, prWithAuthor, noGatingReviews, report);
+
+  assert.equal(report.skipped.length, 0);
+  assert.equal(report.candidates.length, 1);
+  assert.equal(report.candidates[0]?.subjectId, 'PA-3');
+});

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import {
   buildActivitySnapshotSummary,
+  classifyThreadAckOnlyPostDisposition,
   EDITED_AFTER_DISPOSITION_HINT,
   MALFORMED_DISPOSITION_PREFIX_HINT,
   summarizeDispositionEvidenceForGate,
@@ -186,6 +187,167 @@ test('reviewCurrency and dispositionEvidence agree a rejection-confirmed-by-main
     activitySummary.effective.maxActivityUpdatedAt,
     '2026-05-12T00:30:00Z',
   );
+});
+
+// #2618: `classifyThreadAckOnlyPostDisposition` extracted out of
+// `summarizeDispositionEvidenceForGate` into a standalone export so F4's
+// `audit-pr-cleanup.mts` (no review-snapshot watermark) can share it with
+// F2/F3's gate (`snapshotBoundaryAt` supplied). These tests exercise the
+// function directly rather than through the gate, in the F4 shape: no
+// `snapshotBoundaryAt`.
+
+test('classifyThreadAckOnlyPostDisposition recognizes a courtesy ack with no snapshot boundary (#2618)', () => {
+  const thread = {
+    id: 'thread-f4-ack-only',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'F4-1',
+          author: { login: 'reviewer-a' },
+          body: 'please fix this',
+          createdAt: '2026-05-12T00:00:00Z',
+          updatedAt: '2026-05-12T00:00:00Z',
+        },
+        {
+          id: 'F4-2',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'F4-3',
+          author: { login: 'coderabbitai[bot]' },
+          body: 'Thanks for confirming!',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, true);
+});
+
+test('classifyThreadAckOnlyPostDisposition rejects a non-advisory trailing reply (#2618)', () => {
+  const thread = {
+    id: 'thread-f4-human-reply',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'F4H-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'F4H-2',
+          author: { login: 'reviewer-a' },
+          body: 'actually, one more thing',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
+test('classifyThreadAckOnlyPostDisposition fails closed on a genuinely missing disposition (#2618)', () => {
+  const thread = {
+    id: 'thread-f4-no-disposition',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'F4N-1',
+          author: { login: 'reviewer-a' },
+          body: 'please fix this',
+          createdAt: '2026-05-12T00:00:00Z',
+          updatedAt: '2026-05-12T00:00:00Z',
+        },
+        {
+          id: 'F4N-2',
+          author: { login: 'coderabbitai[bot]' },
+          body: 'Thanks for confirming!',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
+test('classifyThreadAckOnlyPostDisposition still honors an explicit snapshot boundary (regression guard, #2618)', () => {
+  // Same shape `summarizeDispositionEvidenceForGate`'s own #2014 test above
+  // exercises through the gate; this confirms the extracted function keeps
+  // the F2/F3 boundary behavior when a caller supplies one.
+  const thread = {
+    id: 'thread-f2-boundary',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'F2B-1',
+          author: { login: 'idd-bot' },
+          body: '**Rejection confirmed by maintainer** — agreed, no action needed.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'F2B-2',
+          author: { login: 'coderabbitai[bot]' },
+          body: 'Thanks for confirming.',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  // The bot's reply predates the boundary, so it never re-blocks the gate.
+  const beforeBoundary = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+    snapshotBoundaryAt: '2026-05-12T03:00:00Z',
+  });
+  assert.equal(beforeBoundary.ackOnlyPostDisposition, false);
+
+  const afterBoundary = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+    snapshotBoundaryAt: '2026-05-12T01:00:00Z',
+  });
+  assert.equal(afterBoundary.ackOnlyPostDisposition, true);
 });
 
 // Codex review findings on this PR (#2014), both verified against source

--- a/tests/review-snapshot.test.mts
+++ b/tests/review-snapshot.test.mts
@@ -99,6 +99,86 @@ test('indexThreadsByReview honors an IDD-scoped disposition-author predicate', (
   assert.equal(scoped.get('REVIEW-9')?.missingDisposition, 1);
 });
 
+test('indexThreadsByReview excludes an ack-only-post-disposition thread from missingDisposition (#2618)', () => {
+  const threads: ThreadLike[] = [
+    {
+      id: 'T-ACK',
+      isResolved: true,
+      comments: {
+        pageInfo: { hasNextPage: false },
+        nodes: [
+          {
+            author: { login: 'idd-bot' },
+            body: '**Accepted** — done.',
+            createdAt: '2026-05-12T00:00:00Z',
+            pullRequestReview: { id: 'REVIEW-ACK' },
+          },
+          {
+            author: { login: 'coderabbitai[bot]' },
+            body: 'Thanks for confirming!',
+            createdAt: '2026-05-12T00:01:00Z',
+            pullRequestReview: { id: 'REVIEW-ACK' },
+          },
+        ],
+      },
+    },
+  ];
+
+  // Without the new options, today's behavior is unchanged: the trailing
+  // bot reply postdates the disposition, so it still counts as missing.
+  assert.equal(
+    indexThreadsByReview(threads, {
+      isDispositionAuthor: (login) => login === 'idd-bot',
+    }).get('REVIEW-ACK')?.missingDisposition,
+    1,
+  );
+
+  // With the ack-only carve-out opted in, the same thread no longer counts.
+  assert.equal(
+    indexThreadsByReview(threads, {
+      isDispositionAuthor: (login) => login === 'idd-bot',
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['coderabbitai[bot]'],
+    }).get('REVIEW-ACK')?.missingDisposition,
+    0,
+  );
+});
+
+test('indexThreadsByReview still counts a genuinely missing disposition with the ack-only carve-out opted in (#2618)', () => {
+  const threads: ThreadLike[] = [
+    {
+      id: 'T-MISSING',
+      isResolved: true,
+      comments: {
+        pageInfo: { hasNextPage: false },
+        nodes: [
+          {
+            author: { login: 'reviewer-a' },
+            body: 'please fix this',
+            createdAt: '2026-05-12T00:00:00Z',
+            pullRequestReview: { id: 'REVIEW-MISSING' },
+          },
+          {
+            author: { login: 'coderabbitai[bot]' },
+            body: 'Thanks for confirming!',
+            createdAt: '2026-05-12T00:01:00Z',
+            pullRequestReview: { id: 'REVIEW-MISSING' },
+          },
+        ],
+      },
+    },
+  ];
+
+  assert.equal(
+    indexThreadsByReview(threads, {
+      isDispositionAuthor: (login) => login === 'idd-bot',
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['coderabbitai[bot]'],
+    }).get('REVIEW-MISSING')?.missingDisposition,
+    1,
+  );
+});
+
 test('classifyRegularBotComment honors an IDD-scoped disposition-author predicate', () => {
   const summary: CommentLike = {
     author: { login: 'coderabbitai[bot]' },


### PR DESCRIPTION
## Summary

- Extracts `classifyThreadAckOnlyPostDisposition` out of
  `summarizeDispositionEvidenceForGate` (F2/F3's merge gate) into a
  standalone export in `protocol-helpers.mts`, making its
  `snapshotBoundaryAt` optional so a caller with no review-snapshot
  watermark (F4) can still use it — every post-disposition external
  comment counts instead of only those after a boundary.
- Wires the extracted function into `audit-pr-cleanup.mts`'s two
  disposition checks (`evaluateReviewComment`'s per-thread check and
  `indexThreadsByReview`'s `missingDisposition` counter), so F4 now
  recognizes the same ack-only-post-disposition shape F2/F3 already
  does: a resolved thread with a genuine IDD disposition followed only
  by a content-free advisory-bot courtesy reply is treated as
  dispositioned, not missing one.
- Adds unit tests for the extracted function (with and without a
  snapshot boundary), for `indexThreadsByReview`'s new opt-in carve-out,
  and for `evaluateReviewComment`'s exported behavior in both the
  ack-only and genuinely-missing-disposition cases.
- `configuredAdvisoryBotLogins()` now honors the `IDD_ADVISORY_BOT_LOGINS`
  env override (flag > env > config), matching `pre-merge-readiness.mts`'s
  existing precedence (Copilot review).

Closes #2618

## Recommended follow-up issues

- A positive-acknowledgment content classifier for
  `classifyThreadAckOnlyPostDisposition` (Codex review, rejected as
  in-scope here): the current signal only checks that a post-disposition
  comment is authored by a configured advisory bot and is not itself
  disposition-shaped, without verifying the body is actually a
  content-free acknowledgment. F2/F3's own merge gate already accepts
  this same signal unattended (`buildPreMergeReadinessSummary`'s
  `soleCauseAckOnlyPostDisposition` override, #2125), so this PR does not
  introduce a new risk class -- but tightening the classifier itself
  (shared by both F2/F3 and F4) would be a good follow-up rather than a
  per-caller patch that would create a new asymmetry.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run build` (`.mjs` mirrors regenerated)
- [x] `node --test tests/*.test.mts` (5058 tests, 0 failures)
- [x] `pnpm run lint` (pre-push-validate chain, including
      `audit-docs.mjs --check`, `audit-code-span-wrap.mjs`,
      `build:check`, `idd-doctor.mjs`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Advisory-bot acknowledgments are now correctly recognized after valid review dispositions.
  * Threads containing qualifying advisory acknowledgments are no longer incorrectly flagged as missing dispositions.
  * Existing behavior remains unchanged when no valid disposition is present.

* **Tests**
  * Added coverage for advisory acknowledgments, snapshot boundaries, courtesy replies, and missing-disposition scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->
