### PR TITLE
feat(schema): add critiqueLoop.telemetryHook to the policy schema

### DIFF
--- a/fixtures/schemas/policy.valid.json
+++ b/fixtures/schemas/policy.valid.json
@@ -68,7 +68,10 @@
   },
   "critiqueLoop": {
     "cPhaseLowSeveritySkipAfter": 3,
-    "e10NoProgressHoldAfter": 3
+    "e10NoProgressHoldAfter": 3,
+    "telemetryHook": {
+      "command": "notify-critique-telemetry"
+    }
   },
   "reviewEscalation": {
     "changesRequestedFirstEscalation": "PT24H",

--- a/schemas/policy.schema.json
+++ b/schemas/policy.schema.json
@@ -641,6 +641,20 @@
             }
           },
           "description": "Repository-configurable C1 critique delegate. Optional; absent keeps today's per-agent-only behavior. An explicit JSON `null` is the local disable sentinel: it prevents inheriting a user-global delegate without installing a local command. `required` and `properties` apply only when the value is an object."
+        },
+        "telemetryHook": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "required": ["command"],
+          "properties": {
+            "command": {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "\\S",
+              "description": "Shell command for a per-round C-phase critique telemetry notification. Required within this object; must contain a non-whitespace character (the `\\S` pattern rejects a whitespace-only value, matching `delegate.command`'s own validation)."
+            }
+          },
+          "description": "Schema-supported, repository-configurable per-round C-phase critique telemetry hook declaration. Optional; not currently invoked by any discover, claim, work, or review runtime consumer — see the roadmap's Track B for the planned resolution and invocation logic. An explicit JSON `null` is the local disable sentinel: it prevents inheriting a user-global hook without installing a local one. `required` and `properties` apply only when the value is an object."
         }
       },
       "description": "Container for the C-phase and E10 critique-loop convergence guardrails. Optional; omitting any nested key keeps that key's own distributed default."

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -956,6 +956,7 @@ test('policy normalization provides default-safe values and supports aliases', (
       critiqueLoop: {
         cPhaseLowSeveritySkipAfter: 4,
         e10NoProgressHoldAfter: 2,
+        telemetryHook: { command: 'notify-hook' },
       },
       reviewEscalation: {
         changesRequestedFirstEscalation: 'PT18H',
@@ -1033,6 +1034,8 @@ test('policy normalization provides default-safe values and supports aliases', (
       claim: {
         verifySettleDelay: 'PT7S',
       },
+      // telemetryHook (#2678) is schema-only in this track and must not
+      // leak into the normalized output -- see the input object above.
       critiqueLoop: {
         cPhaseLowSeveritySkipAfter: 4,
         e10NoProgressHoldAfter: 2,

--- a/tests/policy-helpers.test.mts
+++ b/tests/policy-helpers.test.mts
@@ -773,6 +773,22 @@ test('an unrecognized mode still fails closed after the widening (#2324)', () =>
   );
 });
 
+test('critiqueLoop.telemetryHook has no normalizePolicyConfig resolution yet (schema-only, #2678)', () => {
+  // #2678 adds critiqueLoop.telemetryHook to the JSON schema only; unlike
+  // delegate, no runtime resolution/invocation logic exists yet (deferred to
+  // the roadmap's Track B). This canary pins that boundary: a future track
+  // adding real resolution must consciously update this test.
+  assert.equal(
+    Object.hasOwn(
+      normalizePolicyConfig({
+        critiqueLoop: { telemetryHook: { command: 'notify-critique' } },
+      }).critiqueLoop,
+      'telemetryHook',
+    ),
+    false,
+  );
+});
+
 test('selectDesyncedIndex returns 0 for empty, singleton, or invalid bands', () => {
   assert.equal(selectDesyncedIndex('any-token', 0), 0);
   assert.equal(selectDesyncedIndex('any-token', 1), 0);

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -241,6 +241,7 @@ interface PolicyConfigFile {
       command: string;
       mode?: 'fallback' | 'combined' | 'on-success' | 'never';
     } | null;
+    telemetryHook?: { command: string } | null;
   };
   reviewEscalation?: {
     changesRequestedFirstEscalation?: string;

--- a/tests/schema-validation.test.mts
+++ b/tests/schema-validation.test.mts
@@ -853,6 +853,100 @@ test('policy schema accepts critiqueLoop.delegate JSON null as the local disable
   assert.deepEqual(errors, []);
 });
 
+// --- #2678: critiqueLoop.telemetryHook ----------------------------------
+
+test('policy schema accepts a critiqueLoop.telemetryHook with command only (#2678)', () => {
+  const schema = loadJson('schemas/policy.schema.json');
+  const instance = JSON.parse(
+    JSON.stringify(loadJson('fixtures/schemas/policy.valid.json')),
+  );
+  instance.critiqueLoop = {
+    telemetryHook: { command: 'notify-critique-telemetry --json' },
+  };
+  const errors = validate(instance, schema);
+  assert.deepEqual(errors, []);
+});
+
+test('policy schema rejects a critiqueLoop.telemetryHook missing command (#2678)', () => {
+  const schema = loadJson('schemas/policy.schema.json');
+  const instance = JSON.parse(
+    JSON.stringify(loadJson('fixtures/schemas/policy.valid.json')),
+  );
+  instance.critiqueLoop = { telemetryHook: {} };
+  const errors = validate(instance, schema);
+  assert.ok(
+    errors.some((error) => error.includes('$.critiqueLoop.telemetryHook')),
+    errors.join('\n'),
+  );
+});
+
+test('policy schema rejects a critiqueLoop.telemetryHook with an empty command (#2678)', () => {
+  const schema = loadJson('schemas/policy.schema.json');
+  const instance = JSON.parse(
+    JSON.stringify(loadJson('fixtures/schemas/policy.valid.json')),
+  );
+  instance.critiqueLoop = { telemetryHook: { command: '' } };
+  const errors = validate(instance, schema);
+  assert.ok(
+    errors.some((error) =>
+      error.includes('$.critiqueLoop.telemetryHook.command'),
+    ),
+    errors.join('\n'),
+  );
+});
+
+test('policy schema rejects a critiqueLoop.telemetryHook with a whitespace-only command (#2678)', () => {
+  const schema = loadJson('schemas/policy.schema.json');
+  const instance = JSON.parse(
+    JSON.stringify(loadJson('fixtures/schemas/policy.valid.json')),
+  );
+  // Same rationale as delegate.command above: a whitespace-only command can
+  // never run anything actionable.
+  instance.critiqueLoop = { telemetryHook: { command: '   ' } };
+  const errors = validate(instance, schema);
+  assert.ok(
+    errors.some((error) =>
+      error.includes('$.critiqueLoop.telemetryHook.command'),
+    ),
+    errors.join('\n'),
+  );
+});
+
+test('policy schema rejects an unknown critiqueLoop.telemetryHook subkey (#2678)', () => {
+  const schema = loadJson('schemas/policy.schema.json');
+  const instance = JSON.parse(
+    JSON.stringify(loadJson('fixtures/schemas/policy.valid.json')),
+  );
+  instance.critiqueLoop = {
+    telemetryHook: { command: 'notify-critique-telemetry', bogus: 1 },
+  };
+  const errors = validate(instance, schema);
+  assert.ok(
+    errors.some((error) => error.includes('$.critiqueLoop.telemetryHook')),
+    errors.join('\n'),
+  );
+});
+
+test('policy schema treats a missing critiqueLoop.telemetryHook as the fail-safe default (#2678)', () => {
+  const schema = loadJson('schemas/policy.schema.json');
+  const instance = JSON.parse(
+    JSON.stringify(loadJson('fixtures/schemas/policy.valid.json')),
+  );
+  delete instance.critiqueLoop.telemetryHook;
+  const errors = validate(instance, schema);
+  assert.deepEqual(errors, []);
+});
+
+test('policy schema accepts critiqueLoop.telemetryHook JSON null as the local disable sentinel (#2678)', () => {
+  const schema = loadJson('schemas/policy.schema.json');
+  const instance = JSON.parse(
+    JSON.stringify(loadJson('fixtures/schemas/policy.valid.json')),
+  );
+  instance.critiqueLoop = { ...instance.critiqueLoop, telemetryHook: null };
+  const errors = validate(instance, schema);
+  assert.deepEqual(errors, []);
+});
+
 test('policy schema rejects a whitespace-only branchPatterns entry', () => {
   const schema = loadJson('schemas/policy.schema.json');
   const instance = JSON.parse(


### PR DESCRIPTION
# Summary

Add `critiqueLoop.telemetryHook` to `schemas/policy.schema.json`,
mirroring the sibling `critiqueLoop.delegate` field's validation style
(`object|null`, `additionalProperties: false`, `required: ["command"]`
when an object, `command` non-empty/non-whitespace) but without a
`mode` field, since it is a side-effect-only per-round C-phase
critique telemetry notification that never gates or replaces the
critique mechanism.

This track is schema-only per the parent roadmap's Track B split — no
runtime resolution or invocation logic is added here. A
`tests/policy-helpers.test.mts` canary and a `tests/consistency.test.mts`
snapshot addition pin that `normalizePolicyConfig` does not yet
resolve or leak this field, so a future track adding real resolution
must consciously update those tests.

Changed:

- `schemas/policy.schema.json` — add the `critiqueLoop.telemetryHook`
  property.
- `fixtures/schemas/policy.valid.json` — add an example.
- `tests/schema-validation.test.mts` — accept/reject cases (valid
  command, explicit `null`, missing/empty/whitespace-only command,
  unrecognized subkey, missing-field default).
- `tests/schema-type-reconciliation.test.mts` — add the field to the
  test-local `PolicyConfigFile` interface.
- `tests/policy-helpers.test.mts` — canary asserting no runtime
  resolution yet.
- `tests/consistency.test.mts` — extend the full-override
  `normalizePolicyConfig` snapshot test to confirm the field does not
  leak into the normalized output.

## Linked issue

Closes #2678

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Parent roadmap: #2677. See the roadmap's Background for why the
telemetry hook's own outbound-payload schema does not reopen the
"no schema on the delegate" constraint discussed there.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [x] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191MCYGribBmSeRVTk3AxQ6
