### PR TITLE
feat(schema): add labels.untrustedLabelerLogins to the policy schema

### DIFF
--- a/fixtures/schemas/policy.valid.json
+++ b/fixtures/schemas/policy.valid.json
@@ -94,7 +94,8 @@
   "labels": {
     "roadmapLabelName": "roadmap",
     "blockedByHumanLabelName": "status:blocked-by-human",
-    "needsDecisionLabelName": "status:needs-decision"
+    "needsDecisionLabelName": "status:needs-decision",
+    "untrustedLabelerLogins": ["triage-bot"]
   },
   "mergeGate": {
     "soloCodeownerAdminFallback": "auto-admin-retry"

--- a/schemas/policy.schema.json
+++ b/schemas/policy.schema.json
@@ -765,7 +765,7 @@
             "type": "string",
             "minLength": 1,
             "pattern": "\\S",
-            "description": "Each entry must contain a non-whitespace character. A GitHub login can never be whitespace-only; rejecting one at validation time instead of silently accepting it prevents a validated configuration from covering no actual actor once a consuming guard reads this list."
+            "description": "Each entry must contain a non-whitespace character. A GitHub login can never be whitespace-only; rejecting one at validation time instead of silently accepting it prevents a validated configuration from covering no actual actor once a consuming guard reads this list. The runtime also trims each entry, so a value like \"triage-bot \" is accepted and resolves to \"triage-bot\"."
           },
           "description": "Logins of semantic issue auto-labelers that this repository does not trust to apply IDD's reserved labels. Optional; omit this key for the empty-list case -- `minItems: 1` rejects an explicit `[]`. Schema-supported metadata; no distributed enforcement (CI guard generation) reads this list yet."
         }

--- a/schemas/policy.schema.json
+++ b/schemas/policy.schema.json
@@ -763,7 +763,9 @@
           "minItems": 1,
           "items": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": "Each entry must contain a non-whitespace character. A GitHub login can never be whitespace-only; rejecting one at validation time instead of silently accepting it prevents a validated configuration from covering no actual actor once a consuming guard reads this list."
           },
           "description": "Logins of semantic issue auto-labelers that this repository does not trust to apply IDD's reserved labels. Optional; omit this key for the empty-list case -- `minItems: 1` rejects an explicit `[]`. Schema-supported metadata; no distributed enforcement (CI guard generation) reads this list yet."
         }

--- a/schemas/policy.schema.json
+++ b/schemas/policy.schema.json
@@ -765,7 +765,7 @@
             "type": "string",
             "minLength": 1
           },
-          "description": "Logins of semantic issue auto-labelers that this repository does not trust to apply IDD's reserved labels. Optional; defaults to an empty array when omitted."
+          "description": "Logins of semantic issue auto-labelers that this repository does not trust to apply IDD's reserved labels. Optional; defaults to an empty array when omitted. Schema-supported metadata; no distributed enforcement (CI guard generation) reads this list yet."
         }
       },
       "description": "Container for the three IDD-role label names (roadmap, blocked-by-human, and needs-decision) plus the untrusted-labeler login list. Optional; omitting any nested key keeps that key's own distributed default."

--- a/schemas/policy.schema.json
+++ b/schemas/policy.schema.json
@@ -765,7 +765,7 @@
             "type": "string",
             "minLength": 1
           },
-          "description": "Logins of semantic issue auto-labelers that this repository does not trust to apply IDD's reserved labels. Optional; defaults to an empty array when omitted. Schema-supported metadata; no distributed enforcement (CI guard generation) reads this list yet."
+          "description": "Logins of semantic issue auto-labelers that this repository does not trust to apply IDD's reserved labels. Optional; omit this key for the empty-list case -- `minItems: 1` rejects an explicit `[]`. Schema-supported metadata; no distributed enforcement (CI guard generation) reads this list yet."
         }
       },
       "description": "Container for the three IDD-role label names (roadmap, blocked-by-human, and needs-decision) plus the untrusted-labeler login list. Optional; omitting any nested key keeps that key's own distributed default."

--- a/schemas/policy.schema.json
+++ b/schemas/policy.schema.json
@@ -757,9 +757,18 @@
           "type": "string",
           "minLength": 1,
           "description": "GitHub label name marking an issue as needing a maintainer decision, excluding it from Discover's ready-to-start set. Optional; defaults to `status:needs-decision`."
+        },
+        "untrustedLabelerLogins": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Logins of semantic issue auto-labelers that this repository does not trust to apply IDD's reserved labels. Optional; defaults to an empty array when omitted."
         }
       },
