### PR TITLE
feat(resolve-review-thread): add --claimless mode for operator-authorized unclaimed PRs

### DIFF
--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -167,8 +167,9 @@ reviewer feedback:
 - After posting your reply, **immediately resolve the thread** — except
   for `**Awaiting maintainer decision**`. When helper runtime is enabled,
   the profile-selected resolve-review-thread command (`--pr <number>
-  --comment-id <id> --apply`, with `--body`/`--claim-issue`/`--claim-id`;
-  see `docs/idd-helper-scripts.md`) posts the reply and resolves in one
+  --comment-id <id> --apply`, with `--body`/`--claim-issue`/`--claim-id`
+  or `--claimless`; see `docs/idd-helper-scripts.md`) posts the reply
+  and resolves in one
   call, replying before resolving so a failed reply never leaves a
   silently-resolved thread; the manual REST + GraphQL
   `resolveReviewThread` sequence is the fallback. Resolving means "agent

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1008,7 +1008,10 @@ The adopted helper boundaries are intentionally narrow:
   `node scripts/resolve-review-thread.mjs --pr <number> --comment-id <id>`
   (dry-run); add `--body "<disposition>" --apply --claim-issue <n>
   --claim-id <id>` to post the reply and resolve the thread. Optional
-  `--owner` / `--repo` / `--agent-id` / `--trusted-marker-logins`.
+  `--owner` / `--repo` / `--agent-id` / `--trusted-marker-logins`. For a
+  claimless PR (`closingIssuesReferences` empty), pass `--claimless`
+  instead of `--claim-issue`/`--claim-id` (#2616, mirrors
+  `pre-merge-readiness.mjs`'s `--claimless`, #2017).
 - Maps `--comment-id` (the review comment's REST id) to its owning review
   thread by matching it against the `databaseId` of the comments inside each
   GraphQL `reviewThreads` node (both the threads and the nested comments
@@ -1029,14 +1032,16 @@ The adopted helper boundaries are intentionally narrow:
 - **Dry-run** reports the resolved `threadId` and current `alreadyResolved`
   state without posting; a comment with no owning thread omits `threadId`
   and includes an `error` note.
-- **Fail-closed**: `--apply` requires `--body` and the
-  `--claim-issue` / `--claim-id` pair, re-validates the active claim before
-  **each** of the reply and the resolve (scoped to trusted marker authors,
-  aborting on a targeting `forced-handoff`), and binds the mutation to the
-  claimed PR by requiring the active claim's branch to equal the PR's head
-  branch. GraphQL `errors` fail fast rather than masquerading as a missing
-  thread, and a partial apply (reply posted, resolve not confirmed) still
-  reports the posted `replyId`.
+- **Fail-closed**: `--apply` requires `--body` and, unless `--claimless`,
+  the `--claim-issue` / `--claim-id` pair; absent `--claimless` it
+  re-validates the active claim before **each** of the reply and the
+  resolve (scoped to trusted marker authors, aborting on a targeting
+  `forced-handoff`), and binds the mutation to the claimed PR by requiring
+  the active claim's branch to equal the PR's head branch. `--claimless`
+  itself fails closed against a non-empty `closingIssuesReferences`.
+  GraphQL `errors` fail fast rather than masquerading as a missing thread,
+  and a partial apply (reply posted, resolve not confirmed) still reports
+  the posted `replyId`.
 - Stable contract: [`resolve-review-thread.schema.json`][resolve-review-thread-schema].
 - The written E13 reply-and-resolve rule in
   `idd-review-fix.instructions.md` stays authoritative; this helper is the

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -162,8 +162,9 @@ reviewer feedback:
 - After posting your reply, **immediately resolve the thread** — except
   for `**Awaiting maintainer decision**`. When helper runtime is enabled,
   the profile-selected resolve-review-thread command (`--pr <number>
-  --comment-id <id> --apply`, with `--body`/`--claim-issue`/`--claim-id`;
-  see `docs/idd-helper-scripts.md`) posts the reply and resolves in one
+  --comment-id <id> --apply`, with `--body`/`--claim-issue`/`--claim-id`
+  or `--claimless`; see `docs/idd-helper-scripts.md`) posts the reply
+  and resolves in one
   call, replying before resolving so a failed reply never leaves a
   silently-resolved thread; the manual REST + GraphQL
   `resolveReviewThread` sequence is the fallback. Resolving means "agent

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1008,7 +1008,10 @@ The adopted helper boundaries are intentionally narrow:
   `node scripts/resolve-review-thread.mjs --pr <number> --comment-id <id>`
   (dry-run); add `--body "<disposition>" --apply --claim-issue <n>
   --claim-id <id>` to post the reply and resolve the thread. Optional
