### PR TITLE
chore(release): cut v0.9.0 — suitability-triage changelog, version bump

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://kurone-kito.github.io/idd-skill/schemas/policy.schema.json",
-  "iddVersion": "0.8.0",
+  "iddVersion": "0.9.0",
   "markerPrefix": "idd-skill",
   "mergePolicy": "fully_autonomous_merge",
   "mergePolicyAck": "fully_autonomous_merge",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,72 @@ discipline and has no tag.
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-09-06
+
+Suitability-triage precision, cross-platform test hardening, and
+review/merge-pipeline reliability release.
+
+### Added
+
+- `idd-doctor` now warns (or, under `--strict`, errors) when a
+  repository's branch protection is enforced only via GitHub Rulesets
+  and the classic protection read genuinely 404s without
+  `ciGate.trustEmptyProtectionReads` set — closing a blind spot where
+  the F2/F3 merge gate could still fail on the first attempt despite a
+  clean doctor report.
+- Declaration-scoped `advisoryWait.providerOutage.terminalWindow`
+  override that shortens the terminal-unavailability window only
+  while a live provider-outage declaration is active, wired
+  consistently into the CI-gate verdict, the F2 readiness check, and
+  the active advisory-wait loop.
+- `resolve-review-thread --claimless` mode, mirroring
+  `pre-merge-readiness`'s flag, for operator-authorized reply-and-
+  resolve on a PR with no closing issue references.
+- `idd-pr-submit` mechanically derives the PR body's IDD impact
+  checklist from the actual diff at submission and re-verifies it
+  against the final HEAD immediately before merge, instead of trusting
+  a checklist drafted once from memory.
+- Issue-authoring: a `needs-decision` authoring-bucket marker
+  (mirroring the existing `blocked-by-human` one) so downstream
+  mechanical checks no longer need to re-derive the bucket from prose.
+
+### Changed
+
+- Extensive instruction and documentation precision across claim,
+  pre-merge, advisory-wait, review-fix, review-snapshot, discover, and
+  orchestration-delegation guidance (same-agent live-claim branch
+  correction, third-party bot skip-review notices in F2
+  review-currency, non-inheriting delegation for workers, REST-id-to-
+  node-id conversion notes, and related docs-only work).
+
+### Fixed
+
+- Suitability-triage precision: Check 3 no longer flags a freestanding
+  protocol-name mention, a `process.platform`-style code mention, or a
+  "not a directive to `<verb>`" negation as a policy override; Check 7
+  now accepts a substantive acceptance-criteria checklist without a
+  trigger keyword and recognizes the grooming pass's inline
+  `Maintainer decision (…, Groom hearing, …)` resolved-decision
+  convention alongside the existing heading form.
+- Cross-platform hardening across the test suite and build tooling for
+  native Windows: `tsc`/`biome` bin resolution, null-device and
+  PATH-stubbed `gh` CLI fixtures, POSIX-executable-bit and
+  `chmodSync`-based fault-injection assumptions, `idd-roadmap-audit`
+  git-path joins, the fake install command, `markdownlint-cli2`/
+  `cspell` `node_modules/.bin` spawning, and per-platform config-path
+  roots.
+- Review and merge pipeline: review-triage now captures CodeRabbit's
+  embedded findings; marker-helpers truncates fractional-second
+  timestamps; the advisory-convergence-comment workflow debounces
+  redundant rerun `--apply` calls; `audit-pr-cleanup`'s ack-only
+  post-disposition carve-out now extends to F4; the ack-only
+  classifier requires an exact template match; and `idd-pr-submit`
+  confirms Copilot's review actually landed before re-requesting it.
+- `discover-shared-file-overlap` degrades quietly instead of erroring
+  when the shared-file manifest is missing, and `audit-authored-issue`
+  verifies the owner-marker/publication trail before treating an issue
+  as fully published.
+
 ## [0.8.0] - 2026-09-04
 
 Outage-resilience release: sustain the IDD loop while the Copilot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,9 +45,10 @@ review/merge-pipeline reliability release.
 
 ### Changed
 
