### PR TITLE
feat(helper): propose untrusted-labeler logins via a full-history sweep

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -54,6 +54,7 @@ scripts/idd-doctor.mjs linguist-generated=true
 scripts/idd-merge-execute.mjs linguist-generated=true
 scripts/idd-onboard.mjs linguist-generated=true
 scripts/idd-roadmap-audit-execute.mjs linguist-generated=true
+scripts/idd-suggest-untrusted-labelers.mjs linguist-generated=true
 scripts/live-status-digest.mjs linguist-generated=true
 scripts/local-validation-evidence.mjs linguist-generated=true
 scripts/markdown-code.mjs linguist-generated=true

--- a/bin/idd-suggest-untrusted-labelers.mjs
+++ b/bin/idd-suggest-untrusted-labelers.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-suggest-untrusted-labelers.mts
+//
+// The bin/idd-suggest-untrusted-labelers.mjs copy is generated from the .mts source named above
+// by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+import { runHelper } from './run-helper.mjs';
+
+runHelper('../scripts/idd-suggest-untrusted-labelers.mjs');

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -3139,8 +3139,10 @@ same as `AW4`/`AW5`.
 - **Read-only, unconditionally**: performs no write operation of any
   kind — no `.github/idd/config.json` edit, no GitHub mutation (no
   label change, no comment, no other write call). It only proposes
