### PR TITLE
fix(suitability-triage): Check 7 misses the inline Groom-hearing resolved-decision convention

### DIFF
--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -595,8 +595,8 @@ footer, remove or update the `triage:{outcome}` label, revise
 acceptance criteria to reflect the decision, and record the decision as
 inline prose in the issue body: `Maintainer decision (<provenance>,
 Groom hearing, <date>): <resolution text>` -- the shape
-`suitability-triage.mjs`'s Check 7 recognizes as a resolved decision
-(`#2661`); a comment may additionally note the decision, but the body
+`scripts/suitability-triage.mjs`'s Check 7 recognizes as a resolved
+decision (`#2661`); a comment may additionally note the decision, but the body
 itself is what re-triage reads. The next ordinary Discover pass then
 picks the issue up normally -- grooming itself never claims or works
 the issue (see

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -595,7 +595,7 @@ footer, remove or update the `triage:{outcome}` label, revise
 acceptance criteria to reflect the decision, and record the decision as
 inline prose in the issue body: `Maintainer decision (<provenance>,
 Groom hearing, <date>): <resolution text>` -- the shape
-`scripts/suitability-triage.mjs`'s Check 7 recognizes as a resolved
+`suitability-triage.mjs`'s Check 7 recognizes as a resolved
 decision (`#2661`); a comment may additionally note the decision, but the body
 itself is what re-triage reads. The next ordinary Discover pass then
 picks the issue up normally -- grooming itself never claims or works

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -592,9 +592,14 @@ several unrelated technical topics into one dense batch.
 
 **Apply the operator's answers back onto the issue**: update the score
 footer, remove or update the `triage:{outcome}` label, revise
-acceptance criteria to reflect the decision, and record the decision in
-a comment. The next ordinary Discover pass then picks the issue up
-normally -- grooming itself never claims or works the issue (see
+acceptance criteria to reflect the decision, and record the decision as
+inline prose in the issue body: `Maintainer decision (<provenance>,
+Groom hearing, <date>): <resolution text>` -- the shape
+`suitability-triage.mjs`'s Check 7 recognizes as a resolved decision
+(`#2661`); a comment may additionally note the decision, but the body
+itself is what re-triage reads. The next ordinary Discover pass then
+picks the issue up normally -- grooming itself never claims or works
+the issue (see
 [Mutation Policy and Coordination Rule](../.github/instructions/idd-suitability.instructions.md#mutation-policy-and-coordination-rule)).
 
 **Worked example.** An issue was rejected `needs-decision` at score
@@ -607,7 +612,9 @@ invalidation-on-write. After the operator picks TTL-based expiry, the
 acceptance criteria are rewritten to "cache reads for up to 60 seconds
 via TTL-based expiry; no explicit invalidation path is required", the
 score footer is raised to `4/5`, and the `triage:needs-decision` label
-is removed with a comment recording the decision and its rationale.
+is removed after the body records `Maintainer decision (Groom hearing,
+2026-06-27): TTL-based expiry, chosen over explicit
+invalidation-on-write for simplicity`.
 
 ## Roadmap completion audits
 

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -579,8 +579,8 @@ footer, remove or update the `triage:{outcome}` label, revise
 acceptance criteria to reflect the decision, and record the decision as
 inline prose in the issue body: `Maintainer decision (<provenance>,
 Groom hearing, <date>): <resolution text>` -- the shape
-`suitability-triage.mjs`'s Check 7 recognizes as a resolved decision
-(`#2661`); a comment may additionally note the decision, but the body
+`scripts/suitability-triage.mjs`'s Check 7 recognizes as a resolved
+decision (`#2661`); a comment may additionally note the decision, but the body
 itself is what re-triage reads. The next ordinary Discover pass then
 picks the issue up normally -- grooming itself never claims or works
 the issue (see

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -580,8 +580,11 @@ acceptance criteria to reflect the decision, and record the decision as
 inline prose in the issue body: `Maintainer decision (<provenance>,
 Groom hearing, <date>): <resolution text>` -- the shape
 `scripts/suitability-triage.mjs`'s Check 7 recognizes as a resolved
-decision (`#2661`); a comment may additionally note the decision, but the body
-itself is what re-triage reads. The next ordinary Discover pass then
+decision
+([kurone-kito/idd-skill#2661](https://github.com/kurone-kito/idd-skill/issues/2661)
+in the source repository); a comment may additionally note the
+decision, but the body itself is what re-triage reads. The next
+ordinary Discover pass then
 picks the issue up normally -- grooming itself never claims or works
 the issue (see
 [Mutation Policy and Coordination Rule](../.github/instructions/idd-suitability.instructions.md#mutation-policy-and-coordination-rule)).

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -579,7 +579,7 @@ footer, remove or update the `triage:{outcome}` label, revise
 acceptance criteria to reflect the decision, and record the decision as
 inline prose in the issue body: `Maintainer decision (<provenance>,
 Groom hearing, <date>): <resolution text>` -- the shape
-`scripts/suitability-triage.mjs`'s Check 7 recognizes as a resolved
+`suitability-triage.mjs`'s Check 7 recognizes as a resolved
 decision
 ([kurone-kito/idd-skill#2661](https://github.com/kurone-kito/idd-skill/issues/2661)
 in the source repository); a comment may additionally note the

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -576,9 +576,14 @@ several unrelated technical topics into one dense batch.
 
 **Apply the operator's answers back onto the issue**: update the score
 footer, remove or update the `triage:{outcome}` label, revise
-acceptance criteria to reflect the decision, and record the decision in
-a comment. The next ordinary Discover pass then picks the issue up
-normally -- grooming itself never claims or works the issue (see
+acceptance criteria to reflect the decision, and record the decision as
+inline prose in the issue body: `Maintainer decision (<provenance>,
+Groom hearing, <date>): <resolution text>` -- the shape
+`suitability-triage.mjs`'s Check 7 recognizes as a resolved decision
+(`#2661`); a comment may additionally note the decision, but the body
+itself is what re-triage reads. The next ordinary Discover pass then
+picks the issue up normally -- grooming itself never claims or works
+the issue (see
 [Mutation Policy and Coordination Rule](../.github/instructions/idd-suitability.instructions.md#mutation-policy-and-coordination-rule)).
 
 **Worked example.** An issue was rejected `needs-decision` at score
@@ -591,7 +596,9 @@ invalidation-on-write. After the operator picks TTL-based expiry, the
 acceptance criteria are rewritten to "cache reads for up to 60 seconds
 via TTL-based expiry; no explicit invalidation path is required", the
 score footer is raised to `4/5`, and the `triage:needs-decision` label
-is removed with a comment recording the decision and its rationale.
+is removed after the body records `Maintainer decision (Groom hearing,
+2026-06-27): TTL-based expiry, chosen over explicit
+invalidation-on-write for simplicity`.
 
 ## Roadmap completion audits
 

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -235,15 +235,30 @@ function isFramedAsDescriptive(normalizedBody, paragraphSpans, offset) {
 // without that making the marker itself a quoted example of someone else's
 // decision. A genuine quoting/reporting frame always precedes the quoted
 // marker in natural prose ("issue #2641 states \"Maintainer decision
-// (...)\"..."), so only text before the match need be checked here.
+// (...)\"..."), so only text before the match need be checked here. Bounded
+// to the current SENTENCE, not the whole paragraph prefix (round 6, PR
+// #2662): an unrelated reporting verb in an earlier, already-terminated
+// sentence of the same paragraph -- "The current helper reports status.
+// Maintainer decision (...): choose A" -- must not suppress a genuine
+// decision merely for sharing a paragraph with an unrelated use of the same
+// vocabulary.
 function isPrecededByFramingVerb(normalizedBody, paragraphSpans, offset) {
   const span =
     paragraphSpans.find(
       (candidate) => offset >= candidate.start && offset <= candidate.end,
     ) ?? paragraphSpans[paragraphSpans.length - 1];
-  return FRAMING_VERB_PATTERN.test(
-    normalizedBody.slice(span?.start ?? 0, offset),
+  const scanText = normalizedBody.slice(span?.start ?? 0, offset);
+  const lastSentenceBoundary = Math.max(
+    scanText.lastIndexOf('. '),
+    scanText.lastIndexOf('! '),
+    scanText.lastIndexOf('? '),
+    scanText.lastIndexOf('.\n'),
+    scanText.lastIndexOf('!\n'),
+    scanText.lastIndexOf('?\n'),
   );
+  const sentenceStart =
+    lastSentenceBoundary === -1 ? 0 : lastSentenceBoundary + 2;
+  return FRAMING_VERB_PATTERN.test(scanText.slice(sentenceStart));
 }
 // #2661 PR #2662 review round 2 (Codex): a Markdown blockquote ("> Maintainer
 // decision (...): ...") is itself a quoting signal, independent of
@@ -277,6 +292,20 @@ function isInBlockquotedParagraph(normalizedBody, paragraphSpans, offset) {
     firstLineEnd === -1 ? normalizedBody.length : firstLineEnd,
   );
   return /^[ \t]*>/.test(firstLine);
+}
+// #2661 PR #2662 review round 6 (Codex): an issue-template author commonly
+// leaves hidden instructional scaffolding as an HTML comment -- e.g.
+// `<!-- Maintainer decision (Groom hearing, YYYY-MM-DD): <resolution text>
+// -->` -- invisible in the rendered issue but still present in
+// `normalizedCodeMaskedBody` (Markdown code masking does not touch HTML
+// comments). Masked the same way as inline/fenced code, before the
+// inline-decision pattern scan.
+function findHtmlCommentRanges(text) {
+  const ranges = [];
+  for (const match of text.matchAll(/<!--[\s\S]*?-->/g)) {
+    ranges.push({ start: match.index, end: match.index + match[0].length });
+  }
+  return ranges;
 }
 // Check 3 precision: an unsafe execution directive tells the agent to act on
 // *supplied / untrusted* content, not any command verb that merely lands near
@@ -740,14 +769,18 @@ const RESOLVED_DECISION_PATTERN =
 // resolution-text denylist at all since #1135, and its own docstring
 // accepts exactly this soft-heuristic trade-off. A denylist can never
 // enumerate every future synonym; widen a *class* here only for a
-// concrete reported case, not for a hypothetical one. Between the colon
-// and the
-// lookahead, `[ \t]*(?:\r?\n[ \t]*)?` allows at most a single hard-wrapped
-// line break, never a full blank-line paragraph gap -- a bare `\s*` there
-// let an empty marker ("Maintainer decision (...):" immediately followed by
-// a blank line and the next section) cross into that next section and match
-// its first non-whitespace character as if it were resolution content
-// (Codex round 2, PR #2662). The lookahead right after the opening "("
+// concrete reported case, not for a hypothetical one. Resolution text must
+// start on the SAME LINE as the colon (`[ \t]*`, no newline tolerance): an
+// earlier revision allowed a single hard-wrapped line break here, which
+// fixed the immediate "colon immediately followed by a blank line" case
+// (Codex round 2, PR #2662) but still let an empty marker consume the very
+// next line's first character even with no blank line at all -- e.g. a
+// heading's "#" right after "Maintainer decision (...):\n" (Copilot round
+// 6, PR #2662). Dropping the newline tolerance entirely closes both cases
+// at once; neither of this fix's two real-world citations (#2644, #2641)
+// ever needed it, since GitHub's hard-wrap only splits the provenance
+// parenthetical, never the colon-to-resolution boundary itself. The
+// lookahead right after the opening "("
 // requires the parenthetical to actually contain one of the three
 // provenance signals this shape is documented to carry -- an issue/PR
 // reference, "Groom hearing", or an ISO-style date -- rather than accepting
@@ -767,7 +800,7 @@ const RESOLVED_DECISION_PATTERN =
 // resolution text actually settles the exact approval wording elsewhere in
 // the body.
 const INLINE_MAINTAINER_DECISION_PATTERN =
-  /(?<![\w-])Maintainer decision(?![\w-])\s*\((?=[^)]{0,200}(?:#\d+|Groom hearing|\d{4}-\d{2}-\d{2}))[^)]{0,200}\)\s*:[ \t]*(?:\r?\n[ \t]*)?(?![\s*_`>-]*(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|no\s+(?:decision|consensus|agreement|resolution|verdict|ruling|conclusion)(?:\s+yet)?|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided)|TBD|TBA|TBC|(?:pending|undecided|deferred)(?:\s+(?:yet|still|for\s+now))?[\s*_`]*(?=[.,;:\n]|$)|awaiting\s+(?:a\s+)?(?:decision|consensus|sign-?off|approval)|(?:still|remains?)\s+(?:open|undecided|unresolved|pending|unsettled))(?![a-zA-Z]))\S/i;
+  /(?<![\w-])Maintainer decision(?![\w-])\s*\((?=[^)]{0,200}(?:#\d+|Groom hearing|\d{4}-\d{2}-\d{2}))[^)]{0,200}\)\s*:[ \t]*(?![\s*_`>-]*(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|no\s+(?:decision|consensus|agreement|resolution|verdict|ruling|conclusion)(?:\s+yet)?|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided)|TBD|TBA|TBC|(?:pending|undecided|deferred)(?:\s+(?:yet|still|for\s+now))?[\s*_`]*(?=[.,;:\n]|$)|awaiting\s+(?:a\s+)?(?:decision|consensus|sign-?off|approval)|(?:still|remains?)\s+(?:open|undecided|unresolved|pending|unsettled))(?![a-zA-Z]))\S/i;
 // #2024: a negation word immediately before the trigger verb, allowing at
 // most one intervening word (e.g. "does not *ever* skip") between the
 // negation word and the trailing whitespace that reaches the verb. The
@@ -2166,17 +2199,23 @@ export function checkVerifiability(context) {
   // `isFramedAsDescriptive` at the wrong paragraph (#2531 review).
   const normalizedBody = body.replace(/\r\n/g, '\n');
   const paragraphSpans = getParagraphSpans(normalizedBody);
-  // #2661 PR #2662 review round 5 (Codex): computed against `normalizedBody`
-  // (not the raw `body`-derived `fenceMaskedBody` above, whose offsets are
-  // not CRLF-normalized -- the #2531-class position-alignment risk noted in
-  // this PR's own body) so the inline-decision scan below ignores an
-  // inline/fenced code demonstration of the convention itself, e.g. an issue
-  // documenting the syntax with `` `Maintainer decision (Groom hearing,
-  // 2026-09-05): choose A` ``. `findMarkdownCodeRanges` covers both inline
-  // and fenced spans, unlike `findFencedCodeRanges` alone.
+  // #2661 PR #2662 review rounds 5-6 (Codex): computed against
+  // `normalizedBody` (not the raw `body`-derived `fenceMaskedBody` above,
+  // whose offsets are not CRLF-normalized -- the #2531-class
+  // position-alignment risk noted in this PR's own body) so the
+  // inline-decision scan below ignores both an inline/fenced code
+  // demonstration of the convention itself (e.g. an issue documenting the
+  // syntax with `` `Maintainer decision (Groom hearing, 2026-09-05): choose
+  // A` ``) and hidden HTML-comment template scaffolding (round 6:
+  // `<!-- Maintainer decision (...): <resolution text> -->`).
+  // `findMarkdownCodeRanges` covers both inline and fenced spans, unlike
+  // `findFencedCodeRanges` alone.
   const normalizedCodeMaskedBody = maskMarkdownCodeRegionsPreservingPositions(
     normalizedBody,
-    findMarkdownCodeRanges(normalizedBody),
+    [
+      ...findMarkdownCodeRanges(normalizedBody),
+      ...findHtmlCommentRanges(normalizedBody),
+    ],
   );
   const hasSubjectiveApproval = (() => {
     let lineOffset = 0;

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -249,13 +249,27 @@ function isPrecededByFramingVerb(normalizedBody, paragraphSpans, offset) {
 // decision (...): ...") is itself a quoting signal, independent of
 // `isPrecededByFramingVerb` -- pasting another issue's decision as a
 // blockquote carries no reporting verb of its own, so the framing-verb check
-// alone lets a quoted decision through. Checked per matched LINE (not
-// paragraph): a multi-line blockquote block is still one paragraph span, but
-// only the "> "-prefixed line the match itself sits on need be quoted for
-// the match to count as quoted.
-function isOnBlockquotedLine(normalizedBody, offset) {
-  const lineStart = normalizedBody.lastIndexOf('\n', offset - 1) + 1;
-  return /^[ \t]*>/.test(normalizedBody.slice(lineStart, offset));
+// alone lets a quoted decision through. Checks the containing PARAGRAPH's
+// first line, not just the matched line itself: CommonMark's blockquote
+// "lazy continuation" rule (this repo's own coverage:
+// tests/markdown-code.test.mts's "permits lazy continuation" case) renders
+// a line with no ">" of its own as still inside the quote when it continues
+// a paragraph that started with "> " -- "> Quoted from issue #123:" followed
+// immediately (no blank line) by an unprefixed "Maintainer decision (...)"
+// line is entirely quoted, even though that second physical line carries no
+// ">" marker of its own (Codex round 4, PR #2662).
+function isInBlockquotedParagraph(normalizedBody, paragraphSpans, offset) {
+  const span =
+    paragraphSpans.find(
+      (candidate) => offset >= candidate.start && offset <= candidate.end,
+    ) ?? paragraphSpans[paragraphSpans.length - 1];
+  const paragraphStart = span?.start ?? 0;
+  const firstLineEnd = normalizedBody.indexOf('\n', paragraphStart);
+  const firstLine = normalizedBody.slice(
+    paragraphStart,
+    firstLineEnd === -1 ? normalizedBody.length : firstLineEnd,
+  );
+  return /^[ \t]*>/.test(firstLine);
 }
 // Check 3 precision: an unsafe execution directive tells the agent to act on
 // *supplied / untrusted* content, not any command verb that merely lands near
@@ -734,11 +748,19 @@ const RESOLVED_DECISION_PATTERN =
 // decorative (Copilot review round 2, PR #2662): without this, "Maintainer
 // decision (): ..." or "Maintainer decision (just kidding): ..." could
 // bypass the subjective-approval gate with no real grooming-pass record
-// behind it. This is the same soft co-occurrence heuristic as the heading
-// form: it does not verify the resolution text actually settles the exact
-// approval wording elsewhere in the body.
+// behind it. `pending`/`undecided`/`deferred` additionally require a clause
+// boundary (through optional "yet"/"still"/"for now" and Markdown
+// decoration) immediately after the word -- these three, unlike TBD/TBA/TBC,
+// are ordinary English adjectives that can open a genuinely settled
+// resolution's own sentence ("deferred to follow-up issue #100 so this
+// patch remains scoped", "pending requests will be rejected with HTTP
+// 409"); only a bare, sentence-ending use of the word signals a real
+// placeholder (Codex round 4, PR #2662). This is the same soft
+// co-occurrence heuristic as the heading form: it does not verify the
+// resolution text actually settles the exact approval wording elsewhere in
+// the body.
 const INLINE_MAINTAINER_DECISION_PATTERN =
-  /(?<![\w-])Maintainer decision(?![\w-])\s*\((?=[^)]{0,200}(?:#\d+|Groom hearing|\d{4}-\d{2}-\d{2}))[^)]{0,200}\)\s*:[ \t]*(?:\r?\n[ \t]*)?(?![\s*_`>-]*(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|no\s+(?:decision|consensus|agreement|resolution|verdict|ruling|conclusion)(?:\s+yet)?|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided)|TBD|TBA|TBC|pending|undecided|deferred|awaiting\s+(?:a\s+)?(?:decision|consensus|sign-?off|approval)|(?:still|remains?)\s+(?:open|undecided|unresolved|pending|unsettled))(?![a-zA-Z]))\S/i;
+  /(?<![\w-])Maintainer decision(?![\w-])\s*\((?=[^)]{0,200}(?:#\d+|Groom hearing|\d{4}-\d{2}-\d{2}))[^)]{0,200}\)\s*:[ \t]*(?:\r?\n[ \t]*)?(?![\s*_`>-]*(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|no\s+(?:decision|consensus|agreement|resolution|verdict|ruling|conclusion)(?:\s+yet)?|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided)|TBD|TBA|TBC|(?:pending|undecided|deferred)(?:\s+(?:yet|still|for\s+now))?[\s*_`]*(?=[.,;:\n]|$)|awaiting\s+(?:a\s+)?(?:decision|consensus|sign-?off|approval)|(?:still|remains?)\s+(?:open|undecided|unresolved|pending|unsettled))(?![a-zA-Z]))\S/i;
 // #2024: a negation word immediately before the trigger verb, allowing at
 // most one intervening word (e.g. "does not *ever* skip") between the
 // negation word and the trailing whitespace that reaches the verb. The
@@ -2190,10 +2212,11 @@ export function checkVerifiability(context) {
   // the helper reports an actionable error" -- is not wrongly excluded
   // (Codex review, PR #2662). A Markdown blockquote is a second, independent
   // quoting signal with no reporting verb of its own -- "> Maintainer
-  // decision (...): ..." -- so `isOnBlockquotedLine` also excludes a match
-  // (Codex review round 2, PR #2662). The heading form has no equivalent
-  // gap: a "## Decision (resolved …)" section is, by construction, this
-  // issue's own decision record, never a quoted example of someone else's.
+  // decision (...): ..." -- so `isInBlockquotedParagraph` also excludes a
+  // match (Codex review rounds 2 and 4, PR #2662). The heading form has no
+  // equivalent gap: a "## Decision (resolved …)" section is, by
+  // construction, this issue's own decision record, never a quoted example
+  // of someone else's.
   const hasInlineResolvedDecision = (() => {
     const inlinePattern = new RegExp(
       INLINE_MAINTAINER_DECISION_PATTERN.source,
@@ -2207,7 +2230,11 @@ export function checkVerifiability(context) {
           paragraphSpans,
           inlineMatch.index,
         ) &&
-        !isOnBlockquotedLine(normalizedBody, inlineMatch.index)
+        !isInBlockquotedParagraph(
+          normalizedBody,
+          paragraphSpans,
+          inlineMatch.index,
+        )
       ) {
         return true;
       }

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -712,11 +712,19 @@ const RESOLVED_DECISION_PATTERN =
 // let an empty marker ("Maintainer decision (...):" immediately followed by
 // a blank line and the next section) cross into that next section and match
 // its first non-whitespace character as if it were resolution content
-// (Codex round 2, PR #2662). This is the same soft co-occurrence heuristic
-// as the heading form: it does not verify the resolution text actually
-// settles the exact approval wording elsewhere in the body.
+// (Codex round 2, PR #2662). The lookahead right after the opening "("
+// requires the parenthetical to actually contain one of the three
+// provenance signals this shape is documented to carry -- an issue/PR
+// reference, "Groom hearing", or an ISO-style date -- rather than accepting
+// any (or empty) parenthetical content as if provenance were merely
+// decorative (Copilot review round 2, PR #2662): without this, "Maintainer
+// decision (): ..." or "Maintainer decision (just kidding): ..." could
+// bypass the subjective-approval gate with no real grooming-pass record
+// behind it. This is the same soft co-occurrence heuristic as the heading
+// form: it does not verify the resolution text actually settles the exact
+// approval wording elsewhere in the body.
 const INLINE_MAINTAINER_DECISION_PATTERN =
-  /(?<![\w-])Maintainer decision(?![\w-])\s*\([^)]{0,200}\)\s*:[ \t]*(?:\r?\n[ \t]*)?(?![\s*_`>-]*(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|no\s+decision(?:\s+yet)?|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided)|TBD|pending|undecided|deferred|still\s+open)(?![a-zA-Z]))\S/i;
+  /(?<![\w-])Maintainer decision(?![\w-])\s*\((?=[^)]{0,200}(?:#\d+|Groom hearing|\d{4}-\d{2}-\d{2}))[^)]{0,200}\)\s*:[ \t]*(?:\r?\n[ \t]*)?(?![\s*_`>-]*(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|no\s+decision(?:\s+yet)?|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided)|TBD|pending|undecided|deferred|still\s+open)(?![a-zA-Z]))\S/i;
 // #2024: a negation word immediately before the trigger verb, allowing at
 // most one intervening word (e.g. "does not *ever* skip") between the
 // negation word and the trailing whitespace that reaches the verb. The

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -249,16 +249,23 @@ function isPrecededByFramingVerb(normalizedBody, paragraphSpans, offset) {
 // decision (...): ...") is itself a quoting signal, independent of
 // `isPrecededByFramingVerb` -- pasting another issue's decision as a
 // blockquote carries no reporting verb of its own, so the framing-verb check
-// alone lets a quoted decision through. Checks the containing PARAGRAPH's
-// first line, not just the matched line itself: CommonMark's blockquote
-// "lazy continuation" rule (this repo's own coverage:
-// tests/markdown-code.test.mts's "permits lazy continuation" case) renders
+// alone lets a quoted decision through. Checks BOTH the matched line's own
+// ">" prefix (the direct case -- also covers a quote that starts partway
+// through a paragraph, e.g. "For reference:" followed immediately by
+// "> Maintainer decision (...)": CommonMark starts a new blockquote block at
+// that "> " line regardless of the preceding unquoted line, Codex round 5,
+// PR #2662) AND the containing PARAGRAPH's first line (CommonMark's
+// blockquote "lazy continuation" rule -- this repo's own coverage:
+// tests/markdown-code.test.mts's "permits lazy continuation" case -- renders
 // a line with no ">" of its own as still inside the quote when it continues
-// a paragraph that started with "> " -- "> Quoted from issue #123:" followed
-// immediately (no blank line) by an unprefixed "Maintainer decision (...)"
-// line is entirely quoted, even though that second physical line carries no
-// ">" marker of its own (Codex round 4, PR #2662).
+// a paragraph that started with "> ", Codex round 4, PR #2662). An earlier
+// round-4 revision checked only the paragraph's first line and dropped the
+// original round-2 direct-line check, reintroducing exactly the round-5 gap.
 function isInBlockquotedParagraph(normalizedBody, paragraphSpans, offset) {
+  const lineStart = normalizedBody.lastIndexOf('\n', offset - 1) + 1;
+  if (/^[ \t]*>/.test(normalizedBody.slice(lineStart, offset))) {
+    return true;
+  }
   const span =
     paragraphSpans.find(
       (candidate) => offset >= candidate.start && offset <= candidate.end,
@@ -2159,6 +2166,18 @@ export function checkVerifiability(context) {
   // `isFramedAsDescriptive` at the wrong paragraph (#2531 review).
   const normalizedBody = body.replace(/\r\n/g, '\n');
   const paragraphSpans = getParagraphSpans(normalizedBody);
+  // #2661 PR #2662 review round 5 (Codex): computed against `normalizedBody`
+  // (not the raw `body`-derived `fenceMaskedBody` above, whose offsets are
+  // not CRLF-normalized -- the #2531-class position-alignment risk noted in
+  // this PR's own body) so the inline-decision scan below ignores an
+  // inline/fenced code demonstration of the convention itself, e.g. an issue
+  // documenting the syntax with `` `Maintainer decision (Groom hearing,
+  // 2026-09-05): choose A` ``. `findMarkdownCodeRanges` covers both inline
+  // and fenced spans, unlike `findFencedCodeRanges` alone.
+  const normalizedCodeMaskedBody = maskMarkdownCodeRegionsPreservingPositions(
+    normalizedBody,
+    findMarkdownCodeRanges(normalizedBody),
+  );
   const hasSubjectiveApproval = (() => {
     let lineOffset = 0;
     for (const line of normalizedBody.split('\n')) {
@@ -2222,7 +2241,7 @@ export function checkVerifiability(context) {
       INLINE_MAINTAINER_DECISION_PATTERN.source,
       'gi',
     );
-    let inlineMatch = inlinePattern.exec(normalizedBody);
+    let inlineMatch = inlinePattern.exec(normalizedCodeMaskedBody);
     while (inlineMatch) {
       if (
         !isPrecededByFramingVerb(
@@ -2238,7 +2257,7 @@ export function checkVerifiability(context) {
       ) {
         return true;
       }
-      inlineMatch = inlinePattern.exec(normalizedBody);
+      inlineMatch = inlinePattern.exec(normalizedCodeMaskedBody);
     }
     return false;
   })();

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -245,6 +245,18 @@ function isPrecededByFramingVerb(normalizedBody, paragraphSpans, offset) {
     normalizedBody.slice(span?.start ?? 0, offset),
   );
 }
+// #2661 PR #2662 review round 2 (Codex): a Markdown blockquote ("> Maintainer
+// decision (...): ...") is itself a quoting signal, independent of
+// `isPrecededByFramingVerb` -- pasting another issue's decision as a
+// blockquote carries no reporting verb of its own, so the framing-verb check
+// alone lets a quoted decision through. Checked per matched LINE (not
+// paragraph): a multi-line blockquote block is still one paragraph span, but
+// only the "> "-prefixed line the match itself sits on need be quoted for
+// the match to count as quoted.
+function isOnBlockquotedLine(normalizedBody, offset) {
+  const lineStart = normalizedBody.lastIndexOf('\n', offset - 1) + 1;
+  return /^[ \t]*>/.test(normalizedBody.slice(lineStart, offset));
+}
 // Check 3 precision: an unsafe execution directive tells the agent to act on
 // *supplied / untrusted* content, not any command verb that merely lands near
 // the ordinary determiner "this". Match the strong untrusted-origin signals, or
@@ -692,11 +704,19 @@ const RESOLVED_DECISION_PATTERN =
 // `(?![a-zA-Z])` replaces a plain `\b`, which fails to end the match after
 // "TBD_" (both `D` and `_` are `\w`, so `\b` finds no boundary there) even
 // though the underscore is just a closing emphasis marker, not part of the
-// word. This is the same soft co-occurrence heuristic as the heading form:
-// it does not verify the resolution text actually settles the exact
-// approval wording elsewhere in the body.
+// word. `no\s+decision(?:\s+yet)?` covers the noun-first phrasing "no
+// decision yet", which the earlier verb-first "not (yet) decided" denylist
+// entries do not match (Codex round 2, PR #2662). Between the colon and the
+// lookahead, `[ \t]*(?:\r?\n[ \t]*)?` allows at most a single hard-wrapped
+// line break, never a full blank-line paragraph gap -- a bare `\s*` there
+// let an empty marker ("Maintainer decision (...):" immediately followed by
+// a blank line and the next section) cross into that next section and match
+// its first non-whitespace character as if it were resolution content
+// (Codex round 2, PR #2662). This is the same soft co-occurrence heuristic
+// as the heading form: it does not verify the resolution text actually
+// settles the exact approval wording elsewhere in the body.
 const INLINE_MAINTAINER_DECISION_PATTERN =
-  /(?<![\w-])Maintainer decision(?![\w-])\s*\([^)]{0,200}\)\s*:\s*(?![\s*_`>-]*(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided)|TBD|pending|undecided|deferred|still\s+open)(?![a-zA-Z]))\S/i;
+  /(?<![\w-])Maintainer decision(?![\w-])\s*\([^)]{0,200}\)\s*:[ \t]*(?:\r?\n[ \t]*)?(?![\s*_`>-]*(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|no\s+decision(?:\s+yet)?|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided)|TBD|pending|undecided|deferred|still\s+open)(?![a-zA-Z]))\S/i;
 // #2024: a negation word immediately before the trigger verb, allowing at
 // most one intervening word (e.g. "does not *ever* skip") between the
 // negation word and the trailing whitespace that reaches the verb. The
@@ -2146,9 +2166,12 @@ export function checkVerifiability(context) {
   // whole-paragraph `isFramedAsDescriptive`) so a genuine resolution whose
   // OWN text happens to use a reporting verb -- "Maintainer decision (...):
   // the helper reports an actionable error" -- is not wrongly excluded
-  // (Codex review, PR #2662). The heading form has no equivalent gap: a
-  // "## Decision (resolved …)" section is, by construction, this issue's own
-  // decision record, never a quoted example of someone else's.
+  // (Codex review, PR #2662). A Markdown blockquote is a second, independent
+  // quoting signal with no reporting verb of its own -- "> Maintainer
+  // decision (...): ..." -- so `isOnBlockquotedLine` also excludes a match
+  // (Codex review round 2, PR #2662). The heading form has no equivalent
+  // gap: a "## Decision (resolved …)" section is, by construction, this
+  // issue's own decision record, never a quoted example of someone else's.
   const hasInlineResolvedDecision = (() => {
     const inlinePattern = new RegExp(
       INLINE_MAINTAINER_DECISION_PATTERN.source,
@@ -2161,7 +2184,8 @@ export function checkVerifiability(context) {
           normalizedBody,
           paragraphSpans,
           inlineMatch.index,
-        )
+        ) &&
+        !isOnBlockquotedLine(normalizedBody, inlineMatch.index)
       ) {
         return true;
       }

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -208,6 +208,25 @@ function getParagraphSpans(body) {
   spans.push({ start: cursor, end: body.length });
   return spans;
 }
+// #2661 C1 review: shared between `hasSubjectiveApproval` (#2512's original
+// use) and `hasResolvedDecision`'s inline-form scan. A match landing in a
+// paragraph that reports on another decision/approval as an example --
+// "issue #2641 states \"Maintainer decision (...)\" as an example of the
+// convention" -- uses the vocabulary as the OBJECT of that report, not as
+// this issue's own settled call, in either direction: it must not count as
+// evidence of an unresolved subjective gate (#2512's original case), and it
+// must equally not count as evidence THIS issue's own decision is resolved
+// (#2661's C1 finding -- a body that merely quotes another issue's already-
+// resolved decision as an example must not borrow that resolution).
+function isFramedAsDescriptive(normalizedBody, paragraphSpans, offset) {
+  const span =
+    paragraphSpans.find(
+      (candidate) => offset >= candidate.start && offset <= candidate.end,
+    ) ?? paragraphSpans[paragraphSpans.length - 1];
+  return FRAMING_VERB_PATTERN.test(
+    normalizedBody.slice(span?.start ?? 0, span?.end ?? normalizedBody.length),
+  );
+}
 // Check 3 precision: an unsafe execution directive tells the agent to act on
 // *supplied / untrusted* content, not any command verb that merely lands near
 // the ordinary determiner "this". Match the strong untrusted-origin signals, or
@@ -642,14 +661,17 @@ const RESOLVED_DECISION_PATTERN =
 // span a hard-wrapped line break -- GitHub issue bodies wrap at ~80 chars, so
 // "(kurone-kito/idd-skill#2637, Groom hearing,\n2026-09-05):" routinely splits
 // the provenance across two physical lines (the same line-wrap-is-not-a-
-// boundary shape as the proximity check above, #2512). The same "still open"
-// guard applies immediately after the colon, so a placeholder like
-// "Maintainer decision (...): not yet decided" is not mistaken for a
-// resolution. This is the same soft co-occurrence heuristic as the heading
-// form: it does not verify the resolution text actually settles the exact
-// approval wording elsewhere in the body.
+// boundary shape as the proximity check above, #2512). A "still open" guard
+// applies immediately after the colon, so a placeholder resolution is not
+// mistaken for a real one -- both the heading form's own negated-"resolved"
+// phrasing ("not yet decided") and this inline form's own still-pending
+// vocabulary (TBD, pending, undecided, deferred, "still open"), since the
+// inline form has no positive `\bresolved\b` requirement to fall back on
+// (#2661 C1 review). This is the same soft co-occurrence heuristic as the
+// heading form: it does not verify the resolution text actually settles the
+// exact approval wording elsewhere in the body.
 const INLINE_MAINTAINER_DECISION_PATTERN =
-  /(?<![\w-])Maintainer decision(?![\w-])\s*\([^)]{0,200}\)\s*:\s*(?!(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided))\b)\S/i;
+  /(?<![\w-])Maintainer decision(?![\w-])\s*\([^)]{0,200}\)\s*:\s*(?!(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided)|TBD|pending|undecided|deferred|still\s+open)\b)\S/i;
 // #2024: a negation word immediately before the trigger verb, allowing at
 // most one intervening word (e.g. "does not *ever* skip") between the
 // negation word and the trailing whitespace that reaches the verb. The
@@ -2041,32 +2063,20 @@ export function checkVerifiability(context) {
         'Issue does not provide objective verification signals or substantive acceptance criteria.',
     };
   }
+  // Normalized once so every offset computed below (line-split cursor,
+  // paragraph spans, proximity/inline-decision match index) shares the same
+  // 1-char line separator -- a raw `\r\n` body otherwise drifts the running
+  // `lineOffset` cursor by 1 byte per CRLF line, eventually pointing
+  // `isFramedAsDescriptive` at the wrong paragraph (#2531 review).
+  const normalizedBody = body.replace(/\r\n/g, '\n');
+  const paragraphSpans = getParagraphSpans(normalizedBody);
   const hasSubjectiveApproval = (() => {
-    // Normalized once so every offset computed below (line-split cursor,
-    // paragraph spans, proximity match index) shares the same 1-char line
-    // separator -- a raw `\r\n` body otherwise drifts the running
-    // `lineOffset` cursor by 1 byte per CRLF line, eventually pointing
-    // `isFramedAsDescriptive` at the wrong paragraph (#2531 review).
-    const normalizedBody = body.replace(/\r\n/g, '\n');
-    const paragraphSpans = getParagraphSpans(normalizedBody);
-    const isFramedAsDescriptive = (offset) => {
-      const span =
-        paragraphSpans.find(
-          (candidate) => offset >= candidate.start && offset <= candidate.end,
-        ) ?? paragraphSpans[paragraphSpans.length - 1];
-      return FRAMING_VERB_PATTERN.test(
-        normalizedBody.slice(
-          span?.start ?? 0,
-          span?.end ?? normalizedBody.length,
-        ),
-      );
-    };
     let lineOffset = 0;
     for (const line of normalizedBody.split('\n')) {
       if (
         SUBJECTIVE_SUBJECT_PATTERN.test(line) &&
         SUBJECTIVE_GATE_PATTERN.test(line) &&
-        !isFramedAsDescriptive(lineOffset)
+        !isFramedAsDescriptive(normalizedBody, paragraphSpans, lineOffset)
       ) {
         return true;
       }
@@ -2078,7 +2088,13 @@ export function checkVerifiability(context) {
     );
     let proximityMatch = proximityPattern.exec(normalizedBody);
     while (proximityMatch) {
-      if (!isFramedAsDescriptive(proximityMatch.index)) {
+      if (
+        !isFramedAsDescriptive(
+          normalizedBody,
+          paragraphSpans,
+          proximityMatch.index,
+        )
+      ) {
         return true;
       }
       proximityMatch = proximityPattern.exec(normalizedBody);
@@ -2095,9 +2111,37 @@ export function checkVerifiability(context) {
   // proving the decision resolves the exact approval wording, which is an
   // accepted trade-off for maintainer-authored issues. An approval-gated
   // body with no resolved decision still routes to needs-decision.
+  //
+  // The inline form additionally requires its own paragraph not be framed as
+  // descriptive (#2661 C1 review): a body that merely *quotes* another
+  // issue's already-resolved decision as an example -- "issue #2641 states
+  // \"Maintainer decision (...)\" as an example of the convention" -- must
+  // not borrow that resolution for THIS issue's own subjective gate. The
+  // heading form has no equivalent gap: a "## Decision (resolved …)" section
+  // is, by construction, this issue's own decision record, never a quoted
+  // example of someone else's.
+  const hasInlineResolvedDecision = (() => {
+    const inlinePattern = new RegExp(
+      INLINE_MAINTAINER_DECISION_PATTERN.source,
+      'gi',
+    );
+    let inlineMatch = inlinePattern.exec(normalizedBody);
+    while (inlineMatch) {
+      if (
+        !isFramedAsDescriptive(
+          normalizedBody,
+          paragraphSpans,
+          inlineMatch.index,
+        )
+      ) {
+        return true;
+      }
+      inlineMatch = inlinePattern.exec(normalizedBody);
+    }
+    return false;
+  })();
   const hasResolvedDecision =
-    RESOLVED_DECISION_PATTERN.test(body) ||
-    INLINE_MAINTAINER_DECISION_PATTERN.test(body);
+    RESOLVED_DECISION_PATTERN.test(body) || hasInlineResolvedDecision;
   if (hasSubjectiveApproval && !(hasResolvedDecision && hasObjectiveCriteria)) {
     return {
       pass: false,

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -299,11 +299,21 @@ function isInBlockquotedParagraph(normalizedBody, paragraphSpans, offset) {
 // -->` -- invisible in the rendered issue but still present in
 // `normalizedCodeMaskedBody` (Markdown code masking does not touch HTML
 // comments). Masked the same way as inline/fenced code, before the
-// inline-decision pattern scan.
+// inline-decision pattern scan. An unterminated `<!--` (no matching `-->`)
+// extends to end-of-body: CommonMark renders such an HTML block through
+// EOF, so the entire remaining body -- a genuine marker and Acceptance
+// Criteria included -- can be invisible in the rendered issue while still
+// matching this scan if left unmasked (round 7, PR #2662).
 function findHtmlCommentRanges(text) {
   const ranges = [];
-  for (const match of text.matchAll(/<!--[\s\S]*?-->/g)) {
-    ranges.push({ start: match.index, end: match.index + match[0].length });
+  const openPattern = /<!--/g;
+  let openMatch = openPattern.exec(text);
+  while (openMatch) {
+    const closeIndex = text.indexOf('-->', openMatch.index + 4);
+    const end = closeIndex === -1 ? text.length : closeIndex + 3;
+    ranges.push({ start: openMatch.index, end });
+    openPattern.lastIndex = end;
+    openMatch = openPattern.exec(text);
   }
   return ranges;
 }

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -227,6 +227,24 @@ function isFramedAsDescriptive(normalizedBody, paragraphSpans, offset) {
     normalizedBody.slice(span?.start ?? 0, span?.end ?? normalizedBody.length),
   );
 }
+// #2661 PR #2662 review (Codex): unlike `isFramedAsDescriptive` above, this
+// scans only the paragraph text BEFORE `offset`, not the whole paragraph.
+// Used solely for the inline-decision scan, where the match's own resolution
+// text (after the colon) can legitimately contain an ordinary reporting verb
+// -- "Maintainer decision (...): the helper reports an actionable error" --
+// without that making the marker itself a quoted example of someone else's
+// decision. A genuine quoting/reporting frame always precedes the quoted
+// marker in natural prose ("issue #2641 states \"Maintainer decision
+// (...)\"..."), so only text before the match need be checked here.
+function isPrecededByFramingVerb(normalizedBody, paragraphSpans, offset) {
+  const span =
+    paragraphSpans.find(
+      (candidate) => offset >= candidate.start && offset <= candidate.end,
+    ) ?? paragraphSpans[paragraphSpans.length - 1];
+  return FRAMING_VERB_PATTERN.test(
+    normalizedBody.slice(span?.start ?? 0, offset),
+  );
+}
 // Check 3 precision: an unsafe execution directive tells the agent to act on
 // *supplied / untrusted* content, not any command verb that merely lands near
 // the ordinary determiner "this". Match the strong untrusted-origin signals, or
@@ -667,11 +685,18 @@ const RESOLVED_DECISION_PATTERN =
 // phrasing ("not yet decided") and this inline form's own still-pending
 // vocabulary (TBD, pending, undecided, deferred, "still open"), since the
 // inline form has no positive `\bresolved\b` requirement to fall back on
-// (#2661 C1 review). This is the same soft co-occurrence heuristic as the
-// heading form: it does not verify the resolution text actually settles the
-// exact approval wording elsewhere in the body.
+// (#2661 C1 review). The leading `[\s*_\`>-]*` skips past Markdown emphasis
+// (`**pending**`, `_TBD_`, `` `still open` ``) and list/blockquote markers
+// ("- TBD ...", "> pending ...") that would otherwise land between the colon
+// and the denylist word (Codex + Copilot review, PR #2662); the trailing
+// `(?![a-zA-Z])` replaces a plain `\b`, which fails to end the match after
+// "TBD_" (both `D` and `_` are `\w`, so `\b` finds no boundary there) even
+// though the underscore is just a closing emphasis marker, not part of the
+// word. This is the same soft co-occurrence heuristic as the heading form:
+// it does not verify the resolution text actually settles the exact
+// approval wording elsewhere in the body.
 const INLINE_MAINTAINER_DECISION_PATTERN =
-  /(?<![\w-])Maintainer decision(?![\w-])\s*\([^)]{0,200}\)\s*:\s*(?!(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided)|TBD|pending|undecided|deferred|still\s+open)\b)\S/i;
+  /(?<![\w-])Maintainer decision(?![\w-])\s*\([^)]{0,200}\)\s*:\s*(?![\s*_`>-]*(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided)|TBD|pending|undecided|deferred|still\s+open)(?![a-zA-Z]))\S/i;
 // #2024: a negation word immediately before the trigger verb, allowing at
 // most one intervening word (e.g. "does not *ever* skip") between the
 // negation word and the trailing whitespace that reaches the verb. The
@@ -2112,14 +2137,18 @@ export function checkVerifiability(context) {
   // accepted trade-off for maintainer-authored issues. An approval-gated
   // body with no resolved decision still routes to needs-decision.
   //
-  // The inline form additionally requires its own paragraph not be framed as
-  // descriptive (#2661 C1 review): a body that merely *quotes* another
+  // The inline form additionally requires no framing verb PRECEDE it in its
+  // own paragraph (#2661 C1/PR review): a body that merely *quotes* another
   // issue's already-resolved decision as an example -- "issue #2641 states
   // \"Maintainer decision (...)\" as an example of the convention" -- must
-  // not borrow that resolution for THIS issue's own subjective gate. The
-  // heading form has no equivalent gap: a "## Decision (resolved …)" section
-  // is, by construction, this issue's own decision record, never a quoted
-  // example of someone else's.
+  // not borrow that resolution for THIS issue's own subjective gate. Scoped
+  // to text before the match (`isPrecededByFramingVerb`, not the
+  // whole-paragraph `isFramedAsDescriptive`) so a genuine resolution whose
+  // OWN text happens to use a reporting verb -- "Maintainer decision (...):
+  // the helper reports an actionable error" -- is not wrongly excluded
+  // (Codex review, PR #2662). The heading form has no equivalent gap: a
+  // "## Decision (resolved …)" section is, by construction, this issue's own
+  // decision record, never a quoted example of someone else's.
   const hasInlineResolvedDecision = (() => {
     const inlinePattern = new RegExp(
       INLINE_MAINTAINER_DECISION_PATTERN.source,
@@ -2128,7 +2157,7 @@ export function checkVerifiability(context) {
     let inlineMatch = inlinePattern.exec(normalizedBody);
     while (inlineMatch) {
       if (
-        !isFramedAsDescriptive(
+        !isPrecededByFramingVerb(
           normalizedBody,
           paragraphSpans,
           inlineMatch.index,

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -704,9 +704,23 @@ const RESOLVED_DECISION_PATTERN =
 // `(?![a-zA-Z])` replaces a plain `\b`, which fails to end the match after
 // "TBD_" (both `D` and `_` are `\w`, so `\b` finds no boundary there) even
 // though the underscore is just a closing emphasis marker, not part of the
-// word. `no\s+decision(?:\s+yet)?` covers the noun-first phrasing "no
-// decision yet", which the earlier verb-first "not (yet) decided" denylist
-// entries do not match (Codex round 2, PR #2662). Between the colon and the
+// word. The negated-decision-noun class (`no\s+(?:decision|consensus|
+// agreement|resolution|verdict|ruling|conclusion)(?:\s+yet)?`) and the
+// still-open-state class (`(?:still|remains?)\s+(?:open|undecided|
+// unresolved|pending|unsettled)`) replace the earlier single-phrase
+// entries ("no decision yet", "still open") with their semantic families,
+// covering "no consensus yet" and similar noun-first phrasings the
+// verb-first "not (yet) decided" denylist entries don't match (Codex
+// rounds 2-3, PR #2662) without enumerating every synonym as its own
+// literal. Deliberately NOT a bare `no\s+\w+`: "no changes to the API;
+// keep as-is" is a genuinely resolved decision, not a pending one.
+// **Convergence boundary**: this denylist is already stricter than
+// precedent -- `RESOLVED_DECISION_PATTERN` above has carried no
+// resolution-text denylist at all since #1135, and its own docstring
+// accepts exactly this soft-heuristic trade-off. A denylist can never
+// enumerate every future synonym; widen a *class* here only for a
+// concrete reported case, not for a hypothetical one. Between the colon
+// and the
 // lookahead, `[ \t]*(?:\r?\n[ \t]*)?` allows at most a single hard-wrapped
 // line break, never a full blank-line paragraph gap -- a bare `\s*` there
 // let an empty marker ("Maintainer decision (...):" immediately followed by
@@ -724,7 +738,7 @@ const RESOLVED_DECISION_PATTERN =
 // form: it does not verify the resolution text actually settles the exact
 // approval wording elsewhere in the body.
 const INLINE_MAINTAINER_DECISION_PATTERN =
-  /(?<![\w-])Maintainer decision(?![\w-])\s*\((?=[^)]{0,200}(?:#\d+|Groom hearing|\d{4}-\d{2}-\d{2}))[^)]{0,200}\)\s*:[ \t]*(?:\r?\n[ \t]*)?(?![\s*_`>-]*(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|no\s+decision(?:\s+yet)?|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided)|TBD|pending|undecided|deferred|still\s+open)(?![a-zA-Z]))\S/i;
+  /(?<![\w-])Maintainer decision(?![\w-])\s*\((?=[^)]{0,200}(?:#\d+|Groom hearing|\d{4}-\d{2}-\d{2}))[^)]{0,200}\)\s*:[ \t]*(?:\r?\n[ \t]*)?(?![\s*_`>-]*(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|no\s+(?:decision|consensus|agreement|resolution|verdict|ruling|conclusion)(?:\s+yet)?|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided)|TBD|TBA|TBC|pending|undecided|deferred|awaiting\s+(?:a\s+)?(?:decision|consensus|sign-?off|approval)|(?:still|remains?)\s+(?:open|undecided|unresolved|pending|unsettled))(?![a-zA-Z]))\S/i;
 // #2024: a negation word immediately before the trigger verb, allowing at
 // most one intervening word (e.g. "does not *ever* skip") between the
 // negation word and the trailing whitespace that reaches the verb. The

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -632,6 +632,24 @@ function hasSubstantiveBullet(text) {
 // across JavaScript regex engines.
 const RESOLVED_DECISION_PATTERN =
   /^#{1,6}\s+Decision\b(?![^\n]*\b(?:not(?:\s+yet)?(?:\s+been)?\s+resolved|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+resolved|never(?:\s+been)?\s+resolved)\b)[^\n]*\bresolved\b/im;
+// #2661: the grooming-pass workflow (docs/idd-workflow.md, from #2494)
+// records a resolved decision as inline prose -- "Maintainer decision
+// (<provenance>, <date>): <resolution text>" -- not a "## Decision" heading,
+// so RESOLVED_DECISION_PATTERN above never matches it. The parenthetical's own
+// provenance (an issue reference and/or "Groom hearing" and/or a date) is
+// this shape's resolved signal, so -- unlike the heading form -- the literal
+// word "resolved" is not required. `[^)]` (not `[^)\n]`) lets the parenthetical
+// span a hard-wrapped line break -- GitHub issue bodies wrap at ~80 chars, so
+// "(kurone-kito/idd-skill#2637, Groom hearing,\n2026-09-05):" routinely splits
+// the provenance across two physical lines (the same line-wrap-is-not-a-
+// boundary shape as the proximity check above, #2512). The same "still open"
+// guard applies immediately after the colon, so a placeholder like
+// "Maintainer decision (...): not yet decided" is not mistaken for a
+// resolution. This is the same soft co-occurrence heuristic as the heading
+// form: it does not verify the resolution text actually settles the exact
+// approval wording elsewhere in the body.
+const INLINE_MAINTAINER_DECISION_PATTERN =
+  /(?<![\w-])Maintainer decision(?![\w-])\s*\([^)]{0,200}\)\s*:\s*(?!(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided))\b)\S/i;
 // #2024: a negation word immediately before the trigger verb, allowing at
 // most one intervening word (e.g. "does not *ever* skip") between the
 // negation word and the trailing whitespace that reaches the verb. The
@@ -2068,15 +2086,18 @@ export function checkVerifiability(context) {
     return false;
   })();
   // A body that carries BOTH a resolved-decision marker (a
-  // "## Decision (resolved …)" section) AND a concrete, objectively-verifiable
-  // acceptance-criteria section is treated as having had its subjective call
-  // already settled by a human, so its prose merely *describes* that prior
-  // approval/decision. This is a soft heuristic for a soft advisory gate: it
-  // co-occurrence-matches the two signals rather than proving the decision
-  // resolves the exact approval wording, which is an accepted trade-off for
-  // maintainer-authored issues. An approval-gated body with no resolved
-  // decision still routes to needs-decision.
-  const hasResolvedDecision = RESOLVED_DECISION_PATTERN.test(body);
+  // "## Decision (resolved …)" heading, or the grooming-pass workflow's
+  // inline "Maintainer decision (…): …" prose, #2661) AND a concrete,
+  // objectively-verifiable acceptance-criteria section is treated as having
+  // had its subjective call already settled by a human, so its prose merely
+  // *describes* that prior approval/decision. This is a soft heuristic for a
+  // soft advisory gate: it co-occurrence-matches the two signals rather than
+  // proving the decision resolves the exact approval wording, which is an
+  // accepted trade-off for maintainer-authored issues. An approval-gated
+  // body with no resolved decision still routes to needs-decision.
+  const hasResolvedDecision =
+    RESOLVED_DECISION_PATTERN.test(body) ||
+    INLINE_MAINTAINER_DECISION_PATTERN.test(body);
   if (hasSubjectiveApproval && !(hasResolvedDecision && hasObjectiveCriteria)) {
     return {
       pass: false,

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -777,6 +777,25 @@ function hasSubstantiveBullet(text: string): boolean {
 const RESOLVED_DECISION_PATTERN =
   /^#{1,6}\s+Decision\b(?![^\n]*\b(?:not(?:\s+yet)?(?:\s+been)?\s+resolved|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+resolved|never(?:\s+been)?\s+resolved)\b)[^\n]*\bresolved\b/im;
 
+// #2661: the grooming-pass workflow (docs/idd-workflow.md, from #2494)
+// records a resolved decision as inline prose -- "Maintainer decision
+// (<provenance>, <date>): <resolution text>" -- not a "## Decision" heading,
+// so RESOLVED_DECISION_PATTERN above never matches it. The parenthetical's own
+// provenance (an issue reference and/or "Groom hearing" and/or a date) is
+// this shape's resolved signal, so -- unlike the heading form -- the literal
+// word "resolved" is not required. `[^)]` (not `[^)\n]`) lets the parenthetical
+// span a hard-wrapped line break -- GitHub issue bodies wrap at ~80 chars, so
+// "(kurone-kito/idd-skill#2637, Groom hearing,\n2026-09-05):" routinely splits
+// the provenance across two physical lines (the same line-wrap-is-not-a-
+// boundary shape as the proximity check above, #2512). The same "still open"
+// guard applies immediately after the colon, so a placeholder like
+// "Maintainer decision (...): not yet decided" is not mistaken for a
+// resolution. This is the same soft co-occurrence heuristic as the heading
+// form: it does not verify the resolution text actually settles the exact
+// approval wording elsewhere in the body.
+const INLINE_MAINTAINER_DECISION_PATTERN =
+  /(?<![\w-])Maintainer decision(?![\w-])\s*\([^)]{0,200}\)\s*:\s*(?!(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided))\b)\S/i;
+
 // #2024: a negation word immediately before the trigger verb, allowing at
 // most one intervening word (e.g. "does not *ever* skip") between the
 // negation word and the trailing whitespace that reaches the verb. The
@@ -2297,15 +2316,18 @@ export function checkVerifiability(context: Context): CheckOutcome {
     return false;
   })();
   // A body that carries BOTH a resolved-decision marker (a
-  // "## Decision (resolved …)" section) AND a concrete, objectively-verifiable
-  // acceptance-criteria section is treated as having had its subjective call
-  // already settled by a human, so its prose merely *describes* that prior
-  // approval/decision. This is a soft heuristic for a soft advisory gate: it
-  // co-occurrence-matches the two signals rather than proving the decision
-  // resolves the exact approval wording, which is an accepted trade-off for
-  // maintainer-authored issues. An approval-gated body with no resolved
-  // decision still routes to needs-decision.
-  const hasResolvedDecision = RESOLVED_DECISION_PATTERN.test(body);
+  // "## Decision (resolved …)" heading, or the grooming-pass workflow's
+  // inline "Maintainer decision (…): …" prose, #2661) AND a concrete,
+  // objectively-verifiable acceptance-criteria section is treated as having
+  // had its subjective call already settled by a human, so its prose merely
+  // *describes* that prior approval/decision. This is a soft heuristic for a
+  // soft advisory gate: it co-occurrence-matches the two signals rather than
+  // proving the decision resolves the exact approval wording, which is an
+  // accepted trade-off for maintainer-authored issues. An approval-gated
+  // body with no resolved decision still routes to needs-decision.
+  const hasResolvedDecision =
+    RESOLVED_DECISION_PATTERN.test(body) ||
+    INLINE_MAINTAINER_DECISION_PATTERN.test(body);
   if (hasSubjectiveApproval && !(hasResolvedDecision && hasObjectiveCriteria)) {
     return {
       pass: false,

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -332,6 +332,30 @@ function getParagraphSpans(body: string): { start: number; end: number }[] {
   return spans;
 }
 
+// #2661 C1 review: shared between `hasSubjectiveApproval` (#2512's original
+// use) and `hasResolvedDecision`'s inline-form scan. A match landing in a
+// paragraph that reports on another decision/approval as an example --
+// "issue #2641 states \"Maintainer decision (...)\" as an example of the
+// convention" -- uses the vocabulary as the OBJECT of that report, not as
+// this issue's own settled call, in either direction: it must not count as
+// evidence of an unresolved subjective gate (#2512's original case), and it
+// must equally not count as evidence THIS issue's own decision is resolved
+// (#2661's C1 finding -- a body that merely quotes another issue's already-
+// resolved decision as an example must not borrow that resolution).
+function isFramedAsDescriptive(
+  normalizedBody: string,
+  paragraphSpans: { start: number; end: number }[],
+  offset: number,
+): boolean {
+  const span =
+    paragraphSpans.find(
+      (candidate) => offset >= candidate.start && offset <= candidate.end,
+    ) ?? paragraphSpans[paragraphSpans.length - 1];
+  return FRAMING_VERB_PATTERN.test(
+    normalizedBody.slice(span?.start ?? 0, span?.end ?? normalizedBody.length),
+  );
+}
+
 // Check 3 precision: an unsafe execution directive tells the agent to act on
 // *supplied / untrusted* content, not any command verb that merely lands near
 // the ordinary determiner "this". Match the strong untrusted-origin signals, or
@@ -787,14 +811,17 @@ const RESOLVED_DECISION_PATTERN =
 // span a hard-wrapped line break -- GitHub issue bodies wrap at ~80 chars, so
 // "(kurone-kito/idd-skill#2637, Groom hearing,\n2026-09-05):" routinely splits
 // the provenance across two physical lines (the same line-wrap-is-not-a-
-// boundary shape as the proximity check above, #2512). The same "still open"
-// guard applies immediately after the colon, so a placeholder like
-// "Maintainer decision (...): not yet decided" is not mistaken for a
-// resolution. This is the same soft co-occurrence heuristic as the heading
-// form: it does not verify the resolution text actually settles the exact
-// approval wording elsewhere in the body.
+// boundary shape as the proximity check above, #2512). A "still open" guard
+// applies immediately after the colon, so a placeholder resolution is not
+// mistaken for a real one -- both the heading form's own negated-"resolved"
+// phrasing ("not yet decided") and this inline form's own still-pending
+// vocabulary (TBD, pending, undecided, deferred, "still open"), since the
+// inline form has no positive `\bresolved\b` requirement to fall back on
+// (#2661 C1 review). This is the same soft co-occurrence heuristic as the
+// heading form: it does not verify the resolution text actually settles the
+// exact approval wording elsewhere in the body.
 const INLINE_MAINTAINER_DECISION_PATTERN =
-  /(?<![\w-])Maintainer decision(?![\w-])\s*\([^)]{0,200}\)\s*:\s*(?!(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided))\b)\S/i;
+  /(?<![\w-])Maintainer decision(?![\w-])\s*\([^)]{0,200}\)\s*:\s*(?!(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided)|TBD|pending|undecided|deferred|still\s+open)\b)\S/i;
 
 // #2024: a negation word immediately before the trigger verb, allowing at
 // most one intervening word (e.g. "does not *ever* skip") between the
@@ -2268,33 +2295,20 @@ export function checkVerifiability(context: Context): CheckOutcome {
         'Issue does not provide objective verification signals or substantive acceptance criteria.',
     };
   }
+  // Normalized once so every offset computed below (line-split cursor,
+  // paragraph spans, proximity/inline-decision match index) shares the same
+  // 1-char line separator -- a raw `\r\n` body otherwise drifts the running
+  // `lineOffset` cursor by 1 byte per CRLF line, eventually pointing
+  // `isFramedAsDescriptive` at the wrong paragraph (#2531 review).
+  const normalizedBody = body.replace(/\r\n/g, '\n');
+  const paragraphSpans = getParagraphSpans(normalizedBody);
   const hasSubjectiveApproval = ((): boolean => {
-    // Normalized once so every offset computed below (line-split cursor,
-    // paragraph spans, proximity match index) shares the same 1-char line
-    // separator -- a raw `\r\n` body otherwise drifts the running
-    // `lineOffset` cursor by 1 byte per CRLF line, eventually pointing
-    // `isFramedAsDescriptive` at the wrong paragraph (#2531 review).
-    const normalizedBody = body.replace(/\r\n/g, '\n');
-    const paragraphSpans = getParagraphSpans(normalizedBody);
-    const isFramedAsDescriptive = (offset: number): boolean => {
-      const span =
-        paragraphSpans.find(
-          (candidate) => offset >= candidate.start && offset <= candidate.end,
-        ) ?? paragraphSpans[paragraphSpans.length - 1];
-      return FRAMING_VERB_PATTERN.test(
-        normalizedBody.slice(
-          span?.start ?? 0,
-          span?.end ?? normalizedBody.length,
-        ),
-      );
-    };
-
     let lineOffset = 0;
     for (const line of normalizedBody.split('\n')) {
       if (
         SUBJECTIVE_SUBJECT_PATTERN.test(line) &&
         SUBJECTIVE_GATE_PATTERN.test(line) &&
-        !isFramedAsDescriptive(lineOffset)
+        !isFramedAsDescriptive(normalizedBody, paragraphSpans, lineOffset)
       ) {
         return true;
       }
@@ -2307,7 +2321,13 @@ export function checkVerifiability(context: Context): CheckOutcome {
     );
     let proximityMatch = proximityPattern.exec(normalizedBody);
     while (proximityMatch) {
-      if (!isFramedAsDescriptive(proximityMatch.index)) {
+      if (
+        !isFramedAsDescriptive(
+          normalizedBody,
+          paragraphSpans,
+          proximityMatch.index,
+        )
+      ) {
         return true;
       }
       proximityMatch = proximityPattern.exec(normalizedBody);
@@ -2325,9 +2345,37 @@ export function checkVerifiability(context: Context): CheckOutcome {
   // proving the decision resolves the exact approval wording, which is an
   // accepted trade-off for maintainer-authored issues. An approval-gated
   // body with no resolved decision still routes to needs-decision.
+  //
+  // The inline form additionally requires its own paragraph not be framed as
+  // descriptive (#2661 C1 review): a body that merely *quotes* another
+  // issue's already-resolved decision as an example -- "issue #2641 states
+  // \"Maintainer decision (...)\" as an example of the convention" -- must
+  // not borrow that resolution for THIS issue's own subjective gate. The
+  // heading form has no equivalent gap: a "## Decision (resolved …)" section
+  // is, by construction, this issue's own decision record, never a quoted
+  // example of someone else's.
+  const hasInlineResolvedDecision = ((): boolean => {
+    const inlinePattern = new RegExp(
+      INLINE_MAINTAINER_DECISION_PATTERN.source,
+      'gi',
+    );
+    let inlineMatch = inlinePattern.exec(normalizedBody);
+    while (inlineMatch) {
+      if (
+        !isFramedAsDescriptive(
+          normalizedBody,
+          paragraphSpans,
+          inlineMatch.index,
+        )
+      ) {
+        return true;
+      }
+      inlineMatch = inlinePattern.exec(normalizedBody);
+    }
+    return false;
+  })();
   const hasResolvedDecision =
-    RESOLVED_DECISION_PATTERN.test(body) ||
-    INLINE_MAINTAINER_DECISION_PATTERN.test(body);
+    RESOLVED_DECISION_PATTERN.test(body) || hasInlineResolvedDecision;
   if (hasSubjectiveApproval && !(hasResolvedDecision && hasObjectiveCriteria)) {
     return {
       pass: false,

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -868,11 +868,19 @@ const RESOLVED_DECISION_PATTERN =
 // let an empty marker ("Maintainer decision (...):" immediately followed by
 // a blank line and the next section) cross into that next section and match
 // its first non-whitespace character as if it were resolution content
-// (Codex round 2, PR #2662). This is the same soft co-occurrence heuristic
-// as the heading form: it does not verify the resolution text actually
-// settles the exact approval wording elsewhere in the body.
+// (Codex round 2, PR #2662). The lookahead right after the opening "("
+// requires the parenthetical to actually contain one of the three
+// provenance signals this shape is documented to carry -- an issue/PR
+// reference, "Groom hearing", or an ISO-style date -- rather than accepting
+// any (or empty) parenthetical content as if provenance were merely
+// decorative (Copilot review round 2, PR #2662): without this, "Maintainer
+// decision (): ..." or "Maintainer decision (just kidding): ..." could
+// bypass the subjective-approval gate with no real grooming-pass record
+// behind it. This is the same soft co-occurrence heuristic as the heading
+// form: it does not verify the resolution text actually settles the exact
+// approval wording elsewhere in the body.
 const INLINE_MAINTAINER_DECISION_PATTERN =
-  /(?<![\w-])Maintainer decision(?![\w-])\s*\([^)]{0,200}\)\s*:[ \t]*(?:\r?\n[ \t]*)?(?![\s*_`>-]*(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|no\s+decision(?:\s+yet)?|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided)|TBD|pending|undecided|deferred|still\s+open)(?![a-zA-Z]))\S/i;
+  /(?<![\w-])Maintainer decision(?![\w-])\s*\((?=[^)]{0,200}(?:#\d+|Groom hearing|\d{4}-\d{2}-\d{2}))[^)]{0,200}\)\s*:[ \t]*(?:\r?\n[ \t]*)?(?![\s*_`>-]*(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|no\s+decision(?:\s+yet)?|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided)|TBD|pending|undecided|deferred|still\s+open)(?![a-zA-Z]))\S/i;
 
 // #2024: a negation word immediately before the trigger verb, allowing at
 // most one intervening word (e.g. "does not *ever* skip") between the

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -383,20 +383,27 @@ function isPrecededByFramingVerb(
 // decision (...): ...") is itself a quoting signal, independent of
 // `isPrecededByFramingVerb` -- pasting another issue's decision as a
 // blockquote carries no reporting verb of its own, so the framing-verb check
-// alone lets a quoted decision through. Checks the containing PARAGRAPH's
-// first line, not just the matched line itself: CommonMark's blockquote
-// "lazy continuation" rule (this repo's own coverage:
-// tests/markdown-code.test.mts's "permits lazy continuation" case) renders
+// alone lets a quoted decision through. Checks BOTH the matched line's own
+// ">" prefix (the direct case -- also covers a quote that starts partway
+// through a paragraph, e.g. "For reference:" followed immediately by
+// "> Maintainer decision (...)": CommonMark starts a new blockquote block at
+// that "> " line regardless of the preceding unquoted line, Codex round 5,
+// PR #2662) AND the containing PARAGRAPH's first line (CommonMark's
+// blockquote "lazy continuation" rule -- this repo's own coverage:
+// tests/markdown-code.test.mts's "permits lazy continuation" case -- renders
 // a line with no ">" of its own as still inside the quote when it continues
-// a paragraph that started with "> " -- "> Quoted from issue #123:" followed
-// immediately (no blank line) by an unprefixed "Maintainer decision (...)"
-// line is entirely quoted, even though that second physical line carries no
-// ">" marker of its own (Codex round 4, PR #2662).
+// a paragraph that started with "> ", Codex round 4, PR #2662). An earlier
+// round-4 revision checked only the paragraph's first line and dropped the
+// original round-2 direct-line check, reintroducing exactly the round-5 gap.
 function isInBlockquotedParagraph(
   normalizedBody: string,
   paragraphSpans: { start: number; end: number }[],
   offset: number,
 ): boolean {
+  const lineStart = normalizedBody.lastIndexOf('\n', offset - 1) + 1;
+  if (/^[ \t]*>/.test(normalizedBody.slice(lineStart, offset))) {
+    return true;
+  }
   const span =
     paragraphSpans.find(
       (candidate) => offset >= candidate.start && offset <= candidate.end,
@@ -2401,6 +2408,18 @@ export function checkVerifiability(context: Context): CheckOutcome {
   // `isFramedAsDescriptive` at the wrong paragraph (#2531 review).
   const normalizedBody = body.replace(/\r\n/g, '\n');
   const paragraphSpans = getParagraphSpans(normalizedBody);
+  // #2661 PR #2662 review round 5 (Codex): computed against `normalizedBody`
+  // (not the raw `body`-derived `fenceMaskedBody` above, whose offsets are
+  // not CRLF-normalized -- the #2531-class position-alignment risk noted in
+  // this PR's own body) so the inline-decision scan below ignores an
+  // inline/fenced code demonstration of the convention itself, e.g. an issue
+  // documenting the syntax with `` `Maintainer decision (Groom hearing,
+  // 2026-09-05): choose A` ``. `findMarkdownCodeRanges` covers both inline
+  // and fenced spans, unlike `findFencedCodeRanges` alone.
+  const normalizedCodeMaskedBody = maskMarkdownCodeRegionsPreservingPositions(
+    normalizedBody,
+    findMarkdownCodeRanges(normalizedBody),
+  );
   const hasSubjectiveApproval = ((): boolean => {
     let lineOffset = 0;
     for (const line of normalizedBody.split('\n')) {
@@ -2466,7 +2485,7 @@ export function checkVerifiability(context: Context): CheckOutcome {
       INLINE_MAINTAINER_DECISION_PATTERN.source,
       'gi',
     );
-    let inlineMatch = inlinePattern.exec(normalizedBody);
+    let inlineMatch = inlinePattern.exec(normalizedCodeMaskedBody);
     while (inlineMatch) {
       if (
         !isPrecededByFramingVerb(
@@ -2482,7 +2501,7 @@ export function checkVerifiability(context: Context): CheckOutcome {
       ) {
         return true;
       }
-      inlineMatch = inlinePattern.exec(normalizedBody);
+      inlineMatch = inlinePattern.exec(normalizedCodeMaskedBody);
     }
     return false;
   })();

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -860,9 +860,23 @@ const RESOLVED_DECISION_PATTERN =
 // `(?![a-zA-Z])` replaces a plain `\b`, which fails to end the match after
 // "TBD_" (both `D` and `_` are `\w`, so `\b` finds no boundary there) even
 // though the underscore is just a closing emphasis marker, not part of the
-// word. `no\s+decision(?:\s+yet)?` covers the noun-first phrasing "no
-// decision yet", which the earlier verb-first "not (yet) decided" denylist
-// entries do not match (Codex round 2, PR #2662). Between the colon and the
+// word. The negated-decision-noun class (`no\s+(?:decision|consensus|
+// agreement|resolution|verdict|ruling|conclusion)(?:\s+yet)?`) and the
+// still-open-state class (`(?:still|remains?)\s+(?:open|undecided|
+// unresolved|pending|unsettled)`) replace the earlier single-phrase
+// entries ("no decision yet", "still open") with their semantic families,
+// covering "no consensus yet" and similar noun-first phrasings the
+// verb-first "not (yet) decided" denylist entries don't match (Codex
+// rounds 2-3, PR #2662) without enumerating every synonym as its own
+// literal. Deliberately NOT a bare `no\s+\w+`: "no changes to the API;
+// keep as-is" is a genuinely resolved decision, not a pending one.
+// **Convergence boundary**: this denylist is already stricter than
+// precedent -- `RESOLVED_DECISION_PATTERN` above has carried no
+// resolution-text denylist at all since #1135, and its own docstring
+// accepts exactly this soft-heuristic trade-off. A denylist can never
+// enumerate every future synonym; widen a *class* here only for a
+// concrete reported case, not for a hypothetical one. Between the colon
+// and the
 // lookahead, `[ \t]*(?:\r?\n[ \t]*)?` allows at most a single hard-wrapped
 // line break, never a full blank-line paragraph gap -- a bare `\s*` there
 // let an empty marker ("Maintainer decision (...):" immediately followed by
@@ -880,7 +894,7 @@ const RESOLVED_DECISION_PATTERN =
 // form: it does not verify the resolution text actually settles the exact
 // approval wording elsewhere in the body.
 const INLINE_MAINTAINER_DECISION_PATTERN =
-  /(?<![\w-])Maintainer decision(?![\w-])\s*\((?=[^)]{0,200}(?:#\d+|Groom hearing|\d{4}-\d{2}-\d{2}))[^)]{0,200}\)\s*:[ \t]*(?:\r?\n[ \t]*)?(?![\s*_`>-]*(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|no\s+decision(?:\s+yet)?|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided)|TBD|pending|undecided|deferred|still\s+open)(?![a-zA-Z]))\S/i;
+  /(?<![\w-])Maintainer decision(?![\w-])\s*\((?=[^)]{0,200}(?:#\d+|Groom hearing|\d{4}-\d{2}-\d{2}))[^)]{0,200}\)\s*:[ \t]*(?:\r?\n[ \t]*)?(?![\s*_`>-]*(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|no\s+(?:decision|consensus|agreement|resolution|verdict|ruling|conclusion)(?:\s+yet)?|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided)|TBD|TBA|TBC|pending|undecided|deferred|awaiting\s+(?:a\s+)?(?:decision|consensus|sign-?off|approval)|(?:still|remains?)\s+(?:open|undecided|unresolved|pending|unsettled))(?![a-zA-Z]))\S/i;
 
 // #2024: a negation word immediately before the trigger verb, allowing at
 // most one intervening word (e.g. "does not *ever* skip") between the

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -364,7 +364,13 @@ function isFramedAsDescriptive(
 // without that making the marker itself a quoted example of someone else's
 // decision. A genuine quoting/reporting frame always precedes the quoted
 // marker in natural prose ("issue #2641 states \"Maintainer decision
-// (...)\"..."), so only text before the match need be checked here.
+// (...)\"..."), so only text before the match need be checked here. Bounded
+// to the current SENTENCE, not the whole paragraph prefix (round 6, PR
+// #2662): an unrelated reporting verb in an earlier, already-terminated
+// sentence of the same paragraph -- "The current helper reports status.
+// Maintainer decision (...): choose A" -- must not suppress a genuine
+// decision merely for sharing a paragraph with an unrelated use of the same
+// vocabulary.
 function isPrecededByFramingVerb(
   normalizedBody: string,
   paragraphSpans: { start: number; end: number }[],
@@ -374,9 +380,18 @@ function isPrecededByFramingVerb(
     paragraphSpans.find(
       (candidate) => offset >= candidate.start && offset <= candidate.end,
     ) ?? paragraphSpans[paragraphSpans.length - 1];
-  return FRAMING_VERB_PATTERN.test(
-    normalizedBody.slice(span?.start ?? 0, offset),
+  const scanText = normalizedBody.slice(span?.start ?? 0, offset);
+  const lastSentenceBoundary = Math.max(
+    scanText.lastIndexOf('. '),
+    scanText.lastIndexOf('! '),
+    scanText.lastIndexOf('? '),
+    scanText.lastIndexOf('.\n'),
+    scanText.lastIndexOf('!\n'),
+    scanText.lastIndexOf('?\n'),
   );
+  const sentenceStart =
+    lastSentenceBoundary === -1 ? 0 : lastSentenceBoundary + 2;
+  return FRAMING_VERB_PATTERN.test(scanText.slice(sentenceStart));
 }
 
 // #2661 PR #2662 review round 2 (Codex): a Markdown blockquote ("> Maintainer
@@ -415,6 +430,21 @@ function isInBlockquotedParagraph(
     firstLineEnd === -1 ? normalizedBody.length : firstLineEnd,
   );
   return /^[ \t]*>/.test(firstLine);
+}
+
+// #2661 PR #2662 review round 6 (Codex): an issue-template author commonly
+// leaves hidden instructional scaffolding as an HTML comment -- e.g.
+// `<!-- Maintainer decision (Groom hearing, YYYY-MM-DD): <resolution text>
+// -->` -- invisible in the rendered issue but still present in
+// `normalizedCodeMaskedBody` (Markdown code masking does not touch HTML
+// comments). Masked the same way as inline/fenced code, before the
+// inline-decision pattern scan.
+function findHtmlCommentRanges(text: string): MarkdownCodeRange[] {
+  const ranges: MarkdownCodeRange[] = [];
+  for (const match of text.matchAll(/<!--[\s\S]*?-->/g)) {
+    ranges.push({ start: match.index, end: match.index + match[0].length });
+  }
+  return ranges;
 }
 
 // Check 3 precision: an unsafe execution directive tells the agent to act on
@@ -900,14 +930,18 @@ const RESOLVED_DECISION_PATTERN =
 // resolution-text denylist at all since #1135, and its own docstring
 // accepts exactly this soft-heuristic trade-off. A denylist can never
 // enumerate every future synonym; widen a *class* here only for a
-// concrete reported case, not for a hypothetical one. Between the colon
-// and the
-// lookahead, `[ \t]*(?:\r?\n[ \t]*)?` allows at most a single hard-wrapped
-// line break, never a full blank-line paragraph gap -- a bare `\s*` there
-// let an empty marker ("Maintainer decision (...):" immediately followed by
-// a blank line and the next section) cross into that next section and match
-// its first non-whitespace character as if it were resolution content
-// (Codex round 2, PR #2662). The lookahead right after the opening "("
+// concrete reported case, not for a hypothetical one. Resolution text must
+// start on the SAME LINE as the colon (`[ \t]*`, no newline tolerance): an
+// earlier revision allowed a single hard-wrapped line break here, which
+// fixed the immediate "colon immediately followed by a blank line" case
+// (Codex round 2, PR #2662) but still let an empty marker consume the very
+// next line's first character even with no blank line at all -- e.g. a
+// heading's "#" right after "Maintainer decision (...):\n" (Copilot round
+// 6, PR #2662). Dropping the newline tolerance entirely closes both cases
+// at once; neither of this fix's two real-world citations (#2644, #2641)
+// ever needed it, since GitHub's hard-wrap only splits the provenance
+// parenthetical, never the colon-to-resolution boundary itself. The
+// lookahead right after the opening "("
 // requires the parenthetical to actually contain one of the three
 // provenance signals this shape is documented to carry -- an issue/PR
 // reference, "Groom hearing", or an ISO-style date -- rather than accepting
@@ -927,7 +961,7 @@ const RESOLVED_DECISION_PATTERN =
 // resolution text actually settles the exact approval wording elsewhere in
 // the body.
 const INLINE_MAINTAINER_DECISION_PATTERN =
-  /(?<![\w-])Maintainer decision(?![\w-])\s*\((?=[^)]{0,200}(?:#\d+|Groom hearing|\d{4}-\d{2}-\d{2}))[^)]{0,200}\)\s*:[ \t]*(?:\r?\n[ \t]*)?(?![\s*_`>-]*(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|no\s+(?:decision|consensus|agreement|resolution|verdict|ruling|conclusion)(?:\s+yet)?|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided)|TBD|TBA|TBC|(?:pending|undecided|deferred)(?:\s+(?:yet|still|for\s+now))?[\s*_`]*(?=[.,;:\n]|$)|awaiting\s+(?:a\s+)?(?:decision|consensus|sign-?off|approval)|(?:still|remains?)\s+(?:open|undecided|unresolved|pending|unsettled))(?![a-zA-Z]))\S/i;
+  /(?<![\w-])Maintainer decision(?![\w-])\s*\((?=[^)]{0,200}(?:#\d+|Groom hearing|\d{4}-\d{2}-\d{2}))[^)]{0,200}\)\s*:[ \t]*(?![\s*_`>-]*(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|no\s+(?:decision|consensus|agreement|resolution|verdict|ruling|conclusion)(?:\s+yet)?|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided)|TBD|TBA|TBC|(?:pending|undecided|deferred)(?:\s+(?:yet|still|for\s+now))?[\s*_`]*(?=[.,;:\n]|$)|awaiting\s+(?:a\s+)?(?:decision|consensus|sign-?off|approval)|(?:still|remains?)\s+(?:open|undecided|unresolved|pending|unsettled))(?![a-zA-Z]))\S/i;
 
 // #2024: a negation word immediately before the trigger verb, allowing at
 // most one intervening word (e.g. "does not *ever* skip") between the
@@ -2408,17 +2442,23 @@ export function checkVerifiability(context: Context): CheckOutcome {
   // `isFramedAsDescriptive` at the wrong paragraph (#2531 review).
   const normalizedBody = body.replace(/\r\n/g, '\n');
   const paragraphSpans = getParagraphSpans(normalizedBody);
-  // #2661 PR #2662 review round 5 (Codex): computed against `normalizedBody`
-  // (not the raw `body`-derived `fenceMaskedBody` above, whose offsets are
-  // not CRLF-normalized -- the #2531-class position-alignment risk noted in
-  // this PR's own body) so the inline-decision scan below ignores an
-  // inline/fenced code demonstration of the convention itself, e.g. an issue
-  // documenting the syntax with `` `Maintainer decision (Groom hearing,
-  // 2026-09-05): choose A` ``. `findMarkdownCodeRanges` covers both inline
-  // and fenced spans, unlike `findFencedCodeRanges` alone.
+  // #2661 PR #2662 review rounds 5-6 (Codex): computed against
+  // `normalizedBody` (not the raw `body`-derived `fenceMaskedBody` above,
+  // whose offsets are not CRLF-normalized -- the #2531-class
+  // position-alignment risk noted in this PR's own body) so the
+  // inline-decision scan below ignores both an inline/fenced code
+  // demonstration of the convention itself (e.g. an issue documenting the
+  // syntax with `` `Maintainer decision (Groom hearing, 2026-09-05): choose
+  // A` ``) and hidden HTML-comment template scaffolding (round 6:
+  // `<!-- Maintainer decision (...): <resolution text> -->`).
+  // `findMarkdownCodeRanges` covers both inline and fenced spans, unlike
+  // `findFencedCodeRanges` alone.
   const normalizedCodeMaskedBody = maskMarkdownCodeRegionsPreservingPositions(
     normalizedBody,
-    findMarkdownCodeRanges(normalizedBody),
+    [
+      ...findMarkdownCodeRanges(normalizedBody),
+      ...findHtmlCommentRanges(normalizedBody),
+    ],
   );
   const hasSubjectiveApproval = ((): boolean => {
     let lineOffset = 0;

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -438,11 +438,21 @@ function isInBlockquotedParagraph(
 // -->` -- invisible in the rendered issue but still present in
 // `normalizedCodeMaskedBody` (Markdown code masking does not touch HTML
 // comments). Masked the same way as inline/fenced code, before the
-// inline-decision pattern scan.
+// inline-decision pattern scan. An unterminated `<!--` (no matching `-->`)
+// extends to end-of-body: CommonMark renders such an HTML block through
+// EOF, so the entire remaining body -- a genuine marker and Acceptance
+// Criteria included -- can be invisible in the rendered issue while still
+// matching this scan if left unmasked (round 7, PR #2662).
 function findHtmlCommentRanges(text: string): MarkdownCodeRange[] {
   const ranges: MarkdownCodeRange[] = [];
-  for (const match of text.matchAll(/<!--[\s\S]*?-->/g)) {
-    ranges.push({ start: match.index, end: match.index + match[0].length });
+  const openPattern = /<!--/g;
+  let openMatch = openPattern.exec(text);
+  while (openMatch) {
+    const closeIndex = text.indexOf('-->', openMatch.index + 4);
+    const end = closeIndex === -1 ? text.length : closeIndex + 3;
+    ranges.push({ start: openMatch.index, end });
+    openPattern.lastIndex = end;
+    openMatch = openPattern.exec(text);
   }
   return ranges;
 }

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -383,13 +383,31 @@ function isPrecededByFramingVerb(
 // decision (...): ...") is itself a quoting signal, independent of
 // `isPrecededByFramingVerb` -- pasting another issue's decision as a
 // blockquote carries no reporting verb of its own, so the framing-verb check
-// alone lets a quoted decision through. Checked per matched LINE (not
-// paragraph): a multi-line blockquote block is still one paragraph span, but
-// only the "> "-prefixed line the match itself sits on need be quoted for
-// the match to count as quoted.
-function isOnBlockquotedLine(normalizedBody: string, offset: number): boolean {
-  const lineStart = normalizedBody.lastIndexOf('\n', offset - 1) + 1;
-  return /^[ \t]*>/.test(normalizedBody.slice(lineStart, offset));
+// alone lets a quoted decision through. Checks the containing PARAGRAPH's
+// first line, not just the matched line itself: CommonMark's blockquote
+// "lazy continuation" rule (this repo's own coverage:
+// tests/markdown-code.test.mts's "permits lazy continuation" case) renders
+// a line with no ">" of its own as still inside the quote when it continues
+// a paragraph that started with "> " -- "> Quoted from issue #123:" followed
+// immediately (no blank line) by an unprefixed "Maintainer decision (...)"
+// line is entirely quoted, even though that second physical line carries no
+// ">" marker of its own (Codex round 4, PR #2662).
+function isInBlockquotedParagraph(
+  normalizedBody: string,
+  paragraphSpans: { start: number; end: number }[],
+  offset: number,
+): boolean {
+  const span =
+    paragraphSpans.find(
+      (candidate) => offset >= candidate.start && offset <= candidate.end,
+    ) ?? paragraphSpans[paragraphSpans.length - 1];
+  const paragraphStart = span?.start ?? 0;
+  const firstLineEnd = normalizedBody.indexOf('\n', paragraphStart);
+  const firstLine = normalizedBody.slice(
+    paragraphStart,
+    firstLineEnd === -1 ? normalizedBody.length : firstLineEnd,
+  );
+  return /^[ \t]*>/.test(firstLine);
 }
 
 // Check 3 precision: an unsafe execution directive tells the agent to act on
@@ -890,11 +908,19 @@ const RESOLVED_DECISION_PATTERN =
 // decorative (Copilot review round 2, PR #2662): without this, "Maintainer
 // decision (): ..." or "Maintainer decision (just kidding): ..." could
 // bypass the subjective-approval gate with no real grooming-pass record
-// behind it. This is the same soft co-occurrence heuristic as the heading
-// form: it does not verify the resolution text actually settles the exact
-// approval wording elsewhere in the body.
+// behind it. `pending`/`undecided`/`deferred` additionally require a clause
+// boundary (through optional "yet"/"still"/"for now" and Markdown
+// decoration) immediately after the word -- these three, unlike TBD/TBA/TBC,
+// are ordinary English adjectives that can open a genuinely settled
+// resolution's own sentence ("deferred to follow-up issue #100 so this
+// patch remains scoped", "pending requests will be rejected with HTTP
+// 409"); only a bare, sentence-ending use of the word signals a real
+// placeholder (Codex round 4, PR #2662). This is the same soft
+// co-occurrence heuristic as the heading form: it does not verify the
+// resolution text actually settles the exact approval wording elsewhere in
+// the body.
 const INLINE_MAINTAINER_DECISION_PATTERN =
-  /(?<![\w-])Maintainer decision(?![\w-])\s*\((?=[^)]{0,200}(?:#\d+|Groom hearing|\d{4}-\d{2}-\d{2}))[^)]{0,200}\)\s*:[ \t]*(?:\r?\n[ \t]*)?(?![\s*_`>-]*(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|no\s+(?:decision|consensus|agreement|resolution|verdict|ruling|conclusion)(?:\s+yet)?|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided)|TBD|TBA|TBC|pending|undecided|deferred|awaiting\s+(?:a\s+)?(?:decision|consensus|sign-?off|approval)|(?:still|remains?)\s+(?:open|undecided|unresolved|pending|unsettled))(?![a-zA-Z]))\S/i;
+  /(?<![\w-])Maintainer decision(?![\w-])\s*\((?=[^)]{0,200}(?:#\d+|Groom hearing|\d{4}-\d{2}-\d{2}))[^)]{0,200}\)\s*:[ \t]*(?:\r?\n[ \t]*)?(?![\s*_`>-]*(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|no\s+(?:decision|consensus|agreement|resolution|verdict|ruling|conclusion)(?:\s+yet)?|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided)|TBD|TBA|TBC|(?:pending|undecided|deferred)(?:\s+(?:yet|still|for\s+now))?[\s*_`]*(?=[.,;:\n]|$)|awaiting\s+(?:a\s+)?(?:decision|consensus|sign-?off|approval)|(?:still|remains?)\s+(?:open|undecided|unresolved|pending|unsettled))(?![a-zA-Z]))\S/i;
 
 // #2024: a negation word immediately before the trigger verb, allowing at
 // most one intervening word (e.g. "does not *ever* skip") between the
@@ -2430,10 +2456,11 @@ export function checkVerifiability(context: Context): CheckOutcome {
   // the helper reports an actionable error" -- is not wrongly excluded
   // (Codex review, PR #2662). A Markdown blockquote is a second, independent
   // quoting signal with no reporting verb of its own -- "> Maintainer
-  // decision (...): ..." -- so `isOnBlockquotedLine` also excludes a match
-  // (Codex review round 2, PR #2662). The heading form has no equivalent
-  // gap: a "## Decision (resolved …)" section is, by construction, this
-  // issue's own decision record, never a quoted example of someone else's.
+  // decision (...): ..." -- so `isInBlockquotedParagraph` also excludes a
+  // match (Codex review rounds 2 and 4, PR #2662). The heading form has no
+  // equivalent gap: a "## Decision (resolved …)" section is, by
+  // construction, this issue's own decision record, never a quoted example
+  // of someone else's.
   const hasInlineResolvedDecision = ((): boolean => {
     const inlinePattern = new RegExp(
       INLINE_MAINTAINER_DECISION_PATTERN.source,
@@ -2447,7 +2474,11 @@ export function checkVerifiability(context: Context): CheckOutcome {
           paragraphSpans,
           inlineMatch.index,
         ) &&
-        !isOnBlockquotedLine(normalizedBody, inlineMatch.index)
+        !isInBlockquotedParagraph(
+          normalizedBody,
+          paragraphSpans,
+          inlineMatch.index,
+        )
       ) {
         return true;
       }

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -379,6 +379,19 @@ function isPrecededByFramingVerb(
   );
 }
 
+// #2661 PR #2662 review round 2 (Codex): a Markdown blockquote ("> Maintainer
+// decision (...): ...") is itself a quoting signal, independent of
+// `isPrecededByFramingVerb` -- pasting another issue's decision as a
+// blockquote carries no reporting verb of its own, so the framing-verb check
+// alone lets a quoted decision through. Checked per matched LINE (not
+// paragraph): a multi-line blockquote block is still one paragraph span, but
+// only the "> "-prefixed line the match itself sits on need be quoted for
+// the match to count as quoted.
+function isOnBlockquotedLine(normalizedBody: string, offset: number): boolean {
+  const lineStart = normalizedBody.lastIndexOf('\n', offset - 1) + 1;
+  return /^[ \t]*>/.test(normalizedBody.slice(lineStart, offset));
+}
+
 // Check 3 precision: an unsafe execution directive tells the agent to act on
 // *supplied / untrusted* content, not any command verb that merely lands near
 // the ordinary determiner "this". Match the strong untrusted-origin signals, or
@@ -847,11 +860,19 @@ const RESOLVED_DECISION_PATTERN =
 // `(?![a-zA-Z])` replaces a plain `\b`, which fails to end the match after
 // "TBD_" (both `D` and `_` are `\w`, so `\b` finds no boundary there) even
 // though the underscore is just a closing emphasis marker, not part of the
-// word. This is the same soft co-occurrence heuristic as the heading form:
-// it does not verify the resolution text actually settles the exact
-// approval wording elsewhere in the body.
+// word. `no\s+decision(?:\s+yet)?` covers the noun-first phrasing "no
+// decision yet", which the earlier verb-first "not (yet) decided" denylist
+// entries do not match (Codex round 2, PR #2662). Between the colon and the
+// lookahead, `[ \t]*(?:\r?\n[ \t]*)?` allows at most a single hard-wrapped
+// line break, never a full blank-line paragraph gap -- a bare `\s*` there
+// let an empty marker ("Maintainer decision (...):" immediately followed by
+// a blank line and the next section) cross into that next section and match
+// its first non-whitespace character as if it were resolution content
+// (Codex round 2, PR #2662). This is the same soft co-occurrence heuristic
+// as the heading form: it does not verify the resolution text actually
+// settles the exact approval wording elsewhere in the body.
 const INLINE_MAINTAINER_DECISION_PATTERN =
-  /(?<![\w-])Maintainer decision(?![\w-])\s*\([^)]{0,200}\)\s*:\s*(?![\s*_`>-]*(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided)|TBD|pending|undecided|deferred|still\s+open)(?![a-zA-Z]))\S/i;
+  /(?<![\w-])Maintainer decision(?![\w-])\s*\([^)]{0,200}\)\s*:[ \t]*(?:\r?\n[ \t]*)?(?![\s*_`>-]*(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|no\s+decision(?:\s+yet)?|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided)|TBD|pending|undecided|deferred|still\s+open)(?![a-zA-Z]))\S/i;
 
 // #2024: a negation word immediately before the trigger verb, allowing at
 // most one intervening word (e.g. "does not *ever* skip") between the
@@ -2385,9 +2406,12 @@ export function checkVerifiability(context: Context): CheckOutcome {
   // whole-paragraph `isFramedAsDescriptive`) so a genuine resolution whose
   // OWN text happens to use a reporting verb -- "Maintainer decision (...):
   // the helper reports an actionable error" -- is not wrongly excluded
-  // (Codex review, PR #2662). The heading form has no equivalent gap: a
-  // "## Decision (resolved …)" section is, by construction, this issue's own
-  // decision record, never a quoted example of someone else's.
+  // (Codex review, PR #2662). A Markdown blockquote is a second, independent
+  // quoting signal with no reporting verb of its own -- "> Maintainer
+  // decision (...): ..." -- so `isOnBlockquotedLine` also excludes a match
+  // (Codex review round 2, PR #2662). The heading form has no equivalent
+  // gap: a "## Decision (resolved …)" section is, by construction, this
+  // issue's own decision record, never a quoted example of someone else's.
   const hasInlineResolvedDecision = ((): boolean => {
     const inlinePattern = new RegExp(
       INLINE_MAINTAINER_DECISION_PATTERN.source,
@@ -2400,7 +2424,8 @@ export function checkVerifiability(context: Context): CheckOutcome {
           normalizedBody,
           paragraphSpans,
           inlineMatch.index,
-        )
+        ) &&
+        !isOnBlockquotedLine(normalizedBody, inlineMatch.index)
       ) {
         return true;
       }

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -356,6 +356,29 @@ function isFramedAsDescriptive(
   );
 }
 
+// #2661 PR #2662 review (Codex): unlike `isFramedAsDescriptive` above, this
+// scans only the paragraph text BEFORE `offset`, not the whole paragraph.
+// Used solely for the inline-decision scan, where the match's own resolution
+// text (after the colon) can legitimately contain an ordinary reporting verb
+// -- "Maintainer decision (...): the helper reports an actionable error" --
+// without that making the marker itself a quoted example of someone else's
+// decision. A genuine quoting/reporting frame always precedes the quoted
+// marker in natural prose ("issue #2641 states \"Maintainer decision
+// (...)\"..."), so only text before the match need be checked here.
+function isPrecededByFramingVerb(
+  normalizedBody: string,
+  paragraphSpans: { start: number; end: number }[],
+  offset: number,
+): boolean {
+  const span =
+    paragraphSpans.find(
+      (candidate) => offset >= candidate.start && offset <= candidate.end,
+    ) ?? paragraphSpans[paragraphSpans.length - 1];
+  return FRAMING_VERB_PATTERN.test(
+    normalizedBody.slice(span?.start ?? 0, offset),
+  );
+}
+
 // Check 3 precision: an unsafe execution directive tells the agent to act on
 // *supplied / untrusted* content, not any command verb that merely lands near
 // the ordinary determiner "this". Match the strong untrusted-origin signals, or
@@ -817,11 +840,18 @@ const RESOLVED_DECISION_PATTERN =
 // phrasing ("not yet decided") and this inline form's own still-pending
 // vocabulary (TBD, pending, undecided, deferred, "still open"), since the
 // inline form has no positive `\bresolved\b` requirement to fall back on
-// (#2661 C1 review). This is the same soft co-occurrence heuristic as the
-// heading form: it does not verify the resolution text actually settles the
-// exact approval wording elsewhere in the body.
+// (#2661 C1 review). The leading `[\s*_\`>-]*` skips past Markdown emphasis
+// (`**pending**`, `_TBD_`, `` `still open` ``) and list/blockquote markers
+// ("- TBD ...", "> pending ...") that would otherwise land between the colon
+// and the denylist word (Codex + Copilot review, PR #2662); the trailing
+// `(?![a-zA-Z])` replaces a plain `\b`, which fails to end the match after
+// "TBD_" (both `D` and `_` are `\w`, so `\b` finds no boundary there) even
+// though the underscore is just a closing emphasis marker, not part of the
+// word. This is the same soft co-occurrence heuristic as the heading form:
+// it does not verify the resolution text actually settles the exact
+// approval wording elsewhere in the body.
 const INLINE_MAINTAINER_DECISION_PATTERN =
-  /(?<![\w-])Maintainer decision(?![\w-])\s*\([^)]{0,200}\)\s*:\s*(?!(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided)|TBD|pending|undecided|deferred|still\s+open)\b)\S/i;
+  /(?<![\w-])Maintainer decision(?![\w-])\s*\([^)]{0,200}\)\s*:\s*(?![\s*_`>-]*(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided)|TBD|pending|undecided|deferred|still\s+open)(?![a-zA-Z]))\S/i;
 
 // #2024: a negation word immediately before the trigger verb, allowing at
 // most one intervening word (e.g. "does not *ever* skip") between the
@@ -2346,14 +2376,18 @@ export function checkVerifiability(context: Context): CheckOutcome {
   // accepted trade-off for maintainer-authored issues. An approval-gated
   // body with no resolved decision still routes to needs-decision.
   //
-  // The inline form additionally requires its own paragraph not be framed as
-  // descriptive (#2661 C1 review): a body that merely *quotes* another
+  // The inline form additionally requires no framing verb PRECEDE it in its
+  // own paragraph (#2661 C1/PR review): a body that merely *quotes* another
   // issue's already-resolved decision as an example -- "issue #2641 states
   // \"Maintainer decision (...)\" as an example of the convention" -- must
-  // not borrow that resolution for THIS issue's own subjective gate. The
-  // heading form has no equivalent gap: a "## Decision (resolved …)" section
-  // is, by construction, this issue's own decision record, never a quoted
-  // example of someone else's.
+  // not borrow that resolution for THIS issue's own subjective gate. Scoped
+  // to text before the match (`isPrecededByFramingVerb`, not the
+  // whole-paragraph `isFramedAsDescriptive`) so a genuine resolution whose
+  // OWN text happens to use a reporting verb -- "Maintainer decision (...):
+  // the helper reports an actionable error" -- is not wrongly excluded
+  // (Codex review, PR #2662). The heading form has no equivalent gap: a
+  // "## Decision (resolved …)" section is, by construction, this issue's own
+  // decision record, never a quoted example of someone else's.
   const hasInlineResolvedDecision = ((): boolean => {
     const inlinePattern = new RegExp(
       INLINE_MAINTAINER_DECISION_PATTERN.source,
@@ -2362,7 +2396,7 @@ export function checkVerifiability(context: Context): CheckOutcome {
     let inlineMatch = inlinePattern.exec(normalizedBody);
     while (inlineMatch) {
       if (
-        !isFramedAsDescriptive(
+        !isPrecededByFramingVerb(
           normalizedBody,
           paragraphSpans,
           inlineMatch.index,

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2807,8 +2807,10 @@ Whether to adopt this approach here requires the maintainer's sign-off before we
 });
 
 test('verifiability still fails on noun-first "no decision yet" phrasing (PR #2662 Codex round 2)', () => {
-  // The denylist's verb-first "not (yet) decided" phrasing does not match
-  // the noun-first "no decision yet" phrasing.
+  // The denylist's negated-decision-noun class (added in round 2, then
+  // generalized in round 3) covers the noun-first "no decision yet"
+  // phrasing that the earlier verb-first "not (yet) decided" entries alone
+  // do not match.
   const result = checkVerifiability({
     issue: {
       ...BASE_ISSUE,
@@ -2892,6 +2894,59 @@ Whether to adopt this approach here requires the maintainer's sign-off before we
     },
   } as Context);
   assert.equal(result.pass, false);
+});
+
+test('verifiability still fails when a quote starts partway through a paragraph (PR #2662 Codex round 5)', () => {
+  // A blockquote can start on a LATER line of the same blank-line-delimited
+  // span than an unquoted prose line before it -- CommonMark starts a new
+  // blockquote block at the "> " line regardless of what precedes it. The
+  // matched line's own ">" prefix must be checked directly, not just the
+  // paragraph's first line (an earlier revision dropped this direct check
+  // while adding the lazy-continuation check above).
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `For reference:
+> Maintainer decision (kurone-kito/idd-skill#2637, Groom hearing, 2026-09-05): pattern-match known bot acknowledgment templates
+
+Whether to adopt this approach here requires the maintainer's sign-off before we proceed, since it is ultimately a judgment call about UX.
+
+## Acceptance Criteria
+- [ ] tests pass
+- [ ] output contains the expected token
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
+test('verifiability still fails when the only inline decision is inside inline or fenced code (PR #2662 Codex round 5)', () => {
+  // A body that merely demonstrates the convention's syntax in code (inline
+  // or fenced) must not have that example read as a real resolution.
+  const tick = String.fromCharCode(96);
+  for (const demonstration of [
+    `Issues can record a resolution like ${tick}Maintainer decision (Groom hearing, 2026-09-05): choose A${tick}.`,
+    `\`\`\`\nMaintainer decision (Groom hearing, 2026-09-05): choose A\n\`\`\``,
+  ]) {
+    const result = checkVerifiability({
+      issue: {
+        ...BASE_ISSUE,
+        body: `${demonstration}
+
+Whether to adopt this approach here requires the maintainer's sign-off before we proceed, since it is ultimately a judgment call about UX.
+
+## Acceptance Criteria
+- [ ] tests pass
+- [ ] output contains the expected token
+`,
+      },
+    } as Context);
+    assert.equal(
+      result.pass,
+      false,
+      `expected fail for demonstration: ${demonstration}`,
+    );
+  }
 });
 
 test('verifiability passes settled decisions that begin with a denylist word (PR #2662 Codex round 4)', () => {

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2743,7 +2743,7 @@ test('verifiability still fails when an inline decision uses Markdown-decorated 
   // be defeated by a closing "_" (both the word char before it and "_"
   // itself are `\w`, so a plain `\b` never fires there).
   for (const resolution of [
-    '**pending** further review',
+    '**pending**, further review needed',
     '_TBD_',
     '`still open`',
     '- TBD, no consensus yet',
@@ -2870,6 +2870,79 @@ test('verifiability still passes a genuinely resolved decision containing "no" a
     },
   } as Context);
   assert.equal(result.pass, true);
+});
+
+test('verifiability still fails when a decision is only quoted via blockquote lazy continuation (PR #2662 Codex round 4)', () => {
+  // CommonMark's blockquote "lazy continuation" rule renders a line with no
+  // leading ">" as still inside the quote when it continues a paragraph
+  // that started with "> " -- checked here via the paragraph's first line,
+  // not just the matched line itself.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `> Quoted from issue #123:
+Maintainer decision (kurone-kito/idd-skill#2637, Groom hearing, 2026-09-05): pattern-match known bot acknowledgment templates
+
+Whether to adopt this approach here requires the maintainer's sign-off before we proceed, since it is ultimately a judgment call about UX.
+
+## Acceptance Criteria
+- [ ] tests pass
+- [ ] output contains the expected token
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
+test('verifiability passes settled decisions that begin with a denylist word (PR #2662 Codex round 4)', () => {
+  // "pending"/"undecided"/"deferred" are ordinary English adjectives that
+  // can open a genuinely settled resolution's own sentence -- only a bare,
+  // sentence-ending use of the word signals a real placeholder.
+  for (const resolution of [
+    'deferred to follow-up issue #100 so this patch remains scoped',
+    'pending requests will be rejected with HTTP 409',
+    'undecided items should be escalated to the next grooming pass',
+  ]) {
+    const result = checkVerifiability({
+      issue: {
+        ...BASE_ISSUE,
+        body: `Maintainer decision (Groom hearing, 2026-09-05): ${resolution}
+
+## Acceptance Criteria
+- [ ] tests pass
+- [ ] final sign-off from the maintainer confirms the UX feels right
+`,
+      },
+    } as Context);
+    assert.equal(
+      result.pass,
+      true,
+      `expected pass for resolution: ${resolution}`,
+    );
+  }
+});
+
+test('verifiability still fails when pending/undecided/deferred end the resolution as a bare placeholder (PR #2662 Codex round 4 guard)', () => {
+  // The tightened boundary must still reject a genuine bare placeholder use
+  // of these words, with or without "yet"/"still"/"for now".
+  for (const resolution of ['pending', 'undecided', 'deferred for now']) {
+    const result = checkVerifiability({
+      issue: {
+        ...BASE_ISSUE,
+        body: `Maintainer decision (Groom hearing, 2026-09-05): ${resolution}
+
+## Acceptance Criteria
+- [ ] tests pass
+- [ ] final sign-off from the maintainer confirms the UX feels right
+`,
+      },
+    } as Context);
+    assert.equal(
+      result.pass,
+      false,
+      `expected fail for resolution: ${resolution}`,
+    );
+  }
 });
 
 test('verifiability still fails when the parenthetical carries no real provenance (PR #2662 Copilot round 2)', () => {

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2823,6 +2823,35 @@ test('verifiability still fails on noun-first "no decision yet" phrasing (PR #26
   assert.equal(result.pass, false);
 });
 
+test('verifiability still fails when the parenthetical carries no real provenance (PR #2662 Copilot round 2)', () => {
+  // Any (or empty) parenthetical content must not count as provenance: the
+  // parenthetical must actually contain an issue/PR reference, "Groom
+  // hearing", or an ISO-style date -- otherwise the gate is bypassable with
+  // an unsubstantiated "Maintainer decision (...): ..." claim.
+  for (const parenthetical of [
+    '()',
+    '(just kidding)',
+    '(no real basis here)',
+  ]) {
+    const result = checkVerifiability({
+      issue: {
+        ...BASE_ISSUE,
+        body: `Maintainer decision ${parenthetical}: pursue option 1, per the maintainer's own judgment and approval.
+
+## Acceptance Criteria
+- [ ] tests pass
+- [ ] final sign-off from the maintainer confirms the UX feels right
+`,
+      },
+    } as Context);
+    assert.equal(
+      result.pass,
+      false,
+      `expected fail for parenthetical: ${parenthetical}`,
+    );
+  }
+});
+
 test('verifiability still fails when an inline decision uses still-pending vocabulary (#2661 C1 review)', () => {
   // The negative-lookahead denylist must also reject common still-pending
   // words with no negated-"resolved"/"decided" phrasing of their own (TBD,

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2969,6 +2969,29 @@ Whether to adopt this approach here requires the maintainer's sign-off before we
   assert.equal(result.pass, false);
 });
 
+test('verifiability still fails when an unterminated HTML comment swallows the rest of the body (PR #2662 Codex round 7)', () => {
+  // CommonMark renders an HTML comment opened with no matching "-->" as
+  // extending through end-of-document, so the "real" marker and Acceptance
+  // Criteria after it are also invisible in the rendered issue -- the whole
+  // remaining body must be masked, not just up to a "-->" that never comes.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `<!-- guidance for authors
+
+Maintainer decision (Groom hearing, 2026-09-05): choose option A over option B.
+
+Whether to adopt this approach here requires the maintainer's sign-off before we proceed, since it is ultimately a judgment call about UX.
+
+## Acceptance Criteria
+- [ ] tests pass
+- [ ] output contains the expected token
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
 test('verifiability passes a genuine decision despite an unrelated reporting verb earlier in the paragraph (PR #2662 Codex round 6)', () => {
   // The framing-verb check is bound to the current sentence, not the whole
   // paragraph prefix: an already-terminated, unrelated sentence using a

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2659,7 +2659,7 @@ The maintainer approval is recorded; option 1 was chosen.
 });
 
 test('verifiability passes an inline Groom-hearing resolved-decision issue with objective criteria (#2661)', () => {
-  // Check 7 false-negative that now passes: the grooming-pass workflow
+  // Check 7 false-positive that now passes: the grooming-pass workflow
   // (#2494) records a resolved decision as inline prose, not a "## Decision"
   // heading -- reproduces the shape of kurone-kito/idd-skill#2641's body.
   const result = checkVerifiability({
@@ -2716,6 +2716,56 @@ Whether to adopt this approach here requires the maintainer's sign-off before we
     },
   } as Context);
   assert.equal(result.pass, false);
+});
+
+test('verifiability passes an inline decision whose own resolution text uses a reporting verb (PR #2662 Codex review)', () => {
+  // The framing check must only look at text BEFORE the marker, not the
+  // whole paragraph: a genuine resolution can legitimately use an ordinary
+  // verb like "reports" in its own resolution text without that making the
+  // marker a quoted example of someone else's decision.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `Maintainer decision (Groom hearing, 2026-09-05): the helper reports an actionable error when the input is malformed, instead of silently passing.
+
+## Acceptance Criteria
+- [ ] tests pass
+- [ ] final sign-off from the maintainer confirms the UX feels right
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('verifiability still fails when an inline decision uses Markdown-decorated or list/quote-prefixed still-pending vocabulary (PR #2662 Codex + Copilot review)', () => {
+  // The still-pending denylist must see through a leading Markdown emphasis
+  // delimiter or list/blockquote marker, and its trailing boundary must not
+  // be defeated by a closing "_" (both the word char before it and "_"
+  // itself are `\w`, so a plain `\b` never fires there).
+  for (const resolution of [
+    '**pending** further review',
+    '_TBD_',
+    '`still open`',
+    '- TBD, no consensus yet',
+    '> pending, need more info',
+  ]) {
+    const result = checkVerifiability({
+      issue: {
+        ...BASE_ISSUE,
+        body: `Maintainer decision (Groom hearing, 2026-09-05): ${resolution}
+
+## Acceptance Criteria
+- [ ] tests pass
+- [ ] final sign-off from the maintainer confirms the UX feels right
+`,
+      },
+    } as Context);
+    assert.equal(
+      result.pass,
+      false,
+      `expected fail for resolution: ${resolution}`,
+    );
+  }
 });
 
 test('verifiability still fails when an inline decision uses still-pending vocabulary (#2661 C1 review)', () => {

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2768,6 +2768,61 @@ test('verifiability still fails when an inline decision uses Markdown-decorated 
   }
 });
 
+test('verifiability still fails when an inline marker has no resolution text before the next section (PR #2662 Codex round 2)', () => {
+  // A bare `\s*` between the colon and the resolution text let an EMPTY
+  // marker cross the blank-line paragraph boundary and consume the next
+  // heading's first character as if it were resolution content.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `Maintainer decision (Groom hearing, 2026-09-05):
+
+## Acceptance Criteria
+- [ ] tests pass
+- [ ] final sign-off from the maintainer confirms the UX feels right
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
+test('verifiability still fails when the only inline decision is Markdown-blockquoted (PR #2662 Codex round 2)', () => {
+  // A blockquoted decision ("> Maintainer decision (...): ...") is a
+  // quoting signal on its own, with no reporting verb required --
+  // `isPrecededByFramingVerb` alone would miss this.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `> Maintainer decision (kurone-kito/idd-skill#2637, Groom hearing, 2026-09-05): pattern-match known bot acknowledgment templates
+
+Whether to adopt this approach here requires the maintainer's sign-off before we proceed, since it is ultimately a judgment call about UX.
+
+## Acceptance Criteria
+- [ ] tests pass
+- [ ] output contains the expected token
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
+test('verifiability still fails on noun-first "no decision yet" phrasing (PR #2662 Codex round 2)', () => {
+  // The denylist's verb-first "not (yet) decided" phrasing does not match
+  // the noun-first "no decision yet" phrasing.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `Maintainer decision (Groom hearing, 2026-09-05): no decision yet, still gathering input.
+
+## Acceptance Criteria
+- [ ] tests pass
+- [ ] final sign-off from the maintainer confirms the UX feels right
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
 test('verifiability still fails when an inline decision uses still-pending vocabulary (#2661 C1 review)', () => {
   // The negative-lookahead denylist must also reject common still-pending
   // words with no negated-"resolved"/"decided" phrasing of their own (TBD,

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2658,6 +2658,63 @@ The maintainer approval is recorded; option 1 was chosen.
   assert.equal(result.pass, true);
 });
 
+test('verifiability passes an inline Groom-hearing resolved-decision issue with objective criteria (#2661)', () => {
+  // Check 7 false-negative that now passes: the grooming-pass workflow
+  // (#2494) records a resolved decision as inline prose, not a "## Decision"
+  // heading -- reproduces the shape of kurone-kito/idd-skill#2641's body.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `Maintainer decision (kurone-kito/idd-skill#2637, Groom hearing, 2026-09-05): pattern-match known bot acknowledgment templates (a narrow allowlist), mirroring the maintainer's existing approval.
+
+## Acceptance Criteria
+- [ ] the helper output contains the expected token
+- [ ] tests pass
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('verifiability passes an inline Groom-hearing decision whose parenthetical is hard-wrapped (#2661)', () => {
+  // GitHub issue bodies hard-wrap at ~80 chars, so the provenance parenthetical
+  // routinely splits across two physical lines -- the exact shape of
+  // kurone-kito/idd-skill#2641's real body. `[^)]` (not `[^)\n]`) must still
+  // match across that line break.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `Maintainer decision (kurone-kito/idd-skill#2637, Groom hearing,
+2026-09-05): pattern-match known bot acknowledgment templates (a narrow
+allowlist), mirroring the maintainer's existing approval.
+
+## Acceptance Criteria
+- [ ] the helper output contains the expected token
+- [ ] tests pass
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('verifiability still fails when an inline decision is not yet decided', () => {
+  // A still-open "Maintainer decision (...): not yet decided" must not count
+  // as a resolved decision, so the subjective screen still fires.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `Maintainer decision (Groom hearing, TBD): not yet decided, pending further review.
+
+## Acceptance Criteria
+- [ ] tests pass
+- [ ] output contains the expected token
+- [ ] final sign-off from the maintainer confirms the UX feels right
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
 test('actionability accepts checklist without Scope/Purpose headings', () => {
   const result = checkActionability({
     issue: {

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2823,6 +2823,55 @@ test('verifiability still fails on noun-first "no decision yet" phrasing (PR #26
   assert.equal(result.pass, false);
 });
 
+test('verifiability still fails on negated-decision-noun and still-open-state synonyms (PR #2662 Codex round 3)', () => {
+  // The denylist generalizes to semantic classes (negated-decision-noun,
+  // still-open-state) rather than one literal phrase at a time, covering
+  // "no consensus yet" and siblings the literal "no decision yet" entry
+  // alone would miss.
+  for (const resolution of [
+    'no consensus yet; discussion continues',
+    'no agreement reached',
+    'awaiting a decision from the maintainer',
+    'remains unresolved pending further discussion',
+    'TBA',
+  ]) {
+    const result = checkVerifiability({
+      issue: {
+        ...BASE_ISSUE,
+        body: `Maintainer decision (Groom hearing, 2026-09-05): ${resolution}
+
+## Acceptance Criteria
+- [ ] tests pass
+- [ ] final sign-off from the maintainer confirms the UX feels right
+`,
+      },
+    } as Context);
+    assert.equal(
+      result.pass,
+      false,
+      `expected fail for resolution: ${resolution}`,
+    );
+  }
+});
+
+test('verifiability still passes a genuinely resolved decision containing "no" as an ordinary word (PR #2662 Codex round 3 guard)', () => {
+  // A bare `no\s+\w+` would false-positive on an ordinary resolved
+  // decision that happens to start with "no" as ordinary prose, not a
+  // pending-decision signal.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `Maintainer decision (Groom hearing, 2026-09-05): no changes to the public API; keep the existing signature as-is.
+
+## Acceptance Criteria
+- [ ] tests pass
+- [ ] final sign-off from the maintainer confirms the UX feels right
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
 test('verifiability still fails when the parenthetical carries no real provenance (PR #2662 Copilot round 2)', () => {
   // Any (or empty) parenthetical content must not count as provenance: the
   // parenthetical must actually contain an issue/PR reference, "Groom

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2730,7 +2730,7 @@ test('verifiability passes an inline decision whose own resolution text uses a r
 
 ## Acceptance Criteria
 - [ ] tests pass
-- [ ] final sign-off from the maintainer confirms the UX feels right
+- [ ] the maintainer's sign-off on the UX is already recorded above
 `,
     },
   } as Context);

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2697,6 +2697,47 @@ allowlist), mirroring the maintainer's existing approval.
   assert.equal(result.pass, true);
 });
 
+test("verifiability still fails when the body only quotes another issue's resolved decision as an example (#2661 C1 review)", () => {
+  // A body that merely reports/quotes another issue's already-resolved
+  // decision as an illustrative example -- rather than recording its OWN
+  // resolution -- must not borrow that resolution: its own subjective
+  // sign-off requirement is still unresolved.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `For reference, issue #2641 states "Maintainer decision (kurone-kito/idd-skill#2637, Groom hearing, 2026-09-05): pattern-match known bot acknowledgment templates" as an example of the convention.
+
+Whether to adopt this approach here requires the maintainer's sign-off before we proceed, since it is ultimately a judgment call about UX.
+
+## Acceptance Criteria
+- [ ] tests pass
+- [ ] output contains the expected token
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
+test('verifiability still fails when an inline decision uses still-pending vocabulary (#2661 C1 review)', () => {
+  // The negative-lookahead denylist must also reject common still-pending
+  // words with no negated-"resolved"/"decided" phrasing of their own (TBD,
+  // pending, undecided, deferred, "still open") -- the inline form has no
+  // positive `\bresolved\b` requirement to fall back on, unlike the heading
+  // form.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `Maintainer decision (Groom hearing, 2026-09-05): still open, no consensus yet on the final approach.
+
+## Acceptance Criteria
+- [ ] tests pass
+- [ ] final sign-off from the maintainer confirms the UX feels right
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
 test('verifiability still fails when an inline decision is not yet decided', () => {
   // A still-open "Maintainer decision (...): not yet decided" must not count
   // as a resolved decision, so the subjective screen still fires.

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2949,6 +2949,63 @@ Whether to adopt this approach here requires the maintainer's sign-off before we
   }
 });
 
+test('verifiability still fails when the only inline decision is hidden in an HTML comment (PR #2662 Codex round 6)', () => {
+  // Issue-template scaffolding commonly leaves hidden guidance as an HTML
+  // comment; invisible in the rendered issue, it must not count as a real
+  // resolution.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `<!-- Maintainer decision (Groom hearing, YYYY-MM-DD): <resolution text> -->
+
+Whether to adopt this approach here requires the maintainer's sign-off before we proceed, since it is ultimately a judgment call about UX.
+
+## Acceptance Criteria
+- [ ] tests pass
+- [ ] output contains the expected token
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
+test('verifiability passes a genuine decision despite an unrelated reporting verb earlier in the paragraph (PR #2662 Codex round 6)', () => {
+  // The framing-verb check is bound to the current sentence, not the whole
+  // paragraph prefix: an already-terminated, unrelated sentence using a
+  // reporting verb must not suppress a genuine decision that follows in the
+  // same paragraph.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `The current helper reports status. Maintainer decision (Groom hearing, 2026-09-05): choose option A over option B.
+
+## Acceptance Criteria
+- [ ] tests pass
+- [ ] final sign-off from the maintainer confirms the UX feels right
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('verifiability still fails when an empty inline marker is immediately followed by a heading with no blank line (PR #2662 Copilot round 6)', () => {
+  // Resolution text must start on the same line as the colon: a single
+  // hard-wrap tolerance previously let an empty marker's colon consume the
+  // next line's first character (e.g. a heading's "#") as if it were
+  // resolution content, even with no blank-line paragraph gap at all.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `Maintainer decision (Groom hearing, 2026-09-05):
+## Acceptance Criteria
+- [ ] tests pass
+- [ ] final sign-off from the maintainer confirms the UX feels right
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
 test('verifiability passes settled decisions that begin with a denylist word (PR #2662 Codex round 4)', () => {
   // "pending"/"undecided"/"deferred" are ordinary English adjectives that
   // can open a genuinely settled resolution's own sentence -- only a bare,


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

`checkVerifiability`'s Check 7 resolved-decision carve-out
(`RESOLVED_DECISION_PATTERN`, from `#1135`) only recognized a
`## Decision (resolved …)` Markdown heading. It never recognized the
grooming-pass workflow's own established convention (`#2494`): inline
prose reading `Maintainer decision (<provenance>, Groom hearing,
<date>): <resolution text>`. Reproduced live against `#2644` and
`#2641`'s actual bodies before this fix -- both incorrectly failed
verifiability; both still pass after every commit below.

Adds `INLINE_MAINTAINER_DECISION_PATTERN` as a second resolved-decision
signal. This went through six rounds of Codex/Copilot re-review, each
closing a concrete false-positive or false-negative gap; the current
state:

- **Real provenance required.** The parenthetical must actually contain
  an issue/PR reference, "Groom hearing", or an ISO-style date -- an
  empty or unsubstantiated `Maintainer decision (): ...` cannot bypass
  the gate.
- **Same-line resolution text.** Resolution text must start on the same
  line as the colon (no newline tolerance at all) -- an empty marker
  can no longer consume a following blank-line section's or an
  immediately-adjacent heading's first character as if it were
  resolution content.
- **Quoting exclusion, three independent signals.** A body that merely
  *quotes* another issue's already-resolved decision does not count as
  this issue's own resolution: (1) a reporting verb in the SAME
  SENTENCE as the marker (not the whole paragraph -- an unrelated
  reporting verb in an earlier, already-terminated sentence must not
  suppress a genuine decision); (2) the matched line's own Markdown
  blockquote (`>`) prefix; (3) CommonMark blockquote "lazy
  continuation" -- a line with no `>` of its own still renders as
  quoted when it continues a paragraph that started with `> `.
- **Code and HTML-comment masking.** The scan ignores inline/fenced
  Markdown code (an issue merely demonstrating the convention's syntax)
  and hidden HTML-comment template scaffolding (invisible in the
  rendered issue).
- **Still-pending denylist, generalized to semantic classes.** A
  placeholder resolution (TBD/TBA/TBC, "still open", "no consensus
  yet", "awaiting a decision", etc.) is not mistaken for a real one --
  bounded classes, not an ever-growing literal list. `pending`/
  `undecided`/`deferred` additionally require a clause boundary
  immediately after the word, since (unlike TBD/TBA/TBC) they are
  ordinary English adjectives that can open a genuinely settled
  resolution's own sentence ("deferred to follow-up issue #100 so this
  patch remains scoped").

**Declined, with reasoning left in each thread and the relevant commit
message:** (a) full CommonMark container-nesting correctness for
quoting detection (e.g. a blockquote nested under a list item) -- the
three quoting signals above cover realistic shapes, and deeper nesting
is unusual formatting neither real-world citation exhibits; (b)
distinguishing "substantive rationale" from vague filler after a
placeholder word's clause-boundary punctuation -- not mechanically
checkable without unbounded scope creep. Both cite the denylist's own
stated convergence-boundary comment (directly above
`INLINE_MAINTAINER_DECISION_PATTERN` in the source): a bounded soft
heuristic, matching `RESOLVED_DECISION_PATTERN`'s own precedent (no
resolution-text denylist at all since `#1135`).

Also reconciles `docs/idd-workflow.md`'s grooming-pass section, which
said to record the decision "in a comment" -- the convention that
actually emerged records it inline in the issue body, which is also the
only place Check 7 reads from. Mirrored into
`idd-template/docs/idd-workflow.md`, the canonical template source for
that file (`audit/sync-manifest.json`'s `idd-workflow-doc` pair, mode
`structure`, hand-mirrored -- not auto-regenerated by `sync-docs.mjs`),
using a fully source-qualified issue link and the helper's bare
`suitability-triage.mjs` name (matching this file's own existing
citation convention -- the template tree does not ship
`scripts/suitability-triage.mjs` at that path).

## Linked issue

Closes #2661

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

The two declined findings above are the only known remaining gaps, and
both are deliberate scope boundaries rather than oversights -- see the
convergence-boundary comment in the source and the corresponding
review-thread replies for the full reasoning.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuYsYwJMEmfKEaf67DQ8zG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Grooming decisions can now be recorded directly in issue descriptions with supporting provenance and dates.
  * Re-triage recognizes these inline decision records while continuing to use comments as supplementary context.
  * Decision detection now handles wrapped text, pending-resolution wording, and same-line resolution details more reliably.

* **Bug Fixes**
  * Quoted, code-formatted, blockquoted, and hidden examples are excluded from decision verification.
  * Improved handling of incomplete, ambiguous, or improperly attributed decision records.

* **Documentation**
  * Updated workflow guidance and examples to reflect inline decision recording.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->