### PR TITLE
fix(advisory-convergence-comment): debounce rerun --apply calls

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@
 # migration so hand-written .mjs are never mis-marked; see
 # docs/typescript-sources.md.
 scripts/actions-usage-report.mjs linguist-generated=true
+scripts/advisory-comment-debounce.mjs linguist-generated=true
 scripts/advisory-convergence.mjs linguist-generated=true
 scripts/advisory-wait-policy.mjs linguist-generated=true
 scripts/advisory-wait-state.mjs linguist-generated=true

--- a/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/.github/workflows/idd-advisory-convergence-comment.yml
@@ -112,9 +112,17 @@ jobs:
           # step below.
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           # Both pull_request_review_comment and issue_comment carry the
-          # triggering comment's own timestamp at github.event.comment
-          # (matching COMMENT_BODY above).
-          TRIGGERED_AT: ${{ github.event.comment.created_at }}
+          # triggering comment's own timestamps at github.event.comment
+          # (matching COMMENT_BODY above). Prefer updated_at:
+          # pull_request_review_comment also fires on edited/deleted
+          # (see on: above), and created_at would then still name the
+          # comment's original post time, not this edit -- making every
+          # comment posted between the original post and the edit look
+          # "newer than the trigger" and wrongly skip this run.
+          # updated_at equals created_at for a never-edited comment, so
+          # this is safe for the created-event case too (#2650 review,
+          # Copilot).
+          TRIGGERED_AT: ${{ github.event.comment.updated_at || github.event.comment.created_at }}
         run: node scripts/advisory-comment-debounce.mjs --pr "$PR_NUMBER" --triggered-at "$TRIGGERED_AT"
       - name: Rerun required HEAD check
         if: steps.origin.outputs.idd_originated == 'true' && steps.debounce.outputs.skip != 'true'

--- a/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/.github/workflows/idd-advisory-convergence-comment.yml
@@ -21,6 +21,30 @@
 # present when the commented-on issue is a PR).
 #
 # Job id is deliberately NOT `idd-advisory-convergence`.
+#
+# Debounce (#1381, #2023, #2638): a burst of IDD-originated comments (30
+# in ~15 min on PR #2628) fired `rerun-advisory-convergence.mjs --apply`
+# once per comment, exhausting every same-HEAD instance's one-time rerun
+# budget mid-burst. The "Check for newer qualifying event" step below
+# waits a short quiet window, then re-queries whether a newer
+# IDD-originated comment/review has since landed on the same PR; if so,
+# this run skips its own `--apply` call and leaves it to the
+# later-triggered run (which asks the same question in turn). This is a
+# job-body-level check -- it does not alter `cancel-in-progress: false`
+# below, which stays exactly as #2136 established it. (Note on that
+# setting's actual scope, corrected from an earlier draft of this
+# comment: it protects only the currently in-progress run in this
+# group from cancellation; a merely *pending*, not-yet-started run is
+# still cancelled and replaced by the newest pending run when another
+# is queued behind it, since no `queue:` key is set here -- the
+# debounce below exists for the case where a run has already started
+# and must itself decide whether a newer event supersedes it, which
+# that pending-run replacement does not cover.) If the debounce step's
+# own `gh api` calls fail, the step fails and GitHub Actions' default
+# sequential-failure behavior skips "Rerun required HEAD check"
+# entirely for that run -- safe, since this is a non-required companion
+# refresh, and a later qualifying event (or the required check's own
+# polling) will trigger a fresh attempt.
 concurrency:
   # Do not cancel: a later human LGTM must not abort an in-flight
   # IDD-originated refresh before it reruns the required check (#2136).
@@ -78,8 +102,22 @@ jobs:
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: node scripts/review-comment-origin.mjs
-      - name: Rerun required HEAD check
+      - name: Check for newer qualifying event
+        id: debounce
         if: steps.origin.outputs.idd_originated == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_ENTERPRISE_TOKEN: ${{ github.token }}
+          # Same dual-trigger-family PR-number resolution as the rerun
+          # step below.
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          # Both pull_request_review_comment and issue_comment carry the
+          # triggering comment's own timestamp at github.event.comment
+          # (matching COMMENT_BODY above).
+          TRIGGERED_AT: ${{ github.event.comment.created_at }}
+        run: node scripts/advisory-comment-debounce.mjs --pr "$PR_NUMBER" --triggered-at "$TRIGGERED_AT"
+      - name: Rerun required HEAD check
+        if: steps.origin.outputs.idd_originated == 'true' && steps.debounce.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           GH_ENTERPRISE_TOKEN: ${{ github.token }}

--- a/bin/idd-advisory-comment-debounce.mjs
+++ b/bin/idd-advisory-comment-debounce.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-advisory-comment-debounce.mts
+//
+// The bin/idd-advisory-comment-debounce.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+import { runHelper } from './run-helper.mjs';
+
+runHelper('../scripts/advisory-comment-debounce.mjs');

--- a/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
@@ -35,6 +35,29 @@
 # harmless. The same skip applies when `package-manager` resolves but
 # which package manager to use is ambiguous (see "Detect package
 # manager" below).
+#
+# Debounce (#1381, #2023, #2638): a burst of IDD-originated comments (30
+# in ~15 min on PR #2628) fired `rerun-advisory-convergence.mjs --apply`
+# once per comment, exhausting every same-HEAD instance's one-time rerun
+# budget mid-burst. The "Check for newer qualifying event" step below
+# waits a short quiet window, then re-queries whether a newer
+# IDD-originated comment/review has since landed on the same PR; if so,
+# this run skips its own `--apply` call and leaves it to the
+# later-triggered run (which asks the same question in turn). This is a
+# job-body-level check -- it does not alter `cancel-in-progress: false`
+# below, which stays exactly as #2136 established it. (Note on that
+# setting's actual scope: it protects only the currently in-progress
+# run in this group from cancellation; a merely *pending*, not-yet-
+# started run is still cancelled and replaced by the newest pending run
+# when another is queued behind it, since no `queue:` key is set here
+# -- the debounce below exists for the case where a run has already
+# started and must itself decide whether a newer event supersedes it,
+# which that pending-run replacement does not cover.) If the debounce
+# step's own live-data collection fails, the step fails and GitHub
+# Actions' default sequential-failure behavior skips "Rerun required
+# HEAD check" entirely for that run -- safe, since this is a
+# non-required companion refresh, and a later qualifying event (or the
+# required check's own polling) will trigger a fresh attempt.
 name: IDD advisory-convergence comment refresh
 concurrency:
   # Do not cancel: a later human LGTM must not abort an in-flight