-- Extensive instruction and documentation precision across claim,
-  pre-merge, advisory-wait, review-fix, review-snapshot, discover, and
-  orchestration-delegation guidance (same-agent live-claim branch
+- Extensive instruction and documentation precision across work,
+  claim, pre-merge, advisory-wait, review-fix, review-snapshot,
+  discover, and orchestration-delegation guidance (the B1/F4 path
+  inside a host-isolated worktree, same-agent live-claim branch
   correction, third-party bot skip-review notices in F2
   review-currency, non-inheriting delegation for workers, REST-id-to-
   node-id conversion notes, and related docs-only work).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,8 +73,9 @@ review/merge-pipeline reliability release.
   timestamps; the advisory-convergence-comment workflow debounces
   redundant rerun `--apply` calls; `audit-pr-cleanup`'s ack-only
   post-disposition carve-out now extends to F4; the ack-only
-  classifier requires an exact template match; and `idd-pr-submit`
-  confirms Copilot's review actually landed before re-requesting it.
+  classifier now checks for CodeRabbit's own closure-decision template
+  instead of author and shape alone; and `idd-pr-submit` confirms
+  Copilot's review actually landed before re-requesting it.
 - `discover-shared-file-overlap` degrades quietly instead of erroring
   when the shared-file manifest is missing, and `audit-authored-issue`
   verifies the owner-marker/publication trail before treating an issue

--- a/idd-template/.github/idd/config.json
+++ b/idd-template/.github/idd/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://kurone-kito.github.io/idd-skill/schemas/policy.schema.json",
-  "iddVersion": "0.8.0",
+  "iddVersion": "0.9.0",
   "markerPrefix": "{{PROJECT_MARKER_PREFIX}}",
   "mergePolicy": "human_merge",
   "reviewPolicy": "copilot-advisory",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kurone-kito/idd-skill",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "description": "Issue-Driven Development workflow assets",
   "author": "kurone-kito <krone@kit.black> (https://kit.black/)",


### PR DESCRIPTION
# Summary

Cut `v0.9.0`: bump `iddVersion` / `package.json` `version` to `0.9.0`
in lockstep, and synthesize `## [0.9.0] - 2026-09-06` from the
`eff63104..main` first-parent window (46 merges), led by the
suitability-triage-precision and cross-platform-hardening themes.

## Linked issue

Closes #2665

## Follow-up issues (if any)

- [ ] Annotated `v0.9.0` tag (and no GitHub Release object) stays
      maintainer-reserved after this PR merges, per companion issue
      #2666 — the required post-merge step.

## Background / rationale (if material)

Playbook matches issue `#2183` / pull request `#2212` (`v0.7.0`) and
issue `#2341` / pull request `#2562` (`v0.8.0`): the `## [Unreleased]`
section is not treated as complete; the new section is synthesized
from first-parent history at the `[0.8.0]` entry's editorial
granularity (thematic paragraphs, no raw pull-request list, no `#NNN`
in CHANGELOG copy).

**Version survey** (mechanical, per the issue's step 1):
`git log eff63104..HEAD --no-merges --format='%s'` over 144 commits —
92 `fix`, 24 `docs`, 11 `test`, 9 `feat`, 6 `chore`, 2 `refactor`; zero
`!`/`BREAKING CHANGE:` markers. At least one `feat` with no breaking
marker means a minor bump → `0.9.0`.

Following PR #2562's own precedent, source-repo-local dogfooding work
(this repository's `token-cost-*` tooling, and this repository's own
CI/`pre-push-validate` wiring — neither ships to `idd-template/`) and
plain dependency-version bumps are intentionally omitted from the
public template changelog.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [x] Config schema changed
- [ ] Security / credential / merge behavior changed

Template change is `idd-template/.github/idd/config.json`'s
`iddVersion` only. Config-schema-bearing file `.github/idd/config.json`
also changed (`iddVersion` only, same value).

## Verification

- [x] `pnpm lint` (via `pre-push-validate`: biome / dprint /
      markdownlint / cspell)
- [x] `pnpm test` (`node --test tests/*.test.mts`, 5203 passed)
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (covered by `audit-docs --check`
      above; no instruction-source edits)
- [x] `node scripts/idd-doctor.mjs` (passed; pre-existing
      release-tag-drift warning remains until the maintainer-reserved
      tag from #2666)

Also: `cspell`, `audit-code-span-wrap`, `pnpm run build:check`,
`node scripts/token-cost-report.mjs --check`. Repository-wide `0.8.0`
grep after the bump leaves only unrelated `milestoneScope` example
literals (tests/docs/fixtures, pre-existing) and `pnpm-lock.yaml`
third-party versions.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

## CHANGELOG coverage map (PR body only)

Walked `git log eff63104..HEAD --first-parent --oneline` (46 merges),
mapped to each merge's own issue number via its branch name. Clusters:

- Suitability-triage precision (Fixed): issues `#2588`, `#2589`,
  `#2608`, `#2609`, `#2661`
- Cross-platform / native-Windows hardening (Fixed): issues `#2569`,
  `#2570`, `#2571`, `#2576`, `#2577`, `#2580`, `#2581`, `#2582`,
  `#2585`
- Review/merge pipeline (Fixed): issues `#2559`, `#2592`, `#2618`,
  `#2622`, `#2641`, `#2643`
- Discover / issue-authoring integrity (Fixed): issues `#2617`,
  `#2621`
- New capabilities (Added): issues `#2554`, `#2587`, `#2616`, `#2634`,
  `#2642`
- Instruction/documentation precision (Changed): issues `#2232`,
  `#2578`, `#2590`, `#2591`, `#2607`, `#2620`, `#2624`
- Omitted (source-repo-local token-cost dogfooding tooling, not
  `idd-template/`): issues `#2432`, `#2619`, `#2623`, `#2651`,
  `#2652`, `#2654`, `#2658`
- Omitted (source-repo-local CI/config wiring, not `idd-template/`):
  issues `#2611`, `#2640`
- Omitted (internal refactor, no user-facing behavior change): issue
  `#2568`
- Omitted (plain dependency-version bumps, no linked issue): pull
  requests `#2660`, `#2663`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZDp3cvgkSpSbsBB9VARzC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the 0.9.0 changelog entry, covering diagnostic improvements, review and merge reliability updates, native Windows support, and publication verification fixes.
* **Chores**
  * Updated the product version to 0.9.0 across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->