### PR TITLE
fix(token-cost-harvest): keep the earliest open enter per attempt

### DIFF
--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -815,6 +815,18 @@ export function readEventWindows(path) {
   // events that carry a non-empty vendorSessionId.
   const enterAtByAttempt = new Map();
   const exitAtByAttempt = new Map();
+  // bareKey -> set of vendorSessionIds whose most recent `enter` has not
+  // yet been closed by a same-attempt `exit` (#2651). A second `enter`
+  // for an attempt that is still open is a resumed/re-entered stage --
+  // for example a context-compaction-resumed session re-entering a
+  // stage it already entered, without ever logging an `exit` for the
+  // interrupted first entry -- not a new attempt cycle. Without this
+  // guard, `enterAtByAttempt.set` below unconditionally overwrites the
+  // attempt's true start time with the later, spurious re-entry,
+  // silently narrowing the resolved window. A genuinely new cycle
+  // (`enter` -> `exit` -> `enter` -> `exit`) still overwrites normally,
+  // since `exit` clears the attempt's open flag first.
+  const openEnterByAttempt = new Map();
   // bareKey -> vendorSessionId -> claimId of whichever event set that
   // attempt's CURRENT latest timestamp above (#2432). Only meaningful
   // alongside an identified (vendorSessionId-bearing) attempt -- an
@@ -860,17 +872,27 @@ export function readEventWindows(path) {
       enterAt.set(key, atMs);
       enterAtOwner.set(key, vendorSessionId);
       if (vendorSessionId !== undefined) {
-        const byAttempt = enterAtByAttempt.get(key) ?? new Map();
-        byAttempt.set(vendorSessionId, atMs);
-        enterAtByAttempt.set(key, byAttempt);
-        const claimIdByAttempt = enterClaimIdByAttempt.get(key) ?? new Map();
-        claimIdByAttempt.set(vendorSessionId, claimId);
-        enterClaimIdByAttempt.set(key, claimIdByAttempt);
+        const openSet = openEnterByAttempt.get(key) ?? new Set();
+        const alreadyOpen = openSet.has(vendorSessionId);
+        openSet.add(vendorSessionId);
+        openEnterByAttempt.set(key, openSet);
+        if (!alreadyOpen) {
+          const byAttempt = enterAtByAttempt.get(key) ?? new Map();
+          byAttempt.set(vendorSessionId, atMs);
+          enterAtByAttempt.set(key, byAttempt);
+          const claimIdByAttempt = enterClaimIdByAttempt.get(key) ?? new Map();
+          claimIdByAttempt.set(vendorSessionId, claimId);
+          enterClaimIdByAttempt.set(key, claimIdByAttempt);
+        }
+        // else: a duplicate `enter` for an attempt that is still open --
+        // keep the earlier enter's timestamp/claimId as the attempt's
+        // true start (see openEnterByAttempt's doc comment above).
       }
     } else {
       exitAt.set(key, atMs);
       exitAtOwner.set(key, vendorSessionId);
       if (vendorSessionId !== undefined) {
+        openEnterByAttempt.get(key)?.delete(vendorSessionId);
         const byAttempt = exitAtByAttempt.get(key) ?? new Map();
         byAttempt.set(vendorSessionId, atMs);
         exitAtByAttempt.set(key, byAttempt);
@@ -1097,10 +1119,20 @@ function eventWindowsForIssue(all, issueNumber, vendor) {
  * The window's `endMs` is ALWAYS the valid cleanup window's own `endMs`
  * -- never a max across every stage -- and a stage only widens `startMs`
  * when its OWN window (both ends) falls at or before that cleanup exit.
- * This guards against `readEventWindows`'s own pairing: it pairs the
- * LATEST `--enter` seen for a (issue, vendor, stage) key with the LATEST
+ * This guards against `readEventWindows`'s own pairing: for an
+ * IDENTIFIED attempt (`vendorSessionId` present, #2651) it pairs that
+ * attempt's EARLIEST still-open `--enter` with its EXIT, so a duplicate
+ * re-`--enter` (no intervening `--exit` -- for example a
+ * compaction-resumed session re-entering a stage) cannot narrow the
+ * window; a genuinely new cycle (`--enter` -> `--exit` -> `--enter`)
+ * still starts fresh, since `--exit` closes the open attempt first. The
+ * legacy, identity-less bareKey pairing (no `vendorSessionId` on the
+ * event at all -- historical data, or a vendor with no session-id
+ * source) is deliberately UNCHANGED: it still pairs the LATEST
+ * `--enter` seen for a (issue, vendor, stage) key with the LATEST
  * `--exit`, across the whole append-only file, with no knowledge of
- * which attempt either belongs to.
+ * which attempt either belongs to -- there is no attempt identity to
+ * scope an "earliest open enter" rule to in that path.
  *
  * - A completed run followed by a re-attempt that enters `cleanup` again
  *   but never exits pairs that new, still-open enter with the FIRST
@@ -1369,6 +1401,16 @@ export function buildCompletedIssueWindows(eventWindowsAll, vendor) {
  * and an adjacent issue's window begins matches only the later window,
  * rather than being wrongly treated as ambiguous between the two.
  * Preserves each group's original file-order relative to itself.
+ *
+ * Known limitation (#2652): `issueWindows` today is the GLOBAL set of
+ * every Claude-vendor issue's completed window, not scoped to the file
+ * currently being segmented. Two different CONCURRENT sessions working
+ * different issues over overlapping wall-clock time (this repository's
+ * normal multi-session dogfooding shape) make every record in that
+ * overlap ambiguous and drop out of both groups, even though each
+ * record obviously belongs to its own file's session. #2652 tracks
+ * scoping the comparison to windows a file could plausibly own or
+ * contribute to.
  */
 export function segmentRecordsByEventWindow(
   records,

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -1020,6 +1020,18 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
   // events that carry a non-empty vendorSessionId.
   const enterAtByAttempt = new Map<string, Map<string, number>>();
   const exitAtByAttempt = new Map<string, Map<string, number>>();
+  // bareKey -> set of vendorSessionIds whose most recent `enter` has not
+  // yet been closed by a same-attempt `exit` (#2651). A second `enter`
+  // for an attempt that is still open is a resumed/re-entered stage --
+  // for example a context-compaction-resumed session re-entering a
+  // stage it already entered, without ever logging an `exit` for the
+  // interrupted first entry -- not a new attempt cycle. Without this
+  // guard, `enterAtByAttempt.set` below unconditionally overwrites the
+  // attempt's true start time with the later, spurious re-entry,
+  // silently narrowing the resolved window. A genuinely new cycle
+  // (`enter` -> `exit` -> `enter` -> `exit`) still overwrites normally,
+  // since `exit` clears the attempt's open flag first.
+  const openEnterByAttempt = new Map<string, Set<string>>();
   // bareKey -> vendorSessionId -> claimId of whichever event set that
   // attempt's CURRENT latest timestamp above (#2432). Only meaningful
   // alongside an identified (vendorSessionId-bearing) attempt -- an
@@ -1075,20 +1087,30 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
       enterAt.set(key, atMs);
       enterAtOwner.set(key, vendorSessionId);
       if (vendorSessionId !== undefined) {
-        const byAttempt =
-          enterAtByAttempt.get(key) ?? new Map<string, number>();
-        byAttempt.set(vendorSessionId, atMs);
-        enterAtByAttempt.set(key, byAttempt);
-        const claimIdByAttempt =
-          enterClaimIdByAttempt.get(key) ??
-          new Map<string, string | undefined>();
-        claimIdByAttempt.set(vendorSessionId, claimId);
-        enterClaimIdByAttempt.set(key, claimIdByAttempt);
+        const openSet = openEnterByAttempt.get(key) ?? new Set<string>();
+        const alreadyOpen = openSet.has(vendorSessionId);
+        openSet.add(vendorSessionId);
+        openEnterByAttempt.set(key, openSet);
+        if (!alreadyOpen) {
+          const byAttempt =
+            enterAtByAttempt.get(key) ?? new Map<string, number>();
+          byAttempt.set(vendorSessionId, atMs);
+          enterAtByAttempt.set(key, byAttempt);
+          const claimIdByAttempt =
+            enterClaimIdByAttempt.get(key) ??
+            new Map<string, string | undefined>();
+          claimIdByAttempt.set(vendorSessionId, claimId);
+          enterClaimIdByAttempt.set(key, claimIdByAttempt);
+        }
+        // else: a duplicate `enter` for an attempt that is still open --
+        // keep the earlier enter's timestamp/claimId as the attempt's
+        // true start (see openEnterByAttempt's doc comment above).
       }
     } else {
       exitAt.set(key, atMs);
       exitAtOwner.set(key, vendorSessionId);
       if (vendorSessionId !== undefined) {
+        openEnterByAttempt.get(key)?.delete(vendorSessionId);
         const byAttempt = exitAtByAttempt.get(key) ?? new Map<string, number>();
         byAttempt.set(vendorSessionId, atMs);
         exitAtByAttempt.set(key, byAttempt);
@@ -1379,10 +1401,20 @@ export interface CompletedIssueWindow {
  * The window's `endMs` is ALWAYS the valid cleanup window's own `endMs`
  * -- never a max across every stage -- and a stage only widens `startMs`
  * when its OWN window (both ends) falls at or before that cleanup exit.
- * This guards against `readEventWindows`'s own pairing: it pairs the
- * LATEST `--enter` seen for a (issue, vendor, stage) key with the LATEST
+ * This guards against `readEventWindows`'s own pairing: for an
+ * IDENTIFIED attempt (`vendorSessionId` present, #2651) it pairs that
+ * attempt's EARLIEST still-open `--enter` with its EXIT, so a duplicate
+ * re-`--enter` (no intervening `--exit` -- for example a
+ * compaction-resumed session re-entering a stage) cannot narrow the
+ * window; a genuinely new cycle (`--enter` -> `--exit` -> `--enter`)
+ * still starts fresh, since `--exit` closes the open attempt first. The
+ * legacy, identity-less bareKey pairing (no `vendorSessionId` on the
+ * event at all -- historical data, or a vendor with no session-id
+ * source) is deliberately UNCHANGED: it still pairs the LATEST
+ * `--enter` seen for a (issue, vendor, stage) key with the LATEST
  * `--exit`, across the whole append-only file, with no knowledge of
- * which attempt either belongs to.
+ * which attempt either belongs to -- there is no attempt identity to
+ * scope an "earliest open enter" rule to in that path.
  *
  * - A completed run followed by a re-attempt that enters `cleanup` again
  *   but never exits pairs that new, still-open enter with the FIRST
@@ -1662,6 +1694,16 @@ export function buildCompletedIssueWindows(
  * and an adjacent issue's window begins matches only the later window,
  * rather than being wrongly treated as ambiguous between the two.
  * Preserves each group's original file-order relative to itself.
+ *
+ * Known limitation (#2652): `issueWindows` today is the GLOBAL set of
+ * every Claude-vendor issue's completed window, not scoped to the file
+ * currently being segmented. Two different CONCURRENT sessions working
+ * different issues over overlapping wall-clock time (this repository's
+ * normal multi-session dogfooding shape) make every record in that
+ * overlap ambiguous and drop out of both groups, even though each
+ * record obviously belongs to its own file's session. #2652 tracks
+ * scoping the comparison to windows a file could plausibly own or
+ * contribute to.
  */
 export function segmentRecordsByEventWindow(
   records: readonly unknown[],

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -2797,6 +2797,110 @@ test('readEventWindows: tags a window with claimId when both enter and exit shar
   }
 });
 
+test('readEventWindows: a duplicate same-attempt enter with no intervening exit keeps the EARLIER enter as the window start (#2651)', () => {
+  // Reproduces a context-compaction-resumed session re-entering a stage
+  // it already entered, without ever logging an exit for the
+  // interrupted first entry -- issue #2643's own `review` stage on
+  // 2026-09-05. Before the fix, the second enter silently overwrote the
+  // first in `enterAtByAttempt`, narrowing the resolved window to
+  // [second-enter, exit) instead of the true [first-enter, exit).
+  const { dir, path } = writeEventsFile([
+    tokenCostEvent(
+      'enter',
+      'review',
+      '2026-01-01T00:10:00Z',
+      7,
+      'sess-A',
+      'claude',
+      'claim-shared',
+    ),
+    tokenCostEvent(
+      'enter',
+      'review',
+      '2026-01-01T00:40:00Z',
+      7,
+      'sess-A',
+      'claude',
+      'claim-shared',
+    ),
+    tokenCostEvent(
+      'exit',
+      'review',
+      '2026-01-01T00:50:00Z',
+      7,
+      'sess-A',
+      'claude',
+      'claim-shared',
+    ),
+  ]);
+  try {
+    const windows = readEventWindows(path);
+    const window = windows.get('7:claude:review');
+    assert.ok(window);
+    assert.equal(window?.startMs, ms('2026-01-01T00:10:00Z'));
+    assert.equal(window?.endMs, ms('2026-01-01T00:50:00Z'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('readEventWindows: a same-attempt enter after a completed exit starts a genuinely new window (#2651)', () => {
+  // Contrast with the duplicate-enter case above: once an attempt's
+  // enter has been closed by its own exit, a LATER enter for the same
+  // (issueNumber, vendor, stageId, vendorSessionId) is a fresh cycle
+  // (for example an E-phase return-to-E1 recovery loop within the same
+  // long-lived session) and must overwrite, not merge with, the prior
+  // completed window -- matching this map's existing recency-preferring
+  // semantics for legitimate retries.
+  const { dir, path } = writeEventsFile([
+    tokenCostEvent(
+      'enter',
+      'review',
+      '2026-01-01T00:10:00Z',
+      7,
+      'sess-A',
+      'claude',
+      'claim-shared',
+    ),
+    tokenCostEvent(
+      'exit',
+      'review',
+      '2026-01-01T00:20:00Z',
+      7,
+      'sess-A',
+      'claude',
+      'claim-shared',
+    ),
+    tokenCostEvent(
+      'enter',
+      'review',
+      '2026-01-01T00:40:00Z',
+      7,
+      'sess-A',
+      'claude',
+      'claim-shared',
+    ),
+    tokenCostEvent(
+      'exit',
+      'review',
+      '2026-01-01T00:50:00Z',
+      7,
+      'sess-A',
+      'claude',
+      'claim-shared',
+    ),
+  ]);
+  try {
+    const windows = readEventWindows(path);
+    const window = windows.get('7:claude:review');
+    assert.ok(window);
+    assert.equal(window?.startMs, ms('2026-01-01T00:40:00Z'));
+    assert.equal(window?.endMs, ms('2026-01-01T00:50:00Z'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('readEventWindows: excludes the whole candidate (not just its claimId) when the enter and exit claimId genuinely disagree (#2432, Codex review PR #2627)', () => {
   // Both sides carry a DIFFERENT, non-empty claimId -- a stronger signal
   // than one side merely being absent: degrading this to claim-less would


### PR DESCRIPTION
## Summary

- `readEventWindows` (`src/scripts/token-cost-harvest.mts`) tracked
  each attempt's `enter` timestamp with a plain last-write-wins map. A
  duplicate `enter` for the same `(issueNumber, vendor, stageId,
  vendorSessionId)` key, with no intervening `exit`, silently
  overwrote the attempt's true start time -- this happens for real
  when a context-compaction-resumed session re-enters a stage it
  already entered without a logged `exit` for the interrupted first
  entry.
- Now keeps the earliest still-open `enter` per attempt instead; a
  genuinely new cycle (`enter` -> `exit` -> `enter`) still overwrites
  normally, since `exit` closes the open attempt first.
- Found auditing roadmap #2296 (2026-09-05): issue #2643's own
  `review` stage lost its true `14:27:23Z` start to a later,
  spurious re-entry at `14:40:33Z`. This fix does **not** by itself
  change the harvest's total `issue-loop` sample count -- that
  symptom's actual cause is a separate defect, filed as #2652.

Closes #2651

## Test plan

- [x] `node --test tests/token-cost-harvest.test.mts` (110/110 pass,
      including 2 new regression tests for the duplicate-enter case
      and the genuinely-new-cycle contrast case)
- [x] `node --test tests/*.test.mts` (5177/5177 pass)
- [x] `pnpm run build:check`
- [x] `node scripts/token-cost-report.mjs --check`
- [x] `node scripts/idd-doctor.mjs`
- [x] `npx biome check`, `npx dprint check`, `npx markdownlint-cli2`,
      `npx cspell lint`, `node scripts/audit-docs.mjs --check`,
      `node scripts/audit-code-span-wrap.mjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuYsYwJMEmfKEaf67DQ8zG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event-window tracking for identified sessions with duplicate re-entry events, preserving the original session start until exit.
  * Completed enter/exit cycles now correctly begin a new session window.
  * Identity-less event pairing behavior remains unchanged.

* **Documentation**
  * Clarified event-window behavior and known limitations in record segmentation.

* **Tests**
  * Added regression coverage for duplicate entries and repeated completed cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->