@@ -225,8 +248,47 @@ jobs:
               npx --yes --package "$SPEC" idd-review-comment-origin
               ;;
           esac
-      - name: Rerun required HEAD check
+      - name: Check for newer qualifying event
+        id: debounce
         if: steps.origin.outputs.idd_originated == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_ENTERPRISE_TOKEN: ${{ github.token }}
+          # Same dual-trigger-family PR-number resolution as the rerun
+          # step below.
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          # Both pull_request_review_comment and issue_comment carry the
+          # triggering comment's own timestamp at github.event.comment
+          # (matching COMMENT_BODY above).
+          TRIGGERED_AT: ${{ github.event.comment.created_at }}
+          PROFILE: ${{ steps.profile.outputs.profile }}
+          PACKAGE_SPEC: ${{ steps.profile.outputs.package-spec }}
+          MANAGER: ${{ steps.manager.outputs.manager }}
+        run: |
+          case "$PROFILE" in
+            vendored-node)
+              node scripts/advisory-comment-debounce.mjs --pr "$PR_NUMBER" --triggered-at "$TRIGGERED_AT"
+              ;;
+            package-manager)
+              case "$MANAGER" in
+                pnpm)
+                  pnpm exec idd-advisory-comment-debounce --pr "$PR_NUMBER" --triggered-at "$TRIGGERED_AT"
+                  ;;
+                yarn)
+                  yarn idd-advisory-comment-debounce --pr "$PR_NUMBER" --triggered-at "$TRIGGERED_AT"
+                  ;;
+                *)
+                  npm exec idd-advisory-comment-debounce -- --pr "$PR_NUMBER" --triggered-at "$TRIGGERED_AT"
+                  ;;
+              esac
+              ;;
+            ephemeral-npx)
+              SPEC="${PACKAGE_SPEC:-https://codeload.github.com/kurone-kito/idd-skill/tar.gz/refs/heads/main}"
+              npx --yes --package "$SPEC" idd-advisory-comment-debounce --pr "$PR_NUMBER" --triggered-at "$TRIGGERED_AT"
+              ;;
+          esac
+      - name: Rerun required HEAD check
+        if: steps.origin.outputs.idd_originated == 'true' && steps.debounce.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           GH_ENTERPRISE_TOKEN: ${{ github.token }}

