### PR TITLE
fix(audit-authored-issue): verify the owner-marker/publication trail

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -22,9 +22,11 @@ required as one of a small set of mutually exclusive input flags on
 `discover-viability-gate.mjs` (or `--issues`) and
 `suitability-triage.mjs` (or `--body-file` / `--stdin`) -- which primes
 the instinct to reach for it elsewhere. `audit-authored-issue.mjs` also
-accepts a genuine, functioning `--issue`, but optionally: it only
-sharpens the `authoring-owner-marker-trail` check's target match and is
-never required. But the claim-revalidation flag
+accepts a genuine, functioning `--issue`: normally optional (it only
+sharpens the `authoring-owner-marker-trail` check's target match), but
+required once `--new-issue` and `--journal-comments-file` are both
+given, so the journal cross-check always has a resolvable issue
+identity to verify against. But the claim-revalidation flag
 on most mutation-capable helpers is named `--claim-issue` instead, and
 requiredness varies by helper:
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -21,7 +21,10 @@ functioning flag on several other helpers -- required outright on
 required as one of a small set of mutually exclusive input flags on
 `discover-viability-gate.mjs` (or `--issues`) and
 `suitability-triage.mjs` (or `--body-file` / `--stdin`) -- which primes
-the instinct to reach for it elsewhere. But the claim-revalidation flag
+the instinct to reach for it elsewhere. `audit-authored-issue.mjs` also
+accepts a genuine, functioning `--issue`, but optionally: it only
+sharpens the `authoring-owner-marker-trail` check's target match and is
+never required. But the claim-revalidation flag
 on most mutation-capable helpers is named `--claim-issue` instead, and
 requiredness varies by helper:
 

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -682,6 +682,15 @@ updates issues. The label name comes from
 `issueAuthoring.authoringLabelName`, with `status:authoring` as the
 distributed default.
 
+`src/scripts/audit-authored-issue.mts`'s `authoring-owner-marker-trail`
+check mechanically verifies, from pre-fetched comment data a caller
+supplies, that an authoring-labeled issue carries a valid owner marker
+and (for a newly created issue) the publication-token trail this
+section defines -- structural/shape checking only, not the live
+trust/permission re-verification the runtime protocol below still
+owns. The module stays network-free; no caller currently wires it into
+the publish flow below (Refs #2621, non-blocking).
+
 During Stage 1 (author-and-publish), the skill must ensure the label
 exists in the target repository before first use. For the bundled
 GitHub CLI publication flow, create a missing label with

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -22,9 +22,11 @@ required as one of a small set of mutually exclusive input flags on
 `discover-viability-gate.mjs` (or `--issues`) and
 `suitability-triage.mjs` (or `--body-file` / `--stdin`) -- which primes
 the instinct to reach for it elsewhere. `audit-authored-issue.mjs` also
-accepts a genuine, functioning `--issue`, but optionally: it only
-sharpens the `authoring-owner-marker-trail` check's target match and is
-never required. But the claim-revalidation flag
+accepts a genuine, functioning `--issue`: normally optional (it only
+sharpens the `authoring-owner-marker-trail` check's target match), but
+required once `--new-issue` and `--journal-comments-file` are both
+given, so the journal cross-check always has a resolvable issue
+identity to verify against. But the claim-revalidation flag
 on most mutation-capable helpers is named `--claim-issue` instead, and
 requiredness varies by helper:
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -21,7 +21,10 @@ functioning flag on several other helpers -- required outright on
 required as one of a small set of mutually exclusive input flags on
 `discover-viability-gate.mjs` (or `--issues`) and
 `suitability-triage.mjs` (or `--body-file` / `--stdin`) -- which primes
-the instinct to reach for it elsewhere. But the claim-revalidation flag
+the instinct to reach for it elsewhere. `audit-authored-issue.mjs` also
+accepts a genuine, functioning `--issue`, but optionally: it only
+sharpens the `authoring-owner-marker-trail` check's target match and is
+never required. But the claim-revalidation flag
 on most mutation-capable helpers is named `--claim-issue` instead, and
 requiredness varies by helper:
 

--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -36,6 +36,11 @@ import { extractRoadmapMarkerId } from './discover-roadmap-graph.mjs';
 import { parseEffortMarker } from './effort.mjs';
 import { loadIddConfig, loadPolicyConfig } from './idd-config.mjs';
 import { stripMarkdownCodeRegions } from './markdown-code.mjs';
+import {
+  parseAuthoringOwnerComment,
+  parseAuthoringPublicationComment,
+  parseAuthoringPublicationIntentComment,
+} from './marker-helpers.mjs';
 import { createMarkerRegex, escapeRegex } from './marker-regex.mjs';
 import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mjs';
 
@@ -264,9 +269,30 @@ const AUDIT_AUTHORED_ISSUE_FLAG_SPEC = {
   '--marker-prefix': { type: 'string' },
   '--config': { type: 'string' },
   '--current-repo': { type: 'string' },
+  '--issue': { type: 'string' },
   '--label': { type: 'string', multiple: true },
+  '--comments-file': { type: 'string' },
+  '--journal-comments-file': { type: 'string' },
+  '--new-issue': { type: 'boolean', default: false },
   '--format': { type: 'string', default: 'json' },
 };
+// Declared here (alongside the flag spec above), not next to
+// checkAuthoringOwnerMarkerTrail further down: the import.meta.main trigger
+// immediately below calls main() -> auditAuthoredIssue() ->
+// checkAuthoringOwnerMarkerTrail() synchronously at module-evaluation time,
+// and a `const` declared after that point is still in the temporal dead
+// zone when the trigger fires (same TDZ hazard as AUDIT_AUTHORED_ISSUE_FLAG_SPEC
+// itself and the LIST_ITEM_MARKER_PATTERN family further down this file).
+const AUTHORING_OWNER_QUALIFYING_MODES = new Set([
+  'acquire',
+  'bootstrap',
+  'resume',
+]);
+const AUTHORING_PUBLICATION_INTENT_MEMBER_OR_LATER = new Set([
+  'member',
+  'cleanup',
+  'abandoned',
+]);
 if (import.meta.main) {
   main();
 }
@@ -318,6 +344,7 @@ export function auditAuthoredIssue(body, options) {
     checkSuitabilityVisibleLineAgreement(text, markerPrefix, suitability),
     checkEffortVisibleLineAgreement(text, markerPrefix),
     checkProseOnlyDependency(text, normalizeCurrentRepo(options.currentRepo)),
+    checkAuthoringOwnerMarkerTrail(text, markerPrefix, labels, options),
   ];
   return {
     shape,
@@ -601,6 +628,124 @@ function checkEffortVisibleLineAgreement(text, markerPrefix) {
     id,
     name,
     `visible line agrees with marker value ${effort.value}`,
+  );
+}
+/**
+ * Verify that an authoring-labeled issue carries the owner-marker/
+ * publication-token trail the "Authoring label lifecycle" contract
+ * (docs/issue-authoring-skill.md) requires. Not applicable (`pass`) when the
+ * issue never carries the configured authoring label at all — this is a
+ * forward-looking gate on newly authoring-labeled issues, never a
+ * retroactive backfill requirement — or when the caller did not supply
+ * `comments` (this module stays network-free; a caller not opting into
+ * comment-aware checking must not see a false failure).
+ */
+function checkAuthoringOwnerMarkerTrail(text, markerPrefix, labels, options) {
+  const id = 'authoring-owner-marker-trail';
+  const name =
+    'Authoring-labeled issue carries the owner-marker/publication-token trail';
+  const authoringLabelName = (
+    options.authoringLabelName ??
+    POLICY_DEFAULTS.issueAuthoring.authoringLabelName
+  )
+    .trim()
+    .toLowerCase();
+  if (!labels.includes(authoringLabelName)) {
+    return pass(
+      id,
+      name,
+      'not applicable: issue does not carry the authoring label',
+    );
+  }
+  if (options.comments === undefined) {
+    return pass(
+      id,
+      name,
+      'not applicable: no comment data supplied to this check',
+    );
+  }
+  const currentRepo = normalizeCurrentRepo(options.currentRepo);
+  const currentIssueRef =
+    currentRepo && options.issueNumber !== undefined
+      ? `${currentRepo}#${options.issueNumber}`
+      : undefined;
+  const ownerMarkers = options.comments
+    .map((comment) => parseAuthoringOwnerComment(comment.body, markerPrefix))
+    .filter((marker) => marker !== null);
+  const hasQualifyingOwnerMarker = ownerMarkers.some(
+    (marker) =>
+      AUTHORING_OWNER_QUALIFYING_MODES.has(marker.mode) &&
+      (currentIssueRef === undefined || marker.target === currentIssueRef),
+  );
+  if (!hasQualifyingOwnerMarker) {
+    return fail(
+      id,
+      name,
+      'no valid authoring-owner comment (mode acquire/bootstrap/resume, target matching this issue) was found',
+    );
+  }
+  if (options.newIssue !== true) {
+    return pass(
+      id,
+      name,
+      'owner-marker present; not applicable for the publication-token line (not a new issue)',
+    );
+  }
+  const publicationMarker = parseAuthoringPublicationComment(
+    text,
+    markerPrefix,
+  );
+  const leadingPublicationMarkerPattern = new RegExp(
+    `^\\s*<!--\\s*${escapeRegex(markerPrefix)}-authoring-publication:`,
+    'i',
+  );
+  const publicationMarkerIsFirstLine =
+    leadingPublicationMarkerPattern.test(text);
+  if (publicationMarker === null || !publicationMarkerIsFirstLine) {
+    return fail(
+      id,
+      name,
+      'new issue is missing a well-formed authoring-publication marker as the first line of the body',
+    );
+  }
+  if (options.journalComments === undefined) {
+    return pass(
+      id,
+      name,
+      'owner-marker and publication-token line present; not applicable for the journal cross-check (no journal comment data supplied)',
+    );
+  }
+  const hasMatchingIntentRecord = options.journalComments.some((comment) => {
+    const intent = parseAuthoringPublicationIntentComment(
+      comment.body,
+      markerPrefix,
+    );
+    if (intent === null || intent.target !== publicationMarker.target) {
+      return false;
+    }
+    if (!AUTHORING_PUBLICATION_INTENT_MEMBER_OR_LATER.has(intent.state)) {
+      return false;
+    }
+    if (
+      currentIssueRef !== undefined &&
+      intent.issue !== 'none' &&
+      intent.issue !== currentIssueRef
+    ) {
+      return false;
+    }
+    return true;
+  });
+  if (!hasMatchingIntentRecord) {
+    return fail(
+      id,
+      name,
+      'no matching authoring-publication-intent record reaching state=member or later was found on the journal issue',
+    );
+  }
+  return pass(
+    id,
+    name,
+    'owner-marker, publication-token line, and journal publication-intent record are all present and well-formed',
   );
 }
 // An empty or whitespace-only currentRepo (reachable via an explicit
@@ -1137,6 +1282,33 @@ function pass(id, name, detail) {
 function fail(id, name, detail) {
   return { id, name, result: 'fail', detail };
 }
+/**
+ * Read and JSON-parse a comments file (an array of
+ * `{body, author?, createdAt?}` objects) the same uncaught-throw-on-
+ * malformed-input way `--body-file` already behaves: a missing file or
+ * invalid JSON propagates as an unhandled exception rather than a new
+ * soft-degrade path this file does not otherwise have.
+ */
+function readCommentsFile(path) {
+  const raw = readFileSync(resolve(process.cwd(), path), 'utf8');
+  const parsed = JSON.parse(raw);
+  if (!Array.isArray(parsed)) {
+    throw new Error(`${path} must contain a JSON array of comments`);
+  }
+  return parsed.map((entry, index) => {
+    const record = entry;
+    if (typeof record?.body !== 'string') {
+      throw new Error(`${path}[${index}] is missing a string "body" field`);
+    }
+    return {
+      body: record.body,
+      ...(typeof record.author === 'string' ? { author: record.author } : {}),
+      ...(typeof record.createdAt === 'string'
+        ? { createdAt: record.createdAt }
+        : {}),
+    };
+  });
+}
 function main() {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
@@ -1155,6 +1327,9 @@ function main() {
   const bodyText = args.stdin
     ? readFileSync(0, 'utf8')
     : readFileSync(resolve(process.cwd(), args.bodyFile), 'utf8');
+  if (args.issue !== undefined && !/^[1-9]\d*$/.test(args.issue)) {
+    fail_('--issue must be a positive integer');
+  }
   const policy = loadPolicy(args.configPath);
   const markerPrefix = args.markerPrefix ?? policy.markerPrefix;
   const report = auditAuthoredIssue(bodyText, {
@@ -1162,12 +1337,22 @@ function main() {
     markerPrefix,
     labels: args.labels,
     blockedByHumanLabelName: policy.blockedByHumanLabelName,
+    authoringLabelName: policy.authoringLabelName,
     // Explicit --current-repo wins; otherwise fall back to the
     // GITHUB_REPOSITORY env var GitHub Actions sets automatically, so CI
     // usage narrows cross-repo URL false positives with no extra flag.
     // undefined (neither present) keeps the pre-#1399-fix default of
     // flagging every full-URL reference.
     currentRepo: args.currentRepo ?? process.env.GITHUB_REPOSITORY,
+    issueNumber:
+      args.issue !== undefined ? Number.parseInt(args.issue, 10) : undefined,
+    comments: args.commentsFile
+      ? readCommentsFile(args.commentsFile)
+      : undefined,
+    journalComments: args.journalCommentsFile
+      ? readCommentsFile(args.journalCommentsFile)
+      : undefined,
+    newIssue: args.newIssue,
   });
   writeReport(report, args.format);
   process.exit(report.passed ? 0 : 1);
@@ -1224,12 +1409,15 @@ function loadPolicy(configPath) {
     return {
       markerPrefix: DEFAULT_MARKER_PREFIX,
       blockedByHumanLabelName: POLICY_DEFAULTS.labels.blockedByHumanLabelName,
+      authoringLabelName: POLICY_DEFAULTS.issueAuthoring.authoringLabelName,
     };
   }
   return {
     markerPrefix: normalizeMarkerPrefix(config.markerPrefix),
     blockedByHumanLabelName:
       normalizePolicyConfig(config).labels.blockedByHumanLabelName,
+    authoringLabelName:
+      normalizePolicyConfig(config).issueAuthoring.authoringLabelName,
   };
 }
 function writeReport(report, format) {
@@ -1278,7 +1466,11 @@ function parseArgs(argv) {
     markerPrefix: values['marker-prefix'],
     configPath: values.config,
     currentRepo: values['current-repo'],
+    issue: values.issue,
     labels: values.label ?? [],
+    commentsFile: values['comments-file'],
+    journalCommentsFile: values['journal-comments-file'],
+    newIssue: values['new-issue'],
     format,
   };
 }
@@ -1293,9 +1485,11 @@ section headings for the declared shape, the roadmap-id/blocked-by
 dependency-marker rules, visible/hidden suitability+effort line
 agreement, and an advisory (warning-severity only) check that flags an
 issue/PR reference used near coordination language with no corresponding
-dependency marker. Exits 0 when every check passes, 1 when any check
-fails, 2 on a usage error; the advisory check never affects the exit
-code.
+dependency marker, and (when --comments-file is supplied) the
+authoring-owner-marker-trail check that verifies an authoring-labeled
+issue carries the owner-marker/publication-token trail. Exits 0 when
+every check passes, 1 when any check fails, 2 on a usage error; the
+advisory check never affects the exit code.
 
 Options:
   --shape <orphan|roadmap|child>   declared issue shape (required)
@@ -1305,10 +1499,24 @@ Options:
   --config <path>                  policy config path (default: .github/idd/config.json)
   --label <name>                   a label currently applied/proposed on the issue
                                     (repeatable; used for the suitability=1
-                                    cross-field check)
+                                    cross-field check and the authoring-label
+                                    check for authoring-owner-marker-trail)
   --current-repo <owner/repo>      this repository, for the prose-dependency check
                                     to recognize a full-URL issue/PR reference as
-                                    cross-repo (default: $GITHUB_REPOSITORY)
+                                    cross-repo (default: $GITHUB_REPOSITORY), and
+                                    for authoring-owner-marker-trail's target match
+  --issue <number>                 this issue's number, for authoring-owner-marker-trail's
+                                    target match (requires --current-repo)
+  --comments-file <path>           JSON array of this issue's pre-fetched comments
+                                    ({body, author?, createdAt?}); enables
+                                    authoring-owner-marker-trail (network-free: this
+                                    module never fetches comments itself)
+  --journal-comments-file <path>   JSON array of the journal issue's pre-fetched
+                                    comments, for the new-issue publication-intent
+                                    cross-check (requires --new-issue)
+  --new-issue                      this issue was just created in this invocation
+                                    (not an edit); requires the leading
+                                    authoring-publication body line
   --format <json|table>            output format (default: json)
   --help                           show this help
 `);

--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -658,9 +658,13 @@ function checkAuthoringOwnerMarkerTrail(text, markerPrefix, labels, options) {
     );
   }
   const currentRepo = normalizeCurrentRepo(options.currentRepo);
+  // Lowercased: GitHub owner/repo names are case-insensitive, matching the
+  // normalization checkProseOnlyDependency already applies to its own
+  // owner/repo comparisons (#2628 review, CodeRabbit). Every comparison
+  // against currentIssueRef below lowercases its own operand to match.
   const currentIssueRef =
     currentRepo && options.issueNumber !== undefined
-      ? `${currentRepo}#${options.issueNumber}`
+      ? `${currentRepo}#${options.issueNumber}`.toLowerCase()
       : undefined;
   // Validate the new-issue publication line FIRST, independent of whether
   // comment data was supplied: this half only needs the body text and the
@@ -690,8 +694,18 @@ function checkAuthoringOwnerMarkerTrail(text, markerPrefix, labels, options) {
         : 'publication-token line present; not applicable for the owner-marker/journal checks (no comment data supplied to this check)',
     );
   }
+  // Strip fenced/inline code regions before parsing, matching the same
+  // stripMarkdownCodeRegions(rawText) pass auditAuthoredIssue() already
+  // applies to the issue body: a pasted illustrative example wrapped in a
+  // comment's own code block must not count as a real marker (#2628
+  // review, CodeRabbit).
   const ownerMarkers = options.comments
-    .map((comment) => parseAuthoringOwnerComment(comment.body, markerPrefix))
+    .map((comment) =>
+      parseAuthoringOwnerComment(
+        stripMarkdownCodeRegions(comment.body),
+        markerPrefix,
+      ),
+    )
     .filter((marker) => marker !== null);
   const hasQualifyingOwnerMarker = ownerMarkers.some(
     (marker) =>
@@ -701,7 +715,8 @@ function checkAuthoringOwnerMarkerTrail(text, markerPrefix, labels, options) {
       // (`none` is only ever legitimate on an anchor-only release-guard
       // marker per docs/issue-authoring-skill.md -- #2628 review, Codex).
       marker.bodySha256 !== 'none' &&
-      (currentIssueRef === undefined || marker.target === currentIssueRef) &&
+      (currentIssueRef === undefined ||
+        marker.target.toLowerCase() === currentIssueRef) &&
       (publicationMarker === null ||
         (marker.set === publicationMarker.set &&
           marker.session === publicationMarker.session)),
@@ -746,7 +761,7 @@ function checkAuthoringOwnerMarkerTrail(text, markerPrefix, labels, options) {
   // tolerable gap.
   const hasMatchingIntentRecord = options.journalComments.some((comment) => {
     const intent = parseAuthoringPublicationIntentComment(
-      comment.body,
+      stripMarkdownCodeRegions(comment.body),
       markerPrefix,
     );
     if (
@@ -762,7 +777,10 @@ function checkAuthoringOwnerMarkerTrail(text, markerPrefix, labels, options) {
     if (!AUTHORING_PUBLICATION_INTENT_MEMBER_OR_LATER.has(intent.state)) {
       return false;
     }
-    if (currentIssueRef !== undefined && intent.issue !== currentIssueRef) {
+    if (
+      currentIssueRef !== undefined &&
+      intent.issue.toLowerCase() !== currentIssueRef
+    ) {
       return false;
     }
     return true;
@@ -1373,6 +1391,16 @@ function main() {
   if (args.journalCommentsFile && !args.commentsFile) {
     fail_('--journal-comments-file requires --comments-file');
   }
+  // Without this, a new-issue check with real owner-marker evidence but no
+  // journal data would report "not applicable" for the journal half and
+  // still exit 0 -- a misleading success for the AC's combined
+  // publication-line + journal-record requirement (#2628 review,
+  // CodeRabbit). The pure auditAuthoredIssue() function itself keeps the
+  // graceful not-applicable degradation for a direct (non-CLI) caller that
+  // deliberately wants a partial check.
+  if (args.newIssue && args.commentsFile && !args.journalCommentsFile) {
+    fail_('--new-issue with --comments-file requires --journal-comments-file');
+  }
   // Explicit --current-repo wins; otherwise fall back to the
   // GITHUB_REPOSITORY env var GitHub Actions sets automatically, so CI
   // usage narrows cross-repo URL false positives with no extra flag.
@@ -1568,7 +1596,9 @@ Options:
                                     --comments-file)
   --new-issue                      this issue was just created in this invocation
                                     (not an edit); requires the leading
-                                    authoring-publication body line
+                                    authoring-publication body line, and (when
+                                    --comments-file is also given) requires
+                                    --journal-comments-file too
   --format <json|table>            output format (default: json)
   --help                           show this help
 `);

--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -669,19 +669,55 @@ function checkAuthoringOwnerMarkerTrail(text, markerPrefix, labels, options) {
     currentRepo && options.issueNumber !== undefined
       ? `${currentRepo}#${options.issueNumber}`
       : undefined;
+  // For a new issue, resolve the publication marker BEFORE searching for a
+  // qualifying owner marker: its `set`/`session` bind the "generation" a
+  // qualifying owner marker must itself belong to (#2628 review, Codex) --
+  // otherwise a stale owner marker from an earlier acquire/bootstrap cycle
+  // could combine with a fresh publication token to produce a false pass.
+  let publicationMarker = null;
+  if (options.newIssue === true) {
+    publicationMarker = parseAuthoringPublicationComment(text, markerPrefix);
+    // "HTML-first body line" (docs/issue-authoring-skill.md) means the
+    // marker's own literal first bytes, not merely "somewhere before other
+    // content" -- no leading blank line or whitespace tolerance (#2628
+    // review, Copilot).
+    const leadingPublicationMarkerPattern = new RegExp(
+      `^<!--\\s*${escapeRegex(markerPrefix)}-authoring-publication:`,
+      'i',
+    );
+    if (
+      publicationMarker === null ||
+      !leadingPublicationMarkerPattern.test(text)
+    ) {
+      return fail(
+        id,
+        name,
+        'new issue is missing a well-formed authoring-publication marker as the first line of the body',
+      );
+    }
+  }
   const ownerMarkers = options.comments
     .map((comment) => parseAuthoringOwnerComment(comment.body, markerPrefix))
     .filter((marker) => marker !== null);
   const hasQualifyingOwnerMarker = ownerMarkers.some(
     (marker) =>
       AUTHORING_OWNER_QUALIFYING_MODES.has(marker.mode) &&
-      (currentIssueRef === undefined || marker.target === currentIssueRef),
+      (currentIssueRef === undefined || marker.target === currentIssueRef) &&
+      (publicationMarker === null ||
+        (marker.set === publicationMarker.set &&
+          marker.session === publicationMarker.session)),
   );
   if (!hasQualifyingOwnerMarker) {
+    const targetNote =
+      currentIssueRef === undefined ? '' : ', target matching this issue';
+    const generationNote =
+      publicationMarker === null
+        ? ''
+        : ", set/session matching the publication marker's generation";
     return fail(
       id,
       name,
-      'no valid authoring-owner comment (mode acquire/bootstrap/resume, target matching this issue) was found',
+      `no valid authoring-owner comment (mode acquire/bootstrap/resume${targetNote}${generationNote}) was found`,
     );
   }
   if (options.newIssue !== true) {
@@ -691,23 +727,9 @@ function checkAuthoringOwnerMarkerTrail(text, markerPrefix, labels, options) {
       'owner-marker present; not applicable for the publication-token line (not a new issue)',
     );
   }
-  const publicationMarker = parseAuthoringPublicationComment(
-    text,
-    markerPrefix,
-  );
-  const leadingPublicationMarkerPattern = new RegExp(
-    `^\\s*<!--\\s*${escapeRegex(markerPrefix)}-authoring-publication:`,
-    'i',
-  );
-  const publicationMarkerIsFirstLine =
-    leadingPublicationMarkerPattern.test(text);
-  if (publicationMarker === null || !publicationMarkerIsFirstLine) {
-    return fail(
-      id,
-      name,
-      'new issue is missing a well-formed authoring-publication marker as the first line of the body',
-    );
-  }
+  // publicationMarker is non-null here: newIssue === true already returned
+  // above on a missing/malformed marker.
+  const resolvedPublicationMarker = publicationMarker;
   if (options.journalComments === undefined) {
     return pass(
       id,
@@ -715,22 +737,33 @@ function checkAuthoringOwnerMarkerTrail(text, markerPrefix, labels, options) {
       'owner-marker and publication-token line present; not applicable for the journal cross-check (no journal comment data supplied)',
     );
   }
+  // Match the FULL token tuple (target/anchor/set/session/token), not just
+  // target -- an unrelated or out-of-generation journal record sharing only
+  // `target` must not be accepted as evidence (#2628 review, Codex). When
+  // the current issue's identity is known, also require the record's own
+  // `issue` field to name it exactly: per the protocol, `issue` is resolved
+  // to the real identity no later than the `member` transition, so `none`
+  // at state=member-or-later is itself a protocol violation, not a
+  // tolerable gap.
   const hasMatchingIntentRecord = options.journalComments.some((comment) => {
     const intent = parseAuthoringPublicationIntentComment(
       comment.body,
       markerPrefix,
     );
-    if (intent === null || intent.target !== publicationMarker.target) {
+    if (
+      intent === null ||
+      intent.target !== resolvedPublicationMarker.target ||
+      intent.anchor !== resolvedPublicationMarker.anchor ||
+      intent.set !== resolvedPublicationMarker.set ||
+      intent.session !== resolvedPublicationMarker.session ||
+      intent.token !== resolvedPublicationMarker.token
+    ) {
       return false;
     }
     if (!AUTHORING_PUBLICATION_INTENT_MEMBER_OR_LATER.has(intent.state)) {
       return false;
     }
-    if (
-      currentIssueRef !== undefined &&
-      intent.issue !== 'none' &&
-      intent.issue !== currentIssueRef
-    ) {
+    if (currentIssueRef !== undefined && intent.issue !== currentIssueRef) {
       return false;
     }
     return true;
@@ -1330,6 +1363,21 @@ function main() {
   if (args.issue !== undefined && !/^[1-9]\d*$/.test(args.issue)) {
     fail_('--issue must be a positive integer');
   }
+  if (args.journalCommentsFile && !args.newIssue) {
+    fail_('--journal-comments-file requires --new-issue');
+  }
+  // Explicit --current-repo wins; otherwise fall back to the
+  // GITHUB_REPOSITORY env var GitHub Actions sets automatically, so CI
+  // usage narrows cross-repo URL false positives with no extra flag.
+  // undefined (neither present) keeps the pre-#1399-fix default of
+  // flagging every full-URL reference for the prose-dependency check --
+  // but --issue's target match needs a resolvable repo to mean anything,
+  // so require one explicitly rather than silently widening the match
+  // (#2628 review, Codex and Copilot both flagged the silent-widening gap).
+  const currentRepo = args.currentRepo ?? process.env.GITHUB_REPOSITORY;
+  if (args.issue !== undefined && !currentRepo) {
+    fail_('--issue requires --current-repo (or $GITHUB_REPOSITORY) to be set');
+  }
   const policy = loadPolicy(args.configPath);
   const markerPrefix = args.markerPrefix ?? policy.markerPrefix;
   const report = auditAuthoredIssue(bodyText, {
@@ -1338,12 +1386,7 @@ function main() {
     labels: args.labels,
     blockedByHumanLabelName: policy.blockedByHumanLabelName,
     authoringLabelName: policy.authoringLabelName,
-    // Explicit --current-repo wins; otherwise fall back to the
-    // GITHUB_REPOSITORY env var GitHub Actions sets automatically, so CI
-    // usage narrows cross-repo URL false positives with no extra flag.
-    // undefined (neither present) keeps the pre-#1399-fix default of
-    // flagging every full-URL reference.
-    currentRepo: args.currentRepo ?? process.env.GITHUB_REPOSITORY,
+    currentRepo,
     issueNumber:
       args.issue !== undefined ? Number.parseInt(args.issue, 10) : undefined,
     comments: args.commentsFile

--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -657,38 +657,23 @@ function checkAuthoringOwnerMarkerTrail(text, markerPrefix, labels, options) {
       'not applicable: issue does not carry the authoring label',
     );
   }
-  if (options.comments === undefined) {
-    return pass(
-      id,
-      name,
-      'not applicable: no comment data supplied to this check',
-    );
-  }
   const currentRepo = normalizeCurrentRepo(options.currentRepo);
   const currentIssueRef =
     currentRepo && options.issueNumber !== undefined
       ? `${currentRepo}#${options.issueNumber}`
       : undefined;
-  // For a new issue, resolve the publication marker BEFORE searching for a
-  // qualifying owner marker: its `set`/`session` bind the "generation" a
-  // qualifying owner marker must itself belong to (#2628 review, Codex) --
-  // otherwise a stale owner marker from an earlier acquire/bootstrap cycle
-  // could combine with a fresh publication token to produce a false pass.
+  // Validate the new-issue publication line FIRST, independent of whether
+  // comment data was supplied: this half only needs the body text and the
+  // `newIssue` flag, so it must not be silently skipped just because the
+  // caller omitted `comments` -- a genuinely broken new-issue body (no
+  // publication line at all) must not get a free pass from a missing
+  // --comments-file alone (#2628 review, Codex). parseAuthoringPublicationComment
+  // itself requires the marker's literal first bytes (marker-helpers.mts),
+  // so no separate first-line regex is needed here.
   let publicationMarker = null;
   if (options.newIssue === true) {
     publicationMarker = parseAuthoringPublicationComment(text, markerPrefix);
-    // "HTML-first body line" (docs/issue-authoring-skill.md) means the
-    // marker's own literal first bytes, not merely "somewhere before other
-    // content" -- no leading blank line or whitespace tolerance (#2628
-    // review, Copilot).
-    const leadingPublicationMarkerPattern = new RegExp(
-      `^<!--\\s*${escapeRegex(markerPrefix)}-authoring-publication:`,
-      'i',
-    );
-    if (
-      publicationMarker === null ||
-      !leadingPublicationMarkerPattern.test(text)
-    ) {
+    if (publicationMarker === null) {
       return fail(
         id,
         name,
@@ -696,12 +681,26 @@ function checkAuthoringOwnerMarkerTrail(text, markerPrefix, labels, options) {
       );
     }
   }
+  if (options.comments === undefined) {
+    return pass(
+      id,
+      name,
+      publicationMarker === null
+        ? 'not applicable: no comment data supplied to this check'
+        : 'publication-token line present; not applicable for the owner-marker/journal checks (no comment data supplied to this check)',
+    );
+  }
   const ownerMarkers = options.comments
     .map((comment) => parseAuthoringOwnerComment(comment.body, markerPrefix))
     .filter((marker) => marker !== null);
   const hasQualifyingOwnerMarker = ownerMarkers.some(
     (marker) =>
       AUTHORING_OWNER_QUALIFYING_MODES.has(marker.mode) &&
+      // A qualifying acquire/bootstrap/resume marker targets a real issue,
+      // so its body-sha256 must hash an actual body read, never `none`
+      // (`none` is only ever legitimate on an anchor-only release-guard
+      // marker per docs/issue-authoring-skill.md -- #2628 review, Codex).
+      marker.bodySha256 !== 'none' &&
       (currentIssueRef === undefined || marker.target === currentIssueRef) &&
       (publicationMarker === null ||
         (marker.set === publicationMarker.set &&
@@ -1366,6 +1365,14 @@ function main() {
   if (args.journalCommentsFile && !args.newIssue) {
     fail_('--journal-comments-file requires --new-issue');
   }
+  // Supplying journal data with no --comments-file would silently produce
+  // a misleading pass: the owner-marker check (a prerequisite for even
+  // reaching the journal cross-check) reports "not applicable" without
+  // --comments-file, so the journal data would never actually be consulted
+  // (#2628 review, Copilot).
+  if (args.journalCommentsFile && !args.commentsFile) {
+    fail_('--journal-comments-file requires --comments-file');
+  }
   // Explicit --current-repo wins; otherwise fall back to the
   // GITHUB_REPOSITORY env var GitHub Actions sets automatically, so CI
   // usage narrows cross-repo URL false positives with no extra flag.
@@ -1549,14 +1556,16 @@ Options:
                                     cross-repo (default: $GITHUB_REPOSITORY), and
                                     for authoring-owner-marker-trail's target match
   --issue <number>                 this issue's number, for authoring-owner-marker-trail's
-                                    target match (requires --current-repo)
+                                    target match (requires --current-repo or
+                                    $GITHUB_REPOSITORY to be resolvable)
   --comments-file <path>           JSON array of this issue's pre-fetched comments
                                     ({body, author?, createdAt?}); enables
                                     authoring-owner-marker-trail (network-free: this
                                     module never fetches comments itself)
   --journal-comments-file <path>   JSON array of the journal issue's pre-fetched
                                     comments, for the new-issue publication-intent
-                                    cross-check (requires --new-issue)
+                                    cross-check (requires --new-issue and
+                                    --comments-file)
   --new-issue                      this issue was just created in this invocation
                                     (not an edit); requires the leading
                                     authoring-publication body line

--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -718,7 +718,8 @@ function checkAuthoringOwnerMarkerTrail(text, markerPrefix, labels, options) {
       (currentIssueRef === undefined ||
         marker.target.toLowerCase() === currentIssueRef) &&
       (publicationMarker === null ||
-        (marker.set === publicationMarker.set &&
+        (marker.anchor === publicationMarker.anchor &&
+          marker.set === publicationMarker.set &&
           marker.session === publicationMarker.session)),
   );
   if (!hasQualifyingOwnerMarker) {
@@ -727,7 +728,7 @@ function checkAuthoringOwnerMarkerTrail(text, markerPrefix, labels, options) {
     const generationNote =
       publicationMarker === null
         ? ''
-        : ", set/session matching the publication marker's generation";
+        : ", anchor/set/session matching the publication marker's generation";
     return fail(
       id,
       name,
@@ -775,6 +776,15 @@ function checkAuthoringOwnerMarkerTrail(text, markerPrefix, labels, options) {
       return false;
     }
     if (!AUTHORING_PUBLICATION_INTENT_MEMBER_OR_LATER.has(intent.state)) {
+      return false;
+    }
+    // issue=none is only ever valid at state=pending (docs/issue-authoring-skill.md):
+    // "Append the returned identity while it remains pending, append
+    // member only after the owner marker is verified" -- a member-or-later
+    // record with issue=none is itself a protocol violation, regardless of
+    // whether the caller happens to know the current issue's identity
+    // (#2628 review, Copilot and Codex).
+    if (intent.issue.toLowerCase() === 'none') {
       return false;
     }
     if (
@@ -1401,6 +1411,13 @@ function main() {
   if (args.newIssue && args.commentsFile && !args.journalCommentsFile) {
     fail_('--new-issue with --comments-file requires --journal-comments-file');
   }
+  // Without a known current-issue identity, the journal cross-check cannot
+  // verify a publication-intent record actually names THIS issue -- an
+  // intent record naming a different (non-none) issue would otherwise pass
+  // silently whenever the caller omitted --issue (#2628 review, Codex).
+  if (args.newIssue && args.journalCommentsFile && args.issue === undefined) {
+    fail_('--new-issue with --journal-comments-file requires --issue');
+  }
   // Explicit --current-repo wins; otherwise fall back to the
   // GITHUB_REPOSITORY env var GitHub Actions sets automatically, so CI
   // usage narrows cross-repo URL false positives with no extra flag.
@@ -1598,7 +1615,7 @@ Options:
                                     (not an edit); requires the leading
                                     authoring-publication body line, and (when
                                     --comments-file is also given) requires
-                                    --journal-comments-file too
+                                    --journal-comments-file and --issue too
   --format <json|table>            output format (default: json)
   --help                           show this help
 `);

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -143,7 +143,7 @@ const HELPER_COMMANDS = [
     entryPath: 'scripts/audit-authored-issue.mjs',
     vendoredCommand: 'node scripts/audit-authored-issue.mjs',
     description:
-      'Mechanically audit a drafted issue body against the issue-authoring contract: the autopilot-suitability marker, its blocked-by-human cross-field rule, markerPrefix consistency, required headings, dependency-marker rules, and visible/hidden footer agreement.',
+      'Mechanically audit a drafted issue body against the issue-authoring contract: the autopilot-suitability marker, its blocked-by-human cross-field rule, markerPrefix consistency, required headings, dependency-marker rules, visible/hidden footer agreement, and (given pre-fetched comments) the owner-marker/publication-token trail.',
   },
   {
     id: 'audit-pr-cleanup',

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -940,8 +940,13 @@ function parseSemicolonFieldMarker(body, markerPrefix, suffix) {
   // quoted after prose, inside a fenced example, or opened across a
   // newline (`<!--\nidd-skill-authoring-owner: ...`), none of which are the
   // real marker the protocol posts (#2628 review, Codex).
+  // The payload capture (and its surrounding whitespace) is restricted to
+  // same-line spaces/tabs -- these are "HTML-first body line" markers in
+  // their entirety, not just at their opener, so a multi-line comment
+  // starting at byte 0 must not parse as well-formed either (#2628 review,
+  // Copilot and Codex).
   const pattern = new RegExp(
-    `^<!--[ \\t]*${escapeRegex(markerPrefix)}-${suffix}:\\s*([\\s\\S]*?)\\s*-->`,
+    `^<!--[ \\t]*${escapeRegex(markerPrefix)}-${suffix}:[ \\t]*([^\\r\\n]*?)[ \\t]*-->`,
     'i',
   );
   const match = body.match(pattern);

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -932,8 +932,16 @@ const AUTHORING_OWNER_DIGEST_PATTERN = /^(?:none|[0-9a-f]{64})$/;
  * differs.
  */
 function parseSemicolonFieldMarker(body, markerPrefix, suffix) {
+  // Anchored at `^` (position 0, not "anywhere in body") and restricted to
+  // same-line whitespace between `<!--` and the prefix-suffix token: the
+  // contract requires each of these three markers to be an "HTML-first"
+  // comment/body line, not merely present somewhere in a longer comment or
+  // pasted example -- an unanchored search would also accept a marker
+  // quoted after prose, inside a fenced example, or opened across a
+  // newline (`<!--\nidd-skill-authoring-owner: ...`), none of which are the
+  // real marker the protocol posts (#2628 review, Codex).
   const pattern = new RegExp(
-    `<!--\\s*${escapeRegex(markerPrefix)}-${suffix}:\\s*([\\s\\S]*?)\\s*-->`,
+    `^<!--[ \\t]*${escapeRegex(markerPrefix)}-${suffix}:\\s*([\\s\\S]*?)\\s*-->`,
     'i',
   );
   const match = body.match(pattern);

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -916,6 +916,11 @@ const AUTHORING_PUBLICATION_INTENT_STATES = new Set([
   'cleanup',
   'abandoned',
 ]);
+// docs/issue-authoring-skill.md documents body-sha256/snapshot-sha256 as
+// `<64-lowercase-hex|none>` specifically -- presence alone (accepting a
+// garbage value like `body-sha256=garbage`) is not shape-valid per that
+// grammar (#2628 review, Codex and Copilot both flagged this).
+const AUTHORING_OWNER_DIGEST_PATTERN = /^(?:none|[0-9a-f]{64})$/;
 /**
  * Parse the `field=value; field2=value2; ...` payload of a
  * `<!-- {markerPrefix}-{suffix}: ... -->` marker into a raw field map. Each
@@ -966,8 +971,8 @@ export function parseAuthoringOwnerComment(body, markerPrefix) {
     !fields.owner ||
     !fields.set ||
     !fields.session ||
-    !fields['body-sha256'] ||
-    !fields['snapshot-sha256'] ||
+    !AUTHORING_OWNER_DIGEST_PATTERN.test(fields['body-sha256'] ?? '') ||
+    !AUTHORING_OWNER_DIGEST_PATTERN.test(fields['snapshot-sha256'] ?? '') ||
     !fields.supersedes
   ) {
     return null;

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -901,6 +901,148 @@ export function parseLocalValidationEvidenceComment(body, createdAt) {
     createdAt: isValidIsoTimestamp(createdAt) ? createdAt : 'none',
   };
 }
+const AUTHORING_OWNER_MODES = new Set([
+  'acquire',
+  'resume',
+  'bootstrap',
+  'heartbeat',
+  'release',
+  'release-guard',
+  'release-complete',
+]);
+const AUTHORING_PUBLICATION_INTENT_STATES = new Set([
+  'pending',
+  'member',
+  'cleanup',
+  'abandoned',
+]);
+/**
+ * Parse the `field=value; field2=value2; ...` payload of a
+ * `<!-- {markerPrefix}-{suffix}: ... -->` marker into a raw field map. Each
+ * value is split on the first `=` only and trimmed on both sides; a field
+ * with no `=` is dropped rather than treated as a key with an empty value,
+ * since none of the three markers above have a valueless field. Returns
+ * `null` when the marker itself is absent -- callers validate the required
+ * field set and any enum values themselves, since each marker's requirement
+ * differs.
+ */
+function parseSemicolonFieldMarker(body, markerPrefix, suffix) {
+  const pattern = new RegExp(
+    `<!--\\s*${escapeRegex(markerPrefix)}-${suffix}:\\s*([\\s\\S]*?)\\s*-->`,
+    'i',
+  );
+  const match = body.match(pattern);
+  if (!match) {
+    return null;
+  }
+  const fields = {};
+  for (const part of match[1].split(';')) {
+    const separatorIndex = part.indexOf('=');
+    if (separatorIndex < 0) {
+      continue;
+    }
+    const key = part.slice(0, separatorIndex).trim();
+    const value = part.slice(separatorIndex + 1).trim();
+    if (key) {
+      fields[key] = value;
+    }
+  }
+  return fields;
+}
+export function parseAuthoringOwnerComment(body, markerPrefix) {
+  const fields = parseSemicolonFieldMarker(
+    body,
+    markerPrefix,
+    'authoring-owner',
+  );
+  if (!fields) {
+    return null;
+  }
+  const mode = fields.mode;
+  if (
+    !fields.target ||
+    !fields.anchor ||
+    !AUTHORING_OWNER_MODES.has(mode) ||
+    !fields.owner ||
+    !fields.set ||
+    !fields.session ||
+    !fields['body-sha256'] ||
+    !fields['snapshot-sha256'] ||
+    !fields.supersedes
+  ) {
+    return null;
+  }
+  return {
+    target: fields.target,
+    anchor: fields.anchor,
+    mode: mode,
+    owner: fields.owner,
+    set: fields.set,
+    session: fields.session,
+    bodySha256: fields['body-sha256'],
+    snapshotSha256: fields['snapshot-sha256'],
+    supersedes: fields.supersedes,
+  };
+}
+export function parseAuthoringPublicationComment(body, markerPrefix) {
+  const fields = parseSemicolonFieldMarker(
+    body,
+    markerPrefix,
+    'authoring-publication',
+  );
+  if (
+    !fields ||
+    !fields.target ||
+    !fields.anchor ||
+    !fields.set ||
+    !fields.session ||
+    !fields.token
+  ) {
+    return null;
+  }
+  return {
+    target: fields.target,
+    anchor: fields.anchor,
+    set: fields.set,
+    session: fields.session,
+    token: fields.token,
+  };
+}
+export function parseAuthoringPublicationIntentComment(body, markerPrefix) {
+  const fields = parseSemicolonFieldMarker(
+    body,
+    markerPrefix,
+    'authoring-publication-intent',
+  );
+  if (!fields) {
+    return null;
+  }
+  const state = fields.state;
+  if (
+    !fields.target ||
+    !fields.anchor ||
+    !fields.set ||
+    !fields.session ||
+    !fields.token ||
+    !fields.journal ||
+    !fields.issue ||
+    !fields.actor ||
+    !AUTHORING_PUBLICATION_INTENT_STATES.has(state)
+  ) {
+    return null;
+  }
+  return {
+    target: fields.target,
+    anchor: fields.anchor,
+    set: fields.set,
+    session: fields.session,
+    token: fields.token,
+    journal: fields.journal,
+    issue: fields.issue,
+    actor: fields.actor,
+    state: state,
+  };
+}
 // --- Per-cycle marker body renderers (#900) ---
 //
 // Pure, network-free renderers for the three operational markers an agent

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -867,19 +867,57 @@ function checkAuthoringOwnerMarkerTrail(
       ? `${currentRepo}#${options.issueNumber}`
       : undefined;
 
+  // For a new issue, resolve the publication marker BEFORE searching for a
+  // qualifying owner marker: its `set`/`session` bind the "generation" a
+  // qualifying owner marker must itself belong to (#2628 review, Codex) --
+  // otherwise a stale owner marker from an earlier acquire/bootstrap cycle
+  // could combine with a fresh publication token to produce a false pass.
+  let publicationMarker: ReturnType<typeof parseAuthoringPublicationComment> =
+    null;
+  if (options.newIssue === true) {
+    publicationMarker = parseAuthoringPublicationComment(text, markerPrefix);
+    // "HTML-first body line" (docs/issue-authoring-skill.md) means the
+    // marker's own literal first bytes, not merely "somewhere before other
+    // content" -- no leading blank line or whitespace tolerance (#2628
+    // review, Copilot).
+    const leadingPublicationMarkerPattern = new RegExp(
+      `^<!--\\s*${escapeRegex(markerPrefix)}-authoring-publication:`,
+      'i',
+    );
+    if (
+      publicationMarker === null ||
+      !leadingPublicationMarkerPattern.test(text)
+    ) {
+      return fail(
+        id,
+        name,
+        'new issue is missing a well-formed authoring-publication marker as the first line of the body',
+      );
+    }
+  }
+
   const ownerMarkers = options.comments
     .map((comment) => parseAuthoringOwnerComment(comment.body, markerPrefix))
     .filter((marker): marker is NonNullable<typeof marker> => marker !== null);
   const hasQualifyingOwnerMarker = ownerMarkers.some(
     (marker) =>
       AUTHORING_OWNER_QUALIFYING_MODES.has(marker.mode) &&
-      (currentIssueRef === undefined || marker.target === currentIssueRef),
+      (currentIssueRef === undefined || marker.target === currentIssueRef) &&
+      (publicationMarker === null ||
+        (marker.set === publicationMarker.set &&
+          marker.session === publicationMarker.session)),
   );
   if (!hasQualifyingOwnerMarker) {
+    const targetNote =
+      currentIssueRef === undefined ? '' : ', target matching this issue';
+    const generationNote =
+      publicationMarker === null
+        ? ''
+        : ", set/session matching the publication marker's generation";
     return fail(
       id,
       name,
-      'no valid authoring-owner comment (mode acquire/bootstrap/resume, target matching this issue) was found',
+      `no valid authoring-owner comment (mode acquire/bootstrap/resume${targetNote}${generationNote}) was found`,
     );
   }
 
@@ -890,24 +928,11 @@ function checkAuthoringOwnerMarkerTrail(
       'owner-marker present; not applicable for the publication-token line (not a new issue)',
     );
   }
-
-  const publicationMarker = parseAuthoringPublicationComment(
-    text,
-    markerPrefix,
-  );
-  const leadingPublicationMarkerPattern = new RegExp(
-    `^\\s*<!--\\s*${escapeRegex(markerPrefix)}-authoring-publication:`,
-    'i',
-  );
-  const publicationMarkerIsFirstLine =
-    leadingPublicationMarkerPattern.test(text);
-  if (publicationMarker === null || !publicationMarkerIsFirstLine) {
-    return fail(
-      id,
-      name,
-      'new issue is missing a well-formed authoring-publication marker as the first line of the body',
-    );
-  }
+  // publicationMarker is non-null here: newIssue === true already returned
+  // above on a missing/malformed marker.
+  const resolvedPublicationMarker = publicationMarker as NonNullable<
+    typeof publicationMarker
+  >;
 
   if (options.journalComments === undefined) {
     return pass(
@@ -917,22 +942,33 @@ function checkAuthoringOwnerMarkerTrail(
     );
   }
 
+  // Match the FULL token tuple (target/anchor/set/session/token), not just
+  // target -- an unrelated or out-of-generation journal record sharing only
+  // `target` must not be accepted as evidence (#2628 review, Codex). When
+  // the current issue's identity is known, also require the record's own
+  // `issue` field to name it exactly: per the protocol, `issue` is resolved
+  // to the real identity no later than the `member` transition, so `none`
+  // at state=member-or-later is itself a protocol violation, not a
+  // tolerable gap.
   const hasMatchingIntentRecord = options.journalComments.some((comment) => {
     const intent = parseAuthoringPublicationIntentComment(
       comment.body,
       markerPrefix,
     );
-    if (intent === null || intent.target !== publicationMarker.target) {
+    if (
+      intent === null ||
+      intent.target !== resolvedPublicationMarker.target ||
+      intent.anchor !== resolvedPublicationMarker.anchor ||
+      intent.set !== resolvedPublicationMarker.set ||
+      intent.session !== resolvedPublicationMarker.session ||
+      intent.token !== resolvedPublicationMarker.token
+    ) {
       return false;
     }
     if (!AUTHORING_PUBLICATION_INTENT_MEMBER_OR_LATER.has(intent.state)) {
       return false;
     }
-    if (
-      currentIssueRef !== undefined &&
-      intent.issue !== 'none' &&
-      intent.issue !== currentIssueRef
-    ) {
+    if (currentIssueRef !== undefined && intent.issue !== currentIssueRef) {
       return false;
     }
     return true;
@@ -1614,6 +1650,22 @@ function main(): void {
   if (args.issue !== undefined && !/^[1-9]\d*$/.test(args.issue)) {
     fail_('--issue must be a positive integer');
   }
+  if (args.journalCommentsFile && !args.newIssue) {
+    fail_('--journal-comments-file requires --new-issue');
+  }
+
+  // Explicit --current-repo wins; otherwise fall back to the
+  // GITHUB_REPOSITORY env var GitHub Actions sets automatically, so CI
+  // usage narrows cross-repo URL false positives with no extra flag.
+  // undefined (neither present) keeps the pre-#1399-fix default of
+  // flagging every full-URL reference for the prose-dependency check --
+  // but --issue's target match needs a resolvable repo to mean anything,
+  // so require one explicitly rather than silently widening the match
+  // (#2628 review, Codex and Copilot both flagged the silent-widening gap).
+  const currentRepo = args.currentRepo ?? process.env.GITHUB_REPOSITORY;
+  if (args.issue !== undefined && !currentRepo) {
+    fail_('--issue requires --current-repo (or $GITHUB_REPOSITORY) to be set');
+  }
 
   const policy = loadPolicy(args.configPath);
   const markerPrefix = args.markerPrefix ?? policy.markerPrefix;
@@ -1624,12 +1676,7 @@ function main(): void {
     labels: args.labels,
     blockedByHumanLabelName: policy.blockedByHumanLabelName,
     authoringLabelName: policy.authoringLabelName,
-    // Explicit --current-repo wins; otherwise fall back to the
-    // GITHUB_REPOSITORY env var GitHub Actions sets automatically, so CI
-    // usage narrows cross-repo URL false positives with no extra flag.
-    // undefined (neither present) keeps the pre-#1399-fix default of
-    // flagging every full-URL reference.
-    currentRepo: args.currentRepo ?? process.env.GITHUB_REPOSITORY,
+    currentRepo,
     issueNumber:
       args.issue !== undefined ? Number.parseInt(args.issue, 10) : undefined,
     comments: args.commentsFile

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -919,7 +919,8 @@ function checkAuthoringOwnerMarkerTrail(
       (currentIssueRef === undefined ||
         marker.target.toLowerCase() === currentIssueRef) &&
       (publicationMarker === null ||
-        (marker.set === publicationMarker.set &&
+        (marker.anchor === publicationMarker.anchor &&
+          marker.set === publicationMarker.set &&
           marker.session === publicationMarker.session)),
   );
   if (!hasQualifyingOwnerMarker) {
@@ -928,7 +929,7 @@ function checkAuthoringOwnerMarkerTrail(
     const generationNote =
       publicationMarker === null
         ? ''
-        : ", set/session matching the publication marker's generation";
+        : ", anchor/set/session matching the publication marker's generation";
     return fail(
       id,
       name,
@@ -981,6 +982,15 @@ function checkAuthoringOwnerMarkerTrail(
       return false;
     }
     if (!AUTHORING_PUBLICATION_INTENT_MEMBER_OR_LATER.has(intent.state)) {
+      return false;
+    }
+    // issue=none is only ever valid at state=pending (docs/issue-authoring-skill.md):
+    // "Append the returned identity while it remains pending, append
+    // member only after the owner marker is verified" -- a member-or-later
+    // record with issue=none is itself a protocol violation, regardless of
+    // whether the caller happens to know the current issue's identity
+    // (#2628 review, Copilot and Codex).
+    if (intent.issue.toLowerCase() === 'none') {
       return false;
     }
     if (
@@ -1689,6 +1699,13 @@ function main(): void {
   if (args.newIssue && args.commentsFile && !args.journalCommentsFile) {
     fail_('--new-issue with --comments-file requires --journal-comments-file');
   }
+  // Without a known current-issue identity, the journal cross-check cannot
+  // verify a publication-intent record actually names THIS issue -- an
+  // intent record naming a different (non-none) issue would otherwise pass
+  // silently whenever the caller omitted --issue (#2628 review, Codex).
+  if (args.newIssue && args.journalCommentsFile && args.issue === undefined) {
+    fail_('--new-issue with --journal-comments-file requires --issue');
+  }
 
   // Explicit --current-repo wins; otherwise fall back to the
   // GITHUB_REPOSITORY env var GitHub Actions sets automatically, so CI
@@ -1903,7 +1920,7 @@ Options:
                                     (not an edit); requires the leading
                                     authoring-publication body line, and (when
                                     --comments-file is also given) requires
-                                    --journal-comments-file too
+                                    --journal-comments-file and --issue too
   --format <json|table>            output format (default: json)
   --help                           show this help
 `);

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -855,9 +855,13 @@ function checkAuthoringOwnerMarkerTrail(
   }
 
   const currentRepo = normalizeCurrentRepo(options.currentRepo);
+  // Lowercased: GitHub owner/repo names are case-insensitive, matching the
+  // normalization checkProseOnlyDependency already applies to its own
+  // owner/repo comparisons (#2628 review, CodeRabbit). Every comparison
+  // against currentIssueRef below lowercases its own operand to match.
   const currentIssueRef =
     currentRepo && options.issueNumber !== undefined
-      ? `${currentRepo}#${options.issueNumber}`
+      ? `${currentRepo}#${options.issueNumber}`.toLowerCase()
       : undefined;
 
   // Validate the new-issue publication line FIRST, independent of whether
@@ -891,8 +895,18 @@ function checkAuthoringOwnerMarkerTrail(
     );
   }
 
+  // Strip fenced/inline code regions before parsing, matching the same
+  // stripMarkdownCodeRegions(rawText) pass auditAuthoredIssue() already
+  // applies to the issue body: a pasted illustrative example wrapped in a
+  // comment's own code block must not count as a real marker (#2628
+  // review, CodeRabbit).
   const ownerMarkers = options.comments
-    .map((comment) => parseAuthoringOwnerComment(comment.body, markerPrefix))
+    .map((comment) =>
+      parseAuthoringOwnerComment(
+        stripMarkdownCodeRegions(comment.body),
+        markerPrefix,
+      ),
+    )
     .filter((marker): marker is NonNullable<typeof marker> => marker !== null);
   const hasQualifyingOwnerMarker = ownerMarkers.some(
     (marker) =>
@@ -902,7 +916,8 @@ function checkAuthoringOwnerMarkerTrail(
       // (`none` is only ever legitimate on an anchor-only release-guard
       // marker per docs/issue-authoring-skill.md -- #2628 review, Codex).
       marker.bodySha256 !== 'none' &&
-      (currentIssueRef === undefined || marker.target === currentIssueRef) &&
+      (currentIssueRef === undefined ||
+        marker.target.toLowerCase() === currentIssueRef) &&
       (publicationMarker === null ||
         (marker.set === publicationMarker.set &&
           marker.session === publicationMarker.session)),
@@ -952,7 +967,7 @@ function checkAuthoringOwnerMarkerTrail(
   // tolerable gap.
   const hasMatchingIntentRecord = options.journalComments.some((comment) => {
     const intent = parseAuthoringPublicationIntentComment(
-      comment.body,
+      stripMarkdownCodeRegions(comment.body),
       markerPrefix,
     );
     if (
@@ -968,7 +983,10 @@ function checkAuthoringOwnerMarkerTrail(
     if (!AUTHORING_PUBLICATION_INTENT_MEMBER_OR_LATER.has(intent.state)) {
       return false;
     }
-    if (currentIssueRef !== undefined && intent.issue !== currentIssueRef) {
+    if (
+      currentIssueRef !== undefined &&
+      intent.issue.toLowerCase() !== currentIssueRef
+    ) {
       return false;
     }
     return true;
@@ -1661,6 +1679,16 @@ function main(): void {
   if (args.journalCommentsFile && !args.commentsFile) {
     fail_('--journal-comments-file requires --comments-file');
   }
+  // Without this, a new-issue check with real owner-marker evidence but no
+  // journal data would report "not applicable" for the journal half and
+  // still exit 0 -- a misleading success for the AC's combined
+  // publication-line + journal-record requirement (#2628 review,
+  // CodeRabbit). The pure auditAuthoredIssue() function itself keeps the
+  // graceful not-applicable degradation for a direct (non-CLI) caller that
+  // deliberately wants a partial check.
+  if (args.newIssue && args.commentsFile && !args.journalCommentsFile) {
+    fail_('--new-issue with --comments-file requires --journal-comments-file');
+  }
 
   // Explicit --current-repo wins; otherwise fall back to the
   // GITHUB_REPOSITORY env var GitHub Actions sets automatically, so CI
@@ -1873,7 +1901,9 @@ Options:
                                     --comments-file)
   --new-issue                      this issue was just created in this invocation
                                     (not an edit); requires the leading
-                                    authoring-publication body line
+                                    authoring-publication body line, and (when
+                                    --comments-file is also given) requires
+                                    --journal-comments-file too
   --format <json|table>            output format (default: json)
   --help                           show this help
 `);

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -853,13 +853,6 @@ function checkAuthoringOwnerMarkerTrail(
       'not applicable: issue does not carry the authoring label',
     );
   }
-  if (options.comments === undefined) {
-    return pass(
-      id,
-      name,
-      'not applicable: no comment data supplied to this check',
-    );
-  }
 
   const currentRepo = normalizeCurrentRepo(options.currentRepo);
   const currentIssueRef =
@@ -867,27 +860,19 @@ function checkAuthoringOwnerMarkerTrail(
       ? `${currentRepo}#${options.issueNumber}`
       : undefined;
 
-  // For a new issue, resolve the publication marker BEFORE searching for a
-  // qualifying owner marker: its `set`/`session` bind the "generation" a
-  // qualifying owner marker must itself belong to (#2628 review, Codex) --
-  // otherwise a stale owner marker from an earlier acquire/bootstrap cycle
-  // could combine with a fresh publication token to produce a false pass.
+  // Validate the new-issue publication line FIRST, independent of whether
+  // comment data was supplied: this half only needs the body text and the
+  // `newIssue` flag, so it must not be silently skipped just because the
+  // caller omitted `comments` -- a genuinely broken new-issue body (no
+  // publication line at all) must not get a free pass from a missing
+  // --comments-file alone (#2628 review, Codex). parseAuthoringPublicationComment
+  // itself requires the marker's literal first bytes (marker-helpers.mts),
+  // so no separate first-line regex is needed here.
   let publicationMarker: ReturnType<typeof parseAuthoringPublicationComment> =
     null;
   if (options.newIssue === true) {
     publicationMarker = parseAuthoringPublicationComment(text, markerPrefix);
-    // "HTML-first body line" (docs/issue-authoring-skill.md) means the
-    // marker's own literal first bytes, not merely "somewhere before other
-    // content" -- no leading blank line or whitespace tolerance (#2628
-    // review, Copilot).
-    const leadingPublicationMarkerPattern = new RegExp(
-      `^<!--\\s*${escapeRegex(markerPrefix)}-authoring-publication:`,
-      'i',
-    );
-    if (
-      publicationMarker === null ||
-      !leadingPublicationMarkerPattern.test(text)
-    ) {
+    if (publicationMarker === null) {
       return fail(
         id,
         name,
@@ -896,12 +881,27 @@ function checkAuthoringOwnerMarkerTrail(
     }
   }
 
+  if (options.comments === undefined) {
+    return pass(
+      id,
+      name,
+      publicationMarker === null
+        ? 'not applicable: no comment data supplied to this check'
+        : 'publication-token line present; not applicable for the owner-marker/journal checks (no comment data supplied to this check)',
+    );
+  }
+
   const ownerMarkers = options.comments
     .map((comment) => parseAuthoringOwnerComment(comment.body, markerPrefix))
     .filter((marker): marker is NonNullable<typeof marker> => marker !== null);
   const hasQualifyingOwnerMarker = ownerMarkers.some(
     (marker) =>
       AUTHORING_OWNER_QUALIFYING_MODES.has(marker.mode) &&
+      // A qualifying acquire/bootstrap/resume marker targets a real issue,
+      // so its body-sha256 must hash an actual body read, never `none`
+      // (`none` is only ever legitimate on an anchor-only release-guard
+      // marker per docs/issue-authoring-skill.md -- #2628 review, Codex).
+      marker.bodySha256 !== 'none' &&
       (currentIssueRef === undefined || marker.target === currentIssueRef) &&
       (publicationMarker === null ||
         (marker.set === publicationMarker.set &&
@@ -1653,6 +1653,14 @@ function main(): void {
   if (args.journalCommentsFile && !args.newIssue) {
     fail_('--journal-comments-file requires --new-issue');
   }
+  // Supplying journal data with no --comments-file would silently produce
+  // a misleading pass: the owner-marker check (a prerequisite for even
+  // reaching the journal cross-check) reports "not applicable" without
+  // --comments-file, so the journal data would never actually be consulted
+  // (#2628 review, Copilot).
+  if (args.journalCommentsFile && !args.commentsFile) {
+    fail_('--journal-comments-file requires --comments-file');
+  }
 
   // Explicit --current-repo wins; otherwise fall back to the
   // GITHUB_REPOSITORY env var GitHub Actions sets automatically, so CI
@@ -1853,14 +1861,16 @@ Options:
                                     cross-repo (default: $GITHUB_REPOSITORY), and
                                     for authoring-owner-marker-trail's target match
   --issue <number>                 this issue's number, for authoring-owner-marker-trail's
-                                    target match (requires --current-repo)
+                                    target match (requires --current-repo or
+                                    $GITHUB_REPOSITORY to be resolvable)
   --comments-file <path>           JSON array of this issue's pre-fetched comments
                                     ({body, author?, createdAt?}); enables
                                     authoring-owner-marker-trail (network-free: this
                                     module never fetches comments itself)
   --journal-comments-file <path>   JSON array of the journal issue's pre-fetched
                                     comments, for the new-issue publication-intent
-                                    cross-check (requires --new-issue)
+                                    cross-check (requires --new-issue and
+                                    --comments-file)
   --new-issue                      this issue was just created in this invocation
                                     (not an edit); requires the leading
                                     authoring-publication body line

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -39,6 +39,11 @@ import type { EffortMarkerDetection } from './effort.mts';
 import { parseEffortMarker } from './effort.mts';
 import { loadIddConfig, loadPolicyConfig } from './idd-config.mts';
 import { stripMarkdownCodeRegions } from './markdown-code.mts';
+import {
+  parseAuthoringOwnerComment,
+  parseAuthoringPublicationComment,
+  parseAuthoringPublicationIntentComment,
+} from './marker-helpers.mts';
 import { createMarkerRegex, escapeRegex } from './marker-regex.mts';
 import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mts';
 
@@ -126,6 +131,62 @@ export interface AuditOptions {
    * option entirely — never as a known, non-matching repo.
    */
   currentRepo?: string;
+  /**
+   * The current issue's number, paired with {@link currentRepo} to form its
+   * canonical `owner/repo#number` identity for the
+   * `authoring-owner-marker-trail` check's `target` comparison. Absent when
+   * that check is not applicable (e.g. no issue number is yet known).
+   */
+  issueNumber?: number;
+  /**
+   * The configured authoring label (`issueAuthoring.authoringLabelName`).
+   * Defaults to `POLICY_DEFAULTS.issueAuthoring.authoringLabelName`
+   * (`status:authoring`). Used only by `authoring-owner-marker-trail` to
+   * decide whether the check applies at all — an issue that never carries
+   * this label is unaffected by the check, matching {@link labels}'
+   * case-insensitive comparison.
+   */
+  authoringLabelName?: string;
+  /**
+   * The current issue's own pre-fetched comments, used by
+   * `authoring-owner-marker-trail` to look for a valid `authoring-owner`
+   * marker. This module stays network-free: the caller fetches comments and
+   * supplies them here. `undefined` means the caller did not opt into
+   * comment-aware checking at all, so the check reports "not applicable"
+   * rather than a false failure (distinct from an empty array, which means
+   * comments were fetched and there genuinely are none).
+   */
+  comments?: readonly AuthoringCommentInput[];
+  /**
+   * The journal issue's pre-fetched comments (the durable
+   * `authoring-publication-intent` record location per the "Authoring
+   * label lifecycle" contract). The caller resolves which issue is the
+   * journal — this module does not derive anchor/journal identity itself.
+   * Same `undefined`-vs-empty-array distinction as {@link comments}.
+   */
+  journalComments?: readonly AuthoringCommentInput[];
+  /**
+   * True when the caller knows this issue was just created (not an edit to
+   * a pre-existing issue) in the current invocation. Only when true does
+   * `authoring-owner-marker-trail` require the leading
+   * `authoring-publication` body line. Deliberately a caller-supplied
+   * boolean rather than an inferred "age relative to first label
+   * application" heuristic (the issue's own suggested approach): the
+   * caller already knows this fact firsthand at the moment of publishing,
+   * so a boolean avoids clock-skew and timestamp-parsing fragility for no
+   * loss of precision.
+   */
+  newIssue?: boolean;
+}
+
+/** One pre-fetched comment, as supplied to {@link AuditOptions.comments} and
+ * {@link AuditOptions.journalComments}. Only `body` is inspected today;
+ * `author`/`createdAt` are accepted for forward compatibility with a future
+ * trust/recency check but currently unused. */
+export interface AuthoringCommentInput {
+  body: string;
+  author?: string;
+  createdAt?: string;
 }
 
 interface HeadingRequirement {
@@ -360,9 +421,31 @@ const AUDIT_AUTHORED_ISSUE_FLAG_SPEC = {
   '--marker-prefix': { type: 'string' },
   '--config': { type: 'string' },
   '--current-repo': { type: 'string' },
+  '--issue': { type: 'string' },
   '--label': { type: 'string', multiple: true },
+  '--comments-file': { type: 'string' },
+  '--journal-comments-file': { type: 'string' },
+  '--new-issue': { type: 'boolean', default: false },
   '--format': { type: 'string', default: 'json' },
 } as const;
+
+// Declared here (alongside the flag spec above), not next to
+// checkAuthoringOwnerMarkerTrail further down: the import.meta.main trigger
+// immediately below calls main() -> auditAuthoredIssue() ->
+// checkAuthoringOwnerMarkerTrail() synchronously at module-evaluation time,
+// and a `const` declared after that point is still in the temporal dead
+// zone when the trigger fires (same TDZ hazard as AUDIT_AUTHORED_ISSUE_FLAG_SPEC
+// itself and the LIST_ITEM_MARKER_PATTERN family further down this file).
+const AUTHORING_OWNER_QUALIFYING_MODES = new Set([
+  'acquire',
+  'bootstrap',
+  'resume',
+]);
+const AUTHORING_PUBLICATION_INTENT_MEMBER_OR_LATER = new Set([
+  'member',
+  'cleanup',
+  'abandoned',
+]);
 
 if (import.meta.main) {
   main();
@@ -421,6 +504,7 @@ export function auditAuthoredIssue(
     checkSuitabilityVisibleLineAgreement(text, markerPrefix, suitability),
     checkEffortVisibleLineAgreement(text, markerPrefix),
     checkProseOnlyDependency(text, normalizeCurrentRepo(options.currentRepo)),
+    checkAuthoringOwnerMarkerTrail(text, markerPrefix, labels, options),
   ];
 
   return {
@@ -734,6 +818,137 @@ function checkEffortVisibleLineAgreement(
     id,
     name,
     `visible line agrees with marker value ${effort.value}`,
+  );
+}
+
+/**
+ * Verify that an authoring-labeled issue carries the owner-marker/
+ * publication-token trail the "Authoring label lifecycle" contract
+ * (docs/issue-authoring-skill.md) requires. Not applicable (`pass`) when the
+ * issue never carries the configured authoring label at all — this is a
+ * forward-looking gate on newly authoring-labeled issues, never a
+ * retroactive backfill requirement — or when the caller did not supply
+ * `comments` (this module stays network-free; a caller not opting into
+ * comment-aware checking must not see a false failure).
+ */
+function checkAuthoringOwnerMarkerTrail(
+  text: string,
+  markerPrefix: string,
+  labels: readonly string[],
+  options: AuditOptions,
+): AuditFinding {
+  const id = 'authoring-owner-marker-trail';
+  const name =
+    'Authoring-labeled issue carries the owner-marker/publication-token trail';
+  const authoringLabelName = (
+    options.authoringLabelName ??
+    POLICY_DEFAULTS.issueAuthoring.authoringLabelName
+  )
+    .trim()
+    .toLowerCase();
+  if (!labels.includes(authoringLabelName)) {
+    return pass(
+      id,
+      name,
+      'not applicable: issue does not carry the authoring label',
+    );
+  }
+  if (options.comments === undefined) {
+    return pass(
+      id,
+      name,
+      'not applicable: no comment data supplied to this check',
+    );
+  }
+
+  const currentRepo = normalizeCurrentRepo(options.currentRepo);
+  const currentIssueRef =
+    currentRepo && options.issueNumber !== undefined
+      ? `${currentRepo}#${options.issueNumber}`
+      : undefined;
+
+  const ownerMarkers = options.comments
+    .map((comment) => parseAuthoringOwnerComment(comment.body, markerPrefix))
+    .filter((marker): marker is NonNullable<typeof marker> => marker !== null);
+  const hasQualifyingOwnerMarker = ownerMarkers.some(
+    (marker) =>
+      AUTHORING_OWNER_QUALIFYING_MODES.has(marker.mode) &&
+      (currentIssueRef === undefined || marker.target === currentIssueRef),
+  );
+  if (!hasQualifyingOwnerMarker) {
+    return fail(
+      id,
+      name,
+      'no valid authoring-owner comment (mode acquire/bootstrap/resume, target matching this issue) was found',
+    );
+  }
+
+  if (options.newIssue !== true) {
+    return pass(
+      id,
+      name,
+      'owner-marker present; not applicable for the publication-token line (not a new issue)',
+    );
+  }
+
+  const publicationMarker = parseAuthoringPublicationComment(
+    text,
+    markerPrefix,
+  );
+  const leadingPublicationMarkerPattern = new RegExp(
+    `^\\s*<!--\\s*${escapeRegex(markerPrefix)}-authoring-publication:`,
+    'i',
+  );
+  const publicationMarkerIsFirstLine =
+    leadingPublicationMarkerPattern.test(text);
+  if (publicationMarker === null || !publicationMarkerIsFirstLine) {
+    return fail(
+      id,
+      name,
+      'new issue is missing a well-formed authoring-publication marker as the first line of the body',
+    );
+  }
+
+  if (options.journalComments === undefined) {
+    return pass(
+      id,
+      name,
+      'owner-marker and publication-token line present; not applicable for the journal cross-check (no journal comment data supplied)',
+    );
+  }
+
+  const hasMatchingIntentRecord = options.journalComments.some((comment) => {
+    const intent = parseAuthoringPublicationIntentComment(
+      comment.body,
+      markerPrefix,
+    );
+    if (intent === null || intent.target !== publicationMarker.target) {
+      return false;
+    }
+    if (!AUTHORING_PUBLICATION_INTENT_MEMBER_OR_LATER.has(intent.state)) {
+      return false;
+    }
+    if (
+      currentIssueRef !== undefined &&
+      intent.issue !== 'none' &&
+      intent.issue !== currentIssueRef
+    ) {
+      return false;
+    }
+    return true;
+  });
+  if (!hasMatchingIntentRecord) {
+    return fail(
+      id,
+      name,
+      'no matching authoring-publication-intent record reaching state=member or later was found on the journal issue',
+    );
+  }
+
+  return pass(
+    id,
+    name,
+    'owner-marker, publication-token line, and journal publication-intent record are all present and well-formed',
   );
 }
 
@@ -1336,6 +1551,42 @@ interface CliArgs {
   labels: string[];
   format: string;
   currentRepo?: string;
+  issue?: string;
+  commentsFile?: string;
+  journalCommentsFile?: string;
+  newIssue: boolean;
+}
+
+/**
+ * Read and JSON-parse a comments file (an array of
+ * `{body, author?, createdAt?}` objects) the same uncaught-throw-on-
+ * malformed-input way `--body-file` already behaves: a missing file or
+ * invalid JSON propagates as an unhandled exception rather than a new
+ * soft-degrade path this file does not otherwise have.
+ */
+function readCommentsFile(path: string): AuthoringCommentInput[] {
+  const raw = readFileSync(resolve(process.cwd(), path), 'utf8');
+  const parsed: unknown = JSON.parse(raw);
+  if (!Array.isArray(parsed)) {
+    throw new Error(`${path} must contain a JSON array of comments`);
+  }
+  return parsed.map((entry, index) => {
+    const record = entry as {
+      body?: unknown;
+      author?: unknown;
+      createdAt?: unknown;
+    };
+    if (typeof record?.body !== 'string') {
+      throw new Error(`${path}[${index}] is missing a string "body" field`);
+    }
+    return {
+      body: record.body,
+      ...(typeof record.author === 'string' ? { author: record.author } : {}),
+      ...(typeof record.createdAt === 'string'
+        ? { createdAt: record.createdAt }
+        : {}),
+    };
+  });
 }
 
 function main(): void {
@@ -1360,6 +1611,10 @@ function main(): void {
     ? readFileSync(0, 'utf8')
     : readFileSync(resolve(process.cwd(), args.bodyFile as string), 'utf8');
 
+  if (args.issue !== undefined && !/^[1-9]\d*$/.test(args.issue)) {
+    fail_('--issue must be a positive integer');
+  }
+
   const policy = loadPolicy(args.configPath);
   const markerPrefix = args.markerPrefix ?? policy.markerPrefix;
 
@@ -1368,12 +1623,22 @@ function main(): void {
     markerPrefix,
     labels: args.labels,
     blockedByHumanLabelName: policy.blockedByHumanLabelName,
+    authoringLabelName: policy.authoringLabelName,
     // Explicit --current-repo wins; otherwise fall back to the
     // GITHUB_REPOSITORY env var GitHub Actions sets automatically, so CI
     // usage narrows cross-repo URL false positives with no extra flag.
     // undefined (neither present) keeps the pre-#1399-fix default of
     // flagging every full-URL reference.
     currentRepo: args.currentRepo ?? process.env.GITHUB_REPOSITORY,
+    issueNumber:
+      args.issue !== undefined ? Number.parseInt(args.issue, 10) : undefined,
+    comments: args.commentsFile
+      ? readCommentsFile(args.commentsFile)
+      : undefined,
+    journalComments: args.journalCommentsFile
+      ? readCommentsFile(args.journalCommentsFile)
+      : undefined,
+    newIssue: args.newIssue,
   });
 
   writeReport(report, args.format);
@@ -1399,6 +1664,7 @@ function isIssueShape(value: string): value is IssueShape {
 function loadPolicy(configPath?: string): {
   markerPrefix: string;
   blockedByHumanLabelName: string;
+  authoringLabelName: string;
 } {
   // Default path: reuse the shared loadIddConfig() (idd-config.mts) rather
   // than a second "readFileSync + JSON.parse, null on error" copy of the
@@ -1436,6 +1702,7 @@ function loadPolicy(configPath?: string): {
     return {
       markerPrefix: DEFAULT_MARKER_PREFIX,
       blockedByHumanLabelName: POLICY_DEFAULTS.labels.blockedByHumanLabelName,
+      authoringLabelName: POLICY_DEFAULTS.issueAuthoring.authoringLabelName,
     };
   }
   return {
@@ -1444,6 +1711,8 @@ function loadPolicy(configPath?: string): {
     ),
     blockedByHumanLabelName:
       normalizePolicyConfig(config).labels.blockedByHumanLabelName,
+    authoringLabelName:
+      normalizePolicyConfig(config).issueAuthoring.authoringLabelName,
   };
 }
 
@@ -1496,7 +1765,11 @@ function parseArgs(argv: string[]): CliArgs {
     markerPrefix: values['marker-prefix'] as string | undefined,
     configPath: values.config as string | undefined,
     currentRepo: values['current-repo'] as string | undefined,
+    issue: values.issue as string | undefined,
     labels: (values.label as string[] | undefined) ?? [],
+    commentsFile: values['comments-file'] as string | undefined,
+    journalCommentsFile: values['journal-comments-file'] as string | undefined,
+    newIssue: values['new-issue'] as boolean,
     format,
   };
 }
@@ -1512,9 +1785,11 @@ section headings for the declared shape, the roadmap-id/blocked-by
 dependency-marker rules, visible/hidden suitability+effort line
 agreement, and an advisory (warning-severity only) check that flags an
 issue/PR reference used near coordination language with no corresponding
-dependency marker. Exits 0 when every check passes, 1 when any check
-fails, 2 on a usage error; the advisory check never affects the exit
-code.
+dependency marker, and (when --comments-file is supplied) the
+authoring-owner-marker-trail check that verifies an authoring-labeled
+issue carries the owner-marker/publication-token trail. Exits 0 when
+every check passes, 1 when any check fails, 2 on a usage error; the
+advisory check never affects the exit code.
 
 Options:
   --shape <orphan|roadmap|child>   declared issue shape (required)
@@ -1524,10 +1799,24 @@ Options:
   --config <path>                  policy config path (default: .github/idd/config.json)
   --label <name>                   a label currently applied/proposed on the issue
                                     (repeatable; used for the suitability=1
-                                    cross-field check)
+                                    cross-field check and the authoring-label
+                                    check for authoring-owner-marker-trail)
   --current-repo <owner/repo>      this repository, for the prose-dependency check
                                     to recognize a full-URL issue/PR reference as
-                                    cross-repo (default: $GITHUB_REPOSITORY)
+                                    cross-repo (default: $GITHUB_REPOSITORY), and
+                                    for authoring-owner-marker-trail's target match
+  --issue <number>                 this issue's number, for authoring-owner-marker-trail's
+                                    target match (requires --current-repo)
+  --comments-file <path>           JSON array of this issue's pre-fetched comments
+                                    ({body, author?, createdAt?}); enables
+                                    authoring-owner-marker-trail (network-free: this
+                                    module never fetches comments itself)
+  --journal-comments-file <path>   JSON array of the journal issue's pre-fetched
+                                    comments, for the new-issue publication-intent
+                                    cross-check (requires --new-issue)
+  --new-issue                      this issue was just created in this invocation
+                                    (not an edit); requires the leading
+                                    authoring-publication body line
   --format <json|table>            output format (default: json)
   --help                           show this help
 `);

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -227,7 +227,7 @@ const HELPER_COMMANDS: HelperCommand[] = [
     entryPath: 'scripts/audit-authored-issue.mjs',
     vendoredCommand: 'node scripts/audit-authored-issue.mjs',
     description:
-      'Mechanically audit a drafted issue body against the issue-authoring contract: the autopilot-suitability marker, its blocked-by-human cross-field rule, markerPrefix consistency, required headings, dependency-marker rules, and visible/hidden footer agreement.',
+      'Mechanically audit a drafted issue body against the issue-authoring contract: the autopilot-suitability marker, its blocked-by-human cross-field rule, markerPrefix consistency, required headings, dependency-marker rules, visible/hidden footer agreement, and (given pre-fetched comments) the owner-marker/publication-token trail.',
   },
   {
     id: 'audit-pr-cleanup',

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -1278,6 +1278,218 @@ export function parseLocalValidationEvidenceComment(
   };
 }
 
+// --- Issue-authoring owner/publication markers (#2621) ---
+//
+// Three markers from the issue-authoring skill's "Authoring label lifecycle"
+// protocol (docs/issue-authoring-skill.md), each using a semicolon-separated
+// `key=value; key2=value2` grammar distinct from every marker above (which
+// use fixed positional tokens). Parsing only -- nothing in this codebase
+// renders these; the issue-authoring skill posts them directly via its own
+// documented HTTP path, not through a shared renderer here.
+
+/** Parsed `<!-- {prefix}-authoring-owner: ... -->` marker. */
+export interface ParsedAuthoringOwnerMarker {
+  target: string;
+  anchor: string;
+  mode:
+    | 'acquire'
+    | 'resume'
+    | 'bootstrap'
+    | 'heartbeat'
+    | 'release'
+    | 'release-guard'
+    | 'release-complete';
+  owner: string;
+  set: string;
+  session: string;
+  bodySha256: string;
+  snapshotSha256: string;
+  supersedes: string;
+}
+
+/** Parsed `<!-- {prefix}-authoring-publication: ... -->` marker. */
+export interface ParsedAuthoringPublicationMarker {
+  target: string;
+  anchor: string;
+  set: string;
+  session: string;
+  token: string;
+}
+
+/** Parsed `<!-- {prefix}-authoring-publication-intent: ... -->` marker. */
+export interface ParsedAuthoringPublicationIntentMarker {
+  target: string;
+  anchor: string;
+  set: string;
+  session: string;
+  token: string;
+  journal: string;
+  issue: string;
+  actor: string;
+  state: 'pending' | 'member' | 'cleanup' | 'abandoned';
+}
+
+const AUTHORING_OWNER_MODES = new Set([
+  'acquire',
+  'resume',
+  'bootstrap',
+  'heartbeat',
+  'release',
+  'release-guard',
+  'release-complete',
+]);
+
+const AUTHORING_PUBLICATION_INTENT_STATES = new Set([
+  'pending',
+  'member',
+  'cleanup',
+  'abandoned',
+]);
+
+/**
+ * Parse the `field=value; field2=value2; ...` payload of a
+ * `<!-- {markerPrefix}-{suffix}: ... -->` marker into a raw field map. Each
+ * value is split on the first `=` only and trimmed on both sides; a field
+ * with no `=` is dropped rather than treated as a key with an empty value,
+ * since none of the three markers above have a valueless field. Returns
+ * `null` when the marker itself is absent -- callers validate the required
+ * field set and any enum values themselves, since each marker's requirement
+ * differs.
+ */
+function parseSemicolonFieldMarker(
+  body: string,
+  markerPrefix: string,
+  suffix: string,
+): Record<string, string> | null {
+  const pattern = new RegExp(
+    `<!--\\s*${escapeRegex(markerPrefix)}-${suffix}:\\s*([\\s\\S]*?)\\s*-->`,
+    'i',
+  );
+  const match = body.match(pattern);
+  if (!match) {
+    return null;
+  }
+  const fields: Record<string, string> = {};
+  for (const part of match[1].split(';')) {
+    const separatorIndex = part.indexOf('=');
+    if (separatorIndex < 0) {
+      continue;
+    }
+    const key = part.slice(0, separatorIndex).trim();
+    const value = part.slice(separatorIndex + 1).trim();
+    if (key) {
+      fields[key] = value;
+    }
+  }
+  return fields;
+}
+
+export function parseAuthoringOwnerComment(
+  body: string,
+  markerPrefix: string,
+): ParsedAuthoringOwnerMarker | null {
+  const fields = parseSemicolonFieldMarker(
+    body,
+    markerPrefix,
+    'authoring-owner',
+  );
+  if (!fields) {
+    return null;
+  }
+  const mode = fields.mode;
+  if (
+    !fields.target ||
+    !fields.anchor ||
+    !AUTHORING_OWNER_MODES.has(mode) ||
+    !fields.owner ||
+    !fields.set ||
+    !fields.session ||
+    !fields['body-sha256'] ||
+    !fields['snapshot-sha256'] ||
+    !fields.supersedes
+  ) {
+    return null;
+  }
+  return {
+    target: fields.target,
+    anchor: fields.anchor,
+    mode: mode as ParsedAuthoringOwnerMarker['mode'],
+    owner: fields.owner,
+    set: fields.set,
+    session: fields.session,
+    bodySha256: fields['body-sha256'],
+    snapshotSha256: fields['snapshot-sha256'],
+    supersedes: fields.supersedes,
+  };
+}
+
+export function parseAuthoringPublicationComment(
+  body: string,
+  markerPrefix: string,
+): ParsedAuthoringPublicationMarker | null {
+  const fields = parseSemicolonFieldMarker(
+    body,
+    markerPrefix,
+    'authoring-publication',
+  );
+  if (
+    !fields ||
+    !fields.target ||
+    !fields.anchor ||
+    !fields.set ||
+    !fields.session ||
+    !fields.token
+  ) {
+    return null;
+  }
+  return {
+    target: fields.target,
+    anchor: fields.anchor,
+    set: fields.set,
+    session: fields.session,
+    token: fields.token,
+  };
+}
+
+export function parseAuthoringPublicationIntentComment(
+  body: string,
+  markerPrefix: string,
+): ParsedAuthoringPublicationIntentMarker | null {
+  const fields = parseSemicolonFieldMarker(
+    body,
+    markerPrefix,
+    'authoring-publication-intent',
+  );
+  if (!fields) {
+    return null;
+  }
+  const state = fields.state;
+  if (
+    !fields.target ||
+    !fields.anchor ||
+    !fields.set ||
+    !fields.session ||
+    !fields.token ||
+    !fields.journal ||
+    !fields.issue ||
+    !fields.actor ||
+    !AUTHORING_PUBLICATION_INTENT_STATES.has(state)
+  ) {
+    return null;
+  }
+  return {
+    target: fields.target,
+    anchor: fields.anchor,
+    set: fields.set,
+    session: fields.session,
+    token: fields.token,
+    journal: fields.journal,
+    issue: fields.issue,
+    actor: fields.actor,
+    state: state as ParsedAuthoringPublicationIntentMarker['state'],
+  };
+}
+
 // --- Per-cycle marker body renderers (#900) ---
 //
 // Pure, network-free renderers for the three operational markers an agent

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -1367,8 +1367,16 @@ function parseSemicolonFieldMarker(
   markerPrefix: string,
   suffix: string,
 ): Record<string, string> | null {
+  // Anchored at `^` (position 0, not "anywhere in body") and restricted to
+  // same-line whitespace between `<!--` and the prefix-suffix token: the
+  // contract requires each of these three markers to be an "HTML-first"
+  // comment/body line, not merely present somewhere in a longer comment or
+  // pasted example -- an unanchored search would also accept a marker
+  // quoted after prose, inside a fenced example, or opened across a
+  // newline (`<!--\nidd-skill-authoring-owner: ...`), none of which are the
+  // real marker the protocol posts (#2628 review, Codex).
   const pattern = new RegExp(
-    `<!--\\s*${escapeRegex(markerPrefix)}-${suffix}:\\s*([\\s\\S]*?)\\s*-->`,
+    `^<!--[ \\t]*${escapeRegex(markerPrefix)}-${suffix}:\\s*([\\s\\S]*?)\\s*-->`,
     'i',
   );
   const match = body.match(pattern);

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -1346,6 +1346,12 @@ const AUTHORING_PUBLICATION_INTENT_STATES = new Set([
   'abandoned',
 ]);
 
+// docs/issue-authoring-skill.md documents body-sha256/snapshot-sha256 as
+// `<64-lowercase-hex|none>` specifically -- presence alone (accepting a
+// garbage value like `body-sha256=garbage`) is not shape-valid per that
+// grammar (#2628 review, Codex and Copilot both flagged this).
+const AUTHORING_OWNER_DIGEST_PATTERN = /^(?:none|[0-9a-f]{64})$/;
+
 /**
  * Parse the `field=value; field2=value2; ...` payload of a
  * `<!-- {markerPrefix}-{suffix}: ... -->` marker into a raw field map. Each
@@ -1404,8 +1410,8 @@ export function parseAuthoringOwnerComment(
     !fields.owner ||
     !fields.set ||
     !fields.session ||
-    !fields['body-sha256'] ||
-    !fields['snapshot-sha256'] ||
+    !AUTHORING_OWNER_DIGEST_PATTERN.test(fields['body-sha256'] ?? '') ||
+    !AUTHORING_OWNER_DIGEST_PATTERN.test(fields['snapshot-sha256'] ?? '') ||
     !fields.supersedes
   ) {
     return null;

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -1375,8 +1375,13 @@ function parseSemicolonFieldMarker(
   // quoted after prose, inside a fenced example, or opened across a
   // newline (`<!--\nidd-skill-authoring-owner: ...`), none of which are the
   // real marker the protocol posts (#2628 review, Codex).
+  // The payload capture (and its surrounding whitespace) is restricted to
+  // same-line spaces/tabs -- these are "HTML-first body line" markers in
+  // their entirety, not just at their opener, so a multi-line comment
+  // starting at byte 0 must not parse as well-formed either (#2628 review,
+  // Copilot and Codex).
   const pattern = new RegExp(
-    `^<!--[ \\t]*${escapeRegex(markerPrefix)}-${suffix}:\\s*([\\s\\S]*?)\\s*-->`,
+    `^<!--[ \\t]*${escapeRegex(markerPrefix)}-${suffix}:[ \\t]*([^\\r\\n]*?)[ \\t]*-->`,
     'i',
   );
   const match = body.match(pattern);

--- a/tests/audit-authored-issue.test.mts
+++ b/tests/audit-authored-issue.test.mts
@@ -2299,3 +2299,33 @@ test('authoring-owner-marker-trail reports not-applicable (not fail) for a compl
   assert.equal(finding?.result, 'pass');
   assert.match(finding?.detail ?? '', /not applicable/);
 });
+
+test('authoring-owner-marker-trail compares issue identity case-insensitively', () => {
+  const report = auditAuthoredIssue(orphanBody(), {
+    shape: 'orphan',
+    labels: ['status:authoring'],
+    currentRepo: 'Kurone-Kito/Idd-Skill',
+    issueNumber: 9001,
+    comments: [ownerMarkerComment({ target: 'kurone-kito/idd-skill#9001' })],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-owner-marker-trail',
+  );
+  assert.equal(finding?.result, 'pass');
+});
+
+test('authoring-owner-marker-trail ignores a marker-shaped fenced-code example in a comment', () => {
+  const report = auditAuthoredIssue(orphanBody(), {
+    shape: 'orphan',
+    labels: ['status:authoring'],
+    comments: [
+      {
+        body: `\`\`\`html\n${ownerMarkerComment().body}\n\`\`\``,
+      },
+    ],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-owner-marker-trail',
+  );
+  assert.equal(finding?.result, 'fail');
+});

--- a/tests/audit-authored-issue.test.mts
+++ b/tests/audit-authored-issue.test.mts
@@ -2329,3 +2329,37 @@ test('authoring-owner-marker-trail ignores a marker-shaped fenced-code example i
   );
   assert.equal(finding?.result, 'fail');
 });
+
+test('authoring-owner-marker-trail rejects issue=none at state=member even when the current issue is unknown', () => {
+  const report = auditAuthoredIssue(bodyWithPublicationLine(), {
+    shape: 'orphan',
+    labels: ['status:authoring'],
+    newIssue: true,
+    comments: [ownerMarkerComment()],
+    journalComments: [publicationIntentComment({ issue: 'none' })],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-owner-marker-trail',
+  );
+  assert.equal(finding?.result, 'fail');
+});
+
+test('authoring-owner-marker-trail rejects an owner marker with a mismatched anchor from the publication generation', () => {
+  const report = auditAuthoredIssue(bodyWithPublicationLine(), {
+    shape: 'orphan',
+    labels: ['status:authoring'],
+    currentRepo: 'kurone-kito/idd-skill',
+    issueNumber: 9001,
+    newIssue: true,
+    comments: [
+      {
+        body: '<!-- idd-skill-authoring-owner: target=kurone-kito/idd-skill#9001; anchor=kurone-kito/idd-skill#DIFFERENT; mode=acquire; owner=owner-tok1; set=set-xyz789; session=sess-1; body-sha256=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; snapshot-sha256=none; supersedes=none -->',
+      },
+    ],
+    journalComments: [publicationIntentComment()],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-owner-marker-trail',
+  );
+  assert.equal(finding?.result, 'fail');
+});

--- a/tests/audit-authored-issue.test.mts
+++ b/tests/audit-authored-issue.test.mts
@@ -1958,15 +1958,23 @@ test('markerPrefix defaults to idd-skill when not provided', () => {
 
 // --- authoring-owner-marker-trail (#2621) ---
 
+const TEST_BODY_SHA256 = 'a'.repeat(64);
+
 function ownerMarkerComment({
   target = 'kurone-kito/idd-skill#9001',
   mode = 'acquire',
+  set = 'set-xyz789',
+  session = 'sess-1',
+  bodySha256 = TEST_BODY_SHA256,
 }: {
   target?: string;
   mode?: string;
+  set?: string;
+  session?: string;
+  bodySha256?: string;
 } = {}): { body: string } {
   return {
-    body: `<!-- idd-skill-authoring-owner: target=${target}; anchor=kurone-kito/idd-skill#9001; mode=${mode}; owner=owner-tok1; set=set-xyz789; session=sess-1; body-sha256=none; snapshot-sha256=none; supersedes=none -->`,
+    body: `<!-- idd-skill-authoring-owner: target=${target}; anchor=kurone-kito/idd-skill#9001; mode=${mode}; owner=owner-tok1; set=${set}; session=${session}; body-sha256=${bodySha256}; snapshot-sha256=none; supersedes=none -->`,
   };
 }
 
@@ -2199,9 +2207,7 @@ test('authoring-owner-marker-trail rejects an owner marker from a different gene
     issueNumber: 9001,
     newIssue: true,
     comments: [
-      {
-        body: '<!-- idd-skill-authoring-owner: target=kurone-kito/idd-skill#9001; anchor=kurone-kito/idd-skill#9001; mode=acquire; owner=owner-tok1; set=STALE-set; session=STALE-session; body-sha256=none; snapshot-sha256=none; supersedes=none -->',
-      },
+      ownerMarkerComment({ set: 'STALE-set', session: 'STALE-session' }),
     ],
     journalComments: [publicationIntentComment()],
   });
@@ -2254,4 +2260,42 @@ test('authoring-owner-marker-trail requires the publication marker as the litera
     (entry) => entry.id === 'authoring-owner-marker-trail',
   );
   assert.equal(finding?.result, 'fail');
+});
+
+test('authoring-owner-marker-trail rejects body-sha256=none for a qualifying acquire-mode marker', () => {
+  const report = auditAuthoredIssue(orphanBody(), {
+    shape: 'orphan',
+    labels: ['status:authoring'],
+    comments: [ownerMarkerComment({ bodySha256: 'none' })],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-owner-marker-trail',
+  );
+  assert.equal(finding?.result, 'fail');
+});
+
+test('authoring-owner-marker-trail validates the new-issue publication line even when no comment data is supplied', () => {
+  const report = auditAuthoredIssue(orphanBody(), {
+    shape: 'orphan',
+    labels: ['status:authoring'],
+    newIssue: true,
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-owner-marker-trail',
+  );
+  assert.equal(finding?.result, 'fail');
+  assert.match(finding?.detail ?? '', /missing.*publication marker/);
+});
+
+test('authoring-owner-marker-trail reports not-applicable (not fail) for a compliant new-issue body when comments are not supplied', () => {
+  const report = auditAuthoredIssue(bodyWithPublicationLine(), {
+    shape: 'orphan',
+    labels: ['status:authoring'],
+    newIssue: true,
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-owner-marker-trail',
+  );
+  assert.equal(finding?.result, 'pass');
+  assert.match(finding?.detail ?? '', /not applicable/);
 });

--- a/tests/audit-authored-issue.test.mts
+++ b/tests/audit-authored-issue.test.mts
@@ -1955,3 +1955,218 @@ test('markerPrefix defaults to idd-skill when not provided', () => {
   const report = auditAuthoredIssue(orphanBody(), { shape: 'orphan' });
   assert.equal(report.markerPrefix, 'idd-skill');
 });
+
+// --- authoring-owner-marker-trail (#2621) ---
+
+function ownerMarkerComment({
+  target = 'kurone-kito/idd-skill#9001',
+  mode = 'acquire',
+}: {
+  target?: string;
+  mode?: string;
+} = {}): { body: string } {
+  return {
+    body: `<!-- idd-skill-authoring-owner: target=${target}; anchor=kurone-kito/idd-skill#9001; mode=${mode}; owner=owner-tok1; set=set-xyz789; session=sess-1; body-sha256=none; snapshot-sha256=none; supersedes=none -->`,
+  };
+}
+
+function publicationIntentComment({
+  target = 'target-abc123',
+  issue = 'kurone-kito/idd-skill#9001',
+  state = 'member',
+}: {
+  target?: string;
+  issue?: string;
+  state?: string;
+} = {}): {
+  body: string;
+} {
+  return {
+    body: `<!-- idd-skill-authoring-publication-intent: target=${target}; anchor=kurone-kito/idd-skill#9001; set=set-xyz789; session=sess-1; token=pub-token1; journal=kurone-kito/idd-skill#9001; issue=${issue}; actor=kurone-kito; state=${state} -->`,
+  };
+}
+
+function bodyWithPublicationLine(): string {
+  return `<!-- idd-skill-authoring-publication: target=target-abc123; anchor=kurone-kito/idd-skill#9001; set=set-xyz789; session=sess-1; token=pub-token1 -->\n\n${orphanBody()}`;
+}
+
+test('authoring-owner-marker-trail is not applicable when the issue does not carry the authoring label', () => {
+  const report = auditAuthoredIssue(orphanBody(), {
+    shape: 'orphan',
+    labels: [],
+    comments: [],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-owner-marker-trail',
+  );
+  assert.equal(finding?.result, 'pass');
+  assert.match(finding?.detail ?? '', /not applicable.*authoring label/);
+});
+
+test('authoring-owner-marker-trail is not applicable when no comment data is supplied', () => {
+  const report = auditAuthoredIssue(orphanBody(), {
+    shape: 'orphan',
+    labels: ['status:authoring'],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-owner-marker-trail',
+  );
+  assert.equal(finding?.result, 'pass');
+  assert.match(finding?.detail ?? '', /not applicable.*comment data/);
+});
+
+test('authoring-owner-marker-trail fails when no valid owner-marker comment exists', () => {
+  const report = auditAuthoredIssue(orphanBody(), {
+    shape: 'orphan',
+    labels: ['status:authoring'],
+    comments: [],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-owner-marker-trail',
+  );
+  assert.equal(finding?.result, 'fail');
+  assert.match(finding?.detail ?? '', /no valid authoring-owner comment/);
+});
+
+test('authoring-owner-marker-trail fails when the only owner-marker mode is heartbeat', () => {
+  const report = auditAuthoredIssue(orphanBody(), {
+    shape: 'orphan',
+    labels: ['status:authoring'],
+    comments: [ownerMarkerComment({ mode: 'heartbeat' })],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-owner-marker-trail',
+  );
+  assert.equal(finding?.result, 'fail');
+});
+
+test('authoring-owner-marker-trail fails when the owner-marker target does not match the current issue', () => {
+  const report = auditAuthoredIssue(orphanBody(), {
+    shape: 'orphan',
+    labels: ['status:authoring'],
+    currentRepo: 'kurone-kito/idd-skill',
+    issueNumber: 9001,
+    comments: [ownerMarkerComment({ target: 'kurone-kito/idd-skill#9002' })],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-owner-marker-trail',
+  );
+  assert.equal(finding?.result, 'fail');
+});
+
+test('authoring-owner-marker-trail passes on an edit (not a new issue) with a valid owner-marker', () => {
+  const report = auditAuthoredIssue(orphanBody(), {
+    shape: 'orphan',
+    labels: ['status:authoring'],
+    comments: [ownerMarkerComment()],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-owner-marker-trail',
+  );
+  assert.equal(finding?.result, 'pass');
+  assert.match(finding?.detail ?? '', /not a new issue/);
+});
+
+test('authoring-owner-marker-trail fails when a new issue is missing the leading publication-token line', () => {
+  const report = auditAuthoredIssue(orphanBody(), {
+    shape: 'orphan',
+    labels: ['status:authoring'],
+    newIssue: true,
+    comments: [ownerMarkerComment()],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-owner-marker-trail',
+  );
+  assert.equal(finding?.result, 'fail');
+  assert.match(finding?.detail ?? '', /missing.*publication marker/);
+});
+
+test('authoring-owner-marker-trail fails when the publication line is well-formed but not the first line', () => {
+  const report = auditAuthoredIssue(
+    `${orphanBody()}\n\n<!-- idd-skill-authoring-publication: target=target-abc123; anchor=kurone-kito/idd-skill#9001; set=set-xyz789; session=sess-1; token=pub-token1 -->`,
+    {
+      shape: 'orphan',
+      labels: ['status:authoring'],
+      newIssue: true,
+      comments: [ownerMarkerComment()],
+    },
+  );
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-owner-marker-trail',
+  );
+  assert.equal(finding?.result, 'fail');
+});
+
+test('authoring-owner-marker-trail passes a new issue when journal comments are not supplied (not applicable for the journal half)', () => {
+  const report = auditAuthoredIssue(bodyWithPublicationLine(), {
+    shape: 'orphan',
+    labels: ['status:authoring'],
+    newIssue: true,
+    comments: [ownerMarkerComment()],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-owner-marker-trail',
+  );
+  assert.equal(finding?.result, 'pass');
+  assert.match(finding?.detail ?? '', /not applicable.*journal/);
+});
+
+test('authoring-owner-marker-trail fails when no journal record reaches state=member or later', () => {
+  const report = auditAuthoredIssue(bodyWithPublicationLine(), {
+    shape: 'orphan',
+    labels: ['status:authoring'],
+    newIssue: true,
+    comments: [ownerMarkerComment()],
+    journalComments: [publicationIntentComment({ state: 'pending' })],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-owner-marker-trail',
+  );
+  assert.equal(finding?.result, 'fail');
+});
+
+test('authoring-owner-marker-trail fails when the journal record names a different issue', () => {
+  const report = auditAuthoredIssue(bodyWithPublicationLine(), {
+    shape: 'orphan',
+    labels: ['status:authoring'],
+    currentRepo: 'kurone-kito/idd-skill',
+    issueNumber: 9001,
+    newIssue: true,
+    comments: [ownerMarkerComment()],
+    journalComments: [
+      publicationIntentComment({ issue: 'kurone-kito/idd-skill#9999' }),
+    ],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-owner-marker-trail',
+  );
+  assert.equal(finding?.result, 'fail');
+});
+
+test('authoring-owner-marker-trail passes a fully compliant new-issue trail', () => {
+  const report = auditAuthoredIssue(bodyWithPublicationLine(), {
+    shape: 'orphan',
+    labels: ['status:authoring'],
+    currentRepo: 'kurone-kito/idd-skill',
+    issueNumber: 9001,
+    newIssue: true,
+    comments: [ownerMarkerComment()],
+    journalComments: [publicationIntentComment()],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-owner-marker-trail',
+  );
+  assert.equal(finding?.result, 'pass');
+});
+
+test('authoring-owner-marker-trail label comparison is case-insensitive', () => {
+  const report = auditAuthoredIssue(orphanBody(), {
+    shape: 'orphan',
+    labels: ['Status:Authoring'],
+    comments: [],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-owner-marker-trail',
+  );
+  assert.equal(finding?.result, 'fail');
+});

--- a/tests/audit-authored-issue.test.mts
+++ b/tests/audit-authored-issue.test.mts
@@ -2170,3 +2170,88 @@ test('authoring-owner-marker-trail label comparison is case-insensitive', () => 
   );
   assert.equal(finding?.result, 'fail');
 });
+
+test('authoring-owner-marker-trail rejects a journal record that shares only the target (different generation)', () => {
+  const report = auditAuthoredIssue(bodyWithPublicationLine(), {
+    shape: 'orphan',
+    labels: ['status:authoring'],
+    currentRepo: 'kurone-kito/idd-skill',
+    issueNumber: 9001,
+    newIssue: true,
+    comments: [ownerMarkerComment()],
+    journalComments: [
+      {
+        body: '<!-- idd-skill-authoring-publication-intent: target=target-abc123; anchor=kurone-kito/idd-skill#9001; set=DIFFERENT-set; session=sess-1; token=pub-token1; journal=kurone-kito/idd-skill#9001; issue=kurone-kito/idd-skill#9001; actor=kurone-kito; state=member -->',
+      },
+    ],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-owner-marker-trail',
+  );
+  assert.equal(finding?.result, 'fail');
+});
+
+test('authoring-owner-marker-trail rejects an owner marker from a different generation than the publication marker', () => {
+  const report = auditAuthoredIssue(bodyWithPublicationLine(), {
+    shape: 'orphan',
+    labels: ['status:authoring'],
+    currentRepo: 'kurone-kito/idd-skill',
+    issueNumber: 9001,
+    newIssue: true,
+    comments: [
+      {
+        body: '<!-- idd-skill-authoring-owner: target=kurone-kito/idd-skill#9001; anchor=kurone-kito/idd-skill#9001; mode=acquire; owner=owner-tok1; set=STALE-set; session=STALE-session; body-sha256=none; snapshot-sha256=none; supersedes=none -->',
+      },
+    ],
+    journalComments: [publicationIntentComment()],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-owner-marker-trail',
+  );
+  assert.equal(finding?.result, 'fail');
+});
+
+test('authoring-owner-marker-trail rejects a malformed digest field on the owner marker', () => {
+  const report = auditAuthoredIssue(orphanBody(), {
+    shape: 'orphan',
+    labels: ['status:authoring'],
+    comments: [
+      {
+        body: '<!-- idd-skill-authoring-owner: target=kurone-kito/idd-skill#9001; anchor=kurone-kito/idd-skill#9001; mode=acquire; owner=owner-tok1; set=set-xyz789; session=sess-1; body-sha256=garbage; snapshot-sha256=none; supersedes=none -->',
+      },
+    ],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-owner-marker-trail',
+  );
+  assert.equal(finding?.result, 'fail');
+});
+
+test('authoring-owner-marker-trail rejects issue=none on a state=member journal record', () => {
+  const report = auditAuthoredIssue(bodyWithPublicationLine(), {
+    shape: 'orphan',
+    labels: ['status:authoring'],
+    currentRepo: 'kurone-kito/idd-skill',
+    issueNumber: 9001,
+    newIssue: true,
+    comments: [ownerMarkerComment()],
+    journalComments: [publicationIntentComment({ issue: 'none' })],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-owner-marker-trail',
+  );
+  assert.equal(finding?.result, 'fail');
+});
+
+test('authoring-owner-marker-trail requires the publication marker as the literal first bytes (no leading blank line)', () => {
+  const report = auditAuthoredIssue(`\n${bodyWithPublicationLine()}`, {
+    shape: 'orphan',
+    labels: ['status:authoring'],
+    newIssue: true,
+    comments: [ownerMarkerComment()],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-owner-marker-trail',
+  );
+  assert.equal(finding?.result, 'fail');
+});

--- a/tests/authoring-owner-marker.test.mts
+++ b/tests/authoring-owner-marker.test.mts
@@ -109,3 +109,21 @@ test('parseAuthoringPublicationIntentComment returns null when a required field 
     '<!-- idd-skill-authoring-publication-intent: target=target-abc; anchor=kurone-kito/idd-skill#2606; set=set-xyz; session=sess-1; token=pub-tok; journal=kurone-kito/idd-skill#2606; state=member -->';
   assert.equal(parseAuthoringPublicationIntentComment(body, 'idd-skill'), null);
 });
+
+test('parseAuthoringOwnerComment returns null when the marker follows other prose (not first bytes)', () => {
+  const body =
+    'Some preamble.\n<!-- idd-skill-authoring-owner: target=kurone-kito/idd-skill#9001; anchor=kurone-kito/idd-skill#9001; mode=acquire; owner=owner-tok1; set=set-xyz789; session=sess-1; body-sha256=none; snapshot-sha256=none; supersedes=none -->';
+  assert.equal(parseAuthoringOwnerComment(body, 'idd-skill'), null);
+});
+
+test('parseAuthoringPublicationComment returns null when the opener spans a newline', () => {
+  const body =
+    '<!--\nidd-skill-authoring-publication: target=target-abc; anchor=kurone-kito/idd-skill#2606; set=set-xyz; session=sess-1; token=pub-tok -->';
+  assert.equal(parseAuthoringPublicationComment(body, 'idd-skill'), null);
+});
+
+test('parseAuthoringPublicationComment returns null when preceded by a leading blank line', () => {
+  const body =
+    '\n<!-- idd-skill-authoring-publication: target=target-abc; anchor=kurone-kito/idd-skill#2606; set=set-xyz; session=sess-1; token=pub-tok -->';
+  assert.equal(parseAuthoringPublicationComment(body, 'idd-skill'), null);
+});

--- a/tests/authoring-owner-marker.test.mts
+++ b/tests/authoring-owner-marker.test.mts
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  parseAuthoringOwnerComment,
+  parseAuthoringPublicationComment,
+  parseAuthoringPublicationIntentComment,
+} from '../src/scripts/marker-helpers.mts';
+
+// --- parseAuthoringOwnerComment ---
+
+test('parseAuthoringOwnerComment parses a well-formed marker', () => {
+  const body =
+    '<!-- idd-skill-authoring-owner: target=kurone-kito/idd-skill#9001; anchor=kurone-kito/idd-skill#9001; mode=acquire; owner=owner-tok1; set=set-xyz789; session=sess-1; body-sha256=none; snapshot-sha256=none; supersedes=none -->\n\n_Issue-authoring ownership marker. Do not edit or delete._';
+  const parsed = parseAuthoringOwnerComment(body, 'idd-skill');
+  assert.deepEqual(parsed, {
+    target: 'kurone-kito/idd-skill#9001',
+    anchor: 'kurone-kito/idd-skill#9001',
+    mode: 'acquire',
+    owner: 'owner-tok1',
+    set: 'set-xyz789',
+    session: 'sess-1',
+    bodySha256: 'none',
+    snapshotSha256: 'none',
+    supersedes: 'none',
+  });
+});
+
+test('parseAuthoringOwnerComment returns null when a required field is missing', () => {
+  const body =
+    '<!-- idd-skill-authoring-owner: target=kurone-kito/idd-skill#9001; anchor=kurone-kito/idd-skill#9001; mode=acquire; owner=owner-tok1; set=set-xyz789; session=sess-1 -->';
+  assert.equal(parseAuthoringOwnerComment(body, 'idd-skill'), null);
+});
+
+test('parseAuthoringOwnerComment returns null on an invalid mode', () => {
+  const body =
+    '<!-- idd-skill-authoring-owner: target=kurone-kito/idd-skill#9001; anchor=kurone-kito/idd-skill#9001; mode=not-a-real-mode; owner=owner-tok1; set=set-xyz789; session=sess-1; body-sha256=none; snapshot-sha256=none; supersedes=none -->';
+  assert.equal(parseAuthoringOwnerComment(body, 'idd-skill'), null);
+});
+
+test('parseAuthoringOwnerComment returns null when the marker prefix does not match', () => {
+  const body =
+    '<!-- other-prefix-authoring-owner: target=kurone-kito/idd-skill#9001; anchor=kurone-kito/idd-skill#9001; mode=acquire; owner=owner-tok1; set=set-xyz789; session=sess-1; body-sha256=none; snapshot-sha256=none; supersedes=none -->';
+  assert.equal(parseAuthoringOwnerComment(body, 'idd-skill'), null);
+});
+
+test('parseAuthoringOwnerComment returns null on a comment with no marker at all', () => {
+  assert.equal(
+    parseAuthoringOwnerComment('just a regular comment', 'idd-skill'),
+    null,
+  );
+});
+
+// --- parseAuthoringPublicationComment ---
+
+test('parseAuthoringPublicationComment parses a well-formed marker', () => {
+  const body =
+    '<!-- idd-skill-authoring-publication: target=target-bcc0eda161bb750b; anchor=kurone-kito/idd-skill#2606; set=set-6c69b1881138f0df; session=claude-idd1-268c8f142825; token=pub-f1c89630be3de2b3 -->';
+  const parsed = parseAuthoringPublicationComment(body, 'idd-skill');
+  assert.deepEqual(parsed, {
+    target: 'target-bcc0eda161bb750b',
+    anchor: 'kurone-kito/idd-skill#2606',
+    set: 'set-6c69b1881138f0df',
+    session: 'claude-idd1-268c8f142825',
+    token: 'pub-f1c89630be3de2b3',
+  });
+});
+
+test('parseAuthoringPublicationComment returns null when a required field is missing', () => {
+  const body =
+    '<!-- idd-skill-authoring-publication: target=target-abc; anchor=kurone-kito/idd-skill#2606; set=set-xyz -->';
+  assert.equal(parseAuthoringPublicationComment(body, 'idd-skill'), null);
+});
+
+// --- parseAuthoringPublicationIntentComment ---
+
+test('parseAuthoringPublicationIntentComment parses a well-formed member-state record', () => {
+  const body =
+    '<!-- idd-skill-authoring-publication-intent: target=target-abc; anchor=kurone-kito/idd-skill#2606; set=set-xyz; session=sess-1; token=pub-tok; journal=kurone-kito/idd-skill#2606; issue=kurone-kito/idd-skill#2621; actor=kurone-kito; state=member -->';
+  const parsed = parseAuthoringPublicationIntentComment(body, 'idd-skill');
+  assert.deepEqual(parsed, {
+    target: 'target-abc',
+    anchor: 'kurone-kito/idd-skill#2606',
+    set: 'set-xyz',
+    session: 'sess-1',
+    token: 'pub-tok',
+    journal: 'kurone-kito/idd-skill#2606',
+    issue: 'kurone-kito/idd-skill#2621',
+    actor: 'kurone-kito',
+    state: 'member',
+  });
+});
+
+test('parseAuthoringPublicationIntentComment accepts the issue=none / state=pending pre-creation shape', () => {
+  const body =
+    '<!-- idd-skill-authoring-publication-intent: target=target-abc; anchor=kurone-kito/idd-skill#2606; set=set-xyz; session=sess-1; token=pub-tok; journal=kurone-kito/idd-skill#2606; issue=none; actor=kurone-kito; state=pending -->';
+  const parsed = parseAuthoringPublicationIntentComment(body, 'idd-skill');
+  assert.equal(parsed?.issue, 'none');
+  assert.equal(parsed?.state, 'pending');
+});
+
+test('parseAuthoringPublicationIntentComment returns null on an invalid state', () => {
+  const body =
+    '<!-- idd-skill-authoring-publication-intent: target=target-abc; anchor=kurone-kito/idd-skill#2606; set=set-xyz; session=sess-1; token=pub-tok; journal=kurone-kito/idd-skill#2606; issue=none; actor=kurone-kito; state=not-a-real-state -->';
+  assert.equal(parseAuthoringPublicationIntentComment(body, 'idd-skill'), null);
+});
+
+test('parseAuthoringPublicationIntentComment returns null when a required field is missing', () => {
+  const body =
+    '<!-- idd-skill-authoring-publication-intent: target=target-abc; anchor=kurone-kito/idd-skill#2606; set=set-xyz; session=sess-1; token=pub-tok; journal=kurone-kito/idd-skill#2606; state=member -->';
+  assert.equal(parseAuthoringPublicationIntentComment(body, 'idd-skill'), null);
+});

--- a/tests/authoring-owner-marker.test.mts
+++ b/tests/authoring-owner-marker.test.mts
@@ -127,3 +127,9 @@ test('parseAuthoringPublicationComment returns null when preceded by a leading b
     '\n<!-- idd-skill-authoring-publication: target=target-abc; anchor=kurone-kito/idd-skill#2606; set=set-xyz; session=sess-1; token=pub-tok -->';
   assert.equal(parseAuthoringPublicationComment(body, 'idd-skill'), null);
 });
+
+test('parseAuthoringOwnerComment returns null when the payload itself spans a newline', () => {
+  const body =
+    '<!-- idd-skill-authoring-owner: target=kurone-kito/idd-skill#9001;\nanchor=kurone-kito/idd-skill#9001; mode=acquire; owner=owner-tok1; set=set-xyz789; session=sess-1; body-sha256=none; snapshot-sha256=none; supersedes=none -->';
+  assert.equal(parseAuthoringOwnerComment(body, 'idd-skill'), null);
+});


### PR DESCRIPTION
## Summary

`audit-authored-issue.mts` had zero checks for the issue-authoring skill's owner-marker/publication-token protocol (`docs/issue-authoring-skill.md`'s "Authoring label lifecycle") -- a subagent given a narrow research-only task instead authored and published 10 real issues under the authoring label, correctly running this linter but skipping the marker protocol entirely, and the linter had no way to catch that.

Adds a new `authoring-owner-marker-trail` check: for an authoring-labeled issue, requires at least one `authoring-owner` comment (mode `acquire`/`bootstrap`/`resume`, `target` matching the issue) and, for a newly created issue, a leading `authoring-publication` body line whose `target` is backed by a matching `authoring-publication-intent` record reaching `state=member` or later on the journal issue.

## Design notes

- **Stays network-free**, matching the module's documented design: new `--comments-file`/`--journal-comments-file` flags take pre-fetched comment data, the same pattern `--body-file` and `--label` already use. This module never fetches from GitHub itself.
- **No caller wires this in yet.** Nothing in the current issue-authoring workflow supplies `--comments-file`/`--new-issue` today, so this is a mechanical check with no active enforcement path until a follow-up wires it into the publish flow. Flagged, not silently implied as end-to-end.
- **`--new-issue` instead of a timestamp heuristic**: the issue's own suggested "age relative to first label application" approach was not used -- a caller-supplied boolean is exact (the caller already knows this fact when it publishes) and avoids clock-skew/timestamp-parsing fragility for no loss of precision. Documented as a deliberate deviation.
- Added a shared `parseSemicolonFieldMarker` helper in `marker-helpers.mts` plus three typed parsers (`parseAuthoringOwnerComment`, `parseAuthoringPublicationComment`, `parseAuthoringPublicationIntentComment`) for the `key=value; key2=value2` grammar these three markers use -- distinct from every existing marker in that file, which uses positional tokens.
- The journal cross-check additionally validates the intent record's `issue` field against the current issue's identity (when present), strengthening the AC's literal target-only wording per review feedback during planning.

Went through a B2 plan → critique-subagent pass → refined plan cycle before implementation (per this repo's IDD workflow); the critique caught a weaker journal-binding check, an incorrect doc-mirror claim, and a missing flag-naming-conventions doc update, all addressed here.

Closes #2621

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuYsYwJMEmfKEaf67DQ8zG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added auditing for authoring owner markers, publication markers, and publication-intent trails.
  * Added support for validating pre-fetched issue and journal comments, issue identity, and new-issue publication requirements.
  * Added optional command-line inputs for issue details, comment files, journal comments, and new-issue checks.

* **Documentation**
  * Documented the optional issue flag and expanded guidance for authoring lifecycle checks.

* **Bug Fixes**
  * Improved validation of marker fields, supported states, owner digests, and publication history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->