### PR TITLE
feat(issue-authoring): add authoring-bucket marker for needs-decision

### DIFF
--- a/.claude/skills/issue-authoring/SKILL.md
+++ b/.claude/skills/issue-authoring/SKILL.md
@@ -77,11 +77,12 @@ needs-decision, blocked-by-human, and out-of-scope.
    `instructions-only` installs with no helper runtime. Resolve every
    reported failure before treating the issue as ready. Before newly
    publishing a body into the `needs-decision` or `blocked-by-human`
-   bucket instead, also run the linter, passing `--expect-bucket
-   needs-decision|blocked-by-human` — the same gate section's
-   `--expect-bucket` flag requires the matching `authoring-bucket`
-   marker for that publish, closing the gap where a non-ready body
-   would otherwise never be audited at all.
+   bucket instead, also run the linter, passing
+   `--expect-bucket <needs-decision|blocked-by-human>` (choose the one
+   matching value) — the same gate section's `--expect-bucket` flag
+   requires the matching `authoring-bucket` marker for that publish,
+   closing the gap where a non-ready body would otherwise never be
+   audited at all.
 7. Publish each `ready` drafted body directly under the authoring hold
    once it passes the mechanical gate (step 6) and the critique pass
    (the Intake and Clarification phase above) — no separate publish

--- a/.claude/skills/issue-authoring/SKILL.md
+++ b/.claude/skills/issue-authoring/SKILL.md
@@ -75,7 +75,13 @@ needs-decision, blocked-by-human, and out-of-scope.
    [Mechanical pre-publish gate](references/contract.md#mechanical-pre-publish-gate)
    in the bundled contract, including the manual fallback for
    `instructions-only` installs with no helper runtime. Resolve every
-   reported failure before treating the issue as ready.
+   reported failure before treating the issue as ready. Before newly
+   publishing a body into the `needs-decision` or `blocked-by-human`
+   bucket instead, also run the linter, passing `--expect-bucket
+   needs-decision|blocked-by-human` — the same gate section's
+   `--expect-bucket` flag requires the matching `authoring-bucket`
+   marker for that publish, closing the gap where a non-ready body
+   would otherwise never be audited at all.
 7. Publish each `ready` drafted body directly under the authoring hold
    once it passes the mechanical gate (step 6) and the critique pass
    (the Intake and Clarification phase above) — no separate publish
@@ -273,8 +279,10 @@ needs-decision, blocked-by-human, and out-of-scope.
 - Avoid widening drafting output beyond the user request without saying
   so.
 - Run the `audit-authored-issue` linter (or its manual fallback in
-  `instructions-only` installs) against every drafted ready body and
-  resolve every reported failure before publishing.
+  `instructions-only` installs) against every drafted ready body, and
+  against every body newly published into `needs-decision` or
+  `blocked-by-human` with `--expect-bucket`; resolve every reported
+  failure before publishing.
 - Name a concrete surface to edit and an objective verification for
   every `ready` candidate; route anything else to `needs-decision` or
   ask instead of guessing (the under-clarification stop rule).

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -1071,6 +1071,44 @@ Binding rules:
 Backfill is opportunistic and follows the same claim-state precondition
 as the suitability footer.
 
