### PR TITLE
docs(idd-claim): land same-agent live-claim branch correction

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -439,6 +439,27 @@ to be safe, the displaced original pair too — using each pair's exact
 recorded `{agent-id}` / `{claim-id}`, then post a fresh `claimed-by
 supersedes: none` with a self-chosen pair).
 
+### Same-agent live-claim branch correction
+
+A different case from the sticky-successor escape above:
+**this session's own** live, non-stale claim recorded the wrong
+`branch`. Neither existing mechanism fixes it: **supersede**
+([Claim-state parsing](#claim-state-parsing) rule 4) only activates
+when the current claim is already stale, so a live claim's supersede
+post is silently invalid; **heartbeat** (rule 3.5) treats a
+different-`{branch}` re-post as anomalous and never updates the
+branch.
+
+Use **release-then-fresh** instead: post `unclaimed-by` for your own
+pair (safe — you provably hold it, [Claim verification](#claim-verification)),
+then a fresh `claimed-by supersedes: none` with a new `{claim-id}` and
+the corrected `branch`, then a fresh
+[activation-nonce](#activation-nonce-format), verified the same way.
+Propagate the new `{claim-id}` into every later call (disposition
+replies, watermarks, F2/F3, cleanup) — the old one is dead once
+released. On an open issue, re-verify no competing claim landed in the
+release-to-fresh gap before posting; not a risk on a closed one.
+
 ### Orchestrator delegation
 
 An orchestrating session that has posted and verified a claim's

--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -458,7 +458,9 @@ the corrected `branch`, then a fresh
 Propagate the new `{claim-id}` into every later call (disposition
 replies, watermarks, F2/F3, cleanup) — the old one is dead once
 released. On an open issue, re-verify no competing claim landed in the
-release-to-fresh gap before posting; not a risk on a closed one.
+release-to-fresh gap before posting. If one exists, stop and wait;
+do not post the fresh claim or continue. This is not a risk on a
+closed issue.
 
 ### Orchestrator delegation
 

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -258,14 +258,14 @@
       "glob": ".github/instructions/idd-*.instructions.md",
       "alwaysLoadedPattern": "applyTo:\\s*\"\\*\\*\"",
       "alwaysLoadedLimitBytes": 20000,
-      "phaseLimitBytes": 34000
+      "phaseLimitBytes": 36000
     },
     {
       "id": "instruction-size-budgets-idd-template",
       "glob": "idd-template/.github/instructions/idd-*.instructions.md",
       "alwaysLoadedPattern": "applyTo:\\s*\"\\*\\*\"",
       "alwaysLoadedLimitBytes": 20000,
-      "phaseLimitBytes": 34000
+      "phaseLimitBytes": 36000
     }
   ],
   "bundleBudgets": [

--- a/docs/okf-frontmatter.md
+++ b/docs/okf-frontmatter.md
@@ -31,7 +31,7 @@ and the checker never widens into them:
   instructions loader parses; mixing in OKF keys would collide with
   that contract. They are also the tightest byte-budget surface in the
   repository — `instructionSizeBudgets` caps each file at 20,000 or
-  34,000 bytes and `bundleBudgets` caps whole phase bundles at
+  36,000 bytes and `bundleBudgets` caps whole phase bundles at
   104,000–126,000 bytes
   (see [Policy constants](policy-constants.md)) — because every byte is
   loaded verbatim into an agent's context on every session. Frontmatter

--- a/docs/okf-frontmatter.md
+++ b/docs/okf-frontmatter.md
@@ -31,9 +31,9 @@ and the checker never widens into them:
   instructions loader parses; mixing in OKF keys would collide with
   that contract. They are also the tightest byte-budget surface in the
   repository — `instructionSizeBudgets` caps each file at 20,000 or
-  36,000 bytes and `bundleBudgets` caps whole phase bundles at
-  104,000–126,000 bytes
-  (see [Policy constants](policy-constants.md)) — because every byte is
+  36,000 bytes and `bundleBudgets` caps whole phase bundles, per the
+  current limits in [Policy constants](policy-constants.md) — because
+  every byte is
   loaded verbatim into an agent's context on every session. Frontmatter
   metadata that provides no runtime value to the loop is not worth
   spending that budget on. A later session must not widen this bundle's

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -487,7 +487,7 @@ files, or express it without the `bytes` suffix.
 | Limit type    | Value        | Applies to                                                                 | Rationale                                                                                                                                                                                               |
 | ------------- | ------------ | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Always-loaded | 20,000 bytes | Files with `applyTo: "**"` in `.github/instructions/idd-*.instructions.md` | These files load on every phase regardless of which is active, so this is the strictest ceiling — it bounds the fixed floor cost every session pays before any phase-specific content is even selected. |
-| Phase         | 34,000 bytes | Other files in `.github/instructions/idd-*.instructions.md`                | Only the one file matching the active phase loads at a time, so this ceiling can run larger than the always-loaded one without raising a session's floor cost.                                          |
+| Phase         | 36,000 bytes | Other files in `.github/instructions/idd-*.instructions.md`                | Only the one file matching the active phase loads at a time, so this ceiling can run larger than the always-loaded one without raising a session's floor cost.                                          |
 
 ### Bundle limits
 

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -434,6 +434,27 @@ to be safe, the displaced original pair too — using each pair's exact
 recorded `{agent-id}` / `{claim-id}`, then post a fresh `claimed-by
 supersedes: none` with a self-chosen pair).
 
+### Same-agent live-claim branch correction
+
+A different case from the sticky-successor escape above:
+**this session's own** live, non-stale claim recorded the wrong
+`branch`. Neither existing mechanism fixes it: **supersede**
+([Claim-state parsing](#claim-state-parsing) rule 4) only activates
+when the current claim is already stale, so a live claim's supersede
+post is silently invalid; **heartbeat** (rule 3.5) treats a
+different-`{branch}` re-post as anomalous and never updates the
+branch.
+
+Use **release-then-fresh** instead: post `unclaimed-by` for your own
+pair (safe — you provably hold it, [Claim verification](#claim-verification)),
+then a fresh `claimed-by supersedes: none` with a new `{claim-id}` and
+the corrected `branch`, then a fresh
+[activation-nonce](#activation-nonce-format), verified the same way.
+Propagate the new `{claim-id}` into every later call (disposition
+replies, watermarks, F2/F3, cleanup) — the old one is dead once
+released. On an open issue, re-verify no competing claim landed in the
+release-to-fresh gap before posting; not a risk on a closed one.
+
 ### Orchestrator delegation
 
 An orchestrating session that has posted and verified a claim's

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -453,7 +453,9 @@ the corrected `branch`, then a fresh
 Propagate the new `{claim-id}` into every later call (disposition
 replies, watermarks, F2/F3, cleanup) — the old one is dead once
 released. On an open issue, re-verify no competing claim landed in the
-release-to-fresh gap before posting; not a risk on a closed one.
+release-to-fresh gap before posting. If one exists, stop and wait;
+do not post the fresh claim or continue. This is not a risk on a
+closed issue.
 
 ### Orchestrator delegation
 

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -487,7 +487,7 @@ files, or express it without the `bytes` suffix.
 | Limit type    | Value        | Applies to                                                                 | Rationale                                                                                                                                                                                               |
 | ------------- | ------------ | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Always-loaded | 20,000 bytes | Files with `applyTo: "**"` in `.github/instructions/idd-*.instructions.md` | These files load on every phase regardless of which is active, so this is the strictest ceiling — it bounds the fixed floor cost every session pays before any phase-specific content is even selected. |
-| Phase         | 34,000 bytes | Other files in `.github/instructions/idd-*.instructions.md`                | Only the one file matching the active phase loads at a time, so this ceiling can run larger than the always-loaded one without raising a session's floor cost.                                          |
+| Phase         | 36,000 bytes | Other files in `.github/instructions/idd-*.instructions.md`                | Only the one file matching the active phase loads at a time, so this ceiling can run larger than the always-loaded one without raising a session's floor cost.                                          |
 
 ### Bundle limits
 

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -405,7 +405,7 @@ test('instruction size budget excludes the generated-from banner from the measur
 // instructionSizeBudgets (currently on main).
 const DOC_BUDGET_SIZE = {
   alwaysLoadedLimitBytes: 20_000,
-  phaseLimitBytes: 34_000,
+  phaseLimitBytes: 36_000,
 };
 // Keep representative of live audit/sync-manifest.json bundleBudgets
 // (standard + lite independent ceilings currently on main).
@@ -419,7 +419,7 @@ const DOC_BUDGET_BUNDLES = [
 
 test('doc budget guard passes when documented values match the manifest', () => {
   const texts: Record<string, string> = {
-    'README.md': '| Phase | 34,000 bytes |\n| Always | 20,000 bytes |',
+    'README.md': '| Phase | 36,000 bytes |\n| Always | 20,000 bytes |',
     // a hardcoded bundle value that still matches the manifest is allowed
     'strategy.md': 'discovery bundle is 104,000 bytes',
     // a doc that reads limits live via jq carries no number → never flagged
@@ -445,7 +445,7 @@ test('doc budget guard flags a value that drifted from every manifest budget', (
   assert.equal(result.errors.length, 1);
   assert.match(
     result.errors[0],
-    /doc-budget-drift: README\.md states 30,000 bytes, which is not a current sync-manifest budget value \(valid: 16000, 20000, 24000, 26000, 34000, 45000, 104000\)/,
+    /doc-budget-drift: README\.md states 30,000 bytes, which is not a current sync-manifest budget value \(valid: 16000, 20000, 24000, 26000, 36000, 45000, 104000\)/,
   );
 });
 


### PR DESCRIPTION
# Summary

Raises `audit/sync-manifest.json`'s `instructionSizeBudgets.phaseLimitBytes`
from 34,000 to 36,000 bytes (both glob entries), giving
`idd-claim.instructions.md` room to land the already-drafted
"Same-agent live-claim branch correction" subsection. The subsection
documents `release-then-fresh` as the recovery path when a live
session's own claim recorded the wrong `branch`, since neither
`supersede` (requires staleness) nor `heartbeat` (treats a
different-`branch` re-post as anomalous) covers that case.

Syncs the same 34,000 -> 36,000 figure everywhere it was mirrored:
`docs/policy-constants.md`'s Per-file limits table (regenerated from
its `idd-template/` source), `docs/okf-frontmatter.md`, and the
`DOC_BUDGET_SIZE` test fixture (plus dependent assertions) in
`tests/consistency.test.mts`.

## Linked issue

Closes #2620

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

The byte-budget lever and target value (36,000, not `bundle-discovery`'s
`limitBytes`) were decided by the maintainer in #2620's Groom hearing
after a B2.1 premise-verification hold found the issue's original
Background named the wrong lever. See #2620's 2026-09-05T04:46:42Z and
2026-09-05T11:09:43Z comments for the full history. This repository's
established precedent for raising this budget family is #2091, #2181,
#2377, #2567 (and the same-day 33,000 -> 34,000 raise this issue's own
Background cites).

The drafted subsection text was saved verbatim in #2451's
2026-09-02T15:16:17Z comment and landed unchanged here (only the
`[Claim verification](#claim-verification)` link's line-wrap point
differs, to satisfy this repository's 80-column Markdown line-length
lint).

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [x] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`biome check`, `dprint check`, `markdownlint-cli2`, `cspell` all pass)
- [x] `pnpm test` (5,140/5,140 passing)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (`node scripts/sync-docs.mjs --check`)
- [x] `node scripts/idd-doctor.mjs` (passed; 3 pre-existing unrelated warnings)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none -- doc/config-only change)
- [x] Context budget impact reviewed (`bundle-discovery` utilization moves
      95.65% -> 96.65%, still under the 98% hard-fail threshold; see
      `node scripts/audit-docs.mjs --check`'s notices)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for correcting an active claim assigned to the wrong branch, including safely replacing the claim and verifying its activation.
  - Increased the documented instruction-file size limit from 34,000 to 36,000 bytes.

- **Tests**
  - Updated consistency checks and validation messages to reflect the new 36,000-byte instruction-file limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->