### PR TITLE
fix(idd-config): wire token-cost-report --check into pre-push-validate

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -23,7 +23,7 @@
   "commands": {
     "install-deps": "node scripts/verify-install-deps.mjs --key-binary node_modules/.bin/tsc --install-command \"pnpm install --frozen-lockfile\"",
     "fix-validate": "npx biome check --write && npx dprint fmt \"**/*.md\" && npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\"",
-    "pre-push-validate": "npx biome check && npx dprint check \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress && node scripts/audit-docs.mjs --check && node scripts/audit-code-span-wrap.mjs && node --test tests/*.test.mts && pnpm run build:check && node scripts/idd-doctor.mjs",
+    "pre-push-validate": "npx biome check && npx dprint check \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress && node scripts/audit-docs.mjs --check && node scripts/audit-code-span-wrap.mjs && node --test tests/*.test.mts && pnpm run build:check && node scripts/idd-doctor.mjs && node scripts/token-cost-report.mjs --check",
     "post-fix-validate": "npx biome check --write && npx dprint fmt \"**/*.md\" && npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress && node scripts/audit-docs.mjs --check && node scripts/audit-code-span-wrap.mjs"
   },
   "helperRuntime": {

--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -267,7 +267,7 @@ enabled and default approval actors to
 | Name | Commands |
 | --- | --- |
 | **fix-validate** | `npx biome check --write && npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"` |
-| **pre-push-validate** | `npx biome check && npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress && node scripts/audit-docs.mjs --check && node scripts/audit-code-span-wrap.mjs && node --test tests/*.test.mts && pnpm run build:check && node scripts/idd-doctor.mjs` |
+| **pre-push-validate** | `npx biome check && npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress && node scripts/audit-docs.mjs --check && node scripts/audit-code-span-wrap.mjs && node --test tests/*.test.mts && pnpm run build:check && node scripts/idd-doctor.mjs && node scripts/token-cost-report.mjs --check` |
 | **post-fix-validate** | `npx biome check --write && npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress && node scripts/audit-docs.mjs --check && node scripts/audit-code-span-wrap.mjs` |
 | **install-deps** | `node scripts/verify-install-deps.mjs --key-binary node_modules/.bin/tsc --install-command "pnpm install --frozen-lockfile"` |
 | **issue-scope** | `roadmap-first` |

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -388,7 +388,7 @@
         ".github/instructions/idd-overview-core.instructions.md",
         ".github/instructions/idd-pre-merge.instructions.md"
       ],
-      "limitBytes": 122000
+      "limitBytes": 132000
     }
   ],
   "contextCeiling": {
@@ -569,7 +569,7 @@
         },
         {
           "from": "| **pre-push-validate** | `{{PRE_PUSH_VALIDATE_COMMANDS}}` |",
-          "to": "| **pre-push-validate** | `npx biome check && npx dprint check \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress && node scripts/audit-docs.mjs --check && node scripts/audit-code-span-wrap.mjs && node --test tests/*.test.mts && pnpm run build:check && node scripts/idd-doctor.mjs` |"
+          "to": "| **pre-push-validate** | `npx biome check && npx dprint check \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress && node scripts/audit-docs.mjs --check && node scripts/audit-code-span-wrap.mjs && node --test tests/*.test.mts && pnpm run build:check && node scripts/idd-doctor.mjs && node scripts/token-cost-report.mjs --check` |"
         },
         {
           "from": "| **post-fix-validate** | `{{POST_FIX_VALIDATE_COMMANDS}}` |",

--- a/docs/token-cost.md
+++ b/docs/token-cost.md
@@ -119,13 +119,12 @@ attribution once available.
   [`README.ja.md`](../README.ja.md) blurb.
 - `--check` verifies the committed snapshot still matches the rendered
   regions in those three files — it never re-harvests or reads raw
-  samples, only the committed snapshot. Wiring `--check` into this
-  repository's own `pre-push-validate` / `post-fix-validate` chain is
-  deferred: doing so would push the `bundle-work` documentation
-  context-ceiling budget over its configured threshold (see issue
-  `#2294`'s implementation notes), and the fix belongs to a separate,
-  deliberate byte-budget decision rather than this reporter's own
-  scope.
+  samples, only the committed snapshot. It is wired into this
+  repository's own `pre-push-validate` chain (`.github/idd/config.json`'s
+  `commands.pre-push-validate` and `audit/sync-manifest.json`'s
+  `idd-overview-core-instructions` syncPair replacement) so a push
+  cannot drift the committed snapshot out of sync with the rendered
+  README/methodology regions.
 - `--apply` is also cwd-sensitive, the same way `token-cost-harvest.mjs`
   is above: it refuses to run while the current branch is the
   repository's default branch, since a stray `--apply` left dirty on

--- a/tests/helper-invocation-profile.test.mts
+++ b/tests/helper-invocation-profile.test.mts
@@ -15,7 +15,7 @@
 // separate, broader guard (docs/** and idd-template/ mirrors too, plus
 // three more invocation forms, plus the bin/idd-* distributed-file ban)
 // rather than an extension of that narrower, already-reviewed guard --
-// the two allowlists overlap on four names (kept in sync manually; a
+// the two allowlists overlap on five names (kept in sync manually; a
 // name added to one is exceedingly unlikely to need the other without a
 // human noticing, since both represent the same "maintainer/CI-only,
 // never adopter-run" fact).

--- a/tests/helper-runtime-manifest.test.mts
+++ b/tests/helper-runtime-manifest.test.mts
@@ -734,6 +734,14 @@ const DOGFOOD_ONLY_CONCRETE_TOOLS = new Set([
   'scripts/verify-install-deps.mjs',
   'scripts/audit-docs.mjs',
   'scripts/audit-code-span-wrap.mjs',
+  // token-cost-report.mjs (#2619): this repository's own dogfood
+  // measurement reporter, now wired into the pre-push-validate row of
+  // `.github/instructions/idd-overview-core.instructions.md` itself
+  // (source: `audit/sync-manifest.json`'s `idd-overview-core-instructions`
+  // syncPair, never `idd-template`'s `{{PRE_PUSH_VALIDATE_COMMANDS}}`
+  // placeholder). Mirrors the identical exemption #2294 already added to
+  // `tests/helper-invocation-profile.test.mts`.
+  'scripts/token-cost-report.mjs',
 ]);
 
 // Collect every helper the instruction files tell adopters to RUN as


### PR DESCRIPTION
# Summary

Wires `node scripts/token-cost-report.mjs --check` into this repository's
`pre-push-validate` chain, satisfying roadmap #2296's 5th success
criterion. Raises `bundle-merge`'s byte-budget headroom in
`audit/sync-manifest.json` so the shared `idd-overview-core.instructions.md`
context-ceiling bundles stay comfortably under the 98% hard-fail
threshold after the new command string lands.

- `.github/idd/config.json`'s `commands.pre-push-validate` and
  `audit/sync-manifest.json`'s `idd-overview-core-instructions` syncPair
  replacement both now include `&& node scripts/token-cost-report.mjs
  --check`. `idd-template/.github/instructions/idd-overview-core.instructions.md`'s
  `{{PRE_PUSH_VALIDATE_COMMANDS}}` placeholder is untouched, per the
  B2.1-verified maintainer decision recorded on the issue (this
  repository's `token-cost-report.mjs` is dogfood-only and never
  distributed to adopters).
- `docs/token-cost.md` no longer describes the wiring as deferred.
- `tests/helper-runtime-manifest.test.mts`'s `DOGFOOD_ONLY_CONCRETE_TOOLS`
  allowlist now includes `token-cost-report.mjs`, mirroring its existing
  exemption in `tests/helper-invocation-profile.test.mts` (updated a
  stale "four names" -> "five names" overlap comment there too), since
  the wired command now appears inside the generated
  `.github/instructions/idd-overview-core.instructions.md` mirror.

**Ratchet-rule callout** (`audit/sync-manifest.json`'s own
`instructionSizeBudgets`/`bundleBudgets` ratchet-rule comment requires
this): raises `bundle-merge`'s `limitBytes` from 122,000 to 132,000
(+8.2%), giving ~9.3% headroom over the current measured total
(120,843 bytes / 91.55% utilization) rather than a bare-minimum bump,
mirroring #2377's precedent for `bundle-work`. The other four bundles
sharing `idd-overview-core.instructions.md` (`bundle-discovery`,
`bundle-resume`, `bundle-work`, `bundle-review`) stayed under 98%
without needing a raise.

## Linked issue

Closes #2619

## Follow-up issues (if any)

- [ ] none filed directly (per this repository's own anti-pattern rule
      against ad hoc `gh issue create`) -- but flagging for the
      maintainer: `bundle-work` (97.95%) and `bundle-review` (97.98%)
      are both within roughly 25-30 bytes of the 98% hard-fail ceiling
      independent of this PR's own change, and did not need raising
      here since neither actually crossed 98%. The next unrelated edit
      to `idd-overview-core.instructions.md` or
      `idd-overview-appendix.instructions.md` will likely hard-fail one
      of them; worth a proactive headroom raise before that happens.

## Background / rationale (if material)

Roadmap #2296 tracked this as its final open success criterion; #2567
recorded the maintainer decision to raise `bundle-merge`'s headroom
rather than defer indefinitely, and #2619 (this PR) is the recorded
implementation follow-up. A prior claim on this issue found and
resolved a B2.1 premise-verification conflict (the original plan would
have edited `idd-template`'s generic placeholder instead of this
repository's own concrete replacement) -- see the issue's own comment
history for that resolution; this PR implements the corrected plan.

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [x] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gnftoHtNPz3i4u6xvPLeH