-      "description": "Container for the three IDD-role label names: roadmap, blocked-by-human, and needs-decision. Optional; omitting any nested key keeps that key's own distributed default."
+      "description": "Container for the three IDD-role label names (roadmap, blocked-by-human, and needs-decision) plus the untrusted-labeler login list. Optional; omitting any nested key keeps that key's own distributed default."
     },
     "mergeGate": {
       "type": "object",

--- a/scripts/policy-helpers.mjs
+++ b/scripts/policy-helpers.mjs
@@ -311,6 +311,11 @@ export const POLICY_DEFAULTS = Object.freeze({
     roadmapLabelName: 'roadmap',
     blockedByHumanLabelName: 'status:blocked-by-human',
     needsDecisionLabelName: 'status:needs-decision',
+    // Added in #2669: string array default, resolved like the three
+    // sibling label-name fields above but via parseNonEmptyStringArray
+    // (fail-closed to [] on a non-array or wrong-typed entry) instead of
+    // parseNonEmptyString.
+    untrustedLabelerLogins: Object.freeze([]),
   }),
   // Added in #1521 (solo-CODEOWNER autonomous `--admin` merge fallback).
   mergeGate: Object.freeze({
@@ -734,6 +739,10 @@ export function normalizePolicyConfig(config) {
         c?.labels?.needsDecisionLabelName,
         POLICY_DEFAULTS.labels.needsDecisionLabelName,
       ),
+      untrustedLabelerLogins: parseNonEmptyStringArray(
+        c?.labels?.untrustedLabelerLogins,
+        POLICY_DEFAULTS.labels.untrustedLabelerLogins,
+      ),
     },
     mergeGate: {
       soloCodeownerAdminFallback: parseEnum(
@@ -852,11 +861,12 @@ export function selectDesyncedIndex(token, bandSize) {
  * normalization. This list is deliberately not treated as exhaustive —
  * what matters for this swap is not enumerating every divergence axis,
  * but that `POLICY_DEFAULTS` (below) never contains a value on *any* of
- * them. All 8 call sites in this file were enumerated before making this
- * swap: `normalizePolicyConfig`'s `clone(POLICY_DEFAULTS)`, plus 7 calls
- * across `parsePositiveIntegerArray` and `parseCheckSelectors`, which
- * only ever clone `POLICY_DEFAULTS` itself or one of its own frozen
- * sub-arrays (`discover.legacyRoots`, `ciGate.externalChecks.advisory`,
+ * them. All 10 call sites in this file were enumerated before making this
+ * swap: `normalizePolicyConfig`'s `clone(POLICY_DEFAULTS)`, plus 9 calls
+ * across `parsePositiveIntegerArray`, `parseNonEmptyStringArray`, and
+ * `parseCheckSelectors`, which only ever clone `POLICY_DEFAULTS` itself or
+ * one of its own frozen sub-arrays (`discover.legacyRoots`,
+ * `labels.untrustedLabelerLogins`, `ciGate.externalChecks.advisory`,
  * `.waivable` — all `[]`). `POLICY_DEFAULTS` is a plain, deeply-frozen
  * literal of strings, finite numbers, booleans, and empty arrays only —
  * no function, `Date`, `Map`, `BigInt`, `RegExp`, typed array, exotic
@@ -955,6 +965,27 @@ function parsePositiveIntegerArray(value, fallback) {
 }
 function parseNonEmptyString(value, fallback) {
   return typeof value === 'string' && value.length > 0 ? value : fallback;
+}
+/**
+ * Parse a config array of non-empty strings (e.g. GitHub logins), such as
+ * `labels.untrustedLabelerLogins`. Mirrors `parsePositiveIntegerArray`'s
+ * fail-closed shape: a non-array, empty array, or any entry that is not a
+ * non-empty string falls back to `fallback` as a whole rather than dropping
+ * just the bad entries, so a typo'd login cannot silently vanish from the
+ * set.
+ */
+function parseNonEmptyStringArray(value, fallback) {
+  if (!Array.isArray(value) || value.length === 0) {
+    return clone(fallback);
+  }
+  const normalized = [];
+  for (const entry of value) {
+    if (typeof entry !== 'string' || entry.length === 0) {
+      return clone(fallback);
+    }
+    normalized.push(entry);
+  }
+  return normalized;
 }
 function parseCheckSelectors(value, fallback) {
   if (!Array.isArray(value) || value.length === 0) {

--- a/scripts/policy-helpers.mjs
+++ b/scripts/policy-helpers.mjs
@@ -977,12 +977,15 @@ function parseNonEmptyString(value, fallback) {
   return typeof value === 'string' && value.length > 0 ? value : fallback;
 }
 /**
- * Parse a config array of non-empty strings (e.g. GitHub logins), such as
+ * Parse a config array of non-blank strings (e.g. GitHub logins), such as
  * `labels.untrustedLabelerLogins`. Mirrors `parsePositiveIntegerArray`'s
- * fail-closed shape: a non-array, empty array, or any entry that is not a
- * non-empty string falls back to `fallback` as a whole rather than dropping
- * just the bad entries, so a typo'd login cannot silently vanish from the
- * set.
+ * fail-closed shape: a non-array, empty array, or any entry that is empty
+ * or whitespace-only after trimming falls back to `fallback` as a whole
+ * rather than dropping just the bad entries, so a typo'd login cannot
+ * silently vanish from the set. A surviving entry is itself trimmed
+ * (matches `readWorktreeGuardBranchPatterns` in `idd-doctor.mts`): an
+ * entry with incidental surrounding whitespace otherwise passes but never
+ * matches a real login.
  *
  * Caution for a denylist-semantics caller (#2669 PR review, Codex): "fail
  * closed to `fallback`" is directionally safe only when `fallback` is the
@@ -1004,10 +1007,15 @@ function parseNonEmptyStringArray(value, fallback) {
   }
   const normalized = [];
   for (const entry of value) {
-    if (typeof entry !== 'string' || entry.length === 0) {
+    if (typeof entry !== 'string' || entry.trim().length === 0) {
       return clone(fallback);
     }
-    normalized.push(entry);
+    // Trim surviving entries: matches readWorktreeGuardBranchPatterns's
+    // same rationale (idd-doctor.mts) -- a configured entry with
+    // incidental surrounding whitespace (e.g. "triage-bot ") otherwise
+    // passes validation but never matches a real login, silently
+    // covering nothing.
+    normalized.push(entry.trim());
   }
   return normalized;
 }

--- a/scripts/policy-helpers.mjs
+++ b/scripts/policy-helpers.mjs
@@ -739,6 +739,16 @@ export function normalizePolicyConfig(config) {
         c?.labels?.needsDecisionLabelName,
         POLICY_DEFAULTS.labels.needsDecisionLabelName,
       ),
+      // #2669 PR review (Codex): this resolves to [] (trust everyone) on
+      // any malformed entry, including a mix of valid + invalid logins --
+      // fail-open for this denylist field, unlike an allowlist field's
+      // fail-to-[] (fail-closed). Kept matching the sibling label-name
+      // fields' resolution pattern per #2669's own acceptance criteria;
+      // no consumer reads this list yet (see the schema description), so
+      // there is no live enforcement gap today. Reconsider the fail
+      // direction -- and whether schema validation alone is a sufficient
+      // guarantee for the consumer -- when #2671 designs the actual
+      // enforcement this list feeds.
       untrustedLabelerLogins: parseNonEmptyStringArray(
         c?.labels?.untrustedLabelerLogins,
         POLICY_DEFAULTS.labels.untrustedLabelerLogins,
@@ -973,6 +983,20 @@ function parseNonEmptyString(value, fallback) {
  * non-empty string falls back to `fallback` as a whole rather than dropping
  * just the bad entries, so a typo'd login cannot silently vanish from the
  * set.
+ *
+ * Caution for a denylist-semantics caller (#2669 PR review, Codex): "fail
+ * closed to `fallback`" is directionally safe only when `fallback` is the
+ * maximally *restrictive* value for that field -- true for an allowlist
+ * (`fallback: []` denies everyone) but the opposite for a denylist
+ * (`fallback: []` trusts everyone). `labels.untrustedLabelerLogins` is a
+ * denylist, so one malformed entry alongside otherwise-valid logins
+ * silently drops every previously-declared untrusted login, not just the
+ * bad one. Schema validation (`minItems: 1`, non-empty `items`) is the
+ * actual enforcement boundary before this ever runs; this fallback is
+ * defense-in-depth for callers that bypass it. Partial-preserve filtering
+ * would not fully close this either -- a misspelled-but-non-empty login
+ * still passes this parser and simply matches nothing downstream. See the
+ * call site below for why this is deliberately left unchanged for now.
  */
 function parseNonEmptyStringArray(value, fallback) {
   if (!Array.isArray(value) || value.length === 0) {

--- a/scripts/policy-helpers.mjs
+++ b/scripts/policy-helpers.mjs
@@ -313,8 +313,8 @@ export const POLICY_DEFAULTS = Object.freeze({
     needsDecisionLabelName: 'status:needs-decision',
     // Added in #2669: string array default, resolved like the three
     // sibling label-name fields above but via parseNonEmptyStringArray
-    // (fail-closed to [] on a non-array or wrong-typed entry) instead of
-    // parseNonEmptyString.
+    // (fail-closed to [] on a non-array, an empty array, or any entry
+    // that isn't a non-empty string) instead of parseNonEmptyString.
     untrustedLabelerLogins: Object.freeze([]),
   }),
   // Added in #1521 (solo-CODEOWNER autonomous `--admin` merge fallback).

--- a/src/scripts/policy-helpers.mts
+++ b/src/scripts/policy-helpers.mts
@@ -372,6 +372,7 @@ interface RawConfig {
     roadmapLabelName?: unknown;
     blockedByHumanLabelName?: unknown;
     needsDecisionLabelName?: unknown;
+    untrustedLabelerLogins?: unknown;
   };
   mergeGate?: { soloCodeownerAdminFallback?: unknown };
   providerOutage?: {
@@ -562,6 +563,11 @@ export const POLICY_DEFAULTS = Object.freeze({
     roadmapLabelName: 'roadmap',
     blockedByHumanLabelName: 'status:blocked-by-human',
     needsDecisionLabelName: 'status:needs-decision',
+    // Added in #2669: string array default, resolved like the three
+    // sibling label-name fields above but via parseNonEmptyStringArray
+    // (fail-closed to [] on a non-array or wrong-typed entry) instead of
+    // parseNonEmptyString.
+    untrustedLabelerLogins: Object.freeze([]),
   }),
   // Added in #1521 (solo-CODEOWNER autonomous `--admin` merge fallback).
   mergeGate: Object.freeze({
@@ -1006,6 +1012,10 @@ export function normalizePolicyConfig(config: unknown) {
         c?.labels?.needsDecisionLabelName,
         POLICY_DEFAULTS.labels.needsDecisionLabelName,
       ),
+      untrustedLabelerLogins: parseNonEmptyStringArray(
+        c?.labels?.untrustedLabelerLogins,
+        POLICY_DEFAULTS.labels.untrustedLabelerLogins,
+      ),
     },
     mergeGate: {
       soloCodeownerAdminFallback: parseEnum(
@@ -1136,11 +1146,12 @@ export function selectDesyncedIndex(token: unknown, bandSize: unknown): number {
  * normalization. This list is deliberately not treated as exhaustive —
  * what matters for this swap is not enumerating every divergence axis,
  * but that `POLICY_DEFAULTS` (below) never contains a value on *any* of
- * them. All 8 call sites in this file were enumerated before making this
- * swap: `normalizePolicyConfig`'s `clone(POLICY_DEFAULTS)`, plus 7 calls
- * across `parsePositiveIntegerArray` and `parseCheckSelectors`, which
- * only ever clone `POLICY_DEFAULTS` itself or one of its own frozen
- * sub-arrays (`discover.legacyRoots`, `ciGate.externalChecks.advisory`,
+ * them. All 10 call sites in this file were enumerated before making this
+ * swap: `normalizePolicyConfig`'s `clone(POLICY_DEFAULTS)`, plus 9 calls
+ * across `parsePositiveIntegerArray`, `parseNonEmptyStringArray`, and
+ * `parseCheckSelectors`, which only ever clone `POLICY_DEFAULTS` itself or
+ * one of its own frozen sub-arrays (`discover.legacyRoots`,
+ * `labels.untrustedLabelerLogins`, `ciGate.externalChecks.advisory`,
  * `.waivable` — all `[]`). `POLICY_DEFAULTS` is a plain, deeply-frozen
  * literal of strings, finite numbers, booleans, and empty arrays only —
  * no function, `Date`, `Map`, `BigInt`, `RegExp`, typed array, exotic
@@ -1261,6 +1272,32 @@ function parsePositiveIntegerArray(
 
 function parseNonEmptyString(value: unknown, fallback: string): string {
   return typeof value === 'string' && value.length > 0 ? value : fallback;
+}
+
+/**
+ * Parse a config array of non-empty strings (e.g. GitHub logins), such as
+ * `labels.untrustedLabelerLogins`. Mirrors `parsePositiveIntegerArray`'s
+ * fail-closed shape: a non-array, empty array, or any entry that is not a
+ * non-empty string falls back to `fallback` as a whole rather than dropping
+ * just the bad entries, so a typo'd login cannot silently vanish from the
+ * set.
+ */
+function parseNonEmptyStringArray(
+  value: unknown,
+  fallback: readonly string[],
+): string[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    return clone(fallback) as string[];
+  }
+
+  const normalized: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== 'string' || entry.length === 0) {
+      return clone(fallback) as string[];
+    }
+    normalized.push(entry);
+  }
+  return normalized;
 }
 
 function parseCheckSelectors(

--- a/src/scripts/policy-helpers.mts
+++ b/src/scripts/policy-helpers.mts
@@ -1012,6 +1012,16 @@ export function normalizePolicyConfig(config: unknown) {
         c?.labels?.needsDecisionLabelName,
         POLICY_DEFAULTS.labels.needsDecisionLabelName,
       ),
+      // #2669 PR review (Codex): this resolves to [] (trust everyone) on
+      // any malformed entry, including a mix of valid + invalid logins --
+      // fail-open for this denylist field, unlike an allowlist field's
+      // fail-to-[] (fail-closed). Kept matching the sibling label-name
+      // fields' resolution pattern per #2669's own acceptance criteria;
+      // no consumer reads this list yet (see the schema description), so
+      // there is no live enforcement gap today. Reconsider the fail
+      // direction -- and whether schema validation alone is a sufficient
+      // guarantee for the consumer -- when #2671 designs the actual
+      // enforcement this list feeds.
       untrustedLabelerLogins: parseNonEmptyStringArray(
         c?.labels?.untrustedLabelerLogins,
         POLICY_DEFAULTS.labels.untrustedLabelerLogins,
@@ -1281,6 +1291,20 @@ function parseNonEmptyString(value: unknown, fallback: string): string {
  * non-empty string falls back to `fallback` as a whole rather than dropping
  * just the bad entries, so a typo'd login cannot silently vanish from the
  * set.
+ *
+ * Caution for a denylist-semantics caller (#2669 PR review, Codex): "fail
+ * closed to `fallback`" is directionally safe only when `fallback` is the
+ * maximally *restrictive* value for that field -- true for an allowlist
+ * (`fallback: []` denies everyone) but the opposite for a denylist
+ * (`fallback: []` trusts everyone). `labels.untrustedLabelerLogins` is a
+ * denylist, so one malformed entry alongside otherwise-valid logins
+ * silently drops every previously-declared untrusted login, not just the
+ * bad one. Schema validation (`minItems: 1`, non-empty `items`) is the
+ * actual enforcement boundary before this ever runs; this fallback is
+ * defense-in-depth for callers that bypass it. Partial-preserve filtering
+ * would not fully close this either -- a misspelled-but-non-empty login
+ * still passes this parser and simply matches nothing downstream. See the
+ * call site below for why this is deliberately left unchanged for now.
  */
 function parseNonEmptyStringArray(
   value: unknown,

--- a/src/scripts/policy-helpers.mts
+++ b/src/scripts/policy-helpers.mts
@@ -1285,12 +1285,15 @@ function parseNonEmptyString(value: unknown, fallback: string): string {
 }
 
 /**
- * Parse a config array of non-empty strings (e.g. GitHub logins), such as
+ * Parse a config array of non-blank strings (e.g. GitHub logins), such as
  * `labels.untrustedLabelerLogins`. Mirrors `parsePositiveIntegerArray`'s
- * fail-closed shape: a non-array, empty array, or any entry that is not a
- * non-empty string falls back to `fallback` as a whole rather than dropping
- * just the bad entries, so a typo'd login cannot silently vanish from the
- * set.
+ * fail-closed shape: a non-array, empty array, or any entry that is empty
+ * or whitespace-only after trimming falls back to `fallback` as a whole
+ * rather than dropping just the bad entries, so a typo'd login cannot
+ * silently vanish from the set. A surviving entry is itself trimmed
+ * (matches `readWorktreeGuardBranchPatterns` in `idd-doctor.mts`): an
+ * entry with incidental surrounding whitespace otherwise passes but never
+ * matches a real login.
  *
  * Caution for a denylist-semantics caller (#2669 PR review, Codex): "fail
  * closed to `fallback`" is directionally safe only when `fallback` is the
@@ -1316,10 +1319,15 @@ function parseNonEmptyStringArray(
 
   const normalized: string[] = [];
   for (const entry of value) {
-    if (typeof entry !== 'string' || entry.length === 0) {
+    if (typeof entry !== 'string' || entry.trim().length === 0) {
       return clone(fallback) as string[];
     }
-    normalized.push(entry);
+    // Trim surviving entries: matches readWorktreeGuardBranchPatterns's
+    // same rationale (idd-doctor.mts) -- a configured entry with
+    // incidental surrounding whitespace (e.g. "triage-bot ") otherwise
+    // passes validation but never matches a real login, silently
+    // covering nothing.
+    normalized.push(entry.trim());
   }
   return normalized;
 }

--- a/src/scripts/policy-helpers.mts
+++ b/src/scripts/policy-helpers.mts
@@ -565,8 +565,8 @@ export const POLICY_DEFAULTS = Object.freeze({
     needsDecisionLabelName: 'status:needs-decision',
     // Added in #2669: string array default, resolved like the three
     // sibling label-name fields above but via parseNonEmptyStringArray
-    // (fail-closed to [] on a non-array or wrong-typed entry) instead of
-    // parseNonEmptyString.
+    // (fail-closed to [] on a non-array, an empty array, or any entry
+    // that isn't a non-empty string) instead of parseNonEmptyString.
     untrustedLabelerLogins: Object.freeze([]),
   }),
   // Added in #1521 (solo-CODEOWNER autonomous `--admin` merge fallback).

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -871,6 +871,7 @@ test('policy normalization provides default-safe values and supports aliases', (
       roadmapLabelName: 'roadmap',
       blockedByHumanLabelName: 'status:blocked-by-human',
       needsDecisionLabelName: 'status:needs-decision',
+      untrustedLabelerLogins: [],
     },
     mergeGate: {
       soloCodeownerAdminFallback: 'auto-admin-retry',
@@ -974,6 +975,7 @@ test('policy normalization provides default-safe values and supports aliases', (
         roadmapLabelName: 'epic',
         blockedByHumanLabelName: 'blocked:human',
         needsDecisionLabelName: 'needs:decision',
+        untrustedLabelerLogins: ['triage-bot'],
       },
       mergeGate: {
         soloCodeownerAdminFallback: 'hold-and-report',
@@ -1054,6 +1056,7 @@ test('policy normalization provides default-safe values and supports aliases', (
         roadmapLabelName: 'epic',
         blockedByHumanLabelName: 'blocked:human',
         needsDecisionLabelName: 'needs:decision',
+        untrustedLabelerLogins: ['triage-bot'],
       },
       mergeGate: {
         soloCodeownerAdminFallback: 'hold-and-report',

--- a/tests/policy-helpers.test.mts
+++ b/tests/policy-helpers.test.mts
@@ -103,12 +103,33 @@ test('labels.untrustedLabelerLogins defaults to [] and accepts a configured over
     }).labels.untrustedLabelerLogins,
     ['triage-bot', 'auto-labeler[bot]'],
   );
-  // Fail-closed (parseNonEmptyStringArray mirrors
-  // parsePositiveIntegerArray's shape): a wrong-typed entry falls back to
-  // [] as a whole rather than dropping just the bad entry.
+});
+
+test('labels.untrustedLabelerLogins fails safe to [] on invalid input (#2669)', () => {
+  // Mirrors discover.legacyRoots's dedicated fail-safe test above:
+  // parseNonEmptyStringArray shares parsePositiveIntegerArray's shape, so a
+  // non-array, an empty array, and either an empty-string or a wrong-typed
+  // entry all fall back to the default `[]` as a whole -- a typo'd login
+  // cannot silently vanish from the set by dropping just the bad entry.
+  assert.deepEqual(
+    normalizePolicyConfig({ labels: { untrustedLabelerLogins: 'triage-bot' } })
+      .labels.untrustedLabelerLogins,
+    [],
+  );
+  assert.deepEqual(
+    normalizePolicyConfig({ labels: { untrustedLabelerLogins: [] } }).labels
+      .untrustedLabelerLogins,
+    [],
+  );
   assert.deepEqual(
     normalizePolicyConfig({
       labels: { untrustedLabelerLogins: ['triage-bot', ''] },
+    }).labels.untrustedLabelerLogins,
+    [],
+  );
+  assert.deepEqual(
+    normalizePolicyConfig({
+      labels: { untrustedLabelerLogins: ['triage-bot', 42] },
     }).labels.untrustedLabelerLogins,
     [],
   );

--- a/tests/policy-helpers.test.mts
+++ b/tests/policy-helpers.test.mts
@@ -78,18 +78,40 @@ test('advisoryWait.exemptBotAuthoredPrs defaults to false and only a literal tru
   );
 });
 
-test('POLICY_DEFAULTS.labels exposes the three reserved label name defaults', () => {
+test('POLICY_DEFAULTS.labels exposes the three reserved label name defaults plus untrustedLabelerLogins', () => {
   // Additive only (#1272): POLICY_DEFAULTS carries the literal defaults,
   // and normalizePolicyConfig normalizes this namespace too (for shape
   // parity — see its labels branch), but no consuming helper outside
   // policy-helpers.mts reads it yet. Wiring the discover/claim/
   // roadmap-audit label lookups to it is deferred to the follow-up
-  // (#1273).
+  // (#1273). `untrustedLabelerLogins` (#2669) is not itself a label name —
+  // it is the login list a future generation track will scope a CI guard
+  // to — but it lives in this same namespace.
   assert.deepEqual(POLICY_DEFAULTS.labels, {
     roadmapLabelName: 'roadmap',
     blockedByHumanLabelName: 'status:blocked-by-human',
     needsDecisionLabelName: 'status:needs-decision',
+    untrustedLabelerLogins: [],
   });
+});
+
+test('labels.untrustedLabelerLogins defaults to [] and accepts a configured override (#2669)', () => {
+  assert.deepEqual(normalizePolicyConfig({}).labels.untrustedLabelerLogins, []);
+  assert.deepEqual(
+    normalizePolicyConfig({
+      labels: { untrustedLabelerLogins: ['triage-bot', 'auto-labeler[bot]'] },
+    }).labels.untrustedLabelerLogins,
+    ['triage-bot', 'auto-labeler[bot]'],
+  );
+  // Fail-closed (parseNonEmptyStringArray mirrors
+  // parsePositiveIntegerArray's shape): a wrong-typed entry falls back to
+  // [] as a whole rather than dropping just the bad entry.
+  assert.deepEqual(
+    normalizePolicyConfig({
+      labels: { untrustedLabelerLogins: ['triage-bot', ''] },
+    }).labels.untrustedLabelerLogins,
+    [],
+  );
 });
 
 test('claimTiming.staleAge defaults to PT24H and accepts a configured override', () => {

--- a/tests/policy-helpers.test.mts
+++ b/tests/policy-helpers.test.mts
@@ -133,6 +133,26 @@ test('labels.untrustedLabelerLogins fails safe to [] on invalid input (#2669)', 
     }).labels.untrustedLabelerLogins,
     [],
   );
+  // A whitespace-only entry can never match a real GitHub login; treated
+  // the same as an empty-string entry (#2669 PR review, Codex).
+  assert.deepEqual(
+    normalizePolicyConfig({
+      labels: { untrustedLabelerLogins: ['triage-bot', '   '] },
+    }).labels.untrustedLabelerLogins,
+    [],
+  );
+});
+
+test('labels.untrustedLabelerLogins trims surviving entries (#2669 PR review, Codex)', () => {
+  // Mirrors readWorktreeGuardBranchPatterns's rationale (idd-doctor.mts):
+  // an entry with incidental surrounding whitespace otherwise passes but
+  // never matches a real login.
+  assert.deepEqual(
+    normalizePolicyConfig({
+      labels: { untrustedLabelerLogins: [' triage-bot ', 'auto-labeler[bot]'] },
+    }).labels.untrustedLabelerLogins,
+    ['triage-bot', 'auto-labeler[bot]'],
+  );
 });
 
 test('claimTiming.staleAge defaults to PT24H and accepts a configured override', () => {

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -261,6 +261,7 @@ interface PolicyConfigFile {
     roadmapLabelName?: string;
     blockedByHumanLabelName?: string;
     needsDecisionLabelName?: string;
+    untrustedLabelerLogins?: readonly string[];
   };
   mergeGate?: {
     soloCodeownerAdminFallback?: 'auto-admin-retry' | 'hold-and-report';
@@ -1229,6 +1230,7 @@ const policyConfigFixture = {
     roadmapLabelName: 'roadmap',
     blockedByHumanLabelName: 'status:blocked-by-human',
     needsDecisionLabelName: 'status:needs-decision',
+    untrustedLabelerLogins: ['triage-bot'],
   },
   mergeGate: { soloCodeownerAdminFallback: 'auto-admin-retry' },
   providerOutage: {

--- a/tests/schema-validation.test.mts
+++ b/tests/schema-validation.test.mts
@@ -2338,6 +2338,57 @@ test('policy schema rejects labels unexpected extra keys', () => {
   );
 });
 
+test('policy schema accepts labels.untrustedLabelerLogins as a non-empty string array', () => {
+  const schema = loadJson('schemas/policy.schema.json');
+  const instance = JSON.parse(
+    JSON.stringify(loadJson('fixtures/schemas/policy.valid.json')),
+  );
+  instance.labels = {
+    untrustedLabelerLogins: ['triage-bot', 'auto-labeler[bot]'],
+  };
+  const errors = validate(instance, schema);
+  assert.deepEqual(errors, []);
+});
+
+test('policy schema rejects labels.untrustedLabelerLogins of the wrong type', () => {
+  const schema = loadJson('schemas/policy.schema.json');
+  const instance = JSON.parse(
+    JSON.stringify(loadJson('fixtures/schemas/policy.valid.json')),
+  );
+  instance.labels = { untrustedLabelerLogins: 'triage-bot' };
+  const errors = validate(instance, schema);
+  assert.ok(
+    errors.some((e) => e.includes('$.labels.untrustedLabelerLogins')),
+    errors.join('\n'),
+  );
+});
+
+test('policy schema rejects an empty labels.untrustedLabelerLogins array', () => {
+  const schema = loadJson('schemas/policy.schema.json');
+  const instance = JSON.parse(
+    JSON.stringify(loadJson('fixtures/schemas/policy.valid.json')),
+  );
+  instance.labels = { untrustedLabelerLogins: [] };
+  const errors = validate(instance, schema);
+  assert.ok(
+    errors.some((e) => e.includes('$.labels.untrustedLabelerLogins')),
+    errors.join('\n'),
+  );
+});
+
+test('policy schema rejects a labels.untrustedLabelerLogins entry that is not a non-empty string', () => {
+  const schema = loadJson('schemas/policy.schema.json');
+  const instance = JSON.parse(
+    JSON.stringify(loadJson('fixtures/schemas/policy.valid.json')),
+  );
+  instance.labels = { untrustedLabelerLogins: [''] };
+  const errors = validate(instance, schema);
+  assert.ok(
+    errors.some((e) => e.includes('$.labels.untrustedLabelerLogins[0]')),
+    errors.join('\n'),
+  );
+});
+
 test('policy schema accepts forcedHandoff.mode human-gated', () => {
   const schema = loadJson('schemas/policy.schema.json');
   const instance = JSON.parse(

--- a/tests/schema-validation.test.mts
+++ b/tests/schema-validation.test.mts
@@ -2389,6 +2389,23 @@ test('policy schema rejects a labels.untrustedLabelerLogins entry that is not a 
   );
 });
 
+test('policy schema rejects a whitespace-only labels.untrustedLabelerLogins entry', () => {
+  const schema = loadJson('schemas/policy.schema.json');
+  const instance = JSON.parse(
+    JSON.stringify(loadJson('fixtures/schemas/policy.valid.json')),
+  );
+  // A whitespace-only login can never match a real GitHub actor; the `\S`
+  // pattern rejects it at validation time instead of letting a validated
+  // configuration silently cover no actor (mirrors the same rationale as
+  // worktreeGuard.branchPatterns above).
+  instance.labels = { untrustedLabelerLogins: [' '] };
+  const errors = validate(instance, schema);
+  assert.ok(
+    errors.some((e) => e.includes('$.labels.untrustedLabelerLogins[0]')),
+    errors.join('\n'),
+  );
+});
+
 test('policy schema accepts forcedHandoff.mode human-gated', () => {
   const schema = loadJson('schemas/policy.schema.json');
   const instance = JSON.parse(


### PR DESCRIPTION
# Summary

Adds `labels.untrustedLabelerLogins` to `schemas/policy.schema.json`'s
`labels` object: an optional array of non-empty GitHub login strings
naming semantic issue auto-labelers this repository does not trust to
apply IDD's reserved labels. Defaults to `[]` when omitted.
`additionalProperties` on `labels` stays `false`.

- `schemas/policy.schema.json`: new field, `minItems: 1` (matching every
  other optional array already in this schema — omit the key for the
  empty case rather than passing `[]`), non-empty string items. Its
  description discloses that no distributed enforcement reads the list
  yet — this track is schema surface and resolved default only.
- `fixtures/schemas/policy.valid.json`: non-empty example.
- `src/scripts/policy-helpers.mts`: `POLICY_DEFAULTS.labels` and
  `normalizePolicyConfig`'s resolver gain the field, defaulting to `[]`,
  via a new `parseNonEmptyStringArray` helper mirroring the existing
  `parsePositiveIntegerArray`'s fail-closed shape (a non-array, empty
  array, or any bad entry falls back to the whole default rather than
  dropping just the bad entry).
- Tests: `tests/schema-validation.test.mts` (accept + three reject
  shapes), `tests/policy-helpers.test.mts` (default, override, dedicated
  fail-safe test), `tests/consistency.test.mts` and
  `tests/schema-type-reconciliation.test.mts` (existing full-shape /
  type-mirror assertions updated for the new key).

## Linked issue

Closes #2669

## Follow-up issues (if any)

- [x] none — the generation step that will consume this field
      (`idd-onboard` substituting it into a generated CI guard) and the
      docs update are already tracked as sibling roadmap tracks #2671 and
      #2672 under #2668; this PR intentionally adds only the schema
      surface and resolved default, per the issue's own stated scope.

## Background / rationale (if material)

Part of roadmap #2668 (bundling the reserved-label CI guard with
`idd-onboard`, declaration-based rather than detection-based per prior
rejected approaches in #1203/#1716). This is the schema track; #2671
(generation) is blocked on this field existing. Sibling track #2670
(untrusted-labeler-login sweep helper) already merged as #2676.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [x] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (no docs mirrors touched by this change)
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jz9naVhMefTusdLL9FzLc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional configuration for identifying untrusted labeler logins.
  * Supports validating non-empty arrays of non-empty login strings, with safe defaults for invalid or missing values.

* **Tests**
  * Added coverage for valid configurations, invalid inputs, default behavior, and schema validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->