--- a/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
@@ -258,9 +258,17 @@ jobs:
           # step below.
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           # Both pull_request_review_comment and issue_comment carry the
-          # triggering comment's own timestamp at github.event.comment
-          # (matching COMMENT_BODY above).
-          TRIGGERED_AT: ${{ github.event.comment.created_at }}
+          # triggering comment's own timestamps at github.event.comment
+          # (matching COMMENT_BODY above). Prefer updated_at:
+          # pull_request_review_comment also fires on edited/deleted
+          # (see on: above), and created_at would then still name the
+          # comment's original post time, not this edit -- making every
+          # comment posted between the original post and the edit look
+          # "newer than the trigger" and wrongly skip this run.
+          # updated_at equals created_at for a never-edited comment, so
+          # this is safe for the created-event case too (#2650 review,
+          # Copilot).
+          TRIGGERED_AT: ${{ github.event.comment.updated_at || github.event.comment.created_at }}
           PROFILE: ${{ steps.profile.outputs.profile }}
           PACKAGE_SPEC: ${{ steps.profile.outputs.package-spec }}
           MANAGER: ${{ steps.manager.outputs.manager }}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "repository": "github:kurone-kito/idd-skill",
   "type": "module",
   "bin": {
+    "idd-advisory-comment-debounce": "./bin/idd-advisory-comment-debounce.mjs",
     "idd-advisory-convergence": "./bin/idd-advisory-convergence.mjs",
     "idd-advisory-wait-state": "./bin/idd-advisory-wait-state.mjs",
     "idd-audit-authored-issue": "./bin/idd-audit-authored-issue.mjs",

--- a/scripts/advisory-comment-debounce.mjs
+++ b/scripts/advisory-comment-debounce.mjs
@@ -195,12 +195,18 @@ function waitMs(ms) {
 }
 function collectCandidateEvents(repository, pr) {
   const events = [];
+  // Prefer updated_at over created_at (falling back when absent): an
+  // edited comment's created_at still names its original post time, so
+  // using it alone would misorder an edit against the trigger's own
+  // updated_at-based TRIGGERED_AT (the workflow step passes that in).
+  // updated_at equals created_at for a never-edited comment, so this is
+  // safe for the common case too (#2650 review, Copilot).
   const issueComments = ghPaginatedJson([
     'api',
     `repos/${repository}/issues/${pr}/comments`,
     '--paginate',
     '--jq',
-    '.[] | {createdAt: .created_at, body: .body}',
+    '.[] | {createdAt: (.updated_at // .created_at), body: .body}',
   ]);
   for (const c of issueComments) {
     if (typeof c.createdAt === 'string') {
@@ -212,7 +218,7 @@ function collectCandidateEvents(repository, pr) {
     `repos/${repository}/pulls/${pr}/comments`,
     '--paginate',
     '--jq',
-    '.[] | {createdAt: .created_at, body: .body}',
+    '.[] | {createdAt: (.updated_at // .created_at), body: .body}',
   ]);
   for (const rc of reviewComments) {
     if (typeof rc.createdAt === 'string') {

--- a/scripts/advisory-comment-debounce.mjs
+++ b/scripts/advisory-comment-debounce.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/advisory-comment-debounce.mts
+//
+// The scripts/advisory-comment-debounce.mjs copy is generated from the
+// .mts source named above by `pnpm run build`. Edit the .mts source,
+// never the generated .mjs. See docs/typescript-sources.md.
+//
+// Debounce check for `.github/workflows/idd-advisory-convergence-comment.yml`
+// (#2643, following #2638's Groom-hearing decision). On PR #2628 that
+// workflow's unconditional `rerun-advisory-convergence.mjs --apply` call
+// fired 30 times in ~15 minutes, exhausting every same-HEAD instance's
+// one-time rerun budget mid-burst. This CLI answers "has a newer
+// IDD-originated comment/review event landed on this PR since my own
+// triggering event?" after waiting a short quiet window -- if so, the
+// caller should skip its own `--apply` call and let the later-triggered
+// run (which asks the same question) handle it instead.
+//
+// Pure decision logic (`evaluateDebounceSkip`) is separated from live
+// data collection, mirroring `stalled-session-quiet-check.mts`'s shape,
+// so the decision is unit-testable without a live PR or a real wait.
+import { appendFileSync } from 'node:fs';
+import { parseDurationToMs } from './ci-wait-policy.mjs';
+import { parseCliArgs } from './cli-args.mjs';
+import {
+  DEFAULT_GH_PAGINATED_TIMEOUT_MS,
+  GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+  ghText,
+} from './gh-exec.mjs';
+import { parsePaginatedGhNdjson } from './protocol-helpers.mjs';
+import {
+  classifyReviewCommentOrigin,
+  resolveMarkerPrefix,
+} from './review-comment-origin.mjs';
+
+const DEFAULT_QUIET_WINDOW_MS = 45_000;
+/**
+ * True when `left` is strictly after `right` (both ISO8601). Invalid
+ * timestamps compare as not-after (fail-safe: never treats an
+ * unparsable event as "newer").
+ */
+function isAfter(left, right) {
+  const leftMs = Date.parse(left);
+  const rightMs = Date.parse(right);
+  if (!Number.isFinite(leftMs) || !Number.isFinite(rightMs)) {
+    return false;
+  }
+  return leftMs > rightMs;
+}
+/**
+ * Decide whether to skip this run's own `--apply` call.
+ *
+ * `laterEvents` is the full candidate set (this CLI's live caller passes
+ * every issue/review comment on the PR, not a pre-filtered set) --
+ * events at or before `triggeredAt` are excluded here, not by the
+ * caller, so a caller that forgets to pre-filter still gets the correct
+ * answer. `skip` is true only when at least one strictly-newer event
+ * classifies as IDD-originated via {@link classifyReviewCommentOrigin}
+ * (imported, not reimplemented, so this never drifts from the existing
+ * "Classify review comment" workflow step's own classification).
+ */
+export function evaluateDebounceSkip(input) {
+  const laterCandidates = input.laterEvents.filter((event) =>
+    isAfter(event.createdAt, input.triggeredAt),
+  );
+  const laterIddOriginated = laterCandidates
+    .filter(
+      (event) =>
+        classifyReviewCommentOrigin(event.body, input.markerPrefix)
+          .iddOriginated,
+    )
+    .sort((a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt));
+  if (laterIddOriginated.length === 0) {
+    return {
+      skip: false,
+      reason: 'no-newer-idd-originated-event',
+      newerIddOriginatedEventAt: null,
+      evidence: {
+        laterEventCount: laterCandidates.length,
+        laterIddOriginatedCount: 0,
+      },
+    };
+  }
+  const latest = laterIddOriginated.at(-1);
+  return {
+    skip: true,
+    reason: 'newer-idd-originated-event',
+    newerIddOriginatedEventAt: latest.createdAt,
+    evidence: {
+      laterEventCount: laterCandidates.length,
+      laterIddOriginatedCount: laterIddOriginated.length,
+    },
+  };
+}
+const ADVISORY_COMMENT_DEBOUNCE_FLAG_SPEC = {
+  '--pr': { type: 'string' },
+  '--triggered-at': { type: 'string' },
+  '--owner': { type: 'string', default: '' },
+  '--repo': { type: 'string', default: '' },
+  '--gh-token': { type: 'string', default: '' },
+  '--marker-prefix': { type: 'string', default: '' },
+  '--quiet-window-ms': { type: 'string', default: '' },
+  '--now': { type: 'string', default: '' },
+  '--help': { type: 'boolean', short: 'h' },
+};
+if (import.meta.main) {
+  runCli();
+}
+function runCli() {
+  const { values, help } = parseCliArgs(
+    process.argv.slice(2),
+    ADVISORY_COMMENT_DEBOUNCE_FLAG_SPEC,
+  );
+  if (help) {
+    printUsage();
+    process.exit(0);
+  }
+  const prToken = values.pr;
+  const pr = prToken === undefined ? Number.NaN : Number.parseInt(prToken, 10);
+  if (!Number.isInteger(pr) || pr <= 0) {
+    fail_('--pr is required and must be a positive integer');
+  }
+  const triggeredAt = values['triggered-at'];
+  if (!triggeredAt || Number.isNaN(Date.parse(triggeredAt))) {
+    fail_('--triggered-at is required and must be a valid ISO8601 timestamp');
+  }
+  const ghToken = values['gh-token'];
+  if (ghToken) {
+    process.env.GH_TOKEN = ghToken;
+    process.env.GITHUB_TOKEN = ghToken;
+  }
+  const owner =
+    values.owner ||
+    ghText(
+      ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    );
+  const repo =
+    values.repo ||
+    ghText(
+      ['repo', 'view', '--json', 'name', '--jq', '.name'],
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    );
+  const repository = `${owner}/${repo}`;
+  const quietWindowMs =
+    parseDurationOrMsToken(values['quiet-window-ms']) ??
+    DEFAULT_QUIET_WINDOW_MS;
+  // Wait the quiet window before re-querying: give any in-flight
+  // qualifying comment/review event time to land, so the re-query below
+  // reflects the same "has anything newer arrived" question the design
+  // intends, not a snapshot taken the instant this run started.
+  waitMs(quietWindowMs);
+  const markerPrefix = resolveMarkerPrefix(values['marker-prefix'] ?? '');
+  const laterEvents = collectCandidateEvents(repository, pr);
+  const result = evaluateDebounceSkip({
+    triggeredAt,
+    laterEvents,
+    markerPrefix,
+  });
+  const output = {
+    repository: { owner, repo },
+    pr,
+    triggeredAt,
+    quietWindowMs,
+    now: values.now || new Date().toISOString(),
+    ...result,
+  };
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+  const githubOutput = process.env.GITHUB_OUTPUT;
+  if (githubOutput) {
+    appendFileSync(githubOutput, `skip=${result.skip ? 'true' : 'false'}\n`);
+  }
+}
+function parseDurationOrMsToken(token) {
+  const trimmed = (token ?? '').trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (/^\d+$/.test(trimmed)) {
+    return Number.parseInt(trimmed, 10);
+  }
+  return parseDurationToMs(trimmed);
+}
+function waitMs(ms) {
+  if (ms <= 0) {
+    return;
+  }
+  // Deliberately synchronous (Atomics.wait, not setTimeout+await): this
+  // CLI's entire body runs top-level in `runCli()`, and a GitHub Actions
+  // job step has nothing else useful to do while waiting -- a blocking
+  // wait keeps this file free of async/await plumbing that every other
+  // function in it (and its sibling `stalled-session-quiet-check.mts`)
+  // does not otherwise need.
+  const buffer = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(buffer, 0, 0, ms);
+}
+function collectCandidateEvents(repository, pr) {
+  const events = [];
+  const issueComments = ghPaginatedJson([
+    'api',
+    `repos/${repository}/issues/${pr}/comments`,
+    '--paginate',
+    '--jq',
+    '.[] | {createdAt: .created_at, body: .body}',
+  ]);
+  for (const c of issueComments) {
+    if (typeof c.createdAt === 'string') {
+      events.push({ createdAt: c.createdAt, body: String(c.body ?? '') });
+    }
+  }
+  const reviewComments = ghPaginatedJson([
+    'api',
+    `repos/${repository}/pulls/${pr}/comments`,
+    '--paginate',
+    '--jq',
+    '.[] | {createdAt: .created_at, body: .body}',
+  ]);
+  for (const rc of reviewComments) {
+    if (typeof rc.createdAt === 'string') {
+      events.push({ createdAt: rc.createdAt, body: String(rc.body ?? '') });
+    }
+  }
+  return events;
+}
+function ghPaginatedJson(args) {
+  if (!args.includes('--paginate') || !args.includes('--jq')) {
+    throw new Error(
+      `ghPaginatedJson requires both --paginate and --jq in args, got: ${args.join(' ')}`,
+    );
+  }
+  return parsePaginatedGhNdjson(
+    ghText(args, {
+      ...GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+      timeout: DEFAULT_GH_PAGINATED_TIMEOUT_MS,
+    }),
+  );
+}
+function fail_(message) {
+  console.error(`error: ${message}`);
+  process.exit(2);
+}
+function printUsage() {
+  process.stdout.write(`Usage:
+  node scripts/advisory-comment-debounce.mjs --pr <number> --triggered-at <ISO8601>
+    [--owner <owner>] [--repo <repo>] [--gh-token <token>]
+    [--marker-prefix <prefix>] [--quiet-window-ms <ms>|<ISO8601 duration>]
+    [--now <ISO8601>]
+
+Waits a short quiet window, then checks whether an IDD-originated
+comment/review event has landed on the PR since --triggered-at. Prints
+JSON {skip, reason, newerIddOriginatedEventAt, evidence, ...} and, when
+$GITHUB_OUTPUT is set, writes skip=true|false there. Exit 0 on a
+successful check (including skip=false); non-zero on a usage error or a
+live-data collection failure (safe: the caller's own subsequent \`if:\`
+step is then skipped by GitHub Actions' default sequential-failure
+behavior, so a transient failure here never forces the caller's own
+subsequent apply step to run unverified).
+`);
+}

--- a/scripts/review-comment-origin.mjs
+++ b/scripts/review-comment-origin.mjs
@@ -60,7 +60,16 @@ so a GitHub Actions env: pass does not have to put the comment on the
 argv. Exit 0 always on a successful classify (including "not
 originated"); a non-zero exit is a usage or parse error.
 `;
-function resolveMarkerPrefix(flagValue) {
+/**
+ * Resolve the effective markerPrefix: an explicit non-empty `flagValue`
+ * wins; otherwise fall back to `.github/idd/config.json`'s configured
+ * value. Exported so sibling companion-workflow helpers (e.g.
+ * `advisory-comment-debounce.mts`) resolve the identical effective
+ * prefix this file's own CLI uses, rather than re-deriving the
+ * fallback and risking drift between two classification passes over
+ * the same PR.
+ */
+export function resolveMarkerPrefix(flagValue) {
   const trimmed = flagValue.trim();
   if (trimmed) {
     return trimmed;

--- a/src/bin/idd-advisory-comment-debounce.mts
+++ b/src/bin/idd-advisory-comment-debounce.mts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-advisory-comment-debounce.mts
+//
+// The bin/idd-advisory-comment-debounce.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+
+import { runHelper } from './run-helper.mts';
+
+runHelper('../scripts/advisory-comment-debounce.mjs');

--- a/src/scripts/advisory-comment-debounce.mts
+++ b/src/scripts/advisory-comment-debounce.mts
@@ -244,12 +244,18 @@ function collectCandidateEvents(
 ): DebounceEvent[] {
   const events: DebounceEvent[] = [];
 
+  // Prefer updated_at over created_at (falling back when absent): an
+  // edited comment's created_at still names its original post time, so
+  // using it alone would misorder an edit against the trigger's own
+  // updated_at-based TRIGGERED_AT (the workflow step passes that in).
+  // updated_at equals created_at for a never-edited comment, so this is
+  // safe for the common case too (#2650 review, Copilot).
   const issueComments = ghPaginatedJson([
     'api',
     `repos/${repository}/issues/${pr}/comments`,
     '--paginate',
     '--jq',
-    '.[] | {createdAt: .created_at, body: .body}',
+    '.[] | {createdAt: (.updated_at // .created_at), body: .body}',
   ]) as { createdAt?: unknown; body?: unknown }[];
   for (const c of issueComments) {
     if (typeof c.createdAt === 'string') {
@@ -262,7 +268,7 @@ function collectCandidateEvents(
     `repos/${repository}/pulls/${pr}/comments`,
     '--paginate',
     '--jq',
-    '.[] | {createdAt: .created_at, body: .body}',
+    '.[] | {createdAt: (.updated_at // .created_at), body: .body}',
   ]) as { createdAt?: unknown; body?: unknown }[];
   for (const rc of reviewComments) {
     if (typeof rc.createdAt === 'string') {

--- a/src/scripts/advisory-comment-debounce.mts
+++ b/src/scripts/advisory-comment-debounce.mts
@@ -1,0 +1,312 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/advisory-comment-debounce.mts
+//
+// The scripts/advisory-comment-debounce.mjs copy is generated from the
+// .mts source named above by `pnpm run build`. Edit the .mts source,
+// never the generated .mjs. See docs/typescript-sources.md.
+//
+// Debounce check for `.github/workflows/idd-advisory-convergence-comment.yml`
+// (#2643, following #2638's Groom-hearing decision). On PR #2628 that
+// workflow's unconditional `rerun-advisory-convergence.mjs --apply` call
+// fired 30 times in ~15 minutes, exhausting every same-HEAD instance's
+// one-time rerun budget mid-burst. This CLI answers "has a newer
+// IDD-originated comment/review event landed on this PR since my own
+// triggering event?" after waiting a short quiet window -- if so, the
+// caller should skip its own `--apply` call and let the later-triggered
+// run (which asks the same question) handle it instead.
+//
+// Pure decision logic (`evaluateDebounceSkip`) is separated from live
+// data collection, mirroring `stalled-session-quiet-check.mts`'s shape,
+// so the decision is unit-testable without a live PR or a real wait.
+
+import { appendFileSync } from 'node:fs';
+import { parseDurationToMs } from './ci-wait-policy.mts';
+import { parseCliArgs } from './cli-args.mts';
+import {
+  DEFAULT_GH_PAGINATED_TIMEOUT_MS,
+  GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+  ghText,
+} from './gh-exec.mts';
+import { parsePaginatedGhNdjson } from './protocol-helpers.mts';
+import {
+  classifyReviewCommentOrigin,
+  resolveMarkerPrefix,
+} from './review-comment-origin.mts';
+
+const DEFAULT_QUIET_WINDOW_MS = 45_000;
+
+export interface DebounceEvent {
+  createdAt: string;
+  body: string;
+}
+
+export interface DebounceCheckInput {
+  triggeredAt: string;
+  laterEvents: readonly DebounceEvent[];
+  markerPrefix?: string;
+}
+
+export interface DebounceCheckResult {
+  skip: boolean;
+  reason: string;
+  newerIddOriginatedEventAt: string | null;
+  evidence: {
+    laterEventCount: number;
+    laterIddOriginatedCount: number;
+  };
+}
+
+/**
+ * True when `left` is strictly after `right` (both ISO8601). Invalid
+ * timestamps compare as not-after (fail-safe: never treats an
+ * unparsable event as "newer").
+ */
+function isAfter(left: string, right: string): boolean {
+  const leftMs = Date.parse(left);
+  const rightMs = Date.parse(right);
+  if (!Number.isFinite(leftMs) || !Number.isFinite(rightMs)) {
+    return false;
+  }
+  return leftMs > rightMs;
+}
+
+/**
+ * Decide whether to skip this run's own `--apply` call.
+ *
+ * `laterEvents` is the full candidate set (this CLI's live caller passes
+ * every issue/review comment on the PR, not a pre-filtered set) --
+ * events at or before `triggeredAt` are excluded here, not by the
+ * caller, so a caller that forgets to pre-filter still gets the correct
+ * answer. `skip` is true only when at least one strictly-newer event
+ * classifies as IDD-originated via {@link classifyReviewCommentOrigin}
+ * (imported, not reimplemented, so this never drifts from the existing
+ * "Classify review comment" workflow step's own classification).
+ */
+export function evaluateDebounceSkip(
+  input: DebounceCheckInput,
+): DebounceCheckResult {
+  const laterCandidates = input.laterEvents.filter((event) =>
+    isAfter(event.createdAt, input.triggeredAt),
+  );
+  const laterIddOriginated = laterCandidates
+    .filter(
+      (event) =>
+        classifyReviewCommentOrigin(event.body, input.markerPrefix)
+          .iddOriginated,
+    )
+    .sort((a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt));
+
+  if (laterIddOriginated.length === 0) {
+    return {
+      skip: false,
+      reason: 'no-newer-idd-originated-event',
+      newerIddOriginatedEventAt: null,
+      evidence: {
+        laterEventCount: laterCandidates.length,
+        laterIddOriginatedCount: 0,
+      },
+    };
+  }
+
+  const latest = laterIddOriginated.at(-1) as DebounceEvent;
+  return {
+    skip: true,
+    reason: 'newer-idd-originated-event',
+    newerIddOriginatedEventAt: latest.createdAt,
+    evidence: {
+      laterEventCount: laterCandidates.length,
+      laterIddOriginatedCount: laterIddOriginated.length,
+    },
+  };
+}
+
+const ADVISORY_COMMENT_DEBOUNCE_FLAG_SPEC = {
+  '--pr': { type: 'string' },
+  '--triggered-at': { type: 'string' },
+  '--owner': { type: 'string', default: '' },
+  '--repo': { type: 'string', default: '' },
+  '--gh-token': { type: 'string', default: '' },
+  '--marker-prefix': { type: 'string', default: '' },
+  '--quiet-window-ms': { type: 'string', default: '' },
+  '--now': { type: 'string', default: '' },
+  '--help': { type: 'boolean', short: 'h' },
+} as const;
+
+if (import.meta.main) {
+  runCli();
+}
+
+function runCli(): void {
+  const { values, help } = parseCliArgs(
+    process.argv.slice(2),
+    ADVISORY_COMMENT_DEBOUNCE_FLAG_SPEC,
+  );
+  if (help) {
+    printUsage();
+    process.exit(0);
+  }
+
+  const prToken = values.pr as string | undefined;
+  const pr = prToken === undefined ? Number.NaN : Number.parseInt(prToken, 10);
+  if (!Number.isInteger(pr) || pr <= 0) {
+    fail_('--pr is required and must be a positive integer');
+  }
+  const triggeredAt = values['triggered-at'] as string | undefined;
+  if (!triggeredAt || Number.isNaN(Date.parse(triggeredAt))) {
+    fail_('--triggered-at is required and must be a valid ISO8601 timestamp');
+  }
+
+  const ghToken = values['gh-token'] as string;
+  if (ghToken) {
+    process.env.GH_TOKEN = ghToken;
+    process.env.GITHUB_TOKEN = ghToken;
+  }
+
+  const owner =
+    (values.owner as string) ||
+    ghText(
+      ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    );
+  const repo =
+    (values.repo as string) ||
+    ghText(
+      ['repo', 'view', '--json', 'name', '--jq', '.name'],
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    );
+  const repository = `${owner}/${repo}`;
+
+  const quietWindowMs =
+    parseDurationOrMsToken(values['quiet-window-ms'] as string) ??
+    DEFAULT_QUIET_WINDOW_MS;
+
+  // Wait the quiet window before re-querying: give any in-flight
+  // qualifying comment/review event time to land, so the re-query below
+  // reflects the same "has anything newer arrived" question the design
+  // intends, not a snapshot taken the instant this run started.
+  waitMs(quietWindowMs);
+
+  const markerPrefix = resolveMarkerPrefix(
+    (values['marker-prefix'] as string) ?? '',
+  );
+
+  const laterEvents = collectCandidateEvents(repository, pr);
+
+  const result = evaluateDebounceSkip({
+    triggeredAt,
+    laterEvents,
+    markerPrefix,
+  });
+
+  const output = {
+    repository: { owner, repo },
+    pr,
+    triggeredAt,
+    quietWindowMs,
+    now: (values.now as string) || new Date().toISOString(),
+    ...result,
+  };
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+  const githubOutput = process.env.GITHUB_OUTPUT;
+  if (githubOutput) {
+    appendFileSync(githubOutput, `skip=${result.skip ? 'true' : 'false'}\n`);
+  }
+}
+
+function parseDurationOrMsToken(token: string): number | null {
+  const trimmed = (token ?? '').trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (/^\d+$/.test(trimmed)) {
+    return Number.parseInt(trimmed, 10);
+  }
+  return parseDurationToMs(trimmed);
+}
+
+function waitMs(ms: number): void {
+  if (ms <= 0) {
+    return;
+  }
+  // Deliberately synchronous (Atomics.wait, not setTimeout+await): this
+  // CLI's entire body runs top-level in `runCli()`, and a GitHub Actions
+  // job step has nothing else useful to do while waiting -- a blocking
+  // wait keeps this file free of async/await plumbing that every other
+  // function in it (and its sibling `stalled-session-quiet-check.mts`)
+  // does not otherwise need.
+  const buffer = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(buffer, 0, 0, ms);
+}
+
+function collectCandidateEvents(
+  repository: string,
+  pr: number,
+): DebounceEvent[] {
+  const events: DebounceEvent[] = [];
+
+  const issueComments = ghPaginatedJson([
+    'api',
+    `repos/${repository}/issues/${pr}/comments`,
+    '--paginate',
+    '--jq',
+    '.[] | {createdAt: .created_at, body: .body}',
+  ]) as { createdAt?: unknown; body?: unknown }[];
+  for (const c of issueComments) {
+    if (typeof c.createdAt === 'string') {
+      events.push({ createdAt: c.createdAt, body: String(c.body ?? '') });
+    }
+  }
+
+  const reviewComments = ghPaginatedJson([
+    'api',
+    `repos/${repository}/pulls/${pr}/comments`,
+    '--paginate',
+    '--jq',
+    '.[] | {createdAt: .created_at, body: .body}',
+  ]) as { createdAt?: unknown; body?: unknown }[];
+  for (const rc of reviewComments) {
+    if (typeof rc.createdAt === 'string') {
+      events.push({ createdAt: rc.createdAt, body: String(rc.body ?? '') });
+    }
+  }
+
+  return events;
+}
+
+function ghPaginatedJson(args: string[]): unknown[] {
+  if (!args.includes('--paginate') || !args.includes('--jq')) {
+    throw new Error(
+      `ghPaginatedJson requires both --paginate and --jq in args, got: ${args.join(' ')}`,
+    );
+  }
+  return parsePaginatedGhNdjson(
+    ghText(args, {
+      ...GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+      timeout: DEFAULT_GH_PAGINATED_TIMEOUT_MS,
+    }),
+  );
+}
+
+function fail_(message: string): never {
+  console.error(`error: ${message}`);
+  process.exit(2);
+}
+
+function printUsage(): void {
+  process.stdout.write(`Usage:
+  node scripts/advisory-comment-debounce.mjs --pr <number> --triggered-at <ISO8601>
+    [--owner <owner>] [--repo <repo>] [--gh-token <token>]
+    [--marker-prefix <prefix>] [--quiet-window-ms <ms>|<ISO8601 duration>]
+    [--now <ISO8601>]
+
+Waits a short quiet window, then checks whether an IDD-originated
+comment/review event has landed on the PR since --triggered-at. Prints
+JSON {skip, reason, newerIddOriginatedEventAt, evidence, ...} and, when
+$GITHUB_OUTPUT is set, writes skip=true|false there. Exit 0 on a
+successful check (including skip=false); non-zero on a usage error or a
+live-data collection failure (safe: the caller's own subsequent \`if:\`
+step is then skipped by GitHub Actions' default sequential-failure
+behavior, so a transient failure here never forces the caller's own
+subsequent apply step to run unverified).
+`);
+}

--- a/src/scripts/review-comment-origin.mts
+++ b/src/scripts/review-comment-origin.mts
@@ -77,7 +77,16 @@ argv. Exit 0 always on a successful classify (including "not
 originated"); a non-zero exit is a usage or parse error.
 `;
 
-function resolveMarkerPrefix(flagValue: string): string | undefined {
+/**
+ * Resolve the effective markerPrefix: an explicit non-empty `flagValue`
+ * wins; otherwise fall back to `.github/idd/config.json`'s configured
+ * value. Exported so sibling companion-workflow helpers (e.g.
+ * `advisory-comment-debounce.mts`) resolve the identical effective
+ * prefix this file's own CLI uses, rather than re-deriving the
+ * fallback and risking drift between two classification passes over
+ * the same PR.
+ */
+export function resolveMarkerPrefix(flagValue: string): string | undefined {
   const trimmed = flagValue.trim();
   if (trimmed) {
     return trimmed;

--- a/tests/advisory-comment-debounce.test.mts
+++ b/tests/advisory-comment-debounce.test.mts
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { evaluateDebounceSkip } from '../src/scripts/advisory-comment-debounce.mts';
+
+describe('advisory-comment-debounce', () => {
+  const triggeredAt = '2026-09-05T12:00:00Z';
+
+  it('does not skip when there are no later events at all', () => {
+    const result = evaluateDebounceSkip({ triggeredAt, laterEvents: [] });
+
+    assert.deepStrictEqual(result, {
+      skip: false,
+      reason: 'no-newer-idd-originated-event',
+      newerIddOriginatedEventAt: null,
+      evidence: { laterEventCount: 0, laterIddOriginatedCount: 0 },
+    });
+  });
+
+  it('does not skip when a later event exists but is not IDD-originated', () => {
+    const result = evaluateDebounceSkip({
+      triggeredAt,
+      laterEvents: [{ createdAt: '2026-09-05T12:01:00Z', body: 'LGTM!' }],
+    });
+
+    assert.strictEqual(result.skip, false);
+    assert.strictEqual(result.reason, 'no-newer-idd-originated-event');
+    assert.strictEqual(result.evidence.laterEventCount, 1);
+    assert.strictEqual(result.evidence.laterIddOriginatedCount, 0);
+  });
+
+  it('skips when a later event is IDD-originated (disposition prefix)', () => {
+    const result = evaluateDebounceSkip({
+      triggeredAt,
+      laterEvents: [
+        {
+          createdAt: '2026-09-05T12:01:00Z',
+          body: '**Accepted** — confirmed, fixed.',
+        },
+      ],
+    });
+
+    assert.strictEqual(result.skip, true);
+    assert.strictEqual(result.reason, 'newer-idd-originated-event');
+    assert.strictEqual(
+      result.newerIddOriginatedEventAt,
+      '2026-09-05T12:01:00Z',
+    );
+    assert.strictEqual(result.evidence.laterEventCount, 1);
+    assert.strictEqual(result.evidence.laterIddOriginatedCount, 1);
+  });
+
+  it('reports the latest of several newer IDD-originated events', () => {
+    const result = evaluateDebounceSkip({
+      triggeredAt,
+      laterEvents: [
+        {
+          createdAt: '2026-09-05T12:01:00Z',
+          body: '**Accepted** — first.',
+        },
+        {
+          createdAt: '2026-09-05T12:03:00Z',
+          body: '**Rejected** — second, most recent.',
+        },
+        {
+          createdAt: '2026-09-05T12:02:00Z',
+          body: '**Accepted** — third, out of order.',
+        },
+      ],
+    });
+
+    assert.strictEqual(result.skip, true);
+    assert.strictEqual(
+      result.newerIddOriginatedEventAt,
+      '2026-09-05T12:03:00Z',
+    );
+    assert.strictEqual(result.evidence.laterEventCount, 3);
+    assert.strictEqual(result.evidence.laterIddOriginatedCount, 3);
+  });
+
+  it('ignores events at or before triggeredAt (boundary is exclusive)', () => {
+    const result = evaluateDebounceSkip({
+      triggeredAt,
+      laterEvents: [
+        {
+          createdAt: '2026-09-05T12:00:00Z', // exactly triggeredAt
+          body: '**Accepted** — same instant, not "newer".',
+        },
+        {
+          createdAt: '2026-09-05T11:59:00Z', // before triggeredAt
+          body: '**Accepted** — earlier, not "newer".',
+        },
+      ],
+    });
+
+    assert.strictEqual(result.skip, false);
+    assert.strictEqual(result.evidence.laterEventCount, 0);
+    assert.strictEqual(result.evidence.laterIddOriginatedCount, 0);
+  });
+
+  it('a mix of qualifying and non-qualifying later events still skips', () => {
+    const result = evaluateDebounceSkip({
+      triggeredAt,
+      laterEvents: [
+        { createdAt: '2026-09-05T12:01:00Z', body: 'thanks!' },
+        {
+          createdAt: '2026-09-05T12:02:00Z',
+          body: '**Rejected** — verified false.',
+        },
+      ],
+    });
+
+    assert.strictEqual(result.skip, true);
+    assert.strictEqual(result.evidence.laterEventCount, 2);
+    assert.strictEqual(result.evidence.laterIddOriginatedCount, 1);
+  });
+
+  it('treats an unparsable event timestamp as not-newer (fail-safe)', () => {
+    const result = evaluateDebounceSkip({
+      triggeredAt,
+      laterEvents: [
+        {
+          createdAt: 'not-a-timestamp',
+          body: '**Accepted** — would otherwise trigger a skip.',
+        },
+      ],
+    });
+
+    assert.strictEqual(result.skip, false);
+    assert.strictEqual(result.evidence.laterEventCount, 0);
+  });
+
+  it('passes markerPrefix through to the reused classifier', () => {
+    const withDefaultPrefix = evaluateDebounceSkip({
+      triggeredAt,
+      laterEvents: [
+        {
+          createdAt: '2026-09-05T12:01:00Z',
+          body: '<!-- idd-skill-review-reply -->',
+        },
+      ],
+    });
+    assert.strictEqual(withDefaultPrefix.skip, true);
+
+    const withOtherPrefix = evaluateDebounceSkip({
+      triggeredAt,
+      markerPrefix: 'other-prefix',
+      laterEvents: [
+        {
+          createdAt: '2026-09-05T12:01:00Z',
+          body: '<!-- idd-skill-review-reply -->',
+        },
+      ],
+    });
+    assert.strictEqual(withOtherPrefix.skip, false);
+  });
+});

--- a/tests/advisory-convergence-comment-workflow.test.mts
+++ b/tests/advisory-convergence-comment-workflow.test.mts
@@ -122,3 +122,71 @@ test('comment-refresh workflow files exist next to the required copies', () => {
     assert.ok(readFileSync(`${REPO_ROOT}/${path}`, 'utf8').length > 0);
   }
 });
+
+// #2643: a burst of IDD-originated comments must not exhaust the
+// required check's rerun budget by firing --apply once per comment.
+test('comment-refresh workflows debounce the rerun call and preserve cancel-in-progress: false', () => {
+  for (const path of COMMENT_PATHS) {
+    const text = readWorkflow(path);
+    assert.match(
+      text,
+      /- name: Check for newer qualifying event/,
+      `${path} must have a "Check for newer qualifying event" debounce step`,
+    );
+    assert.match(
+      text,
+      /id:\s*debounce/,
+      `${path} debounce step must expose id: debounce`,
+    );
+    assert.match(
+      text,
+      /advisory-comment-debounce/,
+      `${path} must invoke the advisory-comment-debounce helper`,
+    );
+    // The debounce step must run (and be able to gate the rerun step)
+    // only after classification, not before or in place of it.
+    const originIndex = text.indexOf('- name: Classify review comment');
+    const debounceIndex = text.indexOf(
+      '- name: Check for newer qualifying event',
+    );
+    const rerunIndex = text.indexOf('- name: Rerun required HEAD check');
+    assert.ok(originIndex !== -1 && debounceIndex !== -1 && rerunIndex !== -1);
+    assert.ok(
+      originIndex < debounceIndex && debounceIndex < rerunIndex,
+      `${path} steps must run in order: classify, debounce, rerun`,
+    );
+    // The rerun step's own `if:` must require both a positive origin
+    // classification AND a non-skip debounce verdict -- neither alone
+    // is sufficient (#2643 review floor: a debounce step that exists
+    // but doesn't actually gate the rerun call would be a no-op fix).
+    const rerunStepText = text.slice(
+      rerunIndex,
+      text.indexOf('\n      - name:', rerunIndex + 1) === -1
+        ? undefined
+        : text.indexOf('\n      - name:', rerunIndex + 1),
+    );
+    const ifLine = rerunStepText
+      .split('\n')
+      .find((line) => line.trim().startsWith('if:'));
+    assert.ok(
+      ifLine,
+      `${path} Rerun required HEAD check step must have an if: condition`,
+    );
+    assert.match(
+      ifLine as string,
+      /steps\.origin\.outputs\.idd_originated\s*==\s*'true'/,
+      `${path} rerun step's if: must still require idd_originated`,
+    );
+    assert.match(
+      ifLine as string,
+      /steps\.debounce\.outputs\.skip\s*!=\s*'true'/,
+      `${path} rerun step's if: must require the debounce step did not skip`,
+    );
+    // #2136's invariant must survive this change unmodified.
+    assert.match(
+      text,
+      /cancel-in-progress:\s*false/,
+      `${path} must not cancel an in-flight IDD refresh`,
+    );
+  }
+});

--- a/tests/help-text-flags.test.mts
+++ b/tests/help-text-flags.test.mts
@@ -164,6 +164,7 @@ const CROSS_REFERENCE_FLAGS: Readonly<Record<string, readonly string[]>> = {
 // with a function literally named printHelp().
 const COVERED_HELPERS = [
   'actions-usage-report',
+  'advisory-comment-debounce',
   'advisory-convergence',
   'advisory-wait-state',
   'audit-authored-issue',


### PR DESCRIPTION
# Summary

A burst of IDD-originated comments (30 in ~15 minutes on PR #2628) fired
`idd-advisory-convergence-comment.yml`'s `rerun-advisory-convergence.mjs
--apply` once per comment, exhausting every same-HEAD instance's
one-time rerun budget mid-burst -- even though the check's own live
`--assert` had already confirmed `converged: true, ready: true` on all
6/6 instances, and the live-coverage-recovery exception (#2549) could
not help because it requires a passing sibling, and this burst left
zero passing siblings.

Adds a "Check for newer qualifying event" step (`advisory-comment-debounce.mts`,
mirroring `stalled-session-quiet-check.mts`'s pure-function +
thin-CLI-shell shape) between the existing classify and rerun steps.
It waits a short quiet window (default 45s, `--quiet-window-ms`
overridable), then re-queries whether a newer IDD-originated
comment/review has landed on the PR since this run's own triggering
event -- reusing the existing `classifyReviewCommentOrigin` classifier
(now also exporting its `resolveMarkerPrefix` fallback, so both
classification passes agree on the effective prefix, never
re-implemented). If a newer qualifying event exists, this run skips
its own `--apply` call and leaves it to the later-triggered run, which
asks the same question in turn. `cancel-in-progress: false` is
unchanged -- this is a job-body-level check, not a concurrency-group
change (#2136's invariant is untouched).

Applied to both the source repo's workflow and the portable
`idd-template/` copy (the latter wired across all four
`helperRuntime` profiles: vendored-node, package-manager,
ephemeral-npx, instructions-only).

## Linked issue

Closes #2643

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

The maintainer decision (#2638, Groom hearing, 2026-09-05) chose to
debounce the companion workflow's `--apply` call (Option A) rather than
widening the live-coverage-recovery exception (Option B, would loosen
a deliberately conservative fail-closed gate) or adding new
per-instance rerun-rate-limit state (Option C), and specifically
directed mirroring this repository's existing quiet-window precedent
(`stalled-session-quiet-check.mts`) instead of inventing a new
mechanism.

**Caveat this PR cannot fully close on its own**: this issue's own
autopilot-suitability note (3/5, at the floor) flags that GitHub
Actions timing behavior is hard to fully verify by automated test
alone, and recommends close review of the actual runtime behavior
before merge. I verified the design reasoning carefully (including an
independent critique pass that caught and fixed three correctness
gaps: an inaccurate `cancel-in-progress` semantics claim, an
undocumented failure mode for the debounce step's own `gh api` calls,
and a `resolveMarkerPrefix` parity gap between the two classification
passes) and added unit tests for the pure decision logic plus
structural tests for the workflow wiring, but the actual live-burst
behavior on a real PR comment storm is not something this session can
mechanically reproduce or verify. Flagging this explicitly per the
issue's own acceptance criteria rather than claiming a mechanical proof
it doesn't support.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed (modifies the
      rerun cadence of the required `idd-advisory-convergence` check's
      non-required companion workflow -- see the Caveat above)

## Verification

- [x] `pnpm lint` (`biome check`, `dprint check`, `markdownlint-cli2`, `cspell` all pass)
- [x] `pnpm test` (5,167/5,167 passing, including 8 new decision-logic
      tests and structural workflow-wiring tests)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (`node scripts/sync-docs.mjs --check`)
- [x] `node scripts/idd-doctor.mjs` (passed; 3 pre-existing unrelated warnings)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (see the IDD impact checkbox and
      Caveat above -- this changes when the non-required companion
      workflow refreshes the required check, not the required check's
      own pass/fail logic)
- [x] Context budget impact reviewed (no `.github/instructions/` files
      touched; not byte-budget-gated)