-  candidates for a human to review; adding a login to
-  `labels.untrustedLabelerLogins` stays a manual, adopter-owned edit
+  candidates for a human to review; adding an accepted candidate's
+  login as one of the [Reserved-label guard recipe](customization.md#reserved-label-guard-recipe)'s
+  `<labeler-bot-login-N>` placeholders in
+  `strip-untrusted-labels.yml` stays a manual, adopter-owned edit
   after judging each candidate's event count. Not a phase step in any
   `idd-*.instructions.md` file — like the Merged-PR feedback sweep
   above, this is a manually-invoked, operator-run spot-check, run once

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -3100,6 +3100,54 @@ same as `AW4`/`AW5`.
     universal adopter policy — this sweep is a detection aid only: never
     an automatic recovery path or a retroactive merge gate.
 
+### Untrusted-labeler login sweep
+
+- Source repo / vendored-node command:
+
+  ```sh
+  node scripts/idd-suggest-untrusted-labelers.mjs [--owner <owner>] [--repo <repo>] [--format table|json]
+  ```
+
+- Package-manager / ephemeral-npx command: use the profile-selected
+  `idd:suggest-untrusted-labelers` command from the helper runtime
+  manifest wiring above; the literal invocation is:
+
+  ```sh
+  npx --yes --package <helper-package-spec> \
+    idd-suggest-untrusted-labelers [--owner <owner>] [--repo <repo>] [--format table|json]
+  ```
+
+- Automates the full-history sweep technique the
+  [Reserved-label guard recipe](customization.md#reserved-label-guard-recipe)
+  already documents in prose: paginates `GET
+  /repos/{owner}/{repo}/issues/events` to completion, keeping only
+  entries where `event == "labeled"` and the actor's `type == "Bot"`
+  (the REST Issue Event object's `actor` field — a nullable simple-user
+  object — not the webhook payload's `sender` field), deduplicates by
+  `actor.login`, and prints each distinct bot login with a count of
+  `labeled` events attributed to it (`--format table`, the default) or
+  the full result as JSON (`--format json`, including `scannedEventCount`
+  and `pageCount` completeness evidence). `--owner`/`--repo` default to
+  the current repository via `gh repo view` auto-detection.
+- Pages manually (`page=1,2,...` with `per_page=100`), not via `gh api
+  --paginate` in one subprocess call: the repository-level endpoint
+  embeds the full parent `issue` object in every event, and `gh`'s
+  synchronous execution path this repository's helpers share exposes no
+  `maxBuffer` override, so an unbounded repository-wide sweep pages one
+  request at a time instead of risking a single oversized buffered
+  response.
+- **Read-only, unconditionally**: performs no write operation of any
+  kind — no `.github/idd/config.json` edit, no GitHub mutation (no
+  label change, no comment, no other write call). It only proposes
+  candidates for a human to review; adding a login to
+  `labels.untrustedLabelerLogins` stays a manual, adopter-owned edit
+  after judging each candidate's event count. Not a phase step in any
+  `idd-*.instructions.md` file — like the Merged-PR feedback sweep
+  above, this is a manually-invoked, operator-run spot-check, run once
+  when first building the reserved-label guard's bot-login list and
+  again after enabling new automation or after a long gap (a bot with
+  no history yet can still start labeling later).
+
 ## Signed-Commit Merge Wrapper (Shared Git Procedure)
 
 `idd-review-triage.instructions.md`'s E-phase sync path and

--- a/fixtures/idd-suggest-untrusted-labelers/basic.json
+++ b/fixtures/idd-suggest-untrusted-labelers/basic.json
@@ -1,0 +1,17 @@
+{
+  "input": {
+    "events": [
+      { "event": "labeled", "actor": { "login": "noisy-bot", "type": "Bot" } },
+      { "event": "labeled", "actor": { "login": "noisy-bot", "type": "Bot" } },
+      { "event": "labeled", "actor": { "login": "noisy-bot", "type": "Bot" } },
+      { "event": "labeled", "actor": { "login": "quiet-bot", "type": "Bot" } },
+      { "event": "labeled", "actor": { "login": "kurone-kito", "type": "User" } },
+      { "event": "unlabeled", "actor": { "login": "noisy-bot", "type": "Bot" } },
+      { "event": "closed", "actor": { "login": "kurone-kito", "type": "User" } }
+    ]
+  },
+  "expected": [
+    { "login": "noisy-bot", "labeledEventCount": 3 },
+    { "login": "quiet-bot", "labeledEventCount": 1 }
+  ]
+}

--- a/fixtures/idd-suggest-untrusted-labelers/edge-cases.json
+++ b/fixtures/idd-suggest-untrusted-labelers/edge-cases.json
@@ -1,0 +1,18 @@
+{
+  "input": {
+    "events": [
+      { "event": "labeled", "actor": null },
+      { "event": "labeled", "actor": {} },
+      { "event": "labeled", "actor": { "login": null, "type": "Bot" } },
+      { "event": "labeled", "actor": { "login": "   ", "type": "Bot" } },
+      { "event": "labeled", "actor": { "login": "same-count-a", "type": "Bot" } },
+      { "event": "labeled", "actor": { "login": "same-count-b", "type": "Bot" } },
+      { "event": null, "actor": { "login": "ignored-bot", "type": "Bot" } },
+      { "actor": { "login": "another-ignored-bot", "type": "Bot" } }
+    ]
+  },
+  "expected": [
+    { "login": "same-count-a", "labeledEventCount": 1 },
+    { "login": "same-count-b", "labeledEventCount": 1 }
+  ]
+}

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -3139,8 +3139,10 @@ same as `AW4`/`AW5`.
 - **Read-only, unconditionally**: performs no write operation of any
   kind — no `.github/idd/config.json` edit, no GitHub mutation (no
   label change, no comment, no other write call). It only proposes
-  candidates for a human to review; adding a login to
-  `labels.untrustedLabelerLogins` stays a manual, adopter-owned edit
+  candidates for a human to review; adding an accepted candidate's
+  login as one of the [Reserved-label guard recipe](customization.md#reserved-label-guard-recipe)'s
+  `<labeler-bot-login-N>` placeholders in
+  `strip-untrusted-labels.yml` stays a manual, adopter-owned edit
   after judging each candidate's event count. Not a phase step in any
   `idd-*.instructions.md` file — like the Merged-PR feedback sweep
   above, this is a manually-invoked, operator-run spot-check, run once

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -3100,6 +3100,54 @@ same as `AW4`/`AW5`.
     universal adopter policy — this sweep is a detection aid only: never
     an automatic recovery path or a retroactive merge gate.
 
+### Untrusted-labeler login sweep
+
+- Source repo / vendored-node command:
+
+  ```sh
+  node scripts/idd-suggest-untrusted-labelers.mjs [--owner <owner>] [--repo <repo>] [--format table|json]
+  ```
+
+- Package-manager / ephemeral-npx command: use the profile-selected
+  `idd:suggest-untrusted-labelers` command from the helper runtime
+  manifest wiring above; the literal invocation is:
+
+  ```sh
+  npx --yes --package <helper-package-spec> \
+    idd-suggest-untrusted-labelers [--owner <owner>] [--repo <repo>] [--format table|json]
+  ```
+
+- Automates the full-history sweep technique the
+  [Reserved-label guard recipe](customization.md#reserved-label-guard-recipe)
+  already documents in prose: paginates `GET
+  /repos/{owner}/{repo}/issues/events` to completion, keeping only
+  entries where `event == "labeled"` and the actor's `type == "Bot"`
+  (the REST Issue Event object's `actor` field — a nullable simple-user
+  object — not the webhook payload's `sender` field), deduplicates by
+  `actor.login`, and prints each distinct bot login with a count of
+  `labeled` events attributed to it (`--format table`, the default) or
+  the full result as JSON (`--format json`, including `scannedEventCount`
+  and `pageCount` completeness evidence). `--owner`/`--repo` default to
+  the current repository via `gh repo view` auto-detection.
+- Pages manually (`page=1,2,...` with `per_page=100`), not via `gh api
+  --paginate` in one subprocess call: the repository-level endpoint
+  embeds the full parent `issue` object in every event, and `gh`'s
+  synchronous execution path this repository's helpers share exposes no
+  `maxBuffer` override, so an unbounded repository-wide sweep pages one
+  request at a time instead of risking a single oversized buffered
+  response.
+- **Read-only, unconditionally**: performs no write operation of any
+  kind — no `.github/idd/config.json` edit, no GitHub mutation (no
+  label change, no comment, no other write call). It only proposes
+  candidates for a human to review; adding a login to
+  `labels.untrustedLabelerLogins` stays a manual, adopter-owned edit
+  after judging each candidate's event count. Not a phase step in any
+  `idd-*.instructions.md` file — like the Merged-PR feedback sweep
+  above, this is a manually-invoked, operator-run spot-check, run once
+  when first building the reserved-label guard's bot-login list and
+  again after enabling new automation or after a long gap (a bot with
+  no history yet can still start labeling later).
+
 ## Signed-Commit Merge Wrapper (Shared Git Procedure)
 
 `idd-review-triage.instructions.md`'s E-phase sync path and

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "idd-roadmap-audit-execute": "./bin/idd-roadmap-audit-execute.mjs",
     "idd-select-desynced-index": "./bin/idd-select-desynced-index.mjs",
     "idd-stalled-session-quiet-check": "./bin/idd-stalled-session-quiet-check.mjs",
+    "idd-suggest-untrusted-labelers": "./bin/idd-suggest-untrusted-labelers.mjs",
     "idd-suitability-close-execute": "./bin/idd-suitability-close-execute.mjs",
     "idd-suitability-triage": "./bin/idd-suitability-triage.mjs"
   },

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -522,6 +522,15 @@ const HELPER_COMMANDS = [
     contractPaths: ['schemas/stalled-session-quiet-check.schema.json'],
   },
   {
+    id: 'suggest-untrusted-labelers',
+    scriptName: 'idd:suggest-untrusted-labelers',
+    binName: 'idd-suggest-untrusted-labelers',
+    entryPath: 'scripts/idd-suggest-untrusted-labelers.mjs',
+    vendoredCommand: 'node scripts/idd-suggest-untrusted-labelers.mjs',
+    description:
+      'Sweep GET /repos/{owner}/{repo}/issues/events to completion and report distinct bot logins that produced a labeled event, with a count each (read-only).',
+  },
+  {
     id: 'suitability-close-execute',
     scriptName: 'idd:suitability-close-execute',
     binName: 'idd-suitability-close-execute',

--- a/scripts/idd-suggest-untrusted-labelers.mjs
+++ b/scripts/idd-suggest-untrusted-labelers.mjs
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/idd-suggest-untrusted-labelers.mts
+//
+// The scripts/idd-suggest-untrusted-labelers.mjs copy is generated from
+// the .mts source named above by `pnpm run build`. Edit the .mts source,
+// never the generated .mjs. See docs/typescript-sources.md.
+//
+// #2670: automates `docs/customization.md`'s Reserved-label guard
+// recipe's "full-history sweep" technique for building the
+// untrusted-labeler login list -- a paginated `GET
+// /repos/{owner}/{repo}/issues/events` read, filtered to `event ==
+// "labeled"` entries whose actor `type == "Bot"`, deduplicated by
+// login and counted. This is a read-only reporting tool only: it never
+// edits `.github/idd/config.json` and never mutates GitHub state (no
+// label removal, no comments, no other write call of any kind). Adding
+// a login to `labels.untrustedLabelerLogins` stays a manual,
+// adopter-owned edit after reviewing this report.
+import { parseCliArgs } from './cli-args.mjs';
+import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghApiJson, ghText } from './gh-exec.mjs';
+/**
+ * Filter `events` to `event === 'labeled'` entries whose actor `type ===
+ * 'Bot'`, deduplicate by `actor.login`, and count occurrences per login.
+ * Pure and offline: takes already-fetched events, never calls `gh` itself
+ * (the paginated fetch lives in {@link sweepUntrustedLabelerCandidates}
+ * below), matching `actions-usage-report.mts`'s aggregate/fetch split so
+ * this function is the one covered by an offline fixture test.
+ *
+ * An event whose `actor` is `null`/absent (GitHub omits `actor` for some
+ * system-generated events), or whose `actor.login` is empty/whitespace, is
+ * skipped rather than counted under an empty-string login.
+ */
+export function aggregateUntrustedLabelerCandidates(events) {
+  const counts = new Map();
+  for (const event of events) {
+    if (event?.event !== 'labeled') {
+      continue;
+    }
+    if (event.actor?.type !== 'Bot') {
+      continue;
+    }
+    const login = event.actor?.login?.trim();
+    if (!login) {
+      continue;
+    }
+    counts.set(login, (counts.get(login) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([login, labeledEventCount]) => ({ login, labeledEventCount }))
+    .sort(
+      (a, b) =>
+        b.labeledEventCount - a.labeledEventCount ||
+        a.login.localeCompare(b.login),
+    );
+}
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+export function renderTable(result) {
+  const lines = [
+    '| Bot login | Labeled events |',
+    '| --- | --- |',
+    ...result.candidates.map(
+      (row) => `| ${row.login} | ${row.labeledEventCount} |`,
+    ),
+    '',
+    `Total: ${result.candidates.length} distinct bot login(s) found across ` +
+      `${result.scannedEventCount} scanned issue/PR event(s) over ` +
+      `${result.pageCount} page(s).`,
+  ];
+  return lines.join('\n');
+}
+// ---------------------------------------------------------------------------
+// GitHub fetch (I/O -- not exercised by the offline fixture test)
+// ---------------------------------------------------------------------------
+/** Events requested per page. GitHub's REST list endpoints accept up to
+ * 100 per `per_page`. */
+const EVENTS_PER_PAGE = 100;
+/** Hard ceiling on pages fetched in one sweep -- a fail-closed guard
+ * against a runaway loop (a malformed injected `fetchPage`, or a paged
+ * endpoint that never returns a short final page), not a limit this
+ * repository's real event history is expected to approach. */
+const MAX_SWEEP_PAGES = 100_000;
+/**
+ * Fetch one page of `GET /repos/{owner}/{repo}/issues/events`, projected
+ * down to just `event`/`actor.login`/`actor.type` via a server-side `--jq`
+ * filter (the repository-level endpoint embeds the full parent `issue`
+ * object -- including its body -- in every event, so a page fetched
+ * without this projection, from a repository with thousands of
+ * issues/PRs, can run to several MB).
+ *
+ * Deliberately **not** `ghApiJson(path, { paginate: true })`: that call
+ * walks every page inside one `gh` subprocess via `ghText`'s synchronous
+ * `execFileSync`, whose `GhTextOptions` exposes no `maxBuffer` override
+ * (only the async `ghTextAsync` does) -- so even a well-projected single
+ * `--paginate` call is hard-capped at Node's default 1 MiB *total*
+ * accumulated stdout across every page, with no override available
+ * through this repository's sync `gh`-exec primitives. This helper's
+ * sweep is repository-wide and unbounded by design (unlike every other
+ * paginated caller in this repository, which is PR/issue-scoped and
+ * bounded in practice to a few pages -- see `DEFAULT_GH_PAGINATED_TIMEOUT_MS`'s
+ * own doc comment in `gh-exec.mts`), so this fetches one page at a time
+ * instead: each page is independently bounded (a few KB after
+ * projection) and results accumulate in JS memory rather than one
+ * subprocess's stdout buffer.
+ *
+ * `page`/`per_page` MUST stay in the URL query string, never passed via
+ * `gh api -F`/`-f` -- `gh api` silently switches the request method to
+ * POST the instant any `-F`/`-f` parameter is added, which would turn
+ * this read-only sweep into a write call and violate its no-mutation
+ * contract.
+ */
+function fetchLabeledBotEventsPage(owner, repo, page) {
+  const raw = ghApiJson(
+    `repos/${owner}/${repo}/issues/events?per_page=${EVENTS_PER_PAGE}&page=${page}`,
+    {
+      extraArgs: [
+        '--jq',
+        '[.[] | {event: .event, actor: {login: (.actor.login // null), type: (.actor.type // null)}}]',
+      ],
+    },
+  );
+  return raw;
+}
+/**
+ * Sweep `GET /repos/{owner}/{repo}/issues/events` to completion (paging
+ * manually -- see {@link fetchLabeledBotEventsPage}'s doc comment for
+ * why), then aggregate the result via
+ * {@link aggregateUntrustedLabelerCandidates}. Stops at the first page
+ * shorter than {@link EVENTS_PER_PAGE} (the last page); a page fetch
+ * itself never mutates anything -- see {@link fetchLabeledBotEventsPage}.
+ */
+export function sweepUntrustedLabelerCandidates(owner, repo, deps = {}) {
+  const fetchPage = deps.fetchPage ?? fetchLabeledBotEventsPage;
+  const events = [];
+  let page = 1;
+  let pageCount = 0;
+  for (;;) {
+    const items = fetchPage(owner, repo, page);
+    pageCount += 1;
+    events.push(...items);
+    if (items.length < EVENTS_PER_PAGE) {
+      break;
+    }
+    if (pageCount >= MAX_SWEEP_PAGES) {
+      throw new Error(
+        `idd-suggest-untrusted-labelers: exceeded ${MAX_SWEEP_PAGES} pages without reaching a short final page -- aborting instead of looping forever`,
+      );
+    }
+    page += 1;
+  }
+  return {
+    candidates: aggregateUntrustedLabelerCandidates(events),
+    scannedEventCount: events.length,
+    pageCount,
+  };
+}
+/** Resolves `{owner, repo}` the same way other CLI helpers in this
+ * repository do: explicit flags first, else `gh repo view` auto-detection
+ * (matching `stalled-session-quiet-check.mts`'s inline style rather than
+ * importing the heavier `provider-adapter-github.mts` module just for
+ * this one lookup). */
+function resolveOwnerRepo(owner, repo) {
+  return {
+    owner:
+      owner ||
+      ghText(
+        ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
+        GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+      ),
+    repo:
+      repo ||
+      ghText(
+        ['repo', 'view', '--json', 'name', '--jq', '.name'],
+        GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+      ),
+  };
+}
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+// Flag-spec keys stay the dashed literal on purpose -- see cli-args.mts's
+// module header (tests/flag-name-matrix.test.mts scans each helper's own
+// compiled .mjs source text for its canonical flags as quoted literals).
+const IDD_SUGGEST_UNTRUSTED_LABELERS_FLAG_SPEC = {
+  '--owner': { type: 'string', default: '' },
+  '--repo': { type: 'string', default: '' },
+  '--format': { type: 'string', default: 'table' },
+  '--help': { type: 'boolean', short: 'h' },
+};
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/idd-suggest-untrusted-labelers.mjs [--owner <owner>] [--repo <repo>] [--format table|json]
+
+  --owner <owner>     Repository owner (default: auto-detected via gh repo view).
+  --repo <repo>       Repository name (default: auto-detected via gh repo view).
+  --format <format>   Output format: table (default) or json.
+  --help, -h          Show this help.
+
+Paginates GET /repos/{owner}/{repo}/issues/events to completion, filters to
+event == "labeled" entries whose actor type == "Bot", deduplicates by
+login, and prints each distinct bot login with its labeled-event count.
+Read-only: performs no write or mutating GitHub call of any kind.
+`);
+}
+if (import.meta.main) {
+  const { values, help } = parseCliArgs(
+    process.argv.slice(2),
+    IDD_SUGGEST_UNTRUSTED_LABELERS_FLAG_SPEC,
+  );
+  if (help) {
+    printHelp();
+    process.exit(0);
+  }
+  const format = values.format;
+  if (format !== 'table' && format !== 'json') {
+    process.stderr.write(
+      `idd-suggest-untrusted-labelers: --format must be table or json, got: ${format}\n`,
+    );
+    process.exit(2);
+  }
+  const { owner, repo } = resolveOwnerRepo(values.owner, values.repo);
+  const result = sweepUntrustedLabelerCandidates(owner, repo);
+  process.stdout.write(
+    format === 'json'
+      ? `${JSON.stringify({ owner, repo, ...result }, null, 2)}\n`
+      : `${renderTable(result)}\n`,
+  );
+}

--- a/scripts/idd-suggest-untrusted-labelers.mjs
+++ b/scripts/idd-suggest-untrusted-labelers.mjs
@@ -22,23 +22,52 @@ import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghApiJson, ghText } from './gh-exec.mjs';
 import { deriveGhHttpStatus } from './gh-http-status.mjs';
 
 /**
- * Filter `events` to `event === 'labeled'` entries whose actor `type ===
- * 'Bot'`, and count occurrences per `actor.login` into `counts` (mutated
- * in place). Pure and offline: takes an already-fetched batch, never
- * calls `gh` itself. Extracted so both {@link aggregateUntrustedLabelerCandidates}
- * (a single whole-array call, what the offline fixture test covers) and
- * {@link sweepUntrustedLabelerCandidates}'s per-page loop (repeated calls
- * with one page's events at a time, so no page's events need outlive this
- * call) share one counting primitive instead of two independently
- * maintained copies (#2670 review: a whole-sweep event array would
- * otherwise grow without bound against {@link MAX_SWEEP_PAGES}).
+ * Deduplicates `events` by numeric `id` against `seenEventIds` (mutated in
+ * place -- an id already present means this row was already counted, so
+ * it is skipped entirely), then filters the remaining ones to `event ===
+ * 'labeled'` entries whose actor `type === 'Bot'` and counts occurrences
+ * per `actor.login` into `counts` (mutated in place). Returns the number
+ * of *new* (non-duplicate) events in this batch, for the caller's own
+ * completeness accounting.
+ *
+ * The id-dedup exists because `GET /repos/{owner}/{repo}/issues/events`
+ * sorts newest-first and this sweep pages by page number (#2670 review):
+ * a page fetched while new events are still being created can shift
+ * already-fetched events across a page boundary and return one again on
+ * a later page, inflating both `labeledEventCount` and the completeness
+ * evidence on an active repository -- exactly where a full-history sweep
+ * takes longest and is most exposed to this. An event with no usable
+ * `id` (missing/non-numeric -- never produced by the real fetch path,
+ * only possible from a hand-built test fixture) is never deduplicated,
+ * matching this function's original pre-dedup behavior.
+ *
+ * Pure and offline: takes an already-fetched batch, never calls `gh`
+ * itself. Extracted so both {@link aggregateUntrustedLabelerCandidates}
+ * (a single whole-array call with a fresh `seenEventIds`, what the
+ * offline fixture test covers) and {@link sweepUntrustedLabelerCandidates}'s
+ * per-page loop (repeated calls sharing one `seenEventIds` across the
+ * whole sweep, so no page's events need outlive this call) share one
+ * counting primitive instead of two independently maintained copies --
+ * a whole-sweep event array would otherwise grow without bound against
+ * {@link MAX_SWEEP_PAGES}.
  *
  * An event whose `actor` is `null`/absent (GitHub omits `actor` for some
  * system-generated events), or whose `actor.login` is empty/whitespace, is
- * skipped rather than counted under an empty-string login.
+ * skipped rather than counted under an empty-string login (this skip is
+ * independent of the id dedup above -- the event still counts toward the
+ * returned new-event total even when it doesn't end up in `counts`).
  */
-function accumulateLabeledBotEvents(events, counts) {
+function accumulateLabeledBotEvents(events, counts, seenEventIds) {
+  let newEventCount = 0;
   for (const event of events) {
+    const id = typeof event?.id === 'number' ? event.id : null;
+    if (id !== null) {
+      if (seenEventIds.has(id)) {
+        continue;
+      }
+      seenEventIds.add(id);
+    }
+    newEventCount += 1;
     if (event?.event !== 'labeled') {
       continue;
     }
@@ -51,6 +80,7 @@ function accumulateLabeledBotEvents(events, counts) {
     }
     counts.set(login, (counts.get(login) ?? 0) + 1);
   }
+  return newEventCount;
 }
 /** Sorts an `actor.login` -> count map into the final candidate list:
  * count descending, then login ascending for a stable order. */
@@ -65,15 +95,16 @@ function finalizeUntrustedLabelerCandidates(counts) {
 }
 /**
  * Filter `events` to `event === 'labeled'` entries whose actor `type ===
- * 'Bot'`, deduplicate by `actor.login`, and count occurrences per login.
- * Pure and offline: takes already-fetched events, never calls `gh` itself
- * (the paginated fetch lives in {@link sweepUntrustedLabelerCandidates}
- * below), matching `actions-usage-report.mts`'s aggregate/fetch split so
- * this function is the one covered by an offline fixture test.
+ * 'Bot'`, deduplicate by numeric `id` (when present) and by
+ * `actor.login`, and count occurrences per login. Pure and offline:
+ * takes already-fetched events, never calls `gh` itself (the paginated
+ * fetch lives in {@link sweepUntrustedLabelerCandidates} below),
+ * matching `actions-usage-report.mts`'s aggregate/fetch split so this
+ * function is the one covered by an offline fixture test.
  */
 export function aggregateUntrustedLabelerCandidates(events) {
   const counts = new Map();
-  accumulateLabeledBotEvents(events, counts);
+  accumulateLabeledBotEvents(events, counts, new Set());
   return finalizeUntrustedLabelerCandidates(counts);
 }
 // ---------------------------------------------------------------------------
@@ -145,7 +176,7 @@ function fetchLabeledBotEventsPage(owner, repo, page) {
       {
         extraArgs: [
           '--jq',
-          '[.[] | {event: .event, actor: {login: (.actor.login // null), type: (.actor.type // null)}}]',
+          '[.[] | {id: .id, event: .event, actor: {login: (.actor.login // null), type: (.actor.type // null)}}]',
         ],
       },
     );
@@ -178,23 +209,29 @@ function fetchLabeledBotEventsPage(owner, repo, page) {
  * collecting every page's events into one array first. A repository-wide
  * sweep against {@link MAX_SWEEP_PAGES}'s ceiling could otherwise retain
  * up to ~10,000,000 projected event objects simultaneously even though
- * only the per-login counts and two totals are ever needed (#2670
- * review) -- this keeps peak memory bounded by the distinct-login count,
- * not the total event count. Stops at the first page shorter than
+ * only the per-login counts, the id-dedup set, and two totals are ever
+ * needed (#2670 review) -- this keeps peak memory to roughly one integer
+ * per distinct event seen (the id-dedup set below) plus one entry per
+ * distinct login, both far smaller than retaining full event objects for
+ * the whole sweep. Stops at the first page shorter than
  * {@link EVENTS_PER_PAGE} (the last page); a page fetch itself never
  * mutates anything -- see {@link fetchLabeledBotEventsPage}.
  */
 export function sweepUntrustedLabelerCandidates(owner, repo, deps = {}) {
   const fetchPage = deps.fetchPage ?? fetchLabeledBotEventsPage;
   const counts = new Map();
+  const seenEventIds = new Set();
   let scannedEventCount = 0;
   let page = 1;
   let pageCount = 0;
   for (;;) {
     const items = fetchPage(owner, repo, page);
     pageCount += 1;
-    scannedEventCount += items.length;
-    accumulateLabeledBotEvents(items, counts);
+    scannedEventCount += accumulateLabeledBotEvents(
+      items,
+      counts,
+      seenEventIds,
+    );
     if (items.length < EVENTS_PER_PAGE) {
       break;
     }

--- a/scripts/idd-suggest-untrusted-labelers.mjs
+++ b/scripts/idd-suggest-untrusted-labelers.mjs
@@ -19,6 +19,7 @@
 // adopter-owned edit after reviewing this report.
 import { parseCliArgs } from './cli-args.mjs';
 import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghApiJson, ghText } from './gh-exec.mjs';
+import { deriveGhHttpStatus } from './gh-http-status.mjs';
 
 /**
  * Filter `events` to `event === 'labeled'` entries whose actor `type ===
@@ -138,16 +139,36 @@ const MAX_SWEEP_PAGES = 100_000;
  * contract.
  */
 function fetchLabeledBotEventsPage(owner, repo, page) {
-  const raw = ghApiJson(
-    `repos/${owner}/${repo}/issues/events?per_page=${EVENTS_PER_PAGE}&page=${page}`,
-    {
-      extraArgs: [
-        '--jq',
-        '[.[] | {event: .event, actor: {login: (.actor.login // null), type: (.actor.type // null)}}]',
-      ],
-    },
-  );
-  return raw;
+  try {
+    const raw = ghApiJson(
+      `repos/${owner}/${repo}/issues/events?per_page=${EVENTS_PER_PAGE}&page=${page}`,
+      {
+        extraArgs: [
+          '--jq',
+          '[.[] | {event: .event, actor: {login: (.actor.login // null), type: (.actor.type // null)}}]',
+        ],
+      },
+    );
+    return raw;
+  } catch (error) {
+    // #2670 review: turn a rate-limit-caused failure into an actionable
+    // message instead of a raw `gh api` stack trace. This does not add
+    // retry/backoff or a resumable cursor -- a genuinely exhausted
+    // primary rate limit (5,000 requests/hour) needs a real wait, which
+    // a bounded in-process retry can't shorten, and no progress is saved
+    // between runs, so a re-run after the reset simply restarts the
+    // sweep. Full rate-limit-aware resumable pagination is a reasonable
+    // follow-up for a repository whose full history is large enough to
+    // approach that ceiling; out of scope for this reporting tool today.
+    const status = deriveGhHttpStatus(error);
+    if (status === 403 || status === 429) {
+      throw new Error(
+        `idd-suggest-untrusted-labelers: GitHub API request failed with HTTP ${status} while fetching page ${page} of GET /repos/${owner}/${repo}/issues/events -- likely a rate limit (GitHub's authenticated primary limit is 5,000 requests/hour; a sweep issues one request per ${EVENTS_PER_PAGE} events, so a repository with several hundred thousand events can exhaust it mid-sweep). No progress from this run is saved -- wait for the rate limit to reset (check \`gh api rate_limit\`) and re-run.`,
+        { cause: error },
+      );
+    }
+    throw error;
+  }
 }
 /**
  * Sweep `GET /repos/{owner}/{repo}/issues/events` to completion (paging

--- a/scripts/idd-suggest-untrusted-labelers.mjs
+++ b/scripts/idd-suggest-untrusted-labelers.mjs
@@ -19,20 +19,24 @@
 // adopter-owned edit after reviewing this report.
 import { parseCliArgs } from './cli-args.mjs';
 import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghApiJson, ghText } from './gh-exec.mjs';
+
 /**
  * Filter `events` to `event === 'labeled'` entries whose actor `type ===
- * 'Bot'`, deduplicate by `actor.login`, and count occurrences per login.
- * Pure and offline: takes already-fetched events, never calls `gh` itself
- * (the paginated fetch lives in {@link sweepUntrustedLabelerCandidates}
- * below), matching `actions-usage-report.mts`'s aggregate/fetch split so
- * this function is the one covered by an offline fixture test.
+ * 'Bot'`, and count occurrences per `actor.login` into `counts` (mutated
+ * in place). Pure and offline: takes an already-fetched batch, never
+ * calls `gh` itself. Extracted so both {@link aggregateUntrustedLabelerCandidates}
+ * (a single whole-array call, what the offline fixture test covers) and
+ * {@link sweepUntrustedLabelerCandidates}'s per-page loop (repeated calls
+ * with one page's events at a time, so no page's events need outlive this
+ * call) share one counting primitive instead of two independently
+ * maintained copies (#2670 review: a whole-sweep event array would
+ * otherwise grow without bound against {@link MAX_SWEEP_PAGES}).
  *
  * An event whose `actor` is `null`/absent (GitHub omits `actor` for some
  * system-generated events), or whose `actor.login` is empty/whitespace, is
  * skipped rather than counted under an empty-string login.
  */
-export function aggregateUntrustedLabelerCandidates(events) {
-  const counts = new Map();
+function accumulateLabeledBotEvents(events, counts) {
   for (const event of events) {
     if (event?.event !== 'labeled') {
       continue;
@@ -46,6 +50,10 @@ export function aggregateUntrustedLabelerCandidates(events) {
     }
     counts.set(login, (counts.get(login) ?? 0) + 1);
   }
+}
+/** Sorts an `actor.login` -> count map into the final candidate list:
+ * count descending, then login ascending for a stable order. */
+function finalizeUntrustedLabelerCandidates(counts) {
   return [...counts.entries()]
     .map(([login, labeledEventCount]) => ({ login, labeledEventCount }))
     .sort(
@@ -53,6 +61,19 @@ export function aggregateUntrustedLabelerCandidates(events) {
         b.labeledEventCount - a.labeledEventCount ||
         a.login.localeCompare(b.login),
     );
+}
+/**
+ * Filter `events` to `event === 'labeled'` entries whose actor `type ===
+ * 'Bot'`, deduplicate by `actor.login`, and count occurrences per login.
+ * Pure and offline: takes already-fetched events, never calls `gh` itself
+ * (the paginated fetch lives in {@link sweepUntrustedLabelerCandidates}
+ * below), matching `actions-usage-report.mts`'s aggregate/fetch split so
+ * this function is the one covered by an offline fixture test.
+ */
+export function aggregateUntrustedLabelerCandidates(events) {
+  const counts = new Map();
+  accumulateLabeledBotEvents(events, counts);
+  return finalizeUntrustedLabelerCandidates(counts);
 }
 // ---------------------------------------------------------------------------
 // Rendering
@@ -84,11 +105,15 @@ const EVENTS_PER_PAGE = 100;
 const MAX_SWEEP_PAGES = 100_000;
 /**
  * Fetch one page of `GET /repos/{owner}/{repo}/issues/events`, projected
- * down to just `event`/`actor.login`/`actor.type` via a server-side `--jq`
- * filter (the repository-level endpoint embeds the full parent `issue`
- * object -- including its body -- in every event, so a page fetched
- * without this projection, from a repository with thousands of
- * issues/PRs, can run to several MB).
+ * down to just `event`/`actor.login`/`actor.type` via a `--jq` filter --
+ * applied client-side by the `gh` CLI itself (`gh` still receives the
+ * full, unfiltered REST response; `--jq` only shrinks what `gh` then
+ * writes to *this process's own* stdout, which is what actually needs
+ * bounding here) rather than a server-side reduction. The
+ * repository-level endpoint embeds the full parent `issue` object --
+ * including its body -- in every event, so a page fetched without this
+ * projection, from a repository with thousands of issues/PRs, can run
+ * to several MB of stdout for `execFileSync` to buffer.
  *
  * Deliberately **not** `ghApiJson(path, { paginate: true })`: that call
  * walks every page inside one `gh` subprocess via its own synchronous
@@ -102,9 +127,9 @@ const MAX_SWEEP_PAGES = 100_000;
  * paginated caller in this repository, which is PR/issue-scoped and
  * bounded in practice to a few pages -- see `DEFAULT_GH_PAGINATED_TIMEOUT_MS`'s
  * own doc comment in `gh-exec.mts`), so this fetches one page at a time
- * instead: each page is independently bounded (a few KB after
- * projection) and results accumulate in JS memory rather than one
- * subprocess's stdout buffer.
+ * instead: each page's stdout is independently bounded (a few KB after
+ * projection), and {@link sweepUntrustedLabelerCandidates} below never
+ * retains a page's raw events past its own counting pass.
  *
  * `page`/`per_page` MUST stay in the URL query string, never passed via
  * `gh api -F`/`-f` -- `gh api` silently switches the request method to
@@ -127,20 +152,28 @@ function fetchLabeledBotEventsPage(owner, repo, page) {
 /**
  * Sweep `GET /repos/{owner}/{repo}/issues/events` to completion (paging
  * manually -- see {@link fetchLabeledBotEventsPage}'s doc comment for
- * why), then aggregate the result via
- * {@link aggregateUntrustedLabelerCandidates}. Stops at the first page
- * shorter than {@link EVENTS_PER_PAGE} (the last page); a page fetch
- * itself never mutates anything -- see {@link fetchLabeledBotEventsPage}.
+ * why), counting each page into a running `actor.login` -> count map via
+ * {@link accumulateLabeledBotEvents} as it arrives, rather than
+ * collecting every page's events into one array first. A repository-wide
+ * sweep against {@link MAX_SWEEP_PAGES}'s ceiling could otherwise retain
+ * up to ~10,000,000 projected event objects simultaneously even though
+ * only the per-login counts and two totals are ever needed (#2670
+ * review) -- this keeps peak memory bounded by the distinct-login count,
+ * not the total event count. Stops at the first page shorter than
+ * {@link EVENTS_PER_PAGE} (the last page); a page fetch itself never
+ * mutates anything -- see {@link fetchLabeledBotEventsPage}.
  */
 export function sweepUntrustedLabelerCandidates(owner, repo, deps = {}) {
   const fetchPage = deps.fetchPage ?? fetchLabeledBotEventsPage;
-  const events = [];
+  const counts = new Map();
+  let scannedEventCount = 0;
   let page = 1;
   let pageCount = 0;
   for (;;) {
     const items = fetchPage(owner, repo, page);
     pageCount += 1;
-    events.push(...items);
+    scannedEventCount += items.length;
+    accumulateLabeledBotEvents(items, counts);
     if (items.length < EVENTS_PER_PAGE) {
       break;
     }
@@ -152,8 +185,8 @@ export function sweepUntrustedLabelerCandidates(owner, repo, deps = {}) {
     page += 1;
   }
   return {
-    candidates: aggregateUntrustedLabelerCandidates(events),
-    scannedEventCount: events.length,
+    candidates: finalizeUntrustedLabelerCandidates(counts),
+    scannedEventCount,
     pageCount,
   };
 }

--- a/scripts/idd-suggest-untrusted-labelers.mjs
+++ b/scripts/idd-suggest-untrusted-labelers.mjs
@@ -13,7 +13,9 @@
 // login and counted. This is a read-only reporting tool only: it never
 // edits `.github/idd/config.json` and never mutates GitHub state (no
 // label removal, no comments, no other write call of any kind). Adding
-// a login to `labels.untrustedLabelerLogins` stays a manual,
+// an accepted candidate's login as one of the recipe's
+// `<labeler-bot-login-N>` placeholders in
+// `.github/workflows/strip-untrusted-labels.yml` stays a manual,
 // adopter-owned edit after reviewing this report.
 import { parseCliArgs } from './cli-args.mjs';
 import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghApiJson, ghText } from './gh-exec.mjs';
@@ -89,12 +91,13 @@ const MAX_SWEEP_PAGES = 100_000;
  * issues/PRs, can run to several MB).
  *
  * Deliberately **not** `ghApiJson(path, { paginate: true })`: that call
- * walks every page inside one `gh` subprocess via `ghText`'s synchronous
- * `execFileSync`, whose `GhTextOptions` exposes no `maxBuffer` override
- * (only the async `ghTextAsync` does) -- so even a well-projected single
- * `--paginate` call is hard-capped at Node's default 1 MiB *total*
- * accumulated stdout across every page, with no override available
- * through this repository's sync `gh`-exec primitives. This helper's
+ * walks every page inside one `gh` subprocess via its own synchronous
+ * `execFileSync`, whose `GhApiJsonOptions` exposes no `maxBuffer`
+ * override (only the async `ghTextAsync`'s `GhTextAsyncOptions` does)
+ * -- so even a well-projected single `--paginate` call is hard-capped
+ * at Node's default 1 MiB *total* accumulated stdout across every
+ * page, with no override available through this repository's sync
+ * `gh`-exec primitives. This helper's
  * sweep is repository-wide and unbounded by design (unlike every other
  * paginated caller in this repository, which is PR/issue-scoped and
  * bounded in practice to a few pages -- see `DEFAULT_GH_PAGINATED_TIMEOUT_MS`'s

--- a/src/bin/idd-suggest-untrusted-labelers.mts
+++ b/src/bin/idd-suggest-untrusted-labelers.mts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-suggest-untrusted-labelers.mts
+//
+// The bin/idd-suggest-untrusted-labelers.mjs copy is generated from the .mts source named above
+// by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+import { runHelper } from './run-helper.mts';
+
+runHelper('../scripts/idd-suggest-untrusted-labelers.mjs');

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -606,6 +606,15 @@ const HELPER_COMMANDS: HelperCommand[] = [
     contractPaths: ['schemas/stalled-session-quiet-check.schema.json'],
   },
   {
+    id: 'suggest-untrusted-labelers',
+    scriptName: 'idd:suggest-untrusted-labelers',
+    binName: 'idd-suggest-untrusted-labelers',
+    entryPath: 'scripts/idd-suggest-untrusted-labelers.mjs',
+    vendoredCommand: 'node scripts/idd-suggest-untrusted-labelers.mjs',
+    description:
+      'Sweep GET /repos/{owner}/{repo}/issues/events to completion and report distinct bot logins that produced a labeled event, with a count each (read-only).',
+  },
+  {
     id: 'suitability-close-execute',
     scriptName: 'idd:suitability-close-execute',
     binName: 'idd-suitability-close-execute',

--- a/src/scripts/idd-suggest-untrusted-labelers.mts
+++ b/src/scripts/idd-suggest-untrusted-labelers.mts
@@ -21,6 +21,7 @@
 
 import { parseCliArgs } from './cli-args.mts';
 import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghApiJson, ghText } from './gh-exec.mts';
+import { deriveGhHttpStatus } from './gh-http-status.mts';
 
 // ---------------------------------------------------------------------------
 // Aggregation (pure -- offline fixture-testable, no network)
@@ -208,16 +209,36 @@ function fetchLabeledBotEventsPage(
   repo: string,
   page: number,
 ): RawIssueEvent[] {
-  const raw = ghApiJson(
-    `repos/${owner}/${repo}/issues/events?per_page=${EVENTS_PER_PAGE}&page=${page}`,
-    {
-      extraArgs: [
-        '--jq',
-        '[.[] | {event: .event, actor: {login: (.actor.login // null), type: (.actor.type // null)}}]',
-      ],
-    },
-  );
-  return raw as RawIssueEvent[];
+  try {
+    const raw = ghApiJson(
+      `repos/${owner}/${repo}/issues/events?per_page=${EVENTS_PER_PAGE}&page=${page}`,
+      {
+        extraArgs: [
+          '--jq',
+          '[.[] | {event: .event, actor: {login: (.actor.login // null), type: (.actor.type // null)}}]',
+        ],
+      },
+    );
+    return raw as RawIssueEvent[];
+  } catch (error) {
+    // #2670 review: turn a rate-limit-caused failure into an actionable
+    // message instead of a raw `gh api` stack trace. This does not add
+    // retry/backoff or a resumable cursor -- a genuinely exhausted
+    // primary rate limit (5,000 requests/hour) needs a real wait, which
+    // a bounded in-process retry can't shorten, and no progress is saved
+    // between runs, so a re-run after the reset simply restarts the
+    // sweep. Full rate-limit-aware resumable pagination is a reasonable
+    // follow-up for a repository whose full history is large enough to
+    // approach that ceiling; out of scope for this reporting tool today.
+    const status = deriveGhHttpStatus(error);
+    if (status === 403 || status === 429) {
+      throw new Error(
+        `idd-suggest-untrusted-labelers: GitHub API request failed with HTTP ${status} while fetching page ${page} of GET /repos/${owner}/${repo}/issues/events -- likely a rate limit (GitHub's authenticated primary limit is 5,000 requests/hour; a sweep issues one request per ${EVENTS_PER_PAGE} events, so a repository with several hundred thousand events can exhaust it mid-sweep). No progress from this run is saved -- wait for the rate limit to reset (check \`gh api rate_limit\`) and re-run.`,
+        { cause: error },
+      );
+    }
+    throw error;
+  }
 }
 
 /**

--- a/src/scripts/idd-suggest-untrusted-labelers.mts
+++ b/src/scripts/idd-suggest-untrusted-labelers.mts
@@ -14,7 +14,9 @@
 // login and counted. This is a read-only reporting tool only: it never
 // edits `.github/idd/config.json` and never mutates GitHub state (no
 // label removal, no comments, no other write call of any kind). Adding
-// a login to `labels.untrustedLabelerLogins` stays a manual,
+// an accepted candidate's login as one of the recipe's
+// `<labeler-bot-login-N>` placeholders in
+// `.github/workflows/strip-untrusted-labels.yml` stays a manual,
 // adopter-owned edit after reviewing this report.
 
 import { parseCliArgs } from './cli-args.mts';
@@ -41,8 +43,9 @@ export interface RawIssueEvent {
 
 /** One distinct bot login found in the sweep, with how many `labeled`
  * events it produced -- the count lets the operator judge how frequently
- * each candidate actually labels before deciding whether to add it to
- * `labels.untrustedLabelerLogins`. */
+ * each candidate actually labels before deciding whether to add it as a
+ * `<labeler-bot-login-N>` placeholder in the Reserved-label guard
+ * recipe's `strip-untrusted-labels.yml`. */
 export interface UntrustedLabelerCandidate {
   login: string;
   labeledEventCount: number;
@@ -148,12 +151,13 @@ export interface UntrustedLabelerSweepDeps {
  * issues/PRs, can run to several MB).
  *
  * Deliberately **not** `ghApiJson(path, { paginate: true })`: that call
- * walks every page inside one `gh` subprocess via `ghText`'s synchronous
- * `execFileSync`, whose `GhTextOptions` exposes no `maxBuffer` override
- * (only the async `ghTextAsync` does) -- so even a well-projected single
- * `--paginate` call is hard-capped at Node's default 1 MiB *total*
- * accumulated stdout across every page, with no override available
- * through this repository's sync `gh`-exec primitives. This helper's
+ * walks every page inside one `gh` subprocess via its own synchronous
+ * `execFileSync`, whose `GhApiJsonOptions` exposes no `maxBuffer`
+ * override (only the async `ghTextAsync`'s `GhTextAsyncOptions` does)
+ * -- so even a well-projected single `--paginate` call is hard-capped
+ * at Node's default 1 MiB *total* accumulated stdout across every
+ * page, with no override available through this repository's sync
+ * `gh`-exec primitives. This helper's
  * sweep is repository-wide and unbounded by design (unlike every other
  * paginated caller in this repository, which is PR/issue-scoped and
  * bounded in practice to a few pages -- see `DEFAULT_GH_PAGINATED_TIMEOUT_MS`'s

--- a/src/scripts/idd-suggest-untrusted-labelers.mts
+++ b/src/scripts/idd-suggest-untrusted-labelers.mts
@@ -36,8 +36,13 @@ export interface RawIssueEventActor {
   type?: string | null;
 }
 
-/** One issue/PR event, reduced to the fields this helper's filter needs. */
+/** One issue/PR event, reduced to the fields this helper's filter needs.
+ * `id` is the event's own numeric id (distinct from the issue/PR it
+ * belongs to) -- optional so a caller passing hand-built fixture events
+ * with no `id` still gets this module's pre-dedup behavior (every event
+ * counts; see {@link accumulateLabeledBotEvents}). */
 export interface RawIssueEvent {
+  id?: number | null;
   event?: string | null;
   actor?: RawIssueEventActor | null;
 }
@@ -54,10 +59,12 @@ export interface UntrustedLabelerCandidate {
 
 /** Full sweep result: the deduplicated, counted candidates (sorted by
  * count descending, then login ascending for a stable order) plus
- * completeness evidence -- `scannedEventCount` (every event examined,
- * before the `labeled`/`Bot` filter) and `pageCount` (pages fetched) --
- * so the operator can trust the sweep actually reached the end of the
- * event history rather than stopping early. */
+ * completeness evidence -- `scannedEventCount` (every *distinct* event
+ * examined, before the `labeled`/`Bot` filter but after id-based
+ * pagination-window dedup -- see {@link accumulateLabeledBotEvents}) and
+ * `pageCount` (pages fetched) -- so the operator can trust the sweep
+ * actually reached the end of the event history rather than stopping
+ * early, and that the totals aren't inflated by a re-fetched event. */
 export interface UntrustedLabelerSweepResult {
   candidates: UntrustedLabelerCandidate[];
   scannedEventCount: number;
@@ -65,26 +72,56 @@ export interface UntrustedLabelerSweepResult {
 }
 
 /**
- * Filter `events` to `event === 'labeled'` entries whose actor `type ===
- * 'Bot'`, and count occurrences per `actor.login` into `counts` (mutated
- * in place). Pure and offline: takes an already-fetched batch, never
- * calls `gh` itself. Extracted so both {@link aggregateUntrustedLabelerCandidates}
- * (a single whole-array call, what the offline fixture test covers) and
- * {@link sweepUntrustedLabelerCandidates}'s per-page loop (repeated calls
- * with one page's events at a time, so no page's events need outlive this
- * call) share one counting primitive instead of two independently
- * maintained copies (#2670 review: a whole-sweep event array would
- * otherwise grow without bound against {@link MAX_SWEEP_PAGES}).
+ * Deduplicates `events` by numeric `id` against `seenEventIds` (mutated in
+ * place -- an id already present means this row was already counted, so
+ * it is skipped entirely), then filters the remaining ones to `event ===
+ * 'labeled'` entries whose actor `type === 'Bot'` and counts occurrences
+ * per `actor.login` into `counts` (mutated in place). Returns the number
+ * of *new* (non-duplicate) events in this batch, for the caller's own
+ * completeness accounting.
+ *
+ * The id-dedup exists because `GET /repos/{owner}/{repo}/issues/events`
+ * sorts newest-first and this sweep pages by page number (#2670 review):
+ * a page fetched while new events are still being created can shift
+ * already-fetched events across a page boundary and return one again on
+ * a later page, inflating both `labeledEventCount` and the completeness
+ * evidence on an active repository -- exactly where a full-history sweep
+ * takes longest and is most exposed to this. An event with no usable
+ * `id` (missing/non-numeric -- never produced by the real fetch path,
+ * only possible from a hand-built test fixture) is never deduplicated,
+ * matching this function's original pre-dedup behavior.
+ *
+ * Pure and offline: takes an already-fetched batch, never calls `gh`
+ * itself. Extracted so both {@link aggregateUntrustedLabelerCandidates}
+ * (a single whole-array call with a fresh `seenEventIds`, what the
+ * offline fixture test covers) and {@link sweepUntrustedLabelerCandidates}'s
+ * per-page loop (repeated calls sharing one `seenEventIds` across the
+ * whole sweep, so no page's events need outlive this call) share one
+ * counting primitive instead of two independently maintained copies --
+ * a whole-sweep event array would otherwise grow without bound against
+ * {@link MAX_SWEEP_PAGES}.
  *
  * An event whose `actor` is `null`/absent (GitHub omits `actor` for some
  * system-generated events), or whose `actor.login` is empty/whitespace, is
- * skipped rather than counted under an empty-string login.
+ * skipped rather than counted under an empty-string login (this skip is
+ * independent of the id dedup above -- the event still counts toward the
+ * returned new-event total even when it doesn't end up in `counts`).
  */
 function accumulateLabeledBotEvents(
   events: readonly RawIssueEvent[],
   counts: Map<string, number>,
-): void {
+  seenEventIds: Set<number>,
+): number {
+  let newEventCount = 0;
   for (const event of events) {
+    const id = typeof event?.id === 'number' ? event.id : null;
+    if (id !== null) {
+      if (seenEventIds.has(id)) {
+        continue;
+      }
+      seenEventIds.add(id);
+    }
+    newEventCount += 1;
     if (event?.event !== 'labeled') {
       continue;
     }
@@ -97,6 +134,7 @@ function accumulateLabeledBotEvents(
     }
     counts.set(login, (counts.get(login) ?? 0) + 1);
   }
+  return newEventCount;
 }
 
 /** Sorts an `actor.login` -> count map into the final candidate list:
@@ -115,17 +153,18 @@ function finalizeUntrustedLabelerCandidates(
 
 /**
  * Filter `events` to `event === 'labeled'` entries whose actor `type ===
- * 'Bot'`, deduplicate by `actor.login`, and count occurrences per login.
- * Pure and offline: takes already-fetched events, never calls `gh` itself
- * (the paginated fetch lives in {@link sweepUntrustedLabelerCandidates}
- * below), matching `actions-usage-report.mts`'s aggregate/fetch split so
- * this function is the one covered by an offline fixture test.
+ * 'Bot'`, deduplicate by numeric `id` (when present) and by
+ * `actor.login`, and count occurrences per login. Pure and offline:
+ * takes already-fetched events, never calls `gh` itself (the paginated
+ * fetch lives in {@link sweepUntrustedLabelerCandidates} below),
+ * matching `actions-usage-report.mts`'s aggregate/fetch split so this
+ * function is the one covered by an offline fixture test.
  */
 export function aggregateUntrustedLabelerCandidates(
   events: readonly RawIssueEvent[],
 ): UntrustedLabelerCandidate[] {
   const counts = new Map<string, number>();
-  accumulateLabeledBotEvents(events, counts);
+  accumulateLabeledBotEvents(events, counts, new Set<number>());
   return finalizeUntrustedLabelerCandidates(counts);
 }
 
@@ -215,7 +254,7 @@ function fetchLabeledBotEventsPage(
       {
         extraArgs: [
           '--jq',
-          '[.[] | {event: .event, actor: {login: (.actor.login // null), type: (.actor.type // null)}}]',
+          '[.[] | {id: .id, event: .event, actor: {login: (.actor.login // null), type: (.actor.type // null)}}]',
         ],
       },
     );
@@ -249,9 +288,11 @@ function fetchLabeledBotEventsPage(
  * collecting every page's events into one array first. A repository-wide
  * sweep against {@link MAX_SWEEP_PAGES}'s ceiling could otherwise retain
  * up to ~10,000,000 projected event objects simultaneously even though
- * only the per-login counts and two totals are ever needed (#2670
- * review) -- this keeps peak memory bounded by the distinct-login count,
- * not the total event count. Stops at the first page shorter than
+ * only the per-login counts, the id-dedup set, and two totals are ever
+ * needed (#2670 review) -- this keeps peak memory to roughly one integer
+ * per distinct event seen (the id-dedup set below) plus one entry per
+ * distinct login, both far smaller than retaining full event objects for
+ * the whole sweep. Stops at the first page shorter than
  * {@link EVENTS_PER_PAGE} (the last page); a page fetch itself never
  * mutates anything -- see {@link fetchLabeledBotEventsPage}.
  */
@@ -262,14 +303,18 @@ export function sweepUntrustedLabelerCandidates(
 ): UntrustedLabelerSweepResult {
   const fetchPage = deps.fetchPage ?? fetchLabeledBotEventsPage;
   const counts = new Map<string, number>();
+  const seenEventIds = new Set<number>();
   let scannedEventCount = 0;
   let page = 1;
   let pageCount = 0;
   for (;;) {
     const items = fetchPage(owner, repo, page);
     pageCount += 1;
-    scannedEventCount += items.length;
-    accumulateLabeledBotEvents(items, counts);
+    scannedEventCount += accumulateLabeledBotEvents(
+      items,
+      counts,
+      seenEventIds,
+    );
     if (items.length < EVENTS_PER_PAGE) {
       break;
     }

--- a/src/scripts/idd-suggest-untrusted-labelers.mts
+++ b/src/scripts/idd-suggest-untrusted-labelers.mts
@@ -65,20 +65,24 @@ export interface UntrustedLabelerSweepResult {
 
 /**
  * Filter `events` to `event === 'labeled'` entries whose actor `type ===
- * 'Bot'`, deduplicate by `actor.login`, and count occurrences per login.
- * Pure and offline: takes already-fetched events, never calls `gh` itself
- * (the paginated fetch lives in {@link sweepUntrustedLabelerCandidates}
- * below), matching `actions-usage-report.mts`'s aggregate/fetch split so
- * this function is the one covered by an offline fixture test.
+ * 'Bot'`, and count occurrences per `actor.login` into `counts` (mutated
+ * in place). Pure and offline: takes an already-fetched batch, never
+ * calls `gh` itself. Extracted so both {@link aggregateUntrustedLabelerCandidates}
+ * (a single whole-array call, what the offline fixture test covers) and
+ * {@link sweepUntrustedLabelerCandidates}'s per-page loop (repeated calls
+ * with one page's events at a time, so no page's events need outlive this
+ * call) share one counting primitive instead of two independently
+ * maintained copies (#2670 review: a whole-sweep event array would
+ * otherwise grow without bound against {@link MAX_SWEEP_PAGES}).
  *
  * An event whose `actor` is `null`/absent (GitHub omits `actor` for some
  * system-generated events), or whose `actor.login` is empty/whitespace, is
  * skipped rather than counted under an empty-string login.
  */
-export function aggregateUntrustedLabelerCandidates(
+function accumulateLabeledBotEvents(
   events: readonly RawIssueEvent[],
-): UntrustedLabelerCandidate[] {
-  const counts = new Map<string, number>();
+  counts: Map<string, number>,
+): void {
   for (const event of events) {
     if (event?.event !== 'labeled') {
       continue;
@@ -92,6 +96,13 @@ export function aggregateUntrustedLabelerCandidates(
     }
     counts.set(login, (counts.get(login) ?? 0) + 1);
   }
+}
+
+/** Sorts an `actor.login` -> count map into the final candidate list:
+ * count descending, then login ascending for a stable order. */
+function finalizeUntrustedLabelerCandidates(
+  counts: Map<string, number>,
+): UntrustedLabelerCandidate[] {
   return [...counts.entries()]
     .map(([login, labeledEventCount]) => ({ login, labeledEventCount }))
     .sort(
@@ -99,6 +110,22 @@ export function aggregateUntrustedLabelerCandidates(
         b.labeledEventCount - a.labeledEventCount ||
         a.login.localeCompare(b.login),
     );
+}
+
+/**
+ * Filter `events` to `event === 'labeled'` entries whose actor `type ===
+ * 'Bot'`, deduplicate by `actor.login`, and count occurrences per login.
+ * Pure and offline: takes already-fetched events, never calls `gh` itself
+ * (the paginated fetch lives in {@link sweepUntrustedLabelerCandidates}
+ * below), matching `actions-usage-report.mts`'s aggregate/fetch split so
+ * this function is the one covered by an offline fixture test.
+ */
+export function aggregateUntrustedLabelerCandidates(
+  events: readonly RawIssueEvent[],
+): UntrustedLabelerCandidate[] {
+  const counts = new Map<string, number>();
+  accumulateLabeledBotEvents(events, counts);
+  return finalizeUntrustedLabelerCandidates(counts);
 }
 
 // ---------------------------------------------------------------------------
@@ -144,11 +171,15 @@ export interface UntrustedLabelerSweepDeps {
 
 /**
  * Fetch one page of `GET /repos/{owner}/{repo}/issues/events`, projected
- * down to just `event`/`actor.login`/`actor.type` via a server-side `--jq`
- * filter (the repository-level endpoint embeds the full parent `issue`
- * object -- including its body -- in every event, so a page fetched
- * without this projection, from a repository with thousands of
- * issues/PRs, can run to several MB).
+ * down to just `event`/`actor.login`/`actor.type` via a `--jq` filter --
+ * applied client-side by the `gh` CLI itself (`gh` still receives the
+ * full, unfiltered REST response; `--jq` only shrinks what `gh` then
+ * writes to *this process's own* stdout, which is what actually needs
+ * bounding here) rather than a server-side reduction. The
+ * repository-level endpoint embeds the full parent `issue` object --
+ * including its body -- in every event, so a page fetched without this
+ * projection, from a repository with thousands of issues/PRs, can run
+ * to several MB of stdout for `execFileSync` to buffer.
  *
  * Deliberately **not** `ghApiJson(path, { paginate: true })`: that call
  * walks every page inside one `gh` subprocess via its own synchronous
@@ -162,9 +193,9 @@ export interface UntrustedLabelerSweepDeps {
  * paginated caller in this repository, which is PR/issue-scoped and
  * bounded in practice to a few pages -- see `DEFAULT_GH_PAGINATED_TIMEOUT_MS`'s
  * own doc comment in `gh-exec.mts`), so this fetches one page at a time
- * instead: each page is independently bounded (a few KB after
- * projection) and results accumulate in JS memory rather than one
- * subprocess's stdout buffer.
+ * instead: each page's stdout is independently bounded (a few KB after
+ * projection), and {@link sweepUntrustedLabelerCandidates} below never
+ * retains a page's raw events past its own counting pass.
  *
  * `page`/`per_page` MUST stay in the URL query string, never passed via
  * `gh api -F`/`-f` -- `gh api` silently switches the request method to
@@ -192,10 +223,16 @@ function fetchLabeledBotEventsPage(
 /**
  * Sweep `GET /repos/{owner}/{repo}/issues/events` to completion (paging
  * manually -- see {@link fetchLabeledBotEventsPage}'s doc comment for
- * why), then aggregate the result via
- * {@link aggregateUntrustedLabelerCandidates}. Stops at the first page
- * shorter than {@link EVENTS_PER_PAGE} (the last page); a page fetch
- * itself never mutates anything -- see {@link fetchLabeledBotEventsPage}.
+ * why), counting each page into a running `actor.login` -> count map via
+ * {@link accumulateLabeledBotEvents} as it arrives, rather than
+ * collecting every page's events into one array first. A repository-wide
+ * sweep against {@link MAX_SWEEP_PAGES}'s ceiling could otherwise retain
+ * up to ~10,000,000 projected event objects simultaneously even though
+ * only the per-login counts and two totals are ever needed (#2670
+ * review) -- this keeps peak memory bounded by the distinct-login count,
+ * not the total event count. Stops at the first page shorter than
+ * {@link EVENTS_PER_PAGE} (the last page); a page fetch itself never
+ * mutates anything -- see {@link fetchLabeledBotEventsPage}.
  */
 export function sweepUntrustedLabelerCandidates(
   owner: string,
@@ -203,13 +240,15 @@ export function sweepUntrustedLabelerCandidates(
   deps: UntrustedLabelerSweepDeps = {},
 ): UntrustedLabelerSweepResult {
   const fetchPage = deps.fetchPage ?? fetchLabeledBotEventsPage;
-  const events: RawIssueEvent[] = [];
+  const counts = new Map<string, number>();
+  let scannedEventCount = 0;
   let page = 1;
   let pageCount = 0;
   for (;;) {
     const items = fetchPage(owner, repo, page);
     pageCount += 1;
-    events.push(...items);
+    scannedEventCount += items.length;
+    accumulateLabeledBotEvents(items, counts);
     if (items.length < EVENTS_PER_PAGE) {
       break;
     }
@@ -221,8 +260,8 @@ export function sweepUntrustedLabelerCandidates(
     page += 1;
   }
   return {
-    candidates: aggregateUntrustedLabelerCandidates(events),
-    scannedEventCount: events.length,
+    candidates: finalizeUntrustedLabelerCandidates(counts),
+    scannedEventCount,
     pageCount,
   };
 }

--- a/src/scripts/idd-suggest-untrusted-labelers.mts
+++ b/src/scripts/idd-suggest-untrusted-labelers.mts
@@ -1,0 +1,307 @@
+#!/usr/bin/env node
+
+// idd-generated-from: src/scripts/idd-suggest-untrusted-labelers.mts
+//
+// The scripts/idd-suggest-untrusted-labelers.mjs copy is generated from
+// the .mts source named above by `pnpm run build`. Edit the .mts source,
+// never the generated .mjs. See docs/typescript-sources.md.
+//
+// #2670: automates `docs/customization.md`'s Reserved-label guard
+// recipe's "full-history sweep" technique for building the
+// untrusted-labeler login list -- a paginated `GET
+// /repos/{owner}/{repo}/issues/events` read, filtered to `event ==
+// "labeled"` entries whose actor `type == "Bot"`, deduplicated by
+// login and counted. This is a read-only reporting tool only: it never
+// edits `.github/idd/config.json` and never mutates GitHub state (no
+// label removal, no comments, no other write call of any kind). Adding
+// a login to `labels.untrustedLabelerLogins` stays a manual,
+// adopter-owned edit after reviewing this report.
+
+import { parseCliArgs } from './cli-args.mts';
+import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghApiJson, ghText } from './gh-exec.mts';
+
+// ---------------------------------------------------------------------------
+// Aggregation (pure -- offline fixture-testable, no network)
+// ---------------------------------------------------------------------------
+
+/** One issue/PR event's actor, reduced to the two fields this helper reads
+ * (the REST "Issue Event" object's `actor` field -- a nullable simple-user
+ * object -- not the webhook payload's `sender` field used elsewhere in
+ * `docs/customization.md`'s single-observed-event validation guidance). */
+export interface RawIssueEventActor {
+  login?: string | null;
+  type?: string | null;
+}
+
+/** One issue/PR event, reduced to the fields this helper's filter needs. */
+export interface RawIssueEvent {
+  event?: string | null;
+  actor?: RawIssueEventActor | null;
+}
+
+/** One distinct bot login found in the sweep, with how many `labeled`
+ * events it produced -- the count lets the operator judge how frequently
+ * each candidate actually labels before deciding whether to add it to
+ * `labels.untrustedLabelerLogins`. */
+export interface UntrustedLabelerCandidate {
+  login: string;
+  labeledEventCount: number;
+}
+
+/** Full sweep result: the deduplicated, counted candidates (sorted by
+ * count descending, then login ascending for a stable order) plus
+ * completeness evidence -- `scannedEventCount` (every event examined,
+ * before the `labeled`/`Bot` filter) and `pageCount` (pages fetched) --
+ * so the operator can trust the sweep actually reached the end of the
+ * event history rather than stopping early. */
+export interface UntrustedLabelerSweepResult {
+  candidates: UntrustedLabelerCandidate[];
+  scannedEventCount: number;
+  pageCount: number;
+}
+
+/**
+ * Filter `events` to `event === 'labeled'` entries whose actor `type ===
+ * 'Bot'`, deduplicate by `actor.login`, and count occurrences per login.
+ * Pure and offline: takes already-fetched events, never calls `gh` itself
+ * (the paginated fetch lives in {@link sweepUntrustedLabelerCandidates}
+ * below), matching `actions-usage-report.mts`'s aggregate/fetch split so
+ * this function is the one covered by an offline fixture test.
+ *
+ * An event whose `actor` is `null`/absent (GitHub omits `actor` for some
+ * system-generated events), or whose `actor.login` is empty/whitespace, is
+ * skipped rather than counted under an empty-string login.
+ */
+export function aggregateUntrustedLabelerCandidates(
+  events: readonly RawIssueEvent[],
+): UntrustedLabelerCandidate[] {
+  const counts = new Map<string, number>();
+  for (const event of events) {
+    if (event?.event !== 'labeled') {
+      continue;
+    }
+    if (event.actor?.type !== 'Bot') {
+      continue;
+    }
+    const login = event.actor?.login?.trim();
+    if (!login) {
+      continue;
+    }
+    counts.set(login, (counts.get(login) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([login, labeledEventCount]) => ({ login, labeledEventCount }))
+    .sort(
+      (a, b) =>
+        b.labeledEventCount - a.labeledEventCount ||
+        a.login.localeCompare(b.login),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+export function renderTable(result: UntrustedLabelerSweepResult): string {
+  const lines = [
+    '| Bot login | Labeled events |',
+    '| --- | --- |',
+    ...result.candidates.map(
+      (row) => `| ${row.login} | ${row.labeledEventCount} |`,
+    ),
+    '',
+    `Total: ${result.candidates.length} distinct bot login(s) found across ` +
+      `${result.scannedEventCount} scanned issue/PR event(s) over ` +
+      `${result.pageCount} page(s).`,
+  ];
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// GitHub fetch (I/O -- not exercised by the offline fixture test)
+// ---------------------------------------------------------------------------
+
+/** Events requested per page. GitHub's REST list endpoints accept up to
+ * 100 per `per_page`. */
+const EVENTS_PER_PAGE = 100;
+
+/** Hard ceiling on pages fetched in one sweep -- a fail-closed guard
+ * against a runaway loop (a malformed injected `fetchPage`, or a paged
+ * endpoint that never returns a short final page), not a limit this
+ * repository's real event history is expected to approach. */
+const MAX_SWEEP_PAGES = 100_000;
+
+/** One page-fetch call, injectable for tests (same DI shape as
+ * `gh-exec.mts`'s `resolveViewerLogin(options, deps)`) so
+ * {@link sweepUntrustedLabelerCandidates}'s pagination loop is exercised
+ * against fixture pages with no live `gh`/network call. */
+export interface UntrustedLabelerSweepDeps {
+  fetchPage?: (owner: string, repo: string, page: number) => RawIssueEvent[];
+}
+
+/**
+ * Fetch one page of `GET /repos/{owner}/{repo}/issues/events`, projected
+ * down to just `event`/`actor.login`/`actor.type` via a server-side `--jq`
+ * filter (the repository-level endpoint embeds the full parent `issue`
+ * object -- including its body -- in every event, so a page fetched
+ * without this projection, from a repository with thousands of
+ * issues/PRs, can run to several MB).
+ *
+ * Deliberately **not** `ghApiJson(path, { paginate: true })`: that call
+ * walks every page inside one `gh` subprocess via `ghText`'s synchronous
+ * `execFileSync`, whose `GhTextOptions` exposes no `maxBuffer` override
+ * (only the async `ghTextAsync` does) -- so even a well-projected single
+ * `--paginate` call is hard-capped at Node's default 1 MiB *total*
+ * accumulated stdout across every page, with no override available
+ * through this repository's sync `gh`-exec primitives. This helper's
+ * sweep is repository-wide and unbounded by design (unlike every other
+ * paginated caller in this repository, which is PR/issue-scoped and
+ * bounded in practice to a few pages -- see `DEFAULT_GH_PAGINATED_TIMEOUT_MS`'s
+ * own doc comment in `gh-exec.mts`), so this fetches one page at a time
+ * instead: each page is independently bounded (a few KB after
+ * projection) and results accumulate in JS memory rather than one
+ * subprocess's stdout buffer.
+ *
+ * `page`/`per_page` MUST stay in the URL query string, never passed via
+ * `gh api -F`/`-f` -- `gh api` silently switches the request method to
+ * POST the instant any `-F`/`-f` parameter is added, which would turn
+ * this read-only sweep into a write call and violate its no-mutation
+ * contract.
+ */
+function fetchLabeledBotEventsPage(
+  owner: string,
+  repo: string,
+  page: number,
+): RawIssueEvent[] {
+  const raw = ghApiJson(
+    `repos/${owner}/${repo}/issues/events?per_page=${EVENTS_PER_PAGE}&page=${page}`,
+    {
+      extraArgs: [
+        '--jq',
+        '[.[] | {event: .event, actor: {login: (.actor.login // null), type: (.actor.type // null)}}]',
+      ],
+    },
+  );
+  return raw as RawIssueEvent[];
+}
+
+/**
+ * Sweep `GET /repos/{owner}/{repo}/issues/events` to completion (paging
+ * manually -- see {@link fetchLabeledBotEventsPage}'s doc comment for
+ * why), then aggregate the result via
+ * {@link aggregateUntrustedLabelerCandidates}. Stops at the first page
+ * shorter than {@link EVENTS_PER_PAGE} (the last page); a page fetch
+ * itself never mutates anything -- see {@link fetchLabeledBotEventsPage}.
+ */
+export function sweepUntrustedLabelerCandidates(
+  owner: string,
+  repo: string,
+  deps: UntrustedLabelerSweepDeps = {},
+): UntrustedLabelerSweepResult {
+  const fetchPage = deps.fetchPage ?? fetchLabeledBotEventsPage;
+  const events: RawIssueEvent[] = [];
+  let page = 1;
+  let pageCount = 0;
+  for (;;) {
+    const items = fetchPage(owner, repo, page);
+    pageCount += 1;
+    events.push(...items);
+    if (items.length < EVENTS_PER_PAGE) {
+      break;
+    }
+    if (pageCount >= MAX_SWEEP_PAGES) {
+      throw new Error(
+        `idd-suggest-untrusted-labelers: exceeded ${MAX_SWEEP_PAGES} pages without reaching a short final page -- aborting instead of looping forever`,
+      );
+    }
+    page += 1;
+  }
+  return {
+    candidates: aggregateUntrustedLabelerCandidates(events),
+    scannedEventCount: events.length,
+    pageCount,
+  };
+}
+
+/** Resolves `{owner, repo}` the same way other CLI helpers in this
+ * repository do: explicit flags first, else `gh repo view` auto-detection
+ * (matching `stalled-session-quiet-check.mts`'s inline style rather than
+ * importing the heavier `provider-adapter-github.mts` module just for
+ * this one lookup). */
+function resolveOwnerRepo(
+  owner: string,
+  repo: string,
+): { owner: string; repo: string } {
+  return {
+    owner:
+      owner ||
+      ghText(
+        ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
+        GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+      ),
+    repo:
+      repo ||
+      ghText(
+        ['repo', 'view', '--json', 'name', '--jq', '.name'],
+        GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+      ),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+// Flag-spec keys stay the dashed literal on purpose -- see cli-args.mts's
+// module header (tests/flag-name-matrix.test.mts scans each helper's own
+// compiled .mjs source text for its canonical flags as quoted literals).
+const IDD_SUGGEST_UNTRUSTED_LABELERS_FLAG_SPEC = {
+  '--owner': { type: 'string', default: '' },
+  '--repo': { type: 'string', default: '' },
+  '--format': { type: 'string', default: 'table' },
+  '--help': { type: 'boolean', short: 'h' },
+} as const;
+
+function printHelp(): void {
+  process.stdout.write(`Usage:
+  node scripts/idd-suggest-untrusted-labelers.mjs [--owner <owner>] [--repo <repo>] [--format table|json]
+
+  --owner <owner>     Repository owner (default: auto-detected via gh repo view).
+  --repo <repo>       Repository name (default: auto-detected via gh repo view).
+  --format <format>   Output format: table (default) or json.
+  --help, -h          Show this help.
+
+Paginates GET /repos/{owner}/{repo}/issues/events to completion, filters to
+event == "labeled" entries whose actor type == "Bot", deduplicates by
+login, and prints each distinct bot login with its labeled-event count.
+Read-only: performs no write or mutating GitHub call of any kind.
+`);
+}
+
+if (import.meta.main) {
+  const { values, help } = parseCliArgs(
+    process.argv.slice(2),
+    IDD_SUGGEST_UNTRUSTED_LABELERS_FLAG_SPEC,
+  );
+  if (help) {
+    printHelp();
+    process.exit(0);
+  }
+  const format = values.format as string;
+  if (format !== 'table' && format !== 'json') {
+    process.stderr.write(
+      `idd-suggest-untrusted-labelers: --format must be table or json, got: ${format}\n`,
+    );
+    process.exit(2);
+  }
+  const { owner, repo } = resolveOwnerRepo(
+    values.owner as string,
+    values.repo as string,
+  );
+  const result = sweepUntrustedLabelerCandidates(owner, repo);
+  process.stdout.write(
+    format === 'json'
+      ? `${JSON.stringify({ owner, repo, ...result }, null, 2)}\n`
+      : `${renderTable(result)}\n`,
+  );
+}

--- a/tests/help-text-flags.test.mts
+++ b/tests/help-text-flags.test.mts
@@ -189,6 +189,7 @@ const COVERED_HELPERS = [
   'idd-critique-delegate',
   'idd-doctor',
   'idd-roadmap-audit-execute',
+  'idd-suggest-untrusted-labelers',
   'live-status-digest',
   'local-validation-evidence',
   'merged-pr-feedback-sweep',

--- a/tests/idd-suggest-untrusted-labelers.test.mts
+++ b/tests/idd-suggest-untrusted-labelers.test.mts
@@ -204,11 +204,12 @@ process.exit(1);
 function runStubbedCli(
   cliArgs: string[],
   responses: Map<string, string>,
+  stubScript: (responses: Map<string, string>) => string = buildStubGh,
 ): string {
   const cwdRoot = mkdtempSync(
     join(tmpdir(), 'idd-suggest-untrusted-labelers-cwd-'),
   );
-  const restore = stubExecutable('gh', buildStubGh(responses));
+  const restore = stubExecutable('gh', stubScript(responses));
   try {
     return execFileSync(
       process.execPath,
@@ -227,6 +228,30 @@ function runStubbedCli(
     restore();
     rmSync(cwdRoot, { recursive: true, force: true });
   }
+}
+
+/** Like {@link buildStubGh}, but the page-1 events call fails with an
+ * `(HTTP 403)`-shaped stderr (gh's real rate-limit failure shape --
+ * `deriveGhHttpStatus` in `gh-http-status.mts` parses exactly this) instead
+ * of returning a page from `responses`. Used only by the rate-limit test
+ * below. */
+function buildStubGhWithPage1RateLimit(responses: Map<string, string>): string {
+  const table = JSON.stringify([...responses.entries()]);
+  const rateLimitKey = JSON.stringify(eventsPageArgv(1));
+  return `const args = process.argv.slice(2);
+const table = new Map(${table});
+const key = JSON.stringify(args);
+if (key === ${JSON.stringify(rateLimitKey)}) {
+  process.stderr.write('gh: API rate limit exceeded (HTTP 403)\\n');
+  process.exit(1);
+}
+if (table.has(key)) {
+  process.stdout.write(table.get(key));
+  process.exit(0);
+}
+process.stderr.write('unexpected gh invocation: ' + args.join(' ') + '\\n');
+process.exit(1);
+`;
 }
 
 test('idd-suggest-untrusted-labelers.mjs CLI: pages to completion across a full page and a short final page, with no other gh call made', () => {
@@ -326,4 +351,23 @@ test('idd-suggest-untrusted-labelers.mjs CLI: --owner/--repo omitted auto-detect
   assert.deepEqual(report.candidates, [
     { login: 'auto-detected-bot', labeledEventCount: 1 },
   ]);
+});
+
+test('idd-suggest-untrusted-labelers.mjs CLI: a rate-limit-shaped (HTTP 403) page failure surfaces an actionable message, not a raw gh stack trace', () => {
+  assert.throws(
+    () =>
+      runStubbedCli(
+        ['--owner', OWNER, '--repo', REPO],
+        new Map(),
+        buildStubGhWithPage1RateLimit,
+      ),
+    (error: unknown) => {
+      const stderr = String((error as { stderr?: unknown }).stderr ?? '');
+      assert.match(stderr, /idd-suggest-untrusted-labelers:/);
+      assert.match(stderr, /HTTP 403/);
+      assert.match(stderr, /rate limit/i);
+      assert.match(stderr, /page 1/);
+      return true;
+    },
+  );
 });

--- a/tests/idd-suggest-untrusted-labelers.test.mts
+++ b/tests/idd-suggest-untrusted-labelers.test.mts
@@ -161,6 +161,54 @@ test('sweepUntrustedLabelerCandidates: no events at all reports zero candidates 
   assert.deepEqual(result.candidates, []);
 });
 
+test('sweepUntrustedLabelerCandidates: an event id repeated across a shifted pagination window is counted once', () => {
+  // Reproduces the #2670 review scenario: GET .../issues/events sorts
+  // newest-first and this sweep pages by page number, so a page fetched
+  // while new events are still being created can shift an
+  // already-fetched event across a page boundary and return it again on
+  // a later page. Page 1 (100 items, full -- continues pagination) ends
+  // with event id 100 (the "oldest" item on that page); a fresh event
+  // arriving between fetches pushes id 100 back into page 2's window, so
+  // it reappears there alongside two genuinely new events.
+  const page1 = Array.from({ length: 100 }, (_unused, index) => ({
+    id: 100 - index,
+    event: 'labeled',
+    actor: { login: 'prolific-bot', type: 'Bot' },
+  }));
+  const page2 = [
+    // Re-fetched due to the shifted window -- must NOT be counted twice.
+    {
+      id: 100,
+      event: 'labeled',
+      actor: { login: 'prolific-bot', type: 'Bot' },
+    },
+    // A genuinely new event -- id well outside page 1's 1-100 range so
+    // it can't accidentally collide with one already counted there.
+    { id: 5000, event: 'labeled', actor: { login: 'second-bot', type: 'Bot' } },
+  ];
+  const result = sweepUntrustedLabelerCandidates('o', 'r', {
+    fetchPage: (_owner, _repo, page) => (page === 1 ? page1 : page2),
+  });
+  assert.equal(result.pageCount, 2);
+  // 100 distinct events from page 1, plus exactly 1 new event from page 2
+  // (id 5000) -- id 100's repeat is excluded, not 102 total.
+  assert.equal(result.scannedEventCount, 101);
+  assert.deepEqual(result.candidates, [
+    { login: 'prolific-bot', labeledEventCount: 100 },
+    { login: 'second-bot', labeledEventCount: 1 },
+  ]);
+});
+
+test('aggregateUntrustedLabelerCandidates: events with no id field are never deduplicated (pre-dedup fixture behavior preserved)', () => {
+  const events: RawIssueEvent[] = [
+    { event: 'labeled', actor: { login: 'no-id-bot', type: 'Bot' } },
+    { event: 'labeled', actor: { login: 'no-id-bot', type: 'Bot' } },
+  ];
+  assert.deepEqual(aggregateUntrustedLabelerCandidates(events), [
+    { login: 'no-id-bot', labeledEventCount: 2 },
+  ]);
+});
+
 // ---------------------------------------------------------------------------
 // CLI subprocess: stub `gh` on PATH, matched by exact argv (same technique
 // as tests/gh-pagination-parsing-smoke.test.mts). Proves, against the
@@ -176,7 +224,7 @@ test('sweepUntrustedLabelerCandidates: no events at all reports zero candidates 
 const OWNER = 'o';
 const REPO = 'r';
 const EVENTS_PROJECTION_JQ =
-  '[.[] | {event: .event, actor: {login: (.actor.login // null), type: (.actor.type // null)}}]';
+  '[.[] | {id: .id, event: .event, actor: {login: (.actor.login // null), type: (.actor.type // null)}}]';
 
 function eventsPageArgv(page: number): string[] {
   return [

--- a/tests/idd-suggest-untrusted-labelers.test.mts
+++ b/tests/idd-suggest-untrusted-labelers.test.mts
@@ -1,0 +1,286 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  aggregateUntrustedLabelerCandidates,
+  type RawIssueEvent,
+  renderTable,
+  sweepUntrustedLabelerCandidates,
+  type UntrustedLabelerSweepResult,
+} from '../src/scripts/idd-suggest-untrusted-labelers.mts';
+import { readJson, stubExecutable } from './test-utils.mts';
+
+const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
+
+interface Fixture {
+  input: { events: RawIssueEvent[] };
+  expected: ReturnType<typeof aggregateUntrustedLabelerCandidates>;
+}
+
+function loadFixture(name: string): Fixture {
+  return readJson(
+    `fixtures/idd-suggest-untrusted-labelers/${name}.json`,
+  ) as Fixture;
+}
+
+// ---------------------------------------------------------------------------
+// aggregateUntrustedLabelerCandidates: pure, offline, fixture-driven
+// ---------------------------------------------------------------------------
+
+test('aggregateUntrustedLabelerCandidates: counts labeled events per bot login, sorted count desc then login asc', () => {
+  const { input, expected } = loadFixture('basic');
+  assert.deepEqual(aggregateUntrustedLabelerCandidates(input.events), expected);
+});
+
+test('aggregateUntrustedLabelerCandidates: a non-labeled event from a bot is not counted', () => {
+  const { input } = loadFixture('basic');
+  const candidates = aggregateUntrustedLabelerCandidates(input.events);
+  // "noisy-bot" also produced one "unlabeled" event in the fixture; only
+  // its 3 "labeled" events count.
+  const noisyBot = candidates.find((row) => row.login === 'noisy-bot');
+  assert.ok(noisyBot);
+  assert.equal(noisyBot.labeledEventCount, 3);
+});
+
+test('aggregateUntrustedLabelerCandidates: a labeled event from a non-Bot actor is excluded', () => {
+  const { input } = loadFixture('basic');
+  const candidates = aggregateUntrustedLabelerCandidates(input.events);
+  assert.equal(
+    candidates.some((row) => row.login === 'kurone-kito'),
+    false,
+  );
+});
+
+test('aggregateUntrustedLabelerCandidates: null/empty actor and login are skipped, tie-broken candidates sort by login ascending', () => {
+  const { input, expected } = loadFixture('edge-cases');
+  assert.deepEqual(aggregateUntrustedLabelerCandidates(input.events), expected);
+});
+
+test('aggregateUntrustedLabelerCandidates: a missing/null event field is skipped, not treated as "labeled"', () => {
+  const { input } = loadFixture('edge-cases');
+  const candidates = aggregateUntrustedLabelerCandidates(input.events);
+  assert.equal(
+    candidates.some(
+      (row) =>
+        row.login === 'ignored-bot' || row.login === 'another-ignored-bot',
+    ),
+    false,
+  );
+});
+
+test('aggregateUntrustedLabelerCandidates: empty input reports no candidates', () => {
+  assert.deepEqual(aggregateUntrustedLabelerCandidates([]), []);
+});
+
+// ---------------------------------------------------------------------------
+// renderTable
+// ---------------------------------------------------------------------------
+
+test('renderTable: renders one row per candidate plus a totals line', () => {
+  const result: UntrustedLabelerSweepResult = {
+    candidates: [
+      { login: 'noisy-bot', labeledEventCount: 3 },
+      { login: 'quiet-bot', labeledEventCount: 1 },
+    ],
+    scannedEventCount: 7,
+    pageCount: 1,
+  };
+  const table = renderTable(result);
+  assert.match(table, /\| noisy-bot \| 3 \|/);
+  assert.match(table, /\| quiet-bot \| 1 \|/);
+  assert.match(
+    table,
+    /Total: 2 distinct bot login\(s\) found across 7 scanned issue\/PR event\(s\) over 1 page\(s\)\./,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// sweepUntrustedLabelerCandidates: pagination loop, injectable fetcher (no
+// subprocess -- exercises the pagination-stop condition fast)
+// ---------------------------------------------------------------------------
+
+test('sweepUntrustedLabelerCandidates: pages until a short page, merging and aggregating across pages', () => {
+  const pages: Record<number, RawIssueEvent[]> = {
+    1: Array.from({ length: 100 }, () => ({
+      event: 'labeled',
+      actor: { login: 'prolific-bot', type: 'Bot' },
+    })),
+    2: [
+      { event: 'labeled', actor: { login: 'prolific-bot', type: 'Bot' } },
+      { event: 'labeled', actor: { login: 'second-bot', type: 'Bot' } },
+      { event: 'labeled', actor: { login: 'a-human', type: 'User' } },
+    ],
+  };
+  const calls: number[] = [];
+  const result = sweepUntrustedLabelerCandidates('o', 'r', {
+    fetchPage: (owner, repo, page) => {
+      assert.equal(owner, 'o');
+      assert.equal(repo, 'r');
+      calls.push(page);
+      const items = pages[page];
+      assert.ok(items, `unexpected page requested: ${page}`);
+      return items;
+    },
+  });
+  assert.deepEqual(calls, [1, 2]);
+  assert.equal(result.pageCount, 2);
+  assert.equal(result.scannedEventCount, 103);
+  assert.deepEqual(result.candidates, [
+    { login: 'prolific-bot', labeledEventCount: 101 },
+    { login: 'second-bot', labeledEventCount: 1 },
+  ]);
+});
+
+test('sweepUntrustedLabelerCandidates: an immediately-short first page stops after one call', () => {
+  const calls: number[] = [];
+  const result = sweepUntrustedLabelerCandidates('o', 'r', {
+    fetchPage: (_owner, _repo, page) => {
+      calls.push(page);
+      return [{ event: 'labeled', actor: { login: 'only-bot', type: 'Bot' } }];
+    },
+  });
+  assert.deepEqual(calls, [1]);
+  assert.equal(result.pageCount, 1);
+  assert.equal(result.scannedEventCount, 1);
+  assert.deepEqual(result.candidates, [
+    { login: 'only-bot', labeledEventCount: 1 },
+  ]);
+});
+
+test('sweepUntrustedLabelerCandidates: no events at all reports zero candidates from one page', () => {
+  const result = sweepUntrustedLabelerCandidates('o', 'r', {
+    fetchPage: () => [],
+  });
+  assert.equal(result.pageCount, 1);
+  assert.equal(result.scannedEventCount, 0);
+  assert.deepEqual(result.candidates, []);
+});
+
+// ---------------------------------------------------------------------------
+// CLI subprocess: stub `gh` on PATH, matched by exact argv (same technique
+// as tests/gh-pagination-parsing-smoke.test.mts). Proves, against the
+// COMPILED scripts/idd-suggest-untrusted-labelers.mjs: (1) the sweep pages
+// to completion across a 100-item page and a short final page, merging and
+// filtering correctly end-to-end; (2) no mutating (or any other) `gh` call
+// is made -- the stub table below registers ONLY the two read GET calls,
+// and an unmatched call fails the stub loudly instead of the test silently
+// passing, so this doubles as the "no mutating call" acceptance-criterion
+// proof.
+// ---------------------------------------------------------------------------
+
+const OWNER = 'o';
+const REPO = 'r';
+const EVENTS_PROJECTION_JQ =
+  '[.[] | {event: .event, actor: {login: (.actor.login // null), type: (.actor.type // null)}}]';
+
+function eventsPageArgv(page: number): string[] {
+  return [
+    'api',
+    `repos/${OWNER}/${REPO}/issues/events?per_page=100&page=${page}`,
+    '--jq',
+    EVENTS_PROJECTION_JQ,
+  ];
+}
+
+function buildStubGh(responses: Map<string, string>): string {
+  const table = JSON.stringify([...responses.entries()]);
+  return `const args = process.argv.slice(2);
+const table = new Map(${table});
+const key = JSON.stringify(args);
+if (table.has(key)) {
+  process.stdout.write(table.get(key));
+  process.exit(0);
+}
+process.stderr.write('unexpected gh invocation: ' + args.join(' ') + '\\n');
+process.exit(1);
+`;
+}
+
+function runStubbedCli(
+  cliArgs: string[],
+  responses: Map<string, string>,
+): string {
+  const cwdRoot = mkdtempSync(
+    join(tmpdir(), 'idd-suggest-untrusted-labelers-cwd-'),
+  );
+  const restore = stubExecutable('gh', buildStubGh(responses));
+  try {
+    return execFileSync(
+      process.execPath,
+      [
+        join(REPO_ROOT, 'scripts', 'idd-suggest-untrusted-labelers.mjs'),
+        ...cliArgs,
+      ],
+      {
+        cwd: cwdRoot,
+        encoding: 'utf8',
+        env: { ...process.env },
+        timeout: 60_000,
+      },
+    );
+  } finally {
+    restore();
+    rmSync(cwdRoot, { recursive: true, force: true });
+  }
+}
+
+test('idd-suggest-untrusted-labelers.mjs CLI: pages to completion across a full page and a short final page, with no other gh call made', () => {
+  const page1 = Array.from({ length: 100 }, () => ({
+    event: 'labeled',
+    actor: { login: 'prolific-bot', type: 'Bot' },
+  }));
+  const page2 = [
+    { event: 'labeled', actor: { login: 'prolific-bot', type: 'Bot' } },
+    { event: 'labeled', actor: { login: 'second-bot', type: 'Bot' } },
+    { event: 'labeled', actor: { login: 'a-human', type: 'User' } },
+    { event: 'unlabeled', actor: { login: 'second-bot', type: 'Bot' } },
+  ];
+  const responses = new Map<string, string>([
+    [JSON.stringify(eventsPageArgv(1)), JSON.stringify(page1)],
+    [JSON.stringify(eventsPageArgv(2)), JSON.stringify(page2)],
+  ]);
+
+  const output = runStubbedCli(
+    ['--owner', OWNER, '--repo', REPO, '--format', 'json'],
+    responses,
+  );
+
+  assert.doesNotMatch(output, /ReferenceError|before initialization/);
+  const report = JSON.parse(output) as UntrustedLabelerSweepResult & {
+    owner: string;
+    repo: string;
+  };
+  assert.equal(report.owner, OWNER);
+  assert.equal(report.repo, REPO);
+  assert.equal(report.pageCount, 2);
+  assert.equal(report.scannedEventCount, 104);
+  assert.deepEqual(report.candidates, [
+    { login: 'prolific-bot', labeledEventCount: 101 },
+    { login: 'second-bot', labeledEventCount: 1 },
+  ]);
+});
+
+test('idd-suggest-untrusted-labelers.mjs CLI: table format renders the same aggregated result', () => {
+  const responses = new Map<string, string>([
+    [
+      JSON.stringify(eventsPageArgv(1)),
+      JSON.stringify([
+        { event: 'labeled', actor: { login: 'only-bot', type: 'Bot' } },
+      ]),
+    ],
+  ]);
+
+  const output = runStubbedCli(['--owner', OWNER, '--repo', REPO], responses);
+
+  assert.doesNotMatch(output, /ReferenceError|before initialization/);
+  assert.match(output, /\| only-bot \| 1 \|/);
+  assert.match(
+    output,
+    /Total: 1 distinct bot login\(s\) found across 1 scanned issue\/PR event\(s\) over 1 page\(s\)\./,
+  );
+});

--- a/tests/idd-suggest-untrusted-labelers.test.mts
+++ b/tests/idd-suggest-untrusted-labelers.test.mts
@@ -284,3 +284,46 @@ test('idd-suggest-untrusted-labelers.mjs CLI: table format renders the same aggr
     /Total: 1 distinct bot login\(s\) found across 1 scanned issue\/PR event\(s\) over 1 page\(s\)\./,
   );
 });
+
+test('idd-suggest-untrusted-labelers.mjs CLI: --owner/--repo omitted auto-detects via gh repo view, with no other gh call made', () => {
+  // Same no-mutation proof as the explicit-flags tests above, but for the
+  // default (auto-detect) invocation shape: the stub table registers only
+  // the two `gh repo view` reads plus the one events page -- any other
+  // call, mutating or not, fails the stub loudly.
+  const responses = new Map<string, string>([
+    [
+      JSON.stringify([
+        'repo',
+        'view',
+        '--json',
+        'owner',
+        '--jq',
+        '.owner.login',
+      ]),
+      OWNER,
+    ],
+    [JSON.stringify(['repo', 'view', '--json', 'name', '--jq', '.name']), REPO],
+    [
+      JSON.stringify(eventsPageArgv(1)),
+      JSON.stringify([
+        {
+          event: 'labeled',
+          actor: { login: 'auto-detected-bot', type: 'Bot' },
+        },
+      ]),
+    ],
+  ]);
+
+  const output = runStubbedCli(['--format', 'json'], responses);
+
+  assert.doesNotMatch(output, /ReferenceError|before initialization/);
+  const report = JSON.parse(output) as UntrustedLabelerSweepResult & {
+    owner: string;
+    repo: string;
+  };
+  assert.equal(report.owner, OWNER);
+  assert.equal(report.repo, REPO);
+  assert.deepEqual(report.candidates, [
+    { login: 'auto-detected-bot', labeledEventCount: 1 },
+  ]);
+});


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Adds `idd-suggest-untrusted-labelers`, a new read-only helper that
automates `docs/customization.md`'s Reserved-label guard recipe's
"full-history sweep" technique: it paginates `GET
/repos/{owner}/{repo}/issues/events` to completion, filters to `event
== "labeled"` entries whose actor `type == "Bot"`, deduplicates by
login, and prints each distinct bot login with a count of `labeled`
events attributed to it — so an adopter no longer has to hand-construct
the `gh api --paginate` call and filter the JSON themselves before
building `strip-untrusted-labels.yml`'s `<labeler-bot-login-N>` list.

Follows this repository's TypeScript-source convention (`.mts` source →
generated `.mjs` → `bin/` shim): `src/scripts/idd-suggest-untrusted-labelers.mts`
generates `scripts/idd-suggest-untrusted-labelers.mjs` and
`bin/idd-suggest-untrusted-labelers.mjs`, registered in
`HELPER_COMMANDS` and `package.json`'s `bin` map.

**Performs no write operation of any kind** — no `.github/idd/config.json`
edit, no GitHub mutation. It pages manually (`page=1,2,...&per_page=100`,
one `gh api` GET per page with a size-reducing `--jq` projection) rather
than a single `gh api --paginate` subprocess call, because the
repository-level `issues/events` endpoint embeds the full parent `issue`
object in every event and this repository's synchronous `gh`-exec path
has no `maxBuffer` override — a single buffered call could exceed Node's
default 1 MiB cap on a large repository's full history.

Test coverage (`tests/idd-suggest-untrusted-labelers.test.mts`, 13 cases):
fixture-driven tests for the pure aggregation function; dependency-injected
unit tests for the pagination loop; and three stub-`gh`-on-`PATH`
CLI-subprocess tests (mirroring `tests/gh-pagination-parsing-smoke.test.mts`'s
existing pattern) that run the compiled `.mjs` against an exact-argv
response table — since the table registers only the expected read `GET`
calls (covering both the explicit `--owner`/`--repo` path and the
`gh repo view` auto-detect path), any other or mutating `gh` invocation
fails the stub loudly, which is the "no mutating call" proof the issue's
acceptance criteria call for.

A C1 critique pass (both a fresh-subagent review and self-review) on
the initial diff caught two doc/comment inaccuracies (a fabricated
`labels.untrustedLabelerLogins` config field that doesn't exist — the
real destination is `strip-untrusted-labels.yml`'s
`<labeler-bot-login-N>` placeholder — and a misattributed `ghText`/
`GhTextOptions` reference where the code actually uses `ghApiJson`/
`GhApiJsonOptions`) and one test-coverage gap (the auto-detect path was
untested); all three are fixed in this branch's third commit.

## Linked issue

Closes #2670

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`docs/customization.md`'s Reserved-label guard recipe already documents
the sweep technique in prose (added for #1928); this PR is purely
automation of an already-documented manual procedure, not a new policy.
The helper is deliberately scoped to reporting only — deciding which
candidates are genuinely untrusted and editing the workflow YAML stays
a manual, adopter-owned judgment call, per the issue's acceptance
criteria.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jz9naVhMefTusdLL9FzLc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only helper that scans repository issue events to identify and count bot labelers.
  * Supports repository auto-detection, paginated scanning, and table or JSON output.
  * Added safeguards against runaway pagination and mutating command usage.

* **Documentation**
  * Added usage guidance, output details, filtering behavior, and manual review requirements.

* **Tests**
  * Added coverage for filtering, deduplication, pagination, output formats, edge cases, and empty results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->