### PR TITLE
docs(orchestration): prefer non-inheriting delegation for workers

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -473,7 +473,10 @@ recognizing the brief reassigns it to a single-issue worker role. The
 delegation brief must state explicitly that the delegate is the sole
 worker for the named issue, that no peer workers exist for it to
 coordinate with or wait on, and that it must perform the implementation
-work itself rather than re-delegate or wait for a reply (#2179).
+work itself rather than re-delegate or wait for a reply (#2179). Prefer
+a non-context-inheriting mechanism instead, when the tool offers one —
+see [docs/idd-workflow.md's Orchestrator fan-out
+variant](../../docs/idd-workflow.md#orchestrator-fan-out-variant).
 
 **Restate the CI/advisory-wait topology-safety condition; use the
 snapshot-then-stop pattern.** Carry — verbatim or by reference — the

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -258,14 +258,14 @@
       "glob": ".github/instructions/idd-*.instructions.md",
       "alwaysLoadedPattern": "applyTo:\\s*\"\\*\\*\"",
       "alwaysLoadedLimitBytes": 20000,
-      "phaseLimitBytes": 33000
+      "phaseLimitBytes": 34000
     },
     {
       "id": "instruction-size-budgets-idd-template",
       "glob": "idd-template/.github/instructions/idd-*.instructions.md",
       "alwaysLoadedPattern": "applyTo:\\s*\"\\*\\*\"",
       "alwaysLoadedLimitBytes": 20000,
-      "phaseLimitBytes": 33000
+      "phaseLimitBytes": 34000
     }
   ],
   "bundleBudgets": [

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -694,6 +694,20 @@ external scheduler.
 
 Running this variant safely requires:
 
+- **A non-context-inheriting delegation mechanism for the full
+  B-through-F4 worker role, when the calling tool offers one.** A
+  context-inheriting worker (e.g. Claude Code's `fork` subagent) can let
+  the orchestrator's own recent framing compete with, and sometimes
+  override, the delegation brief's own role statement — the same
+  mechanism [Critique pass invocation](#critique-pass-invocation)
+  already avoids for Claude Code's narrower critique-pass role, by
+  preferring a fresh `general-purpose` agent over a context-sharing
+  fork. Extend that same preference to this full worker role, whenever
+  the tool exposes the choice, and fall back to the explicit
+  role-statement wording in
+  [Orchestrator delegation](../.github/instructions/idd-claim.instructions.md#orchestrator-delegation)
+  as defense-in-depth when only a context-inheriting mechanism is
+  available (kurone-kito/idd-skill#2221, kurone-kito/idd-skill#2624).
 - **A small concurrency cap**, sized against CI-minute cost and
   shared-file contention rather than raised without bound. The optional
   `discover-shared-file-overlap` helper (see

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -699,12 +699,12 @@ Running this variant safely requires:
   context-inheriting worker (e.g. Claude Code's `fork` subagent) can let
   the orchestrator's own recent framing compete with, and sometimes
   override, the delegation brief's own role statement — the same
-  mechanism [Critique pass invocation](#critique-pass-invocation)
-  already avoids for Claude Code's narrower critique-pass role, by
-  preferring a fresh `general-purpose` agent over a context-sharing
-  fork. Extend that same preference to this full worker role, whenever
-  the tool exposes the choice, and fall back to the explicit
-  role-statement wording in
+  problem [Critique pass invocation](#critique-pass-invocation) already
+  avoids for Claude Code's narrower critique-pass role, since that row
+  also picks a fresh `general-purpose` agent rather than a
+  context-inheriting one. Extend that same preference to this full
+  worker role, whenever the tool exposes the choice, and fall back to
+  the explicit role-statement wording in
   [Orchestrator delegation](../.github/instructions/idd-claim.instructions.md#orchestrator-delegation)
   as defense-in-depth when only a context-inheriting mechanism is
   available (kurone-kito/idd-skill#2221, kurone-kito/idd-skill#2624).

--- a/docs/okf-frontmatter.md
+++ b/docs/okf-frontmatter.md
@@ -31,7 +31,7 @@ and the checker never widens into them:
   instructions loader parses; mixing in OKF keys would collide with
   that contract. They are also the tightest byte-budget surface in the
   repository — `instructionSizeBudgets` caps each file at 20,000 or
-  33,000 bytes and `bundleBudgets` caps whole phase bundles at
+  34,000 bytes and `bundleBudgets` caps whole phase bundles at
   104,000–126,000 bytes
   (see [Policy constants](policy-constants.md)) — because every byte is
   loaded verbatim into an agent's context on every session. Frontmatter

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -487,7 +487,7 @@ files, or express it without the `bytes` suffix.
 | Limit type    | Value        | Applies to                                                                 | Rationale                                                                                                                                                                                               |
 | ------------- | ------------ | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Always-loaded | 20,000 bytes | Files with `applyTo: "**"` in `.github/instructions/idd-*.instructions.md` | These files load on every phase regardless of which is active, so this is the strictest ceiling — it bounds the fixed floor cost every session pays before any phase-specific content is even selected. |
-| Phase         | 33,000 bytes | Other files in `.github/instructions/idd-*.instructions.md`                | Only the one file matching the active phase loads at a time, so this ceiling can run larger than the always-loaded one without raising a session's floor cost.                                          |
+| Phase         | 34,000 bytes | Other files in `.github/instructions/idd-*.instructions.md`                | Only the one file matching the active phase loads at a time, so this ceiling can run larger than the always-loaded one without raising a session's floor cost.                                          |
 
 ### Bundle limits
 

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -468,7 +468,10 @@ recognizing the brief reassigns it to a single-issue worker role. The
 delegation brief must state explicitly that the delegate is the sole
 worker for the named issue, that no peer workers exist for it to
 coordinate with or wait on, and that it must perform the implementation
-work itself rather than re-delegate or wait for a reply (#2179).
+work itself rather than re-delegate or wait for a reply (#2179). Prefer
+a non-context-inheriting mechanism instead, when the tool offers one —
+see [docs/idd-workflow.md's Orchestrator fan-out
+variant](../../docs/idd-workflow.md#orchestrator-fan-out-variant).
 
 **Restate the CI/advisory-wait topology-safety condition; use the
 snapshot-then-stop pattern.** Carry — verbatim or by reference — the

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -678,6 +678,20 @@ external scheduler.
 
 Running this variant safely requires:
 
+- **A non-context-inheriting delegation mechanism for the full
+  B-through-F4 worker role, when the calling tool offers one.** A
+  context-inheriting worker (one that receives the orchestrator's
+  complete conversation, such as Claude Code's `fork` subagent) can let
+  the orchestrator's own recent framing compete with, and sometimes
+  override, the delegation brief's own role statement — the same
+  problem [Critique pass invocation](#critique-pass-invocation) already
+  avoids for Claude Code's narrower critique-pass role, since that row
+  also picks a fresh `general-purpose` agent rather than a
+  context-inheriting one. Extend that same preference to this full
+  worker role, whenever the tool exposes the choice, and fall back to
+  the explicit role-statement wording in [Orchestrator delegation](../.github/instructions/idd-claim.instructions.md#orchestrator-delegation)
+  as defense-in-depth when only a context-inheriting mechanism is
+  available.
 - **A small concurrency cap**, sized against CI-minute cost and
   shared-file contention rather than raised without bound. The optional
   `discover-shared-file-overlap` helper (see

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -487,7 +487,7 @@ files, or express it without the `bytes` suffix.
 | Limit type    | Value        | Applies to                                                                 | Rationale                                                                                                                                                                                               |
 | ------------- | ------------ | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Always-loaded | 20,000 bytes | Files with `applyTo: "**"` in `.github/instructions/idd-*.instructions.md` | These files load on every phase regardless of which is active, so this is the strictest ceiling — it bounds the fixed floor cost every session pays before any phase-specific content is even selected. |
-| Phase         | 33,000 bytes | Other files in `.github/instructions/idd-*.instructions.md`                | Only the one file matching the active phase loads at a time, so this ceiling can run larger than the always-loaded one without raising a session's floor cost.                                          |
+| Phase         | 34,000 bytes | Other files in `.github/instructions/idd-*.instructions.md`                | Only the one file matching the active phase loads at a time, so this ceiling can run larger than the always-loaded one without raising a session's floor cost.                                          |
 
 ### Bundle limits
 

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -401,9 +401,11 @@ test('instruction size budget excludes the generated-from banner from the measur
   assert.deepEqual(result.errors, []);
 });
 
+// Keep representative of live audit/sync-manifest.json
+// instructionSizeBudgets (currently on main).
 const DOC_BUDGET_SIZE = {
   alwaysLoadedLimitBytes: 20_000,
-  phaseLimitBytes: 33_000,
+  phaseLimitBytes: 34_000,
 };
 // Keep representative of live audit/sync-manifest.json bundleBudgets
 // (standard + lite independent ceilings currently on main).
@@ -417,7 +419,7 @@ const DOC_BUDGET_BUNDLES = [
 
 test('doc budget guard passes when documented values match the manifest', () => {
   const texts: Record<string, string> = {
-    'README.md': '| Phase | 33,000 bytes |\n| Always | 20,000 bytes |',
+    'README.md': '| Phase | 34,000 bytes |\n| Always | 20,000 bytes |',
     // a hardcoded bundle value that still matches the manifest is allowed
     'strategy.md': 'discovery bundle is 104,000 bytes',
     // a doc that reads limits live via jq carries no number → never flagged
@@ -443,7 +445,7 @@ test('doc budget guard flags a value that drifted from every manifest budget', (
   assert.equal(result.errors.length, 1);
   assert.match(
     result.errors[0],
-    /doc-budget-drift: README\.md states 30,000 bytes, which is not a current sync-manifest budget value \(valid: 16000, 20000, 24000, 26000, 33000, 45000, 104000\)/,
+    /doc-budget-drift: README\.md states 30,000 bytes, which is not a current sync-manifest budget value \(valid: 16000, 20000, 24000, 26000, 34000, 45000, 104000\)/,
   );
 });
 


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Extends `docs/idd-workflow.md`'s Orchestrator fan-out variant with a
preference for a non-context-inheriting delegation mechanism (e.g.
Claude Code's `Agent(subagent_type="general-purpose")`) over a
context-inheriting one (e.g. a `fork` subagent) for the full
B-through-F4 worker role, whenever the calling tool offers the choice.

- The same preference already exists, narrower in scope, in the same
  doc's "Critique pass invocation" table (Claude Code row); this PR
  extends it to the Orchestrator fan-out variant's own delegation.
- Falls back to the existing explicit role-statement wording in
  `idd-claim.instructions.md`'s "Orchestrator delegation" section as
  defense-in-depth whenever only a context-inheriting mechanism is
  available — that wording is unchanged.

## Linked issue

Closes #2624

## Follow-up issues (if any)

- [x] #2631 — the investigation (see the evidence-table comment on
  #2624) found that this fix does not reach a structurally different
  failure shape: a **main, non-delegated session** ending a turn on a
  reportable milestone or stated future intention with no armed
  background wait. No delegation-mechanism choice can address that
  shape since no delegation occurs there at all; #2631 records it as
  its own needs-decision issue per #2624's own escape-hatch acceptance
  criterion.

## Background / rationale (if material)

#2221 (closed) accumulated evidence across roughly a dozen occurrences
that wording-only reinforcement of the delegation brief's role
statement (#2179) has plateaued: a context-inheriting delegate can let
the orchestrator's own recent framing compete with, and override, the
brief's own role statement. Two shapes of this were directly observed:
a fork's first turn echoing the orchestrator's own dispatch language
back as its "final report" (#2221's own 2026-09-04/05 data point,
confirmed by re-dispatching the identical task as a fresh
non-inheriting agent, which worked on the first attempt), and — a new
data point from this issue's own investigation — a fork exceeding a
narrowly scoped research-only brief by autonomously implementing,
committing, and opening a PR (this session's own #2432/PR #2627
incident).

#2624's own comment thread carries the full evidence table built while
investigating this issue, citing which of #2221's recorded failure
shapes are and are not addressed by this direction.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [x] Config schema changed
- [ ] Security / credential / merge behavior changed

**Correction (post-merge):** the checklist above and this paragraph
were originally drafted before a critique pass (C1) added a
cross-reference in `idd-claim.instructions.md`, which then cascaded
into a `phaseLimitBytes` budget raise and its dependent doc updates.
The description below reflects what actually merged; editing it now
is a record correction only, not a code change — the PR is already
merged and the claim already released.

Files touched by the merged diff (9):

- `docs/idd-workflow.md` — the in-scope fix (Orchestrator fan-out
  variant, non-inheriting-delegation preference).
- `idd-template/docs/idd-workflow.md` — mirrored the same addition
  (this file's sync mode is `structure`, not mechanically required,
  but done for adopter completeness).
- `.github/instructions/idd-claim.instructions.md` and its
  `idd-template/` counterpart — added one cross-reference sentence in
  "Orchestrator delegation," found necessary by an independent
  non-context-inheriting critique pass (the same preference this PR
  argues for) that flagged the original one-directional
  cross-reference as a BLOCKING gap. Both are distributed
  `.github/instructions/` phase files, hence the checked "Instruction
  files changed" and "Template files changed" boxes above.
- `audit/sync-manifest.json` — raised `instructionSizeBudgets`'
  `phaseLimitBytes` from `33000` to `34000` for both the dogfood and
  `idd-template` glob entries, following the #2377/#2567/#2619
  precedent of raising with real headroom rather than a bare-minimum
  bump. **Budget raise, per this manifest's own ratchet-rule
  requirement for an explicit PR-description callout:** the added
  cross-reference sentence pushed both instruction-file copies over
  the pre-existing 33,000-byte cap — the file was already 196 bytes
  over budget at HEAD before this edit, a latent violation invisible
  until a diff touched it, since `audit-docs.mjs --check` only
  evaluates changed files.
- `docs/policy-constants.md` and `idd-template/docs/policy-constants.md`
  — updated the "Phase" row to match the raised budget (`mode: exact`
  sync pair).
- `docs/okf-frontmatter.md` — fixed a stale "33,000 bytes" mention;
  this was a genuine Copilot review finding on this PR.
- `tests/consistency.test.mts` — updated `DOC_BUDGET_SIZE` and its
  fixture/regex assertions to `34_000` to keep the `doc-budget-drift`
  check passing.

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L4CWg4REnG881fe8wd2kd7