+## Authoring-bucket marker
+
+Authored issues in the `needs-decision` or `blocked-by-human` readiness
+buckets (see [Readiness buckets](#readiness-buckets)) may also carry an
+**authoring-bucket marker** — a hidden, machine-readable record of which
+of those two axes applies, so `audit-authored-issue.mts` can mechanically
+enforce the matching label the same way it already enforces
+`status:blocked-by-human` for a suitability score of `1`
+(`checkSuitabilityBlockedByHuman`). `ready` and other buckets omit the
+marker entirely.
+
+```text
+<!-- {marker-prefix}-authoring-bucket: needs-decision|blocked-by-human -->
+```
+
+Binding rules:
+
+- **Two axes only.** Scoped to the two buckets with a real behavioral
+  consequence today (a required label) — `deferred` and `out-of-scope`
+  have none, so they carry no marker.
+- **Folds the existing suitability-1 check.** When present, this marker
+  decides `suitability-blocked-by-human`'s applicability instead of the
+  suitability score: `blocked-by-human` requires
+  `status:blocked-by-human` regardless of score; `needs-decision` means
+  that check does not apply, even at a suitability score of `1`. Absent
+  or malformed, `checkSuitabilityBlockedByHuman` falls back to the
+  pre-existing suitability-1-only rule — no backfill onto issues
+  published before this marker existed.
+- **Authoring marker, not operational marker.** Like
+  `autopilot-suitability`, it is body content and must never be added to
+  `OPERATIONAL_MARKERS` or subjected to F4 minimization.
+- **Fail-safe on absence.** A missing or malformed marker means "no
+  bucket": both mechanical checks fall back to their pre-existing
+  behavior.
+
+Backfill is opportunistic and follows the same claim-state precondition
+as the suitability footer.
+
 ## Authoring hold and release
 
 Issue authoring uses a two-stage contract: drafting and publishing

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -808,8 +808,9 @@ Before publishing a drafted `ready` **orphan, roadmap, or child** body
 (the shapes the linter supports), run the `audit-authored-issue`
 linter against it when a helper runtime is available. Before newly
 publishing a body into the **`needs-decision`** or **`blocked-by-human`**
-bucket instead, also run it, passing `--expect-bucket
-needs-decision|blocked-by-human`: without this, the two mechanical
+bucket instead, also run it, passing
+`--expect-bucket <needs-decision|blocked-by-human>` (choose the one
+matching value): without this, the two mechanical
 checks below that key off the `authoring-bucket` marker
 (see [Authoring-bucket marker](#authoring-bucket-marker)) never
 actually fire in practice, since a non-`ready` body is otherwise never
@@ -921,7 +922,7 @@ confirm the reference is a mere breadcrumb.
 node scripts/audit-authored-issue.mjs --shape <orphan|roadmap|child> \
   --marker-prefix <resolved-target-prefix> \
   --body-file <path-to-drafted-body> [--label <label>]... \
-  [--expect-bucket needs-decision|blocked-by-human]
+  [--expect-bucket <needs-decision|blocked-by-human>]
 ```
 
 Or, for npx/package-manager profiles, the equivalent

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -805,16 +805,31 @@ marginally-ready issue.
 ## Mechanical pre-publish gate
 
 Before publishing a drafted `ready` **orphan, roadmap, or child** body
-(the shapes the linter supports — not the non-ready buckets below,
-which are not audited by this gate), run the
-`audit-authored-issue` linter against it when a helper runtime is
-available. It mechanically re-checks a subset of the structural rules
-this contract states in prose — the autopilot-suitability marker's
+(the shapes the linter supports), run the `audit-authored-issue`
+linter against it when a helper runtime is available. Before newly
+publishing a body into the **`needs-decision`** or **`blocked-by-human`**
+bucket instead, also run it, passing `--expect-bucket
+needs-decision|blocked-by-human`: without this, the two mechanical
+checks below that key off the `authoring-bucket` marker
+(see [Authoring-bucket marker](#authoring-bucket-marker)) never
+actually fire in practice, since a non-`ready` body is otherwise never
+run through this gate at all — exactly the gap that let #2636/#2637
+publish without their required label (#2639 follow-up). `--expect-bucket`
+requires the matching marker to be present, failing when it is absent
+or disagrees; omit it for a `ready` publish or an edit to an
+already-published legacy body, where the marker stays optional and
+fail-safe on absence as documented in that section. `deferred` and
+`out-of-scope` bodies are not audited by this gate either way. It
+mechanically re-checks a subset of the structural rules this contract
+states in prose — the autopilot-suitability marker's
 exactly-one/coherent-value rule, the one-directional check that a
-suitability score of `1` carries the configured `blocked-by-human`
-label (it does not check the reverse: a non-`1` score paired with the
-label still passes), markerPrefix consistency across every authoring
-marker, the declared shape's required section headings, the
+suitability score of `1` (or an `authoring-bucket: blocked-by-human`
+marker, when present) carries the configured `blocked-by-human` label
+(it does not check the reverse: a non-`1` score paired with the label
+still passes), the equivalent one-directional check for
+`authoring-bucket: needs-decision` and the configured
+`needsDecisionLabelName` label, markerPrefix consistency across every
+authoring marker, the declared shape's required section headings, the
 roadmap-id/blocked-by dependency-marker rules, and visible/hidden line
 agreement for the suitability and effort footers — so a weak model does
 not have to hold every rule in its head at once while drafting.
@@ -905,7 +920,8 @@ confirm the reference is a mere breadcrumb.
 ```sh
 node scripts/audit-authored-issue.mjs --shape <orphan|roadmap|child> \
   --marker-prefix <resolved-target-prefix> \
-  --body-file <path-to-drafted-body> [--label <label>]...
+  --body-file <path-to-drafted-body> [--label <label>]... \
+  [--expect-bucket needs-decision|blocked-by-human]
 ```
 
 Or, for npx/package-manager profiles, the equivalent
@@ -1073,14 +1089,17 @@ as the suitability footer.
 
 ## Authoring-bucket marker
 
-Authored issues in the `needs-decision` or `blocked-by-human` readiness
-buckets (see [Readiness buckets](#readiness-buckets)) may also carry an
-**authoring-bucket marker** — a hidden, machine-readable record of which
-of those two axes applies, so `audit-authored-issue.mts` can mechanically
+A newly authored issue in the `needs-decision` or `blocked-by-human`
+readiness bucket (see [Readiness buckets](#readiness-buckets)) carries a
+hidden, machine-readable **authoring-bucket marker** recording which of
+those two axes applies, so `audit-authored-issue.mts` can mechanically
 enforce the matching label the same way it already enforces
 `status:blocked-by-human` for a suitability score of `1`
-(`checkSuitabilityBlockedByHuman`). `ready` and other buckets omit the
-marker entirely.
+(`checkSuitabilityBlockedByHuman`) — see
+[Mechanical pre-publish gate](#mechanical-pre-publish-gate)'s
+`--expect-bucket` flag for the enforcement path. `ready` and other
+buckets omit the marker entirely; so does a legacy body already
+published before this marker existed.
 
 ```text
 <!-- {marker-prefix}-authoring-bucket: needs-decision|blocked-by-human -->
@@ -1102,9 +1121,12 @@ Binding rules:
 - **Authoring marker, not operational marker.** Like
   `autopilot-suitability`, it is body content and must never be added to
   `OPERATIONAL_MARKERS` or subjected to F4 minimization.
-- **Fail-safe on absence.** A missing or malformed marker means "no
-  bucket": both mechanical checks fall back to their pre-existing
-  behavior.
+- **Fail-safe on absence, except when explicitly expected.** A missing
+  or malformed marker means "no bucket": both mechanical checks above
+  fall back to their pre-existing behavior. The gate's `--expect-bucket`
+  flag is the deliberate exception — passed only for a body newly
+  published into that bucket, it turns "no bucket" into a hard failure
+  instead (`authoring-bucket-marker-required`).
 
 Backfill is opportunistic and follows the same claim-state precondition
 as the suitability footer.

--- a/.claude/skills/issue-authoring/references/draft-patterns.md
+++ b/.claude/skills/issue-authoring/references/draft-patterns.md
@@ -100,10 +100,8 @@ Before you publish a ready issue, confirm:
 
 ## Mechanical pre-publish gate
 
-Before you publish a drafted **ready orphan, roadmap, or child** body
-(scoped to those ready shapes — non-ready buckets like
-`blocked-by-human` are not audited by this gate), run the
-`audit-authored-issue` linter against it when a helper runtime
+Before you publish a drafted **ready orphan, roadmap, or child** body,
+run the `audit-authored-issue` linter against it when a helper runtime
 is available. It mechanically catches shape and marker mistakes — a
 missing or duplicated autopilot-suitability footer, a wrong
 markerPrefix, a missing required heading for the declared shape, a
@@ -113,6 +111,23 @@ mask:
 ```sh
 node scripts/audit-authored-issue.mjs --shape orphan \
   --marker-prefix <resolved-target-prefix> --body-file draft.md
+```
+
+Before newly publishing a body into the `needs-decision` or
+`blocked-by-human` bucket instead, also run it, adding
+`--expect-bucket <needs-decision|blocked-by-human>` (choose the one
+matching value) — without it, the marker/label checks that key off
+`authoring-bucket` never fire, since a non-ready body is otherwise
+never run through this gate at all. Passing `--expect-bucket` also
+skips the ready-shape-only checks (the suitability footer and required
+headings) that a bucket body like `#431` below is never expected to
+carry:
+
+```sh
+node scripts/audit-authored-issue.mjs --shape orphan \
+  --marker-prefix <resolved-target-prefix> --body-file draft.md \
+  --expect-bucket needs-decision \
+  --label status:needs-decision
 ```
 
 **Always pass `--marker-prefix`** with the prefix resolved under

--- a/.claude/skills/issue-authoring/references/draft-patterns.md
+++ b/.claude/skills/issue-authoring/references/draft-patterns.md
@@ -423,6 +423,8 @@ secret in CI so automated tests can verify the signature check.
 ## Ready signal
 
 Close this issue after confirming the secret is available in CI.
+
+<!-- {marker-prefix}-authoring-bucket: blocked-by-human -->
 ```
 
 `#432` — autonomous execution issue (Blocked by #431):

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -201,6 +201,24 @@ rules.
 - A missing or invalid hint is **fail-safe**: selection behaves exactly
   as today (a missing hint sorts as the neutral middle, as-if `M`).
 
+### Authoring-bucket marker
+
+A `needs-decision` or `blocked-by-human` issue may also carry a hidden
+**authoring-bucket marker**
+(`<!-- {marker-prefix}-authoring-bucket: needs-decision|blocked-by-human -->`)
+so `audit-authored-issue.mts` can mechanically enforce the matching
+label the same way it already enforces `status:blocked-by-human` for a
+suitability score of `1`. See the
+[Authoring-bucket marker](https://github.com/kurone-kito/idd-skill/blob/main/skills/issue-authoring/references/contract.md#authoring-bucket-marker)
+section of the contract for the binding rules.
+
+- Scoped to the two buckets with a real behavioral consequence today;
+  `ready`, `deferred`, and `out-of-scope` carry no marker.
+- When present, it decides the suitability-1/`blocked-by-human` check's
+  applicability instead of the score; absent or malformed, that check
+  falls back to its pre-existing suitability-1-only rule (no backfill
+  onto issues published before this marker existed).
+
 ## Specificity target
 
 Issue drafting should aim for a level of specificity where a

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -205,7 +205,7 @@ rules.
 
 A newly published `needs-decision` or `blocked-by-human` issue carries a
 hidden **authoring-bucket marker**
-(`<!-- {marker-prefix}-authoring-bucket: <needs-decision|blocked-by-human> -->`)
+(`<!-- {marker-prefix}-authoring-bucket: needs-decision|blocked-by-human -->`)
 so `audit-authored-issue.mts` can mechanically enforce the matching
 label the same way it already enforces `status:blocked-by-human` for a
 suitability score of `1`. Publishing into either bucket runs the linter

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -205,12 +205,14 @@ rules.
 
 A newly published `needs-decision` or `blocked-by-human` issue carries a
 hidden **authoring-bucket marker**
-(`<!-- {marker-prefix}-authoring-bucket: needs-decision|blocked-by-human -->`)
+(`<!-- {marker-prefix}-authoring-bucket: <needs-decision|blocked-by-human> -->`)
 so `audit-authored-issue.mts` can mechanically enforce the matching
 label the same way it already enforces `status:blocked-by-human` for a
 suitability score of `1`. Publishing into either bucket runs the linter
-with `--expect-bucket` (see step 6 above), requiring the marker rather
-than treating its absence as fail-safe. See the
+with `--expect-bucket` (see
+[Mechanical pre-publish gate](#mechanical-pre-publish-gate) below),
+requiring the marker rather than treating its absence as fail-safe. See
+the
 [Authoring-bucket marker](https://github.com/kurone-kito/idd-skill/blob/main/skills/issue-authoring/references/contract.md#authoring-bucket-marker)
 section of the contract for the binding rules.
 
@@ -584,15 +586,27 @@ resolve the issue during drafting instead of publishing it.
 ### Mechanical pre-publish gate
 
 Before publishing a drafted `ready` **orphan, roadmap, or sub-issue**
-body (the linter's `orphan|roadmap|child` shapes; not the non-ready
-buckets above), run the `audit-authored-issue` linter
+body (the linter's `orphan|roadmap|child` shapes), run the
+`audit-authored-issue` linter
 (`scripts/audit-authored-issue.mjs` / `bin/idd-audit-authored-issue.mjs`)
-against it when a helper runtime is available. It mechanically
+against it when a helper runtime is available. Before newly publishing
+a body into the `needs-decision` or `blocked-by-human` bucket instead,
+also run it, adding `--expect-bucket <needs-decision|blocked-by-human>`
+(choose the one matching value) — without it, the marker/label checks
+that key off `authoring-bucket` never fire, since a non-ready body is
+otherwise never run through this gate at all (the exact gap #2636/#2637
+hit). Passing `--expect-bucket` also skips the ready-shape-only checks
+(the suitability footer and required headings) that a bucket body is
+never expected to carry, since it uses its own
+Background/Required action/Ready signal shape instead. It mechanically
 re-checks a subset of the structural rules this document states in
 prose — the autopilot-suitability marker's exactly-one/coherent-value
-rule, the one-directional check that a suitability score of `1` carries
-the configured `blocked-by-human` label (it does not check the reverse:
-a non-`1` score paired with the label still passes), markerPrefix
+rule, the one-directional check that a suitability score of `1` (or an
+`authoring-bucket: blocked-by-human` marker, when present) carries the
+configured `blocked-by-human` label (it does not check the reverse:
+a non-`1` score paired with the label still passes), the equivalent
+one-directional check for `authoring-bucket: needs-decision` and the
+configured `needsDecisionLabelName` label, markerPrefix
 consistency across every authoring marker, the declared shape's
 required section headings, the roadmap-id/blocked-by dependency-marker
 rules, and visible/hidden line agreement for the suitability and effort
@@ -660,7 +674,8 @@ confirm the reference is a mere breadcrumb.
 ```sh
 node scripts/audit-authored-issue.mjs --shape <orphan|roadmap|child> \
   --marker-prefix <resolved-target-prefix> \
-  --body-file <path-to-drafted-body> [--label <label>]...
+  --body-file <path-to-drafted-body> [--label <label>]... \
+  [--expect-bucket <needs-decision|blocked-by-human>]
 ```
 
 **Always keep `--marker-prefix`, and always replace the placeholder**

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -203,12 +203,14 @@ rules.
 
 ### Authoring-bucket marker
 
-A `needs-decision` or `blocked-by-human` issue may also carry a hidden
-**authoring-bucket marker**
+A newly published `needs-decision` or `blocked-by-human` issue carries a
+hidden **authoring-bucket marker**
 (`<!-- {marker-prefix}-authoring-bucket: needs-decision|blocked-by-human -->`)
 so `audit-authored-issue.mts` can mechanically enforce the matching
 label the same way it already enforces `status:blocked-by-human` for a
-suitability score of `1`. See the
+suitability score of `1`. Publishing into either bucket runs the linter
+with `--expect-bucket` (see step 6 above), requiring the marker rather
+than treating its absence as fail-safe. See the
 [Authoring-bucket marker](https://github.com/kurone-kito/idd-skill/blob/main/skills/issue-authoring/references/contract.md#authoring-bucket-marker)
 section of the contract for the binding rules.
 
@@ -217,7 +219,8 @@ section of the contract for the binding rules.
 - When present, it decides the suitability-1/`blocked-by-human` check's
   applicability instead of the score; absent or malformed, that check
   falls back to its pre-existing suitability-1-only rule (no backfill
-  onto issues published before this marker existed).
+  onto issues published before this marker existed, or on an edit to
+  one).
 
 ## Specificity target
 

--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -533,17 +533,37 @@ function checkAuthoringBucketMarkerRequired(authoringBucket, expectedBucket) {
  * {@link stripMarkdownCodeRegions}-masked (every caller in this file
  * passes the shared `text`, not `rawText`), so a marker merely quoted in
  * prose cannot be mistaken for a real one.
+ *
+ * Uses the same rawCount-vs-coherent-count gap {@link
+ * checkEffortVisibleLineAgreement} closes for the `effort` marker: the
+ * value-capturing regex below requires a non-empty token
+ * (`[^\s>]+`), so a value-less marker like
+ * `<!-- {prefix}-authoring-bucket: -->` would otherwise never match it
+ * at all and read as `present: false` — indistinguishable from no
+ * marker, which would also make {@link checkAuthoringBucketMarkerRequired}
+ * misreport a present-but-invalid marker as "none was found" (#2648
+ * review, Copilot). `countMarkerOccurrences`'s detection-only regex
+ * matches regardless of value, so comparing the two counts recovers the
+ * distinction.
  */
 function parseAuthoringBucketMarker(text, markerPrefix) {
+  const rawCount = countMarkerOccurrences(
+    text,
+    markerPrefix,
+    'authoring-bucket',
+  );
+  if (rawCount === 0) {
+    return { present: false, value: null, malformed: false };
+  }
   const regex = new RegExp(
     `<!--\\s*${escapeRegex(markerPrefix)}-authoring-bucket:\\s*([^\\s>]+)\\s*-->`,
     'gi',
   );
-  let present = false;
+  let coherentCount = 0;
   let value = null;
   let match = regex.exec(text);
   while (match) {
-    present = true;
+    coherentCount += 1;
     const raw = match[1];
     const parsed = isAuthoringBucketValue(raw) ? raw : null;
     // Fail-safe: any invalid token, or a value disagreeing with an
@@ -554,8 +574,11 @@ function parseAuthoringBucketMarker(text, markerPrefix) {
     value = parsed;
     match = regex.exec(text);
   }
-  if (!present) {
-    return { present: false, value: null, malformed: false };
+  if (coherentCount !== rawCount) {
+    // At least one occurrence matched the raw (any-value) scan but not
+    // the value-capturing one -- a value-less or otherwise malformed-shape
+    // marker.
+    return { present: true, value: null, malformed: true };
   }
   return { present: true, value, malformed: false };
 }

--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -272,6 +272,7 @@ const AUDIT_AUTHORED_ISSUE_FLAG_SPEC = {
   '--current-repo': { type: 'string' },
   '--issue': { type: 'string' },
   '--label': { type: 'string', multiple: true },
+  '--expect-bucket': { type: 'string' },
   '--comments-file': { type: 'string' },
   '--journal-comments-file': { type: 'string' },
   '--new-issue': { type: 'boolean', default: false },
@@ -350,6 +351,10 @@ export function auditAuthoredIssue(body, options) {
       authoringBucket,
       labels,
       needsDecisionLabelName,
+    ),
+    checkAuthoringBucketMarkerRequired(
+      authoringBucket,
+      options.expectedAuthoringBucket,
     ),
     checkMarkerPrefixConsistency(text, markerPrefix),
     checkRequiredHeadings(text, shape),
@@ -454,6 +459,49 @@ function checkAuthoringBucketNeedsDecision(
     id,
     name,
     `authoring-bucket marker reads needs-decision but the ${needsDecisionLabelName} label was not provided`,
+  );
+}
+/**
+ * Requires the `authoring-bucket` marker to actually be present and match
+ * `expectedBucket`, when the caller declares one (#2639 follow-up). The two
+ * checks above only validate the marker/label pair *when a marker already
+ * exists*; without this check, a body that omits the marker entirely -- the
+ * exact gap #2636/#2637 hit -- silently reads as "not applicable" from both,
+ * since a `ready`-shape publish is the only case the Mechanical pre-publish
+ * gate otherwise audits. `expectedBucket` must be supplied by the caller
+ * when (and only when) auditing a body about to be newly published into the
+ * `needs-decision` or `blocked-by-human` bucket; a `ready` publish, or an
+ * already-published legacy body, passes `undefined` and this check no-ops.
+ */
+function checkAuthoringBucketMarkerRequired(authoringBucket, expectedBucket) {
+  const id = 'authoring-bucket-marker-required';
+  const name =
+    'A newly published needs-decision/blocked-by-human body carries the matching authoring-bucket marker';
+  if (expectedBucket === undefined) {
+    return pass(
+      id,
+      name,
+      'not applicable: no expected bucket declared for this audit (ready publish, or a legacy body)',
+    );
+  }
+  if (authoringBucket.value === expectedBucket) {
+    return pass(
+      id,
+      name,
+      `authoring-bucket marker matches the declared ${expectedBucket} bucket`,
+    );
+  }
+  if (authoringBucket.value === null) {
+    return fail(
+      id,
+      name,
+      `expected an authoring-bucket: ${expectedBucket} marker for a newly published ${expectedBucket} body, but none was found`,
+    );
+  }
+  return fail(
+    id,
+    name,
+    `expected an authoring-bucket: ${expectedBucket} marker, but found authoring-bucket: ${authoringBucket.value} instead`,
   );
 }
 /**
@@ -1488,6 +1536,12 @@ function main() {
   if (args.issue !== undefined && !/^[1-9]\d*$/.test(args.issue)) {
     fail_('--issue must be a positive integer');
   }
+  if (
+    args.expectBucket !== undefined &&
+    !isAuthoringBucketValue(args.expectBucket)
+  ) {
+    fail_('--expect-bucket must be needs-decision or blocked-by-human');
+  }
   if (args.journalCommentsFile && !args.newIssue) {
     fail_('--journal-comments-file requires --new-issue');
   }
@@ -1536,6 +1590,7 @@ function main() {
     labels: args.labels,
     blockedByHumanLabelName: policy.blockedByHumanLabelName,
     needsDecisionLabelName: policy.needsDecisionLabelName,
+    expectedAuthoringBucket: args.expectBucket,
     authoringLabelName: policy.authoringLabelName,
     currentRepo,
     issueNumber:
@@ -1665,6 +1720,7 @@ function parseArgs(argv) {
     currentRepo: values['current-repo'],
     issue: values.issue,
     labels: values.label ?? [],
+    expectBucket: values['expect-bucket'],
     commentsFile: values['comments-file'],
     journalCommentsFile: values['journal-comments-file'],
     newIssue: values['new-issue'],
@@ -1695,9 +1751,15 @@ Options:
   --marker-prefix <prefix>         override the resolved markerPrefix
   --config <path>                  policy config path (default: .github/idd/config.json)
   --label <name>                   a label currently applied/proposed on the issue
-                                    (repeatable; used for the suitability=1
-                                    cross-field check and the authoring-label
-                                    check for authoring-owner-marker-trail)
+                                    (repeatable; used for the suitability=1 /
+                                    authoring-bucket cross-field checks and the
+                                    authoring-label check for
+                                    authoring-owner-marker-trail)
+  --expect-bucket <bucket>         needs-decision or blocked-by-human; set only when
+                                    auditing a body about to be newly published into
+                                    that bucket -- requires the matching
+                                    authoring-bucket marker to be present (omit for a
+                                    ready publish or a legacy body)
   --current-repo <owner/repo>      this repository, for the prose-dependency check
                                     to recognize a full-URL issue/PR reference as
                                     cross-repo (default: $GITHUB_REPOSITORY), and

--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -45,7 +45,7 @@ import { createMarkerRegex, escapeRegex } from './marker-regex.mjs';
 import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mjs';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
-// The four authoring-marker suffixes defined in the contract. Operational
+// The five authoring-marker suffixes defined in the contract. Operational
 // markers (claimed-by, review-watermark, ...) never take this
 // `{prefix}-{suffix}` shape, so they cannot collide with this scan.
 const AUTHORING_MARKER_SUFFIXES = [
@@ -53,6 +53,7 @@ const AUTHORING_MARKER_SUFFIXES = [
   'blocked-by',
   'autopilot-suitability',
   'effort',
+  'authoring-bucket',
 ];
 const SHAPE_HEADING_REQUIREMENTS = {
   orphan: [
@@ -322,6 +323,11 @@ export function auditAuthoredIssue(body, options) {
     options.blockedByHumanLabelName.length > 0
       ? options.blockedByHumanLabelName
       : POLICY_DEFAULTS.labels.blockedByHumanLabelName;
+  const needsDecisionLabelName =
+    typeof options.needsDecisionLabelName === 'string' &&
+    options.needsDecisionLabelName.length > 0
+      ? options.needsDecisionLabelName
+      : POLICY_DEFAULTS.labels.needsDecisionLabelName;
   const labels = (options.labels ?? []).map((label) =>
     String(label).trim().toLowerCase(),
   );
@@ -331,12 +337,19 @@ export function auditAuthoredIssue(body, options) {
     markerPrefix,
     'autopilot-suitability',
   );
+  const authoringBucket = parseAuthoringBucketMarker(text, markerPrefix);
   const findings = [
     checkSuitabilityMarker(suitabilityCount, suitability),
     checkSuitabilityBlockedByHuman(
       suitability,
+      authoringBucket,
       labels,
       blockedByHumanLabelName,
+    ),
+    checkAuthoringBucketNeedsDecision(
+      authoringBucket,
+      labels,
+      needsDecisionLabelName,
     ),
     checkMarkerPrefixConsistency(text, markerPrefix),
     checkRequiredHeadings(text, shape),
@@ -375,25 +388,110 @@ function checkSuitabilityMarker(count, suitability) {
   }
   return pass(id, name, `suitability score is ${suitability.value}`);
 }
+/**
+ * Suitability=1 implies `blockedByHumanLabelName` -- unless an
+ * `authoring-bucket` marker is present, in which case that marker's value
+ * decides applicability instead (#2639): `blocked-by-human` requires the
+ * label regardless of the suitability score; any other coherent value
+ * (currently only `needs-decision`) means this check does not apply, even
+ * at suitability 1. A malformed or absent marker (`value: null`) falls
+ * back to the pre-existing suitability-1-only rule, preserving behavior
+ * for every issue published before this marker existed.
+ */
 function checkSuitabilityBlockedByHuman(
   suitability,
+  authoringBucket,
   labels,
   blockedByHumanLabelName,
 ) {
   const id = 'suitability-blocked-by-human';
-  const name = `Suitability score of 1 carries the ${blockedByHumanLabelName} label`;
-  if (suitability.value !== 1) {
-    return pass(id, name, 'not applicable: suitability score is not 1');
+  const name = `Suitability 1 (or an authoring-bucket: blocked-by-human marker) carries the ${blockedByHumanLabelName} label`;
+  const applies =
+    authoringBucket.value === 'blocked-by-human' ||
+    (authoringBucket.value === null && suitability.value === 1);
+  if (!applies) {
+    return pass(
+      id,
+      name,
+      'not applicable: neither the authoring-bucket marker nor a suitability score of 1 apply',
+    );
   }
   const target = blockedByHumanLabelName.trim().toLowerCase();
   if (labels.includes(target)) {
     return pass(id, name, `${blockedByHumanLabelName} label is present`);
   }
+  const reason =
+    authoringBucket.value === 'blocked-by-human'
+      ? `authoring-bucket marker reads blocked-by-human but the ${blockedByHumanLabelName} label was not provided`
+      : `suitability score is 1 but the ${blockedByHumanLabelName} label was not provided`;
+  return fail(id, name, reason);
+}
+/**
+ * `authoring-bucket: needs-decision` implies `needsDecisionLabelName`
+ * (#2639), mirroring {@link checkSuitabilityBlockedByHuman}'s
+ * `blocked-by-human` handling. Not applicable when the marker is absent,
+ * malformed, or reads `blocked-by-human` instead.
+ */
+function checkAuthoringBucketNeedsDecision(
+  authoringBucket,
+  labels,
+  needsDecisionLabelName,
+) {
+  const id = 'authoring-bucket-needs-decision';
+  const name = `authoring-bucket: needs-decision carries the ${needsDecisionLabelName} label`;
+  if (authoringBucket.value !== 'needs-decision') {
+    return pass(
+      id,
+      name,
+      'not applicable: authoring-bucket marker does not read needs-decision',
+    );
+  }
+  const target = needsDecisionLabelName.trim().toLowerCase();
+  if (labels.includes(target)) {
+    return pass(id, name, `${needsDecisionLabelName} label is present`);
+  }
   return fail(
     id,
     name,
-    `suitability score is 1 but the ${blockedByHumanLabelName} label was not provided`,
+    `authoring-bucket marker reads needs-decision but the ${needsDecisionLabelName} label was not provided`,
   );
+}
+/**
+ * Canonical parser for the authored
+ * `<!-- {prefix}-authoring-bucket: needs-decision|blocked-by-human -->`
+ * marker, mirroring {@link parseAutopilotSuitabilityMarker}'s fail-safe
+ * shape and repeated/disagreeing-value handling. `text` must already be
+ * {@link stripMarkdownCodeRegions}-masked (every caller in this file
+ * passes the shared `text`, not `rawText`), so a marker merely quoted in
+ * prose cannot be mistaken for a real one.
+ */
+function parseAuthoringBucketMarker(text, markerPrefix) {
+  const regex = new RegExp(
+    `<!--\\s*${escapeRegex(markerPrefix)}-authoring-bucket:\\s*([^\\s>]+)\\s*-->`,
+    'gi',
+  );
+  let present = false;
+  let value = null;
+  let match = regex.exec(text);
+  while (match) {
+    present = true;
+    const raw = match[1];
+    const parsed = isAuthoringBucketValue(raw) ? raw : null;
+    // Fail-safe: any invalid token, or a value disagreeing with an
+    // earlier coherent one, yields no bucket.
+    if (parsed === null || (value !== null && parsed !== value)) {
+      return { present: true, value: null, malformed: true };
+    }
+    value = parsed;
+    match = regex.exec(text);
+  }
+  if (!present) {
+    return { present: false, value: null, malformed: false };
+  }
+  return { present: true, value, malformed: false };
+}
+function isAuthoringBucketValue(value) {
+  return value === 'needs-decision' || value === 'blocked-by-human';
 }
 function checkMarkerPrefixConsistency(text, markerPrefix) {
   const id = 'marker-prefix-consistency';
@@ -1437,6 +1535,7 @@ function main() {
     markerPrefix,
     labels: args.labels,
     blockedByHumanLabelName: policy.blockedByHumanLabelName,
+    needsDecisionLabelName: policy.needsDecisionLabelName,
     authoringLabelName: policy.authoringLabelName,
     currentRepo,
     issueNumber:
@@ -1504,6 +1603,7 @@ function loadPolicy(configPath) {
     return {
       markerPrefix: DEFAULT_MARKER_PREFIX,
       blockedByHumanLabelName: POLICY_DEFAULTS.labels.blockedByHumanLabelName,
+      needsDecisionLabelName: POLICY_DEFAULTS.labels.needsDecisionLabelName,
       authoringLabelName: POLICY_DEFAULTS.issueAuthoring.authoringLabelName,
     };
   }
@@ -1511,6 +1611,8 @@ function loadPolicy(configPath) {
     markerPrefix: normalizeMarkerPrefix(config.markerPrefix),
     blockedByHumanLabelName:
       normalizePolicyConfig(config).labels.blockedByHumanLabelName,
+    needsDecisionLabelName:
+      normalizePolicyConfig(config).labels.needsDecisionLabelName,
     authoringLabelName:
       normalizePolicyConfig(config).issueAuthoring.authoringLabelName,
   };

--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -45,6 +45,16 @@ import { createMarkerRegex, escapeRegex } from './marker-regex.mjs';
 import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mjs';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
+// Shared "skip" detail for every ready-shape-only check when
+// `--expect-bucket` is set (#2648 review, Codex): a needs-decision/
+// blocked-by-human body uses its own distinct heading/footer shape
+// (see skills/issue-authoring/references/draft-patterns.md's
+// blocked-by-human example), not the ready orphan/roadmap/child shapes
+// these checks validate, so running them against a bucket audit would
+// fail a correctly-formed bucket body instead of reading as
+// not-applicable.
+const NOT_APPLICABLE_BUCKET_AUDIT_DETAIL =
+  'not applicable: auditing a needs-decision/blocked-by-human bucket publish (--expect-bucket), not a ready-shape body';
 // The five authoring-marker suffixes defined in the contract. Operational
 // markers (claimed-by, review-watermark, ...) never take this
 // `{prefix}-{suffix}` shape, so they cannot collide with this scan.
@@ -339,8 +349,9 @@ export function auditAuthoredIssue(body, options) {
     'autopilot-suitability',
   );
   const authoringBucket = parseAuthoringBucketMarker(text, markerPrefix);
+  const isBucketAudit = options.expectedAuthoringBucket !== undefined;
   const findings = [
-    checkSuitabilityMarker(suitabilityCount, suitability),
+    checkSuitabilityMarker(suitabilityCount, suitability, isBucketAudit),
     checkSuitabilityBlockedByHuman(
       suitability,
       authoringBucket,
@@ -357,7 +368,7 @@ export function auditAuthoredIssue(body, options) {
       options.expectedAuthoringBucket,
     ),
     checkMarkerPrefixConsistency(text, markerPrefix),
-    checkRequiredHeadings(text, shape),
+    checkRequiredHeadings(text, shape, isBucketAudit),
     checkDependencyMarkerRule(text, markerPrefix, shape),
     checkSuitabilityVisibleLineAgreement(text, markerPrefix, suitability),
     checkEffortVisibleLineAgreement(text, markerPrefix),
@@ -371,9 +382,12 @@ export function auditAuthoredIssue(body, options) {
     findings,
   };
 }
-function checkSuitabilityMarker(count, suitability) {
+function checkSuitabilityMarker(count, suitability, isBucketAudit) {
   const id = 'suitability-marker';
   const name = 'Exactly one coherent autopilot-suitability marker (1-5)';
+  if (isBucketAudit) {
+    return pass(id, name, NOT_APPLICABLE_BUCKET_AUDIT_DETAIL);
+  }
   if (count === 0) {
     return fail(id, name, 'missing autopilot-suitability marker');
   }
@@ -491,11 +505,18 @@ function checkAuthoringBucketMarkerRequired(authoringBucket, expectedBucket) {
       `authoring-bucket marker matches the declared ${expectedBucket} bucket`,
     );
   }
-  if (authoringBucket.value === null) {
+  if (!authoringBucket.present) {
     return fail(
       id,
       name,
       `expected an authoring-bucket: ${expectedBucket} marker for a newly published ${expectedBucket} body, but none was found`,
+    );
+  }
+  if (authoringBucket.malformed) {
+    return fail(
+      id,
+      name,
+      `expected an authoring-bucket: ${expectedBucket} marker, but the marker present is malformed (an unrecognized value, or repeated with disagreeing values)`,
     );
   }
   return fail(
@@ -576,9 +597,12 @@ function checkMarkerPrefixConsistency(text, markerPrefix) {
   }
   return pass(id, name, 'all authoring markers use the resolved markerPrefix');
 }
-function checkRequiredHeadings(text, shape) {
+function checkRequiredHeadings(text, shape, isBucketAudit) {
   const id = 'required-headings';
   const name = `Required section headings present for the ${shape} shape`;
+  if (isBucketAudit) {
+    return pass(id, name, NOT_APPLICABLE_BUCKET_AUDIT_DETAIL);
+  }
   const headings = extractHeadings(text);
   const missing = SHAPE_HEADING_REQUIREMENTS[shape].filter(
     (requirement) =>

--- a/skills/issue-authoring/SKILL.md
+++ b/skills/issue-authoring/SKILL.md
@@ -77,11 +77,12 @@ needs-decision, blocked-by-human, and out-of-scope.
    `instructions-only` installs with no helper runtime. Resolve every
    reported failure before treating the issue as ready. Before newly
    publishing a body into the `needs-decision` or `blocked-by-human`
-   bucket instead, also run the linter, passing `--expect-bucket
-   needs-decision|blocked-by-human` — the same gate section's
-   `--expect-bucket` flag requires the matching `authoring-bucket`
-   marker for that publish, closing the gap where a non-ready body
-   would otherwise never be audited at all.
+   bucket instead, also run the linter, passing
+   `--expect-bucket <needs-decision|blocked-by-human>` (choose the one
+   matching value) — the same gate section's `--expect-bucket` flag
+   requires the matching `authoring-bucket` marker for that publish,
+   closing the gap where a non-ready body would otherwise never be
+   audited at all.
 7. Publish each `ready` drafted body directly under the authoring hold
    once it passes the mechanical gate (step 6) and the critique pass
    (the Intake and Clarification phase above) — no separate publish

--- a/skills/issue-authoring/SKILL.md
+++ b/skills/issue-authoring/SKILL.md
@@ -75,7 +75,13 @@ needs-decision, blocked-by-human, and out-of-scope.
    [Mechanical pre-publish gate](references/contract.md#mechanical-pre-publish-gate)
    in the bundled contract, including the manual fallback for
    `instructions-only` installs with no helper runtime. Resolve every
-   reported failure before treating the issue as ready.
+   reported failure before treating the issue as ready. Before newly
+   publishing a body into the `needs-decision` or `blocked-by-human`
+   bucket instead, also run the linter, passing `--expect-bucket
+   needs-decision|blocked-by-human` — the same gate section's
+   `--expect-bucket` flag requires the matching `authoring-bucket`
+   marker for that publish, closing the gap where a non-ready body
+   would otherwise never be audited at all.
 7. Publish each `ready` drafted body directly under the authoring hold
    once it passes the mechanical gate (step 6) and the critique pass
    (the Intake and Clarification phase above) — no separate publish
@@ -273,8 +279,10 @@ needs-decision, blocked-by-human, and out-of-scope.
 - Avoid widening drafting output beyond the user request without saying
   so.
 - Run the `audit-authored-issue` linter (or its manual fallback in
-  `instructions-only` installs) against every drafted ready body and
-  resolve every reported failure before publishing.
+  `instructions-only` installs) against every drafted ready body, and
+  against every body newly published into `needs-decision` or
+  `blocked-by-human` with `--expect-bucket`; resolve every reported
+  failure before publishing.
 - Name a concrete surface to edit and an objective verification for
   every `ready` candidate; route anything else to `needs-decision` or
   ask instead of guessing (the under-clarification stop rule).

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -1071,6 +1071,44 @@ Binding rules:
 Backfill is opportunistic and follows the same claim-state precondition
 as the suitability footer.
 
+## Authoring-bucket marker
+
+Authored issues in the `needs-decision` or `blocked-by-human` readiness
+buckets (see [Readiness buckets](#readiness-buckets)) may also carry an
+**authoring-bucket marker** — a hidden, machine-readable record of which
+of those two axes applies, so `audit-authored-issue.mts` can mechanically
+enforce the matching label the same way it already enforces
+`status:blocked-by-human` for a suitability score of `1`
+(`checkSuitabilityBlockedByHuman`). `ready` and other buckets omit the
+marker entirely.
+
+```text
+<!-- {marker-prefix}-authoring-bucket: needs-decision|blocked-by-human -->
+```
+
+Binding rules:
+
+- **Two axes only.** Scoped to the two buckets with a real behavioral
+  consequence today (a required label) — `deferred` and `out-of-scope`
+  have none, so they carry no marker.
+- **Folds the existing suitability-1 check.** When present, this marker
+  decides `suitability-blocked-by-human`'s applicability instead of the
+  suitability score: `blocked-by-human` requires
+  `status:blocked-by-human` regardless of score; `needs-decision` means
+  that check does not apply, even at a suitability score of `1`. Absent
+  or malformed, `checkSuitabilityBlockedByHuman` falls back to the
+  pre-existing suitability-1-only rule — no backfill onto issues
+  published before this marker existed.
+- **Authoring marker, not operational marker.** Like
+  `autopilot-suitability`, it is body content and must never be added to
+  `OPERATIONAL_MARKERS` or subjected to F4 minimization.
+- **Fail-safe on absence.** A missing or malformed marker means "no
+  bucket": both mechanical checks fall back to their pre-existing
+  behavior.
+
+Backfill is opportunistic and follows the same claim-state precondition
+as the suitability footer.
+
 ## Authoring hold and release
 
 Issue authoring uses a two-stage contract: drafting and publishing

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -808,8 +808,9 @@ Before publishing a drafted `ready` **orphan, roadmap, or child** body
 (the shapes the linter supports), run the `audit-authored-issue`
 linter against it when a helper runtime is available. Before newly
 publishing a body into the **`needs-decision`** or **`blocked-by-human`**
-bucket instead, also run it, passing `--expect-bucket
-needs-decision|blocked-by-human`: without this, the two mechanical
+bucket instead, also run it, passing
+`--expect-bucket <needs-decision|blocked-by-human>` (choose the one
+matching value): without this, the two mechanical
 checks below that key off the `authoring-bucket` marker
 (see [Authoring-bucket marker](#authoring-bucket-marker)) never
 actually fire in practice, since a non-`ready` body is otherwise never
@@ -921,7 +922,7 @@ confirm the reference is a mere breadcrumb.
 node scripts/audit-authored-issue.mjs --shape <orphan|roadmap|child> \
   --marker-prefix <resolved-target-prefix> \
   --body-file <path-to-drafted-body> [--label <label>]... \
-  [--expect-bucket needs-decision|blocked-by-human]
+  [--expect-bucket <needs-decision|blocked-by-human>]
 ```
 
 Or, for npx/package-manager profiles, the equivalent

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -805,16 +805,31 @@ marginally-ready issue.
 ## Mechanical pre-publish gate
 
 Before publishing a drafted `ready` **orphan, roadmap, or child** body
-(the shapes the linter supports — not the non-ready buckets below,
-which are not audited by this gate), run the
-`audit-authored-issue` linter against it when a helper runtime is
-available. It mechanically re-checks a subset of the structural rules
-this contract states in prose — the autopilot-suitability marker's
+(the shapes the linter supports), run the `audit-authored-issue`
+linter against it when a helper runtime is available. Before newly
+publishing a body into the **`needs-decision`** or **`blocked-by-human`**
+bucket instead, also run it, passing `--expect-bucket
+needs-decision|blocked-by-human`: without this, the two mechanical
+checks below that key off the `authoring-bucket` marker
+(see [Authoring-bucket marker](#authoring-bucket-marker)) never
+actually fire in practice, since a non-`ready` body is otherwise never
+run through this gate at all — exactly the gap that let #2636/#2637
+publish without their required label (#2639 follow-up). `--expect-bucket`
+requires the matching marker to be present, failing when it is absent
+or disagrees; omit it for a `ready` publish or an edit to an
+already-published legacy body, where the marker stays optional and
+fail-safe on absence as documented in that section. `deferred` and
+`out-of-scope` bodies are not audited by this gate either way. It
+mechanically re-checks a subset of the structural rules this contract
+states in prose — the autopilot-suitability marker's
 exactly-one/coherent-value rule, the one-directional check that a
-suitability score of `1` carries the configured `blocked-by-human`
-label (it does not check the reverse: a non-`1` score paired with the
-label still passes), markerPrefix consistency across every authoring
-marker, the declared shape's required section headings, the
+suitability score of `1` (or an `authoring-bucket: blocked-by-human`
+marker, when present) carries the configured `blocked-by-human` label
+(it does not check the reverse: a non-`1` score paired with the label
+still passes), the equivalent one-directional check for
+`authoring-bucket: needs-decision` and the configured
+`needsDecisionLabelName` label, markerPrefix consistency across every
+authoring marker, the declared shape's required section headings, the
 roadmap-id/blocked-by dependency-marker rules, and visible/hidden line
 agreement for the suitability and effort footers — so a weak model does
 not have to hold every rule in its head at once while drafting.
@@ -905,7 +920,8 @@ confirm the reference is a mere breadcrumb.
 ```sh
 node scripts/audit-authored-issue.mjs --shape <orphan|roadmap|child> \
   --marker-prefix <resolved-target-prefix> \
-  --body-file <path-to-drafted-body> [--label <label>]...
+  --body-file <path-to-drafted-body> [--label <label>]... \
+  [--expect-bucket needs-decision|blocked-by-human]
 ```
 
 Or, for npx/package-manager profiles, the equivalent
@@ -1073,14 +1089,17 @@ as the suitability footer.
 
 ## Authoring-bucket marker
 
-Authored issues in the `needs-decision` or `blocked-by-human` readiness
-buckets (see [Readiness buckets](#readiness-buckets)) may also carry an
-**authoring-bucket marker** — a hidden, machine-readable record of which
-of those two axes applies, so `audit-authored-issue.mts` can mechanically
+A newly authored issue in the `needs-decision` or `blocked-by-human`
+readiness bucket (see [Readiness buckets](#readiness-buckets)) carries a
+hidden, machine-readable **authoring-bucket marker** recording which of
+those two axes applies, so `audit-authored-issue.mts` can mechanically
 enforce the matching label the same way it already enforces
 `status:blocked-by-human` for a suitability score of `1`
-(`checkSuitabilityBlockedByHuman`). `ready` and other buckets omit the
-marker entirely.
+(`checkSuitabilityBlockedByHuman`) — see
+[Mechanical pre-publish gate](#mechanical-pre-publish-gate)'s
+`--expect-bucket` flag for the enforcement path. `ready` and other
+buckets omit the marker entirely; so does a legacy body already
+published before this marker existed.
 
 ```text
 <!-- {marker-prefix}-authoring-bucket: needs-decision|blocked-by-human -->
@@ -1102,9 +1121,12 @@ Binding rules:
 - **Authoring marker, not operational marker.** Like
   `autopilot-suitability`, it is body content and must never be added to
   `OPERATIONAL_MARKERS` or subjected to F4 minimization.
-- **Fail-safe on absence.** A missing or malformed marker means "no
-  bucket": both mechanical checks fall back to their pre-existing
-  behavior.
+- **Fail-safe on absence, except when explicitly expected.** A missing
+  or malformed marker means "no bucket": both mechanical checks above
+  fall back to their pre-existing behavior. The gate's `--expect-bucket`
+  flag is the deliberate exception — passed only for a body newly
+  published into that bucket, it turns "no bucket" into a hard failure
+  instead (`authoring-bucket-marker-required`).
 
 Backfill is opportunistic and follows the same claim-state precondition
 as the suitability footer.

--- a/skills/issue-authoring/references/draft-patterns.md
+++ b/skills/issue-authoring/references/draft-patterns.md
@@ -100,10 +100,8 @@ Before you publish a ready issue, confirm:
 
 ## Mechanical pre-publish gate
 
-Before you publish a drafted **ready orphan, roadmap, or child** body
-(scoped to those ready shapes — non-ready buckets like
-`blocked-by-human` are not audited by this gate), run the
-`audit-authored-issue` linter against it when a helper runtime
+Before you publish a drafted **ready orphan, roadmap, or child** body,
+run the `audit-authored-issue` linter against it when a helper runtime
 is available. It mechanically catches shape and marker mistakes — a
 missing or duplicated autopilot-suitability footer, a wrong
 markerPrefix, a missing required heading for the declared shape, a
@@ -113,6 +111,23 @@ mask:
 ```sh
 node scripts/audit-authored-issue.mjs --shape orphan \
   --marker-prefix <resolved-target-prefix> --body-file draft.md
+```
+
+Before newly publishing a body into the `needs-decision` or
+`blocked-by-human` bucket instead, also run it, adding
+`--expect-bucket <needs-decision|blocked-by-human>` (choose the one
+matching value) — without it, the marker/label checks that key off
+`authoring-bucket` never fire, since a non-ready body is otherwise
+never run through this gate at all. Passing `--expect-bucket` also
+skips the ready-shape-only checks (the suitability footer and required
+headings) that a bucket body like `#431` below is never expected to
+carry:
+
+```sh
+node scripts/audit-authored-issue.mjs --shape orphan \
+  --marker-prefix <resolved-target-prefix> --body-file draft.md \
+  --expect-bucket needs-decision \
+  --label status:needs-decision
 ```
 
 **Always pass `--marker-prefix`** with the prefix resolved under

--- a/skills/issue-authoring/references/draft-patterns.md
+++ b/skills/issue-authoring/references/draft-patterns.md
@@ -423,6 +423,8 @@ secret in CI so automated tests can verify the signature check.
 ## Ready signal
 
 Close this issue after confirming the secret is available in CI.
+
+<!-- {marker-prefix}-authoring-bucket: blocked-by-human -->
 ```
 
 `#432` — autonomous execution issue (Blocked by #431):

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -49,7 +49,7 @@ import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mts';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
 
-// The four authoring-marker suffixes defined in the contract. Operational
+// The five authoring-marker suffixes defined in the contract. Operational
 // markers (claimed-by, review-watermark, ...) never take this
 // `{prefix}-{suffix}` shape, so they cannot collide with this scan.
 const AUTHORING_MARKER_SUFFIXES = [
@@ -57,7 +57,27 @@ const AUTHORING_MARKER_SUFFIXES = [
   'blocked-by',
   'autopilot-suitability',
   'effort',
+  'authoring-bucket',
 ] as const;
+
+/** The two axes `authoring-bucket` may declare (#2639). */
+type AuthoringBucketMarkerValue = 'needs-decision' | 'blocked-by-human';
+
+/**
+ * Detection shape for the authored
+ * `<!-- {prefix}-authoring-bucket: needs-decision|blocked-by-human -->`
+ * marker, mirroring {@link AutopilotSuitabilityMarkerDetection}'s shape:
+ * `present` is false only when no marker appears; `value` is the single
+ * coherent enum value or null (fail-safe = "no bucket") when the marker is
+ * absent, an unrecognized token, or repeated with disagreeing values;
+ * `malformed` is true when a marker is present but its value is not one of
+ * the two recognized tokens.
+ */
+interface AuthoringBucketMarkerDetection {
+  present: boolean;
+  value: AuthoringBucketMarkerValue | null;
+  malformed: boolean;
+}
 
 export type IssueShape = 'orphan' | 'roadmap' | 'child';
 
@@ -95,12 +115,18 @@ export interface AuditOptions {
   markerPrefix?: string;
   /**
    * Labels currently applied or proposed on the issue. Used only by the
-   * suitability=1 cross-field check, since label state is not part of the
-   * body text.
+   * suitability=1 / authoring-bucket cross-field checks, since label state
+   * is not part of the body text.
    */
   labels?: readonly string[];
   /** Defaults to `POLICY_DEFAULTS.labels.blockedByHumanLabelName`. */
   blockedByHumanLabelName?: string;
+  /**
+   * Defaults to `POLICY_DEFAULTS.labels.needsDecisionLabelName`. Checked
+   * against `labels` only when the body carries an `authoring-bucket:
+   * needs-decision` marker (#2639).
+   */
+  needsDecisionLabelName?: string;
   /**
    * The repository the drafted body belongs to, as `owner/repo` (matching
    * the `GITHUB_REPOSITORY` env var's own format). Used only by the
@@ -480,6 +506,11 @@ export function auditAuthoredIssue(
     options.blockedByHumanLabelName.length > 0
       ? options.blockedByHumanLabelName
       : POLICY_DEFAULTS.labels.blockedByHumanLabelName;
+  const needsDecisionLabelName =
+    typeof options.needsDecisionLabelName === 'string' &&
+    options.needsDecisionLabelName.length > 0
+      ? options.needsDecisionLabelName
+      : POLICY_DEFAULTS.labels.needsDecisionLabelName;
   const labels = (options.labels ?? []).map((label) =>
     String(label).trim().toLowerCase(),
   );
@@ -490,13 +521,20 @@ export function auditAuthoredIssue(
     markerPrefix,
     'autopilot-suitability',
   );
+  const authoringBucket = parseAuthoringBucketMarker(text, markerPrefix);
 
   const findings: AuditFinding[] = [
     checkSuitabilityMarker(suitabilityCount, suitability),
     checkSuitabilityBlockedByHuman(
       suitability,
+      authoringBucket,
       labels,
       blockedByHumanLabelName,
+    ),
+    checkAuthoringBucketNeedsDecision(
+      authoringBucket,
+      labels,
+      needsDecisionLabelName,
     ),
     checkMarkerPrefixConsistency(text, markerPrefix),
     checkRequiredHeadings(text, shape),
@@ -541,25 +579,118 @@ function checkSuitabilityMarker(
   return pass(id, name, `suitability score is ${suitability.value}`);
 }
 
+/**
+ * Suitability=1 implies `blockedByHumanLabelName` -- unless an
+ * `authoring-bucket` marker is present, in which case that marker's value
+ * decides applicability instead (#2639): `blocked-by-human` requires the
+ * label regardless of the suitability score; any other coherent value
+ * (currently only `needs-decision`) means this check does not apply, even
+ * at suitability 1. A malformed or absent marker (`value: null`) falls
+ * back to the pre-existing suitability-1-only rule, preserving behavior
+ * for every issue published before this marker existed.
+ */
 function checkSuitabilityBlockedByHuman(
   suitability: AutopilotSuitabilityMarkerDetection,
+  authoringBucket: AuthoringBucketMarkerDetection,
   labels: readonly string[],
   blockedByHumanLabelName: string,
 ): AuditFinding {
   const id = 'suitability-blocked-by-human';
-  const name = `Suitability score of 1 carries the ${blockedByHumanLabelName} label`;
-  if (suitability.value !== 1) {
-    return pass(id, name, 'not applicable: suitability score is not 1');
+  const name = `Suitability 1 (or an authoring-bucket: blocked-by-human marker) carries the ${blockedByHumanLabelName} label`;
+  const applies =
+    authoringBucket.value === 'blocked-by-human' ||
+    (authoringBucket.value === null && suitability.value === 1);
+  if (!applies) {
+    return pass(
+      id,
+      name,
+      'not applicable: neither the authoring-bucket marker nor a suitability score of 1 apply',
+    );
   }
   const target = blockedByHumanLabelName.trim().toLowerCase();
   if (labels.includes(target)) {
     return pass(id, name, `${blockedByHumanLabelName} label is present`);
   }
+  const reason =
+    authoringBucket.value === 'blocked-by-human'
+      ? `authoring-bucket marker reads blocked-by-human but the ${blockedByHumanLabelName} label was not provided`
+      : `suitability score is 1 but the ${blockedByHumanLabelName} label was not provided`;
+  return fail(id, name, reason);
+}
+
+/**
+ * `authoring-bucket: needs-decision` implies `needsDecisionLabelName`
+ * (#2639), mirroring {@link checkSuitabilityBlockedByHuman}'s
+ * `blocked-by-human` handling. Not applicable when the marker is absent,
+ * malformed, or reads `blocked-by-human` instead.
+ */
+function checkAuthoringBucketNeedsDecision(
+  authoringBucket: AuthoringBucketMarkerDetection,
+  labels: readonly string[],
+  needsDecisionLabelName: string,
+): AuditFinding {
+  const id = 'authoring-bucket-needs-decision';
+  const name = `authoring-bucket: needs-decision carries the ${needsDecisionLabelName} label`;
+  if (authoringBucket.value !== 'needs-decision') {
+    return pass(
+      id,
+      name,
+      'not applicable: authoring-bucket marker does not read needs-decision',
+    );
+  }
+  const target = needsDecisionLabelName.trim().toLowerCase();
+  if (labels.includes(target)) {
+    return pass(id, name, `${needsDecisionLabelName} label is present`);
+  }
   return fail(
     id,
     name,
-    `suitability score is 1 but the ${blockedByHumanLabelName} label was not provided`,
+    `authoring-bucket marker reads needs-decision but the ${needsDecisionLabelName} label was not provided`,
   );
+}
+
+/**
+ * Canonical parser for the authored
+ * `<!-- {prefix}-authoring-bucket: needs-decision|blocked-by-human -->`
+ * marker, mirroring {@link parseAutopilotSuitabilityMarker}'s fail-safe
+ * shape and repeated/disagreeing-value handling. `text` must already be
+ * {@link stripMarkdownCodeRegions}-masked (every caller in this file
+ * passes the shared `text`, not `rawText`), so a marker merely quoted in
+ * prose cannot be mistaken for a real one.
+ */
+function parseAuthoringBucketMarker(
+  text: string,
+  markerPrefix: string,
+): AuthoringBucketMarkerDetection {
+  const regex = new RegExp(
+    `<!--\\s*${escapeRegex(markerPrefix)}-authoring-bucket:\\s*([^\\s>]+)\\s*-->`,
+    'gi',
+  );
+  let present = false;
+  let value: AuthoringBucketMarkerValue | null = null;
+  let match = regex.exec(text);
+  while (match) {
+    present = true;
+    const raw = match[1];
+    const parsed = isAuthoringBucketValue(raw) ? raw : null;
+    // Fail-safe: any invalid token, or a value disagreeing with an
+    // earlier coherent one, yields no bucket.
+    if (parsed === null || (value !== null && parsed !== value)) {
+      return { present: true, value: null, malformed: true };
+    }
+    value = parsed;
+    match = regex.exec(text);
+  }
+  if (!present) {
+    return { present: false, value: null, malformed: false };
+  }
+  return { present: true, value, malformed: false };
+}
+
+function isAuthoringBucketValue(
+  value: string,
+): value is AuthoringBucketMarkerValue {
+  return value === 'needs-decision' || value === 'blocked-by-human';
 }
 
 function checkMarkerPrefixConsistency(
@@ -1728,6 +1859,7 @@ function main(): void {
     markerPrefix,
     labels: args.labels,
     blockedByHumanLabelName: policy.blockedByHumanLabelName,
+    needsDecisionLabelName: policy.needsDecisionLabelName,
     authoringLabelName: policy.authoringLabelName,
     currentRepo,
     issueNumber:
@@ -1764,6 +1896,7 @@ function isIssueShape(value: string): value is IssueShape {
 function loadPolicy(configPath?: string): {
   markerPrefix: string;
   blockedByHumanLabelName: string;
+  needsDecisionLabelName: string;
   authoringLabelName: string;
 } {
   // Default path: reuse the shared loadIddConfig() (idd-config.mts) rather
@@ -1802,6 +1935,7 @@ function loadPolicy(configPath?: string): {
     return {
       markerPrefix: DEFAULT_MARKER_PREFIX,
       blockedByHumanLabelName: POLICY_DEFAULTS.labels.blockedByHumanLabelName,
+      needsDecisionLabelName: POLICY_DEFAULTS.labels.needsDecisionLabelName,
       authoringLabelName: POLICY_DEFAULTS.issueAuthoring.authoringLabelName,
     };
   }
@@ -1811,6 +1945,8 @@ function loadPolicy(configPath?: string): {
     ),
     blockedByHumanLabelName:
       normalizePolicyConfig(config).labels.blockedByHumanLabelName,
+    needsDecisionLabelName:
+      normalizePolicyConfig(config).labels.needsDecisionLabelName,
     authoringLabelName:
       normalizePolicyConfig(config).issueAuthoring.authoringLabelName,
   };

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -81,9 +81,9 @@ export type AuthoringBucketMarkerValue = 'needs-decision' | 'blocked-by-human';
  * `present` is false only when no marker appears; `value` is the single
  * coherent enum value or null (fail-safe = "no bucket") when the marker is
  * absent, an unrecognized token, or repeated with disagreeing values;
- * `malformed` is true when a marker is present but either its value is not
- * one of the two recognized tokens, or it is repeated with a disagreeing
- * value.
+ * `malformed` is true when a marker is present but its value is not one of
+ * the two recognized tokens (including a value-less marker with no token
+ * at all), or it is repeated with a disagreeing value.
  */
 interface AuthoringBucketMarkerDetection {
   present: boolean;
@@ -745,20 +745,40 @@ function checkAuthoringBucketMarkerRequired(
  * {@link stripMarkdownCodeRegions}-masked (every caller in this file
  * passes the shared `text`, not `rawText`), so a marker merely quoted in
  * prose cannot be mistaken for a real one.
+ *
+ * Uses the same rawCount-vs-coherent-count gap {@link
+ * checkEffortVisibleLineAgreement} closes for the `effort` marker: the
+ * value-capturing regex below requires a non-empty token
+ * (`[^\s>]+`), so a value-less marker like
+ * `<!-- {prefix}-authoring-bucket: -->` would otherwise never match it
+ * at all and read as `present: false` — indistinguishable from no
+ * marker, which would also make {@link checkAuthoringBucketMarkerRequired}
+ * misreport a present-but-invalid marker as "none was found" (#2648
+ * review, Copilot). `countMarkerOccurrences`'s detection-only regex
+ * matches regardless of value, so comparing the two counts recovers the
+ * distinction.
  */
 function parseAuthoringBucketMarker(
   text: string,
   markerPrefix: string,
 ): AuthoringBucketMarkerDetection {
+  const rawCount = countMarkerOccurrences(
+    text,
+    markerPrefix,
+    'authoring-bucket',
+  );
+  if (rawCount === 0) {
+    return { present: false, value: null, malformed: false };
+  }
   const regex = new RegExp(
     `<!--\\s*${escapeRegex(markerPrefix)}-authoring-bucket:\\s*([^\\s>]+)\\s*-->`,
     'gi',
   );
-  let present = false;
+  let coherentCount = 0;
   let value: AuthoringBucketMarkerValue | null = null;
   let match = regex.exec(text);
   while (match) {
-    present = true;
+    coherentCount += 1;
     const raw = match[1];
     const parsed = isAuthoringBucketValue(raw) ? raw : null;
     // Fail-safe: any invalid token, or a value disagreeing with an
@@ -769,8 +789,11 @@ function parseAuthoringBucketMarker(
     value = parsed;
     match = regex.exec(text);
   }
-  if (!present) {
-    return { present: false, value: null, malformed: false };
+  if (coherentCount !== rawCount) {
+    // At least one occurrence matched the raw (any-value) scan but not
+    // the value-capturing one -- a value-less or otherwise malformed-shape
+    // marker.
+    return { present: true, value: null, malformed: true };
   }
   return { present: true, value, malformed: false };
 }

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -61,7 +61,7 @@ const AUTHORING_MARKER_SUFFIXES = [
 ] as const;
 
 /** The two axes `authoring-bucket` may declare (#2639). */
-type AuthoringBucketMarkerValue = 'needs-decision' | 'blocked-by-human';
+export type AuthoringBucketMarkerValue = 'needs-decision' | 'blocked-by-human';
 
 /**
  * Detection shape for the authored
@@ -70,8 +70,9 @@ type AuthoringBucketMarkerValue = 'needs-decision' | 'blocked-by-human';
  * `present` is false only when no marker appears; `value` is the single
  * coherent enum value or null (fail-safe = "no bucket") when the marker is
  * absent, an unrecognized token, or repeated with disagreeing values;
- * `malformed` is true when a marker is present but its value is not one of
- * the two recognized tokens.
+ * `malformed` is true when a marker is present but either its value is not
+ * one of the two recognized tokens, or it is repeated with a disagreeing
+ * value.
  */
 interface AuthoringBucketMarkerDetection {
   present: boolean;
@@ -127,6 +128,18 @@ export interface AuditOptions {
    * needs-decision` marker (#2639).
    */
   needsDecisionLabelName?: string;
+  /**
+   * Set only when auditing a body being newly published into the
+   * `needs-decision` or `blocked-by-human` bucket (never for the `ready`
+   * shapes this linter otherwise audits) — requires the matching
+   * `authoring-bucket` marker to be present, failing otherwise instead of
+   * treating absence as fail-safe "not applicable" (#2639 follow-up:
+   * without this, a needs-decision/blocked-by-human body is never run
+   * through this linter at all under the Mechanical pre-publish gate's
+   * ready-only scope, so the marker/label checks above never actually
+   * fire in practice). Omit for a `ready` publish or a legacy body.
+   */
+  expectedAuthoringBucket?: AuthoringBucketMarkerValue;
   /**
    * The repository the drafted body belongs to, as `owner/repo` (matching
    * the `GITHUB_REPOSITORY` env var's own format). Used only by the
@@ -449,6 +462,7 @@ const AUDIT_AUTHORED_ISSUE_FLAG_SPEC = {
   '--current-repo': { type: 'string' },
   '--issue': { type: 'string' },
   '--label': { type: 'string', multiple: true },
+  '--expect-bucket': { type: 'string' },
   '--comments-file': { type: 'string' },
   '--journal-comments-file': { type: 'string' },
   '--new-issue': { type: 'boolean', default: false },
@@ -535,6 +549,10 @@ export function auditAuthoredIssue(
       authoringBucket,
       labels,
       needsDecisionLabelName,
+    ),
+    checkAuthoringBucketMarkerRequired(
+      authoringBucket,
+      options.expectedAuthoringBucket,
     ),
     checkMarkerPrefixConsistency(text, markerPrefix),
     checkRequiredHeadings(text, shape),
@@ -646,6 +664,53 @@ function checkAuthoringBucketNeedsDecision(
     id,
     name,
     `authoring-bucket marker reads needs-decision but the ${needsDecisionLabelName} label was not provided`,
+  );
+}
+
+/**
+ * Requires the `authoring-bucket` marker to actually be present and match
+ * `expectedBucket`, when the caller declares one (#2639 follow-up). The two
+ * checks above only validate the marker/label pair *when a marker already
+ * exists*; without this check, a body that omits the marker entirely -- the
+ * exact gap #2636/#2637 hit -- silently reads as "not applicable" from both,
+ * since a `ready`-shape publish is the only case the Mechanical pre-publish
+ * gate otherwise audits. `expectedBucket` must be supplied by the caller
+ * when (and only when) auditing a body about to be newly published into the
+ * `needs-decision` or `blocked-by-human` bucket; a `ready` publish, or an
+ * already-published legacy body, passes `undefined` and this check no-ops.
+ */
+function checkAuthoringBucketMarkerRequired(
+  authoringBucket: AuthoringBucketMarkerDetection,
+  expectedBucket: AuthoringBucketMarkerValue | undefined,
+): AuditFinding {
+  const id = 'authoring-bucket-marker-required';
+  const name =
+    'A newly published needs-decision/blocked-by-human body carries the matching authoring-bucket marker';
+  if (expectedBucket === undefined) {
+    return pass(
+      id,
+      name,
+      'not applicable: no expected bucket declared for this audit (ready publish, or a legacy body)',
+    );
+  }
+  if (authoringBucket.value === expectedBucket) {
+    return pass(
+      id,
+      name,
+      `authoring-bucket marker matches the declared ${expectedBucket} bucket`,
+    );
+  }
+  if (authoringBucket.value === null) {
+    return fail(
+      id,
+      name,
+      `expected an authoring-bucket: ${expectedBucket} marker for a newly published ${expectedBucket} body, but none was found`,
+    );
+  }
+  return fail(
+    id,
+    name,
+    `expected an authoring-bucket: ${expectedBucket} marker, but found authoring-bucket: ${authoringBucket.value} instead`,
   );
 }
 
@@ -1744,6 +1809,7 @@ interface CliArgs {
   markerPrefix?: string;
   configPath?: string;
   labels: string[];
+  expectBucket?: string;
   format: string;
   currentRepo?: string;
   issue?: string;
@@ -1809,6 +1875,12 @@ function main(): void {
   if (args.issue !== undefined && !/^[1-9]\d*$/.test(args.issue)) {
     fail_('--issue must be a positive integer');
   }
+  if (
+    args.expectBucket !== undefined &&
+    !isAuthoringBucketValue(args.expectBucket)
+  ) {
+    fail_('--expect-bucket must be needs-decision or blocked-by-human');
+  }
   if (args.journalCommentsFile && !args.newIssue) {
     fail_('--journal-comments-file requires --new-issue');
   }
@@ -1860,6 +1932,9 @@ function main(): void {
     labels: args.labels,
     blockedByHumanLabelName: policy.blockedByHumanLabelName,
     needsDecisionLabelName: policy.needsDecisionLabelName,
+    expectedAuthoringBucket: args.expectBucket as
+      | AuthoringBucketMarkerValue
+      | undefined,
     authoringLabelName: policy.authoringLabelName,
     currentRepo,
     issueNumber:
@@ -2003,6 +2078,7 @@ function parseArgs(argv: string[]): CliArgs {
     currentRepo: values['current-repo'] as string | undefined,
     issue: values.issue as string | undefined,
     labels: (values.label as string[] | undefined) ?? [],
+    expectBucket: values['expect-bucket'] as string | undefined,
     commentsFile: values['comments-file'] as string | undefined,
     journalCommentsFile: values['journal-comments-file'] as string | undefined,
     newIssue: values['new-issue'] as boolean,
@@ -2034,9 +2110,15 @@ Options:
   --marker-prefix <prefix>         override the resolved markerPrefix
   --config <path>                  policy config path (default: .github/idd/config.json)
   --label <name>                   a label currently applied/proposed on the issue
-                                    (repeatable; used for the suitability=1
-                                    cross-field check and the authoring-label
-                                    check for authoring-owner-marker-trail)
+                                    (repeatable; used for the suitability=1 /
+                                    authoring-bucket cross-field checks and the
+                                    authoring-label check for
+                                    authoring-owner-marker-trail)
+  --expect-bucket <bucket>         needs-decision or blocked-by-human; set only when
+                                    auditing a body about to be newly published into
+                                    that bucket -- requires the matching
+                                    authoring-bucket marker to be present (omit for a
+                                    ready publish or a legacy body)
   --current-repo <owner/repo>      this repository, for the prose-dependency check
                                     to recognize a full-URL issue/PR reference as
                                     cross-repo (default: $GITHUB_REPOSITORY), and

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -49,6 +49,17 @@ import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mts';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
 
+// Shared "skip" detail for every ready-shape-only check when
+// `--expect-bucket` is set (#2648 review, Codex): a needs-decision/
+// blocked-by-human body uses its own distinct heading/footer shape
+// (see skills/issue-authoring/references/draft-patterns.md's
+// blocked-by-human example), not the ready orphan/roadmap/child shapes
+// these checks validate, so running them against a bucket audit would
+// fail a correctly-formed bucket body instead of reading as
+// not-applicable.
+const NOT_APPLICABLE_BUCKET_AUDIT_DETAIL =
+  'not applicable: auditing a needs-decision/blocked-by-human bucket publish (--expect-bucket), not a ready-shape body';
+
 // The five authoring-marker suffixes defined in the contract. Operational
 // markers (claimed-by, review-watermark, ...) never take this
 // `{prefix}-{suffix}` shape, so they cannot collide with this scan.
@@ -536,9 +547,10 @@ export function auditAuthoredIssue(
     'autopilot-suitability',
   );
   const authoringBucket = parseAuthoringBucketMarker(text, markerPrefix);
+  const isBucketAudit = options.expectedAuthoringBucket !== undefined;
 
   const findings: AuditFinding[] = [
-    checkSuitabilityMarker(suitabilityCount, suitability),
+    checkSuitabilityMarker(suitabilityCount, suitability, isBucketAudit),
     checkSuitabilityBlockedByHuman(
       suitability,
       authoringBucket,
@@ -555,7 +567,7 @@ export function auditAuthoredIssue(
       options.expectedAuthoringBucket,
     ),
     checkMarkerPrefixConsistency(text, markerPrefix),
-    checkRequiredHeadings(text, shape),
+    checkRequiredHeadings(text, shape, isBucketAudit),
     checkDependencyMarkerRule(text, markerPrefix, shape),
     checkSuitabilityVisibleLineAgreement(text, markerPrefix, suitability),
     checkEffortVisibleLineAgreement(text, markerPrefix),
@@ -574,9 +586,13 @@ export function auditAuthoredIssue(
 function checkSuitabilityMarker(
   count: number,
   suitability: AutopilotSuitabilityMarkerDetection,
+  isBucketAudit: boolean,
 ): AuditFinding {
   const id = 'suitability-marker';
   const name = 'Exactly one coherent autopilot-suitability marker (1-5)';
+  if (isBucketAudit) {
+    return pass(id, name, NOT_APPLICABLE_BUCKET_AUDIT_DETAIL);
+  }
   if (count === 0) {
     return fail(id, name, 'missing autopilot-suitability marker');
   }
@@ -700,11 +716,18 @@ function checkAuthoringBucketMarkerRequired(
       `authoring-bucket marker matches the declared ${expectedBucket} bucket`,
     );
   }
-  if (authoringBucket.value === null) {
+  if (!authoringBucket.present) {
     return fail(
       id,
       name,
       `expected an authoring-bucket: ${expectedBucket} marker for a newly published ${expectedBucket} body, but none was found`,
+    );
+  }
+  if (authoringBucket.malformed) {
+    return fail(
+      id,
+      name,
+      `expected an authoring-bucket: ${expectedBucket} marker, but the marker present is malformed (an unrecognized value, or repeated with disagreeing values)`,
     );
   }
   return fail(
@@ -797,9 +820,16 @@ function checkMarkerPrefixConsistency(
   return pass(id, name, 'all authoring markers use the resolved markerPrefix');
 }
 
-function checkRequiredHeadings(text: string, shape: IssueShape): AuditFinding {
+function checkRequiredHeadings(
+  text: string,
+  shape: IssueShape,
+  isBucketAudit: boolean,
+): AuditFinding {
   const id = 'required-headings';
   const name = `Required section headings present for the ${shape} shape`;
+  if (isBucketAudit) {
+    return pass(id, name, NOT_APPLICABLE_BUCKET_AUDIT_DETAIL);
+  }
   const headings = extractHeadings(text);
   const missing = SHAPE_HEADING_REQUIREMENTS[shape].filter(
     (requirement) =>

--- a/tests/audit-authored-issue.test.mts
+++ b/tests/audit-authored-issue.test.mts
@@ -184,6 +184,80 @@ test('suitability-blocked-by-human is not applicable for scores other than 1', (
   assert.equal(findingResult(report, 'suitability-blocked-by-human'), 'pass');
 });
 
+// --- authoring-bucket: needs-decision | blocked-by-human (#2639) ---
+
+function withAuthoringBucket(body: string, value: string): string {
+  return `${body}\n\n<!-- idd-skill-authoring-bucket: ${value} -->`;
+}
+
+test('authoring-bucket-needs-decision fails when the marker reads needs-decision without the label', () => {
+  const body = withAuthoringBucket(orphanBody({ score: 4 }), 'needs-decision');
+  const report = auditAuthoredIssue(body, { shape: 'orphan', labels: [] });
+  assert.equal(
+    findingResult(report, 'authoring-bucket-needs-decision'),
+    'fail',
+  );
+});
+
+test('authoring-bucket-needs-decision passes when the marker reads needs-decision with the label present', () => {
+  const body = withAuthoringBucket(orphanBody({ score: 4 }), 'needs-decision');
+  const report = auditAuthoredIssue(body, {
+    shape: 'orphan',
+    labels: ['status:needs-decision'],
+  });
+  assert.equal(
+    findingResult(report, 'authoring-bucket-needs-decision'),
+    'pass',
+  );
+});
+
+test('authoring-bucket-needs-decision is not applicable when no marker is present (no regression)', () => {
+  const report = auditAuthoredIssue(orphanBody({ score: 4 }), {
+    shape: 'orphan',
+    labels: [],
+  });
+  assert.equal(
+    findingResult(report, 'authoring-bucket-needs-decision'),
+    'pass',
+  );
+});
+
+test('suitability-blocked-by-human fails when the marker reads blocked-by-human without the label, even at a non-1 score (existing behavior extended)', () => {
+  const body = withAuthoringBucket(
+    orphanBody({ score: 4 }),
+    'blocked-by-human',
+  );
+  const report = auditAuthoredIssue(body, { shape: 'orphan', labels: [] });
+  assert.equal(findingResult(report, 'suitability-blocked-by-human'), 'fail');
+});
+
+test('suitability-blocked-by-human passes when the marker reads blocked-by-human with the label present', () => {
+  const body = withAuthoringBucket(
+    orphanBody({ score: 4 }),
+    'blocked-by-human',
+  );
+  const report = auditAuthoredIssue(body, {
+    shape: 'orphan',
+    labels: ['status:blocked-by-human'],
+  });
+  assert.equal(findingResult(report, 'suitability-blocked-by-human'), 'pass');
+});
+
+test('suitability-blocked-by-human is not applicable when the marker reads needs-decision, even at score 1 (marker takes precedence over the fallback)', () => {
+  const body = withAuthoringBucket(
+    orphanBody({ score: 1, includeEffort: false }),
+    'needs-decision',
+  );
+  const report = auditAuthoredIssue(body, { shape: 'orphan', labels: [] });
+  assert.equal(findingResult(report, 'suitability-blocked-by-human'), 'pass');
+});
+
+test('suitability-blocked-by-human still falls back to the suitability-1 rule when no marker is present (no regression)', () => {
+  const body = orphanBody({ score: 1, includeEffort: false });
+  const report = auditAuthoredIssue(body, { shape: 'orphan', labels: [] });
+  assert.equal(findingResult(report, 'suitability-blocked-by-human'), 'fail');
+});
+
 // --- marker-prefix-consistency ---
 
 test('marker-prefix-consistency fails when a marker uses the wrong prefix', () => {

--- a/tests/audit-authored-issue.test.mts
+++ b/tests/audit-authored-issue.test.mts
@@ -335,8 +335,7 @@ test('authoring-bucket-marker-required fails when the marker disagrees with the 
 });
 
 test('authoring-bucket-marker-required distinguishes a missing marker from a malformed one in its detail', () => {
-  const missingBody =
-    '## Background\n\nContext.\n\n<!-- idd-skill-authoring-bucket-does-not-exist -->';
+  const missingBody = '## Background\n\nContext.\n\nNo marker at all here.';
   const missing = auditAuthoredIssue(missingBody, {
     shape: 'orphan',
     labels: [],
@@ -357,6 +356,20 @@ test('authoring-bucket-marker-required distinguishes a missing marker from a mal
     (entry) => entry.id === 'authoring-bucket-marker-required',
   );
   assert.match(malformedFinding?.detail ?? '', /malformed/);
+});
+
+test('a value-less authoring-bucket marker is treated as malformed, not missing (#2648 review, Copilot)', () => {
+  const body = `${orphanBody({ score: 4 })}\n\n<!-- idd-skill-authoring-bucket: -->`;
+  const report = auditAuthoredIssue(body, {
+    shape: 'orphan',
+    labels: [],
+    expectedAuthoringBucket: 'needs-decision',
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-bucket-marker-required',
+  );
+  assert.equal(finding?.result, 'fail');
+  assert.match(finding?.detail ?? '', /malformed/);
 });
 
 // --- bucket audits (--expect-bucket) skip the ready-shape-only checks (#2648 review, Codex) ---

--- a/tests/audit-authored-issue.test.mts
+++ b/tests/audit-authored-issue.test.mts
@@ -334,6 +334,60 @@ test('authoring-bucket-marker-required fails when the marker disagrees with the 
   );
 });
 
+test('authoring-bucket-marker-required distinguishes a missing marker from a malformed one in its detail', () => {
+  const missingBody =
+    '## Background\n\nContext.\n\n<!-- idd-skill-authoring-bucket-does-not-exist -->';
+  const missing = auditAuthoredIssue(missingBody, {
+    shape: 'orphan',
+    labels: [],
+    expectedAuthoringBucket: 'needs-decision',
+  });
+  const missingFinding = missing.findings.find(
+    (entry) => entry.id === 'authoring-bucket-marker-required',
+  );
+  assert.match(missingFinding?.detail ?? '', /none was found/);
+
+  const malformedBody = withAuthoringBucket(orphanBody({ score: 4 }), 'nope');
+  const malformed = auditAuthoredIssue(malformedBody, {
+    shape: 'orphan',
+    labels: [],
+    expectedAuthoringBucket: 'needs-decision',
+  });
+  const malformedFinding = malformed.findings.find(
+    (entry) => entry.id === 'authoring-bucket-marker-required',
+  );
+  assert.match(malformedFinding?.detail ?? '', /malformed/);
+});
+
+// --- bucket audits (--expect-bucket) skip the ready-shape-only checks (#2648 review, Codex) ---
+
+test('suitability-marker is not applicable during a bucket audit, even with no suitability footer at all', () => {
+  const body = withAuthoringBucket(
+    '## Background\n\nContext for the decision.\n\n## Required action\n\nDecide the thing.',
+    'needs-decision',
+  );
+  const report = auditAuthoredIssue(body, {
+    shape: 'orphan',
+    labels: ['status:needs-decision'],
+    expectedAuthoringBucket: 'needs-decision',
+  });
+  assert.equal(findingResult(report, 'suitability-marker'), 'pass');
+});
+
+test('required-headings is not applicable during a bucket audit, even with a non-ready-shape heading set', () => {
+  const body = withAuthoringBucket(
+    '## Background\n\nContext for the decision.\n\n## Required action\n\nDecide the thing.\n\n## Ready signal\n\nClose once decided.',
+    'blocked-by-human',
+  );
+  const report = auditAuthoredIssue(body, {
+    shape: 'orphan',
+    labels: ['status:blocked-by-human'],
+    expectedAuthoringBucket: 'blocked-by-human',
+  });
+  assert.equal(report.passed, true);
+  assert.equal(findingResult(report, 'required-headings'), 'pass');
+});
+
 // --- marker-prefix-consistency ---
 
 test('marker-prefix-consistency fails when a marker uses the wrong prefix', () => {

--- a/tests/audit-authored-issue.test.mts
+++ b/tests/audit-authored-issue.test.mts
@@ -258,6 +258,82 @@ test('suitability-blocked-by-human still falls back to the suitability-1 rule wh
   assert.equal(findingResult(report, 'suitability-blocked-by-human'), 'fail');
 });
 
+test('a malformed authoring-bucket marker (unrecognized token) is treated as no bucket, not a hard failure', () => {
+  const body = withAuthoringBucket(orphanBody({ score: 4 }), 'wrong-token');
+  const report = auditAuthoredIssue(body, { shape: 'orphan', labels: [] });
+  assert.equal(
+    findingResult(report, 'authoring-bucket-needs-decision'),
+    'pass',
+  );
+  assert.equal(findingResult(report, 'suitability-blocked-by-human'), 'pass');
+});
+
+test('repeated authoring-bucket markers with disagreeing values are treated as no bucket, not a hard failure', () => {
+  const body = `${withAuthoringBucket(orphanBody({ score: 1, includeEffort: false }), 'needs-decision')}\n\n<!-- idd-skill-authoring-bucket: blocked-by-human -->`;
+  const report = auditAuthoredIssue(body, { shape: 'orphan', labels: [] });
+  // Disagreeing markers fail-safe to "no bucket", so the suitability-1
+  // fallback rule re-applies (score is 1 and no label was provided).
+  assert.equal(findingResult(report, 'suitability-blocked-by-human'), 'fail');
+  assert.equal(
+    findingResult(report, 'authoring-bucket-needs-decision'),
+    'pass',
+  );
+});
+
+// --- authoring-bucket-marker-required: --expect-bucket enforcement (#2639 follow-up) ---
+
+test('authoring-bucket-marker-required is not applicable when no bucket is expected (ready publish or legacy body)', () => {
+  const report = auditAuthoredIssue(orphanBody({ score: 4 }), {
+    shape: 'orphan',
+    labels: [],
+  });
+  assert.equal(
+    findingResult(report, 'authoring-bucket-marker-required'),
+    'pass',
+  );
+});
+
+test('authoring-bucket-marker-required fails when a needs-decision bucket is expected but no marker is present', () => {
+  const report = auditAuthoredIssue(orphanBody({ score: 4 }), {
+    shape: 'orphan',
+    labels: [],
+    expectedAuthoringBucket: 'needs-decision',
+  });
+  assert.equal(
+    findingResult(report, 'authoring-bucket-marker-required'),
+    'fail',
+  );
+});
+
+test('authoring-bucket-marker-required passes when the expected bucket marker matches', () => {
+  const body = withAuthoringBucket(orphanBody({ score: 4 }), 'needs-decision');
+  const report = auditAuthoredIssue(body, {
+    shape: 'orphan',
+    labels: ['status:needs-decision'],
+    expectedAuthoringBucket: 'needs-decision',
+  });
+  assert.equal(
+    findingResult(report, 'authoring-bucket-marker-required'),
+    'pass',
+  );
+});
+
+test('authoring-bucket-marker-required fails when the marker disagrees with the expected bucket', () => {
+  const body = withAuthoringBucket(
+    orphanBody({ score: 4 }),
+    'blocked-by-human',
+  );
+  const report = auditAuthoredIssue(body, {
+    shape: 'orphan',
+    labels: ['status:blocked-by-human'],
+    expectedAuthoringBucket: 'needs-decision',
+  });
+  assert.equal(
+    findingResult(report, 'authoring-bucket-marker-required'),
+    'fail',
+  );
+});
+
 // --- marker-prefix-consistency ---
 
 test('marker-prefix-consistency fails when a marker uses the wrong prefix', () => {


### PR DESCRIPTION
# Summary

`audit-authored-issue.mts` already mechanically enforces
`status:blocked-by-human` for a suitability score of 1
(`checkSuitabilityBlockedByHuman`), but had no equivalent check for
`needsDecisionLabelName` -- despite that policy key already being a
first-class, shared value (`discover-orphan-filter.mts` already reads
and filters on it identically). #2636 and #2637 were both published
without `status:needs-decision` and without any body-level marker,
requiring a later pass to manually re-derive "this is
needs-decision-shaped" by reading the full body.

Adds a dedicated
`<!-- {markerPrefix}-authoring-bucket: needs-decision|blocked-by-human -->`
footer marker, scoped to only the two axes that currently have real
behavioral consequences (folding `blocked-by-human`'s existing
suitability-1 binding into the same marker). `checkSuitabilityBlockedByHuman`
now keys off this marker when present, falling back to the pre-existing
suitability-1-only rule when it is absent -- no backfill onto issues
published before this marker existed. A new
`checkAuthoringBucketNeedsDecision` mirrors it for `needs-decision`.

Documents the marker in `skills/issue-authoring/references/contract.md`
(canonical source, regenerated mirror included) and
`docs/issue-authoring-skill.md`'s summary section.

## Linked issue

Closes #2642

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

The maintainer decision (#2639, Groom hearing, 2026-09-05) chose this
narrow two-axis marker over a full five-bucket marker or free-text/
prose-only detection, mirroring the existing, working
`checkSuitabilityBlockedByHuman` precedent exactly.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`biome check`, `dprint check`, `markdownlint-cli2`, `cspell` all pass)
- [x] `pnpm test` (5,147/5,147 passing, including 7 new test cases)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (`node scripts/sync-docs.mjs --check`)
- [x] `node scripts/idd-doctor.mjs` (passed; 3 pre-existing unrelated warnings)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none -- helper/doc-only change)
- [x] Context budget impact reviewed (`skills/issue-authoring/references/contract.md`
      is not byte-budget-gated by `instructionSizeBudgets`/`bundleBudgets`;
      `bundle-review` stays unchanged at 97.98%)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authoring-bucket validation for newly published “needs-decision” and “blocked-by-human” issues.
  * Added support for the `--expect-bucket` option to enforce matching markers and labels.
  * Documented marker behavior, fallback handling, and publishing requirements.

* **Tests**
  * Added coverage for valid, missing, malformed, conflicting, and unexpected bucket markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->