### PR TITLE
fix(token-cost-harvest): require claimId agreement in legacy fallback

### DIFF
--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -835,7 +835,15 @@ export function readEventWindows(path) {
   // attempt's true start time with the later, spurious re-entry,
   // silently narrowing the resolved window. A genuinely new cycle
   // (`enter` -> `exit` -> `enter` -> `exit`) still overwrites normally,
-  // since `exit` clears the attempt's open flag first.
+  // since `exit` clears the attempt's open flag first. #2654 (Codex
+  // review, PR #2656): this guard ALSO gates the legacy unconditional
+  // maps (enterAt/enterAtOwner/enterClaimIdOwner) for an identified
+  // event, not just the attempt-scoped ones -- otherwise a duplicate
+  // enter carrying a NEW claimId could overwrite the legacy owner/claim
+  // state even though the identified path deliberately keeps the first
+  // enter's claim, letting the legacy fallback "resurrect" an attempt
+  // `attemptCandidates` correctly rejected for a claimId mismatch as an
+  // untagged window.
   const openEnterByAttempt = new Map();
   // bareKey -> vendorSessionId -> claimId of whichever event set that
   // attempt's CURRENT latest timestamp above (#2432). Only meaningful
@@ -880,15 +888,23 @@ export function readEventWindows(path) {
       : undefined;
     const claimId = isNonEmptyString(event.claimId) ? event.claimId : undefined;
     if (event.event === 'enter') {
-      enterAt.set(key, atMs);
-      enterAtOwner.set(key, vendorSessionId);
-      enterClaimIdOwner.set(key, claimId);
       if (vendorSessionId !== undefined) {
         const openSet = openEnterByAttempt.get(key) ?? new Set();
         const alreadyOpen = openSet.has(vendorSessionId);
         openSet.add(vendorSessionId);
         openEnterByAttempt.set(key, openSet);
         if (!alreadyOpen) {
+          // #2654 review (Codex, PR #2656): the legacy unconditional
+          // maps must stay in lockstep with the attempt-scoped ones --
+          // a duplicate enter for an already-open IDENTIFIED attempt
+          // must not overwrite enterAt/enterAtOwner/enterClaimIdOwner
+          // either, or the legacy fallback can "resurrect" an
+          // identified attempt attemptCandidates correctly rejected
+          // (enter/exit claimId mismatch) as an untagged window keyed
+          // off the duplicate enter's own (different) claimId.
+          enterAt.set(key, atMs);
+          enterAtOwner.set(key, vendorSessionId);
+          enterClaimIdOwner.set(key, claimId);
           const byAttempt = enterAtByAttempt.get(key) ?? new Map();
           byAttempt.set(vendorSessionId, atMs);
           enterAtByAttempt.set(key, byAttempt);
@@ -897,8 +913,17 @@ export function readEventWindows(path) {
           enterClaimIdByAttempt.set(key, claimIdByAttempt);
         }
         // else: a duplicate `enter` for an attempt that is still open --
-        // keep the earlier enter's timestamp/claimId as the attempt's
-        // true start (see openEnterByAttempt's doc comment above).
+        // keep the earlier enter's timestamp/claimId, in BOTH the
+        // legacy and attempt-scoped maps, as the attempt's true start
+        // (see openEnterByAttempt's doc comment above).
+      } else {
+        // No vendorSessionId at all: nothing to key an "already open"
+        // check against (historical data, or a vendor with no
+        // session-id source) -- unconditional overwrite, unchanged
+        // from this function's pre-#2651 behavior.
+        enterAt.set(key, atMs);
+        enterAtOwner.set(key, vendorSessionId);
+        enterClaimIdOwner.set(key, claimId);
       }
     } else {
       exitAt.set(key, atMs);

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -811,6 +811,16 @@ export function readEventWindows(path) {
   // resolveWindow below.
   const enterAtOwner = new Map();
   const exitAtOwner = new Map();
+  // bareKey -> claimId of whichever event set enterAtOwner/exitAtOwner's
+  // CURRENT value for that key (#2654). Unconditional, mirroring
+  // enterAtOwner/exitAtOwner above -- so the legacy bareKey pairing below
+  // can require claimId agreement the same way `attemptCandidates`
+  // already does for the identified path (`#2432`), instead of only
+  // comparing `vendorSessionId`. A claim-mismatched pair sharing one
+  // vendorSessionId (rejected by `attemptCandidates`) would otherwise
+  // still slip through here as an "identity-less" legacyWindow.
+  const enterClaimIdOwner = new Map();
+  const exitClaimIdOwner = new Map();
   // bareKey -> vendorSessionId -> latest timestamp. Only populated for
   // events that carry a non-empty vendorSessionId.
   const enterAtByAttempt = new Map();
@@ -871,6 +881,7 @@ export function readEventWindows(path) {
     if (event.event === 'enter') {
       enterAt.set(key, atMs);
       enterAtOwner.set(key, vendorSessionId);
+      enterClaimIdOwner.set(key, claimId);
       if (vendorSessionId !== undefined) {
         const openSet = openEnterByAttempt.get(key) ?? new Set();
         const alreadyOpen = openSet.has(vendorSessionId);
@@ -891,6 +902,7 @@ export function readEventWindows(path) {
     } else {
       exitAt.set(key, atMs);
       exitAtOwner.set(key, vendorSessionId);
+      exitClaimIdOwner.set(key, claimId);
       if (vendorSessionId !== undefined) {
         openEnterByAttempt.get(key)?.delete(vendorSessionId);
         const byAttempt = exitAtByAttempt.get(key) ?? new Map();
@@ -1018,8 +1030,23 @@ export function readEventWindows(path) {
     // pre-#2424 could never resolve either -- identity adds no signal
     // when neither side carries one.
     const legacyOwnersMatch = enterAtOwner.get(key) === exitAtOwner.get(key);
+    // #2654 (CodeRabbit review, PR #2653): `legacyOwnersMatch` alone lets
+    // a claim-mismatched identified attempt through whenever its enter
+    // and exit share one vendorSessionId -- `attemptCandidates` already
+    // rejects that exact case for the identified path (a stronger
+    // signal than one side merely being absent), but this bareKey path
+    // has no equivalent check. Same "absent on either side is ordinary
+    // partial data, not a signal" rule as `attemptCandidates`: only a
+    // BOTH-non-empty, DIFFERENT pair disqualifies the window.
+    const legacyEnterClaimId = enterClaimIdOwner.get(key);
+    const legacyExitClaimId = exitClaimIdOwner.get(key);
+    const legacyClaimIdsCompatible =
+      legacyEnterClaimId === undefined ||
+      legacyExitClaimId === undefined ||
+      legacyEnterClaimId === legacyExitClaimId;
     const legacyWindow =
       legacyOwnersMatch &&
+      legacyClaimIdsCompatible &&
       legacyStartMs !== undefined &&
       legacyEndMs !== undefined &&
       legacyStartMs < legacyEndMs

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -841,7 +841,8 @@ export function readEventWindows(path) {
   // attempt's CURRENT latest timestamp above (#2432). Only meaningful
   // alongside an identified (vendorSessionId-bearing) attempt -- an
   // unidentified event has no attempt bucket to disambiguate a claimId
-  // against, so claimId is never tracked on the legacy bareKey path.
+  // against. (`enterClaimIdOwner`/`exitClaimIdOwner` below track claimId
+  // on the legacy bareKey path instead, unconditionally -- #2654.)
   const enterClaimIdByAttempt = new Map();
   const exitClaimIdByAttempt = new Map();
   const text = readFileSync(path, 'utf8');

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -1040,7 +1040,15 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
   // attempt's true start time with the later, spurious re-entry,
   // silently narrowing the resolved window. A genuinely new cycle
   // (`enter` -> `exit` -> `enter` -> `exit`) still overwrites normally,
-  // since `exit` clears the attempt's open flag first.
+  // since `exit` clears the attempt's open flag first. #2654 (Codex
+  // review, PR #2656): this guard ALSO gates the legacy unconditional
+  // maps (enterAt/enterAtOwner/enterClaimIdOwner) for an identified
+  // event, not just the attempt-scoped ones -- otherwise a duplicate
+  // enter carrying a NEW claimId could overwrite the legacy owner/claim
+  // state even though the identified path deliberately keeps the first
+  // enter's claim, letting the legacy fallback "resurrect" an attempt
+  // `attemptCandidates` correctly rejected for a claimId mismatch as an
+  // untagged window.
   const openEnterByAttempt = new Map<string, Set<string>>();
   // bareKey -> vendorSessionId -> claimId of whichever event set that
   // attempt's CURRENT latest timestamp above (#2432). Only meaningful
@@ -1095,15 +1103,23 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
       : undefined;
     const claimId = isNonEmptyString(event.claimId) ? event.claimId : undefined;
     if (event.event === 'enter') {
-      enterAt.set(key, atMs);
-      enterAtOwner.set(key, vendorSessionId);
-      enterClaimIdOwner.set(key, claimId);
       if (vendorSessionId !== undefined) {
         const openSet = openEnterByAttempt.get(key) ?? new Set<string>();
         const alreadyOpen = openSet.has(vendorSessionId);
         openSet.add(vendorSessionId);
         openEnterByAttempt.set(key, openSet);
         if (!alreadyOpen) {
+          // #2654 review (Codex, PR #2656): the legacy unconditional
+          // maps must stay in lockstep with the attempt-scoped ones --
+          // a duplicate enter for an already-open IDENTIFIED attempt
+          // must not overwrite enterAt/enterAtOwner/enterClaimIdOwner
+          // either, or the legacy fallback can "resurrect" an
+          // identified attempt attemptCandidates correctly rejected
+          // (enter/exit claimId mismatch) as an untagged window keyed
+          // off the duplicate enter's own (different) claimId.
+          enterAt.set(key, atMs);
+          enterAtOwner.set(key, vendorSessionId);
+          enterClaimIdOwner.set(key, claimId);
           const byAttempt =
             enterAtByAttempt.get(key) ?? new Map<string, number>();
           byAttempt.set(vendorSessionId, atMs);
@@ -1115,8 +1131,17 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
           enterClaimIdByAttempt.set(key, claimIdByAttempt);
         }
         // else: a duplicate `enter` for an attempt that is still open --
-        // keep the earlier enter's timestamp/claimId as the attempt's
-        // true start (see openEnterByAttempt's doc comment above).
+        // keep the earlier enter's timestamp/claimId, in BOTH the
+        // legacy and attempt-scoped maps, as the attempt's true start
+        // (see openEnterByAttempt's doc comment above).
+      } else {
+        // No vendorSessionId at all: nothing to key an "already open"
+        // check against (historical data, or a vendor with no
+        // session-id source) -- unconditional overwrite, unchanged
+        // from this function's pre-#2651 behavior.
+        enterAt.set(key, atMs);
+        enterAtOwner.set(key, vendorSessionId);
+        enterClaimIdOwner.set(key, claimId);
       }
     } else {
       exitAt.set(key, atMs);

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -1016,6 +1016,16 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
   // resolveWindow below.
   const enterAtOwner = new Map<string, string | undefined>();
   const exitAtOwner = new Map<string, string | undefined>();
+  // bareKey -> claimId of whichever event set enterAtOwner/exitAtOwner's
+  // CURRENT value for that key (#2654). Unconditional, mirroring
+  // enterAtOwner/exitAtOwner above -- so the legacy bareKey pairing below
+  // can require claimId agreement the same way `attemptCandidates`
+  // already does for the identified path (`#2432`), instead of only
+  // comparing `vendorSessionId`. A claim-mismatched pair sharing one
+  // vendorSessionId (rejected by `attemptCandidates`) would otherwise
+  // still slip through here as an "identity-less" legacyWindow.
+  const enterClaimIdOwner = new Map<string, string | undefined>();
+  const exitClaimIdOwner = new Map<string, string | undefined>();
   // bareKey -> vendorSessionId -> latest timestamp. Only populated for
   // events that carry a non-empty vendorSessionId.
   const enterAtByAttempt = new Map<string, Map<string, number>>();
@@ -1086,6 +1096,7 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
     if (event.event === 'enter') {
       enterAt.set(key, atMs);
       enterAtOwner.set(key, vendorSessionId);
+      enterClaimIdOwner.set(key, claimId);
       if (vendorSessionId !== undefined) {
         const openSet = openEnterByAttempt.get(key) ?? new Set<string>();
         const alreadyOpen = openSet.has(vendorSessionId);
@@ -1109,6 +1120,7 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
     } else {
       exitAt.set(key, atMs);
       exitAtOwner.set(key, vendorSessionId);
+      exitClaimIdOwner.set(key, claimId);
       if (vendorSessionId !== undefined) {
         openEnterByAttempt.get(key)?.delete(vendorSessionId);
         const byAttempt = exitAtByAttempt.get(key) ?? new Map<string, number>();
@@ -1244,8 +1256,23 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
     // pre-#2424 could never resolve either -- identity adds no signal
     // when neither side carries one.
     const legacyOwnersMatch = enterAtOwner.get(key) === exitAtOwner.get(key);
+    // #2654 (CodeRabbit review, PR #2653): `legacyOwnersMatch` alone lets
+    // a claim-mismatched identified attempt through whenever its enter
+    // and exit share one vendorSessionId -- `attemptCandidates` already
+    // rejects that exact case for the identified path (a stronger
+    // signal than one side merely being absent), but this bareKey path
+    // has no equivalent check. Same "absent on either side is ordinary
+    // partial data, not a signal" rule as `attemptCandidates`: only a
+    // BOTH-non-empty, DIFFERENT pair disqualifies the window.
+    const legacyEnterClaimId = enterClaimIdOwner.get(key);
+    const legacyExitClaimId = exitClaimIdOwner.get(key);
+    const legacyClaimIdsCompatible =
+      legacyEnterClaimId === undefined ||
+      legacyExitClaimId === undefined ||
+      legacyEnterClaimId === legacyExitClaimId;
     const legacyWindow =
       legacyOwnersMatch &&
+      legacyClaimIdsCompatible &&
       legacyStartMs !== undefined &&
       legacyEndMs !== undefined &&
       legacyStartMs < legacyEndMs

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -1046,7 +1046,8 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
   // attempt's CURRENT latest timestamp above (#2432). Only meaningful
   // alongside an identified (vendorSessionId-bearing) attempt -- an
   // unidentified event has no attempt bucket to disambiguate a claimId
-  // against, so claimId is never tracked on the legacy bareKey path.
+  // against. (`enterClaimIdOwner`/`exitClaimIdOwner` below track claimId
+  // on the legacy bareKey path instead, unconditionally -- #2654.)
   const enterClaimIdByAttempt = new Map<
     string,
     Map<string, string | undefined>

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -2901,15 +2901,16 @@ test('readEventWindows: a same-attempt enter after a completed exit starts a gen
   }
 });
 
-test('readEventWindows: excludes the whole candidate (not just its claimId) when the enter and exit claimId genuinely disagree (#2432, Codex review PR #2627)', () => {
+test('readEventWindows: excludes the whole candidate (not just its claimId) when the enter and exit claimId genuinely disagree (#2432, Codex review PR #2627; #2654)', () => {
   // Both sides carry a DIFFERENT, non-empty claimId -- a stronger signal
   // than one side merely being absent: degrading this to claim-less would
   // let `idCompatible` treat the resulting window as compatible with ANY
-  // cleanup by default. The whole identified candidate is excluded, so
-  // resolution falls all the way through to the identity-agnostic legacy
-  // pairing (both enter and exit share the same vendorSessionId, so that
-  // legacy pairing is itself valid) -- vendorSessionId is absent too, not
-  // just claimId.
+  // cleanup by default. The whole identified candidate is excluded.
+  // #2654 (CodeRabbit review, PR #2653): the identity-agnostic legacy
+  // pairing must NOT admit this pair either, even though both enter and
+  // exit share one vendorSessionId -- the legacy path now requires
+  // claimId agreement the same way the identified path already does, so
+  // no window is produced for this key at all.
   const { dir, path } = writeEventsFile([
     tokenCostEvent(
       'enter',
@@ -2932,10 +2933,68 @@ test('readEventWindows: excludes the whole candidate (not just its claimId) when
   ]);
   try {
     const windows = readEventWindows(path);
+    assert.equal(windows.get('7:claude:work'), undefined);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('readEventWindows: legacy fallback still admits a genuinely identity-less pair (no claimId on either side) (#2654)', () => {
+  // Contrast with the claim-mismatch case above: when NEITHER side
+  // carries a claimId, there is nothing to disagree about --
+  // `legacyClaimIdsCompatible` degrades to compatible (absent on either
+  // side is ordinary partial data, not a signal), matching this
+  // function's pre-#2654 behavior for genuinely unidentified events.
+  const { dir, path } = writeEventsFile([
+    JSON.stringify({
+      schemaVersion: 1,
+      event: 'enter',
+      stageId: 'work',
+      at: '2026-01-01T00:10:00Z',
+      vendor: 'claude',
+      issueNumber: 7,
+    }),
+    JSON.stringify({
+      schemaVersion: 1,
+      event: 'exit',
+      stageId: 'work',
+      at: '2026-01-01T00:20:00Z',
+      vendor: 'claude',
+      issueNumber: 7,
+    }),
+  ]);
+  try {
+    const windows = readEventWindows(path);
     const window = windows.get('7:claude:work');
     assert.ok(window);
-    assert.equal('claimId' in (window ?? {}), false);
-    assert.equal('vendorSessionId' in (window ?? {}), false);
+    assert.equal(window?.startMs, ms('2026-01-01T00:10:00Z'));
+    assert.equal(window?.endMs, ms('2026-01-01T00:20:00Z'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('readEventWindows: legacy fallback admits a one-sided claimId (absence is not a signal) (#2654)', () => {
+  // One side carries a claimId, the other doesn't -- same "defensive
+  // degrade to compatible" rule `attemptCandidates` already applies for
+  // the identified path. Both enter and exit share vendorSessionId
+  // 'sess-A', so the legacy pairing is otherwise valid.
+  const { dir, path } = writeEventsFile([
+    tokenCostEvent(
+      'enter',
+      'work',
+      '2026-01-01T00:10:00Z',
+      7,
+      'sess-A',
+      'claude',
+      'claim-only-on-enter',
+    ),
+    tokenCostEvent('exit', 'work', '2026-01-01T00:20:00Z', 7, 'sess-A'),
+  ]);
+  try {
+    const windows = readEventWindows(path);
+    const window = windows.get('7:claude:work');
+    assert.ok(window);
     assert.equal(window?.startMs, ms('2026-01-01T00:10:00Z'));
     assert.equal(window?.endMs, ms('2026-01-01T00:20:00Z'));
   } finally {

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -2977,19 +2977,23 @@ test('readEventWindows: legacy fallback still admits a genuinely identity-less p
 test('readEventWindows: legacy fallback admits a one-sided claimId (absence is not a signal) (#2654)', () => {
   // One side carries a claimId, the other doesn't -- same "defensive
   // degrade to compatible" rule `attemptCandidates` already applies for
-  // the identified path. Both enter and exit share vendorSessionId
-  // 'sess-A', so the legacy pairing is otherwise valid.
+  // the identified path. Neither event carries a vendorSessionId, so
+  // this exercises the legacy bareKey fallback specifically (Copilot
+  // review finding, PR #2656): a vendorSessionId on both sides would
+  // instead populate `enterAtByAttempt`/`exitAtByAttempt` and resolve
+  // via the identified path's own claimId degradation, never reaching
+  // legacyClaimIdsCompatible at all.
   const { dir, path } = writeEventsFile([
     tokenCostEvent(
       'enter',
       'work',
       '2026-01-01T00:10:00Z',
       7,
-      'sess-A',
+      undefined,
       'claude',
       'claim-only-on-enter',
     ),
-    tokenCostEvent('exit', 'work', '2026-01-01T00:20:00Z', 7, 'sess-A'),
+    tokenCostEvent('exit', 'work', '2026-01-01T00:20:00Z', 7),
   ]);
   try {
     const windows = readEventWindows(path);

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -3006,6 +3006,54 @@ test('readEventWindows: legacy fallback admits a one-sided claimId (absence is n
   }
 });
 
+test('readEventWindows: a duplicate open-attempt enter with a NEW claimId must not resurrect a claim-mismatched attempt via the legacy fallback (Codex review finding, PR #2656, #2654)', () => {
+  // sess-A enters with claim-one, re-enters (still open, no exit yet)
+  // with claim-two, then exits with claim-two. attemptCandidates keeps
+  // the FIRST enter (claim-one) per #2651's alreadyOpen guard, so the
+  // identified path correctly rejects this as a claimId mismatch
+  // (claim-one vs claim-two). Before this fix, the legacy unconditional
+  // maps were not gated the same way: the duplicate enter overwrote
+  // enterAtOwner/enterClaimIdOwner to (sess-A, claim-two), which then
+  // MATCHED the exit's own (sess-A, claim-two) -- resurrecting the
+  // rejected attempt as an untagged legacyWindow keyed off the
+  // duplicate enter's own timestamp. No window must be produced at all.
+  const { dir, path } = writeEventsFile([
+    tokenCostEvent(
+      'enter',
+      'work',
+      '2026-01-01T00:10:00Z',
+      7,
+      'sess-A',
+      'claude',
+      'claim-one',
+    ),
+    tokenCostEvent(
+      'enter',
+      'work',
+      '2026-01-01T00:15:00Z',
+      7,
+      'sess-A',
+      'claude',
+      'claim-two',
+    ),
+    tokenCostEvent(
+      'exit',
+      'work',
+      '2026-01-01T00:20:00Z',
+      7,
+      'sess-A',
+      'claude',
+      'claim-two',
+    ),
+  ]);
+  try {
+    const windows = readEventWindows(path);
+    assert.equal(windows.get('7:claude:work'), undefined);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('readEventWindows: leaves a window untagged when an event carries no vendorSessionId (historical-data fallback, #2424)', () => {
   const { dir, path } = writeEventsFile([
     tokenCostEvent('enter', 'work', '2026-01-01T00:10:00Z', 7),


### PR DESCRIPTION
## Summary

- `readEventWindows`'s identity-less "legacy" bareKey pairing
  (`enterAt`/`exitAt`/`enterAtOwner`/`exitAtOwner`) only compared
  `vendorSessionId` to decide whether the latest `enter`/`exit` for a
  bareKey belonged to the same attempt. `attemptCandidates` already
  rejects an identified attempt whose `enter` and `exit` carry
  different, both-non-empty `claimId`s (#2432, Codex review PR
  #2627) -- a stronger signal than one side merely being absent --
  but the legacy path had no equivalent check, so a claim-mismatched
  pair could still slip through as an "identity-less" window
  whenever it shared one `vendorSessionId`.
- Now tracks `claimId` unconditionally alongside
  `enterAtOwner`/`exitAtOwner` and requires the same "absent on
  either side is ordinary partial data, only a both-defined mismatch
  disqualifies" rule for the legacy pairing.
- Found via CodeRabbit review on PR #2653
  (kurone-kito/idd-skill#2653#discussion_r3941058187): confirmed as
  a genuine, pre-existing gap, out of scope for that PR's own
  narrowly-scoped fix, so filed and fixed here instead.

Closes #2654

## Test plan

- [x] `node --test tests/token-cost-harvest.test.mts` (112/112 pass,
      including an updated pre-existing test that documented the old
      buggy behavior, and 2 new regression tests for the compatible
      absent-claimId and one-sided-claimId cases)
- [x] `node --test tests/*.test.mts` (5179/5179 pass)
- [x] `pnpm run build:check`
- [x] `node scripts/token-cost-report.mjs --check`
- [x] `node scripts/idd-doctor.mjs`
- [x] `npx biome check`, `npx dprint check`, `npx markdownlint-cli2`,
      `npx cspell lint`, `node scripts/audit-docs.mjs --check`,
      `node scripts/audit-code-span-wrap.mjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuYsYwJMEmfKEaf67DQ8zG
