### PR TITLE
feat(critique-telemetry-hook): resolve and invoke the C1 telemetry hook per round

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -50,6 +50,7 @@ scripts/helper-flag-drift.mjs linguist-generated=true
 scripts/helper-runtime-manifest.mjs linguist-generated=true
 scripts/idd-config.mjs linguist-generated=true
 scripts/idd-critique-delegate.mjs linguist-generated=true
+scripts/idd-critique-telemetry-hook.mjs linguist-generated=true
 scripts/idd-doctor.mjs linguist-generated=true
 scripts/idd-merge-execute.mjs linguist-generated=true
 scripts/idd-onboard.mjs linguist-generated=true

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -466,7 +466,9 @@ floor (C1) has passed, else continue to C5. One or more issues:
 continue to C3 regardless of the floor — C4 applies the floor check
 after Accept/Reject scoring.
 
-**Telemetry hook**: on this skip, invoke `critiqueLoop.telemetryHook`
+**Telemetry hook**: on a zero-issue round (either branch above — a
+round that continues to C5 for the floor only is still a zero-finding
+round and must not lose its record), invoke `critiqueLoop.telemetryHook`
 (C1) with zero findings/accepted/rejected counts — fire-and-forget.
 
 ### C3 — Score issues

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -434,8 +434,12 @@ problems exist. See `idd-overview-appendix.instructions.md` for per-agent
 implementation. The distributed defaults for the C-phase skip and loop
 guards are listed in `docs/policy-constants.md`. A repository may
 configure `critiqueLoop.delegate` to point this step at a different
-reviewer instead of the per-agent mechanism; see `docs/idd-workflow.md`'s
-"Critique pass invocation" section.
+reviewer instead of the per-agent mechanism, or `critiqueLoop.telemetryHook`
+for a separate fire-and-forget per-round JSON record (round, repo,
+issue, PR, findings/severity/accepted/rejected counts, delegate usage,
+timestamp) that C2/C4 below invoke but that never gates control flow;
+see `docs/idd-workflow.md`'s "Critique pass invocation" section for
+both.
 
 **Objective diff validation floor**: neither C2 nor C4 below may skip to
 `idd-pr-submit.instructions.md` unless **fix-validate** — the same
@@ -461,6 +465,9 @@ Zero issues reported: skip to `idd-pr-submit.instructions.md` when the
 floor (C1) has passed, else continue to C5. One or more issues:
 continue to C3 regardless of the floor — C4 applies the floor check
 after Accept/Reject scoring.
+
+**Telemetry hook**: on this skip, invoke `critiqueLoop.telemetryHook`
+(C1) with zero findings/accepted/rejected counts — fire-and-forget.
 
 ### C3 — Score issues
 
@@ -488,6 +495,11 @@ satisfy the floor only; the second bullet's remaining Low Accepts stay
 unfixed, per the guard.
 
 Otherwise continue to C5.
+
+**Telemetry hook**: once final (before C5, PR submission, or a hold),
+invoke `critiqueLoop.telemetryHook` (C1) with this round's findings,
+severity, accepted/rejected counts, and delegate usage —
+fire-and-forget.
 
 ### C5 — Fix accepted issues
 

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -498,10 +498,11 @@ unfixed, per the guard.
 
 Otherwise continue to C5.
 
-**Telemetry hook**: once final (before C5, PR submission, or a hold),
-invoke `critiqueLoop.telemetryHook` (C1) with this round's findings,
-severity, accepted/rejected counts, and delegate usage —
-fire-and-forget.
+**Telemetry hook**: once final (before C5, PR submission, or C4's own
+hold) invoke `critiqueLoop.telemetryHook` (C1) with this round's
+findings, severity, accepted/rejected counts, and delegate usage —
+fire-and-forget. A delegate's own fail-closed hold (`docs/idd-workflow.md`)
+stops before C2 and has no telemetry record.
 
 ### C5 — Fix accepted issues
 

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -299,7 +299,7 @@
         ".github/instructions/idd-overview-core.instructions.md",
         ".github/instructions/idd-work.instructions.md"
       ],
-      "limitBytes": 49500
+      "limitBytes": 52000
     },
     {
       "id": "bundle-work-lite",

--- a/bin/idd-critique-telemetry-hook.mjs
+++ b/bin/idd-critique-telemetry-hook.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-critique-telemetry-hook.mts
+//
+// The bin/idd-critique-telemetry-hook.mjs copy is generated from the .mts source named above
+// by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+import { runHelper } from './run-helper.mjs';
+
+runHelper('../scripts/idd-critique-telemetry-hook.mjs');

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -220,6 +220,13 @@ in this preamble, since the fallback differs per helper.
   `mode`, and a machine-readable `reason` when unusable, delegating
   entirely to the existing exported resolvers (referenced in
   [kurone-kito/idd-skill#2329](https://github.com/kurone-kito/idd-skill/issues/2329))
+- `scripts/idd-critique-telemetry-hook.mjs` for the C-phase effective
+  `critiqueLoop.telemetryHook` verdict (`usable`, `source`, `command`,
+  and a machine-readable `reason` when unusable), plus fire-and-forget
+  invocation via `--invoke`: pipe the per-round JSON payload on stdin
+  and it invokes the resolved hook, always exiting `0` regardless of
+  the hook's own success or failure (referenced in
+  [kurone-kito/idd-skill#2679](https://github.com/kurone-kito/idd-skill/issues/2679))
 
 **Review & Merge Phase Helpers:**
 
@@ -2955,6 +2962,65 @@ same as `AW4`/`AW5`.
   `parseCritiqueLoopDelegate` in `policy-helpers.mts`) with no
   reimplemented validation rule (referenced in
   [kurone-kito/idd-skill#2329](https://github.com/kurone-kito/idd-skill/issues/2329))
+
+### Effective C-phase critique telemetry hook
+
+- Preferred command when helper runtime is enabled:
+  `idd-critique-telemetry-hook [--policy <path>] [--no-user-global]`
+- Source repository equivalent:
+  `node scripts/idd-critique-telemetry-hook.mjs [--policy <path>] [--no-user-global]`
+- Output schema (stable fields):
+
+  ```json
+  {
+    "usable": true,
+    "source": "repository-local",
+    "command": "notify-critique-telemetry --json",
+    "reason": null
+  }
+  ```
+
+- `source` values: `repository-local`, `user-global`, `none`
+- `reason` values (only when `usable` is `false`):
+  `repository-local-explicit-disable` (repo-local
+  `critiqueLoop.telemetryHook` is the JSON `null` sentinel),
+  `invalid-repository-local-telemetry-hook` (a malformed repo-local
+  value, which fails closed and never inherits a user-global hook),
+  `not-configured` (absent at every layer)
+- `usable: true` always carries a non-null `command` and a null
+  `reason`; `usable: false` always carries a null `command` and a
+  non-null `reason`
+- Resolution order matches
+  [User-global critique telemetry hook default](idd-workflow.md#user-global-critique-telemetry-hook-default)
+  exactly: a configured, disabled (`null`), or malformed repository-local
+  `critiqueLoop.telemetryHook` always wins outright and never inherits
+  the user-global layer; only when repository-local is entirely absent
+  does an optional `$XDG_CONFIG_HOME/idd-skill/config.json` (or
+  `$HOME/.config/idd-skill/config.json`) fragment apply
+- Under `GITHUB_ACTIONS=true` the user-global layer is always skipped
+  (repository-local resolution is unaffected), matching the documented
+  invariant that a GitHub-hosted or other remote agent surface never
+  consults it; `--no-user-global` skips it explicitly on any other
+  remote surface the caller recognizes but this helper cannot
+  auto-detect from a single provider variable
+- `--invoke` reads a JSON payload from stdin (see
+  [Repository-configurable critique telemetry hook](idd-workflow.md#repository-configurable-critique-telemetry-hook)
+  for the payload shape) and, only if a hook resolved as usable,
+  invokes its command with that payload on the child's stdin.
+  Fire-and-forget: a missing command, non-zero exit, timeout, or any
+  other failure is silently ignored; this mode always exits `0` and
+  never writes to stdout/stderr, unlike the plain resolution mode above
+  -- the whole point is that a caller never has to inspect this
+  process's own result
+- Deterministic and network-free for resolution; `--invoke` is the one
+  exception (it spawns the resolved command) and is bounded by a
+  default 5-second timeout plus a forced kill, so it can never block or
+  delay its caller; delegates resolution entirely to the existing
+  exported resolvers (`resolveEffectiveCritiqueLoopTelemetryHookFromEnv`
+  in `idd-config.mts`, `resolveEffectiveCritiqueLoopTelemetryHook` /
+  `inspectCritiqueLoopTelemetryHookLayer` in `policy-helpers.mts`) with
+  no reimplemented validation rule (referenced in
+  [kurone-kito/idd-skill#2679](https://github.com/kurone-kito/idd-skill/issues/2679))
 
 ### S2 quiet-window evidence
 

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -1230,6 +1230,10 @@ of C4, once the round's Accept/Reject decision is final (before C5,
 exit, so a clean round that skips C3/C4 entirely still emits a record
 (with zero findings/accepted/rejected counts).
 
+The lite work profile (`lite/idd-work-lite.instructions.md`) does not
+invoke this hook -- per-round telemetry is a full-profile-only feature
+for now.
+
 The JSON payload written to the hook command's stdin:
 
 ```json

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -1211,6 +1211,97 @@ or under `mode: never`, the per-agent pass does not run at all, so an
 operator relying solely on a delegate should expect the lenses below
 are not applied to that PR's diff.
 
+### Repository-configurable critique telemetry hook
+
+A repository may also configure a per-round C-phase telemetry
+notification by setting `critiqueLoop.telemetryHook` in
+`.github/idd/config.json` (see
+[Customization Surfaces](customization.md#customization-surfaces) and
+[Configuration Authority Hierarchy](policy-constants.md#configuration-authority-hierarchy)):
+a `command` string is a shell command invoked once per C-phase round,
+with a JSON payload written to its stdin. Unlike `critiqueLoop.delegate`
+above, this hook never supplies critique findings and never gates
+C-phase control flow — it is a pure observability side channel.
+
+The hook is invoked at two points in the C-phase loop, documented in
+`.github/instructions/idd-work.instructions.md`'s C2 and C4: at the end
+of C4, once the round's Accept/Reject decision is final (before C5,
+`idd-pr-submit.instructions.md`, or a hold); and at C2's zero-issue
+exit, so a clean round that skips C3/C4 entirely still emits a record
+(with zero findings/accepted/rejected counts).
+
+The JSON payload written to the hook command's stdin:
+
+```json
+{
+  "phase": "C",
+  "round": 2,
+  "repo": "owner/repo",
+  "issue": 123,
+  "pr": null,
+  "findingsCount": 3,
+  "severityBreakdown": { "high": 1, "medium": 1, "low": 1 },
+  "acceptedCount": 2,
+  "rejectedCount": 1,
+  "delegateUsed": true,
+  "delegateCommand": "coderabbit-critique",
+  "timestamp": "2026-09-08T12:00:00Z"
+}
+```
+
+`pr` is `null` before a PR exists for this issue; `delegateCommand` is
+present only when `delegateUsed` is `true`.
+
+**Fire-and-forget.** A missing command, non-zero exit, timeout, or any
+other failure invoking the hook is silently ignored and never blocks,
+holds, delays, or otherwise changes C-phase control flow — unlike
+`critiqueLoop.delegate`'s fail-closed hold semantics described above,
+this is a pure side channel. The C-phase objective diff validation
+floor and every other C-phase gate apply identically whether the hook
+is configured, missing, or failing.
+
+### User-global critique telemetry hook default
+
+A local runtime (one that reads the operator's own `$HOME`) may also
+inherit a `critiqueLoop.telemetryHook` from a user-global file when the
+repository leaves the repo-local field genuinely absent — a
+GitHub-hosted or other remote agent surface has no such operator home
+directory and never consults this layer. Resolution order: repo-local
+`critiqueLoop.telemetryHook` (a configured object, an explicit JSON
+`null` disable, or a malformed value) always wins outright and never
+inherits the global layer — an explicit repo-local `null` disables the
+hook entirely even when a global hook exists, and a malformed
+repo-local value fails closed to "no hook" the same way; only when
+repo-local is entirely absent does the global file apply; absent both,
+no hook runs. A malformed or explicit-`null` **global** fragment is
+treated the same as a missing one — silently falls back to "no hook" —
+which is distinct from repo-local `null`'s stronger role of actively
+disabling any inherited hook.
+
+The global file lives at the same path, and under the same
+qualified-root rules, as the critique delegate's own user-global file
+above (`$XDG_CONFIG_HOME/idd-skill/config.json`, falling back to
+`$HOME/.config/idd-skill/config.json`). Only the
+`critiqueLoop.telemetryHook` fragment is read from it; every other key
+— including `critiqueLoop.delegate` — is ignored, and repository-local
+`.github/idd/config.json` stays the sole authority for every other
+policy surface.
+
+Example (a generic local notifier, not a specific product):
+
+```json
+{ "critiqueLoop": { "telemetryHook": { "command": "my-critique-notifier" } } }
+```
+
+Any configured hook command — repo-local or user-global — is executable
+configuration: it may transmit source code or other data available to
+its process to an external service, so enabling one is a deliberate
+operator/repository choice, and neither config file should hold
+secrets. This surface only emits a per-round observability record; it
+never changes which mechanism supplies critique findings, the C-phase
+objective diff validation floor, the E-phase Copilot
+advisory-convergence policy, required checks, or merge gates.
+
 ### Mutation / write-side helper lens
 
 When the diff under critique implements a helper that **mutates GitHub

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -493,10 +493,11 @@ unfixed, per the guard.
 
 Otherwise continue to C5.
 
-**Telemetry hook**: once final (before C5, PR submission, or a hold),
-invoke `critiqueLoop.telemetryHook` (C1) with this round's findings,
-severity, accepted/rejected counts, and delegate usage —
-fire-and-forget.
+**Telemetry hook**: once final (before C5, PR submission, or C4's own
+hold) invoke `critiqueLoop.telemetryHook` (C1) with this round's
+findings, severity, accepted/rejected counts, and delegate usage —
+fire-and-forget. A delegate's own fail-closed hold (`docs/idd-workflow.md`)
+stops before C2 and has no telemetry record.
 
 ### C5 — Fix accepted issues
 

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -429,8 +429,12 @@ problems exist. See `idd-overview-appendix.instructions.md` for per-agent
 implementation. The distributed defaults for the C-phase skip and loop
 guards are listed in `docs/policy-constants.md`. A repository may
 configure `critiqueLoop.delegate` to point this step at a different
-reviewer instead of the per-agent mechanism; see `docs/idd-workflow.md`'s
-"Critique pass invocation" section.
+reviewer instead of the per-agent mechanism, or `critiqueLoop.telemetryHook`
+for a separate fire-and-forget per-round JSON record (round, repo,
+issue, PR, findings/severity/accepted/rejected counts, delegate usage,
+timestamp) that C2/C4 below invoke but that never gates control flow;
+see `docs/idd-workflow.md`'s "Critique pass invocation" section for
+both.
 
 **Objective diff validation floor**: neither C2 nor C4 below may skip to
 `idd-pr-submit.instructions.md` unless **fix-validate** — the same
@@ -456,6 +460,9 @@ Zero issues reported: skip to `idd-pr-submit.instructions.md` when the
 floor (C1) has passed, else continue to C5. One or more issues:
 continue to C3 regardless of the floor — C4 applies the floor check
 after Accept/Reject scoring.
+
+**Telemetry hook**: on this skip, invoke `critiqueLoop.telemetryHook`
+(C1) with zero findings/accepted/rejected counts — fire-and-forget.
 
 ### C3 — Score issues
 
@@ -483,6 +490,11 @@ satisfy the floor only; the second bullet's remaining Low Accepts stay
 unfixed, per the guard.
 
 Otherwise continue to C5.
+
+**Telemetry hook**: once final (before C5, PR submission, or a hold),
+invoke `critiqueLoop.telemetryHook` (C1) with this round's findings,
+severity, accepted/rejected counts, and delegate usage —
+fire-and-forget.
 
 ### C5 — Fix accepted issues
 

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -461,7 +461,9 @@ floor (C1) has passed, else continue to C5. One or more issues:
 continue to C3 regardless of the floor — C4 applies the floor check
 after Accept/Reject scoring.
 
-**Telemetry hook**: on this skip, invoke `critiqueLoop.telemetryHook`
+**Telemetry hook**: on a zero-issue round (either branch above — a
+round that continues to C5 for the floor only is still a zero-finding
+round and must not lose its record), invoke `critiqueLoop.telemetryHook`
 (C1) with zero findings/accepted/rejected counts — fire-and-forget.
 
 ### C3 — Score issues

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -220,6 +220,13 @@ in this preamble, since the fallback differs per helper.
   `mode`, and a machine-readable `reason` when unusable, delegating
   entirely to the existing exported resolvers (referenced in
   [kurone-kito/idd-skill#2329](https://github.com/kurone-kito/idd-skill/issues/2329))
+- `scripts/idd-critique-telemetry-hook.mjs` for the C-phase effective
+  `critiqueLoop.telemetryHook` verdict (`usable`, `source`, `command`,
+  and a machine-readable `reason` when unusable), plus fire-and-forget
+  invocation via `--invoke`: pipe the per-round JSON payload on stdin
+  and it invokes the resolved hook, always exiting `0` regardless of
+  the hook's own success or failure (referenced in
+  [kurone-kito/idd-skill#2679](https://github.com/kurone-kito/idd-skill/issues/2679))
 
 **Review & Merge Phase Helpers:**
 
@@ -2955,6 +2962,65 @@ same as `AW4`/`AW5`.
   `parseCritiqueLoopDelegate` in `policy-helpers.mts`) with no
   reimplemented validation rule (referenced in
   [kurone-kito/idd-skill#2329](https://github.com/kurone-kito/idd-skill/issues/2329))
+
+### Effective C-phase critique telemetry hook
+
+- Preferred command when helper runtime is enabled:
+  `idd-critique-telemetry-hook [--policy <path>] [--no-user-global]`
+- Source repository equivalent:
+  `node scripts/idd-critique-telemetry-hook.mjs [--policy <path>] [--no-user-global]`
+- Output schema (stable fields):
+
+  ```json
+  {
+    "usable": true,
+    "source": "repository-local",
+    "command": "notify-critique-telemetry --json",
+    "reason": null
+  }
+  ```
+
+- `source` values: `repository-local`, `user-global`, `none`
+- `reason` values (only when `usable` is `false`):
+  `repository-local-explicit-disable` (repo-local
+  `critiqueLoop.telemetryHook` is the JSON `null` sentinel),
+  `invalid-repository-local-telemetry-hook` (a malformed repo-local
+  value, which fails closed and never inherits a user-global hook),
+  `not-configured` (absent at every layer)
+- `usable: true` always carries a non-null `command` and a null
+  `reason`; `usable: false` always carries a null `command` and a
+  non-null `reason`
+- Resolution order matches
+  [User-global critique telemetry hook default](idd-workflow.md#user-global-critique-telemetry-hook-default)
+  exactly: a configured, disabled (`null`), or malformed repository-local
+  `critiqueLoop.telemetryHook` always wins outright and never inherits
+  the user-global layer; only when repository-local is entirely absent
+  does an optional `$XDG_CONFIG_HOME/idd-skill/config.json` (or
+  `$HOME/.config/idd-skill/config.json`) fragment apply
+- Under `GITHUB_ACTIONS=true` the user-global layer is always skipped
+  (repository-local resolution is unaffected), matching the documented
+  invariant that a GitHub-hosted or other remote agent surface never
+  consults it; `--no-user-global` skips it explicitly on any other
+  remote surface the caller recognizes but this helper cannot
+  auto-detect from a single provider variable
+- `--invoke` reads a JSON payload from stdin (see
+  [Repository-configurable critique telemetry hook](idd-workflow.md#repository-configurable-critique-telemetry-hook)
+  for the payload shape) and, only if a hook resolved as usable,
+  invokes its command with that payload on the child's stdin.
+  Fire-and-forget: a missing command, non-zero exit, timeout, or any
+  other failure is silently ignored; this mode always exits `0` and
+  never writes to stdout/stderr, unlike the plain resolution mode above
+  -- the whole point is that a caller never has to inspect this
+  process's own result
+- Deterministic and network-free for resolution; `--invoke` is the one
+  exception (it spawns the resolved command) and is bounded by a
+  default 5-second timeout plus a forced kill, so it can never block or
+  delay its caller; delegates resolution entirely to the existing
+  exported resolvers (`resolveEffectiveCritiqueLoopTelemetryHookFromEnv`
+  in `idd-config.mts`, `resolveEffectiveCritiqueLoopTelemetryHook` /
+  `inspectCritiqueLoopTelemetryHookLayer` in `policy-helpers.mts`) with
+  no reimplemented validation rule (referenced in
+  [kurone-kito/idd-skill#2679](https://github.com/kurone-kito/idd-skill/issues/2679))
 
 ### S2 quiet-window evidence
 

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -1214,6 +1214,10 @@ of C4, once the round's Accept/Reject decision is final (before C5,
 exit, so a clean round that skips C3/C4 entirely still emits a record
 (with zero findings/accepted/rejected counts).
 
+The lite work profile (`lite/idd-work-lite.instructions.md`) does not
+invoke this hook -- per-round telemetry is a full-profile-only feature
+for now.
+
 The JSON payload written to the hook command's stdin:
 
 ```json

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -1195,6 +1195,97 @@ or under `mode: never`, the per-agent pass does not run at all, so an
 operator relying solely on a delegate should expect the lenses below
 are not applied to that PR's diff.
 
+### Repository-configurable critique telemetry hook
+
+A repository may also configure a per-round C-phase telemetry
+notification by setting `critiqueLoop.telemetryHook` in
+`.github/idd/config.json` (see
+[Customization Surfaces](customization.md#customization-surfaces) and
+[Configuration Authority Hierarchy](policy-constants.md#configuration-authority-hierarchy)):
+a `command` string is a shell command invoked once per C-phase round,
+with a JSON payload written to its stdin. Unlike `critiqueLoop.delegate`
+above, this hook never supplies critique findings and never gates
+C-phase control flow — it is a pure observability side channel.
+
+The hook is invoked at two points in the C-phase loop, documented in
+`.github/instructions/idd-work.instructions.md`'s C2 and C4: at the end
+of C4, once the round's Accept/Reject decision is final (before C5,
+`idd-pr-submit.instructions.md`, or a hold); and at C2's zero-issue
+exit, so a clean round that skips C3/C4 entirely still emits a record
+(with zero findings/accepted/rejected counts).
+
+The JSON payload written to the hook command's stdin:
+
+```json
+{
+  "phase": "C",
+  "round": 2,
+  "repo": "owner/repo",
+  "issue": 123,
+  "pr": null,
+  "findingsCount": 3,
+  "severityBreakdown": { "high": 1, "medium": 1, "low": 1 },
+  "acceptedCount": 2,
+  "rejectedCount": 1,
+  "delegateUsed": true,
+  "delegateCommand": "coderabbit-critique",
+  "timestamp": "2026-09-08T12:00:00Z"
+}
+```
+
+`pr` is `null` before a PR exists for this issue; `delegateCommand` is
+present only when `delegateUsed` is `true`.
+
+**Fire-and-forget.** A missing command, non-zero exit, timeout, or any
+other failure invoking the hook is silently ignored and never blocks,
+holds, delays, or otherwise changes C-phase control flow — unlike
+`critiqueLoop.delegate`'s fail-closed hold semantics described above,
+this is a pure side channel. The C-phase objective diff validation
+floor and every other C-phase gate apply identically whether the hook
+is configured, missing, or failing.
+
+### User-global critique telemetry hook default
+
+A local runtime (one that reads the operator's own `$HOME`) may also
+inherit a `critiqueLoop.telemetryHook` from a user-global file when the
+repository leaves the repo-local field genuinely absent — a
+GitHub-hosted or other remote agent surface has no such operator home
+directory and never consults this layer. Resolution order: repo-local
+`critiqueLoop.telemetryHook` (a configured object, an explicit JSON
+`null` disable, or a malformed value) always wins outright and never
+inherits the global layer — an explicit repo-local `null` disables the
+hook entirely even when a global hook exists, and a malformed
+repo-local value fails closed to "no hook" the same way; only when
+repo-local is entirely absent does the global file apply; absent both,
+no hook runs. A malformed or explicit-`null` **global** fragment is
+treated the same as a missing one — silently falls back to "no hook" —
+which is distinct from repo-local `null`'s stronger role of actively
+disabling any inherited hook.
+
+The global file lives at the same path, and under the same
+qualified-root rules, as the critique delegate's own user-global file
+above (`$XDG_CONFIG_HOME/idd-skill/config.json`, falling back to
+`$HOME/.config/idd-skill/config.json`). Only the
+`critiqueLoop.telemetryHook` fragment is read from it; every other key
+— including `critiqueLoop.delegate` — is ignored, and repository-local
+`.github/idd/config.json` stays the sole authority for every other
+policy surface.
+
+Example (a generic local notifier, not a specific product):
+
+```json
+{ "critiqueLoop": { "telemetryHook": { "command": "my-critique-notifier" } } }
+```
+
+Any configured hook command — repo-local or user-global — is executable
+configuration: it may transmit source code or other data available to
+its process to an external service, so enabling one is a deliberate
+operator/repository choice, and neither config file should hold
+secrets. This surface only emits a per-round observability record; it
+never changes which mechanism supplies critique findings, the C-phase
+objective diff validation floor, the E-phase Copilot
+advisory-convergence policy, required checks, or merge gates.
+
 ### Mutation / write-side helper lens
 
 When the diff under critique implements a helper that **mutates GitHub

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "idd-claim-lock": "./bin/idd-claim-lock.mjs",
     "idd-clone-lock": "./bin/idd-clone-lock.mjs",
     "idd-critique-delegate": "./bin/idd-critique-delegate.mjs",
+    "idd-critique-telemetry-hook": "./bin/idd-critique-telemetry-hook.mjs",
     "idd-discover-orphan-filter": "./bin/idd-discover-orphan-filter.mjs",
     "idd-discover-readiness-check": "./bin/idd-discover-readiness-check.mjs",
     "idd-discover-roadmap-graph": "./bin/idd-discover-roadmap-graph.mjs",

--- a/schemas/policy.schema.json
+++ b/schemas/policy.schema.json
@@ -654,7 +654,7 @@
               "description": "Shell command for a per-round C-phase critique telemetry notification. Required within this object; must contain a non-whitespace character (the `\\S` pattern rejects a whitespace-only value, matching `delegate.command`'s own validation)."
             }
           },
-          "description": "Schema-supported, repository-configurable per-round C-phase critique telemetry hook declaration. Optional; not currently invoked by any discover, claim, work, or review runtime consumer — see the roadmap's Track B for the planned resolution and invocation logic. An explicit JSON `null` is the local disable sentinel: it prevents inheriting a user-global hook without installing a local one. `required` and `properties` apply only when the value is an object."
+          "description": "Repository-configurable per-round C-phase critique telemetry hook declaration. Optional; resolved and invoked fire-and-forget from the C-phase loop (C2's zero-issue exit and C4's Accept/Reject decision) — see `docs/idd-workflow.md`'s \"Repository-configurable critique telemetry hook\" section for the resolution order and JSON payload shape. Unlike `delegate` above, it never supplies critique findings or gates C-phase control flow. An explicit JSON `null` is the local disable sentinel: it prevents inheriting a user-global hook without installing a local one. `required` and `properties` apply only when the value is an object."
         }
       },
       "description": "Container for the C-phase and E10 critique-loop convergence guardrails. Optional; omitting any nested key keeps that key's own distributed default."

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -228,6 +228,15 @@ const HELPER_COMMANDS = [
       'Resolve the effective C1 critiqueLoop.delegate (repository-local, then user-global).',
   },
   {
+    id: 'critique-telemetry-hook',
+    scriptName: 'idd:critique-telemetry-hook',
+    binName: 'idd-critique-telemetry-hook',
+    entryPath: 'scripts/idd-critique-telemetry-hook.mjs',
+    vendoredCommand: 'node scripts/idd-critique-telemetry-hook.mjs',
+    description:
+      'Resolve the effective C-phase critiqueLoop.telemetryHook and, with --invoke, fire-and-forget invoke it.',
+  },
+  {
     id: 'discover-orphan-filter',
     scriptName: 'idd:discover-orphan-filter',
     binName: 'idd-discover-orphan-filter',

--- a/scripts/idd-config.mjs
+++ b/scripts/idd-config.mjs
@@ -36,7 +36,9 @@ import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mjs';
 import { deriveGhHttpStatus } from './gh-http-status.mjs';
 import {
   inspectCritiqueLoopDelegateLayer,
+  inspectCritiqueLoopTelemetryHookLayer,
   resolveEffectiveCritiqueLoopDelegate,
+  resolveEffectiveCritiqueLoopTelemetryHook,
 } from './policy-helpers.mjs';
 /**
  * Read and parse `.github/idd/config.json` from the current working
@@ -317,6 +319,35 @@ export function resolveEffectiveCritiqueLoopDelegateFromEnv(options) {
     homedir: options?.homedir,
   });
   return resolveEffectiveCritiqueLoopDelegate({
+    localConfig,
+    globalConfig: global.status === 'present' ? global.config : undefined,
+  });
+}
+/**
+ * Opt-in C-phase entry: resolve the effective `critiqueLoop.telemetryHook`
+ * from the repository-local document plus an optional user-global file
+ * (#2679). Structurally identical control flow to
+ * {@link resolveEffectiveCritiqueLoopDelegateFromEnv}: repository-local
+ * always wins outright when present (configured, disabled, or malformed);
+ * only when repository-local is entirely absent does the user-global
+ * fragment apply. Does not run as a side effect of {@link loadIddConfig} or
+ * {@link loadPolicyConfig}.
+ */
+export function resolveEffectiveCritiqueLoopTelemetryHookFromEnv(options) {
+  const localConfig =
+    options && Object.hasOwn(options, 'localConfig')
+      ? options.localConfig
+      : loadPolicyConfig(options?.localPolicyPath).config;
+  const local = inspectCritiqueLoopTelemetryHookLayer(localConfig);
+  if (local.status !== 'absent') {
+    return resolveEffectiveCritiqueLoopTelemetryHook({ localConfig });
+  }
+  const global = loadUserGlobalPolicyDocument({
+    env: options?.env,
+    path: options?.globalConfigPath,
+    homedir: options?.homedir,
+  });
+  return resolveEffectiveCritiqueLoopTelemetryHook({
     localConfig,
     globalConfig: global.status === 'present' ? global.config : undefined,
   });

--- a/scripts/idd-critique-telemetry-hook.mjs
+++ b/scripts/idd-critique-telemetry-hook.mjs
@@ -413,6 +413,19 @@ function spawnWatchdog(spawnFn, pid, timeoutMs) {
       ['-c', `sleep ${seconds}; kill -9 -${pid} 2>/dev/null || true`],
       { detached: true, stdio: 'ignore' },
     );
+    // #2685 review, Codex: a spawn failure that isn't synchronous (e.g. no
+    // `sh` on `PATH` at all, notably a bare Windows install) does not throw
+    // into the `try` above -- `spawn()` still returns a `ChildProcess` and
+    // emits `'error'` on it asynchronously instead. An `EventEmitter` with
+    // no `'error'` listener throws that error back out as an uncaught
+    // exception when it fires, which would crash whatever process called
+    // this hook -- directly violating this file's "never throws" contract.
+    // A no-op listener is all this needs: the caller already treats a
+    // missing watchdog as an accepted, silent gap (see this function's own
+    // doc comment).
+    watchdog.on('error', () => {
+      // Best-effort only -- see doc comment above and on this function.
+    });
     watchdog.unref();
     return watchdog;
   } catch {

--- a/scripts/idd-critique-telemetry-hook.mjs
+++ b/scripts/idd-critique-telemetry-hook.mjs
@@ -222,9 +222,10 @@ export function invokeCritiqueTelemetryHook(command, payload, options) {
     // spawns (e.g. a backgrounded job) -- `detached: true` above makes
     // `child.pid` both the process-group id and session id, so killing
     // the *negative* pid reaches the whole tree.
-    if (typeof child.pid === 'number' && child.pid > 0) {
-      spawnWatchdog(spawnFn, child.pid, timeoutMs);
-    }
+    const watchdog =
+      typeof child.pid === 'number' && child.pid > 0
+        ? spawnWatchdog(spawnFn, child.pid, timeoutMs)
+        : null;
     const timer = setTimeout(() => {
       killProcessGroup(child);
       settle(false);
@@ -233,12 +234,24 @@ export function invokeCritiqueTelemetryHook(command, payload, options) {
     // settles the promise; unref lets the caller's own process exit
     // normally if this hook is the only pending handle.
     timer.unref?.();
+    // #2685 review, Codex (discussion_r3952717...): a hook that exits well
+    // before `timeoutMs` used to leave the watchdog armed for the rest of
+    // its sleep, so a PID (or process-group id, since `detached: true`
+    // makes them the same number) reused by an unrelated process within
+    // that remaining window could be killed by mistake. Disarming the
+    // watchdog here as soon as `child` genuinely settles closes that race
+    // for the normal (non-timeout) exit path -- the only path left open is
+    // a *new* process becoming group leader of that exact recycled id
+    // inside the brief disarm-in-flight window, which `killProcessGroup`'s
+    // own ESRCH-tolerant fallback below cannot avoid either.
     child.on('error', () => {
       clearTimeout(timer);
+      cancelWatchdog(watchdog);
       settle(false);
     });
     child.on('exit', (code) => {
       clearTimeout(timer);
+      cancelWatchdog(watchdog);
       settle(code === 0);
     });
     child.stdin?.on('error', () => {
@@ -259,6 +272,11 @@ export function invokeCritiqueTelemetryHook(command, payload, options) {
  * single-PID kill only when the group-targeted signal itself fails (e.g.
  * `child.pid` is somehow already gone, or a platform without POSIX
  * process-group semantics). Never throws.
+ *
+ * Also used by {@link cancelWatchdog} to disarm the watchdog's own process
+ * group (itself `detached: true` -- see {@link spawnWatchdog}) once it is no
+ * longer needed; `child` in that call is the watchdog's `sh -c` wrapper, not
+ * the hook command.
  */
 function killProcessGroup(child) {
   const pid = child.pid;
@@ -281,42 +299,68 @@ function killProcessGroup(child) {
   }
 }
 /**
+ * Disarm a still-sleeping {@link spawnWatchdog} once the hook it was
+ * guarding has already settled on its own (#2685 review, Codex): without
+ * this, a hook that exits well inside `timeoutMs` still leaves the watchdog
+ * asleep for the remainder of the window, so a PID/process-group id reused
+ * by an unrelated process before the watchdog's `sleep` elapses could be
+ * killed by mistake. `watchdog` is `null` when {@link spawnWatchdog} itself
+ * never ran (no usable `child.pid`) or failed to spawn -- a no-op then, not
+ * an error. Reuses {@link killProcessGroup} since the watchdog is itself
+ * `detached: true` (its own `sh -c 'sleep ...; kill ...'` wrapper is its own
+ * session/group leader); killing it before its `sleep` returns prevents the
+ * trailing `kill -9 -<pid>` from ever running.
+ */
+function cancelWatchdog(watchdog) {
+  if (watchdog) {
+    killProcessGroup(watchdog);
+  }
+}
+/**
  * Best-effort, self-contained deadline enforcement that survives this
  * process exiting before `timeoutMs` elapses (`--invoke`'s whole point).
- * Spawns a detached, unref'd `sh -c 'sleep <n>; kill -9 -<pid> || kill -9
- * <pid> || true'` -- `sleep`/`kill` rather than the `timeout(1)` coreutil,
- * which isn't guaranteed present everywhere. Never throws: spawn failure
- * here (no POSIX shell on `PATH`, e.g. a bare Windows environment)
- * silently forfeits this backup and leaves the JS-level timer above as
- * the only enforcement for a caller that stays alive to see it -- an
- * accepted gap on that platform, not a new one this function introduces.
+ * Spawns a detached, unref'd `sh -c 'sleep <n>; kill -9 -<pid> || true'` --
+ * `sleep`/`kill` rather than the `timeout(1)` coreutil, which isn't
+ * guaranteed present everywhere. Returns the spawned watchdog so the caller
+ * can {@link cancelWatchdog} it once the hook it guards settles on its own,
+ * or `null` if the spawn itself failed. Never throws: spawn failure here
+ * (no POSIX shell on `PATH`, e.g. a bare Windows environment) silently
+ * forfeits this backup and leaves the JS-level timer above as the only
+ * enforcement for a caller that stays alive to see it -- an accepted gap on
+ * that platform, not a new one this function introduces.
  *
  * **No `--` before `-<pid>`** (deliberately, empirically verified): `sh`
  * on Debian/Ubuntu (and derivatives) is `dash`, whose `kill` builtin
  * rejects `kill -9 -- -<pid>` outright ("Illegal number: -") -- unlike
  * bash/GNU `kill`, dash's builtin does not recognize `--` as end-of-options
  * at all, so the *group*-targeted attempt silently failed on every run
- * under dash, invisibly falling through to the single-pid fallback, which
- * by then usually no longer names a live process either (the original
- * spawned pid can itself be a short-lived shell that already exited,
- * leaving only its group-mate descendants alive). `kill -9 -<pid>`
- * (leading `-` attached directly to the digits, no separate `--` token)
- * is the portable form both dash and bash accept.
+ * under dash. `kill -9 -<pid>` (leading `-` attached directly to the
+ * digits, no separate `--` token) is the portable form both dash and bash
+ * accept.
+ *
+ * **No single-PID fallback** (#2685 review, Codex, discussion about the
+ * PID-reuse race): a prior revision retried a bare `kill -9 <pid>` when the
+ * group-targeted kill failed. On POSIX, `kill -9 -<pid>` only fails with
+ * ESRCH once *every* member of that process group has already exited --
+ * meaning the fallback could only ever name something else that happens to
+ * reuse that exact number, never the original hook. It made a rare race
+ * strictly worse (an extra, unconditional attempt to kill an unrelated
+ * process) without ever helping the intended case, so it is dropped: once
+ * the group-targeted `kill` reports no such group, this watchdog gives up.
  */
 function spawnWatchdog(spawnFn, pid, timeoutMs) {
   try {
     const seconds = Math.max(timeoutMs, 0) / 1000;
     const watchdog = spawnFn(
       'sh',
-      [
-        '-c',
-        `sleep ${seconds}; kill -9 -${pid} 2>/dev/null || kill -9 ${pid} 2>/dev/null || true`,
-      ],
+      ['-c', `sleep ${seconds}; kill -9 -${pid} 2>/dev/null || true`],
       { detached: true, stdio: 'ignore' },
     );
     watchdog.unref();
+    return watchdog;
   } catch {
     // See doc comment: best-effort only.
+    return null;
   }
 }
 /**

--- a/scripts/idd-critique-telemetry-hook.mjs
+++ b/scripts/idd-critique-telemetry-hook.mjs
@@ -139,6 +139,18 @@ export function buildCritiqueTelemetryHookPayload(input) {
  * silently absorbed into `{ ok: false }` rather than propagated, unlike
  * `critiqueLoop.delegate`'s fail-closed hold semantics.
  *
+ * `detached: true` (#2685 review, Codex): the child runs in its own
+ * session, so it survives a signal delivered to this process's group (e.g.
+ * the invoking shell's own job-control teardown) instead of dying
+ * alongside it. This function's own promise still always resolves once
+ * the child truly settles (exit, error, or timeout) for any caller that
+ * awaits it (every test below does); the CLI's `--invoke` mode (below)
+ * simply never awaits it, and exits via `process.exit()` -- which
+ * terminates unconditionally regardless of any pending handle -- instead
+ * of waiting for the child to exit or hit `timeoutMs`, which would
+ * otherwise delay every C-phase round invoking this hook by up to that
+ * bound.
+ *
  * Failure modes this deliberately guards against (a naive
  * `spawn().stdin.write()` call crashes the parent process on each of these):
  * - A spawn failure (bad shell, ENOENT, EACCES) emits `'error'` on the
@@ -146,8 +158,9 @@ export function buildCritiqueTelemetryHookPayload(input) {
  * - A child that exits before reading stdin EPIPEs the write asynchronously
  *   -- the write's own try/catch only covers the *synchronous* failure
  *   path, so `stdin`'s own `'error'` listener is required too.
- * - A hanging command would block the caller indefinitely without a bounded
- *   `timeoutMs` + `SIGKILL`.
+ * - A hanging command would block a caller that does choose to await this
+ *   promise (e.g. a test, or a future non-CLI embedder) indefinitely
+ *   without a bounded `timeoutMs` + `SIGKILL`.
  * - Inheriting stdout/stderr would let a chatty hook pollute the caller's
  *   own output, so both are set to `'ignore'`.
  */
@@ -171,6 +184,22 @@ export function invokeCritiqueTelemetryHook(command, payload, options) {
       child = spawnFn(command, {
         shell: true,
         stdio: ['pipe', 'ignore', 'ignore'],
+        // `detached: true` (not `child.unref()`) only: this puts the child
+        // in its own session so it survives a signal sent to this
+        // process's group (e.g. the invoking shell's own job-control
+        // teardown), without unref'ing it. Deliberately NOT calling
+        // `child.unref()` here -- that would remove the *only* thing
+        // keeping the event loop alive long enough for the (also unref'd)
+        // timeout timer below to ever fire for a caller that legitimately
+        // awaits this promise (every test in this file does; a future
+        // non-CLI embedder might too) -- with both unref'd, nothing forces
+        // the loop to keep running, so the promise could stay pending
+        // forever once nothing else in the process needs the loop. The
+        // CLI's own `--invoke` mode (below) doesn't need this ref/unref
+        // distinction at all: it never awaits this promise, and
+        // `process.exit()` terminates unconditionally regardless of any
+        // pending handle's ref status.
+        detached: true,
       });
     } catch {
       settle(false);
@@ -244,19 +273,50 @@ function runCli() {
     printHelp();
     process.exit(0);
   }
+  if (args.invoke) {
+    runInvoke(args);
+    return;
+  }
   const report = buildCritiqueTelemetryHookReport(
     args.policy ? { localPolicyPath: args.policy } : undefined,
     args.noUserGlobal,
   );
-  if (!args.invoke) {
-    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+}
+/**
+ * `--invoke`: the fire-and-forget entry point. Reads the caller-built JSON
+ * payload from stdin, invokes the resolved hook if usable, and always
+ * exits `0` with no output -- a caller can shell out to
+ * `... | node scripts/idd-critique-telemetry-hook.mjs --invoke` and never
+ * have to check this process's result or wait on it.
+ *
+ * Two failure modes this must absorb that the default (non-`--invoke`)
+ * mode deliberately does *not* (#2685 review, Codex):
+ * - **Resolution itself can throw** (e.g. an explicit `--policy` path that
+ *   is missing or malformed JSON -- `loadPolicyConfig` throws for an
+ *   explicit path by design). In the default mode that throw is the
+ *   caller-visible signal; under `--invoke` it must not be, so resolution
+ *   runs inside its own try/catch here, never at module-level `runCli`
+ *   scope.
+ * - **This process must not itself wait for the hook to settle.** Once
+ *   `invokeCritiqueTelemetryHook` has synchronously spawned the (detached,
+ *   `unref`'d) child and issued the stdin write, this function exits
+ *   without awaiting that promise's resolution -- otherwise this CLI
+ *   process (and thus whatever shelled out to it) blocks for up to the
+ *   hook's own `timeoutMs`, contradicting the documented "never delays"
+ *   contract.
+ */
+function runInvoke(args) {
+  let report;
+  try {
+    report = buildCritiqueTelemetryHookReport(
+      args.policy ? { localPolicyPath: args.policy } : undefined,
+      args.noUserGlobal,
+    );
+  } catch {
+    process.exit(0);
     return;
   }
-  // --invoke is the fire-and-forget entry point: read the caller-built JSON
-  // payload from stdin, invoke the resolved hook if usable, and always exit
-  // 0 with no output -- the whole point is that a caller can shell out to
-  // `... | node scripts/idd-critique-telemetry-hook.mjs --invoke` and never
-  // have to check this process's result.
   readStdinBounded()
     .then((raw) => {
       let payload;
@@ -271,9 +331,14 @@ function runCli() {
         payload !== null &&
         typeof payload === 'object'
       ) {
-        return invokeCritiqueTelemetryHook(report.command, payload);
+        // Deliberately not returned/awaited -- see this function's doc
+        // comment. The `.catch` below is defensive only:
+        // invokeCritiqueTelemetryHook's own contract already never
+        // rejects.
+        invokeCritiqueTelemetryHook(report.command, payload).catch(
+          () => undefined,
+        );
       }
-      return undefined;
     })
     .catch(() => undefined)
     .finally(() => process.exit(0));

--- a/scripts/idd-critique-telemetry-hook.mjs
+++ b/scripts/idd-critique-telemetry-hook.mjs
@@ -1,0 +1,325 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/idd-critique-telemetry-hook.mts
+//
+// The scripts/idd-critique-telemetry-hook.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Resolution + fire-and-forget invocation for the C-phase
+// `critiqueLoop.telemetryHook` per-round notification (#2679). Mirrors
+// `idd-critique-delegate.mts`'s shape (typed report interface, a
+// `build*Report` function, a thin CLI wrapper) for the resolution half --
+// delegating entirely to `resolveEffectiveCritiqueLoopTelemetryHookFromEnv`
+// (idd-config.mts), which in turn calls
+// `resolveEffectiveCritiqueLoopTelemetryHook` / `inspectCritiqueLoopTelemetryHookLayer`
+// (policy-helpers.mts) -- but this file additionally owns the *invocation*
+// half `idd-critique-delegate.mts` has no equivalent for: unlike the
+// delegate (whose findings the agent consumes and whose failure can hold
+// C1), the telemetry hook's entire contract is "never blocks, holds, or
+// delays C-phase control flow" -- see `buildCritiqueTelemetryHookPayload`
+// and `invokeCritiqueTelemetryHook` below, and their CLI `--invoke` mode.
+import { spawn } from 'node:child_process';
+import { parseCliArgs } from './cli-args.mjs';
+import { resolveEffectiveCritiqueLoopTelemetryHookFromEnv } from './idd-config.mjs';
+
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `policy:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals such as the --policy spec key
+// below. See cli-args.mts's module header for the full invariant.
+//
+// Declared here, above the import.meta.main trigger below, rather than
+// alongside parseArgs further down: the trigger calls runCli() ->
+// parseArgs() synchronously at module-evaluation time, and a `const`
+// declared after that point is still in the temporal dead zone when the
+// trigger fires.
+const IDD_CRITIQUE_TELEMETRY_HOOK_FLAG_SPEC = {
+  '--policy': { type: 'string' },
+  '--no-user-global': { type: 'boolean', default: false },
+  '--invoke': { type: 'boolean', default: false },
+  '--help': { type: 'boolean', short: 'h' },
+};
+// Also declared above the import.meta.main trigger below, for the same
+// temporal-dead-zone reason as the flag spec above.
+const NO_TELEMETRY_HOOK_REASONS = {
+  disabled: 'repository-local-explicit-disable',
+  none: 'not-configured',
+};
+/** Bound on how long a spawned hook command may run before it is killed. */
+const DEFAULT_INVOKE_TIMEOUT_MS = 5_000;
+/** Bound on how long `--invoke` waits for a piped stdin payload. */
+const STDIN_READ_TIMEOUT_MS = 2_000;
+if (import.meta.main) {
+  runCli();
+}
+/**
+ * `docs/idd-workflow.md`'s "User-global critique telemetry hook default"
+ * contract mirrors the delegate's own: a GitHub-hosted or other remote
+ * agent surface has no operator home directory and never consults this
+ * layer. This local duplicate of `idd-critique-delegate.mts`'s
+ * `isRemoteAgentSurface` is intentional, not an oversight -- see that
+ * file's own function for the full rationale. No shared home for this
+ * one-line check exists elsewhere in the repository (every other
+ * `GITHUB_ACTIONS` read is likewise a local inline check), so duplicating
+ * it here keeps this module independent of the unrelated delegate module
+ * rather than importing a single-purpose helper across a module boundary
+ * for three lines.
+ */
+function isRemoteAgentSurface(env) {
+  return env.GITHUB_ACTIONS === 'true';
+}
+/**
+ * Build the resolution report from the layered resolver's result. Pure
+ * mapping: `status`/`source`/`hook`/`reason` come from
+ * {@link resolveEffectiveCritiqueLoopTelemetryHookFromEnv} unchanged; this
+ * function only decides `usable` and fills in a machine-readable `reason`
+ * for the two unusable statuses that resolver leaves reason-less
+ * (`disabled`, `none`).
+ */
+export function buildCritiqueTelemetryHookReport(
+  options,
+  noUserGlobal = false,
+) {
+  const env = options?.env ?? process.env;
+  // Blanking `env` alone is not enough -- see buildCritiqueDelegateReport's
+  // own comment for the identical reasoning: clear globalConfigPath/homedir
+  // too, so opting out means the layer is never consulted at all.
+  const resolvedOptions =
+    noUserGlobal || isRemoteAgentSurface(env)
+      ? { ...options, env: {}, globalConfigPath: undefined, homedir: undefined }
+      : options;
+  const effective =
+    resolveEffectiveCritiqueLoopTelemetryHookFromEnv(resolvedOptions);
+  const usable = effective.status === 'local' || effective.status === 'global';
+  return {
+    usable,
+    source: effective.source,
+    command: usable ? (effective.hook?.command ?? null) : null,
+    reason: usable
+      ? null
+      : (effective.reason ??
+        NO_TELEMETRY_HOOK_REASONS[effective.status] ??
+        effective.status),
+  };
+}
+/**
+ * Build the JSON payload sent on the hook command's stdin. Pure: no I/O.
+ *
+ * `delegateCommand` is an own-property-**omitted** key -- not `null` --
+ * unless `delegateUsed` is `true` and a non-empty `delegateCommand` was
+ * given, matching the issue's documented payload shape ("`delegateCommand`
+ * present only when `delegateUsed` is `true`").
+ */
+export function buildCritiqueTelemetryHookPayload(input) {
+  const timestamp =
+    input.timestamp ?? (input.now ? input.now() : new Date()).toISOString();
+  const payload = {
+    phase: 'C',
+    round: input.round,
+    repo: input.repo,
+    issue: input.issue,
+    pr: input.pr ?? null,
+    findingsCount: input.findingsCount,
+    severityBreakdown: input.severityBreakdown,
+    acceptedCount: input.acceptedCount,
+    rejectedCount: input.rejectedCount,
+    delegateUsed: input.delegateUsed,
+    timestamp,
+  };
+  if (input.delegateUsed && input.delegateCommand) {
+    payload.delegateCommand = input.delegateCommand;
+  }
+  return payload;
+}
+/**
+ * Fire-and-forget invocation: spawn `command` (a shell command, matching
+ * `critiqueLoop.telemetryHook.command`'s schema description) with `payload`
+ * written to its stdin as JSON, then close stdin. **Never throws and the
+ * returned promise never rejects** -- this function's entire contract is
+ * that a missing command, non-zero exit, timeout, or any other failure is
+ * silently absorbed into `{ ok: false }` rather than propagated, unlike
+ * `critiqueLoop.delegate`'s fail-closed hold semantics.
+ *
+ * Failure modes this deliberately guards against (a naive
+ * `spawn().stdin.write()` call crashes the parent process on each of these):
+ * - A spawn failure (bad shell, ENOENT, EACCES) emits `'error'` on the
+ *   child -- an unhandled listener would surface as an uncaught exception.
+ * - A child that exits before reading stdin EPIPEs the write asynchronously
+ *   -- the write's own try/catch only covers the *synchronous* failure
+ *   path, so `stdin`'s own `'error'` listener is required too.
+ * - A hanging command would block the caller indefinitely without a bounded
+ *   `timeoutMs` + `SIGKILL`.
+ * - Inheriting stdout/stderr would let a chatty hook pollute the caller's
+ *   own output, so both are set to `'ignore'`.
+ */
+export function invokeCritiqueTelemetryHook(command, payload, options) {
+  if (typeof command !== 'string' || command.trim() === '') {
+    return Promise.resolve({ attempted: false, ok: false });
+  }
+  const spawnFn = options?.spawnFn ?? spawn;
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_INVOKE_TIMEOUT_MS;
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = (ok) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve({ attempted: true, ok });
+    };
+    let child;
+    try {
+      child = spawnFn(command, {
+        shell: true,
+        stdio: ['pipe', 'ignore', 'ignore'],
+      });
+    } catch {
+      settle(false);
+      return;
+    }
+    const timer = setTimeout(() => {
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        // Already exited between the timeout firing and this call; ignore.
+      }
+      settle(false);
+    }, timeoutMs);
+    // Never block process exit on this timer alone -- resolve() already
+    // settles the promise; unref lets the caller's own process exit
+    // normally if this hook is the only pending handle.
+    timer.unref?.();
+    child.on('error', () => {
+      clearTimeout(timer);
+      settle(false);
+    });
+    child.on('exit', (code) => {
+      clearTimeout(timer);
+      settle(code === 0);
+    });
+    child.stdin?.on('error', () => {
+      // Asynchronous EPIPE (child exited before reading stdin) or similar --
+      // the 'exit'/'error' handlers above still settle this promise.
+    });
+    try {
+      child.stdin?.write(JSON.stringify(payload));
+      child.stdin?.end();
+    } catch {
+      // Synchronous write failure -- 'error'/'exit' handlers above still
+      // settle this promise.
+    }
+  });
+}
+/**
+ * Read stdin fully as UTF-8 text, bounded by {@link STDIN_READ_TIMEOUT_MS}
+ * so a caller that runs `--invoke` without piping anything (e.g. an
+ * interactive TTY) cannot hang indefinitely -- consistent with this file's
+ * overall "never blocks" contract for `--invoke`. Never rejects: any read
+ * error or timeout resolves to whatever was read so far (possibly empty).
+ */
+function readStdinBounded() {
+  return new Promise((resolve) => {
+    let data = '';
+    let settled = false;
+    const settle = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      resolve(data);
+    };
+    const timer = setTimeout(settle, STDIN_READ_TIMEOUT_MS);
+    timer.unref?.();
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on('end', settle);
+    process.stdin.on('error', settle);
+  });
+}
+function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  const report = buildCritiqueTelemetryHookReport(
+    args.policy ? { localPolicyPath: args.policy } : undefined,
+    args.noUserGlobal,
+  );
+  if (!args.invoke) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    return;
+  }
+  // --invoke is the fire-and-forget entry point: read the caller-built JSON
+  // payload from stdin, invoke the resolved hook if usable, and always exit
+  // 0 with no output -- the whole point is that a caller can shell out to
+  // `... | node scripts/idd-critique-telemetry-hook.mjs --invoke` and never
+  // have to check this process's result.
+  readStdinBounded()
+    .then((raw) => {
+      let payload;
+      try {
+        payload = raw.trim() === '' ? null : JSON.parse(raw);
+      } catch {
+        payload = null;
+      }
+      if (
+        report.usable &&
+        report.command &&
+        payload !== null &&
+        typeof payload === 'object'
+      ) {
+        return invokeCritiqueTelemetryHook(report.command, payload);
+      }
+      return undefined;
+    })
+    .catch(() => undefined)
+    .finally(() => process.exit(0));
+}
+function parseArgs(argv) {
+  const { values, help } = parseCliArgs(
+    argv,
+    IDD_CRITIQUE_TELEMETRY_HOOK_FLAG_SPEC,
+  );
+  return {
+    policy: values.policy ?? '',
+    noUserGlobal: values['no-user-global'],
+    invoke: values.invoke,
+    help,
+  };
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/idd-critique-telemetry-hook.mjs [--policy <path>] [--no-user-global]
+  node scripts/idd-critique-telemetry-hook.mjs --invoke [--policy <path>] [--no-user-global] < payload.json
+
+Resolves the effective C-phase \`critiqueLoop.telemetryHook\` the same way
+resolveEffectiveCritiqueLoopTelemetryHook does: repository-local
+.github/idd/config.json's critiqueLoop.telemetryHook wins outright (a
+configured object, an explicit null disable, or a malformed value all
+stop there); only when it is entirely absent does an optional
+user-global $XDG_CONFIG_HOME/idd-skill/config.json (or
+$HOME/.config/idd-skill/config.json) fragment apply; absent both, no
+hook is usable. Under GITHUB_ACTIONS=true the user-global layer is
+always skipped, matching the documented remote-agent-surface contract;
+pass --no-user-global to skip it explicitly on any other remote surface
+the caller recognizes but this helper cannot auto-detect.
+
+Without --invoke, prints the resolution report:
+{
+  "usable": true,
+  "source": "repository-local|user-global|none",
+  "command": "..." | null,
+  "reason": null | "repository-local-explicit-disable|invalid-repository-local-telemetry-hook|not-configured"
+}
+
+With --invoke, reads a JSON payload from stdin and, only if a hook
+resolved as usable, invokes its command with that payload written to
+the child's stdin. Fire-and-forget: a missing command, non-zero exit,
+timeout, or any other failure is silently ignored. This mode always
+exits 0 and never writes to stdout/stderr -- unlike critiqueLoop.delegate,
+this command's result is never meant to be inspected by its caller.
+`);
+}

--- a/scripts/idd-critique-telemetry-hook.mjs
+++ b/scripts/idd-critique-telemetry-hook.mjs
@@ -185,7 +185,22 @@ export function invokeCritiqueTelemetryHook(command, payload, options) {
     return Promise.resolve({ attempted: false, ok: false });
   }
   const spawnFn = options?.spawnFn ?? spawn;
-  const timeoutMs = options?.timeoutMs ?? DEFAULT_INVOKE_TIMEOUT_MS;
+  // #2685 review, Copilot: `?? DEFAULT_INVOKE_TIMEOUT_MS` alone only
+  // substitutes for `null`/`undefined` -- a caller-supplied `NaN` (or any
+  // other non-finite or negative value) would pass straight through and
+  // reach `setTimeout` below, which treats a non-finite delay as firing on
+  // (near-)the next tick, killing the hook almost instantly instead of
+  // waiting the intended bound. Falling back to the documented default for
+  // *any* unusable value keeps this "never throws" function's behavior
+  // predictable for a caller's own coding mistake, rather than silently
+  // clamping to some other value.
+  const requestedTimeoutMs = options?.timeoutMs;
+  const timeoutMs =
+    typeof requestedTimeoutMs === 'number' &&
+    Number.isFinite(requestedTimeoutMs) &&
+    requestedTimeoutMs >= 0
+      ? requestedTimeoutMs
+      : DEFAULT_INVOKE_TIMEOUT_MS;
   let delivered = false;
   const notifyDelivered = () => {
     if (delivered) {
@@ -407,7 +422,16 @@ function cancelWatchdog(watchdog) {
  */
 function spawnWatchdog(spawnFn, pid, timeoutMs) {
   try {
-    const seconds = Math.max(timeoutMs, 0) / 1000;
+    // #2685 review, Copilot: `Math.ceil`, not a plain division -- some
+    // POSIX `sleep` implementations only accept integer seconds, and a
+    // fractional argument (e.g. a test's `timeoutMs: 500` -> `0.5`) can
+    // make those reject or otherwise skip the delay entirely, SIGKILLing
+    // the hook (near-)immediately instead of after the intended bound.
+    // Rounding up, never down or to nearest, keeps this backup watchdog
+    // from ever firing *earlier* than the primary JS-level timer it
+    // exists to survive past -- the small extra slack on a portable
+    // `sleep` is harmless for a best-effort backup.
+    const seconds = Math.ceil(Math.max(timeoutMs, 0) / 1000);
     const watchdog = spawnFn(
       'sh',
       ['-c', `sleep ${seconds}; kill -9 -${pid} 2>/dev/null || true`],

--- a/scripts/idd-critique-telemetry-hook.mjs
+++ b/scripts/idd-critique-telemetry-hook.mjs
@@ -205,12 +205,28 @@ export function invokeCritiqueTelemetryHook(command, payload, options) {
       settle(false);
       return;
     }
+    // Belt-and-braces deadline enforcement (#2685 review, Codex, both
+    // findings): once `--invoke` stops awaiting this promise (this file's
+    // CLI does, deliberately -- see runInvoke below), the JS-level timer a
+    // few lines down can never fire, because the *process it would run in*
+    // has already exited via `process.exit()`. A hung hook would then be
+    // orphaned forever with no deadline at all. A detached shell watchdog
+    // enforces the same deadline independently of whether this process is
+    // still alive to see it through -- `sleep` + `kill` are effectively
+    // universal on POSIX, unlike relying on the `timeout(1)` coreutil,
+    // which is not guaranteed present everywhere this hook might run.
+    // Also addresses the process-group half of the same finding: `shell:
+    // true` makes `child` the `/bin/sh -c` wrapper, and a plain
+    // single-PID kill (from either this watchdog or the JS timer below)
+    // does not reliably reach a further descendant that wrapper's shell
+    // spawns (e.g. a backgrounded job) -- `detached: true` above makes
+    // `child.pid` both the process-group id and session id, so killing
+    // the *negative* pid reaches the whole tree.
+    if (typeof child.pid === 'number' && child.pid > 0) {
+      spawnWatchdog(spawnFn, child.pid, timeoutMs);
+    }
     const timer = setTimeout(() => {
-      try {
-        child.kill('SIGKILL');
-      } catch {
-        // Already exited between the timeout firing and this call; ignore.
-      }
+      killProcessGroup(child);
       settle(false);
     }, timeoutMs);
     // Never block process exit on this timer alone -- resolve() already
@@ -237,6 +253,71 @@ export function invokeCritiqueTelemetryHook(command, payload, options) {
       // settle this promise.
     }
   });
+}
+/**
+ * SIGKILL the whole detached process group `child` leads, falling back to a
+ * single-PID kill only when the group-targeted signal itself fails (e.g.
+ * `child.pid` is somehow already gone, or a platform without POSIX
+ * process-group semantics). Never throws.
+ */
+function killProcessGroup(child) {
+  const pid = child.pid;
+  if (typeof pid === 'number' && pid > 0) {
+    try {
+      // A negative pid targets the process *group* with that id -- with
+      // `detached: true` above, `child.pid` is both, since the child is
+      // its own session/group leader.
+      process.kill(-pid, 'SIGKILL');
+      return;
+    } catch {
+      // Fall through -- e.g. ESRCH (group leader already exited) or no
+      // POSIX process-group semantics on this platform (Windows).
+    }
+  }
+  try {
+    child.kill('SIGKILL');
+  } catch {
+    // Already exited; ignore.
+  }
+}
+/**
+ * Best-effort, self-contained deadline enforcement that survives this
+ * process exiting before `timeoutMs` elapses (`--invoke`'s whole point).
+ * Spawns a detached, unref'd `sh -c 'sleep <n>; kill -9 -<pid> || kill -9
+ * <pid> || true'` -- `sleep`/`kill` rather than the `timeout(1)` coreutil,
+ * which isn't guaranteed present everywhere. Never throws: spawn failure
+ * here (no POSIX shell on `PATH`, e.g. a bare Windows environment)
+ * silently forfeits this backup and leaves the JS-level timer above as
+ * the only enforcement for a caller that stays alive to see it -- an
+ * accepted gap on that platform, not a new one this function introduces.
+ *
+ * **No `--` before `-<pid>`** (deliberately, empirically verified): `sh`
+ * on Debian/Ubuntu (and derivatives) is `dash`, whose `kill` builtin
+ * rejects `kill -9 -- -<pid>` outright ("Illegal number: -") -- unlike
+ * bash/GNU `kill`, dash's builtin does not recognize `--` as end-of-options
+ * at all, so the *group*-targeted attempt silently failed on every run
+ * under dash, invisibly falling through to the single-pid fallback, which
+ * by then usually no longer names a live process either (the original
+ * spawned pid can itself be a short-lived shell that already exited,
+ * leaving only its group-mate descendants alive). `kill -9 -<pid>`
+ * (leading `-` attached directly to the digits, no separate `--` token)
+ * is the portable form both dash and bash accept.
+ */
+function spawnWatchdog(spawnFn, pid, timeoutMs) {
+  try {
+    const seconds = Math.max(timeoutMs, 0) / 1000;
+    const watchdog = spawnFn(
+      'sh',
+      [
+        '-c',
+        `sleep ${seconds}; kill -9 -${pid} 2>/dev/null || kill -9 ${pid} 2>/dev/null || true`,
+      ],
+      { detached: true, stdio: 'ignore' },
+    );
+    watchdog.unref();
+  } catch {
+    // See doc comment: best-effort only.
+  }
 }
 /**
  * Read stdin fully as UTF-8 text, bounded by {@link STDIN_READ_TIMEOUT_MS}

--- a/scripts/idd-critique-telemetry-hook.mjs
+++ b/scripts/idd-critique-telemetry-hook.mjs
@@ -48,6 +48,18 @@ const NO_TELEMETRY_HOOK_REASONS = {
 const DEFAULT_INVOKE_TIMEOUT_MS = 5_000;
 /** Bound on how long `--invoke` waits for a piped stdin payload. */
 const STDIN_READ_TIMEOUT_MS = 2_000;
+/**
+ * Bound on how long `--invoke` waits for the hook's stdin handoff to
+ * complete before exiting anyway (#2685 review, CodeRabbit) -- a *much*
+ * smaller ask than `DEFAULT_INVOKE_TIMEOUT_MS` above, since it is only
+ * covering the stdin write reaching the child's pipe (normally near-
+ * instant for this small a JSON payload), not the hook running to
+ * completion. A caller that never gets an `onPayloadDelivered` signal at
+ * all (e.g. a `spawnFn` stub that doesn't wire up a real stdin) still
+ * exits promptly rather than hanging on `--invoke`'s "never blocks"
+ * contract.
+ */
+const PAYLOAD_DELIVERY_TIMEOUT_MS = 1_000;
 if (import.meta.main) {
   runCli();
 }
@@ -145,11 +157,15 @@ export function buildCritiqueTelemetryHookPayload(input) {
  * alongside it. This function's own promise still always resolves once
  * the child truly settles (exit, error, or timeout) for any caller that
  * awaits it (every test below does); the CLI's `--invoke` mode (below)
- * simply never awaits it, and exits via `process.exit()` -- which
- * terminates unconditionally regardless of any pending handle -- instead
- * of waiting for the child to exit or hit `timeoutMs`, which would
+ * still never awaits *this* promise, and exits via `process.exit()` --
+ * which terminates unconditionally regardless of any pending handle --
+ * instead of waiting for the child to exit or hit `timeoutMs`, which would
  * otherwise delay every C-phase round invoking this hook by up to that
- * bound.
+ * bound. It does, separately, wait a short bounded time for
+ * {@link InvokeCritiqueTelemetryHookOptions.onPayloadDelivered} (#2685
+ * review, CodeRabbit) -- "the payload reached the child's stdin" is a much
+ * smaller ask than "the hook finished", and guards against `process.exit()`
+ * truncating an in-flight write.
  *
  * Failure modes this deliberately guards against (a naive
  * `spawn().stdin.write()` call crashes the parent process on each of these):
@@ -170,6 +186,14 @@ export function invokeCritiqueTelemetryHook(command, payload, options) {
   }
   const spawnFn = options?.spawnFn ?? spawn;
   const timeoutMs = options?.timeoutMs ?? DEFAULT_INVOKE_TIMEOUT_MS;
+  let delivered = false;
+  const notifyDelivered = () => {
+    if (delivered) {
+      return;
+    }
+    delivered = true;
+    options?.onPayloadDelivered?.();
+  };
   return new Promise((resolve) => {
     let settled = false;
     const settle = (ok) => {
@@ -203,6 +227,7 @@ export function invokeCritiqueTelemetryHook(command, payload, options) {
       });
     } catch {
       settle(false);
+      notifyDelivered();
       return;
     }
     // Belt-and-braces deadline enforcement (#2685 review, Codex, both
@@ -234,19 +259,36 @@ export function invokeCritiqueTelemetryHook(command, payload, options) {
     // settles the promise; unref lets the caller's own process exit
     // normally if this hook is the only pending handle.
     timer.unref?.();
-    // #2685 review, Codex (discussion_r3952717...): a hook that exits well
-    // before `timeoutMs` used to leave the watchdog armed for the rest of
-    // its sleep, so a PID (or process-group id, since `detached: true`
-    // makes them the same number) reused by an unrelated process within
-    // that remaining window could be killed by mistake. Disarming the
-    // watchdog here as soon as `child` genuinely settles closes that race
-    // for the normal (non-timeout) exit path -- the only path left open is
-    // a *new* process becoming group leader of that exact recycled id
-    // inside the brief disarm-in-flight window, which `killProcessGroup`'s
-    // own ESRCH-tolerant fallback below cannot avoid either.
+    // #2685 review, Codex + CodeRabbit (PID-reuse race on early exit): a
+    // hook that exits well before `timeoutMs` used to leave the watchdog
+    // armed for the rest of its sleep, so a PID (or process-group id, since
+    // `detached: true` makes them the same number) reused by an unrelated
+    // process within that remaining window could be killed by mistake.
+    // Disarming the watchdog here closes that race **only for a caller that
+    // awaits this promise** (every test in this file does) -- these
+    // `child.on(...)` listeners run in *this* process, so they only fire if
+    // this process is still alive to run them. `--invoke` (below)
+    // deliberately never awaits this promise and calls `process.exit(0)`
+    // almost immediately after spawning, well before `child` can plausibly
+    // emit `'exit'` -- so on that path, the primary one in practice, the
+    // watchdog stays armed for the full `timeoutMs` exactly as before, by
+    // design: closing that half of the race would require a supervisor
+    // living entirely outside this Node process (a self-contained shell
+    // script that spawns the hook, waits on it, and only then kills its own
+    // watchdog subshell), which trades a narrow, bounded residual for
+    // meaningfully more moving parts -- see the PR discussion for the
+    // rejected fuller design and why it was not taken here. The residual
+    // this leaves is narrower than "PID reuse" alone suggests: POSIX does
+    // not let a pid (or session/group id) be reallocated while *any* task
+    // -- running or zombie, unreaped -- still holds it, so the reused id
+    // must first be freed by the entire group exiting *and* being reaped,
+    // then cycle back around after a full `pid_max` wrap, all inside the
+    // remaining `timeoutMs` window, with the new holder also calling
+    // `setsid`/`setpgid` to become a group leader.
     child.on('error', () => {
       clearTimeout(timer);
       cancelWatchdog(watchdog);
+      notifyDelivered();
       settle(false);
     });
     child.on('exit', (code) => {
@@ -257,13 +299,28 @@ export function invokeCritiqueTelemetryHook(command, payload, options) {
     child.stdin?.on('error', () => {
       // Asynchronous EPIPE (child exited before reading stdin) or similar --
       // the 'exit'/'error' handlers above still settle this promise.
+      notifyDelivered();
     });
+    // 'close' fires once the stdin pipe's write end is actually closed --
+    // after a clean `end()` flush completes, or after an error tears it
+    // down -- independent of whether the child ever reads or exits. This is
+    // the signal `notifyDelivered` needs: "the payload handoff is done",
+    // not "the hook is done".
+    child.stdin?.on('close', notifyDelivered);
+    if (!child.stdin) {
+      // No stdin to wait on at all (unexpected given `stdio: ['pipe', ...]`
+      // above) -- don't leave a caller of onPayloadDelivered waiting for a
+      // signal that can never come.
+      notifyDelivered();
+    }
     try {
       child.stdin?.write(JSON.stringify(payload));
       child.stdin?.end();
     } catch {
       // Synchronous write failure -- 'error'/'exit' handlers above still
-      // settle this promise.
+      // settle this promise; the stdin 'error' handler above still notifies
+      // delivery-completion (as "done", since nothing further can be sent).
+      notifyDelivered();
     }
   });
 }
@@ -409,14 +466,47 @@ function runCli() {
   process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
 }
 /**
+ * Fire off {@link invokeCritiqueTelemetryHook} and resolve as soon as the
+ * payload has reached the child's stdin -- via
+ * {@link InvokeCritiqueTelemetryHookOptions.onPayloadDelivered} -- or after
+ * {@link PAYLOAD_DELIVERY_TIMEOUT_MS} elapses, whichever comes first.
+ * Deliberately does **not** wait for the hook itself to settle (exit,
+ * error, or its own much longer `timeoutMs`) -- only for the much smaller
+ * "the write happened" signal (#2685 review, CodeRabbit). The
+ * `invokeCritiqueTelemetryHook` promise itself is not returned/awaited
+ * here; it keeps running in the background exactly as before (its own
+ * timeout + watchdog still apply) after this function's own promise
+ * resolves.
+ */
+function invokeAndWaitForDelivery(command, payload) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve();
+    };
+    const timer = setTimeout(settle, PAYLOAD_DELIVERY_TIMEOUT_MS);
+    timer.unref?.();
+    invokeCritiqueTelemetryHook(command, payload, {
+      onPayloadDelivered: () => {
+        clearTimeout(timer);
+        settle();
+      },
+    }).catch(() => undefined);
+  });
+}
+/**
  * `--invoke`: the fire-and-forget entry point. Reads the caller-built JSON
  * payload from stdin, invokes the resolved hook if usable, and always
  * exits `0` with no output -- a caller can shell out to
  * `... | node scripts/idd-critique-telemetry-hook.mjs --invoke` and never
  * have to check this process's result or wait on it.
  *
- * Two failure modes this must absorb that the default (non-`--invoke`)
- * mode deliberately does *not* (#2685 review, Codex):
+ * Failure modes this must absorb that the default (non-`--invoke`) mode
+ * deliberately does *not* (#2685 review, Codex + CodeRabbit):
  * - **Resolution itself can throw** (e.g. an explicit `--policy` path that
  *   is missing or malformed JSON -- `loadPolicyConfig` throws for an
  *   explicit path by design). In the default mode that throw is the
@@ -424,12 +514,13 @@ function runCli() {
  *   runs inside its own try/catch here, never at module-level `runCli`
  *   scope.
  * - **This process must not itself wait for the hook to settle.** Once
- *   `invokeCritiqueTelemetryHook` has synchronously spawned the (detached,
- *   `unref`'d) child and issued the stdin write, this function exits
- *   without awaiting that promise's resolution -- otherwise this CLI
- *   process (and thus whatever shelled out to it) blocks for up to the
- *   hook's own `timeoutMs`, contradicting the documented "never delays"
- *   contract.
+ *   `invokeCritiqueTelemetryHook` has synchronously spawned the (detached)
+ *   child and issued the stdin write, this function does not wait for that
+ *   promise's resolution -- otherwise this CLI process (and thus whatever
+ *   shelled out to it) blocks for up to the hook's own `timeoutMs`,
+ *   contradicting the documented "never delays" contract. It does wait,
+ *   briefly, for {@link invokeAndWaitForDelivery}'s much smaller
+ *   "payload reached the child" signal -- see that function's doc comment.
  */
 function runInvoke(args) {
   let report;
@@ -456,14 +547,9 @@ function runInvoke(args) {
         payload !== null &&
         typeof payload === 'object'
       ) {
-        // Deliberately not returned/awaited -- see this function's doc
-        // comment. The `.catch` below is defensive only:
-        // invokeCritiqueTelemetryHook's own contract already never
-        // rejects.
-        invokeCritiqueTelemetryHook(report.command, payload).catch(
-          () => undefined,
-        );
+        return invokeAndWaitForDelivery(report.command, payload);
       }
+      return undefined;
     })
     .catch(() => undefined)
     .finally(() => process.exit(0));

--- a/scripts/policy-helpers.mjs
+++ b/scripts/policy-helpers.mjs
@@ -1181,6 +1181,117 @@ export function resolveEffectiveCritiqueLoopDelegate(input) {
   }
   return { status: 'none', source: 'none' };
 }
+/**
+ * Parse `critiqueLoop.telemetryHook`. Mirrors {@link parseCritiqueLoopDelegate}
+ * but for the simpler `{ command }`-only shape (#2679): a non-object, an
+ * unknown nested key (anything beyond `command`), or a missing/whitespace-only
+ * `command` all normalize to `undefined` (no hook configured), matching the
+ * schema's `additionalProperties: false` / `command`-only shape.
+ */
+function parseCritiqueLoopTelemetryHook(value) {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  const candidate = value;
+  const candidateKeys = Object.keys(candidate);
+  if (candidateKeys.some((key) => key !== 'command')) {
+    return undefined;
+  }
+  // Object.keys() above already excludes inherited keys, but a plain
+  // property read (candidate.command) still walks the prototype chain --
+  // require command to be an own property, mirroring
+  // parseCritiqueLoopDelegate's own-property guard (#2207 review).
+  if (!Object.hasOwn(candidate, 'command')) {
+    return undefined;
+  }
+  const command = parseNonEmptyString(candidate.command, '');
+  if (!command || command.trim() === '') {
+    return undefined;
+  }
+  return { command };
+}
+const INVALID_LOCAL_TELEMETRY_HOOK_REASON =
+  'invalid-repository-local-telemetry-hook';
+/**
+ * Inspect `critiqueLoop.telemetryHook` on a raw policy document without
+ * applying `normalizePolicyConfig`'s fail-safe collapse. Mirrors
+ * {@link inspectCritiqueLoopDelegateLayer}'s absent / disabled / configured /
+ * malformed shape.
+ */
+export function inspectCritiqueLoopTelemetryHookLayer(config) {
+  if (typeof config !== 'object' || config === null || Array.isArray(config)) {
+    return { status: 'absent' };
+  }
+  if (!Object.hasOwn(config, 'critiqueLoop')) {
+    return { status: 'absent' };
+  }
+  const critiqueLoop = config.critiqueLoop;
+  if (
+    typeof critiqueLoop !== 'object' ||
+    critiqueLoop === null ||
+    Array.isArray(critiqueLoop)
+  ) {
+    // A present non-object `critiqueLoop` is a local configuration error:
+    // fail closed rather than treating it as "no hook" and inheriting a
+    // user-global object.
+    return { status: 'malformed', reason: INVALID_LOCAL_TELEMETRY_HOOK_REASON };
+  }
+  if (!Object.hasOwn(critiqueLoop, 'telemetryHook')) {
+    return { status: 'absent' };
+  }
+  const value = critiqueLoop.telemetryHook;
+  if (value === null) {
+    return { status: 'disabled' };
+  }
+  const parsed = parseCritiqueLoopTelemetryHook(value);
+  if (parsed) {
+    return { status: 'configured', hook: parsed };
+  }
+  return { status: 'malformed', reason: INVALID_LOCAL_TELEMETRY_HOOK_REASON };
+}
+/**
+ * Resolve the effective C-phase telemetry hook from a repository-local
+ * document and an optional user-global document. Pure: callers supply
+ * already-loaded JSON (or `undefined` for an absent global file). Never
+ * reads the filesystem.
+ *
+ * Order: local object, local `null` disable, global object, then none --
+ * identical to {@link resolveEffectiveCritiqueLoopDelegate}'s resolution
+ * order. A malformed local hook is fail-closed and does not inherit global.
+ * A malformed or disabled global fragment is treated as absent.
+ */
+export function resolveEffectiveCritiqueLoopTelemetryHook(input) {
+  const local = inspectCritiqueLoopTelemetryHookLayer(input.localConfig);
+  if (local.status === 'configured' && local.hook) {
+    return {
+      status: 'local',
+      source: 'repository-local',
+      hook: local.hook,
+    };
+  }
+  if (local.status === 'disabled') {
+    return { status: 'disabled', source: 'repository-local' };
+  }
+  if (local.status === 'malformed') {
+    return {
+      status: 'local-malformed',
+      source: 'repository-local',
+      reason: local.reason ?? INVALID_LOCAL_TELEMETRY_HOOK_REASON,
+    };
+  }
+  if (input.globalConfig === undefined || input.globalConfig === null) {
+    return { status: 'none', source: 'none' };
+  }
+  const global = inspectCritiqueLoopTelemetryHookLayer(input.globalConfig);
+  if (global.status === 'configured' && global.hook) {
+    return {
+      status: 'global',
+      source: 'user-global',
+      hook: global.hook,
+    };
+  }
+  return { status: 'none', source: 'none' };
+}
 function hasConfiguredCollaboratorMarkerTrust(config) {
   const c = config;
   return (

--- a/src/bin/idd-critique-telemetry-hook.mts
+++ b/src/bin/idd-critique-telemetry-hook.mts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-critique-telemetry-hook.mts
+//
+// The bin/idd-critique-telemetry-hook.mjs copy is generated from the .mts source named above
+// by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+
+import { runHelper } from './run-helper.mts';
+
+runHelper('../scripts/idd-critique-telemetry-hook.mjs');

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -312,6 +312,15 @@ const HELPER_COMMANDS: HelperCommand[] = [
       'Resolve the effective C1 critiqueLoop.delegate (repository-local, then user-global).',
   },
   {
+    id: 'critique-telemetry-hook',
+    scriptName: 'idd:critique-telemetry-hook',
+    binName: 'idd-critique-telemetry-hook',
+    entryPath: 'scripts/idd-critique-telemetry-hook.mjs',
+    vendoredCommand: 'node scripts/idd-critique-telemetry-hook.mjs',
+    description:
+      'Resolve the effective C-phase critiqueLoop.telemetryHook and, with --invoke, fire-and-forget invoke it.',
+  },
+  {
     id: 'discover-orphan-filter',
     scriptName: 'idd:discover-orphan-filter',
     binName: 'idd-discover-orphan-filter',

--- a/src/scripts/idd-config.mts
+++ b/src/scripts/idd-config.mts
@@ -38,8 +38,11 @@ import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mts';
 import { deriveGhHttpStatus } from './gh-http-status.mts';
 import {
   type EffectiveCritiqueLoopDelegate,
+  type EffectiveCritiqueLoopTelemetryHook,
   inspectCritiqueLoopDelegateLayer,
+  inspectCritiqueLoopTelemetryHookLayer,
   resolveEffectiveCritiqueLoopDelegate,
+  resolveEffectiveCritiqueLoopTelemetryHook,
 } from './policy-helpers.mts';
 
 /**
@@ -414,6 +417,53 @@ export function resolveEffectiveCritiqueLoopDelegateFromEnv(
   });
 
   return resolveEffectiveCritiqueLoopDelegate({
+    localConfig,
+    globalConfig: global.status === 'present' ? global.config : undefined,
+  });
+}
+
+/** Options for {@link resolveEffectiveCritiqueLoopTelemetryHookFromEnv}. */
+export interface ResolveEffectiveCritiqueLoopTelemetryHookFromEnvOptions {
+  /** Raw repository-local policy object. When omitted, load from disk. */
+  localConfig?: unknown;
+  /** Path forwarded to {@link loadPolicyConfig} when `localConfig` is omitted. */
+  localPolicyPath?: string;
+  env?: NodeJS.ProcessEnv;
+  /** Injected user-global file path; skips XDG/`HOME` resolution. */
+  globalConfigPath?: string;
+  homedir?: string;
+}
+
+/**
+ * Opt-in C-phase entry: resolve the effective `critiqueLoop.telemetryHook`
+ * from the repository-local document plus an optional user-global file
+ * (#2679). Structurally identical control flow to
+ * {@link resolveEffectiveCritiqueLoopDelegateFromEnv}: repository-local
+ * always wins outright when present (configured, disabled, or malformed);
+ * only when repository-local is entirely absent does the user-global
+ * fragment apply. Does not run as a side effect of {@link loadIddConfig} or
+ * {@link loadPolicyConfig}.
+ */
+export function resolveEffectiveCritiqueLoopTelemetryHookFromEnv(
+  options?: ResolveEffectiveCritiqueLoopTelemetryHookFromEnvOptions,
+): EffectiveCritiqueLoopTelemetryHook {
+  const localConfig =
+    options && Object.hasOwn(options, 'localConfig')
+      ? options.localConfig
+      : loadPolicyConfig(options?.localPolicyPath).config;
+
+  const local = inspectCritiqueLoopTelemetryHookLayer(localConfig);
+  if (local.status !== 'absent') {
+    return resolveEffectiveCritiqueLoopTelemetryHook({ localConfig });
+  }
+
+  const global = loadUserGlobalPolicyDocument({
+    env: options?.env,
+    path: options?.globalConfigPath,
+    homedir: options?.homedir,
+  });
+
+  return resolveEffectiveCritiqueLoopTelemetryHook({
     localConfig,
     globalConfig: global.status === 'present' ? global.config : undefined,
   });

--- a/src/scripts/idd-critique-telemetry-hook.mts
+++ b/src/scripts/idd-critique-telemetry-hook.mts
@@ -309,9 +309,10 @@ export function invokeCritiqueTelemetryHook(
     // spawns (e.g. a backgrounded job) -- `detached: true` above makes
     // `child.pid` both the process-group id and session id, so killing
     // the *negative* pid reaches the whole tree.
-    if (typeof child.pid === 'number' && child.pid > 0) {
-      spawnWatchdog(spawnFn, child.pid, timeoutMs);
-    }
+    const watchdog =
+      typeof child.pid === 'number' && child.pid > 0
+        ? spawnWatchdog(spawnFn, child.pid, timeoutMs)
+        : null;
 
     const timer = setTimeout(() => {
       killProcessGroup(child);
@@ -322,12 +323,24 @@ export function invokeCritiqueTelemetryHook(
     // normally if this hook is the only pending handle.
     timer.unref?.();
 
+    // #2685 review, Codex (discussion_r3952717...): a hook that exits well
+    // before `timeoutMs` used to leave the watchdog armed for the rest of
+    // its sleep, so a PID (or process-group id, since `detached: true`
+    // makes them the same number) reused by an unrelated process within
+    // that remaining window could be killed by mistake. Disarming the
+    // watchdog here as soon as `child` genuinely settles closes that race
+    // for the normal (non-timeout) exit path -- the only path left open is
+    // a *new* process becoming group leader of that exact recycled id
+    // inside the brief disarm-in-flight window, which `killProcessGroup`'s
+    // own ESRCH-tolerant fallback below cannot avoid either.
     child.on('error', () => {
       clearTimeout(timer);
+      cancelWatchdog(watchdog);
       settle(false);
     });
     child.on('exit', (code) => {
       clearTimeout(timer);
+      cancelWatchdog(watchdog);
       settle(code === 0);
     });
     child.stdin?.on('error', () => {
@@ -350,6 +363,11 @@ export function invokeCritiqueTelemetryHook(
  * single-PID kill only when the group-targeted signal itself fails (e.g.
  * `child.pid` is somehow already gone, or a platform without POSIX
  * process-group semantics). Never throws.
+ *
+ * Also used by {@link cancelWatchdog} to disarm the watchdog's own process
+ * group (itself `detached: true` -- see {@link spawnWatchdog}) once it is no
+ * longer needed; `child` in that call is the watchdog's `sh -c` wrapper, not
+ * the hook command.
  */
 function killProcessGroup(child: ChildProcess): void {
   const pid = child.pid;
@@ -373,46 +391,73 @@ function killProcessGroup(child: ChildProcess): void {
 }
 
 /**
+ * Disarm a still-sleeping {@link spawnWatchdog} once the hook it was
+ * guarding has already settled on its own (#2685 review, Codex): without
+ * this, a hook that exits well inside `timeoutMs` still leaves the watchdog
+ * asleep for the remainder of the window, so a PID/process-group id reused
+ * by an unrelated process before the watchdog's `sleep` elapses could be
+ * killed by mistake. `watchdog` is `null` when {@link spawnWatchdog} itself
+ * never ran (no usable `child.pid`) or failed to spawn -- a no-op then, not
+ * an error. Reuses {@link killProcessGroup} since the watchdog is itself
+ * `detached: true` (its own `sh -c 'sleep ...; kill ...'` wrapper is its own
+ * session/group leader); killing it before its `sleep` returns prevents the
+ * trailing `kill -9 -<pid>` from ever running.
+ */
+function cancelWatchdog(watchdog: ChildProcess | null): void {
+  if (watchdog) {
+    killProcessGroup(watchdog);
+  }
+}
+
+/**
  * Best-effort, self-contained deadline enforcement that survives this
  * process exiting before `timeoutMs` elapses (`--invoke`'s whole point).
- * Spawns a detached, unref'd `sh -c 'sleep <n>; kill -9 -<pid> || kill -9
- * <pid> || true'` -- `sleep`/`kill` rather than the `timeout(1)` coreutil,
- * which isn't guaranteed present everywhere. Never throws: spawn failure
- * here (no POSIX shell on `PATH`, e.g. a bare Windows environment)
- * silently forfeits this backup and leaves the JS-level timer above as
- * the only enforcement for a caller that stays alive to see it -- an
- * accepted gap on that platform, not a new one this function introduces.
+ * Spawns a detached, unref'd `sh -c 'sleep <n>; kill -9 -<pid> || true'` --
+ * `sleep`/`kill` rather than the `timeout(1)` coreutil, which isn't
+ * guaranteed present everywhere. Returns the spawned watchdog so the caller
+ * can {@link cancelWatchdog} it once the hook it guards settles on its own,
+ * or `null` if the spawn itself failed. Never throws: spawn failure here
+ * (no POSIX shell on `PATH`, e.g. a bare Windows environment) silently
+ * forfeits this backup and leaves the JS-level timer above as the only
+ * enforcement for a caller that stays alive to see it -- an accepted gap on
+ * that platform, not a new one this function introduces.
  *
  * **No `--` before `-<pid>`** (deliberately, empirically verified): `sh`
  * on Debian/Ubuntu (and derivatives) is `dash`, whose `kill` builtin
  * rejects `kill -9 -- -<pid>` outright ("Illegal number: -") -- unlike
  * bash/GNU `kill`, dash's builtin does not recognize `--` as end-of-options
  * at all, so the *group*-targeted attempt silently failed on every run
- * under dash, invisibly falling through to the single-pid fallback, which
- * by then usually no longer names a live process either (the original
- * spawned pid can itself be a short-lived shell that already exited,
- * leaving only its group-mate descendants alive). `kill -9 -<pid>`
- * (leading `-` attached directly to the digits, no separate `--` token)
- * is the portable form both dash and bash accept.
+ * under dash. `kill -9 -<pid>` (leading `-` attached directly to the
+ * digits, no separate `--` token) is the portable form both dash and bash
+ * accept.
+ *
+ * **No single-PID fallback** (#2685 review, Codex, discussion about the
+ * PID-reuse race): a prior revision retried a bare `kill -9 <pid>` when the
+ * group-targeted kill failed. On POSIX, `kill -9 -<pid>` only fails with
+ * ESRCH once *every* member of that process group has already exited --
+ * meaning the fallback could only ever name something else that happens to
+ * reuse that exact number, never the original hook. It made a rare race
+ * strictly worse (an extra, unconditional attempt to kill an unrelated
+ * process) without ever helping the intended case, so it is dropped: once
+ * the group-targeted `kill` reports no such group, this watchdog gives up.
  */
 function spawnWatchdog(
   spawnFn: typeof spawn,
   pid: number,
   timeoutMs: number,
-): void {
+): ChildProcess | null {
   try {
     const seconds = Math.max(timeoutMs, 0) / 1000;
     const watchdog = spawnFn(
       'sh',
-      [
-        '-c',
-        `sleep ${seconds}; kill -9 -${pid} 2>/dev/null || kill -9 ${pid} 2>/dev/null || true`,
-      ],
+      ['-c', `sleep ${seconds}; kill -9 -${pid} 2>/dev/null || true`],
       { detached: true, stdio: 'ignore' },
     );
     watchdog.unref();
+    return watchdog;
   } catch {
     // See doc comment: best-effort only.
+    return null;
   }
 }
 

--- a/src/scripts/idd-critique-telemetry-hook.mts
+++ b/src/scripts/idd-critique-telemetry-hook.mts
@@ -54,6 +54,19 @@ const DEFAULT_INVOKE_TIMEOUT_MS = 5_000;
 /** Bound on how long `--invoke` waits for a piped stdin payload. */
 const STDIN_READ_TIMEOUT_MS = 2_000;
 
+/**
+ * Bound on how long `--invoke` waits for the hook's stdin handoff to
+ * complete before exiting anyway (#2685 review, CodeRabbit) -- a *much*
+ * smaller ask than `DEFAULT_INVOKE_TIMEOUT_MS` above, since it is only
+ * covering the stdin write reaching the child's pipe (normally near-
+ * instant for this small a JSON payload), not the hook running to
+ * completion. A caller that never gets an `onPayloadDelivered` signal at
+ * all (e.g. a `spawnFn` stub that doesn't wire up a real stdin) still
+ * exits promptly rather than hanging on `--invoke`'s "never blocks"
+ * contract.
+ */
+const PAYLOAD_DELIVERY_TIMEOUT_MS = 1_000;
+
 if (import.meta.main) {
   runCli();
 }
@@ -207,6 +220,18 @@ export interface InvokeCritiqueTelemetryHookOptions {
   timeoutMs?: number;
   /** Injectable for tests; defaults to `node:child_process`'s `spawn`. */
   spawnFn?: typeof spawn;
+  /**
+   * Called once (at most) as soon as `payload` has been fully handed off to
+   * the child's stdin -- on the stdin stream's `'close'` (fires once the
+   * underlying pipe is closed, whether that followed a clean `'finish'` or
+   * an error) or on a spawn/child `'error'` that means no delivery will
+   * ever happen. Lets a fire-and-forget caller (the CLI's `--invoke`, via
+   * `runInvoke` below) wait for the payload to actually reach the child's
+   * pipe without waiting for the hook *process* to settle (#2685 review,
+   * CodeRabbit: `process.exit(0)` racing an in-flight stdin write could
+   * otherwise truncate the JSON the hook receives).
+   */
+  onPayloadDelivered?: () => void;
 }
 
 /**
@@ -224,11 +249,15 @@ export interface InvokeCritiqueTelemetryHookOptions {
  * alongside it. This function's own promise still always resolves once
  * the child truly settles (exit, error, or timeout) for any caller that
  * awaits it (every test below does); the CLI's `--invoke` mode (below)
- * simply never awaits it, and exits via `process.exit()` -- which
- * terminates unconditionally regardless of any pending handle -- instead
- * of waiting for the child to exit or hit `timeoutMs`, which would
+ * still never awaits *this* promise, and exits via `process.exit()` --
+ * which terminates unconditionally regardless of any pending handle --
+ * instead of waiting for the child to exit or hit `timeoutMs`, which would
  * otherwise delay every C-phase round invoking this hook by up to that
- * bound.
+ * bound. It does, separately, wait a short bounded time for
+ * {@link InvokeCritiqueTelemetryHookOptions.onPayloadDelivered} (#2685
+ * review, CodeRabbit) -- "the payload reached the child's stdin" is a much
+ * smaller ask than "the hook finished", and guards against `process.exit()`
+ * truncating an in-flight write.
  *
  * Failure modes this deliberately guards against (a naive
  * `spawn().stdin.write()` call crashes the parent process on each of these):
@@ -254,6 +283,14 @@ export function invokeCritiqueTelemetryHook(
 
   const spawnFn = options?.spawnFn ?? spawn;
   const timeoutMs = options?.timeoutMs ?? DEFAULT_INVOKE_TIMEOUT_MS;
+  let delivered = false;
+  const notifyDelivered = () => {
+    if (delivered) {
+      return;
+    }
+    delivered = true;
+    options?.onPayloadDelivered?.();
+  };
 
   return new Promise((resolve) => {
     let settled = false;
@@ -289,6 +326,7 @@ export function invokeCritiqueTelemetryHook(
       });
     } catch {
       settle(false);
+      notifyDelivered();
       return;
     }
 
@@ -323,19 +361,36 @@ export function invokeCritiqueTelemetryHook(
     // normally if this hook is the only pending handle.
     timer.unref?.();
 
-    // #2685 review, Codex (discussion_r3952717...): a hook that exits well
-    // before `timeoutMs` used to leave the watchdog armed for the rest of
-    // its sleep, so a PID (or process-group id, since `detached: true`
-    // makes them the same number) reused by an unrelated process within
-    // that remaining window could be killed by mistake. Disarming the
-    // watchdog here as soon as `child` genuinely settles closes that race
-    // for the normal (non-timeout) exit path -- the only path left open is
-    // a *new* process becoming group leader of that exact recycled id
-    // inside the brief disarm-in-flight window, which `killProcessGroup`'s
-    // own ESRCH-tolerant fallback below cannot avoid either.
+    // #2685 review, Codex + CodeRabbit (PID-reuse race on early exit): a
+    // hook that exits well before `timeoutMs` used to leave the watchdog
+    // armed for the rest of its sleep, so a PID (or process-group id, since
+    // `detached: true` makes them the same number) reused by an unrelated
+    // process within that remaining window could be killed by mistake.
+    // Disarming the watchdog here closes that race **only for a caller that
+    // awaits this promise** (every test in this file does) -- these
+    // `child.on(...)` listeners run in *this* process, so they only fire if
+    // this process is still alive to run them. `--invoke` (below)
+    // deliberately never awaits this promise and calls `process.exit(0)`
+    // almost immediately after spawning, well before `child` can plausibly
+    // emit `'exit'` -- so on that path, the primary one in practice, the
+    // watchdog stays armed for the full `timeoutMs` exactly as before, by
+    // design: closing that half of the race would require a supervisor
+    // living entirely outside this Node process (a self-contained shell
+    // script that spawns the hook, waits on it, and only then kills its own
+    // watchdog subshell), which trades a narrow, bounded residual for
+    // meaningfully more moving parts -- see the PR discussion for the
+    // rejected fuller design and why it was not taken here. The residual
+    // this leaves is narrower than "PID reuse" alone suggests: POSIX does
+    // not let a pid (or session/group id) be reallocated while *any* task
+    // -- running or zombie, unreaped -- still holds it, so the reused id
+    // must first be freed by the entire group exiting *and* being reaped,
+    // then cycle back around after a full `pid_max` wrap, all inside the
+    // remaining `timeoutMs` window, with the new holder also calling
+    // `setsid`/`setpgid` to become a group leader.
     child.on('error', () => {
       clearTimeout(timer);
       cancelWatchdog(watchdog);
+      notifyDelivered();
       settle(false);
     });
     child.on('exit', (code) => {
@@ -346,14 +401,29 @@ export function invokeCritiqueTelemetryHook(
     child.stdin?.on('error', () => {
       // Asynchronous EPIPE (child exited before reading stdin) or similar --
       // the 'exit'/'error' handlers above still settle this promise.
+      notifyDelivered();
     });
+    // 'close' fires once the stdin pipe's write end is actually closed --
+    // after a clean `end()` flush completes, or after an error tears it
+    // down -- independent of whether the child ever reads or exits. This is
+    // the signal `notifyDelivered` needs: "the payload handoff is done",
+    // not "the hook is done".
+    child.stdin?.on('close', notifyDelivered);
+    if (!child.stdin) {
+      // No stdin to wait on at all (unexpected given `stdio: ['pipe', ...]`
+      // above) -- don't leave a caller of onPayloadDelivered waiting for a
+      // signal that can never come.
+      notifyDelivered();
+    }
 
     try {
       child.stdin?.write(JSON.stringify(payload));
       child.stdin?.end();
     } catch {
       // Synchronous write failure -- 'error'/'exit' handlers above still
-      // settle this promise.
+      // settle this promise; the stdin 'error' handler above still notifies
+      // delivery-completion (as "done", since nothing further can be sent).
+      notifyDelivered();
     }
   });
 }
@@ -518,14 +588,51 @@ function runCli(): void {
 }
 
 /**
+ * Fire off {@link invokeCritiqueTelemetryHook} and resolve as soon as the
+ * payload has reached the child's stdin -- via
+ * {@link InvokeCritiqueTelemetryHookOptions.onPayloadDelivered} -- or after
+ * {@link PAYLOAD_DELIVERY_TIMEOUT_MS} elapses, whichever comes first.
+ * Deliberately does **not** wait for the hook itself to settle (exit,
+ * error, or its own much longer `timeoutMs`) -- only for the much smaller
+ * "the write happened" signal (#2685 review, CodeRabbit). The
+ * `invokeCritiqueTelemetryHook` promise itself is not returned/awaited
+ * here; it keeps running in the background exactly as before (its own
+ * timeout + watchdog still apply) after this function's own promise
+ * resolves.
+ */
+function invokeAndWaitForDelivery(
+  command: string,
+  payload: CritiqueTelemetryHookPayload,
+): Promise<void> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve();
+    };
+    const timer = setTimeout(settle, PAYLOAD_DELIVERY_TIMEOUT_MS);
+    timer.unref?.();
+    invokeCritiqueTelemetryHook(command, payload, {
+      onPayloadDelivered: () => {
+        clearTimeout(timer);
+        settle();
+      },
+    }).catch(() => undefined);
+  });
+}
+
+/**
  * `--invoke`: the fire-and-forget entry point. Reads the caller-built JSON
  * payload from stdin, invokes the resolved hook if usable, and always
  * exits `0` with no output -- a caller can shell out to
  * `... | node scripts/idd-critique-telemetry-hook.mjs --invoke` and never
  * have to check this process's result or wait on it.
  *
- * Two failure modes this must absorb that the default (non-`--invoke`)
- * mode deliberately does *not* (#2685 review, Codex):
+ * Failure modes this must absorb that the default (non-`--invoke`) mode
+ * deliberately does *not* (#2685 review, Codex + CodeRabbit):
  * - **Resolution itself can throw** (e.g. an explicit `--policy` path that
  *   is missing or malformed JSON -- `loadPolicyConfig` throws for an
  *   explicit path by design). In the default mode that throw is the
@@ -533,12 +640,13 @@ function runCli(): void {
  *   runs inside its own try/catch here, never at module-level `runCli`
  *   scope.
  * - **This process must not itself wait for the hook to settle.** Once
- *   `invokeCritiqueTelemetryHook` has synchronously spawned the (detached,
- *   `unref`'d) child and issued the stdin write, this function exits
- *   without awaiting that promise's resolution -- otherwise this CLI
- *   process (and thus whatever shelled out to it) blocks for up to the
- *   hook's own `timeoutMs`, contradicting the documented "never delays"
- *   contract.
+ *   `invokeCritiqueTelemetryHook` has synchronously spawned the (detached)
+ *   child and issued the stdin write, this function does not wait for that
+ *   promise's resolution -- otherwise this CLI process (and thus whatever
+ *   shelled out to it) blocks for up to the hook's own `timeoutMs`,
+ *   contradicting the documented "never delays" contract. It does wait,
+ *   briefly, for {@link invokeAndWaitForDelivery}'s much smaller
+ *   "payload reached the child" signal -- see that function's doc comment.
  */
 function runInvoke(args: ParsedArgs): void {
   let report: CritiqueTelemetryHookReport;
@@ -566,15 +674,12 @@ function runInvoke(args: ParsedArgs): void {
         payload !== null &&
         typeof payload === 'object'
       ) {
-        // Deliberately not returned/awaited -- see this function's doc
-        // comment. The `.catch` below is defensive only:
-        // invokeCritiqueTelemetryHook's own contract already never
-        // rejects.
-        invokeCritiqueTelemetryHook(
+        return invokeAndWaitForDelivery(
           report.command,
           payload as CritiqueTelemetryHookPayload,
-        ).catch(() => undefined);
+        );
       }
+      return undefined;
     })
     .catch(() => undefined)
     .finally(() => process.exit(0));

--- a/src/scripts/idd-critique-telemetry-hook.mts
+++ b/src/scripts/idd-critique-telemetry-hook.mts
@@ -292,12 +292,29 @@ export function invokeCritiqueTelemetryHook(
       return;
     }
 
+    // Belt-and-braces deadline enforcement (#2685 review, Codex, both
+    // findings): once `--invoke` stops awaiting this promise (this file's
+    // CLI does, deliberately -- see runInvoke below), the JS-level timer a
+    // few lines down can never fire, because the *process it would run in*
+    // has already exited via `process.exit()`. A hung hook would then be
+    // orphaned forever with no deadline at all. A detached shell watchdog
+    // enforces the same deadline independently of whether this process is
+    // still alive to see it through -- `sleep` + `kill` are effectively
+    // universal on POSIX, unlike relying on the `timeout(1)` coreutil,
+    // which is not guaranteed present everywhere this hook might run.
+    // Also addresses the process-group half of the same finding: `shell:
+    // true` makes `child` the `/bin/sh -c` wrapper, and a plain
+    // single-PID kill (from either this watchdog or the JS timer below)
+    // does not reliably reach a further descendant that wrapper's shell
+    // spawns (e.g. a backgrounded job) -- `detached: true` above makes
+    // `child.pid` both the process-group id and session id, so killing
+    // the *negative* pid reaches the whole tree.
+    if (typeof child.pid === 'number' && child.pid > 0) {
+      spawnWatchdog(spawnFn, child.pid, timeoutMs);
+    }
+
     const timer = setTimeout(() => {
-      try {
-        child.kill('SIGKILL');
-      } catch {
-        // Already exited between the timeout firing and this call; ignore.
-      }
+      killProcessGroup(child);
       settle(false);
     }, timeoutMs);
     // Never block process exit on this timer alone -- resolve() already
@@ -326,6 +343,77 @@ export function invokeCritiqueTelemetryHook(
       // settle this promise.
     }
   });
+}
+
+/**
+ * SIGKILL the whole detached process group `child` leads, falling back to a
+ * single-PID kill only when the group-targeted signal itself fails (e.g.
+ * `child.pid` is somehow already gone, or a platform without POSIX
+ * process-group semantics). Never throws.
+ */
+function killProcessGroup(child: ChildProcess): void {
+  const pid = child.pid;
+  if (typeof pid === 'number' && pid > 0) {
+    try {
+      // A negative pid targets the process *group* with that id -- with
+      // `detached: true` above, `child.pid` is both, since the child is
+      // its own session/group leader.
+      process.kill(-pid, 'SIGKILL');
+      return;
+    } catch {
+      // Fall through -- e.g. ESRCH (group leader already exited) or no
+      // POSIX process-group semantics on this platform (Windows).
+    }
+  }
+  try {
+    child.kill('SIGKILL');
+  } catch {
+    // Already exited; ignore.
+  }
+}
+
+/**
+ * Best-effort, self-contained deadline enforcement that survives this
+ * process exiting before `timeoutMs` elapses (`--invoke`'s whole point).
+ * Spawns a detached, unref'd `sh -c 'sleep <n>; kill -9 -<pid> || kill -9
+ * <pid> || true'` -- `sleep`/`kill` rather than the `timeout(1)` coreutil,
+ * which isn't guaranteed present everywhere. Never throws: spawn failure
+ * here (no POSIX shell on `PATH`, e.g. a bare Windows environment)
+ * silently forfeits this backup and leaves the JS-level timer above as
+ * the only enforcement for a caller that stays alive to see it -- an
+ * accepted gap on that platform, not a new one this function introduces.
+ *
+ * **No `--` before `-<pid>`** (deliberately, empirically verified): `sh`
+ * on Debian/Ubuntu (and derivatives) is `dash`, whose `kill` builtin
+ * rejects `kill -9 -- -<pid>` outright ("Illegal number: -") -- unlike
+ * bash/GNU `kill`, dash's builtin does not recognize `--` as end-of-options
+ * at all, so the *group*-targeted attempt silently failed on every run
+ * under dash, invisibly falling through to the single-pid fallback, which
+ * by then usually no longer names a live process either (the original
+ * spawned pid can itself be a short-lived shell that already exited,
+ * leaving only its group-mate descendants alive). `kill -9 -<pid>`
+ * (leading `-` attached directly to the digits, no separate `--` token)
+ * is the portable form both dash and bash accept.
+ */
+function spawnWatchdog(
+  spawnFn: typeof spawn,
+  pid: number,
+  timeoutMs: number,
+): void {
+  try {
+    const seconds = Math.max(timeoutMs, 0) / 1000;
+    const watchdog = spawnFn(
+      'sh',
+      [
+        '-c',
+        `sleep ${seconds}; kill -9 -${pid} 2>/dev/null || kill -9 ${pid} 2>/dev/null || true`,
+      ],
+      { detached: true, stdio: 'ignore' },
+    );
+    watchdog.unref();
+  } catch {
+    // See doc comment: best-effort only.
+  }
 }
 
 /**

--- a/src/scripts/idd-critique-telemetry-hook.mts
+++ b/src/scripts/idd-critique-telemetry-hook.mts
@@ -1,0 +1,430 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/idd-critique-telemetry-hook.mts
+//
+// The scripts/idd-critique-telemetry-hook.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Resolution + fire-and-forget invocation for the C-phase
+// `critiqueLoop.telemetryHook` per-round notification (#2679). Mirrors
+// `idd-critique-delegate.mts`'s shape (typed report interface, a
+// `build*Report` function, a thin CLI wrapper) for the resolution half --
+// delegating entirely to `resolveEffectiveCritiqueLoopTelemetryHookFromEnv`
+// (idd-config.mts), which in turn calls
+// `resolveEffectiveCritiqueLoopTelemetryHook` / `inspectCritiqueLoopTelemetryHookLayer`
+// (policy-helpers.mts) -- but this file additionally owns the *invocation*
+// half `idd-critique-delegate.mts` has no equivalent for: unlike the
+// delegate (whose findings the agent consumes and whose failure can hold
+// C1), the telemetry hook's entire contract is "never blocks, holds, or
+// delays C-phase control flow" -- see `buildCritiqueTelemetryHookPayload`
+// and `invokeCritiqueTelemetryHook` below, and their CLI `--invoke` mode.
+
+import { type ChildProcess, spawn } from 'node:child_process';
+
+import { parseCliArgs } from './cli-args.mts';
+import { resolveEffectiveCritiqueLoopTelemetryHookFromEnv } from './idd-config.mts';
+
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `policy:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals such as the --policy spec key
+// below. See cli-args.mts's module header for the full invariant.
+//
+// Declared here, above the import.meta.main trigger below, rather than
+// alongside parseArgs further down: the trigger calls runCli() ->
+// parseArgs() synchronously at module-evaluation time, and a `const`
+// declared after that point is still in the temporal dead zone when the
+// trigger fires.
+const IDD_CRITIQUE_TELEMETRY_HOOK_FLAG_SPEC = {
+  '--policy': { type: 'string' },
+  '--no-user-global': { type: 'boolean', default: false },
+  '--invoke': { type: 'boolean', default: false },
+  '--help': { type: 'boolean', short: 'h' },
+} as const;
+
+// Also declared above the import.meta.main trigger below, for the same
+// temporal-dead-zone reason as the flag spec above.
+const NO_TELEMETRY_HOOK_REASONS: Record<string, string> = {
+  disabled: 'repository-local-explicit-disable',
+  none: 'not-configured',
+};
+
+/** Bound on how long a spawned hook command may run before it is killed. */
+const DEFAULT_INVOKE_TIMEOUT_MS = 5_000;
+
+/** Bound on how long `--invoke` waits for a piped stdin payload. */
+const STDIN_READ_TIMEOUT_MS = 2_000;
+
+if (import.meta.main) {
+  runCli();
+}
+
+export interface CritiqueTelemetryHookReport {
+  usable: boolean;
+  source: 'repository-local' | 'user-global' | 'none';
+  command: string | null;
+  reason: string | null;
+}
+
+/**
+ * `docs/idd-workflow.md`'s "User-global critique telemetry hook default"
+ * contract mirrors the delegate's own: a GitHub-hosted or other remote
+ * agent surface has no operator home directory and never consults this
+ * layer. This local duplicate of `idd-critique-delegate.mts`'s
+ * `isRemoteAgentSurface` is intentional, not an oversight -- see that
+ * file's own function for the full rationale. No shared home for this
+ * one-line check exists elsewhere in the repository (every other
+ * `GITHUB_ACTIONS` read is likewise a local inline check), so duplicating
+ * it here keeps this module independent of the unrelated delegate module
+ * rather than importing a single-purpose helper across a module boundary
+ * for three lines.
+ */
+function isRemoteAgentSurface(env: NodeJS.ProcessEnv): boolean {
+  return env.GITHUB_ACTIONS === 'true';
+}
+
+/**
+ * Build the resolution report from the layered resolver's result. Pure
+ * mapping: `status`/`source`/`hook`/`reason` come from
+ * {@link resolveEffectiveCritiqueLoopTelemetryHookFromEnv} unchanged; this
+ * function only decides `usable` and fills in a machine-readable `reason`
+ * for the two unusable statuses that resolver leaves reason-less
+ * (`disabled`, `none`).
+ */
+export function buildCritiqueTelemetryHookReport(
+  options?: Parameters<
+    typeof resolveEffectiveCritiqueLoopTelemetryHookFromEnv
+  >[0],
+  noUserGlobal = false,
+): CritiqueTelemetryHookReport {
+  const env = options?.env ?? process.env;
+  // Blanking `env` alone is not enough -- see buildCritiqueDelegateReport's
+  // own comment for the identical reasoning: clear globalConfigPath/homedir
+  // too, so opting out means the layer is never consulted at all.
+  const resolvedOptions =
+    noUserGlobal || isRemoteAgentSurface(env)
+      ? { ...options, env: {}, globalConfigPath: undefined, homedir: undefined }
+      : options;
+  const effective =
+    resolveEffectiveCritiqueLoopTelemetryHookFromEnv(resolvedOptions);
+  const usable = effective.status === 'local' || effective.status === 'global';
+  return {
+    usable,
+    source: effective.source,
+    command: usable ? (effective.hook?.command ?? null) : null,
+    reason: usable
+      ? null
+      : (effective.reason ??
+        NO_TELEMETRY_HOOK_REASONS[effective.status] ??
+        effective.status),
+  };
+}
+
+/** Severity counts the C1 critique pass reported for one round. */
+export interface CritiqueTelemetryHookSeverityBreakdown {
+  high: number;
+  medium: number;
+  low: number;
+}
+
+/** The exact JSON shape sent on the hook command's stdin (#2679). */
+export interface CritiqueTelemetryHookPayload {
+  phase: 'C';
+  round: number;
+  repo: string;
+  issue: number;
+  pr: number | null;
+  findingsCount: number;
+  severityBreakdown: CritiqueTelemetryHookSeverityBreakdown;
+  acceptedCount: number;
+  rejectedCount: number;
+  delegateUsed: boolean;
+  delegateCommand?: string;
+  timestamp: string;
+}
+
+/** Input to {@link buildCritiqueTelemetryHookPayload}. */
+export interface BuildCritiqueTelemetryHookPayloadInput {
+  round: number;
+  repo: string;
+  issue: number;
+  /** `null` (the default) before a PR exists. */
+  pr?: number | null;
+  findingsCount: number;
+  severityBreakdown: CritiqueTelemetryHookSeverityBreakdown;
+  acceptedCount: number;
+  rejectedCount: number;
+  delegateUsed: boolean;
+  /** Only meaningful (and only ever emitted) when `delegateUsed` is `true`. */
+  delegateCommand?: string;
+  /** Overrides the default `new Date().toISOString()` timestamp. */
+  timestamp?: string;
+  /** Injectable clock for deterministic tests; ignored when `timestamp` is set. */
+  now?: () => Date;
+}
+
+/**
+ * Build the JSON payload sent on the hook command's stdin. Pure: no I/O.
+ *
+ * `delegateCommand` is an own-property-**omitted** key -- not `null` --
+ * unless `delegateUsed` is `true` and a non-empty `delegateCommand` was
+ * given, matching the issue's documented payload shape ("`delegateCommand`
+ * present only when `delegateUsed` is `true`").
+ */
+export function buildCritiqueTelemetryHookPayload(
+  input: BuildCritiqueTelemetryHookPayloadInput,
+): CritiqueTelemetryHookPayload {
+  const timestamp =
+    input.timestamp ?? (input.now ? input.now() : new Date()).toISOString();
+  const payload: CritiqueTelemetryHookPayload = {
+    phase: 'C',
+    round: input.round,
+    repo: input.repo,
+    issue: input.issue,
+    pr: input.pr ?? null,
+    findingsCount: input.findingsCount,
+    severityBreakdown: input.severityBreakdown,
+    acceptedCount: input.acceptedCount,
+    rejectedCount: input.rejectedCount,
+    delegateUsed: input.delegateUsed,
+    timestamp,
+  };
+  if (input.delegateUsed && input.delegateCommand) {
+    payload.delegateCommand = input.delegateCommand;
+  }
+  return payload;
+}
+
+/** Result of {@link invokeCritiqueTelemetryHook}. */
+export interface InvokeCritiqueTelemetryHookResult {
+  /** `false` when `command` was empty/whitespace-only -- no spawn was attempted. */
+  attempted: boolean;
+  /** `true` only when the spawned command exited `0` within the timeout. */
+  ok: boolean;
+}
+
+/** Options for {@link invokeCritiqueTelemetryHook}. */
+export interface InvokeCritiqueTelemetryHookOptions {
+  timeoutMs?: number;
+  /** Injectable for tests; defaults to `node:child_process`'s `spawn`. */
+  spawnFn?: typeof spawn;
+}
+
+/**
+ * Fire-and-forget invocation: spawn `command` (a shell command, matching
+ * `critiqueLoop.telemetryHook.command`'s schema description) with `payload`
+ * written to its stdin as JSON, then close stdin. **Never throws and the
+ * returned promise never rejects** -- this function's entire contract is
+ * that a missing command, non-zero exit, timeout, or any other failure is
+ * silently absorbed into `{ ok: false }` rather than propagated, unlike
+ * `critiqueLoop.delegate`'s fail-closed hold semantics.
+ *
+ * Failure modes this deliberately guards against (a naive
+ * `spawn().stdin.write()` call crashes the parent process on each of these):
+ * - A spawn failure (bad shell, ENOENT, EACCES) emits `'error'` on the
+ *   child -- an unhandled listener would surface as an uncaught exception.
+ * - A child that exits before reading stdin EPIPEs the write asynchronously
+ *   -- the write's own try/catch only covers the *synchronous* failure
+ *   path, so `stdin`'s own `'error'` listener is required too.
+ * - A hanging command would block the caller indefinitely without a bounded
+ *   `timeoutMs` + `SIGKILL`.
+ * - Inheriting stdout/stderr would let a chatty hook pollute the caller's
+ *   own output, so both are set to `'ignore'`.
+ */
+export function invokeCritiqueTelemetryHook(
+  command: string | null | undefined,
+  payload: CritiqueTelemetryHookPayload,
+  options?: InvokeCritiqueTelemetryHookOptions,
+): Promise<InvokeCritiqueTelemetryHookResult> {
+  if (typeof command !== 'string' || command.trim() === '') {
+    return Promise.resolve({ attempted: false, ok: false });
+  }
+
+  const spawnFn = options?.spawnFn ?? spawn;
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_INVOKE_TIMEOUT_MS;
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = (ok: boolean) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve({ attempted: true, ok });
+    };
+
+    let child: ChildProcess;
+    try {
+      child = spawnFn(command, {
+        shell: true,
+        stdio: ['pipe', 'ignore', 'ignore'],
+      });
+    } catch {
+      settle(false);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        // Already exited between the timeout firing and this call; ignore.
+      }
+      settle(false);
+    }, timeoutMs);
+    // Never block process exit on this timer alone -- resolve() already
+    // settles the promise; unref lets the caller's own process exit
+    // normally if this hook is the only pending handle.
+    timer.unref?.();
+
+    child.on('error', () => {
+      clearTimeout(timer);
+      settle(false);
+    });
+    child.on('exit', (code) => {
+      clearTimeout(timer);
+      settle(code === 0);
+    });
+    child.stdin?.on('error', () => {
+      // Asynchronous EPIPE (child exited before reading stdin) or similar --
+      // the 'exit'/'error' handlers above still settle this promise.
+    });
+
+    try {
+      child.stdin?.write(JSON.stringify(payload));
+      child.stdin?.end();
+    } catch {
+      // Synchronous write failure -- 'error'/'exit' handlers above still
+      // settle this promise.
+    }
+  });
+}
+
+/**
+ * Read stdin fully as UTF-8 text, bounded by {@link STDIN_READ_TIMEOUT_MS}
+ * so a caller that runs `--invoke` without piping anything (e.g. an
+ * interactive TTY) cannot hang indefinitely -- consistent with this file's
+ * overall "never blocks" contract for `--invoke`. Never rejects: any read
+ * error or timeout resolves to whatever was read so far (possibly empty).
+ */
+function readStdinBounded(): Promise<string> {
+  return new Promise((resolve) => {
+    let data = '';
+    let settled = false;
+    const settle = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      resolve(data);
+    };
+    const timer = setTimeout(settle, STDIN_READ_TIMEOUT_MS);
+    timer.unref?.();
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk: string) => {
+      data += chunk;
+    });
+    process.stdin.on('end', settle);
+    process.stdin.on('error', settle);
+  });
+}
+
+interface ParsedArgs {
+  policy: string;
+  noUserGlobal: boolean;
+  invoke: boolean;
+  help: boolean;
+}
+
+function runCli(): void {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  const report = buildCritiqueTelemetryHookReport(
+    args.policy ? { localPolicyPath: args.policy } : undefined,
+    args.noUserGlobal,
+  );
+
+  if (!args.invoke) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    return;
+  }
+
+  // --invoke is the fire-and-forget entry point: read the caller-built JSON
+  // payload from stdin, invoke the resolved hook if usable, and always exit
+  // 0 with no output -- the whole point is that a caller can shell out to
+  // `... | node scripts/idd-critique-telemetry-hook.mjs --invoke` and never
+  // have to check this process's result.
+  readStdinBounded()
+    .then((raw) => {
+      let payload: unknown;
+      try {
+        payload = raw.trim() === '' ? null : JSON.parse(raw);
+      } catch {
+        payload = null;
+      }
+      if (
+        report.usable &&
+        report.command &&
+        payload !== null &&
+        typeof payload === 'object'
+      ) {
+        return invokeCritiqueTelemetryHook(
+          report.command,
+          payload as CritiqueTelemetryHookPayload,
+        );
+      }
+      return undefined;
+    })
+    .catch(() => undefined)
+    .finally(() => process.exit(0));
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const { values, help } = parseCliArgs(
+    argv,
+    IDD_CRITIQUE_TELEMETRY_HOOK_FLAG_SPEC,
+  );
+  return {
+    policy: (values.policy as string | undefined) ?? '',
+    noUserGlobal: values['no-user-global'] as boolean,
+    invoke: values.invoke as boolean,
+    help,
+  };
+}
+
+function printHelp(): void {
+  process.stdout.write(`Usage:
+  node scripts/idd-critique-telemetry-hook.mjs [--policy <path>] [--no-user-global]
+  node scripts/idd-critique-telemetry-hook.mjs --invoke [--policy <path>] [--no-user-global] < payload.json
+
+Resolves the effective C-phase \`critiqueLoop.telemetryHook\` the same way
+resolveEffectiveCritiqueLoopTelemetryHook does: repository-local
+.github/idd/config.json's critiqueLoop.telemetryHook wins outright (a
+configured object, an explicit null disable, or a malformed value all
+stop there); only when it is entirely absent does an optional
+user-global $XDG_CONFIG_HOME/idd-skill/config.json (or
+$HOME/.config/idd-skill/config.json) fragment apply; absent both, no
+hook is usable. Under GITHUB_ACTIONS=true the user-global layer is
+always skipped, matching the documented remote-agent-surface contract;
+pass --no-user-global to skip it explicitly on any other remote surface
+the caller recognizes but this helper cannot auto-detect.
+
+Without --invoke, prints the resolution report:
+{
+  "usable": true,
+  "source": "repository-local|user-global|none",
+  "command": "..." | null,
+  "reason": null | "repository-local-explicit-disable|invalid-repository-local-telemetry-hook|not-configured"
+}
+
+With --invoke, reads a JSON payload from stdin and, only if a hook
+resolved as usable, invokes its command with that payload written to
+the child's stdin. Fire-and-forget: a missing command, non-zero exit,
+timeout, or any other failure is silently ignored. This mode always
+exits 0 and never writes to stdout/stderr -- unlike critiqueLoop.delegate,
+this command's result is never meant to be inspected by its caller.
+`);
+}

--- a/src/scripts/idd-critique-telemetry-hook.mts
+++ b/src/scripts/idd-critique-telemetry-hook.mts
@@ -523,6 +523,19 @@ function spawnWatchdog(
       ['-c', `sleep ${seconds}; kill -9 -${pid} 2>/dev/null || true`],
       { detached: true, stdio: 'ignore' },
     );
+    // #2685 review, Codex: a spawn failure that isn't synchronous (e.g. no
+    // `sh` on `PATH` at all, notably a bare Windows install) does not throw
+    // into the `try` above -- `spawn()` still returns a `ChildProcess` and
+    // emits `'error'` on it asynchronously instead. An `EventEmitter` with
+    // no `'error'` listener throws that error back out as an uncaught
+    // exception when it fires, which would crash whatever process called
+    // this hook -- directly violating this file's "never throws" contract.
+    // A no-op listener is all this needs: the caller already treats a
+    // missing watchdog as an accepted, silent gap (see this function's own
+    // doc comment).
+    watchdog.on('error', () => {
+      // Best-effort only -- see doc comment above and on this function.
+    });
     watchdog.unref();
     return watchdog;
   } catch {

--- a/src/scripts/idd-critique-telemetry-hook.mts
+++ b/src/scripts/idd-critique-telemetry-hook.mts
@@ -282,7 +282,22 @@ export function invokeCritiqueTelemetryHook(
   }
 
   const spawnFn = options?.spawnFn ?? spawn;
-  const timeoutMs = options?.timeoutMs ?? DEFAULT_INVOKE_TIMEOUT_MS;
+  // #2685 review, Copilot: `?? DEFAULT_INVOKE_TIMEOUT_MS` alone only
+  // substitutes for `null`/`undefined` -- a caller-supplied `NaN` (or any
+  // other non-finite or negative value) would pass straight through and
+  // reach `setTimeout` below, which treats a non-finite delay as firing on
+  // (near-)the next tick, killing the hook almost instantly instead of
+  // waiting the intended bound. Falling back to the documented default for
+  // *any* unusable value keeps this "never throws" function's behavior
+  // predictable for a caller's own coding mistake, rather than silently
+  // clamping to some other value.
+  const requestedTimeoutMs = options?.timeoutMs;
+  const timeoutMs =
+    typeof requestedTimeoutMs === 'number' &&
+    Number.isFinite(requestedTimeoutMs) &&
+    requestedTimeoutMs >= 0
+      ? requestedTimeoutMs
+      : DEFAULT_INVOKE_TIMEOUT_MS;
   let delivered = false;
   const notifyDelivered = () => {
     if (delivered) {
@@ -517,7 +532,16 @@ function spawnWatchdog(
   timeoutMs: number,
 ): ChildProcess | null {
   try {
-    const seconds = Math.max(timeoutMs, 0) / 1000;
+    // #2685 review, Copilot: `Math.ceil`, not a plain division -- some
+    // POSIX `sleep` implementations only accept integer seconds, and a
+    // fractional argument (e.g. a test's `timeoutMs: 500` -> `0.5`) can
+    // make those reject or otherwise skip the delay entirely, SIGKILLing
+    // the hook (near-)immediately instead of after the intended bound.
+    // Rounding up, never down or to nearest, keeps this backup watchdog
+    // from ever firing *earlier* than the primary JS-level timer it
+    // exists to survive past -- the small extra slack on a portable
+    // `sleep` is harmless for a best-effort backup.
+    const seconds = Math.ceil(Math.max(timeoutMs, 0) / 1000);
     const watchdog = spawnFn(
       'sh',
       ['-c', `sleep ${seconds}; kill -9 -${pid} 2>/dev/null || true`],

--- a/src/scripts/idd-critique-telemetry-hook.mts
+++ b/src/scripts/idd-critique-telemetry-hook.mts
@@ -218,6 +218,18 @@ export interface InvokeCritiqueTelemetryHookOptions {
  * silently absorbed into `{ ok: false }` rather than propagated, unlike
  * `critiqueLoop.delegate`'s fail-closed hold semantics.
  *
+ * `detached: true` (#2685 review, Codex): the child runs in its own
+ * session, so it survives a signal delivered to this process's group (e.g.
+ * the invoking shell's own job-control teardown) instead of dying
+ * alongside it. This function's own promise still always resolves once
+ * the child truly settles (exit, error, or timeout) for any caller that
+ * awaits it (every test below does); the CLI's `--invoke` mode (below)
+ * simply never awaits it, and exits via `process.exit()` -- which
+ * terminates unconditionally regardless of any pending handle -- instead
+ * of waiting for the child to exit or hit `timeoutMs`, which would
+ * otherwise delay every C-phase round invoking this hook by up to that
+ * bound.
+ *
  * Failure modes this deliberately guards against (a naive
  * `spawn().stdin.write()` call crashes the parent process on each of these):
  * - A spawn failure (bad shell, ENOENT, EACCES) emits `'error'` on the
@@ -225,8 +237,9 @@ export interface InvokeCritiqueTelemetryHookOptions {
  * - A child that exits before reading stdin EPIPEs the write asynchronously
  *   -- the write's own try/catch only covers the *synchronous* failure
  *   path, so `stdin`'s own `'error'` listener is required too.
- * - A hanging command would block the caller indefinitely without a bounded
- *   `timeoutMs` + `SIGKILL`.
+ * - A hanging command would block a caller that does choose to await this
+ *   promise (e.g. a test, or a future non-CLI embedder) indefinitely
+ *   without a bounded `timeoutMs` + `SIGKILL`.
  * - Inheriting stdout/stderr would let a chatty hook pollute the caller's
  *   own output, so both are set to `'ignore'`.
  */
@@ -257,6 +270,22 @@ export function invokeCritiqueTelemetryHook(
       child = spawnFn(command, {
         shell: true,
         stdio: ['pipe', 'ignore', 'ignore'],
+        // `detached: true` (not `child.unref()`) only: this puts the child
+        // in its own session so it survives a signal sent to this
+        // process's group (e.g. the invoking shell's own job-control
+        // teardown), without unref'ing it. Deliberately NOT calling
+        // `child.unref()` here -- that would remove the *only* thing
+        // keeping the event loop alive long enough for the (also unref'd)
+        // timeout timer below to ever fire for a caller that legitimately
+        // awaits this promise (every test in this file does; a future
+        // non-CLI embedder might too) -- with both unref'd, nothing forces
+        // the loop to keep running, so the promise could stay pending
+        // forever once nothing else in the process needs the loop. The
+        // CLI's own `--invoke` mode (below) doesn't need this ref/unref
+        // distinction at all: it never awaits this promise, and
+        // `process.exit()` terminates unconditionally regardless of any
+        // pending handle's ref status.
+        detached: true,
       });
     } catch {
       settle(false);
@@ -342,21 +371,54 @@ function runCli(): void {
     printHelp();
     process.exit(0);
   }
+
+  if (args.invoke) {
+    runInvoke(args);
+    return;
+  }
+
   const report = buildCritiqueTelemetryHookReport(
     args.policy ? { localPolicyPath: args.policy } : undefined,
     args.noUserGlobal,
   );
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+}
 
-  if (!args.invoke) {
-    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+/**
+ * `--invoke`: the fire-and-forget entry point. Reads the caller-built JSON
+ * payload from stdin, invokes the resolved hook if usable, and always
+ * exits `0` with no output -- a caller can shell out to
+ * `... | node scripts/idd-critique-telemetry-hook.mjs --invoke` and never
+ * have to check this process's result or wait on it.
+ *
+ * Two failure modes this must absorb that the default (non-`--invoke`)
+ * mode deliberately does *not* (#2685 review, Codex):
+ * - **Resolution itself can throw** (e.g. an explicit `--policy` path that
+ *   is missing or malformed JSON -- `loadPolicyConfig` throws for an
+ *   explicit path by design). In the default mode that throw is the
+ *   caller-visible signal; under `--invoke` it must not be, so resolution
+ *   runs inside its own try/catch here, never at module-level `runCli`
+ *   scope.
+ * - **This process must not itself wait for the hook to settle.** Once
+ *   `invokeCritiqueTelemetryHook` has synchronously spawned the (detached,
+ *   `unref`'d) child and issued the stdin write, this function exits
+ *   without awaiting that promise's resolution -- otherwise this CLI
+ *   process (and thus whatever shelled out to it) blocks for up to the
+ *   hook's own `timeoutMs`, contradicting the documented "never delays"
+ *   contract.
+ */
+function runInvoke(args: ParsedArgs): void {
+  let report: CritiqueTelemetryHookReport;
+  try {
+    report = buildCritiqueTelemetryHookReport(
+      args.policy ? { localPolicyPath: args.policy } : undefined,
+      args.noUserGlobal,
+    );
+  } catch {
+    process.exit(0);
     return;
   }
 
-  // --invoke is the fire-and-forget entry point: read the caller-built JSON
-  // payload from stdin, invoke the resolved hook if usable, and always exit
-  // 0 with no output -- the whole point is that a caller can shell out to
-  // `... | node scripts/idd-critique-telemetry-hook.mjs --invoke` and never
-  // have to check this process's result.
   readStdinBounded()
     .then((raw) => {
       let payload: unknown;
@@ -371,12 +433,15 @@ function runCli(): void {
         payload !== null &&
         typeof payload === 'object'
       ) {
-        return invokeCritiqueTelemetryHook(
+        // Deliberately not returned/awaited -- see this function's doc
+        // comment. The `.catch` below is defensive only:
+        // invokeCritiqueTelemetryHook's own contract already never
+        // rejects.
+        invokeCritiqueTelemetryHook(
           report.command,
           payload as CritiqueTelemetryHookPayload,
-        );
+        ).catch(() => undefined);
       }
-      return undefined;
     })
     .catch(() => undefined)
     .finally(() => process.exit(0));

--- a/src/scripts/policy-helpers.mts
+++ b/src/scripts/policy-helpers.mts
@@ -100,6 +100,54 @@ export interface EffectiveCritiqueLoopDelegate {
 }
 
 /**
+ * `critiqueLoop.telemetryHook` (#2679): a per-round C-phase telemetry
+ * notification, structurally simpler than {@link CritiqueLoopDelegate} --
+ * `command` only, no `mode` -- because the hook is fire-and-forget and never
+ * gates C-phase control flow the way the delegate can.
+ */
+export interface CritiqueLoopTelemetryHook {
+  command: string;
+}
+
+/** How one policy document presents `critiqueLoop.telemetryHook`. */
+export type CritiqueLoopTelemetryHookLayerStatus =
+  | 'absent'
+  | 'disabled'
+  | 'configured'
+  | 'malformed';
+
+export interface CritiqueLoopTelemetryHookLayer {
+  status: CritiqueLoopTelemetryHookLayerStatus;
+  hook?: CritiqueLoopTelemetryHook;
+  reason?: string;
+}
+
+/**
+ * Outcome of layered telemetry-hook resolution. Mirrors
+ * {@link EffectiveCritiqueLoopDelegateStatus} exactly: `local-malformed` is
+ * fail-closed -- a bad repository-local `telemetryHook` must not inherit a
+ * user-global object.
+ */
+export type EffectiveCritiqueLoopTelemetryHookStatus =
+  | 'local'
+  | 'disabled'
+  | 'global'
+  | 'none'
+  | 'local-malformed';
+
+export type CritiqueLoopTelemetryHookSource =
+  | 'repository-local'
+  | 'user-global'
+  | 'none';
+
+export interface EffectiveCritiqueLoopTelemetryHook {
+  status: EffectiveCritiqueLoopTelemetryHookStatus;
+  source: CritiqueLoopTelemetryHookSource;
+  hook?: CritiqueLoopTelemetryHook;
+  reason?: string;
+}
+
+/**
  * How one policy document presents `developmentBranch` (#2271). `absent`
  * means "no explicit value" -- callers fall back to the repository's live
  * GitHub default branch. `invalid` is fail-closed: a present-but-malformed
@@ -357,6 +405,7 @@ interface RawConfig {
     cPhaseLowSeveritySkipAfter?: unknown;
     e10NoProgressHoldAfter?: unknown;
     delegate?: { command?: unknown; mode?: unknown };
+    telemetryHook?: { command?: unknown };
   };
   reviewEscalation?: {
     changesRequestedFirstEscalation?: unknown;
@@ -1526,6 +1575,140 @@ export function resolveEffectiveCritiqueLoopDelegate(input: {
       status: 'global',
       source: 'user-global',
       delegate: global.delegate,
+    };
+  }
+
+  return { status: 'none', source: 'none' };
+}
+
+/**
+ * Parse `critiqueLoop.telemetryHook`. Mirrors {@link parseCritiqueLoopDelegate}
+ * but for the simpler `{ command }`-only shape (#2679): a non-object, an
+ * unknown nested key (anything beyond `command`), or a missing/whitespace-only
+ * `command` all normalize to `undefined` (no hook configured), matching the
+ * schema's `additionalProperties: false` / `command`-only shape.
+ */
+function parseCritiqueLoopTelemetryHook(
+  value: unknown,
+): CritiqueLoopTelemetryHook | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const candidate = value as { command?: unknown };
+  const candidateKeys = Object.keys(candidate);
+  if (candidateKeys.some((key) => key !== 'command')) {
+    return undefined;
+  }
+  // Object.keys() above already excludes inherited keys, but a plain
+  // property read (candidate.command) still walks the prototype chain --
+  // require command to be an own property, mirroring
+  // parseCritiqueLoopDelegate's own-property guard (#2207 review).
+  if (!Object.hasOwn(candidate, 'command')) {
+    return undefined;
+  }
+
+  const command = parseNonEmptyString(candidate.command, '');
+  if (!command || command.trim() === '') {
+    return undefined;
+  }
+
+  return { command };
+}
+
+const INVALID_LOCAL_TELEMETRY_HOOK_REASON =
+  'invalid-repository-local-telemetry-hook';
+
+/**
+ * Inspect `critiqueLoop.telemetryHook` on a raw policy document without
+ * applying `normalizePolicyConfig`'s fail-safe collapse. Mirrors
+ * {@link inspectCritiqueLoopDelegateLayer}'s absent / disabled / configured /
+ * malformed shape.
+ */
+export function inspectCritiqueLoopTelemetryHookLayer(
+  config: unknown,
+): CritiqueLoopTelemetryHookLayer {
+  if (typeof config !== 'object' || config === null || Array.isArray(config)) {
+    return { status: 'absent' };
+  }
+
+  if (!Object.hasOwn(config, 'critiqueLoop')) {
+    return { status: 'absent' };
+  }
+
+  const critiqueLoop = (config as RawConfig).critiqueLoop;
+  if (
+    typeof critiqueLoop !== 'object' ||
+    critiqueLoop === null ||
+    Array.isArray(critiqueLoop)
+  ) {
+    // A present non-object `critiqueLoop` is a local configuration error:
+    // fail closed rather than treating it as "no hook" and inheriting a
+    // user-global object.
+    return { status: 'malformed', reason: INVALID_LOCAL_TELEMETRY_HOOK_REASON };
+  }
+
+  if (!Object.hasOwn(critiqueLoop, 'telemetryHook')) {
+    return { status: 'absent' };
+  }
+
+  const value = (critiqueLoop as { telemetryHook: unknown }).telemetryHook;
+  if (value === null) {
+    return { status: 'disabled' };
+  }
+
+  const parsed = parseCritiqueLoopTelemetryHook(value);
+  if (parsed) {
+    return { status: 'configured', hook: parsed };
+  }
+
+  return { status: 'malformed', reason: INVALID_LOCAL_TELEMETRY_HOOK_REASON };
+}
+
+/**
+ * Resolve the effective C-phase telemetry hook from a repository-local
+ * document and an optional user-global document. Pure: callers supply
+ * already-loaded JSON (or `undefined` for an absent global file). Never
+ * reads the filesystem.
+ *
+ * Order: local object, local `null` disable, global object, then none --
+ * identical to {@link resolveEffectiveCritiqueLoopDelegate}'s resolution
+ * order. A malformed local hook is fail-closed and does not inherit global.
+ * A malformed or disabled global fragment is treated as absent.
+ */
+export function resolveEffectiveCritiqueLoopTelemetryHook(input: {
+  localConfig: unknown;
+  globalConfig?: unknown;
+}): EffectiveCritiqueLoopTelemetryHook {
+  const local = inspectCritiqueLoopTelemetryHookLayer(input.localConfig);
+  if (local.status === 'configured' && local.hook) {
+    return {
+      status: 'local',
+      source: 'repository-local',
+      hook: local.hook,
+    };
+  }
+  if (local.status === 'disabled') {
+    return { status: 'disabled', source: 'repository-local' };
+  }
+  if (local.status === 'malformed') {
+    return {
+      status: 'local-malformed',
+      source: 'repository-local',
+      reason: local.reason ?? INVALID_LOCAL_TELEMETRY_HOOK_REASON,
+    };
+  }
+
+  if (input.globalConfig === undefined || input.globalConfig === null) {
+    return { status: 'none', source: 'none' };
+  }
+
+  const global = inspectCritiqueLoopTelemetryHookLayer(input.globalConfig);
+  if (global.status === 'configured' && global.hook) {
+    return {
+      status: 'global',
+      source: 'user-global',
+      hook: global.hook,
     };
   }
 

--- a/tests/help-text-flags.test.mts
+++ b/tests/help-text-flags.test.mts
@@ -187,6 +187,7 @@ const COVERED_HELPERS = [
   'forced-handoff-marker',
   'helper-runtime-manifest',
   'idd-critique-delegate',
+  'idd-critique-telemetry-hook',
   'idd-doctor',
   'idd-roadmap-audit-execute',
   'idd-suggest-untrusted-labelers',

--- a/tests/idd-config.test.mts
+++ b/tests/idd-config.test.mts
@@ -12,6 +12,7 @@ import {
   loadTrustedIddConfig,
   loadUserGlobalPolicyDocument,
   resolveEffectiveCritiqueLoopDelegateFromEnv,
+  resolveEffectiveCritiqueLoopTelemetryHookFromEnv,
   resolveUserGlobalConfigPath,
 } from '../src/scripts/idd-config.mts';
 
@@ -531,6 +532,158 @@ test('resolveEffectiveCritiqueLoopDelegateFromEnv fails closed on a malformed re
     status: 'local-malformed',
     source: 'repository-local',
     reason: 'invalid-repository-local-delegate',
+  });
+});
+
+// #2679: resolveEffectiveCritiqueLoopTelemetryHookFromEnv, mirroring every
+// resolveEffectiveCritiqueLoopDelegateFromEnv case above (#2257/#2258) for
+// the simpler `{ command }`-only critiqueLoop.telemetryHook shape.
+
+test('resolveEffectiveCritiqueLoopTelemetryHookFromEnv ignores global keys other than critiqueLoop.telemetryHook (#2679)', () => {
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-user-global-telemetry-hook-extra-'),
+  );
+  const path = join(sandbox, 'config.json');
+  writeFileSync(
+    path,
+    JSON.stringify({
+      mergePolicy: 'must-not-apply',
+      critiqueLoop: { telemetryHook: { command: 'global-hook' } },
+    }),
+  );
+  const result = loadUserGlobalPolicyDocument({ path });
+  assert.equal(result.status, 'present');
+  const resolved = resolveEffectiveCritiqueLoopTelemetryHookFromEnv({
+    localConfig: {},
+    globalConfigPath: path,
+    env: {},
+  });
+  assert.deepEqual(resolved, {
+    status: 'global',
+    source: 'user-global',
+    hook: { command: 'global-hook' },
+  });
+});
+
+test('resolveEffectiveCritiqueLoopTelemetryHookFromEnv skips the global file when local policy already decides (#2679)', () => {
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-user-global-telemetry-hook-skipped-'),
+  );
+  const path = join(sandbox, 'config.json');
+  writeFileSync(
+    path,
+    JSON.stringify({
+      critiqueLoop: { telemetryHook: { command: 'must-not-load' } },
+    }),
+  );
+  const resolved = resolveEffectiveCritiqueLoopTelemetryHookFromEnv({
+    localConfig: {
+      critiqueLoop: { telemetryHook: { command: 'local-hook' } },
+    },
+    globalConfigPath: path,
+    env: {},
+  });
+  assert.deepEqual(resolved, {
+    status: 'local',
+    source: 'repository-local',
+    hook: { command: 'local-hook' },
+  });
+});
+
+test('resolveEffectiveCritiqueLoopTelemetryHookFromEnv does not read HOME when path is injected (#2679)', () => {
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-user-global-telemetry-hook-injected-'),
+  );
+  const path = join(sandbox, 'config.json');
+  writeFileSync(
+    path,
+    JSON.stringify({
+      critiqueLoop: { telemetryHook: { command: 'injected-hook' } },
+    }),
+  );
+  const resolved = resolveEffectiveCritiqueLoopTelemetryHookFromEnv({
+    localConfig: {},
+    globalConfigPath: path,
+    env: { HOME: '/this-must-not-be-read', XDG_CONFIG_HOME: '/neither' },
+  });
+  assert.deepEqual(resolved, {
+    status: 'global',
+    source: 'user-global',
+    hook: { command: 'injected-hook' },
+  });
+});
+
+test('resolveEffectiveCritiqueLoopTelemetryHookFromEnv: commands, mergePolicy, reviewPolicy, and CI-related global keys do not leak into the resolved hook (#2679)', () => {
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-user-global-telemetry-hook-leak-'),
+  );
+  const path = join(sandbox, 'config.json');
+  writeFileSync(
+    path,
+    JSON.stringify({
+      commands: { 'pre-push-validate': 'echo must-not-apply' },
+      mergePolicy: 'fully_autonomous_merge',
+      reviewPolicy: 'copilot-advisory',
+      ciWait: { runningTimeout: 'PT99H' },
+      critiqueLoop: { telemetryHook: { command: 'global-hook' } },
+    }),
+  );
+  const resolved = resolveEffectiveCritiqueLoopTelemetryHookFromEnv({
+    localConfig: {},
+    globalConfigPath: path,
+    env: {},
+  });
+  assert.deepEqual(resolved, {
+    status: 'global',
+    source: 'user-global',
+    hook: { command: 'global-hook' },
+  });
+});
+
+test('resolveEffectiveCritiqueLoopTelemetryHookFromEnv honors a repository-local null disable even when a global hook file exists (#2679)', () => {
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-user-global-telemetry-hook-disabled-'),
+  );
+  const path = join(sandbox, 'config.json');
+  writeFileSync(
+    path,
+    JSON.stringify({
+      critiqueLoop: { telemetryHook: { command: 'must-not-apply' } },
+    }),
+  );
+  const resolved = resolveEffectiveCritiqueLoopTelemetryHookFromEnv({
+    localConfig: { critiqueLoop: { telemetryHook: null } },
+    globalConfigPath: path,
+    env: {},
+  });
+  assert.deepEqual(resolved, {
+    status: 'disabled',
+    source: 'repository-local',
+  });
+});
+
+test('resolveEffectiveCritiqueLoopTelemetryHookFromEnv fails closed on a malformed repository-local hook without inheriting the global object (#2679)', () => {
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-user-global-telemetry-hook-malformed-'),
+  );
+  const path = join(sandbox, 'config.json');
+  writeFileSync(
+    path,
+    JSON.stringify({
+      critiqueLoop: { telemetryHook: { command: 'must-not-apply' } },
+    }),
+  );
+  const resolved = resolveEffectiveCritiqueLoopTelemetryHookFromEnv({
+    localConfig: {
+      critiqueLoop: { telemetryHook: { command: 'local-hook', bogus: 1 } },
+    },
+    globalConfigPath: path,
+    env: {},
+  });
+  assert.deepEqual(resolved, {
+    status: 'local-malformed',
+    source: 'repository-local',
+    reason: 'invalid-repository-local-telemetry-hook',
   });
 });
 

--- a/tests/idd-critique-telemetry-hook.test.mts
+++ b/tests/idd-critique-telemetry-hook.test.mts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -529,6 +529,85 @@ test('CLI --invoke exits 0 promptly when the resolved hook command fails', () =>
   } finally {
     restore();
   }
+});
+
+test('CLI --invoke does not wait for a hanging resolved hook up to its default 5s timeout (#2685 review, Copilot + Codex)', () => {
+  // The regression fixture for the core review finding: --invoke must not
+  // itself block its caller for up to the hook's own timeoutMs (default
+  // 5000ms) -- the CLI process must exit as soon as it has handed the
+  // payload off, regardless of how long (or whether) the resolved command
+  // ever finishes. Before the fix, this test would take >= 5000ms; the
+  // bound below is comfortably under that while still generous for this
+  // repository's documented heavy concurrent-session load.
+  const restore = stubExecutable(
+    'idd-telemetry-hook-cli-hang',
+    // Keep the event loop alive without ever exiting on its own -- the
+    // CLI must still return promptly despite this.
+    'setInterval(() => {}, 1000);\n',
+  );
+  try {
+    const sandbox = mkdtempSync(
+      join(tmpdir(), 'idd-critique-telemetry-hook-cli-invoke-hang-'),
+    );
+    const policyPath = join(sandbox, 'config.json');
+    writeFileSync(
+      policyPath,
+      JSON.stringify({
+        critiqueLoop: {
+          telemetryHook: { command: 'idd-telemetry-hook-cli-hang' },
+        },
+      }),
+    );
+    const startedAt = Date.now();
+    const { stdout } = runCli(
+      ['--policy', policyPath, '--invoke'],
+      undefined,
+      JSON.stringify(samplePayload()),
+    );
+    const elapsedMs = Date.now() - startedAt;
+    assert.equal(stdout, '');
+    assert.ok(
+      elapsedMs < 3_000,
+      `expected --invoke to return well under the hook's 5s default timeout even though it hangs, took ${elapsedMs}ms`,
+    );
+  } finally {
+    restore();
+  }
+});
+
+test('CLI --invoke absorbs a resolution failure (malformed --policy file) instead of exiting non-zero (#2685 review, Codex)', () => {
+  // loadPolicyConfig throws for an explicit --policy path that is missing
+  // or malformed JSON -- deliberately, for the default (non-invoke) mode,
+  // where that throw is the caller-visible signal. Under --invoke it must
+  // not be: this is a pure observability hook, and the documented contract
+  // is "always exits 0, never surfaces an error" regardless of why the
+  // hook turned out to be unusable.
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-critique-telemetry-hook-cli-invoke-malformed-'),
+  );
+  const policyPath = join(sandbox, 'config.json');
+  writeFileSync(policyPath, '{ not valid json');
+  const isolatedHome = mkdtempSync(
+    join(tmpdir(), 'idd-critique-telemetry-hook-invoke-malformed-home-'),
+  );
+  const result = spawnSync(
+    process.execPath,
+    [CLI_PATH, '--policy', policyPath, '--invoke'],
+    {
+      encoding: 'utf8',
+      timeout: 30_000,
+      input: JSON.stringify(samplePayload()),
+      env: {
+        ...process.env,
+        GITHUB_ACTIONS: '',
+        HOME: isolatedHome,
+        XDG_CONFIG_HOME: '',
+      },
+    },
+  );
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout, '');
+  assert.equal(result.stderr, '');
 });
 
 test('CLI --invoke exits 0 when a resolved hook succeeds', () => {

--- a/tests/idd-critique-telemetry-hook.test.mts
+++ b/tests/idd-critique-telemetry-hook.test.mts
@@ -1,9 +1,10 @@
 import assert from 'node:assert/strict';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
+import { setTimeout as delay } from 'node:timers/promises';
 import { fileURLToPath } from 'node:url';
 
 import {
@@ -378,6 +379,48 @@ function samplePayload(): CritiqueTelemetryHookPayload {
   });
 }
 
+/** Polls (rather than a single delayed check) until `pid` no longer exists
+ * or `timeoutMs` elapses -- robust against this repository's documented
+ * heavy concurrent-session scheduling load, which can otherwise delay
+ * exactly when an already-issued kill signal actually reaps the process. */
+async function waitUntilProcessGone(
+  pid: number,
+  timeoutMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return true;
+    }
+    await delay(100);
+  }
+  return false;
+}
+
+/** Polls for `path` to exist and be non-empty, since the CLI's own exit
+ * (fire-and-forget) races the spawned hook's node-startup time -- reading
+ * immediately after the CLI returns is not reliably far enough along. */
+async function waitForNonEmptyFile(
+  path: string,
+  timeoutMs: number,
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const content = readFileSync(path, 'utf8').trim();
+      if (content !== '') {
+        return content;
+      }
+    } catch {
+      // Not written yet; keep polling.
+    }
+    await delay(50);
+  }
+  return readFileSync(path, 'utf8').trim();
+}
+
 test('invokeCritiqueTelemetryHook is a no-op for an empty/whitespace command', async () => {
   assert.deepEqual(await invokeCritiqueTelemetryHook('', samplePayload()), {
     attempted: false,
@@ -475,6 +518,37 @@ test('invokeCritiqueTelemetryHook resolves ok:false promptly (bounded by timeout
   }
 });
 
+test('invokeCritiqueTelemetryHook kills a backgrounded descendant on timeout, not just the shell wrapper (#2685 review, Codex)', async () => {
+  // Regression fixture: `shell: true` makes the spawned `child` the
+  // `/bin/sh -c` wrapper. A command that backgrounds a job of its own
+  // (`cmd & wait`) creates a descendant with a *different* pid than that
+  // wrapper -- a plain single-pid kill would leave it running as an
+  // orphan even though `child` itself died. The fix targets the whole
+  // process group (negative pid), which must still reach it.
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-telemetry-hook-group-kill-'));
+  const pidFile = join(sandbox, 'pid');
+  const nodeScript =
+    `require('fs').writeFileSync(${JSON.stringify(pidFile)}, String(process.pid)); ` +
+    'setInterval(() => {}, 1000);';
+  const command = `${JSON.stringify(process.execPath)} -e ${JSON.stringify(nodeScript)} & wait`;
+
+  const result = await invokeCritiqueTelemetryHook(command, samplePayload(), {
+    timeoutMs: 500,
+  });
+  assert.deepEqual(result, { attempted: true, ok: false });
+
+  const pid = Number(readFileSync(pidFile, 'utf8').trim());
+  assert.ok(
+    Number.isInteger(pid) && pid > 0,
+    `expected the backgrounded descendant to have written its own pid, got ${pid}`,
+  );
+  const gone = await waitUntilProcessGone(pid, 10_000);
+  assert.ok(
+    gone,
+    `expected the backgrounded descendant (pid ${pid}) to be killed by the process-group signal, but it is still running`,
+  );
+});
+
 // --- CLI --invoke: fire-and-forget at the process boundary (#2679) -------
 //
 // The fixture acceptance criterion 3 asks for at the process-boundary
@@ -531,7 +605,7 @@ test('CLI --invoke exits 0 promptly when the resolved hook command fails', () =>
   }
 });
 
-test('CLI --invoke does not wait for a hanging resolved hook up to its default 5s timeout (#2685 review, Copilot + Codex)', () => {
+test('CLI --invoke does not wait for a hanging resolved hook up to its default 5s timeout, and the hook is still killed after the CLI exits (#2685 review, Copilot + Codex)', async () => {
   // The regression fixture for the core review finding: --invoke must not
   // itself block its caller for up to the hook's own timeoutMs (default
   // 5000ms) -- the CLI process must exit as soon as it has handed the
@@ -539,16 +613,23 @@ test('CLI --invoke does not wait for a hanging resolved hook up to its default 5
   // ever finishes. Before the fix, this test would take >= 5000ms; the
   // bound below is comfortably under that while still generous for this
   // repository's documented heavy concurrent-session load.
+  //
+  // The second half proves the *other* half of the same review round: once
+  // the CLI process (and with it, the JS-level timeout timer) is gone, the
+  // hung hook must still not run forever -- only the detached watchdog can
+  // enforce that deadline at this point, since nothing else survives to.
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-critique-telemetry-hook-cli-invoke-hang-'),
+  );
+  const pidFile = join(sandbox, 'pid');
   const restore = stubExecutable(
     'idd-telemetry-hook-cli-hang',
-    // Keep the event loop alive without ever exiting on its own -- the
-    // CLI must still return promptly despite this.
-    'setInterval(() => {}, 1000);\n',
+    // Record this stub's own pid, then hang -- lets the assertions below
+    // confirm it was actually killed, not merely that the CLI returned.
+    `require('fs').writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));\n` +
+      'setInterval(() => {}, 1000);\n',
   );
   try {
-    const sandbox = mkdtempSync(
-      join(tmpdir(), 'idd-critique-telemetry-hook-cli-invoke-hang-'),
-    );
     const policyPath = join(sandbox, 'config.json');
     writeFileSync(
       policyPath,
@@ -569,6 +650,23 @@ test('CLI --invoke does not wait for a hanging resolved hook up to its default 5
     assert.ok(
       elapsedMs < 3_000,
       `expected --invoke to return well under the hook's 5s default timeout even though it hangs, took ${elapsedMs}ms`,
+    );
+
+    // The CLI's own exit (fire-and-forget) races the spawned hook's
+    // node-startup time -- the pid file may not exist yet at this exact
+    // instant even though the CLI itself has already returned.
+    const pid = Number(await waitForNonEmptyFile(pidFile, 5_000));
+    assert.ok(
+      Number.isInteger(pid) && pid > 0,
+      `expected the hung hook to have written its own pid, got ${pid}`,
+    );
+    // This one waits out the CLI's *default* 5s timeout (no --invoke flag
+    // overrides it), so the poll budget below is more generous than the
+    // configured-short-timeout tests above.
+    const gone = await waitUntilProcessGone(pid, 20_000);
+    assert.ok(
+      gone,
+      `expected the hung hook (pid ${pid}) to be killed by the watchdog after the CLI process itself exited, but it is still running`,
     );
   } finally {
     restore();

--- a/tests/idd-critique-telemetry-hook.test.mts
+++ b/tests/idd-critique-telemetry-hook.test.mts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { execFileSync, spawnSync } from 'node:child_process';
+import { execFileSync, spawn, spawnSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -547,6 +547,52 @@ test('invokeCritiqueTelemetryHook kills a backgrounded descendant on timeout, no
     gone,
     `expected the backgrounded descendant (pid ${pid}) to be killed by the process-group signal, but it is still running`,
   );
+});
+
+test('invokeCritiqueTelemetryHook disarms the watchdog once the hook exits well before timeoutMs (#2685 review, Codex)', async () => {
+  // Regression fixture for the PID-reuse race: a hook that settles quickly
+  // used to leave its watchdog asleep for the rest of timeoutMs, so a
+  // process/group id it recycled inside that window could be killed by
+  // mistake. `timeoutMs` here is deliberately large (well beyond this
+  // test's own assertion deadline) -- if disarming did NOT happen, the
+  // watchdog would still be alive (mid-`sleep`) when this test checks it,
+  // proving the assertion actually exercises cancellation rather than the
+  // watchdog's own natural, on-time expiry.
+  let watchdogChild: ReturnType<typeof spawn> | undefined;
+  const spawnFn: typeof spawn = ((...args: Parameters<typeof spawn>) => {
+    const child = spawn(...args);
+    if (args[0] === 'sh') {
+      watchdogChild = child;
+    }
+    return child;
+  }) as typeof spawn;
+
+  const restore = stubExecutable(
+    'idd-telemetry-hook-quick-exit',
+    'process.exit(0);\n',
+  );
+  try {
+    const result = await invokeCritiqueTelemetryHook(
+      'idd-telemetry-hook-quick-exit',
+      samplePayload(),
+      { timeoutMs: 30_000, spawnFn },
+    );
+    assert.deepEqual(result, { attempted: true, ok: true });
+
+    assert.ok(watchdogChild, 'expected the watchdog to have been spawned');
+    const watchdogPid = watchdogChild?.pid;
+    assert.ok(
+      typeof watchdogPid === 'number' && watchdogPid > 0,
+      `expected the watchdog to report a pid, got ${watchdogPid}`,
+    );
+    const gone = await waitUntilProcessGone(watchdogPid as number, 10_000);
+    assert.ok(
+      gone,
+      `expected the watchdog (pid ${watchdogPid}) to be killed once the hook exited, well before its own 30s timeoutMs sleep, but it is still running`,
+    );
+  } finally {
+    restore();
+  }
 });
 
 // --- CLI --invoke: fire-and-forget at the process boundary (#2679) -------

--- a/tests/idd-critique-telemetry-hook.test.mts
+++ b/tests/idd-critique-telemetry-hook.test.mts
@@ -719,6 +719,70 @@ test('CLI --invoke does not wait for a hanging resolved hook up to its default 5
   }
 });
 
+test('CLI --invoke waits for a large payload to fully reach the hook before exiting (#2685 review, CodeRabbit)', async () => {
+  // Regression fixture: `runInvoke` used to fire `invokeCritiqueTelemetryHook`
+  // and call `process.exit(0)` right after, without waiting for the stdin
+  // write to the hook's pipe to actually finish -- fine for a small
+  // payload that completes in a single synchronous write, but a payload
+  // well over the OS pipe buffer (64KB on Linux) cannot land in one write
+  // and needs the child to keep draining it across several event-loop
+  // ticks; exiting mid-write would truncate what the hook receives.
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-critique-telemetry-hook-cli-invoke-large-payload-'),
+  );
+  const receivedPath = join(sandbox, 'received.json');
+  const restore = stubExecutable(
+    'idd-telemetry-hook-capture-stdin',
+    `const fs = require('fs');
+const chunks = [];
+process.stdin.on('data', (c) => chunks.push(c));
+process.stdin.on('end', () => {
+  fs.writeFileSync(${JSON.stringify(receivedPath)}, Buffer.concat(chunks));
+  process.exit(0);
+});
+`,
+  );
+  try {
+    const policyPath = join(sandbox, 'config.json');
+    writeFileSync(
+      policyPath,
+      JSON.stringify({
+        critiqueLoop: {
+          telemetryHook: { command: 'idd-telemetry-hook-capture-stdin' },
+        },
+      }),
+    );
+    const bigPayload = { ...samplePayload(), padding: 'x'.repeat(500_000) };
+    const expected = JSON.stringify(bigPayload);
+    const startedAt = Date.now();
+    const { stdout } = runCli(
+      ['--policy', policyPath, '--invoke'],
+      undefined,
+      expected,
+    );
+    const elapsedMs = Date.now() - startedAt;
+    assert.equal(stdout, '');
+    // Generous vs. PAYLOAD_DELIVERY_TIMEOUT_MS's 1s bound -- proves the CLI
+    // still returns promptly rather than waiting for the hook process
+    // itself (which, unlike the hanging-hook test above, actually does
+    // exit quickly here, but this test is about the write completing, not
+    // about the hook's own runtime).
+    assert.ok(
+      elapsedMs < 5_000,
+      `expected --invoke to return promptly even for a large payload, took ${elapsedMs}ms`,
+    );
+
+    const received = await waitForNonEmptyFile(receivedPath, 5_000);
+    assert.equal(
+      received,
+      expected,
+      'expected the hook to receive the full, untruncated payload',
+    );
+  } finally {
+    restore();
+  }
+});
+
 test('CLI --invoke absorbs a resolution failure (malformed --policy file) instead of exiting non-zero (#2685 review, Codex)', () => {
   // loadPolicyConfig throws for an explicit --policy path that is missing
   // or malformed JSON -- deliberately, for the default (non-invoke) mode,

--- a/tests/idd-critique-telemetry-hook.test.mts
+++ b/tests/idd-critique-telemetry-hook.test.mts
@@ -654,6 +654,84 @@ test("invokeCritiqueTelemetryHook attaches an 'error' listener to the watchdog, 
   }
 });
 
+test('invokeCritiqueTelemetryHook falls back to the default timeout for a non-finite timeoutMs (#2685 review, Copilot)', async () => {
+  // `?? DEFAULT_INVOKE_TIMEOUT_MS` alone only substitutes for
+  // `null`/`undefined` -- a caller-supplied `NaN` would otherwise pass
+  // straight through to `setTimeout`, which treats a non-finite delay as
+  // firing on (near-)the next tick, killing a perfectly healthy hook
+  // almost instantly instead of respecting the intended (here, implicitly
+  // default) bound. Capture the watchdog's `sleep` argument via a spawnFn
+  // spy to prove the sanitized value reached it, rather than waiting out
+  // a real default-5s timeout in this test.
+  let watchdogArgs: string[] | undefined;
+  const spawnFn: typeof spawn = ((...args: Parameters<typeof spawn>) => {
+    if (args[0] === 'sh') {
+      watchdogArgs = args[1] as string[];
+    }
+    return spawn(...args);
+  }) as typeof spawn;
+
+  const restore = stubExecutable(
+    'idd-telemetry-hook-quick-exit-3',
+    'process.exit(0);\n',
+  );
+  try {
+    const result = await invokeCritiqueTelemetryHook(
+      'idd-telemetry-hook-quick-exit-3',
+      samplePayload(),
+      { timeoutMs: Number.NaN, spawnFn },
+    );
+    assert.deepEqual(result, { attempted: true, ok: true });
+    assert.ok(watchdogArgs, 'expected the watchdog to have been spawned');
+    const script = watchdogArgs?.[1] ?? '';
+    assert.match(
+      script,
+      /^sleep 5;/,
+      `expected a NaN timeoutMs to fall back to the default 5s bound, got: ${script}`,
+    );
+  } finally {
+    restore();
+  }
+});
+
+test('spawnWatchdog rounds a fractional timeoutMs up to a whole second (#2685 review, Copilot)', async () => {
+  // Some POSIX `sleep` implementations only accept integer seconds; a
+  // fractional argument (a `timeoutMs` not a multiple of 1000, as several
+  // tests in this file configure) can make those implementations reject
+  // or skip the delay, SIGKILLing (near-)immediately. Assert the
+  // watchdog's `sleep` argument is always a whole number, rounded *up*
+  // (never down, which could fire the backup before the primary JS-level
+  // timer it exists to survive past).
+  let watchdogArgs: string[] | undefined;
+  const spawnFn: typeof spawn = ((...args: Parameters<typeof spawn>) => {
+    if (args[0] === 'sh') {
+      watchdogArgs = args[1] as string[];
+    }
+    return spawn(...args);
+  }) as typeof spawn;
+
+  const restore = stubExecutable(
+    'idd-telemetry-hook-quick-exit-4',
+    'process.exit(0);\n',
+  );
+  try {
+    const result = await invokeCritiqueTelemetryHook(
+      'idd-telemetry-hook-quick-exit-4',
+      samplePayload(),
+      { timeoutMs: 1_500, spawnFn },
+    );
+    assert.deepEqual(result, { attempted: true, ok: true });
+    const script = watchdogArgs?.[1] ?? '';
+    assert.match(
+      script,
+      /^sleep 2;/,
+      `expected timeoutMs: 1500 to round up to a 2s sleep, got: ${script}`,
+    );
+  } finally {
+    restore();
+  }
+});
+
 // --- CLI --invoke: fire-and-forget at the process boundary (#2679) -------
 //
 // The fixture acceptance criterion 3 asks for at the process-boundary

--- a/tests/idd-critique-telemetry-hook.test.mts
+++ b/tests/idd-critique-telemetry-hook.test.mts
@@ -600,6 +600,60 @@ test('invokeCritiqueTelemetryHook disarms the watchdog once the hook exits well 
   }
 });
 
+test("invokeCritiqueTelemetryHook attaches an 'error' listener to the watchdog, guarding against an asynchronous spawn failure (#2685 review, Codex)", async () => {
+  // Regression fixture: `spawn('sh', ...)` for a shell that cannot be
+  // started at all (e.g. no POSIX shell on `PATH`, notably a bare Windows
+  // install) does not throw synchronously -- it still returns a
+  // `ChildProcess` and emits `'error'` on it *asynchronously*, which
+  // `spawnWatchdog`'s own `try`/`catch` around the `spawnFn(...)` call
+  // cannot see. An `EventEmitter` with no `'error'` listener rethrows an
+  // emitted `'error'` as an uncaught exception -- which would crash
+  // whatever process called this hook, directly violating its "never
+  // throws" contract.
+  //
+  // Asserting on the listener being attached (rather than actually
+  // triggering and observing an uncaught exception end-to-end) is
+  // deliberate: `node --test` tracks which async resources belong to which
+  // test, and an exception thrown from a listener-less `EventEmitter`
+  // fired via `queueMicrotask` from inside this test's body was observed,
+  // empirically, to be attributed to a *different* ("after this test
+  // ended") pseudo-test instead of failing this one -- see this commit's
+  // message for the concrete repro. A direct check that the watchdog
+  // carries an `'error'` listener is deterministic and avoids that
+  // reporting quirk entirely, while still failing this test (with the
+  // real fix reverted, `watchdogChild.listenerCount('error')` is `0`) --
+  // manually verified against a version of the file without the fix,
+  // instead of the fragile emit-and-observe alternative.
+  let watchdogChild: ReturnType<typeof spawn> | undefined;
+  const spawnFn: typeof spawn = ((...args: Parameters<typeof spawn>) => {
+    const child = spawn(...args);
+    if (args[0] === 'sh') {
+      watchdogChild = child;
+    }
+    return child;
+  }) as typeof spawn;
+
+  const restore = stubExecutable(
+    'idd-telemetry-hook-quick-exit-2',
+    'process.exit(0);\n',
+  );
+  try {
+    const result = await invokeCritiqueTelemetryHook(
+      'idd-telemetry-hook-quick-exit-2',
+      samplePayload(),
+      { timeoutMs: 30_000, spawnFn },
+    );
+    assert.deepEqual(result, { attempted: true, ok: true });
+    assert.ok(watchdogChild, 'expected the watchdog to have been spawned');
+    assert.ok(
+      (watchdogChild?.listenerCount('error') ?? 0) > 0,
+      "expected the watchdog to have an 'error' listener attached, guarding against an asynchronous spawn failure",
+    );
+  } finally {
+    restore();
+  }
+});
+
 // --- CLI --invoke: fire-and-forget at the process boundary (#2679) -------
 //
 // The fixture acceptance criterion 3 asks for at the process-boundary

--- a/tests/idd-critique-telemetry-hook.test.mts
+++ b/tests/idd-critique-telemetry-hook.test.mts
@@ -527,20 +527,25 @@ test('invokeCritiqueTelemetryHook kills a backgrounded descendant on timeout, no
   // process group (negative pid), which must still reach it.
   const sandbox = mkdtempSync(join(tmpdir(), 'idd-telemetry-hook-group-kill-'));
   const pidFile = join(sandbox, 'pid');
-  const nodeScript =
-    `require('fs').writeFileSync(${JSON.stringify(pidFile)}, String(process.pid)); ` +
-    'setInterval(() => {}, 1000);';
-  const command = `${JSON.stringify(process.execPath)} -e ${JSON.stringify(nodeScript)} & wait`;
+  // #2685 review (CodeRabbit): record the backgrounded descendant's pid via
+  // the shell's own `$!` immediately after backgrounding it, rather than
+  // waiting on the node subprocess to reach and complete its own
+  // `writeFileSync` -- with a short 500ms `timeoutMs` below, a slow node
+  // startup under this repository's documented heavy concurrent-session
+  // load could otherwise race the group-kill and leave `pidFile` never
+  // written at all.
+  const nodeScript = 'setInterval(() => {}, 1000);';
+  const command = `${JSON.stringify(process.execPath)} -e ${JSON.stringify(nodeScript)} & echo $! > ${JSON.stringify(pidFile)}; wait`;
 
   const result = await invokeCritiqueTelemetryHook(command, samplePayload(), {
     timeoutMs: 500,
   });
   assert.deepEqual(result, { attempted: true, ok: false });
 
-  const pid = Number(readFileSync(pidFile, 'utf8').trim());
+  const pid = Number(await waitForNonEmptyFile(pidFile, 5_000));
   assert.ok(
     Number.isInteger(pid) && pid > 0,
-    `expected the backgrounded descendant to have written its own pid, got ${pid}`,
+    `expected the backgrounded descendant's pid to have been recorded, got ${pid}`,
   );
   const gone = await waitUntilProcessGone(pid, 10_000);
   assert.ok(

--- a/tests/idd-critique-telemetry-hook.test.mts
+++ b/tests/idd-critique-telemetry-hook.test.mts
@@ -1,0 +1,576 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  buildCritiqueTelemetryHookPayload,
+  buildCritiqueTelemetryHookReport,
+  type CritiqueTelemetryHookPayload,
+  invokeCritiqueTelemetryHook,
+} from '../src/scripts/idd-critique-telemetry-hook.mts';
+import { stubExecutable } from './test-utils.mts';
+
+const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
+const CLI_PATH = join(REPO_ROOT, 'scripts/idd-critique-telemetry-hook.mjs');
+
+/** Run the built CLI with a fully isolated HOME, mirroring
+ * idd-critique-delegate.test.mts's runCli helper exactly (same isolation
+ * rationale: never leak the real operator's user-global config, and
+ * neutralize an inherited GITHUB_ACTIONS=true from the CI runner's own
+ * environment). */
+function runCli(
+  args: string[],
+  env?: NodeJS.ProcessEnv,
+  input?: string,
+): { stdout: string; status: number } {
+  const isolatedHome = mkdtempSync(
+    join(tmpdir(), 'idd-critique-telemetry-hook-home-'),
+  );
+  const stdout = execFileSync(process.execPath, [CLI_PATH, ...args], {
+    encoding: 'utf8',
+    timeout: 60_000,
+    input: input ?? '',
+    env: {
+      ...process.env,
+      GITHUB_ACTIONS: '',
+      ...env,
+      HOME: isolatedHome,
+      XDG_CONFIG_HOME: '',
+    },
+  });
+  return { stdout, status: 0 };
+}
+
+// buildCritiqueTelemetryHookReport: every layer combination
+// resolveEffectiveCritiqueLoopTelemetryHook already covers (#2679's
+// acceptance criteria), verified against the same fixtures
+// policy-helpers.test.mts and idd-config.test.mts already use for the
+// underlying resolver. Mirrors idd-critique-delegate.test.mts's coverage
+// style for buildCritiqueDelegateReport.
+
+test('reports usable:true, source repository-local for a configured local hook', () => {
+  const report = buildCritiqueTelemetryHookReport({
+    localConfig: {
+      critiqueLoop: { telemetryHook: { command: 'local-notify' } },
+    },
+  });
+  assert.deepEqual(report, {
+    usable: true,
+    source: 'repository-local',
+    command: 'local-notify',
+    reason: null,
+  });
+});
+
+test('reports usable:false, reason repository-local-explicit-disable for a null local hook', () => {
+  const report = buildCritiqueTelemetryHookReport({
+    localConfig: { critiqueLoop: { telemetryHook: null } },
+  });
+  assert.deepEqual(report, {
+    usable: false,
+    source: 'repository-local',
+    command: null,
+    reason: 'repository-local-explicit-disable',
+  });
+});
+
+test('a malformed repository-local hook fails closed and never inherits a configured global hook', () => {
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-critique-telemetry-hook-malformed-'),
+  );
+  const globalPath = join(sandbox, 'config.json');
+  writeFileSync(
+    globalPath,
+    JSON.stringify({
+      critiqueLoop: { telemetryHook: { command: 'global-notify' } },
+    }),
+  );
+  const report = buildCritiqueTelemetryHookReport({
+    localConfig: {
+      critiqueLoop: { telemetryHook: { command: 'x', bogus: 1 } },
+    },
+    globalConfigPath: globalPath,
+    env: {},
+  });
+  assert.deepEqual(report, {
+    usable: false,
+    source: 'repository-local',
+    command: null,
+    reason: 'invalid-repository-local-telemetry-hook',
+  });
+});
+
+test('falls back to a configured user-global hook only when local is entirely absent', () => {
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-critique-telemetry-hook-global-'),
+  );
+  const globalPath = join(sandbox, 'config.json');
+  writeFileSync(
+    globalPath,
+    JSON.stringify({
+      critiqueLoop: { telemetryHook: { command: 'global-notify' } },
+    }),
+  );
+  const report = buildCritiqueTelemetryHookReport({
+    localConfig: {},
+    globalConfigPath: globalPath,
+    env: {},
+  });
+  assert.deepEqual(report, {
+    usable: true,
+    source: 'user-global',
+    command: 'global-notify',
+    reason: null,
+  });
+});
+
+test('consults an $HOME-resolved user-global hook outside GITHUB_ACTIONS', () => {
+  const home = mkdtempSync(
+    join(tmpdir(), 'idd-critique-telemetry-hook-remote-home-'),
+  );
+  mkdirSync(join(home, '.config', 'idd-skill'), { recursive: true });
+  writeFileSync(
+    join(home, '.config', 'idd-skill', 'config.json'),
+    JSON.stringify({
+      critiqueLoop: { telemetryHook: { command: 'home-notify' } },
+    }),
+  );
+  const report = buildCritiqueTelemetryHookReport({
+    localConfig: {},
+    env: { HOME: home },
+  });
+  assert.deepEqual(report, {
+    usable: true,
+    source: 'user-global',
+    command: 'home-notify',
+    reason: null,
+  });
+});
+
+test('skips the $HOME-resolved user-global hook under GITHUB_ACTIONS=true', () => {
+  const home = mkdtempSync(
+    join(tmpdir(), 'idd-critique-telemetry-hook-remote-home-'),
+  );
+  mkdirSync(join(home, '.config', 'idd-skill'), { recursive: true });
+  writeFileSync(
+    join(home, '.config', 'idd-skill', 'config.json'),
+    JSON.stringify({
+      critiqueLoop: { telemetryHook: { command: 'home-notify' } },
+    }),
+  );
+  const report = buildCritiqueTelemetryHookReport({
+    localConfig: {},
+    env: { HOME: home, GITHUB_ACTIONS: 'true' },
+  });
+  assert.deepEqual(report, {
+    usable: false,
+    source: 'none',
+    command: null,
+    reason: 'not-configured',
+  });
+});
+
+test('skips the $HOME-resolved user-global hook when noUserGlobal is passed explicitly, outside GITHUB_ACTIONS', () => {
+  const home = mkdtempSync(
+    join(tmpdir(), 'idd-critique-telemetry-hook-remote-home-'),
+  );
+  mkdirSync(join(home, '.config', 'idd-skill'), { recursive: true });
+  writeFileSync(
+    join(home, '.config', 'idd-skill', 'config.json'),
+    JSON.stringify({
+      critiqueLoop: { telemetryHook: { command: 'home-notify' } },
+    }),
+  );
+  const report = buildCritiqueTelemetryHookReport(
+    { localConfig: {}, env: { HOME: home } },
+    true,
+  );
+  assert.deepEqual(report, {
+    usable: false,
+    source: 'none',
+    command: null,
+    reason: 'not-configured',
+  });
+});
+
+test('reports usable:false, reason not-configured when neither layer has a hook', () => {
+  const report = buildCritiqueTelemetryHookReport({
+    localConfig: {},
+    env: {},
+  });
+  assert.deepEqual(report, {
+    usable: false,
+    source: 'none',
+    command: null,
+    reason: 'not-configured',
+  });
+});
+
+test('CLI --help exits 0 and does not require config resolution', () => {
+  const output = execFileSync(process.execPath, [CLI_PATH, '--help'], {
+    encoding: 'utf8',
+    timeout: 60_000,
+  });
+  assert.match(output, /Usage:/);
+});
+
+test('CLI --policy resolves an absent local config to usable:false with an isolated HOME', () => {
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-critique-telemetry-hook-cli-'),
+  );
+  const policyPath = join(sandbox, 'config.json');
+  writeFileSync(policyPath, JSON.stringify({}));
+  const { stdout } = runCli(['--policy', policyPath]);
+  const report = JSON.parse(stdout) as {
+    usable: boolean;
+    source: string;
+    reason: string | null;
+  };
+  assert.equal(report.usable, false);
+  assert.equal(report.source, 'none');
+  assert.equal(report.reason, 'not-configured');
+});
+
+test('CLI --policy resolves a configured local hook to usable:true', () => {
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-critique-telemetry-hook-cli-local-'),
+  );
+  const policyPath = join(sandbox, 'config.json');
+  writeFileSync(
+    policyPath,
+    JSON.stringify({
+      critiqueLoop: { telemetryHook: { command: 'cli-notify' } },
+    }),
+  );
+  const { stdout } = runCli(['--policy', policyPath]);
+  assert.deepEqual(JSON.parse(stdout), {
+    usable: true,
+    source: 'repository-local',
+    command: 'cli-notify',
+    reason: null,
+  });
+});
+
+// --- buildCritiqueTelemetryHookPayload: the exact JSON shape (#2679) -----
+
+const FIXED_TIMESTAMP = '2026-09-08T12:00:00.000Z';
+
+test('buildCritiqueTelemetryHookPayload builds the full documented shape', () => {
+  const payload = buildCritiqueTelemetryHookPayload({
+    round: 2,
+    repo: 'owner/repo',
+    issue: 123,
+    pr: null,
+    findingsCount: 3,
+    severityBreakdown: { high: 1, medium: 1, low: 1 },
+    acceptedCount: 2,
+    rejectedCount: 1,
+    delegateUsed: true,
+    delegateCommand: 'coderabbit-critique',
+    timestamp: FIXED_TIMESTAMP,
+  });
+  assert.deepEqual(payload, {
+    phase: 'C',
+    round: 2,
+    repo: 'owner/repo',
+    issue: 123,
+    pr: null,
+    findingsCount: 3,
+    severityBreakdown: { high: 1, medium: 1, low: 1 },
+    acceptedCount: 2,
+    rejectedCount: 1,
+    delegateUsed: true,
+    delegateCommand: 'coderabbit-critique',
+    timestamp: FIXED_TIMESTAMP,
+  });
+});
+
+test('buildCritiqueTelemetryHookPayload defaults pr to null', () => {
+  const payload = buildCritiqueTelemetryHookPayload({
+    round: 1,
+    repo: 'owner/repo',
+    issue: 1,
+    findingsCount: 0,
+    severityBreakdown: { high: 0, medium: 0, low: 0 },
+    acceptedCount: 0,
+    rejectedCount: 0,
+    delegateUsed: false,
+    timestamp: FIXED_TIMESTAMP,
+  });
+  assert.equal(payload.pr, null);
+});
+
+test('buildCritiqueTelemetryHookPayload omits delegateCommand (not null) when delegateUsed is false', () => {
+  const payload = buildCritiqueTelemetryHookPayload({
+    round: 1,
+    repo: 'owner/repo',
+    issue: 1,
+    findingsCount: 0,
+    severityBreakdown: { high: 0, medium: 0, low: 0 },
+    acceptedCount: 0,
+    rejectedCount: 0,
+    delegateUsed: false,
+    // Deliberately supplied alongside delegateUsed: false -- must still be
+    // dropped, not merely defaulted, matching "present only when
+    // delegateUsed is true" from the issue's payload contract.
+    delegateCommand: 'must-not-appear',
+    timestamp: FIXED_TIMESTAMP,
+  });
+  assert.equal(Object.hasOwn(payload, 'delegateCommand'), false);
+});
+
+test('buildCritiqueTelemetryHookPayload includes delegateCommand only when delegateUsed is true', () => {
+  const used = buildCritiqueTelemetryHookPayload({
+    round: 1,
+    repo: 'owner/repo',
+    issue: 1,
+    findingsCount: 0,
+    severityBreakdown: { high: 0, medium: 0, low: 0 },
+    acceptedCount: 0,
+    rejectedCount: 0,
+    delegateUsed: true,
+    delegateCommand: 'coderabbit-critique',
+    timestamp: FIXED_TIMESTAMP,
+  });
+  assert.equal(Object.hasOwn(used, 'delegateCommand'), true);
+  assert.equal(used.delegateCommand, 'coderabbit-critique');
+});
+
+test('buildCritiqueTelemetryHookPayload defaults timestamp to an ISO-8601 string via the injected clock', () => {
+  const fixedNow = new Date(FIXED_TIMESTAMP);
+  const payload = buildCritiqueTelemetryHookPayload({
+    round: 1,
+    repo: 'owner/repo',
+    issue: 1,
+    findingsCount: 0,
+    severityBreakdown: { high: 0, medium: 0, low: 0 },
+    acceptedCount: 0,
+    rejectedCount: 0,
+    delegateUsed: false,
+    now: () => fixedNow,
+  });
+  assert.equal(payload.timestamp, FIXED_TIMESTAMP);
+});
+
+// --- invokeCritiqueTelemetryHook: the fire-and-forget contract (#2679) ---
+//
+// Acceptance criterion 3: "a test or fixture demonstrates that a
+// failing/absent hook command does not change C-phase control flow".
+// Every case below asserts the promise settles (never throws, never
+// rejects, never hangs past a short bound) regardless of how the spawned
+// command fails.
+
+function samplePayload(): CritiqueTelemetryHookPayload {
+  return buildCritiqueTelemetryHookPayload({
+    round: 1,
+    repo: 'owner/repo',
+    issue: 1,
+    findingsCount: 0,
+    severityBreakdown: { high: 0, medium: 0, low: 0 },
+    acceptedCount: 0,
+    rejectedCount: 0,
+    delegateUsed: false,
+    timestamp: FIXED_TIMESTAMP,
+  });
+}
+
+test('invokeCritiqueTelemetryHook is a no-op for an empty/whitespace command', async () => {
+  assert.deepEqual(await invokeCritiqueTelemetryHook('', samplePayload()), {
+    attempted: false,
+    ok: false,
+  });
+  assert.deepEqual(await invokeCritiqueTelemetryHook('   ', samplePayload()), {
+    attempted: false,
+    ok: false,
+  });
+  assert.deepEqual(await invokeCritiqueTelemetryHook(null, samplePayload()), {
+    attempted: false,
+    ok: false,
+  });
+  assert.deepEqual(
+    await invokeCritiqueTelemetryHook(undefined, samplePayload()),
+    { attempted: false, ok: false },
+  );
+});
+
+test('invokeCritiqueTelemetryHook resolves ok:false, never throws, for a command that does not exist', async () => {
+  // A generous timeoutMs here: this test asserts correctness (no throw,
+  // ok:false), not speed -- the shell's own command-not-found exit is
+  // normally fast (well under a second), but under this repository's
+  // documented heavy concurrent-session load a shell spawn/exit can be
+  // delayed well past a tight bound. The dedicated hanging-command test
+  // below is the one that specifically exercises and times the
+  // timeoutMs+kill path.
+  const result = await invokeCritiqueTelemetryHook(
+    'idd-nonexistent-telemetry-hook-2679',
+    samplePayload(),
+    { timeoutMs: 10_000 },
+  );
+  assert.equal(result.attempted, true);
+  assert.equal(result.ok, false);
+});
+
+test('invokeCritiqueTelemetryHook resolves ok:true for a command that exits 0', async () => {
+  const restore = stubExecutable('idd-telemetry-hook-ok', 'process.exit(0);\n');
+  try {
+    const result = await invokeCritiqueTelemetryHook(
+      'idd-telemetry-hook-ok',
+      samplePayload(),
+      { timeoutMs: 5_000 },
+    );
+    assert.deepEqual(result, { attempted: true, ok: true });
+  } finally {
+    restore();
+  }
+});
+
+test('invokeCritiqueTelemetryHook resolves ok:false for a command that exits non-zero', async () => {
+  const restore = stubExecutable(
+    'idd-telemetry-hook-fail',
+    'process.exit(1);\n',
+  );
+  try {
+    const result = await invokeCritiqueTelemetryHook(
+      'idd-telemetry-hook-fail',
+      samplePayload(),
+      { timeoutMs: 5_000 },
+    );
+    assert.deepEqual(result, { attempted: true, ok: false });
+  } finally {
+    restore();
+  }
+});
+
+test('invokeCritiqueTelemetryHook resolves ok:false promptly (bounded by timeoutMs) for a hanging command, instead of hanging the caller', async () => {
+  const restore = stubExecutable(
+    'idd-telemetry-hook-hang',
+    // Keep the event loop alive without ever exiting on its own.
+    'setInterval(() => {}, 1000);\n',
+  );
+  try {
+    const timeoutMs = 1_000;
+    const startedAt = Date.now();
+    const result = await invokeCritiqueTelemetryHook(
+      'idd-telemetry-hook-hang',
+      samplePayload(),
+      { timeoutMs },
+    );
+    const elapsedMs = Date.now() - startedAt;
+    assert.deepEqual(result, { attempted: true, ok: false });
+    // Generous upper bound vs. the 1s timeout -- proves the call returned
+    // because of the timeout+kill path (the stubbed command never exits on
+    // its own), not that it happened to hang until some much larger bound.
+    // Kept well above timeoutMs itself to tolerate this repository's
+    // documented heavy concurrent-session scheduling load.
+    assert.ok(
+      elapsedMs < 15_000,
+      `expected invokeCritiqueTelemetryHook to return within a bounded time of its ${timeoutMs}ms timeout, took ${elapsedMs}ms`,
+    );
+  } finally {
+    restore();
+  }
+});
+
+// --- CLI --invoke: fire-and-forget at the process boundary (#2679) -------
+//
+// The fixture acceptance criterion 3 asks for at the process-boundary
+// level, not just the function-unit level above: a caller can pipe a
+// payload into `... --invoke` and the process always exits 0 promptly,
+// whether the resolved hook succeeds, fails, or doesn't exist.
+
+test('CLI --invoke exits 0 with no output when no hook is configured', () => {
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-critique-telemetry-hook-cli-invoke-none-'),
+  );
+  const policyPath = join(sandbox, 'config.json');
+  writeFileSync(policyPath, JSON.stringify({}));
+  const { stdout } = runCli(
+    ['--policy', policyPath, '--invoke'],
+    undefined,
+    JSON.stringify(samplePayload()),
+  );
+  assert.equal(stdout, '');
+});
+
+test('CLI --invoke exits 0 promptly when the resolved hook command fails', () => {
+  const restore = stubExecutable(
+    'idd-telemetry-hook-cli-fail',
+    'process.exit(1);\n',
+  );
+  try {
+    const sandbox = mkdtempSync(
+      join(tmpdir(), 'idd-critique-telemetry-hook-cli-invoke-fail-'),
+    );
+    const policyPath = join(sandbox, 'config.json');
+    writeFileSync(
+      policyPath,
+      JSON.stringify({
+        critiqueLoop: {
+          telemetryHook: { command: 'idd-telemetry-hook-cli-fail' },
+        },
+      }),
+    );
+    const startedAt = Date.now();
+    const { stdout } = runCli(
+      ['--policy', policyPath, '--invoke'],
+      undefined,
+      JSON.stringify(samplePayload()),
+    );
+    const elapsedMs = Date.now() - startedAt;
+    assert.equal(stdout, '');
+    assert.ok(
+      elapsedMs < 30_000,
+      `expected --invoke to return promptly, took ${elapsedMs}ms`,
+    );
+  } finally {
+    restore();
+  }
+});
+
+test('CLI --invoke exits 0 when a resolved hook succeeds', () => {
+  const restore = stubExecutable(
+    'idd-telemetry-hook-cli-ok',
+    'process.exit(0);\n',
+  );
+  try {
+    const sandbox = mkdtempSync(
+      join(tmpdir(), 'idd-critique-telemetry-hook-cli-invoke-ok-'),
+    );
+    const policyPath = join(sandbox, 'config.json');
+    writeFileSync(
+      policyPath,
+      JSON.stringify({
+        critiqueLoop: {
+          telemetryHook: { command: 'idd-telemetry-hook-cli-ok' },
+        },
+      }),
+    );
+    const { stdout } = runCli(
+      ['--policy', policyPath, '--invoke'],
+      undefined,
+      JSON.stringify(samplePayload()),
+    );
+    assert.equal(stdout, '');
+  } finally {
+    restore();
+  }
+});
+
+test('CLI --invoke exits 0 without hanging when stdin carries no payload at all', () => {
+  // Distinct from the "no hook configured" case above: this exercises the
+  // bounded stdin-read timeout itself (STDIN_READ_TIMEOUT_MS) rather than
+  // an empty-but-terminated payload -- runCli's execFileSync always closes
+  // stdin after writing `input`, so an empty string here still reaches
+  // 'end' promptly; this asserts that path resolves cleanly too.
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-critique-telemetry-hook-cli-invoke-empty-'),
+  );
+  const policyPath = join(sandbox, 'config.json');
+  writeFileSync(policyPath, JSON.stringify({}));
+  const { stdout } = runCli(['--policy', policyPath, '--invoke']);
+  assert.equal(stdout, '');
+});

--- a/tests/policy-helpers.test.mts
+++ b/tests/policy-helpers.test.mts
@@ -6,12 +6,14 @@ import {
   DEFAULT_PROVIDER,
   getReviewEscalationChangesRequestedPolicy,
   inspectCritiqueLoopDelegateLayer,
+  inspectCritiqueLoopTelemetryHookLayer,
   inspectDevelopmentBranch,
   inspectProvider,
   normalizePolicyConfig,
   POLICY_DEFAULTS,
   parseIsoDurationToMs,
   resolveEffectiveCritiqueLoopDelegate,
+  resolveEffectiveCritiqueLoopTelemetryHook,
   resolveEffectiveDevelopmentBranch,
   resolveEffectiveProvider,
   selectDesyncedIndex,
@@ -836,11 +838,15 @@ test('an unrecognized mode still fails closed after the widening (#2324)', () =>
   );
 });
 
-test('critiqueLoop.telemetryHook has no normalizePolicyConfig resolution yet (schema-only, #2678)', () => {
-  // #2678 adds critiqueLoop.telemetryHook to the JSON schema only; unlike
-  // delegate, no runtime resolution/invocation logic exists yet (deferred to
-  // the roadmap's Track B). This canary pins that boundary: a future track
-  // adding real resolution must consciously update this test.
+test('critiqueLoop.telemetryHook has no normalizePolicyConfig resolution (#2679)', () => {
+  // #2679 adds a *separate* opt-in resolver for critiqueLoop.telemetryHook
+  // (inspectCritiqueLoopTelemetryHookLayer / resolveEffectiveCritiqueLoopTelemetryHook
+  // below, and resolveEffectiveCritiqueLoopTelemetryHookFromEnv in
+  // idd-config.mts) -- mirroring how critiqueLoop.delegate's own
+  // normalizePolicyConfig fail-safe (see the 'null delegate to absent' test
+  // above) stays intentionally unrelated to its own layered C1 resolver.
+  // normalizePolicyConfig itself is untouched by #2679: this canary still
+  // pins that boundary.
   assert.equal(
     Object.hasOwn(
       normalizePolicyConfig({
@@ -849,6 +855,162 @@ test('critiqueLoop.telemetryHook has no normalizePolicyConfig resolution yet (sc
       'telemetryHook',
     ),
     false,
+  );
+});
+
+// #2679: critiqueLoop.telemetryHook layer/resolver tests, mirroring every
+// critiqueLoop.delegate equivalent above (the '#2257' tests) for the
+// simpler `{ command }`-only shape (no `mode`).
+
+test('inspectCritiqueLoopTelemetryHookLayer distinguishes absent, disabled, configured, and malformed (#2679)', () => {
+  assert.deepEqual(inspectCritiqueLoopTelemetryHookLayer({}), {
+    status: 'absent',
+  });
+  assert.deepEqual(
+    inspectCritiqueLoopTelemetryHookLayer({
+      critiqueLoop: { telemetryHook: null },
+    }),
+    { status: 'disabled' },
+  );
+  assert.deepEqual(
+    inspectCritiqueLoopTelemetryHookLayer({
+      critiqueLoop: { telemetryHook: { command: 'notify-critique' } },
+    }),
+    {
+      status: 'configured',
+      hook: { command: 'notify-critique' },
+    },
+  );
+  assert.deepEqual(
+    inspectCritiqueLoopTelemetryHookLayer({
+      critiqueLoop: { telemetryHook: { command: 'notify-critique', bogus: 1 } },
+    }),
+    {
+      status: 'malformed',
+      reason: 'invalid-repository-local-telemetry-hook',
+    },
+  );
+});
+
+test('inspectCritiqueLoopTelemetryHookLayer fails safe to absent on a missing or empty command (#2679)', () => {
+  assert.deepEqual(
+    inspectCritiqueLoopTelemetryHookLayer({
+      critiqueLoop: { telemetryHook: {} },
+    }),
+    { status: 'malformed', reason: 'invalid-repository-local-telemetry-hook' },
+  );
+  assert.deepEqual(
+    inspectCritiqueLoopTelemetryHookLayer({
+      critiqueLoop: { telemetryHook: { command: '' } },
+    }),
+    { status: 'malformed', reason: 'invalid-repository-local-telemetry-hook' },
+  );
+  assert.deepEqual(
+    inspectCritiqueLoopTelemetryHookLayer({
+      critiqueLoop: { telemetryHook: { command: '   ' } },
+    }),
+    { status: 'malformed', reason: 'invalid-repository-local-telemetry-hook' },
+  );
+});
+
+test('inspectCritiqueLoopTelemetryHookLayer fails safe to malformed on an inherited (non-own) command property (#2679)', () => {
+  const inherited = Object.create({ command: 'inherited-hook' });
+  assert.deepEqual(
+    inspectCritiqueLoopTelemetryHookLayer({
+      critiqueLoop: { telemetryHook: inherited },
+    }),
+    { status: 'malformed', reason: 'invalid-repository-local-telemetry-hook' },
+  );
+});
+
+test('resolveEffectiveCritiqueLoopTelemetryHook prefers a local object over a global object (#2679)', () => {
+  const result = resolveEffectiveCritiqueLoopTelemetryHook({
+    localConfig: {
+      critiqueLoop: { telemetryHook: { command: 'local-hook' } },
+    },
+    globalConfig: {
+      critiqueLoop: { telemetryHook: { command: 'global-hook' } },
+    },
+  });
+  assert.deepEqual(result, {
+    status: 'local',
+    source: 'repository-local',
+    hook: { command: 'local-hook' },
+  });
+});
+
+test('resolveEffectiveCritiqueLoopTelemetryHook honors local JSON null over a valid global object (#2679)', () => {
+  const result = resolveEffectiveCritiqueLoopTelemetryHook({
+    localConfig: { critiqueLoop: { telemetryHook: null } },
+    globalConfig: {
+      critiqueLoop: { telemetryHook: { command: 'global-hook' } },
+    },
+  });
+  assert.deepEqual(result, {
+    status: 'disabled',
+    source: 'repository-local',
+  });
+});
+
+test('resolveEffectiveCritiqueLoopTelemetryHook inherits a global object when local is absent (#2679)', () => {
+  const result = resolveEffectiveCritiqueLoopTelemetryHook({
+    localConfig: {},
+    globalConfig: {
+      mergePolicy: 'must-not-leak',
+      critiqueLoop: { telemetryHook: { command: 'global-hook' } },
+    },
+  });
+  assert.deepEqual(result, {
+    status: 'global',
+    source: 'user-global',
+    hook: { command: 'global-hook' },
+  });
+});
+
+test('resolveEffectiveCritiqueLoopTelemetryHook fails closed on a malformed local hook (#2679)', () => {
+  const result = resolveEffectiveCritiqueLoopTelemetryHook({
+    localConfig: {
+      critiqueLoop: { telemetryHook: { command: 'local-hook', bogus: 1 } },
+    },
+    globalConfig: {
+      critiqueLoop: { telemetryHook: { command: 'global-hook' } },
+    },
+  });
+  assert.deepEqual(result, {
+    status: 'local-malformed',
+    source: 'repository-local',
+    reason: 'invalid-repository-local-telemetry-hook',
+  });
+});
+
+test('resolveEffectiveCritiqueLoopTelemetryHook fails closed on a non-object local critiqueLoop (#2679)', () => {
+  const result = resolveEffectiveCritiqueLoopTelemetryHook({
+    localConfig: { critiqueLoop: 'not-an-object' },
+    globalConfig: {
+      critiqueLoop: { telemetryHook: { command: 'global-hook' } },
+    },
+  });
+  assert.deepEqual(result, {
+    status: 'local-malformed',
+    source: 'repository-local',
+    reason: 'invalid-repository-local-telemetry-hook',
+  });
+});
+
+test('resolveEffectiveCritiqueLoopTelemetryHook treats a malformed global fragment as absent (#2679)', () => {
+  const result = resolveEffectiveCritiqueLoopTelemetryHook({
+    localConfig: {},
+    globalConfig: {
+      critiqueLoop: { telemetryHook: { command: 'global-hook', bogus: 1 } },
+    },
+  });
+  assert.deepEqual(result, { status: 'none', source: 'none' });
+});
+
+test('resolveEffectiveCritiqueLoopTelemetryHook returns none when both layers are absent (#2679)', () => {
+  assert.deepEqual(
+    resolveEffectiveCritiqueLoopTelemetryHook({ localConfig: {} }),
+    { status: 'none', source: 'none' },
   );
 });
 


### PR DESCRIPTION
# Summary

Adds resolution and fire-and-forget invocation for the
`critiqueLoop.telemetryHook` config field #2678 added to the schema,
mirroring `critiqueLoop.delegate`'s layered repo-local-then-user-global
resolution order exactly, and documents invoking it from the C-phase
loop at C2's zero-issue exit and C4's Accept/Reject decision point.

- New `inspectCritiqueLoopTelemetryHookLayer` /
  `resolveEffectiveCritiqueLoopTelemetryHook` (`policy-helpers.mts`) and
  `resolveEffectiveCritiqueLoopTelemetryHookFromEnv` (`idd-config.mts`),
  reusing the existing `resolveUserGlobalConfigPath` /
  `loadUserGlobalPolicyDocument` primitives rather than duplicating that
  logic. Repo-local always wins outright (a configured object, an
  explicit `null` disable, or a malformed value never inherits global);
  only when repo-local is entirely absent does the user-global fragment
  apply.
- New sibling module `idd-critique-telemetry-hook.mts` (matching
  `idd-critique-delegate.mts`'s shape: typed report interface,
  `build*Report`, thin CLI), plus the invocation half the delegate
  helper has no equivalent for, since this hook's entire contract is
  "never blocks, holds, or delays C-phase control flow":
  `buildCritiqueTelemetryHookPayload` (the documented JSON stdin shape)
  and `invokeCritiqueTelemetryHook` (spawns the resolved command
  detached, with error handlers on both the child and its stdin stream
  so an early-exiting child's async EPIPE can't throw, never rejects).
  A JS-level timeout + `SIGKILL` bounds an awaited caller (every test
  in this file); a detached, self-contained shell watchdog
  independently enforces the same deadline for the CLI's fire-and-forget
  `--invoke` mode, which never awaits the hook and exits as soon as the
  payload has reached its stdin (not once the hook itself finishes) --
  see the PR discussion for the review rounds that shaped this
  (process-group kills, watchdog disarming for awaited callers,
  stdin-delivery timing, and its documented residual for `--invoke`,
  which is called out as a follow-up below).
- `idd-template/.github/instructions/idd-work.instructions.md` (the
  template source; regenerated into the `.github/instructions/` copy
  via `sync-docs.mjs --apply`) documents the hook at both required
  invocation points with an explicit fire-and-forget statement,
  contrasting with `critiqueLoop.delegate`'s fail-closed hold.
- `docs/idd-workflow.md` (both the source-repo copy and the
  `idd-template` copy — this file syncs in `structure` mode, so its
  heading text matches while body prose diverges the way the rest of
  the file already does) gains matching "Repository-configurable
  critique telemetry hook" / "User-global critique telemetry hook
  default" sections carrying the full JSON example and the same
  executable-configuration security warning `critiqueLoop.delegate`
  already states, extended to the telemetry hook.
- `docs/idd-helper-scripts.md` gains a matching "Effective C-phase
  critique telemetry hook" section for the new CLI.
- `schemas/policy.schema.json`'s `telemetryHook.description` no longer
  says "not currently invoked ... see the roadmap's Track B" (now
  stale).

## Linked issue

Closes #2679

## Follow-up issues (if any)

- [ ] none directly filed by this session (per
  `idd-work.instructions.md`'s "do not call `gh issue create`"
  constraint) — two gaps identified during this work that a future
  session may want to pick up:
  - `idd-template/.github/instructions/lite/idd-work-lite.instructions.md`
    (the weak-model condensed C-phase profile) does not document
    `critiqueLoop.telemetryHook` at all. No acceptance criterion or
    automated parity check required it here, and the issue's own
    candidate files never named it, so it was left out of scope
    deliberately rather than silently expanded.
  - `docs/customization.md` and `docs/policy-constants.md` document
    `critiqueLoop.delegate` in their settings tables but were not
    extended with a `critiqueLoop.telemetryHook` row; no completeness
    test ties every schema `critiqueLoop.*` key to a docs-table row,
    and the issue's candidate files didn't name these either.
  - `invokeCritiqueTelemetryHook`'s watchdog-cancellation fix
    (review round 3) only disarms the watchdog for a caller that
    awaits the returned promise; the CLI's `--invoke` mode never does
    (it calls `process.exit(0)` before the hook's own `child` can
    plausibly emit `'exit'` in-process), so on that primary path the
    watchdog stays armed for the full `timeoutMs` after the hook
    settles, unchanged. Closing that residual for real needs a
    supervisor living entirely outside this Node process (one
    self-contained shell script that spawns the hook, waits on it,
    and only then kills its own watchdog subshell) — considered and
    not taken in this PR: it must background the hook inside a
    non-interactive shell, whose async-list semantics silently
    redirect the backgrounded job's stdin to `/dev/null` unless
    explicitly worked around (breaking this hook's payload delivery),
    and it loses the ability to target its own process group with
    `kill -9 -$p` once it is not a job-control group leader either —
    a correctness trap, not just more moving parts, that none of this
    PR's tests would catch. The residual this leaves is bounded: a
    recycled pid/pgid would need the *entire* original process group
    to exit and be reaped, then a full `pid_max` wrap, then the new
    holder to call `setsid`/`setpgid`, all inside the default 5s
    `timeoutMs` window — against a documented best-effort,
    fire-and-forget side channel that already carries its own
    executable-configuration security warning.

## Background / rationale (if material)

**Bundle-budget ratchet bump** (`audit/sync-manifest.json`
`bundleBudgets`): raised `bundle-work`'s `limitBytes` `49500 → 52000`.
Baseline utilization was already 97.95% (48485/49500 bytes — only 25
bytes below the 98% `context-ceiling-200k` error threshold) before this
change, so even the aggressively-trimmed addition the acceptance
criteria require (documenting both invocation points, the payload
shape, and fire-and-forget semantics directly in
`idd-work.instructions.md`) could not fit without a bump. The addition
was cut from an initial ~2.1 KB draft to ~0.6 KB net — the literal JSON
payload example and full resolution-order prose were split out into
`docs/idd-workflow.md` (unbudgeted) instead of being duplicated in the
byte-constrained file, which keeps only a field-name enumeration and
the two "Telemetry hook" invocation notes. This lands at 49315 bytes
(94.8% of the new 52000 limit), clearing both the 98% error and 95%
notice thresholds. `docs/policy-constants.md`'s "Bundle-budget growth"
near-ceiling exception normally prefers trimming over a bump at this
utilization; the trim was applied first, and the residual is the
acceptance-criteria floor for what must live in this specific file.
The exception's own stated rationale — protecting the always-resident
`bundle-review`/`bundle-merge` floor for small-context F-phase
sessions — does not apply here: `bundle-work` loads only during B/C
work, never at F-phase.

**Why a new sibling module instead of extending
`idd-critique-delegate.mts`**: the issue explicitly offered both
options ("keeps `idd-critique-delegate.mts`'s existing single-purpose
identity intact"). The telemetry hook's structurally simpler `{
command }`-only shape (no `mode`) and its fire-and-forget invocation
code (which the delegate module has no equivalent for at all) made a
sibling module the cleaner fit.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [x] Config schema changed
- [x] Security / credential / merge behavior changed — adds a new
      opt-in, off-by-default executable-configuration surface (a
      per-round hook command an operator may configure); carries the
      same security warning `critiqueLoop.delegate` already states.
      No change to merge gates, required checks, or the C-phase
      objective diff validation floor.

## Verification

- [x] `pnpm lint` (`biome check`; only pre-existing, unrelated
      warnings in `marker-helpers`/`protocol-helpers` remain, confirmed
      present on `main` before this branch)
- [x] `pnpm test` (`node --test tests/*.test.mts`; 5286/5286 pass)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (`sync-docs.mjs --apply` regenerated
      the mirrored copies; `audit-docs.mjs --check` confirms no drift)
- [x] `node scripts/idd-doctor.mjs` (passes; 2 pre-existing
      environment-level warnings unrelated to this diff)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none — this surface never touches
      merge gates or required checks)
- [x] Context budget impact reviewed (see the bundle-budget ratchet
      callout above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jz9naVhMefTusdLL9FzLc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional critique-loop telemetry hooks for zero-finding exits and completed critique rounds.
  - Added a command-line helper to inspect configuration and invoke hooks asynchronously.
  - Supports repository-local settings, user-global fallback, explicit disabling, payload reporting, and safe timeout/failure handling.

- **Documentation**
  - Documented configuration, payload contents, precedence rules, invocation behavior, and failure handling.

- **Tests**
  - Added comprehensive coverage for configuration resolution, payload creation, invocation, timeouts, and CLI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

