### PR TITLE
feat(idd-pr-submit): re-verify IDD impact checklist pre-merge

### DIFF
--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -176,6 +176,35 @@ follow-up is important enough to file in-repo now, invoke the
 `issue-authoring` skill (its Stage 1 hold) instead of improvising a
 body. Do not add a parallel "worker-lite authoring" contract.
 
+### D3.6 — Derive the IDD impact checklist
+
+`.github/pull_request_template.md`'s IDD impact checklist (`Instruction
+files changed` / `Template files changed` / `Helper scripts changed` /
+`Config schema changed` / `Security / credential / merge behavior
+changed`) is drafted from the branch's actual changed-file list, not
+from memory. Before drafting the body, list the branch's changes
+(`git diff --name-only origin/{development-branch}...HEAD`) and derive
+each checkbox mechanically, using a root-anchored path-prefix match
+(the path starts with the glob's literal prefix, not merely contains
+it):
+
+- **Instruction files changed** — any path starting with
+  `.github/instructions/` (excludes `idd-template/.github/instructions/`
+  paths, which count only under Template files below).
+- **Template files changed** — any path starting with `idd-template/`.
+- **Helper scripts changed** — any path starting with `src/scripts/`,
+  `scripts/`, or `bin/`.
+- **Config schema changed** — `audit/sync-manifest.json`,
+  `.github/idd/config.json`, or another repository-designated
+  config-schema-bearing file.
+- **Security / credential / merge behavior changed** stays a judgment
+  call — leave it to ordinary self-review discretion; it is not
+  mechanically derivable from paths alone.
+
+D3.7 below re-derives this same checklist against the final HEAD before
+merge — later commits (a review-fix round, a critique-pass fix landed
+before the first push) can change the answer.
+
 ### PR body language
 
 The PR body's prose sections above (summary, background/rationale,
@@ -413,6 +442,35 @@ completion.
    (`idd-review-fix.instructions.md` E9-E12) or a `{development-branch}`
    merge — are not automatically covered; re-run this step against the final HEAD
    before F3 merges.
+
+### D3.7 — Re-verify the IDD impact checklist before merge
+
+Immediately before F3 merge (the same "re-run before merge" point as
+D3.5 step 7 above), re-derive D3.6's checklist against the final HEAD's
+full changed-file list and compare it against the PR body's current
+checked boxes. When a ratchet-rule-bearing file (for example,
+`audit/sync-manifest.json`'s own ratchet-rule comment) raises a
+documented budget or limit anywhere in the branch's commits, also
+confirm the file's required PR-description callout is actually present
+in the body now, not only in a commit message — a callout only
+promised at draft time and never landed is the same drift this step
+exists to catch.
+
+On any mismatch: re-run the claim revalidation gate immediately before
+editing (a separate mutation, not covered by an earlier gated push),
+fetch the PR's current full body, edit only the checklist section (and
+the accompanying file-list prose, when present) in the fetched copy,
+and post the complete result back — `gh pr edit {pr-number} --body-file
+<path>` replaces the whole body, so never pass a partial file, which
+would drop the closing-keyword line and every other section. After
+posting, repeat D3.5 step 6's closing-set check, since edited prose can
+introduce a stray keyword-adjacent reference.
+
+**Known gap**: no phase file currently re-invokes D3.5 or this step by
+name from F1-F3, so this re-check depends on the same implicit trigger
+D3.5 step 7 already relies on rather than an explicit F-phase call —
+out of this step's own scope to close; recommend a follow-up issue to
+wire an explicit F2/F3 trigger if this gap is not already tracked.
 
 ## D4 — Wait for CI
 

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -178,11 +178,16 @@ body. Do not add a parallel "worker-lite authoring" contract.
 
 ### D3.6 — Derive the IDD impact checklist
 
-`.github/pull_request_template.md`'s IDD impact checklist (`Instruction
-files changed` / `Template files changed` / `Helper scripts changed` /
-`Config schema changed` / `Security / credential / merge behavior
-changed`) is drafted from the branch's actual changed-file list, not
-from memory. Before drafting the body, list the branch's changes
+Skip this sub-step and D3.7 below entirely when
+`.github/pull_request_template.md` does not exist or has no `IDD
+impact` heading — mirroring D3's own "If no template file exists, use
+the structure below directly" fallback, there is no checklist to
+derive or reconcile. When it exists, `.github/pull_request_template.md`'s
+IDD impact checklist (`Instruction files changed` / `Template files
+changed` / `Helper scripts changed` / `Config schema changed` /
+`Security / credential / merge behavior changed`) is drafted from the
+branch's actual changed-file list, not from memory. Before drafting the
+body, list the branch's changes
 (`git diff --name-only origin/{development-branch}...HEAD`) and derive
 each checkbox mechanically, using a root-anchored path-prefix match
 (the path starts with the glob's literal prefix, not merely contains

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -468,8 +468,11 @@ the accompanying file-list prose, when present) in the fetched copy,
 and post the complete result back — `gh pr edit {pr-number} --body-file
 <path>` replaces the whole body, so never pass a partial file, which
 would drop the closing-keyword line and every other section. After
-posting, repeat D3.5 step 6's closing-set check, since edited prose can
-introduce a stray keyword-adjacent reference.
+posting, repeat D3.5 step 6's closing-set check when D3.5 applies to
+this branch (skip it on the same non-default-`{development-branch}`
+condition D3.5 itself skips under, where `closingIssuesReferences`
+never populates and the check would be meaningless) — edited prose can
+otherwise introduce a stray keyword-adjacent reference.
 
 **Known gap**: no phase file currently re-invokes D3.5 or this step by
 name from F1-F3, so this re-check depends on the same implicit trigger

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -463,8 +463,11 @@ the accompanying file-list prose, when present) in the fetched copy,
 and post the complete result back — `gh pr edit {pr-number} --body-file
 <path>` replaces the whole body, so never pass a partial file, which
 would drop the closing-keyword line and every other section. After
-posting, repeat D3.5 step 6's closing-set check, since edited prose can
-introduce a stray keyword-adjacent reference.
+posting, repeat D3.5 step 6's closing-set check when D3.5 applies to
+this branch (skip it on the same non-default-`{development-branch}`
+condition D3.5 itself skips under, where `closingIssuesReferences`
+never populates and the check would be meaningless) — edited prose can
+otherwise introduce a stray keyword-adjacent reference.
 
 **Known gap**: no phase file currently re-invokes D3.5 or this step by
 name from F1-F3, so this re-check depends on the same implicit trigger

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -171,6 +171,35 @@ follow-up is important enough to file in-repo now, invoke the
 `issue-authoring` skill (its Stage 1 hold) instead of improvising a
 body. Do not add a parallel "worker-lite authoring" contract.
 
+### D3.6 — Derive the IDD impact checklist
+
+`.github/pull_request_template.md`'s IDD impact checklist (`Instruction
+files changed` / `Template files changed` / `Helper scripts changed` /
+`Config schema changed` / `Security / credential / merge behavior
+changed`) is drafted from the branch's actual changed-file list, not
+from memory. Before drafting the body, list the branch's changes
+(`git diff --name-only origin/{development-branch}...HEAD`) and derive
+each checkbox mechanically, using a root-anchored path-prefix match
+(the path starts with the glob's literal prefix, not merely contains
+it):
+
+- **Instruction files changed** — any path starting with
+  `.github/instructions/` (excludes `idd-template/.github/instructions/`
+  paths, which count only under Template files below).
+- **Template files changed** — any path starting with `idd-template/`.
+- **Helper scripts changed** — any path starting with `src/scripts/`,
+  `scripts/`, or `bin/`.
+- **Config schema changed** — `audit/sync-manifest.json`,
+  `.github/idd/config.json`, or another repository-designated
+  config-schema-bearing file.
+- **Security / credential / merge behavior changed** stays a judgment
+  call — leave it to ordinary self-review discretion; it is not
+  mechanically derivable from paths alone.
+
+D3.7 below re-derives this same checklist against the final HEAD before
+merge — later commits (a review-fix round, a critique-pass fix landed
+before the first push) can change the answer.
+
 ### PR body language
 
 The PR body's prose sections above (summary, background/rationale,
@@ -408,6 +437,35 @@ completion.
    (`idd-review-fix.instructions.md` E9-E12) or a `{development-branch}`
    merge — are not automatically covered; re-run this step against the final HEAD
    before F3 merges.
+
+### D3.7 — Re-verify the IDD impact checklist before merge
+
+Immediately before F3 merge (the same "re-run before merge" point as
+D3.5 step 7 above), re-derive D3.6's checklist against the final HEAD's
+full changed-file list and compare it against the PR body's current
+checked boxes. When a ratchet-rule-bearing file (for example,
+`audit/sync-manifest.json`'s own ratchet-rule comment) raises a
+documented budget or limit anywhere in the branch's commits, also
+confirm the file's required PR-description callout is actually present
+in the body now, not only in a commit message — a callout only
+promised at draft time and never landed is the same drift this step
+exists to catch.
+
+On any mismatch: re-run the claim revalidation gate immediately before
+editing (a separate mutation, not covered by an earlier gated push),
+fetch the PR's current full body, edit only the checklist section (and
+the accompanying file-list prose, when present) in the fetched copy,
+and post the complete result back — `gh pr edit {pr-number} --body-file
+<path>` replaces the whole body, so never pass a partial file, which
+would drop the closing-keyword line and every other section. After
+posting, repeat D3.5 step 6's closing-set check, since edited prose can
+introduce a stray keyword-adjacent reference.
+
+**Known gap**: no phase file currently re-invokes D3.5 or this step by
+name from F1-F3, so this re-check depends on the same implicit trigger
+D3.5 step 7 already relies on rather than an explicit F-phase call —
+out of this step's own scope to close; recommend a follow-up issue to
+wire an explicit F2/F3 trigger if this gap is not already tracked.
 
 ## D4 — Wait for CI
 

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -173,11 +173,16 @@ body. Do not add a parallel "worker-lite authoring" contract.
 
 ### D3.6 — Derive the IDD impact checklist
 
-`.github/pull_request_template.md`'s IDD impact checklist (`Instruction
-files changed` / `Template files changed` / `Helper scripts changed` /
-`Config schema changed` / `Security / credential / merge behavior
-changed`) is drafted from the branch's actual changed-file list, not
-from memory. Before drafting the body, list the branch's changes
+Skip this sub-step and D3.7 below entirely when
+`.github/pull_request_template.md` does not exist or has no `IDD
+impact` heading — mirroring D3's own "If no template file exists, use
+the structure below directly" fallback, there is no checklist to
+derive or reconcile. When it exists, `.github/pull_request_template.md`'s
+IDD impact checklist (`Instruction files changed` / `Template files
+changed` / `Helper scripts changed` / `Config schema changed` /
+`Security / credential / merge behavior changed`) is drafted from the
+branch's actual changed-file list, not from memory. Before drafting the
+body, list the branch's changes
 (`git diff --name-only origin/{development-branch}...HEAD`) and derive
 each checkbox mechanically, using a root-anchored path-prefix match
 (the path starts with the glob's literal prefix, not merely contains

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -2759,3 +2759,53 @@ test('idd-ci.instructions.md Exception 3 defers to D4\'s corrected pending:true 
   const row = extractBoundedRegion(readText(path), 'Exception 3:', ' |', path);
   assert.match(row, /D4's `pending: true` recovery check/);
 });
+
+test('D3.6 derives the IDD impact checklist mechanically, excluding the idd-template mirror from Instruction files (idd-skill#2634)', () => {
+  const path =
+    'idd-template/.github/instructions/idd-pr-submit.instructions.md';
+  const section = extractBoundedRegion(
+    readText(path),
+    '### D3.6 — Derive the IDD impact checklist',
+    '### PR body language',
+    path,
+  );
+  for (const label of [
+    'Instruction files changed',
+    'Template files changed',
+    'Helper scripts changed',
+    'Config schema changed',
+    'Security / credential / merge behavior changed',
+  ]) {
+    assert.match(
+      section,
+      new RegExp(label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+      `D3.6 must derive the "${label}" checkbox`,
+    );
+  }
+  assert.match(section, /root-anchored path-prefix match/);
+  assert.match(
+    section,
+    /excludes `idd-template\/\.github\/instructions\/`\s+paths/,
+    'D3.6 must exclude the idd-template mirror from "Instruction files changed"',
+  );
+});
+
+test('D3.7 re-derives the impact checklist against final HEAD before merge, using a generic safe-edit (not round-specific PR-body-sync prose) (idd-skill#2634)', () => {
+  const path =
+    'idd-template/.github/instructions/idd-pr-submit.instructions.md';
+  const section = extractBoundedRegion(
+    readText(path),
+    '### D3.7 — Re-verify the IDD impact checklist before merge',
+    '## D4 — Wait for CI',
+    path,
+  );
+  assert.match(section, /re-derive D3\.6's checklist/);
+  assert.match(section, /ratchet-rule/);
+  assert.match(section, /gh pr edit \{pr-number\} --body-file/);
+  assert.match(section, /never pass a partial file/);
+  assert.match(section, /D3\.5 step 6's closing-set check/);
+  // Must not lean on idd-review-fix.instructions.md's round-specific "this
+  // round's fix" framing verbatim -- the mechanics here are paraphrased
+  // generically since D3.7 can fire with zero E-phase rounds behind it.
+  assert.doesNotMatch(section, /this round's fix/);
+});

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -2788,6 +2788,11 @@ test('D3.6 derives the IDD impact checklist mechanically, excluding the idd-temp
     /excludes `idd-template\/\.github\/instructions\/`\s+paths/,
     'D3.6 must exclude the idd-template mirror from "Instruction files changed"',
   );
+  assert.match(
+    section,
+    /Skip this sub-step and D3\.7 below entirely when/,
+    'D3.6 must skip itself and D3.7 when no pull_request_template.md exists (idd-template/ ships none)',
+  );
 });
 
 test('D3.7 re-derives the impact checklist against final HEAD before merge, using a generic safe-edit (not round-specific PR-body-sync prose) (idd-skill#2634)', () => {


### PR DESCRIPTION
# Summary

## Linked issue

Closes #2634

## Follow-up issues (if any)

- No F-phase caller currently re-invokes D3.5 or the new D3.7 by name before merge (`bundle-merge` doesn't even include `idd-pr-submit.instructions.md`) — this is a pre-existing gap D3.5's own "Re-run before merge" note already had, outside this issue's own scope. Recommend a follow-up issue to wire an explicit F2/F3 trigger for both.

## Background / rationale (if material)

`idd-pr-submit.instructions.md`'s D3.5 already treats closing-keyword detection as merge-critical enough to verify at PR creation *and* explicitly re-run before F3 merge, since later commits can change what the branch does after the body was first drafted. The PR body's IDD impact checklist got no equivalent treatment — drafted once from memory, never re-derived against the final diff.

Concretely observed on #2624/PR #2632: the body described a `docs/idd-workflow.md`-only change with both impact checkboxes unchecked; a pre-submission critique pass then found a genuine gap whose fix touched a distributed instructions file, its `idd-template/` mirror, and two more dependent docs — nine files touched, merged with the stale unchecked body, caught only after merge via a `gh pr edit` correction.

Adds two new subsections:
- **D3.6** derives each checkbox mechanically from `git diff --name-only origin/{development-branch}...HEAD` before drafting the body, using root-anchored path-prefix matching — explicitly excluding the `idd-template/` mirror from "Instruction files changed" (it counts only under "Template files changed").
- **D3.7** re-derives the same checklist against the final HEAD immediately before merge (the same "re-run before merge" point D3.5 step 7 already uses), reconciling any mismatch via a full-body fetch-edit-post (never partial, which would drop the closing-keyword line), and re-running D3.5's closing-set check afterward. Also confirms a ratchet-rule budget-raise callout is present in the body at this same checkpoint — the part a draft-time-only check would have missed, since the issue's own motivating case was a budget raise introduced *after* the body was drafted.

Deviation from the issue's literal candidate-files list: per B2 critique, the pre-merge recheck got its own subsection (D3.7) rather than a step appended inside D3.5, because D3.5's non-default-`{development-branch}` skip clause ("skip this entire sub-step") would otherwise wrongly swallow an unrelated checklist recheck.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (5100 tests)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (not applicable — no code/config change)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed (`idd-pr-submit.instructions.md` is not a member of any `bundleBudgets` sum; `phaseLimitBytes` headroom confirmed via `audit-docs.mjs --check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuYsYwJMEmfKEaf67DQ8zG
