### PR TITLE
fix(idd-doctor): wire --cleanup-backlog-window-days into CI

### DIFF
--- a/.github/workflows/idd-doctor.yml
+++ b/.github/workflows/idd-doctor.yml
@@ -75,4 +75,4 @@ jobs:
           # github.com and lets this same step authenticate on a
           # self-hosted GHES host too.
           GH_ENTERPRISE_TOKEN: ${{ github.token }}
-        run: node scripts/idd-doctor.mjs
+        run: node scripts/idd-doctor.mjs --cleanup-backlog-window-days 1


### PR DESCRIPTION
# Summary

`#2636` found that `docs/idd-helper-scripts.md` and `idd-doctor.mts`'s
`--help` text both claim a local `--cleanup-backlog-window-days 1` run
"mirrors CI," but `.github/workflows/idd-doctor.yml` actually invoked
`idd-doctor.mjs` with no arguments -- CI ran the full 14-day default
window on every `pull_request` trigger.

- `.github/workflows/idd-doctor.yml`: pass `--cleanup-backlog-window-days
  1` to the `Run idd-doctor repository-health check` step, matching the
  originally documented intent (`#1145`). Since this workflow re-runs on
  every PR, a rolling 1-day window still provides cumulative multi-day
  backlog coverage across successive runs, at a fraction of the per-run
  cost.
- No doc wording change: once the workflow change lands, the existing
  "mirrors CI" claim in `docs/idd-helper-scripts.md` and
  `idd-doctor.mts`'s `--help` text becomes accurate again rather than
  describing a mismatch -- confirmed, not adjusted.
- No `idd-template/` change -- it does not ship an `idd-doctor.yml`
  workflow.

Locally confirmed the flag narrows the scan from 193 merged PRs (14-day
default) to 28 (1-day window) with a normal passing report.

## Linked issue

Closes #2640

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Maintainer decision recorded on `#2636` (Groom hearing, 2026-09-05):
wire `--cleanup-backlog-window-days 1` into CI.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gnftoHtNPz3i4u6xvPLeH
