### PR TITLE
fix(discover-shared-file-overlap): degrade quietly on missing manifest

### DIFF
--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -622,8 +622,8 @@ score/desync/milestone/effort: prefer a candidate whose `## Candidate
 files` do **not** overlap an actively-claimed or open-PR issue on one of
 those; `discover-shared-file-overlap` (see
 [IDD helper scripts](../../docs/idd-helper-scripts.md)) reports
-`overlapFlag`/`recommendedOrder`. Never overrides the score or crosses a
-band. See the
+`overlapFlag`/`recommendedOrder`, or `manifestMissing: true` with an
+empty set. See the
 [convention](../../docs/policy-constants.md#high-contention-shared-files).
 
 After picking, proceed to **A4.5** (`idd-suitability.instructions.md`).

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -621,8 +621,12 @@ A4 Step 2 de-prioritization order. Evidence-only: it claims nothing.
   - `manifestMissing`: `boolean` — `true` when `--manifest`'s target file does
     not exist (`ENOENT`); the CLI still exits 0, with `highContentionFiles`
     reported as an empty set rather than fabricated from the manifest path
-    itself. A manifest that exists but fails to parse (malformed JSON, wrong
-    shape) keeps the prior fail-closed behavior (the CLI throws), unchanged.
+    itself. A manifest that fails to parse (invalid JSON syntax) keeps the
+    prior fail-closed behavior (the CLI throws), unchanged. A manifest that
+    parses but has an unexpected shape (e.g. `{}`, a non-array
+    `bundleBudgets`) is not validated here — `resolveHighContentionFiles`
+    silently treats it as contributing no bundle files, a pre-existing
+    behavior this change does not alter.
   - `highContentionFiles`: `string[]` (sorted)
   - `candidates`: `[{ number: number, score: number | null,`
     `effectiveScore: number, candidateFiles: string[],`

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -618,6 +618,11 @@ A4 Step 2 de-prioritization order. Evidence-only: it claims nothing.
 - **JSON output**:
   - `repository`: `{ owner: string, repo: string }`
   - `checkedOverlap`: `boolean`
+  - `manifestMissing`: `boolean` — `true` when `--manifest`'s target file does
+    not exist (`ENOENT`); the CLI still exits 0, with `highContentionFiles`
+    reported as an empty set rather than fabricated from the manifest path
+    itself. A manifest that exists but fails to parse (malformed JSON, wrong
+    shape) keeps the prior fail-closed behavior (the CLI throws), unchanged.
   - `highContentionFiles`: `string[]` (sorted)
   - `candidates`: `[{ number: number, score: number | null,`
     `effectiveScore: number, candidateFiles: string[],`

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -617,8 +617,8 @@ score/desync/milestone/effort: prefer a candidate whose `## Candidate
 files` do **not** overlap an actively-claimed or open-PR issue on one of
 those; `discover-shared-file-overlap` (see
 [IDD helper scripts](../../docs/idd-helper-scripts.md)) reports
-`overlapFlag`/`recommendedOrder`. Never overrides the score or crosses a
-band. See the
+`overlapFlag`/`recommendedOrder`, or `manifestMissing: true` with an
+empty set. See the
 [convention](../../docs/policy-constants.md#high-contention-shared-files).
 
 After picking, proceed to **A4.5** (`idd-suitability.instructions.md`).

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -621,8 +621,12 @@ A4 Step 2 de-prioritization order. Evidence-only: it claims nothing.
   - `manifestMissing`: `boolean` — `true` when `--manifest`'s target file does
     not exist (`ENOENT`); the CLI still exits 0, with `highContentionFiles`
     reported as an empty set rather than fabricated from the manifest path
-    itself. A manifest that exists but fails to parse (malformed JSON, wrong
-    shape) keeps the prior fail-closed behavior (the CLI throws), unchanged.
+    itself. A manifest that fails to parse (invalid JSON syntax) keeps the
+    prior fail-closed behavior (the CLI throws), unchanged. A manifest that
+    parses but has an unexpected shape (e.g. `{}`, a non-array
+    `bundleBudgets`) is not validated here — `resolveHighContentionFiles`
+    silently treats it as contributing no bundle files, a pre-existing
+    behavior this change does not alter.
   - `highContentionFiles`: `string[]` (sorted)
   - `candidates`: `[{ number: number, score: number | null,`
     `effectiveScore: number, candidateFiles: string[],`

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -618,6 +618,11 @@ A4 Step 2 de-prioritization order. Evidence-only: it claims nothing.
 - **JSON output**:
   - `repository`: `{ owner: string, repo: string }`
   - `checkedOverlap`: `boolean`
+  - `manifestMissing`: `boolean` — `true` when `--manifest`'s target file does
+    not exist (`ENOENT`); the CLI still exits 0, with `highContentionFiles`
+    reported as an empty set rather than fabricated from the manifest path
+    itself. A manifest that exists but fails to parse (malformed JSON, wrong
+    shape) keeps the prior fail-closed behavior (the CLI throws), unchanged.
   - `highContentionFiles`: `string[]` (sorted)
   - `candidates`: `[{ number: number, score: number | null,`
     `effectiveScore: number, candidateFiles: string[],`

--- a/scripts/discover-shared-file-overlap.mjs
+++ b/scripts/discover-shared-file-overlap.mjs
@@ -326,14 +326,19 @@ function runCli() {
   const port = createGithubProviderAdapter(owner, repo);
   const policy = loadPolicy(args.policy);
   const now = args.now || new Date().toISOString();
-  const manifest = loadManifest(args.manifest);
-  const highContentionFiles = resolveHighContentionFiles({
-    manifest,
-    bundleIds: args.bundles ?? DEFAULT_BUNDLE_IDS,
-    // Track the manifest actually in use so a custom --manifest is the file
-    // reported (and matched) as high-contention, not the hard-coded default.
-    extraFiles: [args.manifest],
-  });
+  const { manifest, missing: manifestMissing } = loadManifest(args.manifest);
+  // A missing manifest must not fall back to resolveHighContentionFiles's
+  // extraFiles default (the manifest path itself) — that would fabricate a
+  // one-entry high-contention set from a file that doesn't exist.
+  const highContentionFiles = manifestMissing
+    ? new Set()
+    : resolveHighContentionFiles({
+        manifest,
+        bundleIds: args.bundles ?? DEFAULT_BUNDLE_IDS,
+        // Track the manifest actually in use so a custom --manifest is the file
+        // reported (and matched) as high-contention, not the hard-coded default.
+        extraFiles: [args.manifest],
+      });
   const candidates = args.candidates.map((number) => {
     const issue = fetchIssue(port, number);
     return {
@@ -343,7 +348,9 @@ function runCli() {
     };
   });
   let activeIssues = [];
-  if (args.checkOverlap) {
+  // With no high-contention files, every overlap intersection is empty
+  // regardless of active-issue data, so skip the API cost entirely.
+  if (args.checkOverlap && !manifestMissing) {
     activeIssues = discoverActiveIssues({
       port,
       trustedActors: policy.trustedMarkerActors,
@@ -361,6 +368,7 @@ function runCli() {
   const output = {
     repository: { owner, repo },
     checkedOverlap: args.checkOverlap,
+    manifestMissing,
     highContentionFiles: [...highContentionFiles].sort(),
     ...analysis,
   };
@@ -478,16 +486,35 @@ function fetchOpenPrLinkedIssues(port) {
   // than the cap drops the overflow. Acceptable for an advisory signal.
   return port.listIssueNumbersClosedByOpenChangeRequests(OPEN_PR_SCAN_LIMIT);
 }
-function loadManifest(manifestPath) {
+/**
+ * Load the sync manifest. A missing file (`ENOENT` — the common adopter case,
+ * since `audit/sync-manifest.json` is a source-repo audit artifact that
+ * adopter repositories do not ship) degrades quietly: `missing: true`, no
+ * throw. Any other read failure (permissions, a directory in place of the
+ * file, …) or a present-but-malformed manifest still fails closed exactly as
+ * before — an empty manifest would otherwise yield an empty high-contention
+ * set, making every candidate look non-overlapping.
+ */
+export function loadManifest(manifestPath) {
   const targetPath = resolve(
     process.cwd(),
     manifestPath || DEFAULT_MANIFEST_PATH,
   );
+  let raw;
   try {
-    return JSON.parse(readFileSync(targetPath, 'utf8'));
+    raw = readFileSync(targetPath, 'utf8');
   } catch (error) {
-    // Fail closed: an empty manifest would yield an empty high-contention set,
-    // making every candidate look non-overlapping. Surface the load failure.
+    if (error.code === 'ENOENT') {
+      return { manifest: null, missing: true };
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `failed to load sync manifest at ${targetPath}: ${message}`,
+    );
+  }
+  try {
+    return { manifest: JSON.parse(raw), missing: false };
+  } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(
       `failed to load sync manifest at ${targetPath}: ${message}`,

--- a/scripts/discover-shared-file-overlap.mjs
+++ b/scripts/discover-shared-file-overlap.mjs
@@ -348,8 +348,9 @@ function runCli() {
     };
   });
   let activeIssues = [];
-  // With no high-contention files, every overlap intersection is empty
-  // regardless of active-issue data, so skip the API cost entirely.
+  // A missing manifest guarantees an empty high-contention set (see above),
+  // so every overlap intersection would be empty regardless of active-issue
+  // data — skip the API cost entirely in that case.
   if (args.checkOverlap && !manifestMissing) {
     activeIssues = discoverActiveIssues({
       port,

--- a/src/scripts/discover-shared-file-overlap.mts
+++ b/src/scripts/discover-shared-file-overlap.mts
@@ -401,7 +401,9 @@ function intersect(files: string[], highContention: Set<string>): string[] {
 }
 
 // ---------------------------------------------------------------------------
-// CLI glue (not unit-tested; the pure core above is)
+// CLI glue. `loadManifest` is exported and unit-tested for its
+// ENOENT-vs-parse-error boundary; the rest of this section is CLI wiring,
+// not unit-tested (the pure core above is).
 // ---------------------------------------------------------------------------
 
 interface ParsedArgs {
@@ -434,14 +436,19 @@ function runCli(): void {
   const policy = loadPolicy(args.policy);
   const now = args.now || new Date().toISOString();
 
-  const manifest = loadManifest(args.manifest);
-  const highContentionFiles = resolveHighContentionFiles({
-    manifest,
-    bundleIds: args.bundles ?? DEFAULT_BUNDLE_IDS,
-    // Track the manifest actually in use so a custom --manifest is the file
-    // reported (and matched) as high-contention, not the hard-coded default.
-    extraFiles: [args.manifest],
-  });
+  const { manifest, missing: manifestMissing } = loadManifest(args.manifest);
+  // A missing manifest must not fall back to resolveHighContentionFiles's
+  // extraFiles default (the manifest path itself) — that would fabricate a
+  // one-entry high-contention set from a file that doesn't exist.
+  const highContentionFiles = manifestMissing
+    ? new Set<string>()
+    : resolveHighContentionFiles({
+        manifest,
+        bundleIds: args.bundles ?? DEFAULT_BUNDLE_IDS,
+        // Track the manifest actually in use so a custom --manifest is the file
+        // reported (and matched) as high-contention, not the hard-coded default.
+        extraFiles: [args.manifest],
+      });
 
   const candidates: OverlapCandidateInput[] = args.candidates.map((number) => {
     const issue = fetchIssue(port, number);
@@ -453,7 +460,9 @@ function runCli(): void {
   });
 
   let activeIssues: ActiveIssueInput[] = [];
-  if (args.checkOverlap) {
+  // With no high-contention files, every overlap intersection is empty
+  // regardless of active-issue data, so skip the API cost entirely.
+  if (args.checkOverlap && !manifestMissing) {
     activeIssues = discoverActiveIssues({
       port,
       trustedActors: policy.trustedMarkerActors,
@@ -473,6 +482,7 @@ function runCli(): void {
   const output = {
     repository: { owner, repo },
     checkedOverlap: args.checkOverlap,
+    manifestMissing,
     highContentionFiles: [...highContentionFiles].sort(),
     ...analysis,
   };
@@ -616,16 +626,38 @@ function fetchOpenPrLinkedIssues(port: ProviderPort): number[] {
   return port.listIssueNumbersClosedByOpenChangeRequests(OPEN_PR_SCAN_LIMIT);
 }
 
-function loadManifest(manifestPath: string): unknown {
+/**
+ * Load the sync manifest. A missing file (`ENOENT` — the common adopter case,
+ * since `audit/sync-manifest.json` is a source-repo audit artifact that
+ * adopter repositories do not ship) degrades quietly: `missing: true`, no
+ * throw. Any other read failure (permissions, a directory in place of the
+ * file, …) or a present-but-malformed manifest still fails closed exactly as
+ * before — an empty manifest would otherwise yield an empty high-contention
+ * set, making every candidate look non-overlapping.
+ */
+export function loadManifest(manifestPath: string): {
+  manifest: unknown;
+  missing: boolean;
+} {
   const targetPath = resolve(
     process.cwd(),
     manifestPath || DEFAULT_MANIFEST_PATH,
   );
+  let raw: string;
   try {
-    return JSON.parse(readFileSync(targetPath, 'utf8'));
+    raw = readFileSync(targetPath, 'utf8');
   } catch (error) {
-    // Fail closed: an empty manifest would yield an empty high-contention set,
-    // making every candidate look non-overlapping. Surface the load failure.
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { manifest: null, missing: true };
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `failed to load sync manifest at ${targetPath}: ${message}`,
+    );
+  }
+  try {
+    return { manifest: JSON.parse(raw), missing: false };
+  } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(
       `failed to load sync manifest at ${targetPath}: ${message}`,

--- a/src/scripts/discover-shared-file-overlap.mts
+++ b/src/scripts/discover-shared-file-overlap.mts
@@ -402,8 +402,8 @@ function intersect(files: string[], highContention: Set<string>): string[] {
 
 // ---------------------------------------------------------------------------
 // CLI glue. `loadManifest` is exported and unit-tested for its
-// ENOENT-vs-parse-error boundary; the rest of this section is CLI wiring,
-// not unit-tested (the pure core above is).
+// ENOENT-vs-parse-error boundary; `parseArgs` below has its own existing
+// test coverage too. `runCli`/`printHelp` are CLI wiring, not unit-tested.
 // ---------------------------------------------------------------------------
 
 interface ParsedArgs {
@@ -460,8 +460,9 @@ function runCli(): void {
   });
 
   let activeIssues: ActiveIssueInput[] = [];
-  // With no high-contention files, every overlap intersection is empty
-  // regardless of active-issue data, so skip the API cost entirely.
+  // A missing manifest guarantees an empty high-contention set (see above),
+  // so every overlap intersection would be empty regardless of active-issue
+  // data — skip the API cost entirely in that case.
   if (args.checkOverlap && !manifestMissing) {
     activeIssues = discoverActiveIssues({
       port,

--- a/tests/discover-shared-file-overlap.test.mts
+++ b/tests/discover-shared-file-overlap.test.mts
@@ -1,11 +1,14 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { test } from 'node:test';
 
 import {
   type ActiveIssueInput,
   analyzeSharedFileOverlap,
   applyOverlapTieBreaker,
+  loadManifest,
   normalizeContentionPath,
   type OverlapCandidateInput,
   parseArgs,
@@ -217,6 +220,48 @@ test('resolveHighContentionFiles over the real manifest yields the issue-named f
   }
   // A discovery-bundle-only file must not be flagged high-contention.
   assert.equal(resolved.has('idd-suitability.instructions.md'), false);
+});
+
+// ---------------------------------------------------------------------------
+// loadManifest
+// ---------------------------------------------------------------------------
+
+test('loadManifest degrades quietly on a missing manifest (ENOENT)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'discover-shared-file-overlap-'));
+  try {
+    const result = loadManifest(join(dir, 'does-not-exist.json'));
+    assert.deepEqual(result, { manifest: null, missing: true });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('loadManifest still fails closed on a present-but-malformed manifest', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'discover-shared-file-overlap-'));
+  try {
+    const manifestPath = join(dir, 'sync-manifest.json');
+    writeFileSync(manifestPath, '{ not valid json', 'utf8');
+    assert.throws(
+      () => loadManifest(manifestPath),
+      /failed to load sync manifest/,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('loadManifest parses a present, well-formed manifest', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'discover-shared-file-overlap-'));
+  try {
+    const manifestPath = join(dir, 'sync-manifest.json');
+    writeFileSync(manifestPath, JSON.stringify({ bundleBudgets: [] }), 'utf8');
+    assert.deepEqual(loadManifest(manifestPath), {
+      manifest: { bundleBudgets: [] },
+      missing: false,
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
# Summary

`discover-shared-file-overlap.mts`'s `loadManifest` fail-closed on **any**
load error for `audit/sync-manifest.json`, including a simple `ENOENT` on
an adopter repository that doesn't ship the file (this is a source-repo
audit artifact, per `idd-template/ONBOARDING.md`'s core file list) — the
A4 Step 2 overlap helper is documented as advisory, so the throw was pure
noise, not a real block.

`loadManifest` now distinguishes:

- **Missing file (`ENOENT`)** — degrades quietly: returns
  `{ manifest: null, missing: true }`, the CLI reports `manifestMissing:
  true` with an empty high-contention set (never fabricated from
  `resolveHighContentionFiles`'s `extraFiles` default, which would
  otherwise include the missing manifest path itself), and exits 0. The
  `--check-overlap` active-issue scan is also skipped in this case, since
  an empty high-contention set makes any overlap result moot regardless.
- **Any other read failure, or a present-but-malformed manifest** —
  unchanged: still throws (fail-closed), exactly as before.

This mirrors the sibling `loadHighContentionFiles` degrade-on-missing
choice already used in `suitability-triage.mts`'s Check 4.

## Linked issue

Closes #2617

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

`idd-template/.github/instructions/idd-discover.instructions.md` (and its
generated mirror) documents the new `manifestMissing` behavior in the
existing "High-contention shared-file overlap (advisory)" paragraph. That
file sits at 32,993/33,000 bytes against `instructionSizeBudgets.
phaseLimitBytes` (7 bytes of headroom) — a second instance this session hit
of the same budget family that #2620, #2377, and #2567 already hit for
`bundleBudgets` sums. Rather than touch that policy constant (a maintainer
call per this repo's established precedent) or skip the acceptance
criterion, the paragraph's closing sentence ("Never overrides the score or
crosses a band.") was trimmed — it restates an invariant already stated
twice just above it in the same A4 Step 2 tie-breaker block (the desync and
effort-hint paragraphs), so nothing is lost. Net effect: the file is one
byte larger than before (`node scripts/audit-docs.mjs --check` passes;
`bundle-discovery` utilization moved from 95.47% to 95.48%).

`docs/idd-helper-scripts.md`'s Discover Shared File Overlap Contract gained
a `manifestMissing` bullet describing the new field — that file carries no
byte budget, so the note there is fuller.

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`npx biome check`, `npx dprint check`, `npx
      markdownlint-cli2` — pre-existing unrelated warnings in
      `protocol-helpers.mts`/`.mjs`, not touched by this PR)
- [x] `pnpm test` (5053 tests pass, including 3 new `loadManifest` cases:
      missing file, malformed file, well-formed file)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (`node scripts/sync-docs.mjs --apply` run
      before commit; tree clean after)
- [x] `node scripts/idd-doctor.mjs` (passed with 3 pre-existing warnings
      unrelated to this change)
- [x] Manual CLI smoke test: `--manifest <missing path>` → exit 0,
      `manifestMissing: true`, empty `highContentionFiles`;
      `--manifest <malformed path>` → still throws; default manifest →
      unchanged output

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none)
- [x] Context budget impact reviewed (see Background/rationale above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuYsYwJMEmfKEaf67DQ8zG
