### PR TITLE
feat(token-cost): aggregate a legitimate multi-session issue-loop's usage across files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -166,7 +166,11 @@ Include `--issue <n>` on every call from `claim` onward, once an issue
 is claimed — omit it only for `discover`, which precedes any claim. A
 call with no `--issue` is unusable for per-issue attribution (#2418):
 the harvester can only join it back to an issue when the number is
-recorded on the event itself.
+recorded on the event itself. Also include `--claim-id <claim-id>` —
+the active IDD `{claim-id}` — on every call from `claim` onward: it is
+the positive-evidence signal a later harvest uses to merge a genuine
+cross-session handoff/resume of the same claim lineage instead of
+undercounting it (#2432).
 `schemas/token-cost-event.schema.json`'s `vendor` enum (`grok`, `claude`,
 `codex`) has no value for GitHub Copilot yet — skip this call rather
 than pass a mismatched vendor; a wrong tag would corrupt the shared

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,7 +155,11 @@ Include `--issue <n>` on every call from `claim` onward, once an issue
 is claimed — omit it only for `discover`, which precedes any claim. A
 call with no `--issue` is unusable for per-issue attribution (#2418):
 the harvester can only join it back to an issue when the number is
-recorded on the event itself. OpenCode has no matching `vendor` value
+recorded on the event itself. Also include `--claim-id <claim-id>` —
+the active IDD `{claim-id}` — on every call from `claim` onward: it is
+the positive-evidence signal a later harvest uses to merge a genuine
+cross-session handoff/resume of the same claim lineage instead of
+undercounting it (#2432). OpenCode has no matching `vendor` value
 in `schemas/token-cost-event.schema.json` yet — skip this call rather
 than pass a mismatched vendor. Stage ids: `discover`, `claim`, `work`,
 `submit-pr`, `review`, `merge`, `cleanup`. Ignore any failure from this

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,11 @@ Include `--issue <n>` on every call from `claim` onward, once an issue
 is claimed — omit it only for `discover`, which precedes any claim. A
 call with no `--issue` is unusable for per-issue attribution (#2418):
 the harvester can only join it back to an issue when the number is
-recorded on the event itself. Stage ids: `discover`, `claim`, `work`,
+recorded on the event itself. Also include `--claim-id <claim-id>` —
+the active IDD `{claim-id}` — on every call from `claim` onward: it is
+the positive-evidence signal a later harvest uses to merge a genuine
+cross-session handoff/resume of the same claim lineage instead of
+undercounting it (#2432). Stage ids: `discover`, `claim`, `work`,
 `submit-pr`, `review`, `merge`, `cleanup`. Ignore any failure from this
 command — it must never block or slow the IDD loop.
 

--- a/docs/token-cost.md
+++ b/docs/token-cost.md
@@ -88,16 +88,28 @@ themselves unidentified (all historical data, and any vendor with no
 known session-id source) -- once identified events are present, an
 identified stage is never treated as compatible with a differently- or
 un-identified completion, so a stale or unrelated attempt can't be
-silently absorbed. One accepted tradeoff from this: when a single issue
-loop legitimately spans multiple Claude sessions (a handoff or resume,
-Refs Scope above), the event-window fallback currently only harvests
-that loop's usage from the session that posted `cleanup` -- an earlier
-session's own identified stage windows are excluded rather than folded
-in, since a session-id mismatch cannot be told apart from a genuinely
-unrelated, abandoned attempt at the event level. Full multi-session
-aggregation for this path is tracked separately (Refs #2432); the
-harvested sample stays an undercount rather than risking a
-mismatched/contaminated one in the meantime.
+silently absorbed. When a single issue loop legitimately spans multiple
+Claude sessions (a handoff or resume, Refs Scope above), a second,
+independent signal resolves it: passing `--claim-id` (the active IDD
+`{claim-id}`) to `token-cost-event.mjs` persists it as `claimId` on the
+event, and a non-`cleanup` stage window whose `claimId` matches the
+winning `cleanup` window's own is treated as belonging to the same claim
+lineage even when its `vendorSessionId` differs -- the IDD `{claim-id}`
+is this repository's own ground-truth ownership token, independent of
+which process posted the event, so it can positively confirm a genuine
+handoff where a bare session-id mismatch alone cannot (Refs #2432). The
+harvester then also pulls that contributing session's own project log
+file's records into the harvested sample (restricted to its own
+qualifying window bounds), rather than merely widening the reported
+bounds without the usage to back them. Two claim-id-matched windows from
+different sessions that overlap in time -- a narrow, documented race
+where two sessions can momentarily share one active claim-id without one
+being a clean continuation of the other -- are treated as contamination
+and excluded, same as a reversed window. A loop whose events predate this
+field, or whose caller never passes `--claim-id`, falls back to today's
+narrower, single-session-only behavior unchanged -- not a regression,
+since `events.jsonl` is append-only and a later harvest picks up richer
+attribution once available.
 
 `node scripts/token-cost-report.mjs`:
 

--- a/schemas/token-cost-event.schema.json
+++ b/schemas/token-cost-event.schema.json
@@ -44,6 +44,10 @@
       "type": ["string", "null"],
       "description": "Opaque vendor session id when known. Never a filesystem path."
     },
+    "claimId": {
+      "type": ["string", "null"],
+      "description": "The active IDD {claim-id} when this event is claim-scoped. Positive evidence that two differently-vendorSessionId'd stage windows for the same issue belong to one continuous claim lineage (a handoff/resume), not two unrelated attempts."
+    },
     "issueNumber": {
       "type": ["integer", "null"],
       "exclusiveMinimum": 0,

--- a/scripts/token-cost-adapter-claude.mjs
+++ b/scripts/token-cost-adapter-claude.mjs
@@ -352,7 +352,8 @@ function asClaudeHarvestInput(input) {
       ? input.issueNumberOverride
       : undefined;
   const vendorSessionIdOverride =
-    typeof input.vendorSessionIdOverride === 'string'
+    typeof input.vendorSessionIdOverride === 'string' &&
+    input.vendorSessionIdOverride.length > 0
       ? input.vendorSessionIdOverride
       : undefined;
   return {

--- a/scripts/token-cost-adapter-claude.mjs
+++ b/scripts/token-cost-adapter-claude.mjs
@@ -351,20 +351,32 @@ function asClaudeHarvestInput(input) {
     typeof input.issueNumberOverride === 'number'
       ? input.issueNumberOverride
       : undefined;
+  const vendorSessionIdOverride =
+    typeof input.vendorSessionIdOverride === 'string'
+      ? input.vendorSessionIdOverride
+      : undefined;
   return {
     records: input.records,
     fileBasename,
     segmentIndex,
     issueNumberOverride,
+    vendorSessionIdOverride,
   };
 }
 /** Claude Code vendor adapter. `input` must satisfy {@link ClaudeHarvestInput}. */
 export const claudeAdapter = {
   harvest(input) {
-    const { records, fileBasename, segmentIndex, issueNumberOverride } =
-      asClaudeHarvestInput(input);
+    const {
+      records,
+      fileBasename,
+      segmentIndex,
+      issueNumberOverride,
+      vendorSessionIdOverride,
+    } = asClaudeHarvestInput(input);
     const vendorSessionId = deriveVendorSessionId(
-      extractSessionId(records) ?? deriveFallbackSessionId(fileBasename),
+      vendorSessionIdOverride ??
+        extractSessionId(records) ??
+        deriveFallbackSessionId(fileBasename),
       segmentIndex,
       issueNumberOverride,
     );

--- a/scripts/token-cost-event.mjs
+++ b/scripts/token-cost-event.mjs
@@ -120,6 +120,13 @@ export function buildEvent(values, now, env = process.env) {
     }
     event.issueNumber = issueNumber;
   }
+  const claimIdRaw = values['claim-id'];
+  if (claimIdRaw !== undefined) {
+    if (typeof claimIdRaw !== 'string' || claimIdRaw.length === 0) {
+      throw new Error('--claim-id must be a single, non-empty value');
+    }
+    event.claimId = claimIdRaw;
+  }
   return event;
 }
 /**
@@ -149,11 +156,10 @@ const TOKEN_COST_EVENT_FLAG_SPEC = {
   '--exit': { type: 'boolean', default: false },
   '--issue': { type: 'string' },
   '--vendor': { type: 'string' },
-  // Accepted for CLI-surface symmetry with the calling convention this
-  // issue's own sketch shows -- not persisted, since
-  // schemas/token-cost-event.schema.json has no field for an IDD claim id
-  // (distinct from vendorSessionId, the AI vendor's own session
-  // identifier).
+  // The active IDD {claim-id} (distinct from vendorSessionId, the AI
+  // vendor's own session identifier), when this event is claim-scoped
+  // (#2432). Positive evidence a later harvest can use to merge a
+  // legitimate cross-session handoff's usage.
   '--claim-id': { type: 'string' },
   '--out': { type: 'string' },
   '--strict': { type: 'boolean', default: false },
@@ -170,8 +176,8 @@ function printHelp() {
   --enter / --exit   Exactly one is required.
   --issue <n>        Issue number, when this event is issue-scoped.
   --vendor <v>       Agent vendor: grok, claude, or codex. Required.
-  --claim-id <id>    Accepted for calling-convention symmetry; not
-                      persisted (no schema field for it).
+  --claim-id <id>    The active IDD {claim-id}, when this event is
+                     claim-scoped (persisted as claimId, #2432).
   --out <path>       JSONL append target (default:
                      \${XDG_STATE_HOME:-$HOME/.local/state}/idd-skill/token-cost/events.jsonl).
   --strict           Exit non-zero on any failure instead of the default

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -1922,20 +1922,33 @@ export function scanClaudeVendorSessions(
         resolveCandidateSessionId(candidate.fileBasename) ===
           window.vendorSessionId,
     );
-    if (matches.length !== 1) {
+    // #2432/Codex review (PR #2627): a session that moves out of the
+    // target worktree and later returns produces more than one cwd
+    // segment for the SAME file and issue (#2404 segmentation) -- group by
+    // basename first, since several segments of the one uniquely-resolved
+    // file are not the ambiguity this guards against; only more than one
+    // DISTINCT file matching is.
+    const matchesByBasename = new Map();
+    for (const candidate of matches) {
+      const combined = matchesByBasename.get(candidate.fileBasename) ?? [];
+      combined.push(...candidate.records);
+      matchesByBasename.set(candidate.fileBasename, combined);
+    }
+    if (matchesByBasename.size !== 1) {
       process.stderr.write(
         `token-cost-harvest: skipping cwd-attributed primary resolution for issue #${window.issueNumber}: ${
-          matches.length === 0
+          matchesByBasename.size === 0
             ? 'no matching cwd-attributed segment found'
-            : `matched more than one segment (${matches.map((m) => m.fileBasename).join(', ')})`
+            : `matched more than one file (${[...matchesByBasename.keys()].join(', ')})`
         } -- its plain cwd-derived sample (if any) is unaffected\n`,
       );
       continue;
     }
+    const [[primaryBasename, primaryRecords]] = matchesByBasename;
     harvestEventWindowCandidate(
       window.issueNumber,
-      matches[0].fileBasename,
-      matches[0].records,
+      primaryBasename,
+      primaryRecords,
     );
   }
   // #2432: emit each file's own cwd-derived issue-loop sample now that

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -892,12 +892,26 @@ export function readEventWindows(path) {
     for (const [vendorSessionId, startMs] of enters) {
       const endMs = exits.get(vendorSessionId);
       if (endMs !== undefined) {
-        // The attempt's own claimId requires its enter and exit to agree
-        // (both undefined, or the same value) -- one stage's enter/exit
-        // share one claim in practice, so disagreement is defensive: it
-        // degrades to undefined rather than guessing which side is right.
+        // The attempt's own claimId requires its enter and exit to agree.
+        // One side missing (undefined) while the other carries a value is
+        // ordinary partial data -- defensive degrade to undefined, since
+        // one stage's enter/exit share one claim in practice and there is
+        // no way to tell which side is right. Both sides present but
+        // DIFFERENT is a stronger signal: the same long-lived session
+        // revisited the issue under a NEW claim between this enter and
+        // exit (or a boundary write raced with a takeover) -- degrading
+        // that to claim-less would make `idCompatible` treat it as
+        // compatible with ANY cleanup by default, so the whole candidate
+        // is excluded instead (Codex review finding, PR #2627).
         const enterClaimId = enterClaimIds?.get(vendorSessionId);
         const exitClaimId = exitClaimIds?.get(vendorSessionId);
+        if (
+          enterClaimId !== undefined &&
+          exitClaimId !== undefined &&
+          enterClaimId !== exitClaimId
+        ) {
+          continue;
+        }
         const claimId = enterClaimId === exitClaimId ? enterClaimId : undefined;
         candidates.push({
           vendorSessionId,
@@ -1686,6 +1700,16 @@ export function scanClaudeVendorSessions(
   // would otherwise permanently freeze exactly the undercount this
   // feature exists to fix, once the missing contributor becomes available
   // (Codex review finding, PR #2627).
+  // Returns whether a merged sample was actually emitted -- the
+  // cwd-attributed-primary call site below needs to know this to also
+  // suppress the primary's own now-orphaned pending cwd sample on
+  // failure (Codex review finding, PR #2627): unlike the event-window
+  // fallback primary (which never has one), a cwd-attributed primary DOES
+  // have its own solo `pendingCwdSessions` entry, and leaving it
+  // unsuppressed on an aborted merge would let it stand under its own
+  // plain (non-`#ew`-suffixed) key -- a LATER successful merge would then
+  // append a second, differently-keyed sample for the same completed
+  // loop, permanently double-counting it.
   const harvestEventWindowCandidate = (issueNumber, fileBasename, records) => {
     const vendorSessionIdOverride = resolveCandidateSessionId(fileBasename);
     const contributingWindows =
@@ -1745,7 +1769,7 @@ export function scanClaudeVendorSessions(
               : `matched more than one file (${sessionIdMatches.map(([b]) => b).join(', ')})`
           } -- emitting a primary-only sample would freeze an undercount under a stable id\n`,
         );
-        return;
+        return false;
       }
       const [contributingBasename, candidateRecords] = sessionIdMatches[0];
       if (!isEligibleContributorFile(contributingBasename, contributing)) {
@@ -1795,10 +1819,12 @@ export function scanClaudeVendorSessions(
         consumedCwdIssueNumbersByBasename.get(fileBasename) ?? new Set();
       consumedPrimary.add(issueNumber);
       consumedCwdIssueNumbersByBasename.set(fileBasename, consumedPrimary);
+      return true;
     } catch (error) {
       process.stderr.write(
         `token-cost-harvest: skipping event-window issue #${issueNumber}: ${error.message}\n`,
       );
+      return false;
     }
   };
   // Cross-file resolution: event windows carry no session/file identity,
@@ -1945,11 +1971,22 @@ export function scanClaudeVendorSessions(
       continue;
     }
     const [[primaryBasename, primaryRecords]] = matchesByBasename;
-    harvestEventWindowCandidate(
+    const merged = harvestEventWindowCandidate(
       window.issueNumber,
       primaryBasename,
       primaryRecords,
     );
+    if (!merged) {
+      // #2432/Codex review (PR #2627): the merge aborted (an unresolvable
+      // contributor) -- suppress this primary's own pending cwd sample
+      // too, so this run emits NOTHING for the issue rather than a
+      // primary-only sample under a plain (non-`#ew`-suffixed) key that a
+      // later successful merge could never recognize as the same loop.
+      const consumedPrimary =
+        consumedCwdIssueNumbersByBasename.get(primaryBasename) ?? new Set();
+      consumedPrimary.add(window.issueNumber);
+      consumedCwdIssueNumbersByBasename.set(primaryBasename, consumedPrimary);
+    }
   }
   // #2432: emit each file's own cwd-derived issue-loop sample now that
   // every contributor resolution above is final, suppressing only the

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -1422,6 +1422,13 @@ export function scanClaudeVendorSessions(
   // harvested after every file has been scanned -- see the cross-file
   // ambiguity guard below.
   const eventWindowCandidates = [];
+  // #2432: each file's own unattributed records (cwd-inference failed for
+  // every segment), cached for a later contributingWindows lookup --
+  // scoped to the SAME pool eventWindowCandidates itself draws from, so a
+  // file that already independently produced its own cwd-attributed
+  // sample for some OTHER issue is never re-absorbed into a merged #ew
+  // sample here.
+  const unattributedRecordsByBasename = new Map();
   for (const file of files) {
     let records;
     try {
@@ -1475,36 +1482,86 @@ export function scanClaudeVendorSessions(
     // that markAmbiguousOverlaps has no reason to catch (their time
     // ranges don't overlap; they're just both attributed to the same
     // issue).
-    if (
-      !anySegmentHadCwdIssueNumber &&
-      unattributedRecords.length > 0 &&
-      completedIssueWindows.length > 0
-    ) {
-      const eventWindowGroups = segmentRecordsByEventWindow(
-        unattributedRecords,
-        completedIssueWindows,
-        extractRecordTimestampMs,
-      );
-      for (const [issueNumber, groupRecords] of eventWindowGroups) {
-        eventWindowCandidates.push({
-          fileBasename,
-          issueNumber,
-          records: groupRecords,
-        });
+    if (!anySegmentHadCwdIssueNumber && unattributedRecords.length > 0) {
+      unattributedRecordsByBasename.set(fileBasename, unattributedRecords);
+      if (completedIssueWindows.length > 0) {
+        const eventWindowGroups = segmentRecordsByEventWindow(
+          unattributedRecords,
+          completedIssueWindows,
+          extractRecordTimestampMs,
+        );
+        for (const [issueNumber, groupRecords] of eventWindowGroups) {
+          eventWindowCandidates.push({
+            fileBasename,
+            issueNumber,
+            records: groupRecords,
+          });
+        }
       }
     }
   }
+  const sortByTimestampAscending = (records) =>
+    [...records].sort(
+      (a, b) =>
+        (extractRecordTimestampMs(a) ?? Number.POSITIVE_INFINITY) -
+        (extractRecordTimestampMs(b) ?? Number.POSITIVE_INFINITY),
+    );
+  // #2432: pull each confirmed contributing session's own file's records
+  // (restricted to that session's own qualifying window bounds) into the
+  // primary file's own records, one merged harvest() call per issue.
+  // Never a partial-issue failure: a contribution whose own file can't be
+  // uniquely resolved is skipped (stderr diagnostic), keeping the
+  // primary-only, narrower-but-safe harvest instead of dropping the whole
+  // issue's sample.
   const harvestEventWindowCandidate = (issueNumber, fileBasename, records) => {
+    const vendorSessionIdOverride = resolveCandidateSessionId({
+      fileBasename,
+      records,
+    });
+    const contributingWindows =
+      completedIssueWindowByIssue.get(issueNumber)?.contributingWindows ?? [];
+    const mergedRecords = [...records];
+    for (const contributing of contributingWindows) {
+      const matches = [...unattributedRecordsByBasename].filter(
+        ([candidateBasename, candidateRecords]) =>
+          resolveCandidateSessionId({
+            fileBasename: candidateBasename,
+            records: candidateRecords,
+          }) === contributing.vendorSessionId,
+      );
+      if (matches.length !== 1) {
+        process.stderr.write(
+          `token-cost-harvest: skipping contributing session ${contributing.vendorSessionId} for issue #${issueNumber}: ${
+            matches.length === 0
+              ? 'no matching file found'
+              : `matched more than one file (${matches.map(([b]) => b).join(', ')})`
+          }\n`,
+        );
+        continue;
+      }
+      const [, candidateRecords] = matches[0];
+      for (const record of candidateRecords) {
+        const atMs = extractRecordTimestampMs(record);
+        if (
+          atMs !== undefined &&
+          atMs >= contributing.startMs &&
+          atMs < contributing.endMs
+        ) {
+          mergedRecords.push(record);
+        }
+      }
+    }
     try {
       const eventWindowResult = claudeAdapter.harvest({
-        records,
+        records: sortByTimestampAscending(mergedRecords),
         fileBasename,
         issueNumberOverride: issueNumber,
+        vendorSessionIdOverride,
       });
       out.push({
         vendor: 'claude',
         adapterResult: eventWindowResult,
-        timeline: extractClaudeUsageTimeline(records),
+        timeline: extractClaudeUsageTimeline(mergedRecords),
       });
     } catch (error) {
       process.stderr.write(
@@ -1525,10 +1582,10 @@ export function scanClaudeVendorSessions(
     });
     candidatesByIssue.set(candidate.issueNumber, list);
   }
-  const vendorSessionIdByIssue = new Map();
+  const completedIssueWindowByIssue = new Map();
   for (const window of completedIssueWindows) {
-    if (!vendorSessionIdByIssue.has(window.issueNumber)) {
-      vendorSessionIdByIssue.set(window.issueNumber, window.vendorSessionId);
+    if (!completedIssueWindowByIssue.has(window.issueNumber)) {
+      completedIssueWindowByIssue.set(window.issueNumber, window);
     }
   }
   // #2424/Copilot review (PR #2430): a candidate's own session id must
@@ -1550,7 +1607,8 @@ export function scanClaudeVendorSessions(
     // whose own session file got excluded upstream (a cwd-inferred
     // segment already claimed it), leaving only an unrelated concurrent
     // session's file as candidate.
-    const windowVendorSessionId = vendorSessionIdByIssue.get(issueNumber);
+    const windowVendorSessionId =
+      completedIssueWindowByIssue.get(issueNumber)?.vendorSessionId;
     if (windowVendorSessionId !== undefined) {
       const matching = fileCandidates.filter(
         (candidate) =>

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -1755,6 +1755,16 @@ export function scanClaudeVendorSessions(
         )
       );
     };
+    // Resolution is collected in a first pass and consumption is marked
+    // only after the harvest below actually succeeds (self-audited
+    // finding): marking a contributor consumed as soon as ITS OWN window
+    // resolves -- as an earlier revision did -- leaks that contributor's
+    // cwd sample as permanently suppressed whenever a LATER contributing
+    // window in this same loop fails to resolve, or the harvest call
+    // below throws, aborting the whole merge. That earlier contributor's
+    // standalone sample would then vanish with nothing to replace it: an
+    // outright loss of usage data, not merely a double-count.
+    const resolvedContributorBasenames = [];
     for (const contributing of contributingWindows) {
       const sessionIdMatches = [...allRecordsByBasename].filter(
         ([candidateBasename]) =>
@@ -1778,7 +1788,6 @@ export function scanClaudeVendorSessions(
         );
         continue;
       }
-      let contributorHadRecords = false;
       for (const record of candidateRecords) {
         const atMs = extractRecordTimestampMs(record);
         if (
@@ -1787,16 +1796,14 @@ export function scanClaudeVendorSessions(
           atMs < contributing.endMs
         ) {
           mergedRecords.push(record);
-          contributorHadRecords = true;
         }
       }
-      if (contributorHadRecords) {
-        const consumed =
-          consumedCwdIssueNumbersByBasename.get(contributingBasename) ??
-          new Set();
-        consumed.add(issueNumber);
-        consumedCwdIssueNumbersByBasename.set(contributingBasename, consumed);
-      }
+      // Consumed regardless of whether any record actually landed inside
+      // the contributing window: a resolved-but-empty contributor still
+      // correctly contributed zero usage to this loop, which is not the
+      // same as never having resolved at all, and its own plain cwd
+      // sample (if any) must be suppressed either way.
+      resolvedContributorBasenames.push(contributingBasename);
     }
     try {
       const eventWindowResult = claudeAdapter.harvest({
@@ -1814,7 +1821,16 @@ export function scanClaudeVendorSessions(
       // too, not just contributors' -- a no-op for the pre-#2432,
       // event-window-fallback primary (which never had one), but required
       // once a cwd-attributed file can itself be selected as primary (see
-      // the post-scan resolution below).
+      // the post-scan resolution below). Contributors are marked here too,
+      // together and only on confirmed success -- see the comment above
+      // the resolution loop.
+      for (const contributingBasename of resolvedContributorBasenames) {
+        const consumed =
+          consumedCwdIssueNumbersByBasename.get(contributingBasename) ??
+          new Set();
+        consumed.add(issueNumber);
+        consumedCwdIssueNumbersByBasename.set(contributingBasename, consumed);
+      }
       const consumedPrimary =
         consumedCwdIssueNumbersByBasename.get(fileBasename) ?? new Set();
       consumedPrimary.add(issueNumber);

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -1515,11 +1515,15 @@ export function scanClaudeVendorSessions(
       }
     }
   }
+  // A record with no valid timestamp sorts last via MAX_SAFE_INTEGER --
+  // Number.POSITIVE_INFINITY would subtract to NaN when two such records
+  // are compared, which Array.prototype.sort tolerates (undefined order)
+  // but is needlessly fragile.
   const sortByTimestampAscending = (records) =>
     [...records].sort(
       (a, b) =>
-        (extractRecordTimestampMs(a) ?? Number.POSITIVE_INFINITY) -
-        (extractRecordTimestampMs(b) ?? Number.POSITIVE_INFINITY),
+        (extractRecordTimestampMs(a) ?? Number.MAX_SAFE_INTEGER) -
+        (extractRecordTimestampMs(b) ?? Number.MAX_SAFE_INTEGER),
     );
   // #2432: pull each confirmed contributing session's own file's records
   // (restricted to that session's own qualifying window bounds) into the

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -797,6 +797,13 @@ export function readEventWindows(path) {
   // events that carry a non-empty vendorSessionId.
   const enterAtByAttempt = new Map();
   const exitAtByAttempt = new Map();
+  // bareKey -> vendorSessionId -> claimId of whichever event set that
+  // attempt's CURRENT latest timestamp above (#2432). Only meaningful
+  // alongside an identified (vendorSessionId-bearing) attempt -- an
+  // unidentified event has no attempt bucket to disambiguate a claimId
+  // against, so claimId is never tracked on the legacy bareKey path.
+  const enterClaimIdByAttempt = new Map();
+  const exitClaimIdByAttempt = new Map();
   const text = readFileSync(path, 'utf8');
   for (const rawLine of text.split('\n')) {
     const line = rawLine.trim();
@@ -830,6 +837,7 @@ export function readEventWindows(path) {
     const vendorSessionId = isNonEmptyString(event.vendorSessionId)
       ? event.vendorSessionId
       : undefined;
+    const claimId = isNonEmptyString(event.claimId) ? event.claimId : undefined;
     if (event.event === 'enter') {
       enterAt.set(key, atMs);
       enterAtOwner.set(key, vendorSessionId);
@@ -837,6 +845,9 @@ export function readEventWindows(path) {
         const byAttempt = enterAtByAttempt.get(key) ?? new Map();
         byAttempt.set(vendorSessionId, atMs);
         enterAtByAttempt.set(key, byAttempt);
+        const claimIdByAttempt = enterClaimIdByAttempt.get(key) ?? new Map();
+        claimIdByAttempt.set(vendorSessionId, claimId);
+        enterClaimIdByAttempt.set(key, claimIdByAttempt);
       }
     } else {
       exitAt.set(key, atMs);
@@ -845,6 +856,9 @@ export function readEventWindows(path) {
         const byAttempt = exitAtByAttempt.get(key) ?? new Map();
         byAttempt.set(vendorSessionId, atMs);
         exitAtByAttempt.set(key, byAttempt);
+        const claimIdByAttempt = exitClaimIdByAttempt.get(key) ?? new Map();
+        claimIdByAttempt.set(vendorSessionId, claimId);
+        exitClaimIdByAttempt.set(key, claimIdByAttempt);
       }
     }
   }
@@ -854,11 +868,25 @@ export function readEventWindows(path) {
     if (!enters || !exits) {
       return [];
     }
+    const enterClaimIds = enterClaimIdByAttempt.get(key);
+    const exitClaimIds = exitClaimIdByAttempt.get(key);
     const candidates = [];
     for (const [vendorSessionId, startMs] of enters) {
       const endMs = exits.get(vendorSessionId);
       if (endMs !== undefined) {
-        candidates.push({ vendorSessionId, startMs, endMs });
+        // The attempt's own claimId requires its enter and exit to agree
+        // (both undefined, or the same value) -- one stage's enter/exit
+        // share one claim in practice, so disagreement is defensive: it
+        // degrades to undefined rather than guessing which side is right.
+        const enterClaimId = enterClaimIds?.get(vendorSessionId);
+        const exitClaimId = exitClaimIds?.get(vendorSessionId);
+        const claimId = enterClaimId === exitClaimId ? enterClaimId : undefined;
+        candidates.push({
+          vendorSessionId,
+          startMs,
+          endMs,
+          ...(claimId !== undefined ? { claimId } : {}),
+        });
       }
     }
     return candidates;
@@ -874,6 +902,9 @@ export function readEventWindows(path) {
           startMs: preferred.startMs,
           endMs: preferred.endMs,
           vendorSessionId: preferred.vendorSessionId,
+          ...(preferred.claimId !== undefined
+            ? { claimId: preferred.claimId }
+            : {}),
         };
       }
     }
@@ -932,6 +963,9 @@ export function readEventWindows(path) {
             startMs: bestIdentified.startMs,
             endMs: bestIdentified.endMs,
             vendorSessionId: bestIdentified.vendorSessionId,
+            ...(bestIdentified.claimId !== undefined
+              ? { claimId: bestIdentified.claimId }
+              : {}),
           }
         : legacyWindow;
     }
@@ -940,6 +974,9 @@ export function readEventWindows(path) {
         startMs: bestIdentified.startMs,
         endMs: bestIdentified.endMs,
         vendorSessionId: bestIdentified.vendorSessionId,
+        ...(bestIdentified.claimId !== undefined
+          ? { claimId: bestIdentified.claimId }
+          : {}),
       };
     }
     return legacyWindow;
@@ -1108,29 +1145,37 @@ export function buildCompletedIssueWindows(eventWindowsAll, vendor) {
     //   unidentified ones -- byte-identical to the pre-#2424 residual;
     //   identity cannot see it either way.
     //
-    // A third, accepted tradeoff (Codex review finding round 5, PR #2430,
-    // #2424): a `vendorSessionId` mismatch proves a different PROCESS, not
-    // a different ATTEMPT -- docs/token-cost.md's own Scope explicitly
+    // A third case (Codex review finding round 5, PR #2430, #2424; shipped
+    // in #2432): a `vendorSessionId` mismatch proves a different PROCESS,
+    // not a different ATTEMPT -- docs/token-cost.md's own Scope explicitly
     // allows one issue loop to span multiple Claude sessions via a
-    // handoff or resume. This check has no way to tell that legitimate
-    // case apart from a genuinely unrelated, abandoned earlier attempt,
-    // so it excludes both alike. Widening the window to include the
-    // earlier session's own stage would not by itself recover its usage
-    // either: `scanClaudeVendorSessions` harvests one session log file
-    // per completed window, so an earlier handoff session's records live
-    // in a file this resolution never selects -- a widened-but-single-
-    // file harvest would misrepresent its own coverage (bounds spanning
-    // both sessions, records covering only one), which is worse than
-    // today's narrower-but-honest one. Merging records across a
-    // confirmed handoff's files needs a positive-evidence rule this
-    // event stream alone can't supply; tracked separately (#2432) rather
-    // than attempted here. Until then this is a documented undercount,
-    // not a bug: recoverable once #2432 ships, unlike the permanent
-    // contamination a wrong inclusion would freeze under a stable
-    // `#ew<issueNumber>` sample id.
+    // handoff or resume, and this check alone can't tell that legitimate
+    // case apart from a genuinely unrelated, abandoned earlier attempt.
+    // `idCompatible` below adds a second, independent admission path for
+    // exactly this case: a non-cleanup window whose own `claimId` (#2432,
+    // threaded from the IDD `{claim-id}` a caller optionally passes to
+    // `token-cost-event.mjs --claim-id`) MATCHES cleanup's own is treated
+    // as compatible even when its `vendorSessionId` differs -- `claimId`
+    // is this repository's own ground-truth ownership token for "same
+    // claim lineage, possibly handed off across sessions," independent of
+    // which process posted the event. A window admitted only via this
+    // claimId branch (not also same-`vendorSessionId`-or-unidentified) is
+    // additionally recorded as a `contributingWindows` entry so
+    // `scanClaudeVendorSessions` can pull that session's own file's
+    // records in too, instead of merely widening the bounds without the
+    // usage to back them. `claimId` absent on either side (historical
+    // data, or a caller that doesn't pass `--claim-id`) falls back to
+    // today's narrower, single-session-only behavior unchanged. Two
+    // claim-id-matched windows from DIFFERENT vendorSessionIds that
+    // OVERLAP each other in time (a narrow, documented TOCTOU race in
+    // `idd-claim.instructions.md` where two sessions can momentarily
+    // share one active `{claim-id}`) are treated as contamination and
+    // skip the whole issue, same as a reversed window below -- a genuine
+    // sequential handoff never produces overlapping activity.
     const idCompatible = (window) =>
       window.vendorSessionId === undefined ||
-      window.vendorSessionId === cleanup.vendorSessionId;
+      window.vendorSessionId === cleanup.vendorSessionId ||
+      (window.claimId !== undefined && window.claimId === cleanup.claimId);
     const candidateStages = [...stages].filter(
       ([stageId, window]) => stageId === 'cleanup' || idCompatible(window),
     );
@@ -1149,6 +1194,54 @@ export function buildCompletedIssueWindows(eventWindowsAll, vendor) {
         startMs = Math.min(startMs, window.startMs);
       }
     }
+    // #2432: a boundary-consistent, claimId-matched window whose own
+    // vendorSessionId differs from cleanup's own is a genuine
+    // contributing session -- union its range with any sibling windows
+    // sharing the same vendorSessionId (one earlier session can post more
+    // than one qualifying stage) into a single contribution.
+    const contributingRanges = new Map();
+    for (const [stageId, window] of candidateStages) {
+      if (
+        stageId === 'cleanup' ||
+        window.vendorSessionId === undefined ||
+        window.vendorSessionId === cleanup.vendorSessionId ||
+        !(window.startMs <= cleanup.endMs && window.endMs <= cleanup.endMs)
+      ) {
+        continue;
+      }
+      const existing = contributingRanges.get(window.vendorSessionId);
+      contributingRanges.set(window.vendorSessionId, {
+        startMs: existing
+          ? Math.min(existing.startMs, window.startMs)
+          : window.startMs,
+        endMs: existing ? Math.max(existing.endMs, window.endMs) : window.endMs,
+      });
+    }
+    const contributingWindows = [...contributingRanges].map(
+      ([vendorSessionId, range]) => ({ vendorSessionId, ...range }),
+    );
+    // Cross-session overlap guard: a genuine sequential handoff never
+    // produces overlapping activity between two different sessions. Two
+    // claim-id-matched windows from DIFFERENT vendorSessionIds that DO
+    // overlap is evidence of the narrow, documented TOCTOU race in
+    // `idd-claim.instructions.md` where two sessions can momentarily
+    // share one active claim-id without one being a clean continuation of
+    // the other -- treat the whole issue as contaminated, same as a
+    // reversed window above (no sample beats a wrong one). Scoped to
+    // cleanup's own [startMs, endMs) rather than the full widened window,
+    // since only the cleanup-owning session's identity is being compared
+    // against each contributing session's own identity here.
+    const overlaps = (a, b) => a.startMs < b.endMs && b.startMs < a.endMs;
+    const overlapCandidates = [
+      { startMs: cleanup.startMs, endMs: cleanup.endMs },
+      ...contributingWindows,
+    ];
+    const hasCrossSessionOverlap = overlapCandidates.some((a, i) =>
+      overlapCandidates.some((b, j) => i < j && overlaps(a, b)),
+    );
+    if (hasCrossSessionOverlap) {
+      continue;
+    }
     out.push({
       issueNumber,
       startMs,
@@ -1156,6 +1249,8 @@ export function buildCompletedIssueWindows(eventWindowsAll, vendor) {
       ...(cleanup.vendorSessionId !== undefined
         ? { vendorSessionId: cleanup.vendorSessionId }
         : {}),
+      ...(cleanup.claimId !== undefined ? { claimId: cleanup.claimId } : {}),
+      ...(contributingWindows.length > 0 ? { contributingWindows } : {}),
     });
   }
   return out;

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -778,6 +778,24 @@ function isNonEmptyString(value) {
  * forever, since the resulting window's own stable `#ew<issueNumber>` id
  * makes a later harvest treat it as already-present (Codex review
  * finding, PR #2430).
+ *
+ * #2432/Codex review (PR #2627): absent an exact-session match, a
+ * candidate sharing `cleanup`'s own `claimId` is preferred over the plain
+ * recency-based `bestIdentified`/legacy comparison above -- claimId, once
+ * matched, is this repository's own ground-truth ownership token for
+ * "same claim lineage, possibly handed off across sessions," so it must
+ * outrank a merely-more-recent but unrelated attempt at the same bareKey.
+ * Without this tier, a single stray same-stage event from ANY differently-
+ * or un-identified attempt (an unrelated concurrent session, an aborted
+ * retry) could win purely on `endMs` and get returned instead of the
+ * genuine claim-linked candidate -- which `buildCompletedIssueWindows`'s
+ * `idCompatible` would then exclude outright, silently defeating claim-id
+ * recovery before it ever runs. This tier does not close every residual:
+ * if the earlier handoff session and the winning `cleanup` session both
+ * post the identical stage id (a redundant re-post, not the common
+ * disjoint-stage handoff shape), only one window survives per bareKey --
+ * a documented limitation, not a regression, since neither pre-#2424 nor
+ * pre-#2432 behavior could recover it either.
  */
 export function readEventWindows(path) {
   const result = new Map();
@@ -891,7 +909,7 @@ export function readEventWindows(path) {
     }
     return candidates;
   };
-  const resolveWindow = (key, preferredVendorSessionId) => {
+  const resolveWindow = (key, preferredVendorSessionId, preferredClaimId) => {
     const candidates = attemptCandidates(key);
     if (preferredVendorSessionId !== undefined) {
       const preferred = candidates.find(
@@ -911,6 +929,31 @@ export function readEventWindows(path) {
     const valid = candidates.filter(
       (candidate) => candidate.startMs < candidate.endMs,
     );
+    // #2432/Codex review (PR #2627): no exact-session match above means
+    // this stage was posted by some OTHER process than cleanup's own --
+    // among those, a candidate sharing cleanup's own claimId is the SAME
+    // claim lineage (a genuine handoff contributor) and must not be
+    // shadowed by an unrelated, differently- or un-identified attempt
+    // that merely happens to have a later `endMs`. Without this, a single
+    // stray same-stage event from any unrelated attempt would silently
+    // defeat claim-id recovery entirely, before `idCompatible` ever gets
+    // a chance to run.
+    const claimMatched =
+      preferredClaimId !== undefined
+        ? valid.filter((candidate) => candidate.claimId === preferredClaimId)
+        : [];
+    const claimPreferred =
+      claimMatched.length > 0
+        ? claimMatched.reduce((a, b) => (b.endMs > a.endMs ? b : a))
+        : undefined;
+    if (claimPreferred) {
+      return {
+        startMs: claimPreferred.startMs,
+        endMs: claimPreferred.endMs,
+        vendorSessionId: claimPreferred.vendorSessionId,
+        claimId: claimPreferred.claimId,
+      };
+    }
     const bestIdentified =
       valid.length > 0
         ? valid.reduce((a, b) => (b.endMs > a.endMs ? b : a))
@@ -990,7 +1033,7 @@ export function readEventWindows(path) {
   }
   for (const prefix of issueVendorPrefixes) {
     const cleanupKey = `${prefix}:cleanup`;
-    const cleanupWindow = resolveWindow(cleanupKey, undefined);
+    const cleanupWindow = resolveWindow(cleanupKey, undefined, undefined);
     if (cleanupWindow) {
       result.set(cleanupKey, cleanupWindow);
     }
@@ -999,7 +1042,11 @@ export function readEventWindows(path) {
         continue;
       }
       const key = `${prefix}:${stageId}`;
-      const window = resolveWindow(key, cleanupWindow?.vendorSessionId);
+      const window = resolveWindow(
+        key,
+        cleanupWindow?.vendorSessionId,
+        cleanupWindow?.claimId,
+      );
       if (window) {
         result.set(key, window);
       }
@@ -1188,51 +1235,64 @@ export function buildCompletedIssueWindows(eventWindowsAll, vendor) {
     if (hasContaminatedStage) {
       continue;
     }
+    // Named once, reused by the `startMs`/`primaryWindows` widening loop
+    // below and by the `contributingWindows` loop after it, so a future
+    // change to either predicate can't silently desync the two (Copilot
+    // review, PR #2627).
+    const isBoundaryConsistent = (window) =>
+      window.startMs <= cleanup.endMs && window.endMs <= cleanup.endMs;
+    const isSameSessionOrUnidentified = (window) =>
+      window.vendorSessionId === undefined ||
+      window.vendorSessionId === cleanup.vendorSessionId;
     let startMs = cleanup.startMs;
-    // The primary/cleanup-owning session's own full span (union of every
-    // same-vendorSessionId-or-unidentified window, i.e. what `startMs`
-    // would be WITHOUT any claimId-matched contributor) -- kept separate
-    // from `startMs` itself so the cross-session overlap guard below can
-    // compare a contributor against the primary session's REAL activity
-    // range, not just cleanup's own narrow slice.
-    let primaryStartMs = cleanup.startMs;
+    // The primary/cleanup-owning session's own INDIVIDUAL stage windows
+    // (every same-vendorSessionId-or-unidentified window, boundary
+    // consistent) -- kept as separate intervals rather than one enclosing
+    // span, so the cross-session overlap guard below can tell a real
+    // overlap apart from a contributor's window merely falling inside a
+    // GAP between two of the primary session's own disjoint stages (e.g.
+    // an A -> B -> A handoff, where A owns an early stage plus the later
+    // `cleanup` and B owns an intervening stage that never actually
+    // touches either of A's own windows).
+    const primaryWindows = [];
     for (const [, window] of candidateStages) {
-      if (window.startMs <= cleanup.endMs && window.endMs <= cleanup.endMs) {
+      if (isBoundaryConsistent(window)) {
         startMs = Math.min(startMs, window.startMs);
-        if (
-          window.vendorSessionId === undefined ||
-          window.vendorSessionId === cleanup.vendorSessionId
-        ) {
-          primaryStartMs = Math.min(primaryStartMs, window.startMs);
+        if (isSameSessionOrUnidentified(window)) {
+          primaryWindows.push({
+            startMs: window.startMs,
+            endMs: window.endMs,
+          });
         }
       }
     }
     // #2432: a boundary-consistent, claimId-matched window whose own
     // vendorSessionId differs from cleanup's own is a genuine
-    // contributing session -- union its range with any sibling windows
-    // sharing the same vendorSessionId (one earlier session can post more
-    // than one qualifying stage) into a single contribution.
-    const contributingRanges = new Map();
+    // contributing session. Kept as INDIVIDUAL per-stage windows -- never
+    // unioned into one enclosing range per vendorSessionId -- for the same
+    // reason `primaryWindows` above is: a contributing session's own two
+    // stages can themselves be non-adjacent (e.g. an early `work` and a
+    // much later `review`), and a union would falsely "overlap" the
+    // primary session's own unrelated activity that merely falls inside
+    // that GAP, or pull that gap's unrelated records into the merge.
+    const contributingWindows = [];
     for (const [stageId, window] of candidateStages) {
       if (
         stageId === 'cleanup' ||
-        window.vendorSessionId === undefined ||
-        window.vendorSessionId === cleanup.vendorSessionId ||
-        !(window.startMs <= cleanup.endMs && window.endMs <= cleanup.endMs)
+        isSameSessionOrUnidentified(window) ||
+        !isBoundaryConsistent(window)
       ) {
         continue;
       }
-      const existing = contributingRanges.get(window.vendorSessionId);
-      contributingRanges.set(window.vendorSessionId, {
-        startMs: existing
-          ? Math.min(existing.startMs, window.startMs)
-          : window.startMs,
-        endMs: existing ? Math.max(existing.endMs, window.endMs) : window.endMs,
+      contributingWindows.push({
+        // Guaranteed non-undefined here: `isSameSessionOrUnidentified`
+        // already returned false, so `window.vendorSessionId` must be a
+        // defined string that differs from `cleanup.vendorSessionId`.
+        vendorSessionId: window.vendorSessionId,
+        startMs: window.startMs,
+        endMs: window.endMs,
       });
     }
-    const contributingWindows = [...contributingRanges].map(
-      ([vendorSessionId, range]) => ({ vendorSessionId, ...range }),
-    );
     // Cross-session overlap guard: a genuine sequential handoff never
     // produces overlapping activity between two different sessions. Two
     // claim-id-matched windows from DIFFERENT vendorSessionIds that DO
@@ -1241,19 +1301,30 @@ export function buildCompletedIssueWindows(eventWindowsAll, vendor) {
     // share one active claim-id without one being a clean continuation of
     // the other -- treat the whole issue as contaminated, same as a
     // reversed window above (no sample beats a wrong one). Compares each
-    // contributor against the primary session's OWN full span
-    // (`primaryStartMs`..`cleanup.endMs`, every same-session window
-    // unioned), not merely cleanup's own narrow slice -- a contributor
-    // overlapping an earlier same-session stage (e.g. `work`) is just as
-    // much evidence of the race as one overlapping `cleanup` itself.
+    // contributor against the primary session's own INDIVIDUAL stage
+    // windows (`primaryWindows`), not one enclosing span from its
+    // earliest stage to `cleanup.endMs` -- an enclosing span would falsely
+    // flag a legitimate A -> B -> A handoff, where B's own window merely
+    // falls inside the GAP between two of A's own disjoint stages
+    // (Codex review finding, PR #2627).
+    // Deliberately its own local closure, not a reuse of `rangesOverlap`
+    // below: that one compares closed `[min, max]` RecordTimeRanges (real
+    // observed record timestamps), while this compares half-open
+    // `[startMs, endMs)` stage windows (the same convention
+    // `segmentRecordsByEventWindow` uses) -- the boundary is strict `<`
+    // here, not `rangesOverlap`'s inclusive `<=`, because two windows
+    // merely touching at a shared instant is not a genuine overlap under
+    // that convention.
     const overlaps = (a, b) => a.startMs < b.endMs && b.startMs < a.endMs;
-    const overlapCandidates = [
-      { startMs: primaryStartMs, endMs: cleanup.endMs },
-      ...contributingWindows,
-    ];
-    const hasCrossSessionOverlap = overlapCandidates.some((a, i) =>
-      overlapCandidates.some((b, j) => i < j && overlaps(a, b)),
-    );
+    const hasCrossSessionOverlap =
+      contributingWindows.some((contributing) =>
+        primaryWindows.some((primaryWindow) =>
+          overlaps(primaryWindow, contributing),
+        ),
+      ) ||
+      contributingWindows.some((a, i) =>
+        contributingWindows.some((b, j) => i < j && overlaps(a, b)),
+      );
     if (hasCrossSessionOverlap) {
       continue;
     }
@@ -1261,6 +1332,7 @@ export function buildCompletedIssueWindows(eventWindowsAll, vendor) {
       issueNumber,
       startMs,
       endMs: cleanup.endMs,
+      primaryWindows,
       ...(cleanup.vendorSessionId !== undefined
         ? { vendorSessionId: cleanup.vendorSessionId }
         : {}),
@@ -1437,13 +1509,52 @@ export function scanClaudeVendorSessions(
   // harvested after every file has been scanned -- see the cross-file
   // ambiguity guard below.
   const eventWindowCandidates = [];
-  // #2432: each file's own unattributed records (cwd-inference failed for
-  // every segment), cached for a later contributingWindows lookup --
-  // scoped to the SAME pool eventWindowCandidates itself draws from, so a
-  // file that already independently produced its own cwd-attributed
-  // sample for some OTHER issue is never re-absorbed into a merged #ew
-  // sample here.
-  const unattributedRecordsByBasename = new Map();
+  // #2432: every file's own FULL record set (regardless of whether any
+  // segment resolved a cwd issue number), cached for a later
+  // contributingWindows lookup -- a genuine handoff session is very often
+  // launched right inside the issue worktree it is resuming, so its own
+  // records typically already carry a cwd-attributed segment for the
+  // exact issue being merged. Restricting this pool to unattributed-only
+  // records (the pre-#2432 #2418 scoping) would make such a session
+  // permanently unresolvable as a contributor (Codex review finding, PR
+  // #2627); which of its records actually belong to the merge is instead
+  // decided by the contributing window's own timestamp bounds below, not
+  // by which segment they happened to land in.
+  const allRecordsByBasename = new Map();
+  // Every issue number any segment of a file resolved via cwd inference
+  // (almost always zero or one entry; #2404 segmentation can add more for
+  // a session that moved across several worktrees in one file). A file
+  // that cwd-resolved to some OTHER issue is never eligible as a
+  // contributor for a DIFFERENT target issue -- matching its own sessionId
+  // is not enough on its own, or a session that briefly touched an
+  // unrelated issue's worktree could have that unrelated activity folded
+  // into this merge (Codex review finding, PR #2627 -- distinct from the
+  // same-issue suppression case above, which this does not affect).
+  const cwdIssueNumbersByBasename = new Map();
+  // Per-file `resolveCandidateSessionId` result, computed once per file
+  // instead of once per (contributor x file) comparison (Copilot review,
+  // PR #2627) -- `extractSessionId` can scan the whole records array.
+  const sessionIdByBasename = new Map();
+  const resolveCandidateSessionId = (fileBasename) => {
+    if (sessionIdByBasename.has(fileBasename)) {
+      return sessionIdByBasename.get(fileBasename);
+    }
+    const resolved =
+      extractSessionId(allRecordsByBasename.get(fileBasename) ?? []) ??
+      deriveFallbackSessionId(fileBasename);
+    sessionIdByBasename.set(fileBasename, resolved);
+    return resolved;
+  };
+  // #2432: a file's own cwd-derived issue-loop sample(s) whose issue
+  // number turns out to match a confirmed merge target are suppressed
+  // (not pushed to `out`) once that file is resolved as a contributor for
+  // that SAME issue number, so its usage is counted exactly once -- via
+  // the merged `#ew<issueNumber>` sample -- instead of also standing on
+  // its own. A cwd-derived sample for any OTHER issue number is never
+  // touched. Pushing is therefore deferred until every contributor
+  // resolution below has run.
+  const pendingCwdSessions = [];
+  const consumedCwdIssueNumbersByBasename = new Map();
   for (const file of files) {
     let records;
     try {
@@ -1455,6 +1566,7 @@ export function scanClaudeVendorSessions(
       continue;
     }
     const fileBasename = basename(file);
+    allRecordsByBasename.set(fileBasename, records);
     const segments = segmentRecordsByCwd(records);
     const unattributedRecords = [];
     let anySegmentHadCwdIssueNumber = false;
@@ -1476,29 +1588,46 @@ export function scanClaudeVendorSessions(
         );
         return;
       }
-      out.push({
+      const session = {
         vendor: 'claude',
         adapterResult,
         timeline: extractClaudeUsageTimeline(segment.records),
-      });
-      if (adapterResult.joinHints?.issueNumber === undefined) {
+      };
+      const cwdIssueNumber = adapterResult.joinHints?.issueNumber;
+      if (cwdIssueNumber === undefined) {
+        out.push(session);
         unattributedRecords.push(...segment.records);
       } else {
         anySegmentHadCwdIssueNumber = true;
+        const cwdIssues =
+          cwdIssueNumbersByBasename.get(fileBasename) ?? new Set();
+        cwdIssues.add(cwdIssueNumber);
+        cwdIssueNumbersByBasename.set(fileBasename, cwdIssues);
+        // #2432: deferred, not pushed yet -- see `pendingCwdSessions`
+        // above. Suppressed later only if this exact (file, issue number)
+        // pair is confirmed as a merge contributor.
+        pendingCwdSessions.push({
+          fileBasename,
+          issueNumber: cwdIssueNumber,
+          session,
+        });
       }
     });
-    // Only fall back to event-window attribution when NO segment in this
-    // file resolved a cwd-inferred issue number. Otherwise a segment
-    // whose cwd merely isn't issue-shaped (an ordinary subdirectory, not
-    // a worktree move) but whose records still happen to fall inside a
-    // DIFFERENT segment's already cwd-attributed issue window would
-    // produce a second, independent issue-loop sample for that same
-    // issue -- splitting one completed loop's usage across two samples
-    // that markAmbiguousOverlaps has no reason to catch (their time
-    // ranges don't overlap; they're just both attributed to the same
-    // issue).
+    // Only fall back to event-window attribution (for PRIMARY/cleanup-file
+    // selection) when NO segment in this file resolved a cwd-inferred
+    // issue number. Otherwise a segment whose cwd merely isn't
+    // issue-shaped (an ordinary subdirectory, not a worktree move) but
+    // whose records still happen to fall inside a DIFFERENT segment's
+    // already cwd-attributed issue window would produce a second,
+    // independent issue-loop sample for that same issue -- splitting one
+    // completed loop's usage across two samples that markAmbiguousOverlaps
+    // has no reason to catch (their time ranges don't overlap; they're
+    // just both attributed to the same issue). This restriction applies
+    // only to PRIMARY selection: a file excluded here can still be found
+    // as a claim-id-matched CONTRIBUTOR via `allRecordsByBasename` above,
+    // which is never restricted this way (Codex review finding, PR
+    // #2627).
     if (!anySegmentHadCwdIssueNumber && unattributedRecords.length > 0) {
-      unattributedRecordsByBasename.set(fileBasename, unattributedRecords);
       if (completedIssueWindows.length > 0) {
         const eventWindowGroups = segmentRecordsByEventWindow(
           unattributedRecords,
@@ -1527,38 +1656,74 @@ export function scanClaudeVendorSessions(
     );
   // #2432: pull each confirmed contributing session's own file's records
   // (restricted to that session's own qualifying window bounds) into the
-  // primary file's own records, one merged harvest() call per issue.
-  // Never a partial-issue failure: a contribution whose own file can't be
-  // uniquely resolved is skipped (stderr diagnostic), keeping the
-  // primary-only, narrower-but-safe harvest instead of dropping the whole
-  // issue's sample.
+  // primary file's own records, one merged harvest() call per issue. A
+  // contribution whose own file can't be uniquely resolved skips the
+  // WHOLE issue rather than emitting a primary-only sample under the
+  // stable `#ew<issueNumber>` id: the CLI's append-side `vendorSessionKey`
+  // dedup treats that key as already-present on every later run, which
+  // would otherwise permanently freeze exactly the undercount this
+  // feature exists to fix, once the missing contributor becomes available
+  // (Codex review finding, PR #2627).
   const harvestEventWindowCandidate = (issueNumber, fileBasename, records) => {
-    const vendorSessionIdOverride = resolveCandidateSessionId({
-      fileBasename,
-      records,
-    });
+    const vendorSessionIdOverride = resolveCandidateSessionId(fileBasename);
     const contributingWindows =
       completedIssueWindowByIssue.get(issueNumber)?.contributingWindows ?? [];
-    const mergedRecords = [...records];
-    for (const contributing of contributingWindows) {
-      const matches = [...unattributedRecordsByBasename].filter(
-        ([candidateBasename, candidateRecords]) =>
-          resolveCandidateSessionId({
-            fileBasename: candidateBasename,
-            records: candidateRecords,
-          }) === contributing.vendorSessionId,
+    // #2432/Codex review (PR #2627): the primary candidate's own `records`
+    // were selected against the OVERALL (already-widened) issue window,
+    // so they can include this same file's unrelated activity that
+    // happens to fall inside a time range a confirmed contributor already
+    // owns. Drop those before merging in the contributors' own records,
+    // so that time is charged exactly once.
+    const isOwnedByAContributor = (atMs) =>
+      atMs !== undefined &&
+      contributingWindows.some(
+        (contributing) =>
+          atMs >= contributing.startMs && atMs < contributing.endMs,
       );
-      if (matches.length !== 1) {
+    const mergedRecords = records.filter(
+      (record) => !isOwnedByAContributor(extractRecordTimestampMs(record)),
+    );
+    // A candidate file cwd-attributed to some OTHER issue number is never
+    // eligible to lend its records to THIS merge -- a file cwd-attributed
+    // only to THIS same issue (the #2432 same-worktree-handoff case) or to
+    // no issue at all (the pre-#2432 unattributed case) is eligible on a
+    // sessionId match; one cwd-attributed to a different issue is not,
+    // even on a sessionId match (Codex review finding, PR #2627). Unlike a
+    // truly unresolvable contributor below, this is a PERMANENT, structural
+    // disqualification, not a transient gap a later harvest could fix --
+    // so it drops just this one contributor and proceeds, rather than
+    // skipping the whole issue.
+    const isEligibleContributorFile = (candidateBasename) => {
+      const cwdIssues = cwdIssueNumbersByBasename.get(candidateBasename);
+      return (
+        cwdIssues === undefined ||
+        [...cwdIssues].every((cwdIssue) => cwdIssue === issueNumber)
+      );
+    };
+    for (const contributing of contributingWindows) {
+      const sessionIdMatches = [...allRecordsByBasename].filter(
+        ([candidateBasename]) =>
+          resolveCandidateSessionId(candidateBasename) ===
+          contributing.vendorSessionId,
+      );
+      if (sessionIdMatches.length !== 1) {
         process.stderr.write(
-          `token-cost-harvest: skipping contributing session ${contributing.vendorSessionId} for issue #${issueNumber}: ${
-            matches.length === 0
-              ? 'no matching file found'
-              : `matched more than one file (${matches.map(([b]) => b).join(', ')})`
-          }\n`,
+          `token-cost-harvest: skipping issue #${issueNumber} entirely: contributing session ${contributing.vendorSessionId} ${
+            sessionIdMatches.length === 0
+              ? 'has no matching file'
+              : `matched more than one file (${sessionIdMatches.map(([b]) => b).join(', ')})`
+          } -- emitting a primary-only sample would freeze an undercount under a stable id\n`,
+        );
+        return;
+      }
+      const [contributingBasename, candidateRecords] = sessionIdMatches[0];
+      if (!isEligibleContributorFile(contributingBasename)) {
+        process.stderr.write(
+          `token-cost-harvest: dropping contributing session ${contributing.vendorSessionId} for issue #${issueNumber}: its file (${contributingBasename}) is cwd-attributed to a different issue -- proceeding without this contributor\n`,
         );
         continue;
       }
-      const [, candidateRecords] = matches[0];
+      let contributorHadRecords = false;
       for (const record of candidateRecords) {
         const atMs = extractRecordTimestampMs(record);
         if (
@@ -1567,7 +1732,15 @@ export function scanClaudeVendorSessions(
           atMs < contributing.endMs
         ) {
           mergedRecords.push(record);
+          contributorHadRecords = true;
         }
+      }
+      if (contributorHadRecords) {
+        const consumed =
+          consumedCwdIssueNumbersByBasename.get(contributingBasename) ??
+          new Set();
+        consumed.add(issueNumber);
+        consumedCwdIssueNumbersByBasename.set(contributingBasename, consumed);
       }
     }
     try {
@@ -1607,16 +1780,6 @@ export function scanClaudeVendorSessions(
       completedIssueWindowByIssue.set(window.issueNumber, window);
     }
   }
-  // #2424/Copilot review (PR #2430): a candidate's own session id must
-  // fall back to its file basename exactly like `claudeAdapter.harvest()`
-  // itself does -- `extractSessionId()` alone returns `undefined` for a
-  // record shape lacking a top-level `sessionId` field (already
-  // fixture-covered for the adapter's own vendorSessionId derivation),
-  // which would otherwise never match a defined `windowVendorSessionId`
-  // even when the file is genuinely the right one.
-  const resolveCandidateSessionId = (candidate) =>
-    extractSessionId(candidate.records) ??
-    deriveFallbackSessionId(candidate.fileBasename);
   for (const [issueNumber, fileCandidates] of candidatesByIssue) {
     // #2424: resolve by attempt identity before falling back to
     // classify-and-skip (or, for a single candidate, unconditional
@@ -1631,7 +1794,8 @@ export function scanClaudeVendorSessions(
     if (windowVendorSessionId !== undefined) {
       const matching = fileCandidates.filter(
         (candidate) =>
-          resolveCandidateSessionId(candidate) === windowVendorSessionId,
+          resolveCandidateSessionId(candidate.fileBasename) ===
+          windowVendorSessionId,
       );
       if (matching.length === 1) {
         harvestEventWindowCandidate(
@@ -1676,6 +1840,21 @@ export function scanClaudeVendorSessions(
     process.stderr.write(
       `token-cost-harvest: skipping event-window issue #${issueNumber}: matched by more than one project log file (${classification}: ${fileNames.join(', ')})\n`,
     );
+  }
+  // #2432: emit each file's own cwd-derived issue-loop sample now that
+  // every contributor resolution above is final, suppressing only the
+  // exact (file, issue number) pairs confirmed as merged into a
+  // contributor above -- any other cwd-derived sample from the same file
+  // (a different issue number it also touched) is unaffected.
+  for (const pending of pendingCwdSessions) {
+    if (
+      consumedCwdIssueNumbersByBasename
+        .get(pending.fileBasename)
+        ?.has(pending.issueNumber)
+    ) {
+      continue;
+    }
+    out.push(pending.session);
   }
   return out;
 }

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -1189,9 +1189,22 @@ export function buildCompletedIssueWindows(eventWindowsAll, vendor) {
       continue;
     }
     let startMs = cleanup.startMs;
+    // The primary/cleanup-owning session's own full span (union of every
+    // same-vendorSessionId-or-unidentified window, i.e. what `startMs`
+    // would be WITHOUT any claimId-matched contributor) -- kept separate
+    // from `startMs` itself so the cross-session overlap guard below can
+    // compare a contributor against the primary session's REAL activity
+    // range, not just cleanup's own narrow slice.
+    let primaryStartMs = cleanup.startMs;
     for (const [, window] of candidateStages) {
       if (window.startMs <= cleanup.endMs && window.endMs <= cleanup.endMs) {
         startMs = Math.min(startMs, window.startMs);
+        if (
+          window.vendorSessionId === undefined ||
+          window.vendorSessionId === cleanup.vendorSessionId
+        ) {
+          primaryStartMs = Math.min(primaryStartMs, window.startMs);
+        }
       }
     }
     // #2432: a boundary-consistent, claimId-matched window whose own
@@ -1227,13 +1240,15 @@ export function buildCompletedIssueWindows(eventWindowsAll, vendor) {
     // `idd-claim.instructions.md` where two sessions can momentarily
     // share one active claim-id without one being a clean continuation of
     // the other -- treat the whole issue as contaminated, same as a
-    // reversed window above (no sample beats a wrong one). Scoped to
-    // cleanup's own [startMs, endMs) rather than the full widened window,
-    // since only the cleanup-owning session's identity is being compared
-    // against each contributing session's own identity here.
+    // reversed window above (no sample beats a wrong one). Compares each
+    // contributor against the primary session's OWN full span
+    // (`primaryStartMs`..`cleanup.endMs`, every same-session window
+    // unioned), not merely cleanup's own narrow slice -- a contributor
+    // overlapping an earlier same-session stage (e.g. `work`) is just as
+    // much evidence of the race as one overlapping `cleanup` itself.
     const overlaps = (a, b) => a.startMs < b.endMs && b.startMs < a.endMs;
     const overlapCandidates = [
-      { startMs: cleanup.startMs, endMs: cleanup.endMs },
+      { startMs: primaryStartMs, endMs: cleanup.endMs },
       ...contributingWindows,
     ];
     const hasCrossSessionOverlap = overlapCandidates.some((a, i) =>

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -1521,16 +1521,26 @@ export function scanClaudeVendorSessions(
   // decided by the contributing window's own timestamp bounds below, not
   // by which segment they happened to land in.
   const allRecordsByBasename = new Map();
-  // Every issue number any segment of a file resolved via cwd inference
-  // (almost always zero or one entry; #2404 segmentation can add more for
-  // a session that moved across several worktrees in one file). A file
-  // that cwd-resolved to some OTHER issue is never eligible as a
-  // contributor for a DIFFERENT target issue -- matching its own sessionId
-  // is not enough on its own, or a session that briefly touched an
-  // unrelated issue's worktree could have that unrelated activity folded
-  // into this merge (Codex review finding, PR #2627 -- distinct from the
-  // same-issue suppression case above, which this does not affect).
-  const cwdIssueNumbersByBasename = new Map();
+  // Every cwd-attributed segment any file produced (almost always zero or
+  // one; #2404 segmentation can add more for a session that moved across
+  // several worktrees in one file), kept as its own TIME RANGE rather than
+  // just an issue number -- eligibility as a contributor is scoped to
+  // whether some OTHER-issue segment's own time range overlaps the
+  // specific contributing window in question, not whether the file ever
+  // touched a different issue at ANY point in its life. A long-lived file
+  // that visited issue #100 at 00:00-00:10 and then genuinely contributed
+  // to the target issue at 01:00-01:05 must stay eligible for that later
+  // window (Codex review finding, PR #2627).
+  const cwdSegmentsByBasename = new Map();
+  // #2432: a cwd-attributed segment is also a candidate PRIMARY (the
+  // cleanup-owning session is very often launched right inside the issue
+  // worktree it is resuming, so it cwd-resolves like any ordinary session
+  // instead of needing the #2418 unattributed-record fallback at all) --
+  // see the post-scan primary resolution below. Keyed loosely by
+  // (fileBasename, issueNumber, records), not deduplicated against
+  // `eventWindowCandidates` since the two pools are consulted in a
+  // strict, mutually exclusive order (Codex review finding, PR #2627).
+  const cwdAttributedCandidates = [];
   // Per-file `resolveCandidateSessionId` result, computed once per file
   // instead of once per (contributor x file) comparison (Copilot review,
   // PR #2627) -- `extractSessionId` can scan the whole records array.
@@ -1599,13 +1609,25 @@ export function scanClaudeVendorSessions(
         unattributedRecords.push(...segment.records);
       } else {
         anySegmentHadCwdIssueNumber = true;
-        const cwdIssues =
-          cwdIssueNumbersByBasename.get(fileBasename) ?? new Set();
-        cwdIssues.add(cwdIssueNumber);
-        cwdIssueNumbersByBasename.set(fileBasename, cwdIssues);
+        const segmentRange = computeRecordTimeRange(
+          segment.records,
+          extractRecordTimestampMs,
+        );
+        const segments = cwdSegmentsByBasename.get(fileBasename) ?? [];
+        segments.push({
+          issueNumber: cwdIssueNumber,
+          startMs: segmentRange?.minMs ?? Number.NEGATIVE_INFINITY,
+          endMs: segmentRange?.maxMs ?? Number.POSITIVE_INFINITY,
+        });
+        cwdSegmentsByBasename.set(fileBasename, segments);
+        cwdAttributedCandidates.push({
+          fileBasename,
+          issueNumber: cwdIssueNumber,
+          records: segment.records,
+        });
         // #2432: deferred, not pushed yet -- see `pendingCwdSessions`
         // above. Suppressed later only if this exact (file, issue number)
-        // pair is confirmed as a merge contributor.
+        // pair is confirmed as a merge contributor or primary.
         pendingCwdSessions.push({
           fileBasename,
           issueNumber: cwdIssueNumber,
@@ -1683,21 +1705,30 @@ export function scanClaudeVendorSessions(
     const mergedRecords = records.filter(
       (record) => !isOwnedByAContributor(extractRecordTimestampMs(record)),
     );
-    // A candidate file cwd-attributed to some OTHER issue number is never
-    // eligible to lend its records to THIS merge -- a file cwd-attributed
-    // only to THIS same issue (the #2432 same-worktree-handoff case) or to
-    // no issue at all (the pre-#2432 unattributed case) is eligible on a
-    // sessionId match; one cwd-attributed to a different issue is not,
-    // even on a sessionId match (Codex review finding, PR #2627). Unlike a
-    // truly unresolvable contributor below, this is a PERMANENT, structural
-    // disqualification, not a transient gap a later harvest could fix --
-    // so it drops just this one contributor and proceeds, rather than
+    // A candidate file is ineligible to lend its records to THIS
+    // contributing window when some OTHER-issue cwd segment's own time
+    // range overlaps that window -- scoped to the window in question, not
+    // to every issue the file ever touched in its lifetime: a long-lived
+    // file that visited issue #100 earlier and only later, genuinely,
+    // contributed to THIS issue must stay eligible for that later window
+    // (Codex review finding, PR #2627). Unlike a truly unresolvable
+    // contributor below, this is a PERMANENT, structural disqualification
+    // for that one window, not a transient gap a later harvest could fix
+    // -- so it drops just this one contributor and proceeds, rather than
     // skipping the whole issue.
-    const isEligibleContributorFile = (candidateBasename) => {
-      const cwdIssues = cwdIssueNumbersByBasename.get(candidateBasename);
+    const isEligibleContributorFile = (
+      candidateBasename,
+      contributingWindow,
+    ) => {
+      const segments = cwdSegmentsByBasename.get(candidateBasename);
       return (
-        cwdIssues === undefined ||
-        [...cwdIssues].every((cwdIssue) => cwdIssue === issueNumber)
+        segments === undefined ||
+        segments.every(
+          (segment) =>
+            segment.issueNumber === issueNumber ||
+            segment.endMs <= contributingWindow.startMs ||
+            segment.startMs >= contributingWindow.endMs,
+        )
       );
     };
     for (const contributing of contributingWindows) {
@@ -1717,9 +1748,9 @@ export function scanClaudeVendorSessions(
         return;
       }
       const [contributingBasename, candidateRecords] = sessionIdMatches[0];
-      if (!isEligibleContributorFile(contributingBasename)) {
+      if (!isEligibleContributorFile(contributingBasename, contributing)) {
         process.stderr.write(
-          `token-cost-harvest: dropping contributing session ${contributing.vendorSessionId} for issue #${issueNumber}: its file (${contributingBasename}) is cwd-attributed to a different issue -- proceeding without this contributor\n`,
+          `token-cost-harvest: dropping contributing session ${contributing.vendorSessionId} for issue #${issueNumber}: its file (${contributingBasename}) has a different issue's cwd segment overlapping this contributing window -- proceeding without this contributor\n`,
         );
         continue;
       }
@@ -1755,6 +1786,15 @@ export function scanClaudeVendorSessions(
         adapterResult: eventWindowResult,
         timeline: extractClaudeUsageTimeline(mergedRecords),
       });
+      // #2432: suppress the primary file's own plain cwd-derived sample
+      // too, not just contributors' -- a no-op for the pre-#2432,
+      // event-window-fallback primary (which never had one), but required
+      // once a cwd-attributed file can itself be selected as primary (see
+      // the post-scan resolution below).
+      const consumedPrimary =
+        consumedCwdIssueNumbersByBasename.get(fileBasename) ?? new Set();
+      consumedPrimary.add(issueNumber);
+      consumedCwdIssueNumbersByBasename.set(fileBasename, consumedPrimary);
     } catch (error) {
       process.stderr.write(
         `token-cost-harvest: skipping event-window issue #${issueNumber}: ${error.message}\n`,
@@ -1780,6 +1820,13 @@ export function scanClaudeVendorSessions(
       completedIssueWindowByIssue.set(window.issueNumber, window);
     }
   }
+  // #2432/Codex review (PR #2627): tracks which issue numbers this loop
+  // actually resolved a primary for -- distinct from `candidatesByIssue`
+  // merely HAVING an entry, since a contributor's own stray unattributed
+  // records can time-match this pool without ever resolving (its sessionId
+  // never matches cleanup's own). The post-scan cwd-attributed-primary
+  // step below must still run for such an issue.
+  const resolvedViaEventWindowFallback = new Set();
   for (const [issueNumber, fileCandidates] of candidatesByIssue) {
     // #2424: resolve by attempt identity before falling back to
     // classify-and-skip (or, for a single candidate, unconditional
@@ -1798,6 +1845,7 @@ export function scanClaudeVendorSessions(
           windowVendorSessionId,
       );
       if (matching.length === 1) {
+        resolvedViaEventWindowFallback.add(issueNumber);
         harvestEventWindowCandidate(
           issueNumber,
           matching[0].fileBasename,
@@ -1812,6 +1860,7 @@ export function scanClaudeVendorSessions(
         continue;
       }
     } else if (fileCandidates.length === 1) {
+      resolvedViaEventWindowFallback.add(issueNumber);
       harvestEventWindowCandidate(
         issueNumber,
         fileCandidates[0].fileBasename,
@@ -1839,6 +1888,54 @@ export function scanClaudeVendorSessions(
       : 'disjoint activity ranges -- resolvable once events carry session identity, #2424';
     process.stderr.write(
       `token-cost-harvest: skipping event-window issue #${issueNumber}: matched by more than one project log file (${classification}: ${fileNames.join(', ')})\n`,
+    );
+  }
+  // #2432/Codex review (PR #2627): a completed issue window whose primary
+  // (cleanup-owning) session was itself launched inside the target issue's
+  // own worktree cwd-resolves normally and so is EXCLUDED from
+  // `eventWindowCandidates` above (that pool is reserved for
+  // cwd-inference-failed files, to avoid a false PRIMARY duplicate -- see
+  // the comment where `eventWindowCandidates` is populated). Such an issue
+  // is therefore never actually RESOLVED by the loop above -- even when a
+  // contributor's own stray unattributed records happen to time-match the
+  // (widened) window and land in `candidatesByIssue` regardless, that
+  // resolution fails on the sessionId mismatch and is skipped, which is
+  // exactly why `resolvedViaEventWindowFallback` (set only on a genuine
+  // success above), not `candidatesByIssue.has(...)`, is the right guard
+  // here. Without this step a genuine claim-id-matched contributor's usage
+  // would otherwise never be merged at all, even though `contributingWindows`
+  // correctly identified it. Resolve those here: only when the issue has a
+  // genuine contributor to merge (an issue with none is already handled
+  // correctly by the file's own plain cwd-derived sample, untouched).
+  for (const window of completedIssueWindows) {
+    if (
+      resolvedViaEventWindowFallback.has(window.issueNumber) ||
+      window.vendorSessionId === undefined ||
+      !window.contributingWindows ||
+      window.contributingWindows.length === 0
+    ) {
+      continue;
+    }
+    const matches = cwdAttributedCandidates.filter(
+      (candidate) =>
+        candidate.issueNumber === window.issueNumber &&
+        resolveCandidateSessionId(candidate.fileBasename) ===
+          window.vendorSessionId,
+    );
+    if (matches.length !== 1) {
+      process.stderr.write(
+        `token-cost-harvest: skipping cwd-attributed primary resolution for issue #${window.issueNumber}: ${
+          matches.length === 0
+            ? 'no matching cwd-attributed segment found'
+            : `matched more than one segment (${matches.map((m) => m.fileBasename).join(', ')})`
+        } -- its plain cwd-derived sample (if any) is unaffected\n`,
+      );
+      continue;
+    }
+    harvestEventWindowCandidate(
+      window.issueNumber,
+      matches[0].fileBasename,
+      matches[0].records,
     );
   }
   // #2432: emit each file's own cwd-derived issue-loop sample now that

--- a/src/scripts/token-cost-adapter-claude.mts
+++ b/src/scripts/token-cost-adapter-claude.mts
@@ -458,7 +458,8 @@ function asClaudeHarvestInput(input: unknown): ClaudeHarvestInput {
       ? input.issueNumberOverride
       : undefined;
   const vendorSessionIdOverride =
-    typeof input.vendorSessionIdOverride === 'string'
+    typeof input.vendorSessionIdOverride === 'string' &&
+    input.vendorSessionIdOverride.length > 0
       ? input.vendorSessionIdOverride
       : undefined;
   return {

--- a/src/scripts/token-cost-adapter-claude.mts
+++ b/src/scripts/token-cost-adapter-claude.mts
@@ -112,6 +112,18 @@ export interface ClaudeHarvestInput {
    * fallback paths are never combined on the same harvest() call.
    */
   issueNumberOverride?: number;
+  /**
+   * #2432: pins the resulting sample's identity to a specific vendor
+   * session id, bypassing `extractSessionId(records) ??
+   * deriveFallbackSessionId(fileBasename)` outright. For a merged
+   * cross-session handoff harvest, `records` carries lines from more than
+   * one project JSONL file concatenated together -- `extractSessionId`'s
+   * "first non-empty `sessionId` in file order" scan would then pick
+   * whichever file's own id happens to sort first in the merged array,
+   * not necessarily the primary (winning `cleanup`) session's own id.
+   * Set this explicitly instead of relying on record order.
+   */
+  vendorSessionIdOverride?: string;
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -445,22 +457,34 @@ function asClaudeHarvestInput(input: unknown): ClaudeHarvestInput {
     typeof input.issueNumberOverride === 'number'
       ? input.issueNumberOverride
       : undefined;
+  const vendorSessionIdOverride =
+    typeof input.vendorSessionIdOverride === 'string'
+      ? input.vendorSessionIdOverride
+      : undefined;
   return {
     records: input.records,
     fileBasename,
     segmentIndex,
     issueNumberOverride,
+    vendorSessionIdOverride,
   };
 }
 
 /** Claude Code vendor adapter. `input` must satisfy {@link ClaudeHarvestInput}. */
 export const claudeAdapter: TokenCostVendorAdapter = {
   harvest(input: unknown): TokenCostAdapterResult {
-    const { records, fileBasename, segmentIndex, issueNumberOverride } =
-      asClaudeHarvestInput(input);
+    const {
+      records,
+      fileBasename,
+      segmentIndex,
+      issueNumberOverride,
+      vendorSessionIdOverride,
+    } = asClaudeHarvestInput(input);
 
     const vendorSessionId = deriveVendorSessionId(
-      extractSessionId(records) ?? deriveFallbackSessionId(fileBasename),
+      vendorSessionIdOverride ??
+        extractSessionId(records) ??
+        deriveFallbackSessionId(fileBasename),
       segmentIndex,
       issueNumberOverride,
     );

--- a/src/scripts/token-cost-core.mts
+++ b/src/scripts/token-cost-core.mts
@@ -102,6 +102,8 @@ export interface TokenCostEvent {
   at: string;
   vendor: TokenCostVendor;
   vendorSessionId?: string | null;
+  /** The active IDD {claim-id} when this event is claim-scoped (#2432). Positive evidence that two differently-vendorSessionId'd stage windows for the same issue belong to one continuous claim lineage. */
+  claimId?: string | null;
   issueNumber?: number | null;
   usage?: TokenCostUsage | null;
 }

--- a/src/scripts/token-cost-event.mts
+++ b/src/scripts/token-cost-event.mts
@@ -140,6 +140,13 @@ export function buildEvent(
     }
     event.issueNumber = issueNumber;
   }
+  const claimIdRaw = values['claim-id'];
+  if (claimIdRaw !== undefined) {
+    if (typeof claimIdRaw !== 'string' || claimIdRaw.length === 0) {
+      throw new Error('--claim-id must be a single, non-empty value');
+    }
+    event.claimId = claimIdRaw;
+  }
   return event;
 }
 
@@ -172,11 +179,10 @@ const TOKEN_COST_EVENT_FLAG_SPEC = {
   '--exit': { type: 'boolean', default: false },
   '--issue': { type: 'string' },
   '--vendor': { type: 'string' },
-  // Accepted for CLI-surface symmetry with the calling convention this
-  // issue's own sketch shows -- not persisted, since
-  // schemas/token-cost-event.schema.json has no field for an IDD claim id
-  // (distinct from vendorSessionId, the AI vendor's own session
-  // identifier).
+  // The active IDD {claim-id} (distinct from vendorSessionId, the AI
+  // vendor's own session identifier), when this event is claim-scoped
+  // (#2432). Positive evidence a later harvest can use to merge a
+  // legitimate cross-session handoff's usage.
   '--claim-id': { type: 'string' },
   '--out': { type: 'string' },
   '--strict': { type: 'boolean', default: false },
@@ -194,8 +200,8 @@ function printHelp(): void {
   --enter / --exit   Exactly one is required.
   --issue <n>        Issue number, when this event is issue-scoped.
   --vendor <v>       Agent vendor: grok, claude, or codex. Required.
-  --claim-id <id>    Accepted for calling-convention symmetry; not
-                      persisted (no schema field for it).
+  --claim-id <id>    The active IDD {claim-id}, when this event is
+                     claim-scoped (persisted as claimId, #2432).
   --out <path>       JSONL append target (default:
                      \${XDG_STATE_HOME:-$HOME/.local/state}/idd-skill/token-cost/events.jsonl).
   --strict           Exit non-zero on any failure instead of the default

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -983,6 +983,24 @@ interface AttemptCandidate {
  * forever, since the resulting window's own stable `#ew<issueNumber>` id
  * makes a later harvest treat it as already-present (Codex review
  * finding, PR #2430).
+ *
+ * #2432/Codex review (PR #2627): absent an exact-session match, a
+ * candidate sharing `cleanup`'s own `claimId` is preferred over the plain
+ * recency-based `bestIdentified`/legacy comparison above -- claimId, once
+ * matched, is this repository's own ground-truth ownership token for
+ * "same claim lineage, possibly handed off across sessions," so it must
+ * outrank a merely-more-recent but unrelated attempt at the same bareKey.
+ * Without this tier, a single stray same-stage event from ANY differently-
+ * or un-identified attempt (an unrelated concurrent session, an aborted
+ * retry) could win purely on `endMs` and get returned instead of the
+ * genuine claim-linked candidate -- which `buildCompletedIssueWindows`'s
+ * `idCompatible` would then exclude outright, silently defeating claim-id
+ * recovery before it ever runs. This tier does not close every residual:
+ * if the earlier handoff session and the winning `cleanup` session both
+ * post the identical stage id (a redundant re-post, not the common
+ * disjoint-stage handoff shape), only one window survives per bareKey --
+ * a documented limitation, not a regression, since neither pre-#2424 nor
+ * pre-#2432 behavior could recover it either.
  */
 export function readEventWindows(path: string): Map<string, StageEventWindow> {
   const result = new Map<string, StageEventWindow>();
@@ -1116,6 +1134,7 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
   const resolveWindow = (
     key: string,
     preferredVendorSessionId: string | undefined,
+    preferredClaimId: string | undefined,
   ): StageEventWindow | undefined => {
     const candidates = attemptCandidates(key);
     if (preferredVendorSessionId !== undefined) {
@@ -1136,6 +1155,31 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
     const valid = candidates.filter(
       (candidate) => candidate.startMs < candidate.endMs,
     );
+    // #2432/Codex review (PR #2627): no exact-session match above means
+    // this stage was posted by some OTHER process than cleanup's own --
+    // among those, a candidate sharing cleanup's own claimId is the SAME
+    // claim lineage (a genuine handoff contributor) and must not be
+    // shadowed by an unrelated, differently- or un-identified attempt
+    // that merely happens to have a later `endMs`. Without this, a single
+    // stray same-stage event from any unrelated attempt would silently
+    // defeat claim-id recovery entirely, before `idCompatible` ever gets
+    // a chance to run.
+    const claimMatched =
+      preferredClaimId !== undefined
+        ? valid.filter((candidate) => candidate.claimId === preferredClaimId)
+        : [];
+    const claimPreferred =
+      claimMatched.length > 0
+        ? claimMatched.reduce((a, b) => (b.endMs > a.endMs ? b : a))
+        : undefined;
+    if (claimPreferred) {
+      return {
+        startMs: claimPreferred.startMs,
+        endMs: claimPreferred.endMs,
+        vendorSessionId: claimPreferred.vendorSessionId,
+        claimId: claimPreferred.claimId as string,
+      };
+    }
     const bestIdentified =
       valid.length > 0
         ? valid.reduce((a, b) => (b.endMs > a.endMs ? b : a))
@@ -1217,7 +1261,7 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
 
   for (const prefix of issueVendorPrefixes) {
     const cleanupKey = `${prefix}:cleanup`;
-    const cleanupWindow = resolveWindow(cleanupKey, undefined);
+    const cleanupWindow = resolveWindow(cleanupKey, undefined, undefined);
     if (cleanupWindow) {
       result.set(cleanupKey, cleanupWindow);
     }
@@ -1226,7 +1270,11 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
         continue;
       }
       const key = `${prefix}:${stageId}`;
-      const window = resolveWindow(key, cleanupWindow?.vendorSessionId);
+      const window = resolveWindow(
+        key,
+        cleanupWindow?.vendorSessionId,
+        cleanupWindow?.claimId,
+      );
       if (window) {
         result.set(key, window);
       }
@@ -1264,14 +1312,28 @@ export interface CompletedIssueWindow {
   /** The winning `cleanup` window's own claimId (#2432), when known. */
   claimId?: string;
   /**
-   * Other sessions (by vendorSessionId, one entry each, ranges unioned
-   * across every one of that session's own qualifying stage windows)
-   * whose usage a genuine claim-id-matched handoff should also pull in
-   * from their OWN file -- see `scanClaudeVendorSessions`. Present only
-   * when at least one non-cleanup window was admitted via the claimId
-   * branch of `idCompatible` (a different vendorSessionId than
-   * `cleanup`'s own). Absent for a single-session completed window,
-   * exactly as before #2432.
+   * The primary (cleanup-owning) session's own qualifying stage windows
+   * -- cleanup itself plus every boundary-consistent, same-vendorSessionId
+   * -or-unidentified stage -- kept as INDIVIDUAL windows, never unioned
+   * into one enclosing span. `scanClaudeVendorSessions` filters the
+   * primary file's own records against this set (a record must fall
+   * inside at least one of these windows to count), and the cross-session
+   * overlap guard below compares these same individual windows against
+   * each contributor's -- an enclosing span would falsely "overlap" a
+   * contributor sandwiched inside an idle gap between two of the
+   * primary's own stages (Copilot review finding round on PR #2627, #2432).
+   */
+  primaryWindows: { startMs: number; endMs: number }[];
+  /**
+   * Other sessions' own qualifying stage windows, one entry PER admitted
+   * stage (never unioned or deduplicated by vendorSessionId -- the same
+   * reasoning as `primaryWindows` above: a consumer groups entries by
+   * `vendorSessionId` when resolving which file to pull from, but must
+   * keep each stage's own individual bounds for both record filtering and
+   * the overlap guard). Present only when at least one non-cleanup window
+   * was admitted via the claimId branch of `idCompatible` (a different
+   * vendorSessionId than `cleanup`'s own). Absent for a single-session
+   * completed window, exactly as before #2432.
    */
   contributingWindows?: {
     vendorSessionId: string;
@@ -1454,54 +1516,68 @@ export function buildCompletedIssueWindows(
     if (hasContaminatedStage) {
       continue;
     }
+    // Named once, reused by the `startMs`/`primaryWindows` widening loop
+    // below and by the `contributingWindows` loop after it, so a future
+    // change to either predicate can't silently desync the two (Copilot
+    // review, PR #2627).
+    const isBoundaryConsistent = (window: StageEventWindow): boolean =>
+      window.startMs <= cleanup.endMs && window.endMs <= cleanup.endMs;
+    const isSameSessionOrUnidentified = (window: StageEventWindow): boolean =>
+      window.vendorSessionId === undefined ||
+      window.vendorSessionId === cleanup.vendorSessionId;
     let startMs = cleanup.startMs;
-    // The primary/cleanup-owning session's own full span (union of every
-    // same-vendorSessionId-or-unidentified window, i.e. what `startMs`
-    // would be WITHOUT any claimId-matched contributor) -- kept separate
-    // from `startMs` itself so the cross-session overlap guard below can
-    // compare a contributor against the primary session's REAL activity
-    // range, not just cleanup's own narrow slice.
-    let primaryStartMs = cleanup.startMs;
+    // The primary/cleanup-owning session's own INDIVIDUAL stage windows
+    // (every same-vendorSessionId-or-unidentified window, boundary
+    // consistent) -- kept as separate intervals rather than one enclosing
+    // span, so the cross-session overlap guard below can tell a real
+    // overlap apart from a contributor's window merely falling inside a
+    // GAP between two of the primary session's own disjoint stages (e.g.
+    // an A -> B -> A handoff, where A owns an early stage plus the later
+    // `cleanup` and B owns an intervening stage that never actually
+    // touches either of A's own windows).
+    const primaryWindows: { startMs: number; endMs: number }[] = [];
     for (const [, window] of candidateStages) {
-      if (window.startMs <= cleanup.endMs && window.endMs <= cleanup.endMs) {
+      if (isBoundaryConsistent(window)) {
         startMs = Math.min(startMs, window.startMs);
-        if (
-          window.vendorSessionId === undefined ||
-          window.vendorSessionId === cleanup.vendorSessionId
-        ) {
-          primaryStartMs = Math.min(primaryStartMs, window.startMs);
+        if (isSameSessionOrUnidentified(window)) {
+          primaryWindows.push({
+            startMs: window.startMs,
+            endMs: window.endMs,
+          });
         }
       }
     }
     // #2432: a boundary-consistent, claimId-matched window whose own
     // vendorSessionId differs from cleanup's own is a genuine
-    // contributing session -- union its range with any sibling windows
-    // sharing the same vendorSessionId (one earlier session can post more
-    // than one qualifying stage) into a single contribution.
-    const contributingRanges = new Map<
-      string,
-      { startMs: number; endMs: number }
-    >();
+    // contributing session. Kept as INDIVIDUAL per-stage windows -- never
+    // unioned into one enclosing range per vendorSessionId -- for the same
+    // reason `primaryWindows` above is: a contributing session's own two
+    // stages can themselves be non-adjacent (e.g. an early `work` and a
+    // much later `review`), and a union would falsely "overlap" the
+    // primary session's own unrelated activity that merely falls inside
+    // that GAP, or pull that gap's unrelated records into the merge.
+    const contributingWindows: {
+      vendorSessionId: string;
+      startMs: number;
+      endMs: number;
+    }[] = [];
     for (const [stageId, window] of candidateStages) {
       if (
         stageId === 'cleanup' ||
-        window.vendorSessionId === undefined ||
-        window.vendorSessionId === cleanup.vendorSessionId ||
-        !(window.startMs <= cleanup.endMs && window.endMs <= cleanup.endMs)
+        isSameSessionOrUnidentified(window) ||
+        !isBoundaryConsistent(window)
       ) {
         continue;
       }
-      const existing = contributingRanges.get(window.vendorSessionId);
-      contributingRanges.set(window.vendorSessionId, {
-        startMs: existing
-          ? Math.min(existing.startMs, window.startMs)
-          : window.startMs,
-        endMs: existing ? Math.max(existing.endMs, window.endMs) : window.endMs,
+      contributingWindows.push({
+        // Guaranteed non-undefined here: `isSameSessionOrUnidentified`
+        // already returned false, so `window.vendorSessionId` must be a
+        // defined string that differs from `cleanup.vendorSessionId`.
+        vendorSessionId: window.vendorSessionId as string,
+        startMs: window.startMs,
+        endMs: window.endMs,
       });
     }
-    const contributingWindows = [...contributingRanges].map(
-      ([vendorSessionId, range]) => ({ vendorSessionId, ...range }),
-    );
     // Cross-session overlap guard: a genuine sequential handoff never
     // produces overlapping activity between two different sessions. Two
     // claim-id-matched windows from DIFFERENT vendorSessionIds that DO
@@ -1510,22 +1586,33 @@ export function buildCompletedIssueWindows(
     // share one active claim-id without one being a clean continuation of
     // the other -- treat the whole issue as contaminated, same as a
     // reversed window above (no sample beats a wrong one). Compares each
-    // contributor against the primary session's OWN full span
-    // (`primaryStartMs`..`cleanup.endMs`, every same-session window
-    // unioned), not merely cleanup's own narrow slice -- a contributor
-    // overlapping an earlier same-session stage (e.g. `work`) is just as
-    // much evidence of the race as one overlapping `cleanup` itself.
+    // contributor against the primary session's own INDIVIDUAL stage
+    // windows (`primaryWindows`), not one enclosing span from its
+    // earliest stage to `cleanup.endMs` -- an enclosing span would falsely
+    // flag a legitimate A -> B -> A handoff, where B's own window merely
+    // falls inside the GAP between two of A's own disjoint stages
+    // (Codex review finding, PR #2627).
+    // Deliberately its own local closure, not a reuse of `rangesOverlap`
+    // below: that one compares closed `[min, max]` RecordTimeRanges (real
+    // observed record timestamps), while this compares half-open
+    // `[startMs, endMs)` stage windows (the same convention
+    // `segmentRecordsByEventWindow` uses) -- the boundary is strict `<`
+    // here, not `rangesOverlap`'s inclusive `<=`, because two windows
+    // merely touching at a shared instant is not a genuine overlap under
+    // that convention.
     const overlaps = (
       a: { startMs: number; endMs: number },
       b: { startMs: number; endMs: number },
     ): boolean => a.startMs < b.endMs && b.startMs < a.endMs;
-    const overlapCandidates = [
-      { startMs: primaryStartMs, endMs: cleanup.endMs },
-      ...contributingWindows,
-    ];
-    const hasCrossSessionOverlap = overlapCandidates.some((a, i) =>
-      overlapCandidates.some((b, j) => i < j && overlaps(a, b)),
-    );
+    const hasCrossSessionOverlap =
+      contributingWindows.some((contributing) =>
+        primaryWindows.some((primaryWindow) =>
+          overlaps(primaryWindow, contributing),
+        ),
+      ) ||
+      contributingWindows.some((a, i) =>
+        contributingWindows.some((b, j) => i < j && overlaps(a, b)),
+      );
     if (hasCrossSessionOverlap) {
       continue;
     }
@@ -1533,6 +1620,7 @@ export function buildCompletedIssueWindows(
       issueNumber,
       startMs,
       endMs: cleanup.endMs,
+      primaryWindows,
       ...(cleanup.vendorSessionId !== undefined
         ? { vendorSessionId: cleanup.vendorSessionId }
         : {}),
@@ -1735,13 +1823,58 @@ export function scanClaudeVendorSessions(
     issueNumber: number;
     records: unknown[];
   }[] = [];
-  // #2432: each file's own unattributed records (cwd-inference failed for
-  // every segment), cached for a later contributingWindows lookup --
-  // scoped to the SAME pool eventWindowCandidates itself draws from, so a
-  // file that already independently produced its own cwd-attributed
-  // sample for some OTHER issue is never re-absorbed into a merged #ew
-  // sample here.
-  const unattributedRecordsByBasename = new Map<string, unknown[]>();
+  // #2432: every file's own FULL record set (regardless of whether any
+  // segment resolved a cwd issue number), cached for a later
+  // contributingWindows lookup -- a genuine handoff session is very often
+  // launched right inside the issue worktree it is resuming, so its own
+  // records typically already carry a cwd-attributed segment for the
+  // exact issue being merged. Restricting this pool to unattributed-only
+  // records (the pre-#2432 #2418 scoping) would make such a session
+  // permanently unresolvable as a contributor (Codex review finding, PR
+  // #2627); which of its records actually belong to the merge is instead
+  // decided by the contributing window's own timestamp bounds below, not
+  // by which segment they happened to land in.
+  const allRecordsByBasename = new Map<string, unknown[]>();
+  // Every issue number any segment of a file resolved via cwd inference
+  // (almost always zero or one entry; #2404 segmentation can add more for
+  // a session that moved across several worktrees in one file). A file
+  // that cwd-resolved to some OTHER issue is never eligible as a
+  // contributor for a DIFFERENT target issue -- matching its own sessionId
+  // is not enough on its own, or a session that briefly touched an
+  // unrelated issue's worktree could have that unrelated activity folded
+  // into this merge (Codex review finding, PR #2627 -- distinct from the
+  // same-issue suppression case above, which this does not affect).
+  const cwdIssueNumbersByBasename = new Map<string, Set<number>>();
+  // Per-file `resolveCandidateSessionId` result, computed once per file
+  // instead of once per (contributor x file) comparison (Copilot review,
+  // PR #2627) -- `extractSessionId` can scan the whole records array.
+  const sessionIdByBasename = new Map<string, string | undefined>();
+  const resolveCandidateSessionId = (
+    fileBasename: string,
+  ): string | undefined => {
+    if (sessionIdByBasename.has(fileBasename)) {
+      return sessionIdByBasename.get(fileBasename);
+    }
+    const resolved =
+      extractSessionId(allRecordsByBasename.get(fileBasename) ?? []) ??
+      deriveFallbackSessionId(fileBasename);
+    sessionIdByBasename.set(fileBasename, resolved);
+    return resolved;
+  };
+  // #2432: a file's own cwd-derived issue-loop sample(s) whose issue
+  // number turns out to match a confirmed merge target are suppressed
+  // (not pushed to `out`) once that file is resolved as a contributor for
+  // that SAME issue number, so its usage is counted exactly once -- via
+  // the merged `#ew<issueNumber>` sample -- instead of also standing on
+  // its own. A cwd-derived sample for any OTHER issue number is never
+  // touched. Pushing is therefore deferred until every contributor
+  // resolution below has run.
+  const pendingCwdSessions: {
+    fileBasename: string;
+    issueNumber: number;
+    session: VendorSession;
+  }[] = [];
+  const consumedCwdIssueNumbersByBasename = new Map<string, Set<number>>();
   for (const file of files) {
     let records: unknown[];
     try {
@@ -1753,6 +1886,7 @@ export function scanClaudeVendorSessions(
       continue;
     }
     const fileBasename = basename(file);
+    allRecordsByBasename.set(fileBasename, records);
     const segments = segmentRecordsByCwd(records);
     const unattributedRecords: unknown[] = [];
     let anySegmentHadCwdIssueNumber = false;
@@ -1774,30 +1908,47 @@ export function scanClaudeVendorSessions(
         );
         return;
       }
-      out.push({
+      const session: VendorSession = {
         vendor: 'claude',
         adapterResult,
         timeline: extractClaudeUsageTimeline(segment.records),
-      });
-      if (adapterResult.joinHints?.issueNumber === undefined) {
+      };
+      const cwdIssueNumber = adapterResult.joinHints?.issueNumber;
+      if (cwdIssueNumber === undefined) {
+        out.push(session);
         unattributedRecords.push(...segment.records);
       } else {
         anySegmentHadCwdIssueNumber = true;
+        const cwdIssues =
+          cwdIssueNumbersByBasename.get(fileBasename) ?? new Set<number>();
+        cwdIssues.add(cwdIssueNumber);
+        cwdIssueNumbersByBasename.set(fileBasename, cwdIssues);
+        // #2432: deferred, not pushed yet -- see `pendingCwdSessions`
+        // above. Suppressed later only if this exact (file, issue number)
+        // pair is confirmed as a merge contributor.
+        pendingCwdSessions.push({
+          fileBasename,
+          issueNumber: cwdIssueNumber,
+          session,
+        });
       }
     });
 
-    // Only fall back to event-window attribution when NO segment in this
-    // file resolved a cwd-inferred issue number. Otherwise a segment
-    // whose cwd merely isn't issue-shaped (an ordinary subdirectory, not
-    // a worktree move) but whose records still happen to fall inside a
-    // DIFFERENT segment's already cwd-attributed issue window would
-    // produce a second, independent issue-loop sample for that same
-    // issue -- splitting one completed loop's usage across two samples
-    // that markAmbiguousOverlaps has no reason to catch (their time
-    // ranges don't overlap; they're just both attributed to the same
-    // issue).
+    // Only fall back to event-window attribution (for PRIMARY/cleanup-file
+    // selection) when NO segment in this file resolved a cwd-inferred
+    // issue number. Otherwise a segment whose cwd merely isn't
+    // issue-shaped (an ordinary subdirectory, not a worktree move) but
+    // whose records still happen to fall inside a DIFFERENT segment's
+    // already cwd-attributed issue window would produce a second,
+    // independent issue-loop sample for that same issue -- splitting one
+    // completed loop's usage across two samples that markAmbiguousOverlaps
+    // has no reason to catch (their time ranges don't overlap; they're
+    // just both attributed to the same issue). This restriction applies
+    // only to PRIMARY selection: a file excluded here can still be found
+    // as a claim-id-matched CONTRIBUTOR via `allRecordsByBasename` above,
+    // which is never restricted this way (Codex review finding, PR
+    // #2627).
     if (!anySegmentHadCwdIssueNumber && unattributedRecords.length > 0) {
-      unattributedRecordsByBasename.set(fileBasename, unattributedRecords);
       if (completedIssueWindows.length > 0) {
         const eventWindowGroups = segmentRecordsByEventWindow(
           unattributedRecords,
@@ -1828,42 +1979,78 @@ export function scanClaudeVendorSessions(
 
   // #2432: pull each confirmed contributing session's own file's records
   // (restricted to that session's own qualifying window bounds) into the
-  // primary file's own records, one merged harvest() call per issue.
-  // Never a partial-issue failure: a contribution whose own file can't be
-  // uniquely resolved is skipped (stderr diagnostic), keeping the
-  // primary-only, narrower-but-safe harvest instead of dropping the whole
-  // issue's sample.
+  // primary file's own records, one merged harvest() call per issue. A
+  // contribution whose own file can't be uniquely resolved skips the
+  // WHOLE issue rather than emitting a primary-only sample under the
+  // stable `#ew<issueNumber>` id: the CLI's append-side `vendorSessionKey`
+  // dedup treats that key as already-present on every later run, which
+  // would otherwise permanently freeze exactly the undercount this
+  // feature exists to fix, once the missing contributor becomes available
+  // (Codex review finding, PR #2627).
   const harvestEventWindowCandidate = (
     issueNumber: number,
     fileBasename: string,
     records: unknown[],
   ): void => {
-    const vendorSessionIdOverride = resolveCandidateSessionId({
-      fileBasename,
-      records,
-    });
+    const vendorSessionIdOverride = resolveCandidateSessionId(fileBasename);
     const contributingWindows =
       completedIssueWindowByIssue.get(issueNumber)?.contributingWindows ?? [];
-    const mergedRecords = [...records];
-    for (const contributing of contributingWindows) {
-      const matches = [...unattributedRecordsByBasename].filter(
-        ([candidateBasename, candidateRecords]) =>
-          resolveCandidateSessionId({
-            fileBasename: candidateBasename,
-            records: candidateRecords,
-          }) === contributing.vendorSessionId,
+    // #2432/Codex review (PR #2627): the primary candidate's own `records`
+    // were selected against the OVERALL (already-widened) issue window,
+    // so they can include this same file's unrelated activity that
+    // happens to fall inside a time range a confirmed contributor already
+    // owns. Drop those before merging in the contributors' own records,
+    // so that time is charged exactly once.
+    const isOwnedByAContributor = (atMs: number | undefined): boolean =>
+      atMs !== undefined &&
+      contributingWindows.some(
+        (contributing) =>
+          atMs >= contributing.startMs && atMs < contributing.endMs,
       );
-      if (matches.length !== 1) {
+    const mergedRecords = records.filter(
+      (record) => !isOwnedByAContributor(extractRecordTimestampMs(record)),
+    );
+    // A candidate file cwd-attributed to some OTHER issue number is never
+    // eligible to lend its records to THIS merge -- a file cwd-attributed
+    // only to THIS same issue (the #2432 same-worktree-handoff case) or to
+    // no issue at all (the pre-#2432 unattributed case) is eligible on a
+    // sessionId match; one cwd-attributed to a different issue is not,
+    // even on a sessionId match (Codex review finding, PR #2627). Unlike a
+    // truly unresolvable contributor below, this is a PERMANENT, structural
+    // disqualification, not a transient gap a later harvest could fix --
+    // so it drops just this one contributor and proceeds, rather than
+    // skipping the whole issue.
+    const isEligibleContributorFile = (candidateBasename: string): boolean => {
+      const cwdIssues = cwdIssueNumbersByBasename.get(candidateBasename);
+      return (
+        cwdIssues === undefined ||
+        [...cwdIssues].every((cwdIssue) => cwdIssue === issueNumber)
+      );
+    };
+    for (const contributing of contributingWindows) {
+      const sessionIdMatches = [...allRecordsByBasename].filter(
+        ([candidateBasename]) =>
+          resolveCandidateSessionId(candidateBasename) ===
+          contributing.vendorSessionId,
+      );
+      if (sessionIdMatches.length !== 1) {
         process.stderr.write(
-          `token-cost-harvest: skipping contributing session ${contributing.vendorSessionId} for issue #${issueNumber}: ${
-            matches.length === 0
-              ? 'no matching file found'
-              : `matched more than one file (${matches.map(([b]) => b).join(', ')})`
-          }\n`,
+          `token-cost-harvest: skipping issue #${issueNumber} entirely: contributing session ${contributing.vendorSessionId} ${
+            sessionIdMatches.length === 0
+              ? 'has no matching file'
+              : `matched more than one file (${sessionIdMatches.map(([b]) => b).join(', ')})`
+          } -- emitting a primary-only sample would freeze an undercount under a stable id\n`,
+        );
+        return;
+      }
+      const [contributingBasename, candidateRecords] = sessionIdMatches[0];
+      if (!isEligibleContributorFile(contributingBasename)) {
+        process.stderr.write(
+          `token-cost-harvest: dropping contributing session ${contributing.vendorSessionId} for issue #${issueNumber}: its file (${contributingBasename}) is cwd-attributed to a different issue -- proceeding without this contributor\n`,
         );
         continue;
       }
-      const [, candidateRecords] = matches[0];
+      let contributorHadRecords = false;
       for (const record of candidateRecords) {
         const atMs = extractRecordTimestampMs(record);
         if (
@@ -1872,7 +2059,15 @@ export function scanClaudeVendorSessions(
           atMs < contributing.endMs
         ) {
           mergedRecords.push(record);
+          contributorHadRecords = true;
         }
+      }
+      if (contributorHadRecords) {
+        const consumed =
+          consumedCwdIssueNumbersByBasename.get(contributingBasename) ??
+          new Set<number>();
+        consumed.add(issueNumber);
+        consumedCwdIssueNumbersByBasename.set(contributingBasename, consumed);
       }
     }
     try {
@@ -1916,19 +2111,6 @@ export function scanClaudeVendorSessions(
       completedIssueWindowByIssue.set(window.issueNumber, window);
     }
   }
-  // #2424/Copilot review (PR #2430): a candidate's own session id must
-  // fall back to its file basename exactly like `claudeAdapter.harvest()`
-  // itself does -- `extractSessionId()` alone returns `undefined` for a
-  // record shape lacking a top-level `sessionId` field (already
-  // fixture-covered for the adapter's own vendorSessionId derivation),
-  // which would otherwise never match a defined `windowVendorSessionId`
-  // even when the file is genuinely the right one.
-  const resolveCandidateSessionId = (candidate: {
-    fileBasename: string;
-    records: unknown[];
-  }): string | undefined =>
-    extractSessionId(candidate.records) ??
-    deriveFallbackSessionId(candidate.fileBasename);
   for (const [issueNumber, fileCandidates] of candidatesByIssue) {
     // #2424: resolve by attempt identity before falling back to
     // classify-and-skip (or, for a single candidate, unconditional
@@ -1943,7 +2125,8 @@ export function scanClaudeVendorSessions(
     if (windowVendorSessionId !== undefined) {
       const matching = fileCandidates.filter(
         (candidate) =>
-          resolveCandidateSessionId(candidate) === windowVendorSessionId,
+          resolveCandidateSessionId(candidate.fileBasename) ===
+          windowVendorSessionId,
       );
       if (matching.length === 1) {
         harvestEventWindowCandidate(
@@ -1988,6 +2171,21 @@ export function scanClaudeVendorSessions(
     process.stderr.write(
       `token-cost-harvest: skipping event-window issue #${issueNumber}: matched by more than one project log file (${classification}: ${fileNames.join(', ')})\n`,
     );
+  }
+  // #2432: emit each file's own cwd-derived issue-loop sample now that
+  // every contributor resolution above is final, suppressing only the
+  // exact (file, issue number) pairs confirmed as merged into a
+  // contributor above -- any other cwd-derived sample from the same file
+  // (a different issue number it also touched) is unaffected.
+  for (const pending of pendingCwdSessions) {
+    if (
+      consumedCwdIssueNumbersByBasename
+        .get(pending.fileBasename)
+        ?.has(pending.issueNumber)
+    ) {
+      continue;
+    }
+    out.push(pending.session);
   }
   return out;
 }

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -1113,12 +1113,26 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
     for (const [vendorSessionId, startMs] of enters) {
       const endMs = exits.get(vendorSessionId);
       if (endMs !== undefined) {
-        // The attempt's own claimId requires its enter and exit to agree
-        // (both undefined, or the same value) -- one stage's enter/exit
-        // share one claim in practice, so disagreement is defensive: it
-        // degrades to undefined rather than guessing which side is right.
+        // The attempt's own claimId requires its enter and exit to agree.
+        // One side missing (undefined) while the other carries a value is
+        // ordinary partial data -- defensive degrade to undefined, since
+        // one stage's enter/exit share one claim in practice and there is
+        // no way to tell which side is right. Both sides present but
+        // DIFFERENT is a stronger signal: the same long-lived session
+        // revisited the issue under a NEW claim between this enter and
+        // exit (or a boundary write raced with a takeover) -- degrading
+        // that to claim-less would make `idCompatible` treat it as
+        // compatible with ANY cleanup by default, so the whole candidate
+        // is excluded instead (Codex review finding, PR #2627).
         const enterClaimId = enterClaimIds?.get(vendorSessionId);
         const exitClaimId = exitClaimIds?.get(vendorSessionId);
+        if (
+          enterClaimId !== undefined &&
+          exitClaimId !== undefined &&
+          enterClaimId !== exitClaimId
+        ) {
+          continue;
+        }
         const claimId = enterClaimId === exitClaimId ? enterClaimId : undefined;
         candidates.push({
           vendorSessionId,
@@ -2020,11 +2034,21 @@ export function scanClaudeVendorSessions(
   // would otherwise permanently freeze exactly the undercount this
   // feature exists to fix, once the missing contributor becomes available
   // (Codex review finding, PR #2627).
+  // Returns whether a merged sample was actually emitted -- the
+  // cwd-attributed-primary call site below needs to know this to also
+  // suppress the primary's own now-orphaned pending cwd sample on
+  // failure (Codex review finding, PR #2627): unlike the event-window
+  // fallback primary (which never has one), a cwd-attributed primary DOES
+  // have its own solo `pendingCwdSessions` entry, and leaving it
+  // unsuppressed on an aborted merge would let it stand under its own
+  // plain (non-`#ew`-suffixed) key -- a LATER successful merge would then
+  // append a second, differently-keyed sample for the same completed
+  // loop, permanently double-counting it.
   const harvestEventWindowCandidate = (
     issueNumber: number,
     fileBasename: string,
     records: unknown[],
-  ): void => {
+  ): boolean => {
     const vendorSessionIdOverride = resolveCandidateSessionId(fileBasename);
     const contributingWindows =
       completedIssueWindowByIssue.get(issueNumber)?.contributingWindows ?? [];
@@ -2083,7 +2107,7 @@ export function scanClaudeVendorSessions(
               : `matched more than one file (${sessionIdMatches.map(([b]) => b).join(', ')})`
           } -- emitting a primary-only sample would freeze an undercount under a stable id\n`,
         );
-        return;
+        return false;
       }
       const [contributingBasename, candidateRecords] = sessionIdMatches[0];
       if (!isEligibleContributorFile(contributingBasename, contributing)) {
@@ -2134,10 +2158,12 @@ export function scanClaudeVendorSessions(
         new Set<number>();
       consumedPrimary.add(issueNumber);
       consumedCwdIssueNumbersByBasename.set(fileBasename, consumedPrimary);
+      return true;
     } catch (error) {
       process.stderr.write(
         `token-cost-harvest: skipping event-window issue #${issueNumber}: ${(error as Error).message}\n`,
       );
+      return false;
     }
   };
 
@@ -2288,11 +2314,23 @@ export function scanClaudeVendorSessions(
       continue;
     }
     const [[primaryBasename, primaryRecords]] = matchesByBasename;
-    harvestEventWindowCandidate(
+    const merged = harvestEventWindowCandidate(
       window.issueNumber,
       primaryBasename,
       primaryRecords,
     );
+    if (!merged) {
+      // #2432/Codex review (PR #2627): the merge aborted (an unresolvable
+      // contributor) -- suppress this primary's own pending cwd sample
+      // too, so this run emits NOTHING for the issue rather than a
+      // primary-only sample under a plain (non-`#ew`-suffixed) key that a
+      // later successful merge could never recognize as the same loop.
+      const consumedPrimary =
+        consumedCwdIssueNumbersByBasename.get(primaryBasename) ??
+        new Set<number>();
+      consumedPrimary.add(window.issueNumber);
+      consumedCwdIssueNumbersByBasename.set(primaryBasename, consumedPrimary);
+    }
   }
   // #2432: emit each file's own cwd-derived issue-loop sample now that
   // every contributor resolution above is final, suppressing only the

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -1315,13 +1315,17 @@ export interface CompletedIssueWindow {
    * The primary (cleanup-owning) session's own qualifying stage windows
    * -- cleanup itself plus every boundary-consistent, same-vendorSessionId
    * -or-unidentified stage -- kept as INDIVIDUAL windows, never unioned
-   * into one enclosing span. `scanClaudeVendorSessions` filters the
-   * primary file's own records against this set (a record must fall
-   * inside at least one of these windows to count), and the cross-session
-   * overlap guard below compares these same individual windows against
-   * each contributor's -- an enclosing span would falsely "overlap" a
-   * contributor sandwiched inside an idle gap between two of the
-   * primary's own stages (Copilot review finding round on PR #2627, #2432).
+   * into one enclosing span. Used **only** by the cross-session overlap
+   * guard in `buildCompletedIssueWindows` itself, which compares these
+   * individual windows against each contributor's own: an enclosing span
+   * would falsely "overlap" a contributor sandwiched inside an idle gap
+   * between two of the primary's own stages (Copilot review finding, PR
+   * #2627, #2432). `scanClaudeVendorSessions` does NOT filter the primary
+   * file's records against this set -- it instead EXCLUDES, from the
+   * primary's own already-selected records, any timestamp a confirmed
+   * `contributingWindows` entry already owns, so that overlapping
+   * attribution is never double-charged (see `harvestEventWindowCandidate`
+   * in `scanClaudeVendorSessions`).
    */
   primaryWindows: { startMs: number; endMs: number }[];
   /**

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -1455,9 +1455,22 @@ export function buildCompletedIssueWindows(
       continue;
     }
     let startMs = cleanup.startMs;
+    // The primary/cleanup-owning session's own full span (union of every
+    // same-vendorSessionId-or-unidentified window, i.e. what `startMs`
+    // would be WITHOUT any claimId-matched contributor) -- kept separate
+    // from `startMs` itself so the cross-session overlap guard below can
+    // compare a contributor against the primary session's REAL activity
+    // range, not just cleanup's own narrow slice.
+    let primaryStartMs = cleanup.startMs;
     for (const [, window] of candidateStages) {
       if (window.startMs <= cleanup.endMs && window.endMs <= cleanup.endMs) {
         startMs = Math.min(startMs, window.startMs);
+        if (
+          window.vendorSessionId === undefined ||
+          window.vendorSessionId === cleanup.vendorSessionId
+        ) {
+          primaryStartMs = Math.min(primaryStartMs, window.startMs);
+        }
       }
     }
     // #2432: a boundary-consistent, claimId-matched window whose own
@@ -1496,16 +1509,18 @@ export function buildCompletedIssueWindows(
     // `idd-claim.instructions.md` where two sessions can momentarily
     // share one active claim-id without one being a clean continuation of
     // the other -- treat the whole issue as contaminated, same as a
-    // reversed window above (no sample beats a wrong one). Scoped to
-    // cleanup's own [startMs, endMs) rather than the full widened window,
-    // since only the cleanup-owning session's identity is being compared
-    // against each contributing session's own identity here.
+    // reversed window above (no sample beats a wrong one). Compares each
+    // contributor against the primary session's OWN full span
+    // (`primaryStartMs`..`cleanup.endMs`, every same-session window
+    // unioned), not merely cleanup's own narrow slice -- a contributor
+    // overlapping an earlier same-session stage (e.g. `work`) is just as
+    // much evidence of the race as one overlapping `cleanup` itself.
     const overlaps = (
       a: { startMs: number; endMs: number },
       b: { startMs: number; endMs: number },
     ): boolean => a.startMs < b.endMs && b.startMs < a.endMs;
     const overlapCandidates = [
-      { startMs: cleanup.startMs, endMs: cleanup.endMs },
+      { startMs: primaryStartMs, endMs: cleanup.endMs },
       ...contributingWindows,
     ];
     const hasCrossSessionOverlap = overlapCandidates.some((a, i) =>

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -2265,20 +2265,33 @@ export function scanClaudeVendorSessions(
         resolveCandidateSessionId(candidate.fileBasename) ===
           window.vendorSessionId,
     );
-    if (matches.length !== 1) {
+    // #2432/Codex review (PR #2627): a session that moves out of the
+    // target worktree and later returns produces more than one cwd
+    // segment for the SAME file and issue (#2404 segmentation) -- group by
+    // basename first, since several segments of the one uniquely-resolved
+    // file are not the ambiguity this guards against; only more than one
+    // DISTINCT file matching is.
+    const matchesByBasename = new Map<string, unknown[]>();
+    for (const candidate of matches) {
+      const combined = matchesByBasename.get(candidate.fileBasename) ?? [];
+      combined.push(...candidate.records);
+      matchesByBasename.set(candidate.fileBasename, combined);
+    }
+    if (matchesByBasename.size !== 1) {
       process.stderr.write(
         `token-cost-harvest: skipping cwd-attributed primary resolution for issue #${window.issueNumber}: ${
-          matches.length === 0
+          matchesByBasename.size === 0
             ? 'no matching cwd-attributed segment found'
-            : `matched more than one segment (${matches.map((m) => m.fileBasename).join(', ')})`
+            : `matched more than one file (${[...matchesByBasename.keys()].join(', ')})`
         } -- its plain cwd-derived sample (if any) is unaffected\n`,
       );
       continue;
     }
+    const [[primaryBasename, primaryRecords]] = matchesByBasename;
     harvestEventWindowCandidate(
       window.issueNumber,
-      matches[0].fileBasename,
-      matches[0].records,
+      primaryBasename,
+      primaryRecords,
     );
   }
   // #2432: emit each file's own cwd-derived issue-loop sample now that

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -1815,11 +1815,15 @@ export function scanClaudeVendorSessions(
     }
   }
 
+  // A record with no valid timestamp sorts last via MAX_SAFE_INTEGER --
+  // Number.POSITIVE_INFINITY would subtract to NaN when two such records
+  // are compared, which Array.prototype.sort tolerates (undefined order)
+  // but is needlessly fragile.
   const sortByTimestampAscending = (records: unknown[]): unknown[] =>
     [...records].sort(
       (a, b) =>
-        (extractRecordTimestampMs(a) ?? Number.POSITIVE_INFINITY) -
-        (extractRecordTimestampMs(b) ?? Number.POSITIVE_INFINITY),
+        (extractRecordTimestampMs(a) ?? Number.MAX_SAFE_INTEGER) -
+        (extractRecordTimestampMs(b) ?? Number.MAX_SAFE_INTEGER),
     );
 
   // #2432: pull each confirmed contributing session's own file's records

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -2093,6 +2093,16 @@ export function scanClaudeVendorSessions(
         )
       );
     };
+    // Resolution is collected in a first pass and consumption is marked
+    // only after the harvest below actually succeeds (self-audited
+    // finding): marking a contributor consumed as soon as ITS OWN window
+    // resolves -- as an earlier revision did -- leaks that contributor's
+    // cwd sample as permanently suppressed whenever a LATER contributing
+    // window in this same loop fails to resolve, or the harvest call
+    // below throws, aborting the whole merge. That earlier contributor's
+    // standalone sample would then vanish with nothing to replace it: an
+    // outright loss of usage data, not merely a double-count.
+    const resolvedContributorBasenames: string[] = [];
     for (const contributing of contributingWindows) {
       const sessionIdMatches = [...allRecordsByBasename].filter(
         ([candidateBasename]) =>
@@ -2116,7 +2126,6 @@ export function scanClaudeVendorSessions(
         );
         continue;
       }
-      let contributorHadRecords = false;
       for (const record of candidateRecords) {
         const atMs = extractRecordTimestampMs(record);
         if (
@@ -2125,16 +2134,14 @@ export function scanClaudeVendorSessions(
           atMs < contributing.endMs
         ) {
           mergedRecords.push(record);
-          contributorHadRecords = true;
         }
       }
-      if (contributorHadRecords) {
-        const consumed =
-          consumedCwdIssueNumbersByBasename.get(contributingBasename) ??
-          new Set<number>();
-        consumed.add(issueNumber);
-        consumedCwdIssueNumbersByBasename.set(contributingBasename, consumed);
-      }
+      // Consumed regardless of whether any record actually landed inside
+      // the contributing window: a resolved-but-empty contributor still
+      // correctly contributed zero usage to this loop, which is not the
+      // same as never having resolved at all, and its own plain cwd
+      // sample (if any) must be suppressed either way.
+      resolvedContributorBasenames.push(contributingBasename);
     }
     try {
       const eventWindowResult = claudeAdapter.harvest({
@@ -2152,7 +2159,16 @@ export function scanClaudeVendorSessions(
       // too, not just contributors' -- a no-op for the pre-#2432,
       // event-window-fallback primary (which never had one), but required
       // once a cwd-attributed file can itself be selected as primary (see
-      // the post-scan resolution below).
+      // the post-scan resolution below). Contributors are marked here too,
+      // together and only on confirmed success -- see the comment above
+      // the resolution loop.
+      for (const contributingBasename of resolvedContributorBasenames) {
+        const consumed =
+          consumedCwdIssueNumbersByBasename.get(contributingBasename) ??
+          new Set<number>();
+        consumed.add(issueNumber);
+        consumedCwdIssueNumbersByBasename.set(contributingBasename, consumed);
+      }
       const consumedPrimary =
         consumedCwdIssueNumbersByBasename.get(fileBasename) ??
         new Set<number>();

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -1720,6 +1720,13 @@ export function scanClaudeVendorSessions(
     issueNumber: number;
     records: unknown[];
   }[] = [];
+  // #2432: each file's own unattributed records (cwd-inference failed for
+  // every segment), cached for a later contributingWindows lookup --
+  // scoped to the SAME pool eventWindowCandidates itself draws from, so a
+  // file that already independently produced its own cwd-attributed
+  // sample for some OTHER issue is never re-absorbed into a merged #ew
+  // sample here.
+  const unattributedRecordsByBasename = new Map<string, unknown[]>();
   for (const file of files) {
     let records: unknown[];
     try {
@@ -1774,41 +1781,92 @@ export function scanClaudeVendorSessions(
     // that markAmbiguousOverlaps has no reason to catch (their time
     // ranges don't overlap; they're just both attributed to the same
     // issue).
-    if (
-      !anySegmentHadCwdIssueNumber &&
-      unattributedRecords.length > 0 &&
-      completedIssueWindows.length > 0
-    ) {
-      const eventWindowGroups = segmentRecordsByEventWindow(
-        unattributedRecords,
-        completedIssueWindows,
-        extractRecordTimestampMs,
-      );
-      for (const [issueNumber, groupRecords] of eventWindowGroups) {
-        eventWindowCandidates.push({
-          fileBasename,
-          issueNumber,
-          records: groupRecords,
-        });
+    if (!anySegmentHadCwdIssueNumber && unattributedRecords.length > 0) {
+      unattributedRecordsByBasename.set(fileBasename, unattributedRecords);
+      if (completedIssueWindows.length > 0) {
+        const eventWindowGroups = segmentRecordsByEventWindow(
+          unattributedRecords,
+          completedIssueWindows,
+          extractRecordTimestampMs,
+        );
+        for (const [issueNumber, groupRecords] of eventWindowGroups) {
+          eventWindowCandidates.push({
+            fileBasename,
+            issueNumber,
+            records: groupRecords,
+          });
+        }
       }
     }
   }
 
+  const sortByTimestampAscending = (records: unknown[]): unknown[] =>
+    [...records].sort(
+      (a, b) =>
+        (extractRecordTimestampMs(a) ?? Number.POSITIVE_INFINITY) -
+        (extractRecordTimestampMs(b) ?? Number.POSITIVE_INFINITY),
+    );
+
+  // #2432: pull each confirmed contributing session's own file's records
+  // (restricted to that session's own qualifying window bounds) into the
+  // primary file's own records, one merged harvest() call per issue.
+  // Never a partial-issue failure: a contribution whose own file can't be
+  // uniquely resolved is skipped (stderr diagnostic), keeping the
+  // primary-only, narrower-but-safe harvest instead of dropping the whole
+  // issue's sample.
   const harvestEventWindowCandidate = (
     issueNumber: number,
     fileBasename: string,
     records: unknown[],
   ): void => {
+    const vendorSessionIdOverride = resolveCandidateSessionId({
+      fileBasename,
+      records,
+    });
+    const contributingWindows =
+      completedIssueWindowByIssue.get(issueNumber)?.contributingWindows ?? [];
+    const mergedRecords = [...records];
+    for (const contributing of contributingWindows) {
+      const matches = [...unattributedRecordsByBasename].filter(
+        ([candidateBasename, candidateRecords]) =>
+          resolveCandidateSessionId({
+            fileBasename: candidateBasename,
+            records: candidateRecords,
+          }) === contributing.vendorSessionId,
+      );
+      if (matches.length !== 1) {
+        process.stderr.write(
+          `token-cost-harvest: skipping contributing session ${contributing.vendorSessionId} for issue #${issueNumber}: ${
+            matches.length === 0
+              ? 'no matching file found'
+              : `matched more than one file (${matches.map(([b]) => b).join(', ')})`
+          }\n`,
+        );
+        continue;
+      }
+      const [, candidateRecords] = matches[0];
+      for (const record of candidateRecords) {
+        const atMs = extractRecordTimestampMs(record);
+        if (
+          atMs !== undefined &&
+          atMs >= contributing.startMs &&
+          atMs < contributing.endMs
+        ) {
+          mergedRecords.push(record);
+        }
+      }
+    }
     try {
       const eventWindowResult = claudeAdapter.harvest({
-        records,
+        records: sortByTimestampAscending(mergedRecords),
         fileBasename,
         issueNumberOverride: issueNumber,
+        vendorSessionIdOverride,
       } satisfies ClaudeHarvestInput);
       out.push({
         vendor: 'claude',
         adapterResult: eventWindowResult,
-        timeline: extractClaudeUsageTimeline(records),
+        timeline: extractClaudeUsageTimeline(mergedRecords),
       });
     } catch (error) {
       process.stderr.write(
@@ -1833,10 +1891,10 @@ export function scanClaudeVendorSessions(
     });
     candidatesByIssue.set(candidate.issueNumber, list);
   }
-  const vendorSessionIdByIssue = new Map<number, string | undefined>();
+  const completedIssueWindowByIssue = new Map<number, CompletedIssueWindow>();
   for (const window of completedIssueWindows) {
-    if (!vendorSessionIdByIssue.has(window.issueNumber)) {
-      vendorSessionIdByIssue.set(window.issueNumber, window.vendorSessionId);
+    if (!completedIssueWindowByIssue.has(window.issueNumber)) {
+      completedIssueWindowByIssue.set(window.issueNumber, window);
     }
   }
   // #2424/Copilot review (PR #2430): a candidate's own session id must
@@ -1861,7 +1919,8 @@ export function scanClaudeVendorSessions(
     // whose own session file got excluded upstream (a cwd-inferred
     // segment already claimed it), leaving only an unrelated concurrent
     // session's file as candidate.
-    const windowVendorSessionId = vendorSessionIdByIssue.get(issueNumber);
+    const windowVendorSessionId =
+      completedIssueWindowByIssue.get(issueNumber)?.vendorSessionId;
     if (windowVendorSessionId !== undefined) {
       const matching = fileCandidates.filter(
         (candidate) =>

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -296,6 +296,8 @@ export interface StageEventWindow {
   endMs: number;
   /** The enter/exit pair's shared vendorSessionId (#2424), when both events carried one. Absent for historical data and vendors with no known session-id source. */
   vendorSessionId?: string;
+  /** The enter/exit pair's shared IDD {claim-id} (#2432), when both events carried the SAME one and the pair is itself identified (has a vendorSessionId). Positive evidence this window belongs to a specific claim lineage, independent of which process/session posted it. */
+  claimId?: string;
 }
 
 const CLAIM_STAGE_CAP_MS = 15 * 60 * 1000;
@@ -948,6 +950,7 @@ interface AttemptCandidate {
   vendorSessionId: string;
   startMs: number;
   endMs: number;
+  claimId?: string;
 }
 
 /**
@@ -999,6 +1002,19 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
   // events that carry a non-empty vendorSessionId.
   const enterAtByAttempt = new Map<string, Map<string, number>>();
   const exitAtByAttempt = new Map<string, Map<string, number>>();
+  // bareKey -> vendorSessionId -> claimId of whichever event set that
+  // attempt's CURRENT latest timestamp above (#2432). Only meaningful
+  // alongside an identified (vendorSessionId-bearing) attempt -- an
+  // unidentified event has no attempt bucket to disambiguate a claimId
+  // against, so claimId is never tracked on the legacy bareKey path.
+  const enterClaimIdByAttempt = new Map<
+    string,
+    Map<string, string | undefined>
+  >();
+  const exitClaimIdByAttempt = new Map<
+    string,
+    Map<string, string | undefined>
+  >();
   const text = readFileSync(path, 'utf8');
   for (const rawLine of text.split('\n')) {
     const line = rawLine.trim();
@@ -1036,6 +1052,7 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
     const vendorSessionId = isNonEmptyString(event.vendorSessionId)
       ? event.vendorSessionId
       : undefined;
+    const claimId = isNonEmptyString(event.claimId) ? event.claimId : undefined;
     if (event.event === 'enter') {
       enterAt.set(key, atMs);
       enterAtOwner.set(key, vendorSessionId);
@@ -1044,6 +1061,11 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
           enterAtByAttempt.get(key) ?? new Map<string, number>();
         byAttempt.set(vendorSessionId, atMs);
         enterAtByAttempt.set(key, byAttempt);
+        const claimIdByAttempt =
+          enterClaimIdByAttempt.get(key) ??
+          new Map<string, string | undefined>();
+        claimIdByAttempt.set(vendorSessionId, claimId);
+        enterClaimIdByAttempt.set(key, claimIdByAttempt);
       }
     } else {
       exitAt.set(key, atMs);
@@ -1052,6 +1074,11 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
         const byAttempt = exitAtByAttempt.get(key) ?? new Map<string, number>();
         byAttempt.set(vendorSessionId, atMs);
         exitAtByAttempt.set(key, byAttempt);
+        const claimIdByAttempt =
+          exitClaimIdByAttempt.get(key) ??
+          new Map<string, string | undefined>();
+        claimIdByAttempt.set(vendorSessionId, claimId);
+        exitClaimIdByAttempt.set(key, claimIdByAttempt);
       }
     }
   }
@@ -1062,11 +1089,25 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
     if (!enters || !exits) {
       return [];
     }
+    const enterClaimIds = enterClaimIdByAttempt.get(key);
+    const exitClaimIds = exitClaimIdByAttempt.get(key);
     const candidates: AttemptCandidate[] = [];
     for (const [vendorSessionId, startMs] of enters) {
       const endMs = exits.get(vendorSessionId);
       if (endMs !== undefined) {
-        candidates.push({ vendorSessionId, startMs, endMs });
+        // The attempt's own claimId requires its enter and exit to agree
+        // (both undefined, or the same value) -- one stage's enter/exit
+        // share one claim in practice, so disagreement is defensive: it
+        // degrades to undefined rather than guessing which side is right.
+        const enterClaimId = enterClaimIds?.get(vendorSessionId);
+        const exitClaimId = exitClaimIds?.get(vendorSessionId);
+        const claimId = enterClaimId === exitClaimId ? enterClaimId : undefined;
+        candidates.push({
+          vendorSessionId,
+          startMs,
+          endMs,
+          ...(claimId !== undefined ? { claimId } : {}),
+        });
       }
     }
     return candidates;
@@ -1086,6 +1127,9 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
           startMs: preferred.startMs,
           endMs: preferred.endMs,
           vendorSessionId: preferred.vendorSessionId,
+          ...(preferred.claimId !== undefined
+            ? { claimId: preferred.claimId }
+            : {}),
         };
       }
     }
@@ -1144,6 +1188,9 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
             startMs: bestIdentified.startMs,
             endMs: bestIdentified.endMs,
             vendorSessionId: bestIdentified.vendorSessionId,
+            ...(bestIdentified.claimId !== undefined
+              ? { claimId: bestIdentified.claimId }
+              : {}),
           }
         : legacyWindow;
     }
@@ -1152,6 +1199,9 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
         startMs: bestIdentified.startMs,
         endMs: bestIdentified.endMs,
         vendorSessionId: bestIdentified.vendorSessionId,
+        ...(bestIdentified.claimId !== undefined
+          ? { claimId: bestIdentified.claimId }
+          : {}),
       };
     }
     return legacyWindow;
@@ -1211,6 +1261,23 @@ export interface CompletedIssueWindow {
   endMs: number;
   /** The winning `cleanup` window's own vendorSessionId (#2424), when known -- lets a cross-file resolver attribute this window to the one file that actually posted it. */
   vendorSessionId?: string;
+  /** The winning `cleanup` window's own claimId (#2432), when known. */
+  claimId?: string;
+  /**
+   * Other sessions (by vendorSessionId, one entry each, ranges unioned
+   * across every one of that session's own qualifying stage windows)
+   * whose usage a genuine claim-id-matched handoff should also pull in
+   * from their OWN file -- see `scanClaudeVendorSessions`. Present only
+   * when at least one non-cleanup window was admitted via the claimId
+   * branch of `idCompatible` (a different vendorSessionId than
+   * `cleanup`'s own). Absent for a single-session completed window,
+   * exactly as before #2432.
+   */
+  contributingWindows?: {
+    vendorSessionId: string;
+    startMs: number;
+    endMs: number;
+  }[];
 }
 
 /**
@@ -1344,29 +1411,37 @@ export function buildCompletedIssueWindows(
     //   unidentified ones -- byte-identical to the pre-#2424 residual;
     //   identity cannot see it either way.
     //
-    // A third, accepted tradeoff (Codex review finding round 5, PR #2430,
-    // #2424): a `vendorSessionId` mismatch proves a different PROCESS, not
-    // a different ATTEMPT -- docs/token-cost.md's own Scope explicitly
+    // A third case (Codex review finding round 5, PR #2430, #2424; shipped
+    // in #2432): a `vendorSessionId` mismatch proves a different PROCESS,
+    // not a different ATTEMPT -- docs/token-cost.md's own Scope explicitly
     // allows one issue loop to span multiple Claude sessions via a
-    // handoff or resume. This check has no way to tell that legitimate
-    // case apart from a genuinely unrelated, abandoned earlier attempt,
-    // so it excludes both alike. Widening the window to include the
-    // earlier session's own stage would not by itself recover its usage
-    // either: `scanClaudeVendorSessions` harvests one session log file
-    // per completed window, so an earlier handoff session's records live
-    // in a file this resolution never selects -- a widened-but-single-
-    // file harvest would misrepresent its own coverage (bounds spanning
-    // both sessions, records covering only one), which is worse than
-    // today's narrower-but-honest one. Merging records across a
-    // confirmed handoff's files needs a positive-evidence rule this
-    // event stream alone can't supply; tracked separately (#2432) rather
-    // than attempted here. Until then this is a documented undercount,
-    // not a bug: recoverable once #2432 ships, unlike the permanent
-    // contamination a wrong inclusion would freeze under a stable
-    // `#ew<issueNumber>` sample id.
+    // handoff or resume, and this check alone can't tell that legitimate
+    // case apart from a genuinely unrelated, abandoned earlier attempt.
+    // `idCompatible` below adds a second, independent admission path for
+    // exactly this case: a non-cleanup window whose own `claimId` (#2432,
+    // threaded from the IDD `{claim-id}` a caller optionally passes to
+    // `token-cost-event.mjs --claim-id`) MATCHES cleanup's own is treated
+    // as compatible even when its `vendorSessionId` differs -- `claimId`
+    // is this repository's own ground-truth ownership token for "same
+    // claim lineage, possibly handed off across sessions," independent of
+    // which process posted the event. A window admitted only via this
+    // claimId branch (not also same-`vendorSessionId`-or-unidentified) is
+    // additionally recorded as a `contributingWindows` entry so
+    // `scanClaudeVendorSessions` can pull that session's own file's
+    // records in too, instead of merely widening the bounds without the
+    // usage to back them. `claimId` absent on either side (historical
+    // data, or a caller that doesn't pass `--claim-id`) falls back to
+    // today's narrower, single-session-only behavior unchanged. Two
+    // claim-id-matched windows from DIFFERENT vendorSessionIds that
+    // OVERLAP each other in time (a narrow, documented TOCTOU race in
+    // `idd-claim.instructions.md` where two sessions can momentarily
+    // share one active `{claim-id}`) are treated as contamination and
+    // skip the whole issue, same as a reversed window below -- a genuine
+    // sequential handoff never produces overlapping activity.
     const idCompatible = (window: StageEventWindow): boolean =>
       window.vendorSessionId === undefined ||
-      window.vendorSessionId === cleanup.vendorSessionId;
+      window.vendorSessionId === cleanup.vendorSessionId ||
+      (window.claimId !== undefined && window.claimId === cleanup.claimId);
     const candidateStages = [...stages].filter(
       ([stageId, window]) => stageId === 'cleanup' || idCompatible(window),
     );
@@ -1385,6 +1460,60 @@ export function buildCompletedIssueWindows(
         startMs = Math.min(startMs, window.startMs);
       }
     }
+    // #2432: a boundary-consistent, claimId-matched window whose own
+    // vendorSessionId differs from cleanup's own is a genuine
+    // contributing session -- union its range with any sibling windows
+    // sharing the same vendorSessionId (one earlier session can post more
+    // than one qualifying stage) into a single contribution.
+    const contributingRanges = new Map<
+      string,
+      { startMs: number; endMs: number }
+    >();
+    for (const [stageId, window] of candidateStages) {
+      if (
+        stageId === 'cleanup' ||
+        window.vendorSessionId === undefined ||
+        window.vendorSessionId === cleanup.vendorSessionId ||
+        !(window.startMs <= cleanup.endMs && window.endMs <= cleanup.endMs)
+      ) {
+        continue;
+      }
+      const existing = contributingRanges.get(window.vendorSessionId);
+      contributingRanges.set(window.vendorSessionId, {
+        startMs: existing
+          ? Math.min(existing.startMs, window.startMs)
+          : window.startMs,
+        endMs: existing ? Math.max(existing.endMs, window.endMs) : window.endMs,
+      });
+    }
+    const contributingWindows = [...contributingRanges].map(
+      ([vendorSessionId, range]) => ({ vendorSessionId, ...range }),
+    );
+    // Cross-session overlap guard: a genuine sequential handoff never
+    // produces overlapping activity between two different sessions. Two
+    // claim-id-matched windows from DIFFERENT vendorSessionIds that DO
+    // overlap is evidence of the narrow, documented TOCTOU race in
+    // `idd-claim.instructions.md` where two sessions can momentarily
+    // share one active claim-id without one being a clean continuation of
+    // the other -- treat the whole issue as contaminated, same as a
+    // reversed window above (no sample beats a wrong one). Scoped to
+    // cleanup's own [startMs, endMs) rather than the full widened window,
+    // since only the cleanup-owning session's identity is being compared
+    // against each contributing session's own identity here.
+    const overlaps = (
+      a: { startMs: number; endMs: number },
+      b: { startMs: number; endMs: number },
+    ): boolean => a.startMs < b.endMs && b.startMs < a.endMs;
+    const overlapCandidates = [
+      { startMs: cleanup.startMs, endMs: cleanup.endMs },
+      ...contributingWindows,
+    ];
+    const hasCrossSessionOverlap = overlapCandidates.some((a, i) =>
+      overlapCandidates.some((b, j) => i < j && overlaps(a, b)),
+    );
+    if (hasCrossSessionOverlap) {
+      continue;
+    }
     out.push({
       issueNumber,
       startMs,
@@ -1392,6 +1521,8 @@ export function buildCompletedIssueWindows(
       ...(cleanup.vendorSessionId !== undefined
         ? { vendorSessionId: cleanup.vendorSessionId }
         : {}),
+      ...(cleanup.claimId !== undefined ? { claimId: cleanup.claimId } : {}),
+      ...(contributingWindows.length > 0 ? { contributingWindows } : {}),
     });
   }
   return out;

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -1839,16 +1839,33 @@ export function scanClaudeVendorSessions(
   // decided by the contributing window's own timestamp bounds below, not
   // by which segment they happened to land in.
   const allRecordsByBasename = new Map<string, unknown[]>();
-  // Every issue number any segment of a file resolved via cwd inference
-  // (almost always zero or one entry; #2404 segmentation can add more for
-  // a session that moved across several worktrees in one file). A file
-  // that cwd-resolved to some OTHER issue is never eligible as a
-  // contributor for a DIFFERENT target issue -- matching its own sessionId
-  // is not enough on its own, or a session that briefly touched an
-  // unrelated issue's worktree could have that unrelated activity folded
-  // into this merge (Codex review finding, PR #2627 -- distinct from the
-  // same-issue suppression case above, which this does not affect).
-  const cwdIssueNumbersByBasename = new Map<string, Set<number>>();
+  // Every cwd-attributed segment any file produced (almost always zero or
+  // one; #2404 segmentation can add more for a session that moved across
+  // several worktrees in one file), kept as its own TIME RANGE rather than
+  // just an issue number -- eligibility as a contributor is scoped to
+  // whether some OTHER-issue segment's own time range overlaps the
+  // specific contributing window in question, not whether the file ever
+  // touched a different issue at ANY point in its life. A long-lived file
+  // that visited issue #100 at 00:00-00:10 and then genuinely contributed
+  // to the target issue at 01:00-01:05 must stay eligible for that later
+  // window (Codex review finding, PR #2627).
+  const cwdSegmentsByBasename = new Map<
+    string,
+    { issueNumber: number; startMs: number; endMs: number }[]
+  >();
+  // #2432: a cwd-attributed segment is also a candidate PRIMARY (the
+  // cleanup-owning session is very often launched right inside the issue
+  // worktree it is resuming, so it cwd-resolves like any ordinary session
+  // instead of needing the #2418 unattributed-record fallback at all) --
+  // see the post-scan primary resolution below. Keyed loosely by
+  // (fileBasename, issueNumber, records), not deduplicated against
+  // `eventWindowCandidates` since the two pools are consulted in a
+  // strict, mutually exclusive order (Codex review finding, PR #2627).
+  const cwdAttributedCandidates: {
+    fileBasename: string;
+    issueNumber: number;
+    records: unknown[];
+  }[] = [];
   // Per-file `resolveCandidateSessionId` result, computed once per file
   // instead of once per (contributor x file) comparison (Copilot review,
   // PR #2627) -- `extractSessionId` can scan the whole records array.
@@ -1923,13 +1940,25 @@ export function scanClaudeVendorSessions(
         unattributedRecords.push(...segment.records);
       } else {
         anySegmentHadCwdIssueNumber = true;
-        const cwdIssues =
-          cwdIssueNumbersByBasename.get(fileBasename) ?? new Set<number>();
-        cwdIssues.add(cwdIssueNumber);
-        cwdIssueNumbersByBasename.set(fileBasename, cwdIssues);
+        const segmentRange = computeRecordTimeRange(
+          segment.records,
+          extractRecordTimestampMs,
+        );
+        const segments = cwdSegmentsByBasename.get(fileBasename) ?? [];
+        segments.push({
+          issueNumber: cwdIssueNumber,
+          startMs: segmentRange?.minMs ?? Number.NEGATIVE_INFINITY,
+          endMs: segmentRange?.maxMs ?? Number.POSITIVE_INFINITY,
+        });
+        cwdSegmentsByBasename.set(fileBasename, segments);
+        cwdAttributedCandidates.push({
+          fileBasename,
+          issueNumber: cwdIssueNumber,
+          records: segment.records,
+        });
         // #2432: deferred, not pushed yet -- see `pendingCwdSessions`
         // above. Suppressed later only if this exact (file, issue number)
-        // pair is confirmed as a merge contributor.
+        // pair is confirmed as a merge contributor or primary.
         pendingCwdSessions.push({
           fileBasename,
           issueNumber: cwdIssueNumber,
@@ -2014,21 +2043,30 @@ export function scanClaudeVendorSessions(
     const mergedRecords = records.filter(
       (record) => !isOwnedByAContributor(extractRecordTimestampMs(record)),
     );
-    // A candidate file cwd-attributed to some OTHER issue number is never
-    // eligible to lend its records to THIS merge -- a file cwd-attributed
-    // only to THIS same issue (the #2432 same-worktree-handoff case) or to
-    // no issue at all (the pre-#2432 unattributed case) is eligible on a
-    // sessionId match; one cwd-attributed to a different issue is not,
-    // even on a sessionId match (Codex review finding, PR #2627). Unlike a
-    // truly unresolvable contributor below, this is a PERMANENT, structural
-    // disqualification, not a transient gap a later harvest could fix --
-    // so it drops just this one contributor and proceeds, rather than
+    // A candidate file is ineligible to lend its records to THIS
+    // contributing window when some OTHER-issue cwd segment's own time
+    // range overlaps that window -- scoped to the window in question, not
+    // to every issue the file ever touched in its lifetime: a long-lived
+    // file that visited issue #100 earlier and only later, genuinely,
+    // contributed to THIS issue must stay eligible for that later window
+    // (Codex review finding, PR #2627). Unlike a truly unresolvable
+    // contributor below, this is a PERMANENT, structural disqualification
+    // for that one window, not a transient gap a later harvest could fix
+    // -- so it drops just this one contributor and proceeds, rather than
     // skipping the whole issue.
-    const isEligibleContributorFile = (candidateBasename: string): boolean => {
-      const cwdIssues = cwdIssueNumbersByBasename.get(candidateBasename);
+    const isEligibleContributorFile = (
+      candidateBasename: string,
+      contributingWindow: { startMs: number; endMs: number },
+    ): boolean => {
+      const segments = cwdSegmentsByBasename.get(candidateBasename);
       return (
-        cwdIssues === undefined ||
-        [...cwdIssues].every((cwdIssue) => cwdIssue === issueNumber)
+        segments === undefined ||
+        segments.every(
+          (segment) =>
+            segment.issueNumber === issueNumber ||
+            segment.endMs <= contributingWindow.startMs ||
+            segment.startMs >= contributingWindow.endMs,
+        )
       );
     };
     for (const contributing of contributingWindows) {
@@ -2048,9 +2086,9 @@ export function scanClaudeVendorSessions(
         return;
       }
       const [contributingBasename, candidateRecords] = sessionIdMatches[0];
-      if (!isEligibleContributorFile(contributingBasename)) {
+      if (!isEligibleContributorFile(contributingBasename, contributing)) {
         process.stderr.write(
-          `token-cost-harvest: dropping contributing session ${contributing.vendorSessionId} for issue #${issueNumber}: its file (${contributingBasename}) is cwd-attributed to a different issue -- proceeding without this contributor\n`,
+          `token-cost-harvest: dropping contributing session ${contributing.vendorSessionId} for issue #${issueNumber}: its file (${contributingBasename}) has a different issue's cwd segment overlapping this contributing window -- proceeding without this contributor\n`,
         );
         continue;
       }
@@ -2086,6 +2124,16 @@ export function scanClaudeVendorSessions(
         adapterResult: eventWindowResult,
         timeline: extractClaudeUsageTimeline(mergedRecords),
       });
+      // #2432: suppress the primary file's own plain cwd-derived sample
+      // too, not just contributors' -- a no-op for the pre-#2432,
+      // event-window-fallback primary (which never had one), but required
+      // once a cwd-attributed file can itself be selected as primary (see
+      // the post-scan resolution below).
+      const consumedPrimary =
+        consumedCwdIssueNumbersByBasename.get(fileBasename) ??
+        new Set<number>();
+      consumedPrimary.add(issueNumber);
+      consumedCwdIssueNumbersByBasename.set(fileBasename, consumedPrimary);
     } catch (error) {
       process.stderr.write(
         `token-cost-harvest: skipping event-window issue #${issueNumber}: ${(error as Error).message}\n`,
@@ -2115,6 +2163,13 @@ export function scanClaudeVendorSessions(
       completedIssueWindowByIssue.set(window.issueNumber, window);
     }
   }
+  // #2432/Codex review (PR #2627): tracks which issue numbers this loop
+  // actually resolved a primary for -- distinct from `candidatesByIssue`
+  // merely HAVING an entry, since a contributor's own stray unattributed
+  // records can time-match this pool without ever resolving (its sessionId
+  // never matches cleanup's own). The post-scan cwd-attributed-primary
+  // step below must still run for such an issue.
+  const resolvedViaEventWindowFallback = new Set<number>();
   for (const [issueNumber, fileCandidates] of candidatesByIssue) {
     // #2424: resolve by attempt identity before falling back to
     // classify-and-skip (or, for a single candidate, unconditional
@@ -2133,6 +2188,7 @@ export function scanClaudeVendorSessions(
           windowVendorSessionId,
       );
       if (matching.length === 1) {
+        resolvedViaEventWindowFallback.add(issueNumber);
         harvestEventWindowCandidate(
           issueNumber,
           matching[0].fileBasename,
@@ -2147,6 +2203,7 @@ export function scanClaudeVendorSessions(
         continue;
       }
     } else if (fileCandidates.length === 1) {
+      resolvedViaEventWindowFallback.add(issueNumber);
       harvestEventWindowCandidate(
         issueNumber,
         fileCandidates[0].fileBasename,
@@ -2174,6 +2231,54 @@ export function scanClaudeVendorSessions(
       : 'disjoint activity ranges -- resolvable once events carry session identity, #2424';
     process.stderr.write(
       `token-cost-harvest: skipping event-window issue #${issueNumber}: matched by more than one project log file (${classification}: ${fileNames.join(', ')})\n`,
+    );
+  }
+  // #2432/Codex review (PR #2627): a completed issue window whose primary
+  // (cleanup-owning) session was itself launched inside the target issue's
+  // own worktree cwd-resolves normally and so is EXCLUDED from
+  // `eventWindowCandidates` above (that pool is reserved for
+  // cwd-inference-failed files, to avoid a false PRIMARY duplicate -- see
+  // the comment where `eventWindowCandidates` is populated). Such an issue
+  // is therefore never actually RESOLVED by the loop above -- even when a
+  // contributor's own stray unattributed records happen to time-match the
+  // (widened) window and land in `candidatesByIssue` regardless, that
+  // resolution fails on the sessionId mismatch and is skipped, which is
+  // exactly why `resolvedViaEventWindowFallback` (set only on a genuine
+  // success above), not `candidatesByIssue.has(...)`, is the right guard
+  // here. Without this step a genuine claim-id-matched contributor's usage
+  // would otherwise never be merged at all, even though `contributingWindows`
+  // correctly identified it. Resolve those here: only when the issue has a
+  // genuine contributor to merge (an issue with none is already handled
+  // correctly by the file's own plain cwd-derived sample, untouched).
+  for (const window of completedIssueWindows) {
+    if (
+      resolvedViaEventWindowFallback.has(window.issueNumber) ||
+      window.vendorSessionId === undefined ||
+      !window.contributingWindows ||
+      window.contributingWindows.length === 0
+    ) {
+      continue;
+    }
+    const matches = cwdAttributedCandidates.filter(
+      (candidate) =>
+        candidate.issueNumber === window.issueNumber &&
+        resolveCandidateSessionId(candidate.fileBasename) ===
+          window.vendorSessionId,
+    );
+    if (matches.length !== 1) {
+      process.stderr.write(
+        `token-cost-harvest: skipping cwd-attributed primary resolution for issue #${window.issueNumber}: ${
+          matches.length === 0
+            ? 'no matching cwd-attributed segment found'
+            : `matched more than one segment (${matches.map((m) => m.fileBasename).join(', ')})`
+        } -- its plain cwd-derived sample (if any) is unaffected\n`,
+      );
+      continue;
+    }
+    harvestEventWindowCandidate(
+      window.issueNumber,
+      matches[0].fileBasename,
+      matches[0].records,
     );
   }
   // #2432: emit each file's own cwd-derived issue-loop sample now that

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -495,6 +495,7 @@ export const tokenCostEventKeys = [
   'at',
   'vendor',
   'vendorSessionId',
+  'claimId',
   'issueNumber',
   'usage',
 ] as const satisfies readonly (keyof TokenCostEvent)[];

--- a/tests/token-cost-adapter-claude.test.mts
+++ b/tests/token-cost-adapter-claude.test.mts
@@ -242,6 +242,36 @@ test('vendorSessionIdOverride wins over the fileBasename fallback too', () => {
   assert.equal(sample.vendorSessionId, 'sess-primary-0002#ew501');
 });
 
+test('an empty-string vendorSessionIdOverride is ignored, falling back to extractSessionId (Copilot review finding, PR #2627)', () => {
+  // A `??`-based fallback treats '' as authoritative (unlike undefined),
+  // which would otherwise produce a malformed vendorSessionId like
+  // '#ew501' with no real base -- asClaudeHarvestInput must reject an
+  // empty override the same way extractSessionId/deriveFallbackSessionId
+  // already reject an empty sessionId/fileBasename.
+  const { sample } = claudeAdapter.harvest({
+    records: [
+      {
+        type: 'assistant',
+        timestamp: '2026-01-01T00:00:00Z',
+        sessionId: 'sess-real-0001',
+        cwd: '/repo',
+        message: {
+          model: 'm',
+          usage: {
+            input_tokens: 1,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            output_tokens: 1,
+          },
+        },
+      },
+    ],
+    issueNumberOverride: 501,
+    vendorSessionIdOverride: '',
+  });
+  assert.equal(sample.vendorSessionId, 'sess-real-0001#ew501');
+});
+
 test('no issueNumberOverride and no cwd: behavior is unchanged from before #2418', () => {
   const { joinHints, sample } = claudeAdapter.harvest({
     records: [

--- a/tests/token-cost-adapter-claude.test.mts
+++ b/tests/token-cost-adapter-claude.test.mts
@@ -189,6 +189,59 @@ test('segmentIndex is ignored (not appended) when issueNumberOverride is also pr
   assert.equal(sample.vendorSessionId, 'sess-ew-0003#ew501');
 });
 
+test('vendorSessionIdOverride wins over extractSessionId, e.g. when records from a second file were merged in (#2432)', () => {
+  const { sample } = claudeAdapter.harvest({
+    records: [
+      {
+        type: 'assistant',
+        timestamp: '2026-01-01T00:00:00Z',
+        // A DIFFERENT session's own id -- simulates a contributing
+        // handoff session's record concatenated in ahead of the primary
+        // file's own records.
+        sessionId: 'sess-contributor-0001',
+        cwd: '/repo',
+        message: {
+          model: 'm',
+          usage: {
+            input_tokens: 1,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            output_tokens: 1,
+          },
+        },
+      },
+    ],
+    issueNumberOverride: 501,
+    vendorSessionIdOverride: 'sess-primary-0001',
+  });
+  assert.equal(sample.vendorSessionId, 'sess-primary-0001#ew501');
+});
+
+test('vendorSessionIdOverride wins over the fileBasename fallback too', () => {
+  const { sample } = claudeAdapter.harvest({
+    records: [
+      {
+        type: 'assistant',
+        timestamp: '2026-01-01T00:00:00Z',
+        cwd: '/repo',
+        message: {
+          model: 'm',
+          usage: {
+            input_tokens: 1,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            output_tokens: 1,
+          },
+        },
+      },
+    ],
+    fileBasename: 'session-contributor.jsonl',
+    issueNumberOverride: 501,
+    vendorSessionIdOverride: 'sess-primary-0002',
+  });
+  assert.equal(sample.vendorSessionId, 'sess-primary-0002#ew501');
+});
+
 test('no issueNumberOverride and no cwd: behavior is unchanged from before #2418', () => {
   const { joinHints, sample } = claudeAdapter.harvest({
     records: [

--- a/tests/token-cost-event.test.mts
+++ b/tests/token-cost-event.test.mts
@@ -423,7 +423,7 @@ test('CLI --help exits 0 and prints usage without touching --out', () => {
   assert.match(result.stdout, /--stage <id>/);
 });
 
-test('CLI --claim-id is accepted but not persisted in the written event', () => {
+test('CLI --claim-id is persisted as claimId in the written event (#2432)', () => {
   const dir = tempDir();
   try {
     const outPath = join(dir, 'events.jsonl');
@@ -443,8 +443,33 @@ test('CLI --claim-id is accepted but not persisted in the written event', () => 
     ]);
     assert.equal(result.status, 0, result.stderr);
     const written = JSON.parse(readFileSync(outPath, 'utf8').trim());
-    assert.equal('claimId' in written, false);
+    assert.equal(written.claimId, 'abc123');
     assert.equal('claim-id' in written, false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('CLI --claim-id rejects an empty value', () => {
+  const dir = tempDir();
+  try {
+    const outPath = join(dir, 'events.jsonl');
+    const result = runCli([
+      '--stage',
+      'work',
+      '--exit',
+      '--vendor',
+      'grok',
+      '--claim-id',
+      '',
+      '--out',
+      outPath,
+      '--now',
+      NOW.toISOString(),
+      '--strict',
+    ]);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /--claim-id must be a single, non-empty value/);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -1834,6 +1834,74 @@ test('scanClaudeVendorSessions: a cwd-attributed primary that moved out of and b
   assert.equal(issue508Samples[0].adapterResult.sample.usage.output, 12);
 });
 
+test('scanClaudeVendorSessions: an EARLIER contributor that resolved fine is not left permanently suppressed when a LATER contributing window aborts the whole merge (#2432, self-audited)', () => {
+  // Two contributing windows share claim-512: the first (work) resolves to
+  // a real file that is itself cwd-attributed to issue 512's own worktree
+  // (so it also owns a `pendingCwdSessions` entry for issue 512); the
+  // second (review) has no matching file at all, so the overall merge for
+  // issue 512 aborts entirely. Consumption must only be recorded on
+  // confirmed overall success -- marking the first contributor consumed
+  // as soon as ITS OWN window resolved, before the second window's
+  // failure is even discovered, would permanently suppress its own solo
+  // sample with nothing to replace it: real usage silently lost, not
+  // merely double-counted.
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
+  writeFileSync(
+    join(sandbox, 'session-primary-512.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:24:00.000Z","sessionId":"sess-primary-0009","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":7}}}\n',
+  );
+  writeFileSync(
+    join(sandbox, 'session-contribA-512.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:02:00.000Z","sessionId":"sess-contribA-0009","cwd":"/home/user/repo.issue-512-x","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":4}}}\n',
+  );
+  // No file in this sandbox has sessionId 'sess-contribB-missing'.
+  const eventWindowsAll = new Map<string, StageEventWindow>([
+    [
+      '512:claude:work',
+      stageWindow(
+        '2026-01-01T00:00:00Z',
+        '2026-01-01T00:05:00Z',
+        'sess-contribA-0009',
+        'claim-512',
+      ),
+    ],
+    [
+      '512:claude:review',
+      stageWindow(
+        '2026-01-01T00:10:00Z',
+        '2026-01-01T00:15:00Z',
+        'sess-contribB-missing',
+        'claim-512',
+      ),
+    ],
+    [
+      '512:claude:cleanup',
+      stageWindow(
+        '2026-01-01T00:20:00Z',
+        '2026-01-01T00:25:00Z',
+        'sess-primary-0009',
+        'claim-512',
+      ),
+    ],
+  ]);
+
+  const sessions = scanClaudeVendorSessions(sandbox, eventWindowsAll);
+  const mergedSamples = sessions.filter((s) =>
+    s.adapterResult.sample.vendorSessionId.includes('#ew512'),
+  );
+  const contribASamples = sessions.filter(
+    (s) => s.adapterResult.sample.vendorSessionId === 'sess-contribA-0009',
+  );
+
+  // No merged `#ew512` sample -- the unresolvable second contributor
+  // still correctly aborts the whole issue. But the first contributor's
+  // own plain cwd-derived sample for issue 512 (no `#ew` suffix -- it was
+  // never actually merged into anything) must still stand on its own.
+  assert.equal(mergedSamples.length, 0);
+  assert.equal(contribASamples.length, 1);
+  assert.equal(contribASamples[0].adapterResult.sample.usage.output, 4);
+});
+
 test('scanClaudeVendorSessions: a contributor eligible for one contributing window is not disqualified by an EARLIER, non-overlapping cwd segment for a different issue (#2432, Codex review PR #2627)', () => {
   // The contributing session's own file also touched an unrelated issue
   // (#100) much earlier, at a time that does not overlap this contributing

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -208,11 +208,13 @@ function stageWindow(
   startIso: string,
   endIso: string,
   vendorSessionId?: string,
+  claimId?: string,
 ): StageEventWindow {
   return {
     startMs: ms(startIso),
     endMs: ms(endIso),
     ...(vendorSessionId !== undefined ? { vendorSessionId } : {}),
+    ...(claimId !== undefined ? { claimId } : {}),
   };
 }
 
@@ -808,6 +810,196 @@ test('buildCompletedIssueWindows: an IDENTIFIED non-cleanup window from a stale 
   assert.equal(windows[0].startMs, ms('2026-01-01T00:10:00Z'));
   assert.equal(windows[0].endMs, ms('2026-01-01T00:10:05Z'));
   assert.equal('vendorSessionId' in windows[0], false);
+});
+
+test('buildCompletedIssueWindows: a claimId match widens the window across a different vendorSessionId and records a contributingWindows entry (#2432)', () => {
+  // Attempt A (earlier handoff session) posted 'work' under the SAME
+  // claim-id as attempt B (the session that reached cleanup), but a
+  // DIFFERENT vendorSessionId. #2424 alone would exclude 'work' as a
+  // vendorSessionId mismatch; the claimId match is the positive evidence
+  // that this is a genuine handoff, not an unrelated attempt.
+  const all = new Map<string, StageEventWindow>([
+    [
+      '601:claude:work',
+      stageWindow(
+        '2026-01-01T00:00:00Z',
+        '2026-01-01T00:05:00Z',
+        'attempt-A',
+        'claim-shared',
+      ),
+    ],
+    [
+      '601:claude:cleanup',
+      stageWindow(
+        '2026-01-01T00:20:00Z',
+        '2026-01-01T00:25:00Z',
+        'attempt-B',
+        'claim-shared',
+      ),
+    ],
+  ]);
+  const windows = buildCompletedIssueWindows(all, 'claude');
+  assert.equal(windows.length, 1);
+  assert.equal(windows[0].startMs, ms('2026-01-01T00:00:00Z'));
+  assert.equal(windows[0].endMs, ms('2026-01-01T00:25:00Z'));
+  assert.equal(windows[0].vendorSessionId, 'attempt-B');
+  assert.equal(windows[0].claimId, 'claim-shared');
+  assert.deepEqual(windows[0].contributingWindows, [
+    {
+      vendorSessionId: 'attempt-A',
+      startMs: ms('2026-01-01T00:00:00Z'),
+      endMs: ms('2026-01-01T00:05:00Z'),
+    },
+  ]);
+});
+
+test('buildCompletedIssueWindows: a DIFFERENT vendorSessionId AND a different (or absent) claimId is still excluded (#2432 regression guard on #2424 behavior)', () => {
+  const all = new Map<string, StageEventWindow>([
+    [
+      '602:claude:work',
+      stageWindow(
+        '2026-01-01T00:00:00Z',
+        '2026-01-01T00:05:00Z',
+        'attempt-A',
+        'claim-unrelated',
+      ),
+    ],
+    [
+      '602:claude:cleanup',
+      stageWindow(
+        '2026-01-01T00:20:00Z',
+        '2026-01-01T00:25:00Z',
+        'attempt-B',
+        'claim-shared',
+      ),
+    ],
+  ]);
+  const windows = buildCompletedIssueWindows(all, 'claude');
+  assert.equal(windows.length, 1);
+  assert.equal(windows[0].startMs, ms('2026-01-01T00:20:00Z'));
+  assert.equal('contributingWindows' in windows[0], false);
+});
+
+test('buildCompletedIssueWindows: a claimId-matched but reversed window still trips contamination (safety checks apply uniformly, #2432)', () => {
+  const all = new Map<string, StageEventWindow>([
+    [
+      '603:claude:work',
+      stageWindow(
+        '2026-01-01T00:04:00Z',
+        '2026-01-01T00:02:00Z',
+        'attempt-A',
+        'claim-shared',
+      ),
+    ],
+    [
+      '603:claude:cleanup',
+      stageWindow(
+        '2026-01-01T00:05:00Z',
+        '2026-01-01T00:06:00Z',
+        'attempt-B',
+        'claim-shared',
+      ),
+    ],
+  ]);
+  const windows = buildCompletedIssueWindows(all, 'claude');
+  assert.equal(windows.length, 0);
+});
+
+test('buildCompletedIssueWindows: one vendorSessionId contributing two stages unions into a single contributingWindows entry (#2432)', () => {
+  const all = new Map<string, StageEventWindow>([
+    [
+      '604:claude:claim',
+      stageWindow(
+        '2026-01-01T00:00:00Z',
+        '2026-01-01T00:01:00Z',
+        'attempt-A',
+        'claim-shared',
+      ),
+    ],
+    [
+      '604:claude:work',
+      stageWindow(
+        '2026-01-01T00:01:00Z',
+        '2026-01-01T00:05:00Z',
+        'attempt-A',
+        'claim-shared',
+      ),
+    ],
+    [
+      '604:claude:cleanup',
+      stageWindow(
+        '2026-01-01T00:20:00Z',
+        '2026-01-01T00:25:00Z',
+        'attempt-B',
+        'claim-shared',
+      ),
+    ],
+  ]);
+  const windows = buildCompletedIssueWindows(all, 'claude');
+  assert.equal(windows.length, 1);
+  assert.deepEqual(windows[0].contributingWindows, [
+    {
+      vendorSessionId: 'attempt-A',
+      startMs: ms('2026-01-01T00:00:00Z'),
+      endMs: ms('2026-01-01T00:05:00Z'),
+    },
+  ]);
+});
+
+test('buildCompletedIssueWindows: two claimId-matched windows from different vendorSessionIds that OVERLAP each other skip the whole issue (#2432 cross-session overlap guard)', () => {
+  // A documented, narrow TOCTOU race (idd-claim.instructions.md) can leave
+  // two sessions momentarily sharing one active claim-id without one
+  // being a clean sequential continuation -- overlapping activity under a
+  // shared claim-id is evidence of exactly that race, not a genuine
+  // handoff, so this must NOT merge.
+  const all = new Map<string, StageEventWindow>([
+    [
+      '605:claude:work',
+      stageWindow(
+        '2026-01-01T00:00:00Z',
+        '2026-01-01T00:22:00Z',
+        'attempt-A',
+        'claim-shared',
+      ),
+    ],
+    [
+      '605:claude:cleanup',
+      stageWindow(
+        '2026-01-01T00:20:00Z',
+        '2026-01-01T00:25:00Z',
+        'attempt-B',
+        'claim-shared',
+      ),
+    ],
+  ]);
+  const windows = buildCompletedIssueWindows(all, 'claude');
+  assert.equal(windows.length, 0);
+});
+
+test('buildCompletedIssueWindows: claimId-matched windows that are exactly back-to-back (touching, not overlapping) still merge (#2432)', () => {
+  const all = new Map<string, StageEventWindow>([
+    [
+      '606:claude:work',
+      stageWindow(
+        '2026-01-01T00:00:00Z',
+        '2026-01-01T00:20:00Z',
+        'attempt-A',
+        'claim-shared',
+      ),
+    ],
+    [
+      '606:claude:cleanup',
+      stageWindow(
+        '2026-01-01T00:20:00Z',
+        '2026-01-01T00:25:00Z',
+        'attempt-B',
+        'claim-shared',
+      ),
+    ],
+  ]);
+  const windows = buildCompletedIssueWindows(all, 'claude');
+  assert.equal(windows.length, 1);
+  assert.equal(windows[0].startMs, ms('2026-01-01T00:00:00Z'));
 });
 
 test("scanClaudeVendorSessions: a completed cleanup window does not absorb a later retry's activity", () => {

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -274,6 +274,16 @@ test('buildCompletedIssueWindows: builds an overall window only for an issue wit
       issueNumber: 501,
       startMs: ms('2026-01-01T00:00:00Z'),
       endMs: ms('2026-01-01T01:00:00Z'),
+      primaryWindows: [
+        {
+          startMs: ms('2026-01-01T00:00:00Z'),
+          endMs: ms('2026-01-01T00:30:00Z'),
+        },
+        {
+          startMs: ms('2026-01-01T00:55:00Z'),
+          endMs: ms('2026-01-01T01:00:00Z'),
+        },
+      ],
     },
   ]);
 });
@@ -303,11 +313,13 @@ test('segmentRecordsByEventWindow: groups records by the single window each time
       issueNumber: 501,
       startMs: ms('2026-01-01T00:00:00Z'),
       endMs: ms('2026-01-01T01:00:00Z'),
+      primaryWindows: [],
     },
     {
       issueNumber: 502,
       startMs: ms('2026-01-02T00:00:00Z'),
       endMs: ms('2026-01-02T01:00:00Z'),
+      primaryWindows: [],
     },
   ];
   const records = [
@@ -334,6 +346,7 @@ test('segmentRecordsByEventWindow: drops a record with no timestamp, and one mat
       issueNumber: 501,
       startMs: ms('2026-01-01T00:00:00Z'),
       endMs: ms('2026-01-01T01:00:00Z'),
+      primaryWindows: [],
     },
   ];
   const records = [
@@ -356,11 +369,13 @@ test('segmentRecordsByEventWindow: drops a record matching MORE than one window 
       issueNumber: 501,
       startMs: ms('2026-01-01T00:00:00Z'),
       endMs: ms('2026-01-01T02:00:00Z'),
+      primaryWindows: [],
     },
     {
       issueNumber: 502,
       startMs: ms('2026-01-01T01:00:00Z'),
       endMs: ms('2026-01-01T03:00:00Z'),
+      primaryWindows: [],
     },
   ];
   const records = [{ id: 'ambiguous', timestamp: '2026-01-01T01:30:00Z' }];
@@ -376,11 +391,13 @@ test('segmentRecordsByEventWindow: a record at the exact instant one window ends
       issueNumber: 501,
       startMs: ms('2026-01-01T00:00:00Z'),
       endMs: ms('2026-01-01T01:00:00Z'),
+      primaryWindows: [],
     },
     {
       issueNumber: 502,
       startMs: ms('2026-01-01T01:00:00Z'),
       endMs: ms('2026-01-01T02:00:00Z'),
+      primaryWindows: [],
     },
   ];
   const records = [{ id: 'boundary', timestamp: '2026-01-01T01:00:00Z' }];
@@ -907,7 +924,7 @@ test('buildCompletedIssueWindows: a claimId-matched but reversed window still tr
   assert.equal(windows.length, 0);
 });
 
-test('buildCompletedIssueWindows: one vendorSessionId contributing two stages unions into a single contributingWindows entry (#2432)', () => {
+test('buildCompletedIssueWindows: one vendorSessionId contributing two stages keeps two separate contributingWindows entries (#2432, Codex review PR #2627)', () => {
   const all = new Map<string, StageEventWindow>([
     [
       '604:claude:claim',
@@ -939,10 +956,18 @@ test('buildCompletedIssueWindows: one vendorSessionId contributing two stages un
   ]);
   const windows = buildCompletedIssueWindows(all, 'claude');
   assert.equal(windows.length, 1);
+  // Two separate entries, never unioned into one enclosing span -- a union
+  // would falsely "overlap" any primary-session activity that merely falls
+  // inside the GAP between attempt-A's own claim and work stages.
   assert.deepEqual(windows[0].contributingWindows, [
     {
       vendorSessionId: 'attempt-A',
       startMs: ms('2026-01-01T00:00:00Z'),
+      endMs: ms('2026-01-01T00:01:00Z'),
+    },
+    {
+      vendorSessionId: 'attempt-A',
+      startMs: ms('2026-01-01T00:01:00Z'),
       endMs: ms('2026-01-01T00:05:00Z'),
     },
   ]);
@@ -1513,7 +1538,7 @@ test('scanClaudeVendorSessions: a same-issue match from an unrelated concurrent 
   assert.equal(sessions.length, 3);
 });
 
-test('scanClaudeVendorSessions: a contributing session whose file cannot be uniquely resolved degrades to the primary-only sample instead of failing the whole issue (#2432)', () => {
+test('scanClaudeVendorSessions: a contributing session whose file cannot be uniquely resolved skips the whole issue rather than freezing an undercount (#2432, Codex review PR #2627)', () => {
   const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
   // No file in this sandbox has sessionId 'sess-contrib-missing' -- the
   // contributing window's own file was never scanned (e.g. rotated out,
@@ -1548,12 +1573,11 @@ test('scanClaudeVendorSessions: a contributing session whose file cannot be uniq
     s.adapterResult.sample.vendorSessionId.includes('#ew'),
   );
 
-  assert.equal(ewSamples.length, 1);
-  assert.equal(
-    ewSamples[0].adapterResult.sample.vendorSessionId,
-    'sess-primary-0002#ew502',
-  );
-  assert.equal(ewSamples[0].adapterResult.sample.usage.output, 7);
+  // No sample at all for issue 502 -- a primary-only sample would freeze
+  // this undercount permanently under the stable `#ew502` id, since the
+  // CLI's append-side dedup would then skip a later, fuller harvest once
+  // the missing contributor file becomes available.
+  assert.equal(ewSamples.length, 0);
 });
 
 test('scanClaudeVendorSessions: a contributing candidate whose file already independently produced a cwd-attributed sample is never re-absorbed (#2432)', () => {
@@ -2571,6 +2595,67 @@ test("readEventWindows: prefers the winning cleanup attempt's own stage candidat
     assert.equal(work?.vendorSessionId, 'sess-A');
     assert.equal(work?.startMs, ms('2026-01-01T00:00:00Z'));
     assert.equal(work?.endMs, ms('2026-01-01T00:01:00Z'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('readEventWindows: a claimId match beats an unrelated, differently-identified attempt with a later endMs (Codex review finding, PR #2627, #2432)', () => {
+  // Attempt A (claim-shared) completes 'work'. Attempt Z is a wholly
+  // unrelated, later attempt at the same stage with NO matching claimId,
+  // but a LATER endMs. Attempt B (claim-shared) later completes cleanup
+  // without ever re-posting 'work' itself. Pure latest-endMs-wins would
+  // expose Z's window here (and #2432's idCompatible would then reject it
+  // outright, silently discarding A's genuinely claim-linked contribution
+  // before it ever gets a chance) -- claimId, once matched, must outrank
+  // mere recency.
+  const { dir, path } = writeEventsFile([
+    tokenCostEvent(
+      'enter',
+      'work',
+      '2026-01-01T00:00:00Z',
+      504,
+      'sess-A',
+      'claude',
+      'claim-shared',
+    ),
+    tokenCostEvent(
+      'exit',
+      'work',
+      '2026-01-01T00:05:00Z',
+      504,
+      'sess-A',
+      'claude',
+      'claim-shared',
+    ),
+    tokenCostEvent('enter', 'work', '2026-01-01T00:06:00Z', 504, 'sess-Z'),
+    tokenCostEvent('exit', 'work', '2026-01-01T00:08:00Z', 504, 'sess-Z'),
+    tokenCostEvent(
+      'enter',
+      'cleanup',
+      '2026-01-01T00:20:00Z',
+      504,
+      'sess-B',
+      'claude',
+      'claim-shared',
+    ),
+    tokenCostEvent(
+      'exit',
+      'cleanup',
+      '2026-01-01T00:25:00Z',
+      504,
+      'sess-B',
+      'claude',
+      'claim-shared',
+    ),
+  ]);
+  try {
+    const windows = readEventWindows(path);
+    const work = windows.get('504:claude:work');
+    assert.equal(work?.vendorSessionId, 'sess-A');
+    assert.equal(work?.claimId, 'claim-shared');
+    assert.equal(work?.startMs, ms('2026-01-01T00:00:00Z'));
+    assert.equal(work?.endMs, ms('2026-01-01T00:05:00Z'));
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -227,6 +227,7 @@ function tokenCostEvent(
   issueNumber: number,
   vendorSessionId?: string,
   vendor = 'claude',
+  claimId?: string,
 ): string {
   return JSON.stringify({
     schemaVersion: 1,
@@ -236,6 +237,7 @@ function tokenCostEvent(
     vendor,
     issueNumber,
     ...(vendorSessionId !== undefined ? { vendorSessionId } : {}),
+    ...(claimId !== undefined ? { claimId } : {}),
   });
 }
 
@@ -1371,6 +1373,255 @@ test('scanClaudeVendorSessions: a SOLE candidate file is still harvested uncondi
   assert.equal(ewSamples.length, 1);
 });
 
+test('scanClaudeVendorSessions: a genuine handoff (matching claimId, differing vendorSessionId) merges both files into one #ew sample, identity anchored to the primary/cleanup file, with correct startedAt/endedAt despite the contributing session being chronologically EARLIER (#2432)', () => {
+  // The realistic handoff shape: the contributing (earlier) session's own
+  // records are chronologically BEFORE the primary/cleanup session's.
+  // This is the regression test for the ordering bug caught in review --
+  // `extractTimestamps` takes the first/last record in ARRAY order, not a
+  // true min/max, so a naive "concatenate contributing after primary"
+  // merge would produce startedAt > endedAt and throw. The merge must
+  // sort by timestamp before harvesting.
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
+  writeFileSync(
+    join(sandbox, 'session-ew-contrib.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:01:00.000Z","sessionId":"sess-contrib-0001","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":3}}}\n',
+  );
+  writeFileSync(
+    join(sandbox, 'session-ew-primary.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:24:00.000Z","sessionId":"sess-primary-0001","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":7}}}\n',
+  );
+  const eventWindowsAll = new Map<string, StageEventWindow>([
+    [
+      '501:claude:work',
+      stageWindow(
+        '2026-01-01T00:00:00Z',
+        '2026-01-01T00:05:00Z',
+        'sess-contrib-0001',
+        'claim-shared',
+      ),
+    ],
+    [
+      '501:claude:cleanup',
+      stageWindow(
+        '2026-01-01T00:20:00Z',
+        '2026-01-01T00:25:00Z',
+        'sess-primary-0001',
+        'claim-shared',
+      ),
+    ],
+  ]);
+
+  const sessions = scanClaudeVendorSessions(sandbox, eventWindowsAll);
+  const ewSamples = sessions.filter((s) =>
+    s.adapterResult.sample.vendorSessionId.includes('#ew'),
+  );
+
+  assert.equal(ewSamples.length, 1);
+  const sample = ewSamples[0].adapterResult.sample;
+  assert.equal(sample.vendorSessionId, 'sess-primary-0001#ew501');
+  assert.equal(sample.usage.output, 10);
+  assert.equal(sample.startedAt, '2026-01-01T00:01:00.000Z');
+  assert.equal(sample.endedAt, '2026-01-01T00:24:00.000Z');
+  // Each file's own plain per-file sample plus the one merged #ew sample.
+  assert.equal(sessions.length, 3);
+});
+
+test('scanClaudeVendorSessions: a same-issue match from an unrelated concurrent session (different vendorSessionId, no shared claimId) never merges its usage in (#2432 regression guard on #2423/#2424/#2425)', () => {
+  // fileA is the primary/cleanup file; fileB has a DIFFERENT
+  // vendorSessionId AND no claimId relationship to fileA's cleanup event
+  // at all (a genuinely unrelated concurrent session, not a handoff).
+  // Unlike the #2424 "cross-file match resolved via identity" test above
+  // (same vendorSessionId on both ends), this exercises the NEW claimId
+  // branch's negative case through the full merge pipeline: fileB's
+  // own file is present and structurally eligible (unattributed,
+  // timestamp inside the widened window), but must never be pulled in.
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
+  writeFileSync(
+    join(sandbox, 'session-ew-idA.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:20:00.000Z","sessionId":"sess-ew-idA-0001","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}\n',
+  );
+  writeFileSync(
+    join(sandbox, 'session-ew-idB.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:21:00.000Z","sessionId":"sess-ew-idB-0001","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":5,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":5}}}\n',
+  );
+  const eventWindowsAll = new Map<string, StageEventWindow>([
+    [
+      '501:claude:work',
+      stageWindow(
+        '2026-01-01T00:10:00Z',
+        '2026-01-01T00:19:00Z',
+        'sess-ew-idB-0001',
+        'claim-unrelated',
+      ),
+    ],
+    [
+      '501:claude:cleanup',
+      stageWindow(
+        '2026-01-01T00:20:00Z',
+        '2026-01-01T00:25:00Z',
+        'sess-ew-idA-0001',
+        'claim-shared',
+      ),
+    ],
+  ]);
+
+  const sessions = scanClaudeVendorSessions(sandbox, eventWindowsAll);
+  const ewSamples = sessions.filter((s) =>
+    s.adapterResult.sample.vendorSessionId.includes('#ew'),
+  );
+
+  assert.equal(ewSamples.length, 1);
+  const sample = ewSamples[0].adapterResult.sample;
+  assert.equal(sample.vendorSessionId, 'sess-ew-idA-0001#ew501');
+  // Only fileA's own usage (1) -- fileB's usage (5) is never folded in.
+  assert.equal(sample.usage.output, 1);
+  assert.equal(sessions.length, 3);
+});
+
+test('scanClaudeVendorSessions: a contributing session whose file cannot be uniquely resolved degrades to the primary-only sample instead of failing the whole issue (#2432)', () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
+  // No file in this sandbox has sessionId 'sess-contrib-missing' -- the
+  // contributing window's own file was never scanned (e.g. rotated out,
+  // or on a different machine).
+  writeFileSync(
+    join(sandbox, 'session-ew-primary.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:24:00.000Z","sessionId":"sess-primary-0002","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":7}}}\n',
+  );
+  const eventWindowsAll = new Map<string, StageEventWindow>([
+    [
+      '502:claude:work',
+      stageWindow(
+        '2026-01-01T00:00:00Z',
+        '2026-01-01T00:05:00Z',
+        'sess-contrib-missing',
+        'claim-shared',
+      ),
+    ],
+    [
+      '502:claude:cleanup',
+      stageWindow(
+        '2026-01-01T00:20:00Z',
+        '2026-01-01T00:25:00Z',
+        'sess-primary-0002',
+        'claim-shared',
+      ),
+    ],
+  ]);
+
+  const sessions = scanClaudeVendorSessions(sandbox, eventWindowsAll);
+  const ewSamples = sessions.filter((s) =>
+    s.adapterResult.sample.vendorSessionId.includes('#ew'),
+  );
+
+  assert.equal(ewSamples.length, 1);
+  assert.equal(
+    ewSamples[0].adapterResult.sample.vendorSessionId,
+    'sess-primary-0002#ew502',
+  );
+  assert.equal(ewSamples[0].adapterResult.sample.usage.output, 7);
+});
+
+test('scanClaudeVendorSessions: a contributing candidate whose file already independently produced a cwd-attributed sample is never re-absorbed (#2432)', () => {
+  // fileA's own cwd resolves to a DIFFERENT issue (4242) via a real
+  // issue-worktree path -- it already produced its own independent
+  // cwd-attributed sample and must never also be pulled in as a
+  // contributing session for issue 503's merged #ew sample, even though
+  // its own sessionId matches the contributing window's vendorSessionId.
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
+  writeFileSync(
+    join(sandbox, 'session-cwd-attributed.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:01:00.000Z","sessionId":"sess-contrib-0003","cwd":"/home/user/repo.issue-4242-x","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":3}}}\n',
+  );
+  writeFileSync(
+    join(sandbox, 'session-ew-primary.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:24:00.000Z","sessionId":"sess-primary-0003","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":7}}}\n',
+  );
+  const eventWindowsAll = new Map<string, StageEventWindow>([
+    [
+      '503:claude:work',
+      stageWindow(
+        '2026-01-01T00:00:00Z',
+        '2026-01-01T00:05:00Z',
+        'sess-contrib-0003',
+        'claim-shared',
+      ),
+    ],
+    [
+      '503:claude:cleanup',
+      stageWindow(
+        '2026-01-01T00:20:00Z',
+        '2026-01-01T00:25:00Z',
+        'sess-primary-0003',
+        'claim-shared',
+      ),
+    ],
+  ]);
+
+  const sessions = scanClaudeVendorSessions(sandbox, eventWindowsAll);
+  const ewSamples = sessions.filter((s) =>
+    s.adapterResult.sample.vendorSessionId.includes('#ew'),
+  );
+
+  assert.equal(ewSamples.length, 1);
+  // Only the primary file's own usage (7) -- the cwd-attributed file's
+  // usage (3) is never folded in.
+  assert.equal(ewSamples[0].adapterResult.sample.usage.output, 7);
+});
+
+test('scanClaudeVendorSessions: one vendorSessionId contributing two stages merges both stages worth of that session file, not just the last one (#2432)', () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
+  writeFileSync(
+    join(sandbox, 'session-ew-contrib.jsonl'),
+    [
+      '{"type":"assistant","timestamp":"2026-01-01T00:00:30.000Z","sessionId":"sess-contrib-0004","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":2}}}',
+      '{"type":"assistant","timestamp":"2026-01-01T00:03:00.000Z","sessionId":"sess-contrib-0004","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":4}}}',
+    ].join('\n') + '\n',
+  );
+  writeFileSync(
+    join(sandbox, 'session-ew-primary.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:24:00.000Z","sessionId":"sess-primary-0004","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":7}}}\n',
+  );
+  const eventWindowsAll = new Map<string, StageEventWindow>([
+    [
+      '504:claude:claim',
+      stageWindow(
+        '2026-01-01T00:00:00Z',
+        '2026-01-01T00:01:00Z',
+        'sess-contrib-0004',
+        'claim-shared',
+      ),
+    ],
+    [
+      '504:claude:work',
+      stageWindow(
+        '2026-01-01T00:01:00Z',
+        '2026-01-01T00:05:00Z',
+        'sess-contrib-0004',
+        'claim-shared',
+      ),
+    ],
+    [
+      '504:claude:cleanup',
+      stageWindow(
+        '2026-01-01T00:20:00Z',
+        '2026-01-01T00:25:00Z',
+        'sess-primary-0004',
+        'claim-shared',
+      ),
+    ],
+  ]);
+
+  const sessions = scanClaudeVendorSessions(sandbox, eventWindowsAll);
+  const ewSamples = sessions.filter((s) =>
+    s.adapterResult.sample.vendorSessionId.includes('#ew'),
+  );
+
+  assert.equal(ewSamples.length, 1);
+  // 2 (claim stage) + 4 (work stage) + 7 (primary) -- both of the
+  // contributing session's own records are pulled in, not just one.
+  assert.equal(ewSamples[0].adapterResult.sample.usage.output, 13);
+});
+
 test('scanClaudeVendorSessions: an event window is ignored when the segment already has a cwd-inferred issueNumber', () => {
   const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
   writeFileSync(
@@ -2121,6 +2372,66 @@ test('readEventWindows: tags a window with vendorSessionId when both enter and e
   try {
     const windows = readEventWindows(path);
     assert.equal(windows.get('7:claude:work')?.vendorSessionId, 'sess-A');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('readEventWindows: tags a window with claimId when both enter and exit share one (#2432)', () => {
+  const { dir, path } = writeEventsFile([
+    tokenCostEvent(
+      'enter',
+      'work',
+      '2026-01-01T00:10:00Z',
+      7,
+      'sess-A',
+      'claude',
+      'claim-shared',
+    ),
+    tokenCostEvent(
+      'exit',
+      'work',
+      '2026-01-01T00:20:00Z',
+      7,
+      'sess-A',
+      'claude',
+      'claim-shared',
+    ),
+  ]);
+  try {
+    const windows = readEventWindows(path);
+    assert.equal(windows.get('7:claude:work')?.claimId, 'claim-shared');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('readEventWindows: leaves a window claimId-untagged when the enter and exit claimId disagree (#2432, defensive)', () => {
+  const { dir, path } = writeEventsFile([
+    tokenCostEvent(
+      'enter',
+      'work',
+      '2026-01-01T00:10:00Z',
+      7,
+      'sess-A',
+      'claude',
+      'claim-one',
+    ),
+    tokenCostEvent(
+      'exit',
+      'work',
+      '2026-01-01T00:20:00Z',
+      7,
+      'sess-A',
+      'claude',
+      'claim-two',
+    ),
+  ]);
+  try {
+    const windows = readEventWindows(path);
+    const window = windows.get('7:claude:work');
+    assert.ok(window);
+    assert.equal('claimId' in (window ?? {}), false);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -978,6 +978,41 @@ test('buildCompletedIssueWindows: two claimId-matched windows from different ven
   assert.equal(windows.length, 0);
 });
 
+test("buildCompletedIssueWindows: a contributor overlapping the primary session's OWN earlier stage (not cleanup itself) still trips the overlap guard (#2432, C1 review finding)", () => {
+  // The primary session (attempt-B) posted an earlier 'work' stage of its
+  // own, well before its own 'cleanup'. A contributor (attempt-A) whose
+  // window overlaps that earlier 'work' stage -- without overlapping
+  // cleanup's own narrow slice -- is just as much evidence of the
+  // documented TOCTOU race as one overlapping cleanup directly; comparing
+  // only against cleanup's own [startMs, endMs) would miss this.
+  const all = new Map<string, StageEventWindow>([
+    [
+      '607:claude:work',
+      stageWindow('2026-01-01T00:05:00Z', '2026-01-01T00:15:00Z', 'attempt-B'),
+    ],
+    [
+      '607:claude:claim',
+      stageWindow(
+        '2026-01-01T00:10:00Z',
+        '2026-01-01T00:20:00Z',
+        'attempt-A',
+        'claim-shared',
+      ),
+    ],
+    [
+      '607:claude:cleanup',
+      stageWindow(
+        '2026-01-01T00:25:00Z',
+        '2026-01-01T00:30:00Z',
+        'attempt-B',
+        'claim-shared',
+      ),
+    ],
+  ]);
+  const windows = buildCompletedIssueWindows(all, 'claude');
+  assert.equal(windows.length, 0);
+});
+
 test('buildCompletedIssueWindows: claimId-matched windows that are exactly back-to-back (touching, not overlapping) still merge (#2432)', () => {
   const all = new Map<string, StageEventWindow>([
     [
@@ -1572,10 +1607,10 @@ test('scanClaudeVendorSessions: one vendorSessionId contributing two stages merg
   const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
   writeFileSync(
     join(sandbox, 'session-ew-contrib.jsonl'),
-    [
+    `${[
       '{"type":"assistant","timestamp":"2026-01-01T00:00:30.000Z","sessionId":"sess-contrib-0004","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":2}}}',
       '{"type":"assistant","timestamp":"2026-01-01T00:03:00.000Z","sessionId":"sess-contrib-0004","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":4}}}',
-    ].join('\n') + '\n',
+    ].join('\n')}\n`,
   );
   writeFileSync(
     join(sandbox, 'session-ew-primary.jsonl'),

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -1731,6 +1731,63 @@ test('scanClaudeVendorSessions: a cwd-attributed primary (cleanup session launch
   assert.equal(issue506Samples[0].adapterResult.sample.usage.output, 9);
 });
 
+test('scanClaudeVendorSessions: a cwd-attributed primary that moved out of and back into the issue worktree (two segments, one file) still resolves (#2432, Codex review PR #2627)', () => {
+  // The cleanup-owning session's own file produces TWO cwd-attributed
+  // segments for the SAME issue (#2404 segmentation, moved out then back
+  // in) -- this must not read as "matched more than one file" and reject
+  // the resolution; both segments' records belong to the one, uniquely
+  // resolved primary file.
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
+  writeFileSync(
+    join(sandbox, 'session-primary-508.jsonl'),
+    `${[
+      '{"type":"assistant","timestamp":"2026-01-01T00:15:00.000Z","sessionId":"sess-primary-0007","cwd":"/home/user/repo.issue-508-x","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":3}}}',
+      '{"type":"assistant","timestamp":"2026-01-01T00:18:00.000Z","sessionId":"sess-primary-0007","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":5}}}',
+      '{"type":"assistant","timestamp":"2026-01-01T00:24:00.000Z","sessionId":"sess-primary-0007","cwd":"/home/user/repo.issue-508-x","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":7}}}',
+    ].join('\n')}\n`,
+  );
+  writeFileSync(
+    join(sandbox, 'session-contrib-508.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:00:30.000Z","sessionId":"sess-contrib-0007","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":2}}}\n',
+  );
+  const eventWindowsAll = new Map<string, StageEventWindow>([
+    [
+      '508:claude:work',
+      stageWindow(
+        '2026-01-01T00:00:00Z',
+        '2026-01-01T00:05:00Z',
+        'sess-contrib-0007',
+        'claim-shared',
+      ),
+    ],
+    [
+      '508:claude:cleanup',
+      stageWindow(
+        '2026-01-01T00:20:00Z',
+        '2026-01-01T00:25:00Z',
+        'sess-primary-0007',
+        'claim-shared',
+      ),
+    ],
+  ]);
+
+  const sessions = scanClaudeVendorSessions(sandbox, eventWindowsAll);
+  const issue508Samples = sessions.filter((s) =>
+    s.adapterResult.sample.vendorSessionId.includes('508'),
+  );
+
+  assert.equal(issue508Samples.length, 1);
+  assert.equal(
+    issue508Samples[0].adapterResult.sample.vendorSessionId,
+    'sess-primary-0007#ew508',
+  );
+  // 3 + 7 (both cwd-508-attributed segments' own records) + 2
+  // (contributor) -- the middle segment's own 5 tokens, recorded while
+  // cwd was NOT the issue-508 worktree, are correctly excluded: only the
+  // cwd-attributed segments belong to this primary.
+  assert.equal(issue508Samples[0].adapterResult.sample.usage.output, 12);
+});
+
 test('scanClaudeVendorSessions: a contributor eligible for one contributing window is not disqualified by an EARLIER, non-overlapping cwd segment for a different issue (#2432, Codex review PR #2627)', () => {
   // The contributing session's own file also touched an unrelated issue
   // (#100) much earlier, at a time that does not overlap this contributing

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -1681,6 +1681,106 @@ test('scanClaudeVendorSessions: one vendorSessionId contributing two stages merg
   assert.equal(ewSamples[0].adapterResult.sample.usage.output, 13);
 });
 
+test('scanClaudeVendorSessions: a cwd-attributed primary (cleanup session launched inside the issue worktree) still merges a contributor, and its own standalone sample is suppressed (#2432, Codex review PR #2627)', () => {
+  // The cleanup-owning session was launched directly inside the issue's
+  // own worktree, so it cwd-resolves normally and is excluded from the
+  // #2418 unattributed-record fallback pool -- the merge must still fire
+  // by resolving this cwd-attributed file as primary directly.
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
+  writeFileSync(
+    join(sandbox, 'session-primary-506.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:24:00.000Z","sessionId":"sess-primary-0005","cwd":"/home/user/repo.issue-506-x","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":7}}}\n',
+  );
+  writeFileSync(
+    join(sandbox, 'session-contrib-506.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:00:30.000Z","sessionId":"sess-contrib-0005","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":2}}}\n',
+  );
+  const eventWindowsAll = new Map<string, StageEventWindow>([
+    [
+      '506:claude:work',
+      stageWindow(
+        '2026-01-01T00:00:00Z',
+        '2026-01-01T00:05:00Z',
+        'sess-contrib-0005',
+        'claim-shared',
+      ),
+    ],
+    [
+      '506:claude:cleanup',
+      stageWindow(
+        '2026-01-01T00:20:00Z',
+        '2026-01-01T00:25:00Z',
+        'sess-primary-0005',
+        'claim-shared',
+      ),
+    ],
+  ]);
+
+  const sessions = scanClaudeVendorSessions(sandbox, eventWindowsAll);
+  const issue506Samples = sessions.filter((s) =>
+    s.adapterResult.sample.vendorSessionId.includes('506'),
+  );
+
+  // Exactly one sample for issue 506 -- not the merged #ew sample AND a
+  // separate standalone cwd-derived sample for the same completed loop.
+  assert.equal(issue506Samples.length, 1);
+  assert.equal(
+    issue506Samples[0].adapterResult.sample.vendorSessionId,
+    'sess-primary-0005#ew506',
+  );
+  assert.equal(issue506Samples[0].adapterResult.sample.usage.output, 9);
+});
+
+test('scanClaudeVendorSessions: a contributor eligible for one contributing window is not disqualified by an EARLIER, non-overlapping cwd segment for a different issue (#2432, Codex review PR #2627)', () => {
+  // The contributing session's own file also touched an unrelated issue
+  // (#100) much earlier, at a time that does not overlap this contributing
+  // window at all -- the file-wide eligibility check must not reject the
+  // contributor on that basis alone.
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
+  writeFileSync(
+    join(sandbox, 'session-contrib-507.jsonl'),
+    `${[
+      '{"type":"assistant","timestamp":"2025-12-31T00:00:00.000Z","sessionId":"sess-contrib-0006","cwd":"/home/user/repo.issue-100-x","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":99}}}',
+      '{"type":"assistant","timestamp":"2026-01-01T00:00:30.000Z","sessionId":"sess-contrib-0006","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":2}}}',
+    ].join('\n')}\n`,
+  );
+  writeFileSync(
+    join(sandbox, 'session-ew-primary-507.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:24:00.000Z","sessionId":"sess-primary-0006","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":7}}}\n',
+  );
+  const eventWindowsAll = new Map<string, StageEventWindow>([
+    [
+      '507:claude:work',
+      stageWindow(
+        '2026-01-01T00:00:00Z',
+        '2026-01-01T00:05:00Z',
+        'sess-contrib-0006',
+        'claim-shared',
+      ),
+    ],
+    [
+      '507:claude:cleanup',
+      stageWindow(
+        '2026-01-01T00:20:00Z',
+        '2026-01-01T00:25:00Z',
+        'sess-primary-0006',
+        'claim-shared',
+      ),
+    ],
+  ]);
+
+  const sessions = scanClaudeVendorSessions(sandbox, eventWindowsAll);
+  const ewSamples = sessions.filter((s) =>
+    s.adapterResult.sample.vendorSessionId.includes('#ew507'),
+  );
+
+  assert.equal(ewSamples.length, 1);
+  // 7 (primary) + 2 (contributor's own in-window record) -- the
+  // contributor is NOT disqualified by its earlier, disjoint issue-100
+  // segment (99 tokens, correctly excluded from this sum).
+  assert.equal(ewSamples[0].adapterResult.sample.usage.output, 9);
+});
+
 test('scanClaudeVendorSessions: a multi-hop handoff across THREE different sessions (not just two) merges all of them (#2432, C1 review coverage gap)', () => {
   // A -> B -> C: three different vendorSessionIds, one shared claimId,
   // each contributing a different stage from its own file. The primary

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -1657,6 +1657,67 @@ test('scanClaudeVendorSessions: one vendorSessionId contributing two stages merg
   assert.equal(ewSamples[0].adapterResult.sample.usage.output, 13);
 });
 
+test('scanClaudeVendorSessions: a multi-hop handoff across THREE different sessions (not just two) merges all of them (#2432, C1 review coverage gap)', () => {
+  // A -> B -> C: three different vendorSessionIds, one shared claimId,
+  // each contributing a different stage from its own file. The primary
+  // (cleanup-owning) session is C.
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
+  writeFileSync(
+    join(sandbox, 'session-hop-a.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:00:30.000Z","sessionId":"sess-hop-A","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":2}}}\n',
+  );
+  writeFileSync(
+    join(sandbox, 'session-hop-b.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:06:00.000Z","sessionId":"sess-hop-B","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":4}}}\n',
+  );
+  writeFileSync(
+    join(sandbox, 'session-hop-c.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:24:00.000Z","sessionId":"sess-hop-C","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":8}}}\n',
+  );
+  const eventWindowsAll = new Map<string, StageEventWindow>([
+    [
+      '505:claude:claim',
+      stageWindow(
+        '2026-01-01T00:00:00Z',
+        '2026-01-01T00:01:00Z',
+        'sess-hop-A',
+        'claim-shared',
+      ),
+    ],
+    [
+      '505:claude:work',
+      stageWindow(
+        '2026-01-01T00:05:00Z',
+        '2026-01-01T00:10:00Z',
+        'sess-hop-B',
+        'claim-shared',
+      ),
+    ],
+    [
+      '505:claude:cleanup',
+      stageWindow(
+        '2026-01-01T00:20:00Z',
+        '2026-01-01T00:25:00Z',
+        'sess-hop-C',
+        'claim-shared',
+      ),
+    ],
+  ]);
+
+  const sessions = scanClaudeVendorSessions(sandbox, eventWindowsAll);
+  const ewSamples = sessions.filter((s) =>
+    s.adapterResult.sample.vendorSessionId.includes('#ew'),
+  );
+
+  assert.equal(ewSamples.length, 1);
+  const sample = ewSamples[0].adapterResult.sample;
+  assert.equal(sample.vendorSessionId, 'sess-hop-C#ew505');
+  // 2 (A) + 4 (B) + 8 (C) -- all three hops' usage is pulled in.
+  assert.equal(sample.usage.output, 14);
+  assert.equal(sample.startedAt, '2026-01-01T00:00:30.000Z');
+  assert.equal(sample.endedAt, '2026-01-01T00:24:00.000Z');
+});
+
 test('scanClaudeVendorSessions: an event window is ignored when the segment already has a cwd-inferred issueNumber', () => {
   const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
   writeFileSync(

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -1731,6 +1731,52 @@ test('scanClaudeVendorSessions: a cwd-attributed primary (cleanup session launch
   assert.equal(issue506Samples[0].adapterResult.sample.usage.output, 9);
 });
 
+test('scanClaudeVendorSessions: a cwd-attributed primary whose contributor cannot be resolved suppresses its own solo sample too (#2432, Codex review PR #2627)', () => {
+  // The primary is cwd-attributed to the target issue, but the claim-id
+  // matched contributor's own file is missing entirely -- the aborted
+  // merge must ALSO suppress the primary's own pending cwd sample, not
+  // just skip creating the merged one, or a later successful merge would
+  // append a second, differently-keyed sample for the same completed
+  // loop (permanent double-count).
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
+  writeFileSync(
+    join(sandbox, 'session-primary-509.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:24:00.000Z","sessionId":"sess-primary-0008","cwd":"/home/user/repo.issue-509-x","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":7}}}\n',
+  );
+  // No file in this sandbox has sessionId 'sess-contrib-missing'.
+  const eventWindowsAll = new Map<string, StageEventWindow>([
+    [
+      '509:claude:work',
+      stageWindow(
+        '2026-01-01T00:00:00Z',
+        '2026-01-01T00:05:00Z',
+        'sess-contrib-missing',
+        'claim-shared',
+      ),
+    ],
+    [
+      '509:claude:cleanup',
+      stageWindow(
+        '2026-01-01T00:20:00Z',
+        '2026-01-01T00:25:00Z',
+        'sess-primary-0008',
+        'claim-shared',
+      ),
+    ],
+  ]);
+
+  const sessions = scanClaudeVendorSessions(sandbox, eventWindowsAll);
+  const issue509Samples = sessions.filter((s) =>
+    s.adapterResult.sample.vendorSessionId.includes('509'),
+  );
+
+  // No sample at all for issue 509 -- neither a merged #ew sample (the
+  // contributor could not be resolved) NOR the primary's own plain
+  // cwd-derived sample (which would otherwise sit under a different,
+  // unrecognizable dedup key forever).
+  assert.equal(issue509Samples.length, 0);
+});
+
 test('scanClaudeVendorSessions: a cwd-attributed primary that moved out of and back into the issue worktree (two segments, one file) still resolves (#2432, Codex review PR #2627)', () => {
   // The cleanup-owning session's own file produces TWO cwd-attributed
   // segments for the SAME issue (#2404 segmentation, moved out then back
@@ -2683,7 +2729,15 @@ test('readEventWindows: tags a window with claimId when both enter and exit shar
   }
 });
 
-test('readEventWindows: leaves a window claimId-untagged when the enter and exit claimId disagree (#2432, defensive)', () => {
+test('readEventWindows: excludes the whole candidate (not just its claimId) when the enter and exit claimId genuinely disagree (#2432, Codex review PR #2627)', () => {
+  // Both sides carry a DIFFERENT, non-empty claimId -- a stronger signal
+  // than one side merely being absent: degrading this to claim-less would
+  // let `idCompatible` treat the resulting window as compatible with ANY
+  // cleanup by default. The whole identified candidate is excluded, so
+  // resolution falls all the way through to the identity-agnostic legacy
+  // pairing (both enter and exit share the same vendorSessionId, so that
+  // legacy pairing is itself valid) -- vendorSessionId is absent too, not
+  // just claimId.
   const { dir, path } = writeEventsFile([
     tokenCostEvent(
       'enter',
@@ -2709,6 +2763,9 @@ test('readEventWindows: leaves a window claimId-untagged when the enter and exit
     const window = windows.get('7:claude:work');
     assert.ok(window);
     assert.equal('claimId' in (window ?? {}), false);
+    assert.equal('vendorSessionId' in (window ?? {}), false);
+    assert.equal(window?.startMs, ms('2026-01-01T00:10:00Z'));
+    assert.equal(window?.endMs, ms('2026-01-01T00:20:00Z'));
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Adds a positive-evidence rule so `token-cost-harvest.mjs` can correctly
aggregate a *legitimate* multi-session issue-loop's usage (a handoff or
resume) across Claude session log files, instead of undercounting it.

- `token-cost-event.mjs`'s existing `--claim-id` flag (previously
  accepted but discarded) now persists as `claimId` on the emitted
  event (schema + `TokenCostEvent` type updated accordingly).
- `buildCompletedIssueWindows`'s `idCompatible` check gains a second,
  independent admission path: a non-`cleanup` stage window whose
  `claimId` matches the winning `cleanup` window's own is treated as
  the same claim lineage even when its `vendorSessionId` differs — the
  IDD `{claim-id}` is this repository's own ground-truth ownership
  token, unlike a bare session-id mismatch which only proves a
  different *process*, not a different *attempt*.
- A window admitted only via this path is recorded as a
  `contributingWindows` entry; `scanClaudeVendorSessions` resolves that
  contributing session's own project log file the same way it already
  resolves the primary/cleanup file, filters its records to the
  contributing window's own bounds, and merges them into one
  `#ew<issueNumber>` sample — sorted by timestamp before harvesting, to
  avoid an order-dependency bug in `extractTimestamps` caught during an
  independent critique of the implementation plan.
- A cross-session overlap guard skips the whole issue when two
  claim-id-matched windows from different sessions overlap in time (the
  narrow, documented TOCTOU race in `idd-claim.instructions.md` where
  two sessions can momentarily share one active claim-id). **Round-1
  review update**: the comparison now uses the primary session's own
  INDIVIDUAL stage windows, never one enclosing span from its earliest
  stage to `cleanup` — an enclosing span falsely flagged a legitimate
  A → B → A handoff whenever B's window merely fell inside a gap
  between two of A's own disjoint stages (Codex finding).
  `contributingWindows` itself also switched from a per-session union to
  individual per-stage entries for the same reason.
- Contributing-file resolution draws from every scanned file's full
  record set, not only unattributed ones — a contributor launched
  directly inside the target issue's own worktree (cwd-attributed to
  that SAME issue) is now merged, with its now-redundant standalone
  cwd-derived sample suppressed; a file cwd-attributed to a genuinely
  DIFFERENT issue stays excluded, to avoid double-counting (Codex
  finding). The primary candidate's own records are filtered to exclude
  any timestamp a confirmed contributor's window already owns, so that
  time is never charged twice (Codex finding). A contribution whose own
  file can't be uniquely resolved now skips the WHOLE issue rather than
  degrading to a primary-only sample — the original degrade-to-primary
  behavior would have frozen the exact undercount this feature exists to
  fix, permanently, under the stable `#ew<issueNumber>` id once the
  missing file became available (Codex finding, superseding the
  now-stale description from the PR's initial revision).
- `readEventWindows`'s per-stage resolution now also prefers a
  claim-id-matched candidate over the plain recency-based (`latest
  endMs`) fallback: absent an exact-session match, an unrelated,
  differently- or un-identified attempt could otherwise win purely on
  `endMs` and get returned instead of the genuine claim-linked
  candidate, which `idCompatible` would then exclude outright — silently
  defeating claim-id recovery before it ever ran (Codex finding).
- `asClaudeHarvestInput` now also rejects an empty-string
  `vendorSessionIdOverride` (Copilot finding): the adapter combines it
  with `??`, so `''` would otherwise be treated as authoritative instead
  of falling through to `extractSessionId`/`deriveFallbackSessionId`,
  producing a malformed `vendorSessionId` like `#ew501`.

`docs/token-cost.md`'s `vendorSessionId` paragraph, the
`idCompatible` docstring, and the repository's own dogfood call
convention (`CLAUDE.md`/`AGENTS.md`/`.github/copilot-instructions.md`)
are updated to match.

## Linked issue

Closes #2432

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

This supersedes the documented undercount tradeoff from #2424/PR #2430
(round 5 Codex review): widening `idCompatible` alone was rejected there
because `scanClaudeVendorSessions` harvests exactly one file per
completed window, so a widened-but-single-file harvest would misrepresent
its own coverage. This PR ships the positive-evidence rule *and* the
cross-file record merge together, as that review thread anticipated.

The chosen signal (IDD `{claim-id}`) is deliberately not a timestamp
heuristic — #2425 investigated and rejected a disjoint-time-range merge
for the adjacent cross-file-ambiguity problem, because a single stray
record from an unrelated concurrent session can look "disjoint" just as
easily as a genuine continuation. `{claim-id}` is instead the literal
ownership token this repository's own claim protocol already treats as
authoritative for "same attempt, possibly handed off across sessions."

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

This PR touches only source-repo-internal dogfood tooling
(`token-cost-*`), never `idd-template/`, `.github/instructions/`, or
`.github/idd/config.json`'s own `policy.schema.json` — no IDD-framework
surface changes. `CLAUDE.md`/`AGENTS.md`/`.github/copilot-instructions.md`
edits are confined to the pre-existing "Dogfood: token-cost events"
section, which is explicitly source-repo-only.

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L4CWg4REnG881fe8wd2kd7