-  `--owner` / `--repo` / `--agent-id` / `--trusted-marker-logins`.
+  `--owner` / `--repo` / `--agent-id` / `--trusted-marker-logins`. For a
+  claimless PR (`closingIssuesReferences` empty), pass `--claimless`
+  instead of `--claim-issue`/`--claim-id` (#2616, mirrors
+  `pre-merge-readiness.mjs`'s `--claimless`, #2017).
 - Maps `--comment-id` (the review comment's REST id) to its owning review
   thread by matching it against the `databaseId` of the comments inside each
   GraphQL `reviewThreads` node (both the threads and the nested comments
@@ -1029,14 +1032,16 @@ The adopted helper boundaries are intentionally narrow:
 - **Dry-run** reports the resolved `threadId` and current `alreadyResolved`
   state without posting; a comment with no owning thread omits `threadId`
   and includes an `error` note.
-- **Fail-closed**: `--apply` requires `--body` and the
-  `--claim-issue` / `--claim-id` pair, re-validates the active claim before
-  **each** of the reply and the resolve (scoped to trusted marker authors,
-  aborting on a targeting `forced-handoff`), and binds the mutation to the
-  claimed PR by requiring the active claim's branch to equal the PR's head
-  branch. GraphQL `errors` fail fast rather than masquerading as a missing
-  thread, and a partial apply (reply posted, resolve not confirmed) still
-  reports the posted `replyId`.
+- **Fail-closed**: `--apply` requires `--body` and, unless `--claimless`,
+  the `--claim-issue` / `--claim-id` pair; absent `--claimless` it
+  re-validates the active claim before **each** of the reply and the
+  resolve (scoped to trusted marker authors, aborting on a targeting
+  `forced-handoff`), and binds the mutation to the claimed PR by requiring
+  the active claim's branch to equal the PR's head branch. `--claimless`
+  itself fails closed against a non-empty `closingIssuesReferences`.
+  GraphQL `errors` fail fast rather than masquerading as a missing thread,
+  and a partial apply (reply posted, resolve not confirmed) still reports
+  the posted `replyId`.
 - Stable contract: [`resolve-review-thread.schema.json`][resolve-review-thread-schema].
 - The written E13 reply-and-resolve rule in
   `idd-review-fix.instructions.md` stays authoritative; this helper is the

--- a/scripts/resolve-review-thread.mjs
+++ b/scripts/resolve-review-thread.mjs
@@ -11,9 +11,11 @@
 // (`review-activity-snapshot`, `review-disposition-verify`). It follows the
 // write-side helper family conventions: dry-run by default, `--apply` mutates
 // and requires `--claim-issue` / `--claim-id` so the active claim is
-// revalidated immediately before the reply is posted (fail-closed). Reply
-// first, resolve second — a failed reply never leaves a silently-resolved
-// thread with no disposition.
+// revalidated immediately before the reply is posted (fail-closed) --
+// unless `--claimless` (#2616) opts out for a PR with no linked issue to
+// claim against, mirroring `pre-merge-readiness.mjs`'s identical `--claimless`
+// (#2017). Reply first, resolve second — a failed reply never leaves a
+// silently-resolved thread with no disposition.
 import { parseCliArgs } from './cli-args.mjs';
 import {
   isAuthorizedForcedHandoffActor,
@@ -133,6 +135,7 @@ const RESOLVE_REVIEW_THREAD_FLAG_SPEC = {
   '--claim-id': { type: 'string', default: '' },
   '--agent-id': { type: 'string', default: '' },
   '--trusted-marker-logins': { type: 'string', default: '' },
+  '--claimless': { type: 'boolean', default: false },
   '--apply': { type: 'boolean', default: false },
   '--help': { type: 'boolean', short: 'h' },
 };
@@ -174,6 +177,7 @@ export function parseArgs(argv) {
     claimId: values['claim-id'],
     agentId: values['agent-id'],
     trustedMarkerLogins: splitList(values['trusted-marker-logins']),
+    claimless: values.claimless,
     apply: values.apply,
     help,
   };
@@ -191,11 +195,14 @@ thread in one invocation (E13). Dry-run by default; --apply mutates.
                                  appends the reply-identity stamp)
   --owner <owner>                repo owner (default: gh repo view)
   --repo <repo>                  repo name (default: gh repo view)
-  --claim-issue <number>         issue carrying the active claim (required with --apply)
-  --claim-id <claim-id>          active claim id to re-validate (required with --apply)
+  --claim-issue <number>         issue carrying the active claim (required with --apply, unless --claimless)
+  --claim-id <claim-id>          active claim id to re-validate (required with --apply, unless --claimless)
   --agent-id <agent-id>          current session agent id (optional, tightens the claim check)
   --trusted-marker-logins a,b    logins whose claim markers are trusted
                                  (default: your gh login)
+  --claimless                    skip claim fetch/revalidation (#2616). Only for a PR with
+                                 no closingIssuesReferences; cannot combine with
+                                 --claim-issue / --claim-id
   --apply                        post the reply and resolve the thread (default: dry-run)
   -h, --help                     show this help
 `;
@@ -290,18 +297,33 @@ if (import.meta.main) {
     process.stdout.write(USAGE);
     process.exit(args.help ? 0 : 1);
   }
-  // Fail closed: --apply mutates PR state, so the active-claim revalidation and
-  // a reply body are mandatory. Missing inputs must abort before any read or
-  // write rather than silently bypassing the gate.
+  // #2616: --claimless (mirroring pre-merge-readiness.mjs's #2017 flag)
+  // is mutually exclusive with --claim-issue / --claim-id -- both name
+  // the same "which ownership check applies" decision, so combining
+  // them is always a caller mistake, never a stricter intersection.
+  if (args.claimless && (Number.isInteger(args.claimIssue) || args.claimId)) {
+    process.stderr.write(
+      '--claimless cannot be combined with --claim-issue or --claim-id\n',
+    );
+    process.exit(1);
+  }
+  // Fail closed: --apply mutates PR state, so a reply body is always
+  // mandatory, and the active-claim revalidation is mandatory unless
+  // --claimless opts out of it. Missing inputs must abort before any
+  // read or write rather than silently bypassing the gate.
+  if (args.apply && !args.body) {
+    process.stderr.write('--apply requires --body\n');
+    process.exit(1);
+  }
   if (
     args.apply &&
+    !args.claimless &&
     (!Number.isInteger(args.claimIssue) ||
       (args.claimIssue ?? 0) <= 0 ||
-      !args.claimId ||
-      !args.body)
+      !args.claimId)
   ) {
     process.stderr.write(
-      '--apply requires --body and the --claim-issue / --claim-id pair for the mandatory claim revalidation\n',
+      '--apply requires the --claim-issue / --claim-id pair for the mandatory claim revalidation, or --claimless\n',
     );
     process.exit(1);
   }
@@ -335,6 +357,20 @@ if (import.meta.main) {
   const owner = args.owner || currentRepo?.owner || '';
   const repo = args.repo || currentRepo?.repo || '';
   const port = createGithubProviderAdapter(owner, repo);
+  // #2616: mirror pre-merge-readiness.mjs's #2017 scoping rule --
+  // --claimless is only for a PR with no linked issue to claim against.
+  // A PR with closingIssuesReferences has one (or more): use
+  // --claim-issue instead so the claim revalidation gate still applies.
+  if (args.claimless) {
+    const closingRefs =
+      port.getChangeRequestConvergenceView(pr).closingIssuesReferences;
+    if (Array.isArray(closingRefs) && closingRefs.length > 0) {
+      process.stderr.write(
+        '--claimless requires a PR with no closingIssuesReferences; pass --claim-issue instead\n',
+      );
+      process.exit(1);
+    }
+  }
   const match = findThreadForComment(
     toReviewThreadNodes(port.listChangeRequestReviewThreadCommentIds(pr)),
     commentId,
@@ -414,6 +450,12 @@ if (import.meta.main) {
   try {
     const result = applyResolveReviewThread({
       assertClaim: () => {
+        // #2616: --claimless intentionally skips claim revalidation --
+        // the scoping check above already confirmed this PR has no
+        // linked issue to own a claim.
+        if (args.claimless) {
+          return;
+        }
         const active = activeOwnedClaim(
           port,
           args.claimIssue,

--- a/scripts/resolve-review-thread.mjs
+++ b/scripts/resolve-review-thread.mjs
@@ -207,6 +207,21 @@ thread in one invocation (E13). Dry-run by default; --apply mutates.
   -h, --help                     show this help
 `;
 /**
+ * #2616: `--claimless` scoping rule (mirrors `pre-merge-readiness.mjs`'s
+ * #2017 flag) -- true only when the PR has no `closingIssuesReferences`.
+ * Re-fetches live on every call rather than caching a single snapshot:
+ * a caller (dry-run, then again before each `--apply` mutation) must see
+ * a closing issue linked in the window between checks, matching the
+ * existing per-mutation claim-revalidation pattern (Codex review on this
+ * PR: a maintainer linking an issue between checks must not let a
+ * `--claimless` mutation still proceed).
+ */
+export function isClaimlessEligible(port, pr) {
+  const closingRefs =
+    port.getChangeRequestConvergenceView(pr).closingIssuesReferences;
+  return !(Array.isArray(closingRefs) && closingRefs.length > 0);
+}
+/**
  * Throw when a GraphQL response carries top-level `errors`, so a bad
  * PR/repo/auth or any server-side GraphQL failure fails fast with a clear
  * message instead of being silently read as an empty result (which would
@@ -301,7 +316,12 @@ if (import.meta.main) {
   // is mutually exclusive with --claim-issue / --claim-id -- both name
   // the same "which ownership check applies" decision, so combining
   // them is always a caller mistake, never a stricter intersection.
-  if (args.claimless && (Number.isInteger(args.claimIssue) || args.claimId)) {
+  // `args.claimIssue !== null` (not `Number.isInteger`) so a malformed
+  // but still-supplied `--claim-issue nope` (parsed to NaN, not the
+  // parseArgs default of null for an omitted flag) is still caught
+  // here instead of silently falling through to the claimless path
+  // (Codex review on this PR).
+  if (args.claimless && (args.claimIssue !== null || args.claimId)) {
     process.stderr.write(
       '--claimless cannot be combined with --claim-issue or --claim-id\n',
     );
@@ -357,19 +377,14 @@ if (import.meta.main) {
   const owner = args.owner || currentRepo?.owner || '';
   const repo = args.repo || currentRepo?.repo || '';
   const port = createGithubProviderAdapter(owner, repo);
-  // #2616: mirror pre-merge-readiness.mjs's #2017 scoping rule --
-  // --claimless is only for a PR with no linked issue to claim against.
-  // A PR with closingIssuesReferences has one (or more): use
-  // --claim-issue instead so the claim revalidation gate still applies.
-  if (args.claimless) {
-    const closingRefs =
-      port.getChangeRequestConvergenceView(pr).closingIssuesReferences;
-    if (Array.isArray(closingRefs) && closingRefs.length > 0) {
-      process.stderr.write(
-        '--claimless requires a PR with no closingIssuesReferences; pass --claim-issue instead\n',
-      );
-      process.exit(1);
-    }
+  // #2616: fast fail-closed preview for both dry-run and --apply -- the
+  // per-mutation re-check below (inside assertClaim) is the one that
+  // actually gates the apply-mode mutations.
+  if (args.claimless && !isClaimlessEligible(port, pr)) {
+    process.stderr.write(
+      '--claimless requires a PR with no closingIssuesReferences; pass --claim-issue instead\n',
+    );
+    process.exit(1);
   }
   const match = findThreadForComment(
     toReviewThreadNodes(port.listChangeRequestReviewThreadCommentIds(pr)),
@@ -405,44 +420,58 @@ if (import.meta.main) {
     process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
     process.exit(1);
   }
-  // Bind the mutation to the claimed PR: the active claim's branch must be the
-  // PR's head branch, so a valid claim on the issue cannot be used to reply to
-  // and resolve a thread on some other PR passed as --pr.
-  const prHeadRef = port.getChangeRequestHeadRef(pr);
-  // --apply: default the trusted claim authors to this gh login so the
-  // revalidation recognizes the session's own claim markers.
-  const viewerLogin = port.resolveViewerLogin().toLowerCase();
-  const trustedAuthors = new Set(
-    (args.trustedMarkerLogins.length > 0
-      ? args.trustedMarkerLogins
-      : [viewerLogin]
-    ).map((login) => login.toLowerCase()),
-  );
-  const isTrustedAuthor = (login) =>
-    trustedAuthors.has(
-      String(login ?? '')
-        .trim()
-        .toLowerCase(),
-    );
-  // Resolve the forced-handoff policy and build the collaborator-permission
-  // cache ONCE per CLI invocation (not on each assertClaim retry): re-reading
-  // .github/idd/config.json and re-hitting the collaborators API would be a
-  // needless I/O hot path. Mirrors force-handoff.mjs and the audit-pr-cleanup
-  // readActiveClaim comment.
-  const forcedHandoffEnabled = readForcedHandoffMode() === 'human-gated';
-  const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
-  const forcedHandoffPermissionCache = new Map();
-  const forcedHandoffOptions = {
-    forcedHandoffEnabled,
-    isAuthorizedForcedHandoff: (forcedBy) =>
-      isAuthorizedForcedHandoffActor(
-        owner,
-        repo,
-        forcedBy,
-        forcedHandoffAuthorityPolicy,
-        forcedHandoffPermissionCache,
-      ),
+  // #2616: this claim-only setup is unneeded (and un-skippable) network/
+  // identity work for --claimless -- a credential that can read/update
+  // PRs but cannot resolve a viewer identity (e.g. some GitHub App
+  // installation-token setups) must not abort here when neither the
+  // viewer nor the claimed branch is ever consulted in this mode (Codex
+  // review on this PR).
+  let prHeadRef = '';
+  let isTrustedAuthor = () => false;
+  let forcedHandoffOptions = {
+    forcedHandoffEnabled: false,
+    isAuthorizedForcedHandoff: () => false,
   };
+  if (!args.claimless) {
+    // Bind the mutation to the claimed PR: the active claim's branch must be
+    // the PR's head branch, so a valid claim on the issue cannot be used to
+    // reply to and resolve a thread on some other PR passed as --pr.
+    prHeadRef = port.getChangeRequestHeadRef(pr);
+    // --apply: default the trusted claim authors to this gh login so the
+    // revalidation recognizes the session's own claim markers.
+    const viewerLogin = port.resolveViewerLogin().toLowerCase();
+    const trustedAuthors = new Set(
+      (args.trustedMarkerLogins.length > 0
+        ? args.trustedMarkerLogins
+        : [viewerLogin]
+      ).map((login) => login.toLowerCase()),
+    );
+    isTrustedAuthor = (login) =>
+      trustedAuthors.has(
+        String(login ?? '')
+          .trim()
+          .toLowerCase(),
+      );
+    // Resolve the forced-handoff policy and build the collaborator-permission
+    // cache ONCE per CLI invocation (not on each assertClaim retry): re-reading
+    // .github/idd/config.json and re-hitting the collaborators API would be a
+    // needless I/O hot path. Mirrors force-handoff.mjs and the audit-pr-cleanup
+    // readActiveClaim comment.
+    const forcedHandoffEnabled = readForcedHandoffMode() === 'human-gated';
+    const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
+    const forcedHandoffPermissionCache = new Map();
+    forcedHandoffOptions = {
+      forcedHandoffEnabled,
+      isAuthorizedForcedHandoff: (forcedBy) =>
+        isAuthorizedForcedHandoffActor(
+          owner,
+          repo,
+          forcedBy,
+          forcedHandoffAuthorityPolicy,
+          forcedHandoffPermissionCache,
+        ),
+    };
+  }
   // Retain the posted reply id across a later failure so a partial apply (reply
   // posted, resolve not confirmed) reports the reply id instead of looking like
   // nothing was posted — that distinguishes "retry the resolve" from "re-post".
@@ -450,10 +479,17 @@ if (import.meta.main) {
   try {
     const result = applyResolveReviewThread({
       assertClaim: () => {
-        // #2616: --claimless intentionally skips claim revalidation --
-        // the scoping check above already confirmed this PR has no
-        // linked issue to own a claim.
+        // #2616: --claimless intentionally skips claim revalidation, but
+        // re-checks eligibility fresh on every call (not just once,
+        // up front) -- a closing issue linked in the window between
+        // this mutation and the last one must still abort, mirroring
+        // the non-claimless path's own per-mutation claim recheck.
         if (args.claimless) {
+          if (!isClaimlessEligible(port, pr)) {
+            throw new Error(
+              '--claimless requires a PR with no closingIssuesReferences; pass --claim-issue instead',
+            );
+          }
           return;
         }
         const active = activeOwnedClaim(

--- a/src/scripts/resolve-review-thread.mts
+++ b/src/scripts/resolve-review-thread.mts
@@ -11,9 +11,11 @@
 // (`review-activity-snapshot`, `review-disposition-verify`). It follows the
 // write-side helper family conventions: dry-run by default, `--apply` mutates
 // and requires `--claim-issue` / `--claim-id` so the active claim is
-// revalidated immediately before the reply is posted (fail-closed). Reply
-// first, resolve second — a failed reply never leaves a silently-resolved
-// thread with no disposition.
+// revalidated immediately before the reply is posted (fail-closed) --
+// unless `--claimless` (#2616) opts out for a PR with no linked issue to
+// claim against, mirroring `pre-merge-readiness.mjs`'s identical `--claimless`
+// (#2017). Reply first, resolve second — a failed reply never leaves a
+// silently-resolved thread with no disposition.
 
 import { parseCliArgs } from './cli-args.mts';
 import type { CollaboratorPermissionCache } from './collaborator-permission.mts';
@@ -193,6 +195,7 @@ interface CliArgs {
   claimId: string;
   agentId: string;
   trustedMarkerLogins: string[];
+  claimless: boolean;
   apply: boolean;
   help: boolean;
 }
@@ -214,6 +217,7 @@ const RESOLVE_REVIEW_THREAD_FLAG_SPEC = {
   '--claim-id': { type: 'string', default: '' },
   '--agent-id': { type: 'string', default: '' },
   '--trusted-marker-logins': { type: 'string', default: '' },
+  '--claimless': { type: 'boolean', default: false },
   '--apply': { type: 'boolean', default: false },
   '--help': { type: 'boolean', short: 'h' },
 } as const;
@@ -262,6 +266,7 @@ export function parseArgs(argv: string[]): CliArgs {
     claimId: values['claim-id'] as string,
     agentId: values['agent-id'] as string,
     trustedMarkerLogins: splitList(values['trusted-marker-logins'] as string),
+    claimless: values.claimless as boolean,
     apply: values.apply as boolean,
     help,
   };
@@ -280,11 +285,14 @@ thread in one invocation (E13). Dry-run by default; --apply mutates.
                                  appends the reply-identity stamp)
   --owner <owner>                repo owner (default: gh repo view)
   --repo <repo>                  repo name (default: gh repo view)
-  --claim-issue <number>         issue carrying the active claim (required with --apply)
-  --claim-id <claim-id>          active claim id to re-validate (required with --apply)
+  --claim-issue <number>         issue carrying the active claim (required with --apply, unless --claimless)
+  --claim-id <claim-id>          active claim id to re-validate (required with --apply, unless --claimless)
   --agent-id <agent-id>          current session agent id (optional, tightens the claim check)
   --trusted-marker-logins a,b    logins whose claim markers are trusted
                                  (default: your gh login)
+  --claimless                    skip claim fetch/revalidation (#2616). Only for a PR with
+                                 no closingIssuesReferences; cannot combine with
+                                 --claim-issue / --claim-id
   --apply                        post the reply and resolve the thread (default: dry-run)
   -h, --help                     show this help
 `;
@@ -392,18 +400,33 @@ if (import.meta.main) {
     process.stdout.write(USAGE);
     process.exit(args.help ? 0 : 1);
   }
-  // Fail closed: --apply mutates PR state, so the active-claim revalidation and
-  // a reply body are mandatory. Missing inputs must abort before any read or
-  // write rather than silently bypassing the gate.
+  // #2616: --claimless (mirroring pre-merge-readiness.mjs's #2017 flag)
+  // is mutually exclusive with --claim-issue / --claim-id -- both name
+  // the same "which ownership check applies" decision, so combining
+  // them is always a caller mistake, never a stricter intersection.
+  if (args.claimless && (Number.isInteger(args.claimIssue) || args.claimId)) {
+    process.stderr.write(
+      '--claimless cannot be combined with --claim-issue or --claim-id\n',
+    );
+    process.exit(1);
+  }
+  // Fail closed: --apply mutates PR state, so a reply body is always
+  // mandatory, and the active-claim revalidation is mandatory unless
+  // --claimless opts out of it. Missing inputs must abort before any
+  // read or write rather than silently bypassing the gate.
+  if (args.apply && !args.body) {
+    process.stderr.write('--apply requires --body\n');
+    process.exit(1);
+  }
   if (
     args.apply &&
+    !args.claimless &&
     (!Number.isInteger(args.claimIssue) ||
       (args.claimIssue ?? 0) <= 0 ||
-      !args.claimId ||
-      !args.body)
+      !args.claimId)
   ) {
     process.stderr.write(
-      '--apply requires --body and the --claim-issue / --claim-id pair for the mandatory claim revalidation\n',
+      '--apply requires the --claim-issue / --claim-id pair for the mandatory claim revalidation, or --claimless\n',
     );
     process.exit(1);
   }
@@ -437,6 +460,21 @@ if (import.meta.main) {
   const owner = args.owner || currentRepo?.owner || '';
   const repo = args.repo || currentRepo?.repo || '';
   const port = createGithubProviderAdapter(owner, repo);
+
+  // #2616: mirror pre-merge-readiness.mjs's #2017 scoping rule --
+  // --claimless is only for a PR with no linked issue to claim against.
+  // A PR with closingIssuesReferences has one (or more): use
+  // --claim-issue instead so the claim revalidation gate still applies.
+  if (args.claimless) {
+    const closingRefs =
+      port.getChangeRequestConvergenceView(pr).closingIssuesReferences;
+    if (Array.isArray(closingRefs) && closingRefs.length > 0) {
+      process.stderr.write(
+        '--claimless requires a PR with no closingIssuesReferences; pass --claim-issue instead\n',
+      );
+      process.exit(1);
+    }
+  }
 
   const match = findThreadForComment(
     toReviewThreadNodes(port.listChangeRequestReviewThreadCommentIds(pr)),
@@ -525,6 +563,12 @@ if (import.meta.main) {
   try {
     const result = applyResolveReviewThread({
       assertClaim: () => {
+        // #2616: --claimless intentionally skips claim revalidation --
+        // the scoping check above already confirmed this PR has no
+        // linked issue to own a claim.
+        if (args.claimless) {
+          return;
+        }
         const active = activeOwnedClaim(
           port,
           args.claimIssue as number,

--- a/src/scripts/resolve-review-thread.mts
+++ b/src/scripts/resolve-review-thread.mts
@@ -298,6 +298,22 @@ thread in one invocation (E13). Dry-run by default; --apply mutates.
 `;
 
 /**
+ * #2616: `--claimless` scoping rule (mirrors `pre-merge-readiness.mjs`'s
+ * #2017 flag) -- true only when the PR has no `closingIssuesReferences`.
+ * Re-fetches live on every call rather than caching a single snapshot:
+ * a caller (dry-run, then again before each `--apply` mutation) must see
+ * a closing issue linked in the window between checks, matching the
+ * existing per-mutation claim-revalidation pattern (Codex review on this
+ * PR: a maintainer linking an issue between checks must not let a
+ * `--claimless` mutation still proceed).
+ */
+export function isClaimlessEligible(port: ProviderPort, pr: number): boolean {
+  const closingRefs =
+    port.getChangeRequestConvergenceView(pr).closingIssuesReferences;
+  return !(Array.isArray(closingRefs) && closingRefs.length > 0);
+}
+
+/**
  * Throw when a GraphQL response carries top-level `errors`, so a bad
  * PR/repo/auth or any server-side GraphQL failure fails fast with a clear
  * message instead of being silently read as an empty result (which would
@@ -404,7 +420,12 @@ if (import.meta.main) {
   // is mutually exclusive with --claim-issue / --claim-id -- both name
   // the same "which ownership check applies" decision, so combining
   // them is always a caller mistake, never a stricter intersection.
-  if (args.claimless && (Number.isInteger(args.claimIssue) || args.claimId)) {
+  // `args.claimIssue !== null` (not `Number.isInteger`) so a malformed
+  // but still-supplied `--claim-issue nope` (parsed to NaN, not the
+  // parseArgs default of null for an omitted flag) is still caught
+  // here instead of silently falling through to the claimless path
+  // (Codex review on this PR).
+  if (args.claimless && (args.claimIssue !== null || args.claimId)) {
     process.stderr.write(
       '--claimless cannot be combined with --claim-issue or --claim-id\n',
     );
@@ -461,19 +482,14 @@ if (import.meta.main) {
   const repo = args.repo || currentRepo?.repo || '';
   const port = createGithubProviderAdapter(owner, repo);
 
-  // #2616: mirror pre-merge-readiness.mjs's #2017 scoping rule --
-  // --claimless is only for a PR with no linked issue to claim against.
-  // A PR with closingIssuesReferences has one (or more): use
-  // --claim-issue instead so the claim revalidation gate still applies.
-  if (args.claimless) {
-    const closingRefs =
-      port.getChangeRequestConvergenceView(pr).closingIssuesReferences;
-    if (Array.isArray(closingRefs) && closingRefs.length > 0) {
-      process.stderr.write(
-        '--claimless requires a PR with no closingIssuesReferences; pass --claim-issue instead\n',
-      );
-      process.exit(1);
-    }
+  // #2616: fast fail-closed preview for both dry-run and --apply -- the
+  // per-mutation re-check below (inside assertClaim) is the one that
+  // actually gates the apply-mode mutations.
+  if (args.claimless && !isClaimlessEligible(port, pr)) {
+    process.stderr.write(
+      '--claimless requires a PR with no closingIssuesReferences; pass --claim-issue instead\n',
+    );
+    process.exit(1);
   }
 
   const match = findThreadForComment(
@@ -515,46 +531,60 @@ if (import.meta.main) {
     process.exit(1);
   }
 
-  // Bind the mutation to the claimed PR: the active claim's branch must be the
-  // PR's head branch, so a valid claim on the issue cannot be used to reply to
-  // and resolve a thread on some other PR passed as --pr.
-  const prHeadRef = port.getChangeRequestHeadRef(pr);
-
-  // --apply: default the trusted claim authors to this gh login so the
-  // revalidation recognizes the session's own claim markers.
-  const viewerLogin = port.resolveViewerLogin().toLowerCase();
-  const trustedAuthors = new Set(
-    (args.trustedMarkerLogins.length > 0
-      ? args.trustedMarkerLogins
-      : [viewerLogin]
-    ).map((login) => login.toLowerCase()),
-  );
-  const isTrustedAuthor = (login: string): boolean =>
-    trustedAuthors.has(
-      String(login ?? '')
-        .trim()
-        .toLowerCase(),
-    );
-
-  // Resolve the forced-handoff policy and build the collaborator-permission
-  // cache ONCE per CLI invocation (not on each assertClaim retry): re-reading
-  // .github/idd/config.json and re-hitting the collaborators API would be a
-  // needless I/O hot path. Mirrors force-handoff.mjs and the audit-pr-cleanup
-  // readActiveClaim comment.
-  const forcedHandoffEnabled = readForcedHandoffMode() === 'human-gated';
-  const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
-  const forcedHandoffPermissionCache: CollaboratorPermissionCache = new Map();
-  const forcedHandoffOptions: ForcedHandoffGateOptions = {
-    forcedHandoffEnabled,
-    isAuthorizedForcedHandoff: (forcedBy) =>
-      isAuthorizedForcedHandoffActor(
-        owner,
-        repo,
-        forcedBy,
-        forcedHandoffAuthorityPolicy,
-        forcedHandoffPermissionCache,
-      ),
+  // #2616: this claim-only setup is unneeded (and un-skippable) network/
+  // identity work for --claimless -- a credential that can read/update
+  // PRs but cannot resolve a viewer identity (e.g. some GitHub App
+  // installation-token setups) must not abort here when neither the
+  // viewer nor the claimed branch is ever consulted in this mode (Codex
+  // review on this PR).
+  let prHeadRef = '';
+  let isTrustedAuthor: (login: string) => boolean = () => false;
+  let forcedHandoffOptions: ForcedHandoffGateOptions = {
+    forcedHandoffEnabled: false,
+    isAuthorizedForcedHandoff: () => false,
   };
+  if (!args.claimless) {
+    // Bind the mutation to the claimed PR: the active claim's branch must be
+    // the PR's head branch, so a valid claim on the issue cannot be used to
+    // reply to and resolve a thread on some other PR passed as --pr.
+    prHeadRef = port.getChangeRequestHeadRef(pr);
+
+    // --apply: default the trusted claim authors to this gh login so the
+    // revalidation recognizes the session's own claim markers.
+    const viewerLogin = port.resolveViewerLogin().toLowerCase();
+    const trustedAuthors = new Set(
+      (args.trustedMarkerLogins.length > 0
+        ? args.trustedMarkerLogins
+        : [viewerLogin]
+      ).map((login) => login.toLowerCase()),
+    );
+    isTrustedAuthor = (login: string): boolean =>
+      trustedAuthors.has(
+        String(login ?? '')
+          .trim()
+          .toLowerCase(),
+      );
+
+    // Resolve the forced-handoff policy and build the collaborator-permission
+    // cache ONCE per CLI invocation (not on each assertClaim retry): re-reading
+    // .github/idd/config.json and re-hitting the collaborators API would be a
+    // needless I/O hot path. Mirrors force-handoff.mjs and the audit-pr-cleanup
+    // readActiveClaim comment.
+    const forcedHandoffEnabled = readForcedHandoffMode() === 'human-gated';
+    const forcedHandoffAuthorityPolicy = readForcedHandoffAuthorityPolicy();
+    const forcedHandoffPermissionCache: CollaboratorPermissionCache = new Map();
+    forcedHandoffOptions = {
+      forcedHandoffEnabled,
+      isAuthorizedForcedHandoff: (forcedBy) =>
+        isAuthorizedForcedHandoffActor(
+          owner,
+          repo,
+          forcedBy,
+          forcedHandoffAuthorityPolicy,
+          forcedHandoffPermissionCache,
+        ),
+    };
+  }
 
   // Retain the posted reply id across a later failure so a partial apply (reply
   // posted, resolve not confirmed) reports the reply id instead of looking like
@@ -563,10 +593,17 @@ if (import.meta.main) {
   try {
     const result = applyResolveReviewThread({
       assertClaim: () => {
-        // #2616: --claimless intentionally skips claim revalidation --
-        // the scoping check above already confirmed this PR has no
-        // linked issue to own a claim.
+        // #2616: --claimless intentionally skips claim revalidation, but
+        // re-checks eligibility fresh on every call (not just once,
+        // up front) -- a closing issue linked in the window between
+        // this mutation and the last one must still abort, mirroring
+        // the non-claimless path's own per-mutation claim recheck.
         if (args.claimless) {
+          if (!isClaimlessEligible(port, pr)) {
+            throw new Error(
+              '--claimless requires a PR with no closingIssuesReferences; pass --claim-issue instead',
+            );
+          }
           return;
         }
         const active = activeOwnedClaim(

--- a/tests/resolve-review-thread.test.mts
+++ b/tests/resolve-review-thread.test.mts
@@ -14,7 +14,7 @@ import {
   type ReviewThreadNode,
 } from '../src/scripts/resolve-review-thread.mts';
 import { loadJson, validate } from '../src/scripts/validate-schemas.mts';
-import { buildReviewThreadNode } from './test-utils.mts';
+import { buildReviewThreadNode, stubExecutable } from './test-utils.mts';
 
 const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
 
@@ -61,6 +61,17 @@ test('parseArgs reads the apply-mode claim inputs', () => {
   assert.equal(args.claimIssue, 7);
   assert.equal(args.claimId, 'deadbeef');
   assert.deepEqual(args.trustedMarkerLogins, ['kurone-kito', 'second-user']);
+});
+
+test('parseArgs reads --claimless, defaulting to false', () => {
+  assert.equal(
+    parseArgs(['--pr', '42', '--comment-id', '1001']).claimless,
+    false,
+  );
+  assert.equal(
+    parseArgs(['--pr', '42', '--comment-id', '1001', '--claimless']).claimless,
+    true,
+  );
 });
 
 // --- #1450: migration onto the shared cli-args.mts wrapper -----------------
@@ -208,6 +219,26 @@ test('applyResolveReviewThread revalidates the claim before each mutation (reply
   });
   assert.deepEqual(calls, ['claim', 'reply', 'claim', 'resolve']);
   assert.equal(result.replyId, 555);
+});
+
+test('applyResolveReviewThread still posts the reply and resolves the thread when assertClaim is a --claimless no-op (#2616)', () => {
+  // --claimless's own `assertClaim` wiring is exactly this: a no-op that
+  // never fetches or validates a claim. This documents that the shared
+  // orchestration function still runs the full reply-then-resolve
+  // sequence around it.
+  const calls: string[] = [];
+  const result = applyResolveReviewThread({
+    assertClaim: () => {},
+    postReply: () => {
+      calls.push('reply');
+      return { id: 777 };
+    },
+    resolveThread: () => {
+      calls.push('resolve');
+    },
+  });
+  assert.deepEqual(calls, ['reply', 'resolve']);
+  assert.equal(result.replyId, 777);
 });
 
 test('applyResolveReviewThread does not resolve when the second claim check fails after the reply', () => {
@@ -375,6 +406,140 @@ test('--apply rejects a non-conforming --body before any gh call (compiled CLI)'
     return;
   }
   throw new Error('expected the CLI to exit non-zero');
+});
+
+test('--claimless rejects --claim-issue before any gh call (compiled CLI, #2616)', () => {
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        join(REPO_ROOT, 'scripts/resolve-review-thread.mjs'),
+        '--pr',
+        '42',
+        '--comment-id',
+        '1001',
+        '--claimless',
+        '--claim-issue',
+        '2005',
+      ],
+      { cwd: REPO_ROOT, encoding: 'utf8', env: { ...process.env, PATH: '' } },
+    );
+  } catch (error) {
+    const failure = error as { status?: number; stderr?: string };
+    assert.equal(failure.status, 1);
+    assert.match(
+      failure.stderr ?? '',
+      /--claimless cannot be combined with --claim-issue or --claim-id/,
+    );
+    return;
+  }
+  throw new Error('expected the CLI to exit non-zero');
+});
+
+test('--claimless rejects --claim-id before any gh call (compiled CLI, #2616)', () => {
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        join(REPO_ROOT, 'scripts/resolve-review-thread.mjs'),
+        '--pr',
+        '42',
+        '--comment-id',
+        '1001',
+        '--claimless',
+        '--claim-id',
+        'deadbeef',
+      ],
+      { cwd: REPO_ROOT, encoding: 'utf8', env: { ...process.env, PATH: '' } },
+    );
+  } catch (error) {
+    const failure = error as { status?: number; stderr?: string };
+    assert.equal(failure.status, 1);
+    assert.match(
+      failure.stderr ?? '',
+      /--claimless cannot be combined with --claim-issue or --claim-id/,
+    );
+    return;
+  }
+  throw new Error('expected the CLI to exit non-zero');
+});
+
+test('--apply --claimless does not require --claim-issue / --claim-id (compiled CLI, #2616)', () => {
+  // Empty PATH means the run still fails once it reaches a real `gh` call
+  // (the closingIssuesReferences scoping check), but it must NOT fail on
+  // the "requires --claim-issue" validation gate --claimless is meant to
+  // skip.
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        join(REPO_ROOT, 'scripts/resolve-review-thread.mjs'),
+        '--pr',
+        '42',
+        '--comment-id',
+        '1001',
+        '--claimless',
+        '--apply',
+        '--body',
+        '**Accepted** — operator-authorized, no linked issue',
+      ],
+      { cwd: REPO_ROOT, encoding: 'utf8', env: { ...process.env, PATH: '' } },
+    );
+    throw new Error('expected the CLI to exit non-zero');
+  } catch (error) {
+    const failure = error as { status?: number; stderr?: string };
+    assert.notEqual(failure.status, undefined);
+    assert.doesNotMatch(failure.stderr ?? '', /requires the --claim-issue/);
+  }
+});
+
+test('--claimless refuses a PR with closingIssuesReferences (compiled CLI, #2616)', () => {
+  const restore = stubExecutable(
+    'gh',
+    `const fs = require('node:fs');
+const args = process.argv.slice(2);
+if (args[0] === 'pr' && args[1] === 'view') {
+  fs.writeSync(1, JSON.stringify({
+    headRefOid: 'deadbeef',
+    headRefName: 'issue/5-linked',
+    author: { login: 'someone' },
+    url: 'https://example.invalid/pr/42',
+    closingIssuesReferences: [{ number: 5 }],
+  }));
+  process.exit(0);
+}
+fs.writeSync(2, 'unexpected gh invocation: ' + args.join(' '));
+process.exit(1);
+`,
+  );
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        join(REPO_ROOT, 'scripts/resolve-review-thread.mjs'),
+        '--pr',
+        '42',
+        '--comment-id',
+        '1001',
+        '--owner',
+        'o',
+        '--repo',
+        'r',
+        '--claimless',
+      ],
+      { cwd: REPO_ROOT, encoding: 'utf8' },
+    );
+    throw new Error('expected the CLI to exit non-zero');
+  } catch (error) {
+    const failure = error as { status?: number; stderr?: string };
+    assert.equal(failure.status, 1);
+    assert.match(
+      failure.stderr ?? '',
+      /--claimless requires a PR with no closingIssuesReferences; pass --claim-issue instead/,
+    );
+  } finally {
+    restore();
+  }
 });
 
 test('hasKnownDispositionMarkerPrefix accepts "Rejection confirmed by maintainer" regardless of thread resolution state', () => {

--- a/tests/resolve-review-thread.test.mts
+++ b/tests/resolve-review-thread.test.mts
@@ -3,12 +3,13 @@ import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
-
+import type { ProviderPort } from '../src/scripts/provider-port.mts';
 import {
   applyResolveReviewThread,
   assertNoGraphqlErrors,
   findThreadForComment,
   hasKnownDispositionMarkerPrefix,
+  isClaimlessEligible,
   parseArgs,
   type ResolveReviewThreadReport,
   type ReviewThreadNode,
@@ -72,6 +73,20 @@ test('parseArgs reads --claimless, defaulting to false', () => {
     parseArgs(['--pr', '42', '--comment-id', '1001', '--claimless']).claimless,
     true,
   );
+});
+
+test('isClaimlessEligible reflects live closingIssuesReferences on every call, not a cached snapshot (#2616, Codex P2)', () => {
+  let refs: unknown[] = [];
+  const port = {
+    getChangeRequestConvergenceView: () => ({
+      closingIssuesReferences: refs,
+    }),
+  } as unknown as ProviderPort;
+  assert.equal(isClaimlessEligible(port, 42), true);
+  // A closing issue gets linked between two calls -- the second call must
+  // see it, not reuse the first call's answer.
+  refs = [{ number: 5 }];
+  assert.equal(isClaimlessEligible(port, 42), false);
 });
 
 // --- #1450: migration onto the shared cli-args.mts wrapper -----------------
@@ -464,6 +479,39 @@ test('--claimless rejects --claim-id before any gh call (compiled CLI, #2616)', 
   throw new Error('expected the CLI to exit non-zero');
 });
 
+test('--claimless rejects a malformed --claim-issue value too (compiled CLI, #2616, Codex P2)', () => {
+  // `--claim-issue nope` parses to NaN, not the parseArgs default of null
+  // for an omitted flag -- the mutual-exclusion check must key off "was
+  // the flag supplied" (claimIssue !== null), not "did it parse to a
+  // valid positive integer", or this combination silently falls through
+  // to the claimless path instead of being rejected.
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        join(REPO_ROOT, 'scripts/resolve-review-thread.mjs'),
+        '--pr',
+        '42',
+        '--comment-id',
+        '1001',
+        '--claimless',
+        '--claim-issue',
+        'nope',
+      ],
+      { cwd: REPO_ROOT, encoding: 'utf8', env: { ...process.env, PATH: '' } },
+    );
+  } catch (error) {
+    const failure = error as { status?: number; stderr?: string };
+    assert.equal(failure.status, 1);
+    assert.match(
+      failure.stderr ?? '',
+      /--claimless cannot be combined with --claim-issue or --claim-id/,
+    );
+    return;
+  }
+  throw new Error('expected the CLI to exit non-zero');
+});
+
 test('--apply --claimless does not require --claim-issue / --claim-id (compiled CLI, #2616)', () => {
   // Empty PATH means the run still fails once it reaches a real `gh` call
   // (the closingIssuesReferences scoping check), but it must NOT fail on
@@ -537,6 +585,83 @@ process.exit(1);
       failure.stderr ?? '',
       /--claimless requires a PR with no closingIssuesReferences; pass --claim-issue instead/,
     );
+  } finally {
+    restore();
+  }
+});
+
+test('--apply --claimless posts the reply and resolves the thread without ever resolving a viewer identity or claimed branch (compiled CLI, #2616, Codex P2)', () => {
+  // End-to-end success path over a stubbed `gh`. The stub answers every
+  // call a --claimless --apply run legitimately needs (the
+  // closingIssuesReferences scoping check -- called once up front and
+  // again before each mutation, per #2616's Codex P2 recheck fix -- the
+  // thread lookup, the reply POST, and the resolve mutation) and fails
+  // loudly for `gh api user` / `gh api .../pulls/<n> --jq .head.ref`,
+  // which only the non-claimless claim-binding path needs.
+  const restore = stubExecutable(
+    'gh',
+    `const fs = require('node:fs');
+const args = process.argv.slice(2);
+const joined = args.join(' ');
+const out = (s) => { fs.writeSync(1, s); process.exit(0); };
+const fail = (msg) => { fs.writeSync(2, msg); process.exit(1); };
+if (args[0] === 'pr' && args[1] === 'view') {
+  out(JSON.stringify({
+    headRefOid: 'deadbeef',
+    headRefName: 'main',
+    author: { login: 'someone' },
+    url: 'https://example.invalid/pr/42',
+    closingIssuesReferences: [],
+  }));
+}
+if (args[0] === 'api' && args[1] === 'graphql') {
+  if (joined.includes('reviewThreads')) {
+    out(JSON.stringify({ data: { repository: { pullRequest: { reviewThreads: {
+      nodes: [{ id: 'THREAD1', isResolved: false, path: 'x',
+        comments: { nodes: [{ databaseId: 1001 }], pageInfo: { hasNextPage: false, endCursor: null } } }],
+      pageInfo: { hasNextPage: false, endCursor: null } } } } } }));
+  }
+  if (joined.includes('resolveReviewThread')) {
+    out(JSON.stringify({ data: { resolveReviewThread: { thread: { isResolved: true } } } }));
+  }
+  fail('unexpected graphql call: ' + joined);
+}
+if (args[0] === 'api' && args.includes('--method') && args.includes('POST') && joined.includes('replies')) {
+  out(JSON.stringify({ id: 4242 }));
+}
+if (args[0] === 'api' && args[1] === 'user') {
+  fail('FORBIDDEN: resolveViewerLogin was called in --claimless mode');
+}
+if (args[0] === 'api' && joined.includes('.head.ref')) {
+  fail('FORBIDDEN: getChangeRequestHeadRef was called in --claimless mode');
+}
+fail('unexpected gh invocation: ' + joined);
+`,
+  );
+  try {
+    const output = execFileSync(
+      process.execPath,
+      [
+        join(REPO_ROOT, 'scripts/resolve-review-thread.mjs'),
+        '--pr',
+        '42',
+        '--comment-id',
+        '1001',
+        '--owner',
+        'o',
+        '--repo',
+        'r',
+        '--claimless',
+        '--apply',
+        '--body',
+        '**Accepted** — operator-authorized, no linked issue',
+      ],
+      { cwd: REPO_ROOT, encoding: 'utf8' },
+    );
+    const report = JSON.parse(output) as ResolveReviewThreadReport;
+    assert.equal(report.status, 'applied');
+    assert.equal(report.replyId, 4242);
+    assert.equal(report.threadId, 'THREAD1');
   } finally {
     restore();
   }


### PR DESCRIPTION
## Summary

- Adds `--claimless` to `resolve-review-thread.mts`, mirroring
  `pre-merge-readiness.mjs`'s identical flag (#2017): mutually
  exclusive with `--claim-issue`/`--claim-id`, scoped to a PR with no
  `closingIssuesReferences`, skips claim revalidation while keeping the
  same stamped `**Accepted**`/`**Rejected**` reply-and-resolve
  behavior.
- Documents the new flag in `idd-review-triage.instructions.md` (and
  its `idd-template/` source) and in `docs/idd-helper-scripts.md` (and
  its `idd-template/` source).
- Adds unit tests: `--claimless` argument parsing, mutual-exclusion
  with `--claim-issue`/`--claim-id`, the closingIssuesReferences
  scoping rejection, that `--apply --claimless` no longer requires the
  claim pair, and that the shared reply-then-resolve orchestration
  still runs correctly when `assertClaim` is a `--claimless` no-op.

Closes #2616

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run build` (`.mjs` mirror regenerated)
- [x] `node --test tests/*.test.mts` (5068 tests, 0 failures)
- [x] `pnpm run lint` (pre-push-validate chain, including
      `audit-docs.mjs --check`, `audit-code-span-wrap.mjs`,
      `build:check`, `idd-doctor.mjs`)
