### PR TITLE
fix(token-cost-harvest): scope event-window matching per file identity

### DIFF
--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -1402,15 +1402,15 @@ export function buildCompletedIssueWindows(eventWindowsAll, vendor) {
  * rather than being wrongly treated as ambiguous between the two.
  * Preserves each group's original file-order relative to itself.
  *
- * Known limitation (#2652): `issueWindows` today is the GLOBAL set of
- * every Claude-vendor issue's completed window, not scoped to the file
- * currently being segmented. Two different CONCURRENT sessions working
+ * `issueWindows` is trusted as already scoped to what the CALLER'S own
+ * file could plausibly own or contribute to (#2652) -- this function
+ * itself has no file identity to scope by, only the windows it is
+ * handed. `scanClaudeVendorSessions`'s `scopeIssueWindowsForFile` is the
+ * scoping step: without it, two different CONCURRENT sessions working
  * different issues over overlapping wall-clock time (this repository's
- * normal multi-session dogfooding shape) make every record in that
- * overlap ambiguous and drop out of both groups, even though each
- * record obviously belongs to its own file's session. #2652 tracks
- * scoping the comparison to windows a file could plausibly own or
- * contribute to.
+ * normal multi-session dogfooding shape) would make every record in
+ * that overlap ambiguous here and drop out of both groups, even though
+ * each record obviously belongs to its own file's session.
  */
 export function segmentRecordsByEventWindow(
   records,
@@ -1611,6 +1611,33 @@ export function scanClaudeVendorSessions(
     sessionIdByBasename.set(fileBasename, resolved);
     return resolved;
   };
+  // #2652: a completed window's own identity narrows which OTHER completed
+  // windows this file's own unattributed records can plausibly match,
+  // resolving the same overlap ambiguity #2424/#2432 already resolve for the
+  // per-issue candidate resolution below -- but one step earlier, before
+  // `segmentRecordsByEventWindow`'s own "matches more than one window" guard
+  // ever runs. Two DIFFERENT issues' completed windows can genuinely overlap
+  // in wall-clock (concurrent dogfooding is this repository's normal
+  // shape): without this scoping, a record whose timestamp falls in both is
+  // dropped from EVERY group, even when this file's own vendorSessionId
+  // identifies it as belonging to only ONE of them. A window with no
+  // identity at all (historical data, or a vendor with no session-id
+  // source) keeps today's global, unscoped comparison -- there is no
+  // session identity to scope it by. This must still admit a genuine
+  // cross-file compaction/resume continuation (#2425/#2432): a window this
+  // file merely CONTRIBUTES to (its own sessionId listed in that window's
+  // `contributingWindows`, not just the window's own primary
+  // `vendorSessionId`) stays eligible too.
+  const scopeIssueWindowsForFile = (fileVendorSessionId, windows) =>
+    windows.filter(
+      (window) =>
+        window.vendorSessionId === undefined ||
+        window.vendorSessionId === fileVendorSessionId ||
+        (window.contributingWindows ?? []).some(
+          (contributing) =>
+            contributing.vendorSessionId === fileVendorSessionId,
+        ),
+    );
   // #2432: a file's own cwd-derived issue-loop sample(s) whose issue
   // number turns out to match a confirmed merge target are suppressed
   // (not pushed to `out`) once that file is resolved as a contributor for
@@ -1707,9 +1734,13 @@ export function scanClaudeVendorSessions(
     // #2627).
     if (!anySegmentHadCwdIssueNumber && unattributedRecords.length > 0) {
       if (completedIssueWindows.length > 0) {
+        const scopedIssueWindows = scopeIssueWindowsForFile(
+          resolveCandidateSessionId(fileBasename),
+          completedIssueWindows,
+        );
         const eventWindowGroups = segmentRecordsByEventWindow(
           unattributedRecords,
-          completedIssueWindows,
+          scopedIssueWindows,
           extractRecordTimestampMs,
         );
         for (const [issueNumber, groupRecords] of eventWindowGroups) {

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -1695,15 +1695,15 @@ export function buildCompletedIssueWindows(
  * rather than being wrongly treated as ambiguous between the two.
  * Preserves each group's original file-order relative to itself.
  *
- * Known limitation (#2652): `issueWindows` today is the GLOBAL set of
- * every Claude-vendor issue's completed window, not scoped to the file
- * currently being segmented. Two different CONCURRENT sessions working
+ * `issueWindows` is trusted as already scoped to what the CALLER'S own
+ * file could plausibly own or contribute to (#2652) -- this function
+ * itself has no file identity to scope by, only the windows it is
+ * handed. `scanClaudeVendorSessions`'s `scopeIssueWindowsForFile` is the
+ * scoping step: without it, two different CONCURRENT sessions working
  * different issues over overlapping wall-clock time (this repository's
- * normal multi-session dogfooding shape) make every record in that
- * overlap ambiguous and drop out of both groups, even though each
- * record obviously belongs to its own file's session. #2652 tracks
- * scoping the comparison to windows a file could plausibly own or
- * contribute to.
+ * normal multi-session dogfooding shape) would make every record in
+ * that overlap ambiguous here and drop out of both groups, even though
+ * each record obviously belongs to its own file's session.
  */
 export function segmentRecordsByEventWindow(
   records: readonly unknown[],
@@ -1938,6 +1938,36 @@ export function scanClaudeVendorSessions(
     sessionIdByBasename.set(fileBasename, resolved);
     return resolved;
   };
+  // #2652: a completed window's own identity narrows which OTHER completed
+  // windows this file's own unattributed records can plausibly match,
+  // resolving the same overlap ambiguity #2424/#2432 already resolve for the
+  // per-issue candidate resolution below -- but one step earlier, before
+  // `segmentRecordsByEventWindow`'s own "matches more than one window" guard
+  // ever runs. Two DIFFERENT issues' completed windows can genuinely overlap
+  // in wall-clock (concurrent dogfooding is this repository's normal
+  // shape): without this scoping, a record whose timestamp falls in both is
+  // dropped from EVERY group, even when this file's own vendorSessionId
+  // identifies it as belonging to only ONE of them. A window with no
+  // identity at all (historical data, or a vendor with no session-id
+  // source) keeps today's global, unscoped comparison -- there is no
+  // session identity to scope it by. This must still admit a genuine
+  // cross-file compaction/resume continuation (#2425/#2432): a window this
+  // file merely CONTRIBUTES to (its own sessionId listed in that window's
+  // `contributingWindows`, not just the window's own primary
+  // `vendorSessionId`) stays eligible too.
+  const scopeIssueWindowsForFile = (
+    fileVendorSessionId: string | undefined,
+    windows: readonly CompletedIssueWindow[],
+  ): CompletedIssueWindow[] =>
+    windows.filter(
+      (window) =>
+        window.vendorSessionId === undefined ||
+        window.vendorSessionId === fileVendorSessionId ||
+        (window.contributingWindows ?? []).some(
+          (contributing) =>
+            contributing.vendorSessionId === fileVendorSessionId,
+        ),
+    );
   // #2432: a file's own cwd-derived issue-loop sample(s) whose issue
   // number turns out to match a confirmed merge target are suppressed
   // (not pushed to `out`) once that file is resolved as a contributor for
@@ -2039,9 +2069,13 @@ export function scanClaudeVendorSessions(
     // #2627).
     if (!anySegmentHadCwdIssueNumber && unattributedRecords.length > 0) {
       if (completedIssueWindows.length > 0) {
+        const scopedIssueWindows = scopeIssueWindowsForFile(
+          resolveCandidateSessionId(fileBasename),
+          completedIssueWindows,
+        );
         const eventWindowGroups = segmentRecordsByEventWindow(
           unattributedRecords,
-          completedIssueWindows,
+          scopedIssueWindows,
           extractRecordTimestampMs,
         );
         for (const [issueNumber, groupRecords] of eventWindowGroups) {

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -1408,6 +1408,80 @@ test("scanClaudeVendorSessions: a SOLE candidate file is still skipped when the 
   assert.equal(sessions.length, 1);
 });
 
+test('scanClaudeVendorSessions: two DIFFERENT issues whose completed windows overlap in wall-clock still resolve each file to its OWN issue, not dropped from both (#2652)', () => {
+  // The real-workstation shape #2652 reported: two genuinely concurrent
+  // sessions working two DIFFERENT issues, whose overall completed windows
+  // overlap. Before this fix, `segmentRecordsByEventWindow` compared each
+  // file's own unattributed records against the GLOBAL window set, so a
+  // record timestamped inside the overlap matched both windows and was
+  // dropped from both -- even though each file's own identified
+  // `vendorSessionId` unambiguously ties it to just one of the two issues.
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
+  writeFileSync(
+    join(sandbox, 'session-ew-601.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:20:00.000Z","sessionId":"sess-ew-601-0001","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}\n',
+  );
+  writeFileSync(
+    join(sandbox, 'session-ew-602.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:22:00.000Z","sessionId":"sess-ew-602-0001","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":5,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":5}}}\n',
+  );
+  const eventWindowsAll = new Map<string, StageEventWindow>([
+    [
+      '601:claude:work',
+      stageWindow(
+        '2026-01-01T00:10:00Z',
+        '2026-01-01T00:25:00Z',
+        'sess-ew-601-0001',
+      ),
+    ],
+    [
+      '601:claude:cleanup',
+      stageWindow(
+        '2026-01-01T00:26:00Z',
+        '2026-01-01T00:30:00Z',
+        'sess-ew-601-0001',
+      ),
+    ],
+    [
+      '602:claude:work',
+      stageWindow(
+        '2026-01-01T00:15:00Z',
+        '2026-01-01T00:28:00Z',
+        'sess-ew-602-0001',
+      ),
+    ],
+    [
+      '602:claude:cleanup',
+      stageWindow(
+        '2026-01-01T00:29:00Z',
+        '2026-01-01T00:32:00Z',
+        'sess-ew-602-0001',
+      ),
+    ],
+  ]);
+
+  // Windows overlap in [00:15, 00:30); both files' own records fall inside
+  // that overlap.
+  const sessions = scanClaudeVendorSessions(sandbox, eventWindowsAll);
+  const ewSamples = sessions.filter((s) =>
+    s.adapterResult.sample.vendorSessionId.includes('#ew'),
+  );
+
+  assert.equal(ewSamples.length, 2);
+  assert.ok(
+    ewSamples.some(
+      (s) =>
+        s.adapterResult.sample.vendorSessionId === 'sess-ew-601-0001#ew601',
+    ),
+  );
+  assert.ok(
+    ewSamples.some(
+      (s) =>
+        s.adapterResult.sample.vendorSessionId === 'sess-ew-602-0001#ew602',
+    ),
+  );
+});
+
 test('scanClaudeVendorSessions: a SOLE candidate file is still harvested unconditionally when the window carries no identity (backward compat, #2424)', () => {
   const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
   writeFileSync(


### PR DESCRIPTION
# Summary

`#2652` found that `segmentRecordsByEventWindow`'s per-file event-window
attribution (`src/scripts/token-cost-harvest.mts`, added by `#2418`)
compared each project log file's own unattributed records against the
**global** set of every issue's completed window, not scoped to the
file currently being segmented. Two different, genuinely concurrent
sessions working different issues over overlapping wall-clock time --
this repository's normal multi-session dogfooding shape -- made every
record in that overlap match more than one window and drop out of
**both** groups, even though each record's own file already carries a
`vendorSessionId` that unambiguously identifies which issue it belongs
to.

- Adds `scopeIssueWindowsForFile` inside `scanClaudeVendorSessions`:
  before calling `segmentRecordsByEventWindow` for a file's own
  unattributed records, narrows the candidate `issueWindows` to those
  this file could plausibly **own** (`window.vendorSessionId` equals
  this file's own resolved session id) or **contribute to** (this
  file's session id appears in that window's own `contributingWindows`
  -- the `#2432` claim-id-matched handoff path). A window with **no**
  identity at all (historical data, or a vendor with no session-id
  source) keeps today's global, unscoped comparison unchanged -- there
  is no session identity to scope it by.
- `segmentRecordsByEventWindow` itself is unchanged: it still drops any
  record matching zero or more than one of the windows it is handed --
  only what it is handed is now narrower, per file.
- Updates the stale "Known limitation (#2652)" doc comment `#2651`'s PR
  left on `segmentRecordsByEventWindow` (anticipating this exact fix)
  to describe the resolved scoping instead.

## Verification of the fix against real data

Ran `node scripts/token-cost-harvest.mjs --repo kurone-kito/idd-skill
--dry-run` from the primary worktree (this CLI's Claude project-dir
scan is cwd-sensitive), once against current `main` (`#2651`'s
already-merged duplicate-enter fix included, `#2652`'s fix not yet
applied) and once against this branch:

| | issue-loop samples |
| --- | --- |
| `main` (before) | 2 |
| this branch (after) | 3 |

The recovered sample is exactly the class of record #2652 described:
a completed issue-loop whose own unattributed records fell inside a
window that overlapped a concurrent session's own issue window.

## Linked issue

Closes #2652

## Follow-up issues (if any)

- [x] none filed directly (per this repository's own anti-pattern rule
      against ad hoc `gh issue create`)

## Background / rationale (if material)

This branch was created from `main` before `#2651`
(`issue/2651-fix-token-cost-harvest-duplicate-enter`, merged as
`#2653`) landed. Rebased onto latest `main` before the first push (no
conflicts -- `#2651` touches `readEventWindows`; this PR touches
`scanClaudeVendorSessions`/`segmentRecordsByEventWindow`, a disjoint
region of the same file) per this repository's own branch-strategy
rule allowing a pre-publication rebase.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed (additive
      recovery of previously-dropped samples only; no existing
      attribution is narrowed or reassigned)

## Verification

- [x] `pnpm lint` (ran component-by-component: `pnpm run typecheck`,
      `pnpm exec biome check`, `pnpm exec cspell lint "**" --no-progress`
      -- all clean; pre-existing unrelated warnings in
      `marker-helpers.mts`/`protocol-helpers.mts` left untouched)
- [x] `pnpm test` (5178/5178 pass, including the new
      `scanClaudeVendorSessions` regression test reproducing this
      issue's own two-concurrent-issues overlap shape)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable) -- N/A, no
      config/instruction drift introduced
- [x] `pnpm run build:check` (clean after `pnpm run build`)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed (no instruction-bundle files touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gnftoHtNPz3i4u6xvPLeH
