### PR TITLE
docs(customization): document guard, sweep helper, coderabbit snippet

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -36,7 +36,7 @@ behavior change too.
 | Issue scope                         | Roadmap-first discovery (roadmap path first, orphan fallback)                                                                                                                                                                                                                                                                                                                                                                                                                             | Default is `roadmap-first`. Set `issue-scope` to `roadmap` for strict roadmap-only discovery (no orphan fallback), or to `orphan-first` when unblocked orphan issues should be considered before roadmap traversal.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | Orphan-first approval               | No extra gate beyond orphan readiness checks                                                                                                                                                                                                                                                                                                                                                                                                                                              | Keep `orphan-first-policy` as `none`, or opt in to `maintainer-approved` or `public-disabled` when public or community-submitted issues need an explicit maintainer approval layer before A0-O can select them.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | Issue-author approval               | Secure-by-default target contract; unattended work needs a self-authorizing issue author or explicit approval unless the repository opts out                                                                                                                                                                                                                                                                                                                                              | Record the gate decision, approval actors, freshness rule, approval signals, and opt-out semantics in repository-local policy docs and onboarding. Keep this contract aligned with the discovery/claim behavior that already ships, and update both surfaces together if local policy changes later.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| IDD label names                     | `roadmap`, `status:blocked-by-human`, and `status:needs-decision` drive roadmap identification, human-gate holds, and decision holds. A semantic issue auto-labeler (for example CodeRabbit's issue enrichment) can auto-apply any of these three label names to an ordinary issue with no error — silently dropping it from execution candidates or parking it behind a hold — and omitting a label from the labeler's own instruction list does not restrict which labels it may apply. | Configure `labels.roadmapLabelName`, `labels.blockedByHumanLabelName`, and `labels.needsDecisionLabelName` in `.github/idd/config.json` when the repository already uses a different label taxonomy for these three roles. Migration note: when renaming an existing label, first create the new label and apply it alongside the old one on the affected open issues, then update the config value, then delete the old label — discovery and triage then never pass through a window where hold labels stop matching; keep all three configured labels present in the repository afterward. If the repository runs a semantic issue auto-labeler, adopt the [reserved-label guard recipe](#reserved-label-guard-recipe) below to stop it from applying these labels.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| IDD label names                     | `roadmap`, `status:blocked-by-human`, and `status:needs-decision` drive roadmap identification, human-gate holds, and decision holds. A semantic issue auto-labeler (for example CodeRabbit's issue enrichment) can auto-apply any of these three label names to an ordinary issue with no error — silently dropping it from execution candidates or parking it behind a hold — and omitting a label from the labeler's own instruction list does not restrict which labels it may apply. | Configure `labels.roadmapLabelName`, `labels.blockedByHumanLabelName`, and `labels.needsDecisionLabelName` in `.github/idd/config.json` when the repository already uses a different label taxonomy for these three roles. Migration note: when renaming an existing label, first create the new label and apply it alongside the old one on the affected open issues, then update the config value, then delete the old label — discovery and triage then never pass through a window where hold labels stop matching; keep all three configured labels present in the repository afterward. If the repository runs a semantic issue auto-labeler, adopt the [reserved-label guard recipe](#reserved-label-guard-recipe) below — generated from a declared `labels.untrustedLabelerLogins` list when a helper runtime is available, or copied and hand-substituted otherwise — to stop it from applying these labels.                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 | Issue authoring guard               | The configured authoring label is both the draft marker for a held issue and the claim-suppression lock Discover enforces; Discover skips issues carrying it and warns when that label appears stale                                                                                                                                                                                                                                                                                      | Configure `issueAuthoring.authoringLabelName` and `issueAuthoring.authoringStaleAge` in `.github/idd/config.json` when local label naming or timing differs from the distributed defaults. Keep the label available in the target repository and keep `authoringStaleAge` less than `claimTiming.staleAge`; see [IDD policy constants](policy-constants.md#issue-authoring-defaults).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | Workshop example repo               | `idd-doctor` checks that the example repository's README back-links to this repo's `docs/workshop/`                                                                                                                                                                                                                                                                                                                                                                                       | Set `workshop.exampleRepository` in `.github/idd/config.json` to `"<owner>/<repo>"` when this repository publishes a workshop and an external example repository should back-link to it. Leave the field empty / unset to skip the check (default for adopter repos that have not published a workshop).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | Worktree guard                      | Advisory only by default — `idd-doctor` warns on a primary-worktree implementation-branch HEAD but nothing blocks the commit, push, or merge                                                                                                                                                                                                                                                                                                                                              | Opt in by setting `worktreeGuard.enabled: true` in `.github/idd/config.json`; `idd-doctor` then enforces the same as its `--strict` flag would, so a primary-worktree `issue/*` / `roadmap-audit/*` HEAD fails outright instead of only warning. Pair it with the local git hook activation steps in [IDD template onboarding](https://github.com/kurone-kito/idd-skill/blob/main/idd-template/ONBOARDING.md#optional--enable-the-local-worktree-guard) for pre-commit/pre-push enforcement — including its [hook-manager coexistence guidance](https://github.com/kurone-kito/idd-skill/blob/main/idd-template/docs/onboarding/optional-host-setup.md#coexisting-with-an-existing-hook-manager) for a repository where an existing hook manager already owns `core.hooksPath`. Override `worktreeGuard.branchPatterns` to change which branch globs count as implementation branches (default `issue/*`, `roadmap-audit/*`). Absent or `false` keeps the historical advisory-only behavior.                                                                                                                                                                                                                                                                                                                                                                              |
@@ -893,7 +893,51 @@ your own repository below) guards against this with
 `.github/workflows/strip-untrusted-labels.yml`: a same-event
 `issues: labeled` / `pull_request_target: labeled` handler that removes
 a reserved label the instant a configured untrusted actor applies it.
-The recipe below adapts that workflow for adopters. Save it as
+Two paths produce this file for your own repository, below.
+
+### Preferred: generated guard (helper runtime available)
+
+When a helper runtime is available (see the "Helper runtime" row in the
+table above, and
+[IDD helper script evaluation](idd-helper-scripts.md#import-time-selection-order)),
+generate the guard from your own declared configuration instead of
+hand-copying a placeholder recipe:
+
+1. Populate `labels.untrustedLabelerLogins` in `.github/idd/config.json`
+   with the login(s) of whichever semantic issue auto-labeler(s) this
+   repository actually runs. The
+   [Untrusted-labeler login sweep](idd-helper-scripts.md#untrusted-labeler-login-sweep)
+   helper automates the full-history detection technique the manual
+   recipe below documents in prose — run it and filter its output down
+   to the actor(s) recognized as untrusted, excluding any bot already
+   trusted to apply these labels on purpose (for example this
+   repository's own IDD or CI automation).
+2. Run the `idd-onboard` CLI's `--substitute` stage (already part of
+   normal onboarding/re-onboarding; see
+   [IDD template onboarding](https://github.com/kurone-kito/idd-skill/blob/main/idd-template/ONBOARDING.md#cli-assisted-onboarding)):
+   `node scripts/idd-onboard.mjs --substitute --target <target-dir>`.
+   It reads this repository's own configured (or defaulted)
+   `labels.roadmapLabelName` / `labels.blockedByHumanLabelName` /
+   `labels.needsDecisionLabelName` and the declared logins, then writes
+   `.github/workflows/strip-untrusted-labels.yml` with the same trust
+   model documented below (least-privilege `permissions:`, no
+   checkout, `pull_request_target` for the PR branch,
+   `runs-on: ubuntu-latest`). An absent or empty
+   `labels.untrustedLabelerLogins` writes nothing and does not fail
+   (opt-in, not opt-out).
+
+**Scope limit.** The generator covers only the three base labels above.
+A repository that also wants `issueAuthoring.authoringLabelName`
+covered, or the broader shared-prefix form described in the Fallback
+subsection below, has no generated equivalent yet — use the manual
+recipe for that extension instead. Re-running `--substitute` also regenerates
+the file from the current configuration every time, overwriting any
+hand-edit previously made to a generated copy.
+
+### Fallback: manual recipe (`instructions-only` profile, or extended coverage)
+
+Without a helper runtime — or when the scope limit above applies — copy
+the recipe by hand. Save it as
 `.github/workflows/strip-untrusted-labels.yml` and substitute every
 `<...>` placeholder before use:
 
@@ -1056,8 +1100,41 @@ actually runs. A shipped file carrying this source repository's own
 values would silently protect the wrong labels or actors for any
 adopter who configured `labels.*` or runs a different labeler — worse
 than no file, since its presence could be mistaken for coverage it does
-not actually provide. Copy the recipe above and substitute the
-placeholders instead.
+not actually provide. This is why the file is never a static template
+asset either way: the generated path above resolves these same
+per-adopter values from `.github/idd/config.json` at onboarding time
+instead of shipping them pre-filled, and the manual path asks you to
+substitute them by hand.
+
+### Advisory: `.coderabbit.yaml` snippet
+
+Adopters who use CodeRabbit specifically can additionally scope its
+issue auto-labeling away from the reserved label names, mirroring the
+snippet this source repository's own `.coderabbit.yaml` carries:
+
+```yaml
+issue_enrichment:
+  labeling:
+    # Scope issue auto-labeling to content labels only. `<roadmap-label-name>`
+    # (and any other configured reserved IDD label name) is intentionally
+    # left out of the list below — this is hygiene, not a restriction: it
+    # does not stop CodeRabbit's own auto-labeling heuristic from applying
+    # that label anyway. Keep the CI guard above in place regardless.
+    auto_apply_labels: true
+    labeling_instructions:
+      # ... your own content-label entries; omit every reserved IDD label
+      # name from this list.
+```
+
+**This is hygiene alongside the CI guard above, never a substitute for
+it.** Per the risk prose earlier in this section and
+[IDD label names](https://github.com/kurone-kito/idd-skill/blob/main/idd-template/docs/onboarding/policy-decisions.md#idd-label-names)'s
+"omitting a label from the labeler's instructions is not a restriction"
+point: leaving a label out of `labeling_instructions` only tells
+CodeRabbit which labels its content-labeling feature is configured to
+consider — it does not stop CodeRabbit's own auto-labeling heuristic
+from applying that label anyway. Keep the generated or manual CI guard
+above in place regardless of whether this snippet is adopted.
 
 ## Issue Scope
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -915,7 +915,20 @@ hand-copying a placeholder recipe:
 2. Run the `idd-onboard` CLI's `--substitute` stage (already part of
    normal onboarding/re-onboarding; see
    [IDD template onboarding](https://github.com/kurone-kito/idd-skill/blob/main/idd-template/ONBOARDING.md#cli-assisted-onboarding)):
-   `node scripts/idd-onboard.mjs --substitute --target <target-dir>`.
+
+   ```sh
+   node scripts/idd-onboard.mjs --substitute --target <target-dir>
+   ```
+
+   **This path requires a local `kurone-kito/idd-skill` clone**
+   (`scripts/idd-onboard.mjs` runs from that clone, not from an
+   installed helper package) — `idd-onboard` is not part of the
+   `package-manager` / `ephemeral-npx` helper command catalog
+   documented in
+   [IDD helper script evaluation](idd-helper-scripts.md), unlike the
+   sweep helper in step 1. Without a local clone available, use the
+   manual recipe below instead.
+
    It reads this repository's own configured (or defaulted)
    `labels.roadmapLabelName` / `labels.blockedByHumanLabelName` /
    `labels.needsDecisionLabelName` and the declared logins, then writes

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -928,7 +928,7 @@ hand-copying a placeholder recipe:
    package-manager or `npx` form for it. Without a local clone
    available, use the manual recipe below instead.
 
-   It reads this repository's own configured (or defaulted)
+   It reads the target repository's own configured (or defaulted)
    `labels.roadmapLabelName` / `labels.blockedByHumanLabelName` /
    `labels.needsDecisionLabelName` and the declared logins, then writes
    `.github/workflows/strip-untrusted-labels.yml` with the same trust

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -926,6 +926,18 @@ hand-copying a placeholder recipe:
    `labels.untrustedLabelerLogins` writes nothing and does not fail
    (opt-in, not opt-out).
 
+**Ordering matters.** `labels.untrustedLabelerLogins` is neither one of
+the seven `--hear`-derived onboarding placeholders nor a field
+`--record-policy` writes, so a fresh CLI-assisted run's Step 4
+`--substitute` sees it only if step 1 above already wrote it into
+`.github/idd/config.json` by hand first — confirming the item during
+Step 1B's hearing alone does not populate it, and no CLI stage
+populates it for you. Add the list to `.github/idd/config.json`
+yourself before running `--substitute`, or rerun `--substitute` after
+adding it to an already-onboarded repository's config; either way,
+`--substitute` is always safe to rerun (see the Scope limit note
+above).
+
 **Scope limit.** The generator covers only the three base labels above.
 A repository that also wants `issueAuthoring.authoringLabelName`
 covered, or the broader shared-prefix form described in the Fallback

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -917,7 +917,8 @@ hand-copying a placeholder recipe:
    [IDD template onboarding](https://github.com/kurone-kito/idd-skill/blob/main/idd-template/ONBOARDING.md#cli-assisted-onboarding)):
 
    ```sh
-   node scripts/idd-onboard.mjs --substitute --target <target-dir>
+   node scripts/idd-onboard.mjs --substitute --target <target-dir> \
+     --allow-root <target-dir>
    ```
 
    **The supported invocation runs from a local
@@ -926,7 +927,11 @@ hand-copying a placeholder recipe:
    [IDD helper script evaluation](idd-helper-scripts.md), unlike the
    sweep helper in step 1, so this document does not offer a
    package-manager or `npx` form for it. Without a local clone
-   available, use the manual recipe below instead.
+   available, use the manual recipe below instead. `--target` is
+   confined to the current working directory (or an `--allow-root`
+   boundary); when `<target-dir>` is a separate adopter checkout
+   outside the clone, `--allow-root <target-dir>` widens the confined
+   root so the command doesn't exit before generating the guard.
 
    It reads the target repository's own configured (or defaulted)
    `labels.roadmapLabelName` / `labels.blockedByHumanLabelName` /

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -920,14 +920,13 @@ hand-copying a placeholder recipe:
    node scripts/idd-onboard.mjs --substitute --target <target-dir>
    ```
 
-   **This path requires a local `kurone-kito/idd-skill` clone**
-   (`scripts/idd-onboard.mjs` runs from that clone, not from an
-   installed helper package) — `idd-onboard` is not part of the
-   `package-manager` / `ephemeral-npx` helper command catalog
-   documented in
+   **The supported invocation runs from a local
+   `kurone-kito/idd-skill` clone** — `idd-onboard` is not a cataloged
+   `package-manager` / `ephemeral-npx` helper command in
    [IDD helper script evaluation](idd-helper-scripts.md), unlike the
-   sweep helper in step 1. Without a local clone available, use the
-   manual recipe below instead.
+   sweep helper in step 1, so this document does not offer a
+   package-manager or `npx` form for it. Without a local clone
+   available, use the manual recipe below instead.
 
    It reads this repository's own configured (or defaulted)
    `labels.roadmapLabelName` / `labels.blockedByHumanLabelName` /

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -922,9 +922,12 @@ hand-copying a placeholder recipe:
    `.github/workflows/strip-untrusted-labels.yml` with the same trust
    model documented below (least-privilege `permissions:`, no
    checkout, `pull_request_target` for the PR branch,
-   `runs-on: ubuntu-latest`). An absent or empty
-   `labels.untrustedLabelerLogins` writes nothing and does not fail
-   (opt-in, not opt-out).
+   `runs-on: ubuntu-latest`). An absent `labels.untrustedLabelerLogins`
+   writes nothing and does not fail (opt-in, not opt-out) — **omit the
+   key entirely** rather than setting it to `[]`: the policy schema
+   requires at least one entry (`minItems: 1`), so an explicit empty
+   array fails live-config schema validation (for example
+   `idd-doctor`) even though `--substitute` itself tolerates it.
 
 **Ordering matters.** `labels.untrustedLabelerLogins` is neither one of
 the seven `--hear`-derived onboarding placeholders nor a field
@@ -944,7 +947,13 @@ covered, or the broader shared-prefix form described in the Fallback
 subsection below, has no generated equivalent yet — use the manual
 recipe for that extension instead. Re-running `--substitute` also regenerates
 the file from the current configuration every time, overwriting any
-hand-edit previously made to a generated copy.
+hand-edit previously made to a generated copy — but only ever writes or
+leaves the file unchanged, never deletes it: removing
+`labels.untrustedLabelerLogins` from the configuration and rerunning
+`--substitute` does **not** delete a previously generated
+`.github/workflows/strip-untrusted-labels.yml`. Delete that file by
+hand when disabling the guard this way, or the old actor list keeps
+stripping labels despite the current configuration.
 
 ### Fallback: manual recipe (`instructions-only` profile, or extended coverage)
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1109,8 +1109,9 @@ substitute them by hand.
 ### Advisory: `.coderabbit.yaml` snippet
 
 Adopters who use CodeRabbit specifically can additionally scope its
-issue auto-labeling away from the reserved label names, mirroring the
-snippet this source repository's own `.coderabbit.yaml` carries:
+issue auto-labeling away from the reserved label names, adapted from
+this source repository's own `.coderabbit.yaml` snippet with an added
+non-sufficiency caveat that file's own comment does not yet carry:
 
 ```yaml
 issue_enrichment:

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -3139,11 +3139,15 @@ same as `AW4`/`AW5`.
 - **Read-only, unconditionally**: performs no write operation of any
   kind — no `.github/idd/config.json` edit, no GitHub mutation (no
   label change, no comment, no other write call). It only proposes
-  candidates for a human to review; adding an accepted candidate's
-  login as one of the [Reserved-label guard recipe](customization.md#reserved-label-guard-recipe)'s
-  `<labeler-bot-login-N>` placeholders in
-  `strip-untrusted-labels.yml` stays a manual, adopter-owned edit
-  after judging each candidate's event count. Not a phase step in any
+  candidates for a human to review; recording an accepted candidate's
+  login stays a manual, adopter-owned edit after judging each
+  candidate's event count. Add it to `labels.untrustedLabelerLogins` in
+  `.github/idd/config.json` and (re-)run `idd-onboard --substitute` to
+  generate `strip-untrusted-labels.yml`, or add it as one of the
+  [Reserved-label guard recipe](customization.md#reserved-label-guard-recipe)'s
+  `<labeler-bot-login-N>` placeholders when following that recipe's
+  manual fallback instead — see that recipe for when each path applies.
+  Not a phase step in any
   `idd-*.instructions.md` file — like the Merged-PR feedback sweep
   above, this is a manually-invoked, operator-run spot-check, run once
   when first building the reserved-label guard's bot-login list and

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -3142,11 +3142,13 @@ same as `AW4`/`AW5`.
   candidates for a human to review; recording an accepted candidate's
   login stays a manual, adopter-owned edit after judging each
   candidate's event count. Add it to `labels.untrustedLabelerLogins` in
-  `.github/idd/config.json` and (re-)run `idd-onboard --substitute` to
-  generate `strip-untrusted-labels.yml`, or add it as one of the
+  `.github/idd/config.json` and (re-)run the `idd-onboard` CLI's
+  `--substitute` stage to generate `strip-untrusted-labels.yml` (see the
   [Reserved-label guard recipe](customization.md#reserved-label-guard-recipe)'s
-  `<labeler-bot-login-N>` placeholders when following that recipe's
-  manual fallback instead — see that recipe for when each path applies.
+  "Preferred: generated guard" path for the exact invocation), or add it
+  as one of that recipe's `<labeler-bot-login-N>` placeholders when
+  following that recipe's manual fallback instead — see that recipe for
+  when each path applies.
   Not a phase step in any
   `idd-*.instructions.md` file — like the Merged-PR feedback sweep
   above, this is a manually-invoked, operator-run spot-check, run once

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -491,7 +491,10 @@ require explicit operator confirmation:
     three configured label names to an ordinary issue with no error,
     dropping it from execution candidates or parking it behind a hold;
     omitting a label from the labeler's own instruction list does not
-    restrict which labels it may apply. See
+    restrict which labels it may apply. When that risk applies, also
+    confirm `labels.untrustedLabelerLogins`: declaring it lets a helper
+    runtime generate the matching guard workflow automatically instead
+    of requiring the manual recipe. See
     [IDD label names](docs/onboarding/policy-decisions.md#idd-label-names)
     for the field evidence and the guard recipe.
 13. up-to-date-head ruleset check

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -36,7 +36,7 @@ behavior change too.
 | Issue scope                         | Roadmap-first discovery (roadmap path first, orphan fallback)                                                                                                                                                                                                                                                                                                                                                                                                                             | Default is `roadmap-first`. Set `issue-scope` to `roadmap` for strict roadmap-only discovery (no orphan fallback), or to `orphan-first` when unblocked orphan issues should be considered before roadmap traversal.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | Orphan-first approval               | No extra gate beyond orphan readiness checks                                                                                                                                                                                                                                                                                                                                                                                                                                              | Keep `orphan-first-policy` as `none`, or opt in to `maintainer-approved` or `public-disabled` when public or community-submitted issues need an explicit maintainer approval layer before A0-O can select them.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | Issue-author approval               | Secure-by-default target contract; unattended work needs a self-authorizing issue author or explicit approval unless the repository opts out                                                                                                                                                                                                                                                                                                                                              | Record the gate decision, approval actors, freshness rule, approval signals, and opt-out semantics in repository-local policy docs and onboarding. Keep this contract aligned with the discovery/claim behavior that already ships, and update both surfaces together if local policy changes later.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| IDD label names                     | `roadmap`, `status:blocked-by-human`, and `status:needs-decision` drive roadmap identification, human-gate holds, and decision holds. A semantic issue auto-labeler (for example CodeRabbit's issue enrichment) can auto-apply any of these three label names to an ordinary issue with no error — silently dropping it from execution candidates or parking it behind a hold — and omitting a label from the labeler's own instruction list does not restrict which labels it may apply. | Configure `labels.roadmapLabelName`, `labels.blockedByHumanLabelName`, and `labels.needsDecisionLabelName` in `.github/idd/config.json` when the repository already uses a different label taxonomy for these three roles. Migration note: when renaming an existing label, first create the new label and apply it alongside the old one on the affected open issues, then update the config value, then delete the old label — discovery and triage then never pass through a window where hold labels stop matching; keep all three configured labels present in the repository afterward. If the repository runs a semantic issue auto-labeler, adopt the [reserved-label guard recipe](#reserved-label-guard-recipe) below to stop it from applying these labels.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| IDD label names                     | `roadmap`, `status:blocked-by-human`, and `status:needs-decision` drive roadmap identification, human-gate holds, and decision holds. A semantic issue auto-labeler (for example CodeRabbit's issue enrichment) can auto-apply any of these three label names to an ordinary issue with no error — silently dropping it from execution candidates or parking it behind a hold — and omitting a label from the labeler's own instruction list does not restrict which labels it may apply. | Configure `labels.roadmapLabelName`, `labels.blockedByHumanLabelName`, and `labels.needsDecisionLabelName` in `.github/idd/config.json` when the repository already uses a different label taxonomy for these three roles. Migration note: when renaming an existing label, first create the new label and apply it alongside the old one on the affected open issues, then update the config value, then delete the old label — discovery and triage then never pass through a window where hold labels stop matching; keep all three configured labels present in the repository afterward. If the repository runs a semantic issue auto-labeler, adopt the [reserved-label guard recipe](#reserved-label-guard-recipe) below — generated from a declared `labels.untrustedLabelerLogins` list when a helper runtime is available, or copied and hand-substituted otherwise — to stop it from applying these labels.                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 | Issue authoring guard               | The configured authoring label is both the draft marker for a held issue and the claim-suppression lock Discover enforces; Discover skips issues carrying it and warns when that label appears stale                                                                                                                                                                                                                                                                                      | Configure `issueAuthoring.authoringLabelName` and `issueAuthoring.authoringStaleAge` in `.github/idd/config.json` when local label naming or timing differs from the distributed defaults. Keep the label available in the target repository and keep `authoringStaleAge` less than `claimTiming.staleAge`; see [IDD policy constants](policy-constants.md#issue-authoring-defaults).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | Workshop example repo               | `idd-doctor` checks that the example repository's README back-links to this repo's `docs/workshop/`                                                                                                                                                                                                                                                                                                                                                                                       | Set `workshop.exampleRepository` in `.github/idd/config.json` to `"<owner>/<repo>"` when this repository publishes a workshop and an external example repository should back-link to it. Leave the field empty / unset to skip the check (default for adopter repos that have not published a workshop).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | Worktree guard                      | Advisory only by default — `idd-doctor` warns on a primary-worktree implementation-branch HEAD but nothing blocks the commit, push, or merge                                                                                                                                                                                                                                                                                                                                              | Opt in by setting `worktreeGuard.enabled: true` in `.github/idd/config.json`; `idd-doctor` then enforces the same as its `--strict` flag would, so a primary-worktree `issue/*` / `roadmap-audit/*` HEAD fails outright instead of only warning. Pair it with the local git hook activation steps in [IDD template onboarding](https://github.com/kurone-kito/idd-skill/blob/main/idd-template/ONBOARDING.md#optional--enable-the-local-worktree-guard) for pre-commit/pre-push enforcement — including its [hook-manager coexistence guidance](https://github.com/kurone-kito/idd-skill/blob/main/idd-template/docs/onboarding/optional-host-setup.md#coexisting-with-an-existing-hook-manager) for a repository where an existing hook manager already owns `core.hooksPath`. Override `worktreeGuard.branchPatterns` to change which branch globs count as implementation branches (default `issue/*`, `roadmap-audit/*`). Absent or `false` keeps the historical advisory-only behavior.                                                                                                                                                                                                                                                                                                                                                                              |
@@ -893,7 +893,51 @@ your own repository below) guards against this with
 `.github/workflows/strip-untrusted-labels.yml`: a same-event
 `issues: labeled` / `pull_request_target: labeled` handler that removes
 a reserved label the instant a configured untrusted actor applies it.
-The recipe below adapts that workflow for adopters. Save it as
+Two paths produce this file for your own repository, below.
+
+### Preferred: generated guard (helper runtime available)
+
+When a helper runtime is available (see the "Helper runtime" row in the
+table above, and
+[IDD helper script evaluation](idd-helper-scripts.md#import-time-selection-order)),
+generate the guard from your own declared configuration instead of
+hand-copying a placeholder recipe:
+
+1. Populate `labels.untrustedLabelerLogins` in `.github/idd/config.json`
+   with the login(s) of whichever semantic issue auto-labeler(s) this
+   repository actually runs. The
+   [Untrusted-labeler login sweep](idd-helper-scripts.md#untrusted-labeler-login-sweep)
+   helper automates the full-history detection technique the manual
+   recipe below documents in prose — run it and filter its output down
+   to the actor(s) recognized as untrusted, excluding any bot already
+   trusted to apply these labels on purpose (for example this
+   repository's own IDD or CI automation).
+2. Run the `idd-onboard` CLI's `--substitute` stage (already part of
+   normal onboarding/re-onboarding; see
+   [IDD template onboarding](https://github.com/kurone-kito/idd-skill/blob/main/idd-template/ONBOARDING.md#cli-assisted-onboarding)):
+   `node scripts/idd-onboard.mjs --substitute --target <target-dir>`.
+   It reads this repository's own configured (or defaulted)
+   `labels.roadmapLabelName` / `labels.blockedByHumanLabelName` /
+   `labels.needsDecisionLabelName` and the declared logins, then writes
+   `.github/workflows/strip-untrusted-labels.yml` with the same trust
+   model documented below (least-privilege `permissions:`, no
+   checkout, `pull_request_target` for the PR branch,
+   `runs-on: ubuntu-latest`). An absent or empty
+   `labels.untrustedLabelerLogins` writes nothing and does not fail
+   (opt-in, not opt-out).
+
+**Scope limit.** The generator covers only the three base labels above.
+A repository that also wants `issueAuthoring.authoringLabelName`
+covered, or the broader shared-prefix form described in the Fallback
+subsection below, has no generated equivalent yet — use the manual
+recipe for that extension instead. Re-running `--substitute` also regenerates
+the file from the current configuration every time, overwriting any
+hand-edit previously made to a generated copy.
+
+### Fallback: manual recipe (`instructions-only` profile, or extended coverage)
+
+Without a helper runtime — or when the scope limit above applies — copy
+the recipe by hand. Save it as
 `.github/workflows/strip-untrusted-labels.yml` and substitute every
 `<...>` placeholder before use:
 
@@ -1056,8 +1100,41 @@ actually runs. A shipped file carrying this source repository's own
 values would silently protect the wrong labels or actors for any
 adopter who configured `labels.*` or runs a different labeler — worse
 than no file, since its presence could be mistaken for coverage it does
-not actually provide. Copy the recipe above and substitute the
-placeholders instead.
+not actually provide. This is why the file is never a static template
+asset either way: the generated path above resolves these same
+per-adopter values from `.github/idd/config.json` at onboarding time
+instead of shipping them pre-filled, and the manual path asks you to
+substitute them by hand.
+
+### Advisory: `.coderabbit.yaml` snippet
+
+Adopters who use CodeRabbit specifically can additionally scope its
+issue auto-labeling away from the reserved label names, mirroring the
+snippet this source repository's own `.coderabbit.yaml` carries:
+
+```yaml
+issue_enrichment:
+  labeling:
+    # Scope issue auto-labeling to content labels only. `<roadmap-label-name>`
+    # (and any other configured reserved IDD label name) is intentionally
+    # left out of the list below — this is hygiene, not a restriction: it
+    # does not stop CodeRabbit's own auto-labeling heuristic from applying
+    # that label anyway. Keep the CI guard above in place regardless.
+    auto_apply_labels: true
+    labeling_instructions:
+      # ... your own content-label entries; omit every reserved IDD label
+      # name from this list.
+```
+
+**This is hygiene alongside the CI guard above, never a substitute for
+it.** Per the risk prose earlier in this section and
+[IDD label names](https://github.com/kurone-kito/idd-skill/blob/main/idd-template/docs/onboarding/policy-decisions.md#idd-label-names)'s
+"omitting a label from the labeler's instructions is not a restriction"
+point: leaving a label out of `labeling_instructions` only tells
+CodeRabbit which labels its content-labeling feature is configured to
+consider — it does not stop CodeRabbit's own auto-labeling heuristic
+from applying that label anyway. Keep the generated or manual CI guard
+above in place regardless of whether this snippet is adopted.
 
 ## Issue Scope
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -915,7 +915,20 @@ hand-copying a placeholder recipe:
 2. Run the `idd-onboard` CLI's `--substitute` stage (already part of
    normal onboarding/re-onboarding; see
    [IDD template onboarding](https://github.com/kurone-kito/idd-skill/blob/main/idd-template/ONBOARDING.md#cli-assisted-onboarding)):
-   `node scripts/idd-onboard.mjs --substitute --target <target-dir>`.
+
+   ```sh
+   node scripts/idd-onboard.mjs --substitute --target <target-dir>
+   ```
+
+   **This path requires a local `kurone-kito/idd-skill` clone**
+   (`scripts/idd-onboard.mjs` runs from that clone, not from an
+   installed helper package) — `idd-onboard` is not part of the
+   `package-manager` / `ephemeral-npx` helper command catalog
+   documented in
+   [IDD helper script evaluation](idd-helper-scripts.md), unlike the
+   sweep helper in step 1. Without a local clone available, use the
+   manual recipe below instead.
+
    It reads this repository's own configured (or defaulted)
    `labels.roadmapLabelName` / `labels.blockedByHumanLabelName` /
    `labels.needsDecisionLabelName` and the declared logins, then writes

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -928,7 +928,7 @@ hand-copying a placeholder recipe:
    package-manager or `npx` form for it. Without a local clone
    available, use the manual recipe below instead.
 
-   It reads this repository's own configured (or defaulted)
+   It reads the target repository's own configured (or defaulted)
    `labels.roadmapLabelName` / `labels.blockedByHumanLabelName` /
    `labels.needsDecisionLabelName` and the declared logins, then writes
    `.github/workflows/strip-untrusted-labels.yml` with the same trust

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -926,6 +926,18 @@ hand-copying a placeholder recipe:
    `labels.untrustedLabelerLogins` writes nothing and does not fail
    (opt-in, not opt-out).
 
+**Ordering matters.** `labels.untrustedLabelerLogins` is neither one of
+the seven `--hear`-derived onboarding placeholders nor a field
+`--record-policy` writes, so a fresh CLI-assisted run's Step 4
+`--substitute` sees it only if step 1 above already wrote it into
+`.github/idd/config.json` by hand first — confirming the item during
+Step 1B's hearing alone does not populate it, and no CLI stage
+populates it for you. Add the list to `.github/idd/config.json`
+yourself before running `--substitute`, or rerun `--substitute` after
+adding it to an already-onboarded repository's config; either way,
+`--substitute` is always safe to rerun (see the Scope limit note
+above).
+
 **Scope limit.** The generator covers only the three base labels above.
 A repository that also wants `issueAuthoring.authoringLabelName`
 covered, or the broader shared-prefix form described in the Fallback

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -917,7 +917,8 @@ hand-copying a placeholder recipe:
    [IDD template onboarding](https://github.com/kurone-kito/idd-skill/blob/main/idd-template/ONBOARDING.md#cli-assisted-onboarding)):
 
    ```sh
-   node scripts/idd-onboard.mjs --substitute --target <target-dir>
+   node scripts/idd-onboard.mjs --substitute --target <target-dir> \
+     --allow-root <target-dir>
    ```
 
    **The supported invocation runs from a local
@@ -926,7 +927,11 @@ hand-copying a placeholder recipe:
    [IDD helper script evaluation](idd-helper-scripts.md), unlike the
    sweep helper in step 1, so this document does not offer a
    package-manager or `npx` form for it. Without a local clone
-   available, use the manual recipe below instead.
+   available, use the manual recipe below instead. `--target` is
+   confined to the current working directory (or an `--allow-root`
+   boundary); when `<target-dir>` is a separate adopter checkout
+   outside the clone, `--allow-root <target-dir>` widens the confined
+   root so the command doesn't exit before generating the guard.
 
    It reads the target repository's own configured (or defaulted)
    `labels.roadmapLabelName` / `labels.blockedByHumanLabelName` /

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -920,14 +920,13 @@ hand-copying a placeholder recipe:
    node scripts/idd-onboard.mjs --substitute --target <target-dir>
    ```
 
-   **This path requires a local `kurone-kito/idd-skill` clone**
-   (`scripts/idd-onboard.mjs` runs from that clone, not from an
-   installed helper package) — `idd-onboard` is not part of the
-   `package-manager` / `ephemeral-npx` helper command catalog
-   documented in
+   **The supported invocation runs from a local
+   `kurone-kito/idd-skill` clone** — `idd-onboard` is not a cataloged
+   `package-manager` / `ephemeral-npx` helper command in
    [IDD helper script evaluation](idd-helper-scripts.md), unlike the
-   sweep helper in step 1. Without a local clone available, use the
-   manual recipe below instead.
+   sweep helper in step 1, so this document does not offer a
+   package-manager or `npx` form for it. Without a local clone
+   available, use the manual recipe below instead.
 
    It reads this repository's own configured (or defaulted)
    `labels.roadmapLabelName` / `labels.blockedByHumanLabelName` /

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -922,9 +922,12 @@ hand-copying a placeholder recipe:
    `.github/workflows/strip-untrusted-labels.yml` with the same trust
    model documented below (least-privilege `permissions:`, no
    checkout, `pull_request_target` for the PR branch,
-   `runs-on: ubuntu-latest`). An absent or empty
-   `labels.untrustedLabelerLogins` writes nothing and does not fail
-   (opt-in, not opt-out).
+   `runs-on: ubuntu-latest`). An absent `labels.untrustedLabelerLogins`
+   writes nothing and does not fail (opt-in, not opt-out) — **omit the
+   key entirely** rather than setting it to `[]`: the policy schema
+   requires at least one entry (`minItems: 1`), so an explicit empty
+   array fails live-config schema validation (for example
+   `idd-doctor`) even though `--substitute` itself tolerates it.
 
 **Ordering matters.** `labels.untrustedLabelerLogins` is neither one of
 the seven `--hear`-derived onboarding placeholders nor a field
@@ -944,7 +947,13 @@ covered, or the broader shared-prefix form described in the Fallback
 subsection below, has no generated equivalent yet — use the manual
 recipe for that extension instead. Re-running `--substitute` also regenerates
 the file from the current configuration every time, overwriting any
-hand-edit previously made to a generated copy.
+hand-edit previously made to a generated copy — but only ever writes or
+leaves the file unchanged, never deletes it: removing
+`labels.untrustedLabelerLogins` from the configuration and rerunning
+`--substitute` does **not** delete a previously generated
+`.github/workflows/strip-untrusted-labels.yml`. Delete that file by
+hand when disabling the guard this way, or the old actor list keeps
+stripping labels despite the current configuration.
 
 ### Fallback: manual recipe (`instructions-only` profile, or extended coverage)
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -1109,8 +1109,9 @@ substitute them by hand.
 ### Advisory: `.coderabbit.yaml` snippet
 
 Adopters who use CodeRabbit specifically can additionally scope its
-issue auto-labeling away from the reserved label names, mirroring the
-snippet this source repository's own `.coderabbit.yaml` carries:
+issue auto-labeling away from the reserved label names, adapted from
+this source repository's own `.coderabbit.yaml` snippet with an added
+non-sufficiency caveat that file's own comment does not yet carry:
 
 ```yaml
 issue_enrichment:

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -3139,11 +3139,15 @@ same as `AW4`/`AW5`.
 - **Read-only, unconditionally**: performs no write operation of any
   kind — no `.github/idd/config.json` edit, no GitHub mutation (no
   label change, no comment, no other write call). It only proposes
-  candidates for a human to review; adding an accepted candidate's
-  login as one of the [Reserved-label guard recipe](customization.md#reserved-label-guard-recipe)'s
-  `<labeler-bot-login-N>` placeholders in
-  `strip-untrusted-labels.yml` stays a manual, adopter-owned edit
-  after judging each candidate's event count. Not a phase step in any
+  candidates for a human to review; recording an accepted candidate's
+  login stays a manual, adopter-owned edit after judging each
+  candidate's event count. Add it to `labels.untrustedLabelerLogins` in
+  `.github/idd/config.json` and (re-)run `idd-onboard --substitute` to
+  generate `strip-untrusted-labels.yml`, or add it as one of the
+  [Reserved-label guard recipe](customization.md#reserved-label-guard-recipe)'s
+  `<labeler-bot-login-N>` placeholders when following that recipe's
+  manual fallback instead — see that recipe for when each path applies.
+  Not a phase step in any
   `idd-*.instructions.md` file — like the Merged-PR feedback sweep
   above, this is a manually-invoked, operator-run spot-check, run once
   when first building the reserved-label guard's bot-login list and

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -3142,11 +3142,13 @@ same as `AW4`/`AW5`.
   candidates for a human to review; recording an accepted candidate's
   login stays a manual, adopter-owned edit after judging each
   candidate's event count. Add it to `labels.untrustedLabelerLogins` in
-  `.github/idd/config.json` and (re-)run `idd-onboard --substitute` to
-  generate `strip-untrusted-labels.yml`, or add it as one of the
+  `.github/idd/config.json` and (re-)run the `idd-onboard` CLI's
+  `--substitute` stage to generate `strip-untrusted-labels.yml` (see the
   [Reserved-label guard recipe](customization.md#reserved-label-guard-recipe)'s
-  `<labeler-bot-login-N>` placeholders when following that recipe's
-  manual fallback instead — see that recipe for when each path applies.
+  "Preferred: generated guard" path for the exact invocation), or add it
+  as one of that recipe's `<labeler-bot-login-N>` placeholders when
+  following that recipe's manual fallback instead — see that recipe for
+  when each path applies.
   Not a phase step in any
   `idd-*.instructions.md` file — like the Merged-PR feedback sweep
   above, this is a manually-invoked, operator-run spot-check, run once

--- a/idd-template/docs/onboarding/policy-decisions.md
+++ b/idd-template/docs/onboarding/policy-decisions.md
@@ -304,10 +304,14 @@ infer), adopt the guard recipe in
 [Customizing IDD — Reserved-label guard recipe](../customization.md#reserved-label-guard-recipe)
 before relying on unattended discovery or hold semantics. When a helper
 runtime is available, prefer declaring `labels.untrustedLabelerLogins`
-and running the `idd-onboard` CLI's `--substitute` stage (or the
-`idd-suggest-untrusted-labelers` sweep helper to populate the login
-list) over the manual recipe — both paths, and the trade-offs between
-them, are documented at that same recipe link.
+and running the `idd-onboard` CLI's `--substitute` stage over the
+manual recipe — both paths, and the trade-offs between them, are
+documented at that same recipe link. The `idd-suggest-untrusted-labelers`
+sweep helper only proposes candidate logins for a human to review; it
+is read-only and never writes `.github/idd/config.json` itself, so
+still add each accepted candidate to `labels.untrustedLabelerLogins`
+by hand and (re-)run `--substitute` afterward — stopping after the
+sweep alone leaves the repository without the generated guard.
 
 ### Bootstrap execution mode
 

--- a/idd-template/docs/onboarding/policy-decisions.md
+++ b/idd-template/docs/onboarding/policy-decisions.md
@@ -302,11 +302,11 @@ based on content? If yes, and the repository keeps the distributed IDD
 label names (or any other label such an auto-labeler could plausibly
 infer), adopt the guard recipe in
 [Customizing IDD — Reserved-label guard recipe](../customization.md#reserved-label-guard-recipe)
-before relying on unattended discovery or hold semantics. When a helper
-runtime is available, prefer declaring `labels.untrustedLabelerLogins`
-and running the `idd-onboard` CLI's `--substitute` stage over the
-manual recipe — both paths, and the trade-offs between them, are
-documented at that same recipe link. The `idd-suggest-untrusted-labelers`
+before relying on unattended discovery or hold semantics. When a local
+`kurone-kito/idd-skill` clone is available, prefer declaring
+`labels.untrustedLabelerLogins` and running the `idd-onboard` CLI's
+`--substitute` stage over the manual recipe — both paths, and the
+trade-offs between them, are documented at that same recipe link. The `idd-suggest-untrusted-labelers`
 sweep helper only proposes candidate logins for a human to review; it
 is read-only and never writes `.github/idd/config.json` itself, so
 still add each accepted candidate to `labels.untrustedLabelerLogins`

--- a/idd-template/docs/onboarding/policy-decisions.md
+++ b/idd-template/docs/onboarding/policy-decisions.md
@@ -302,7 +302,12 @@ based on content? If yes, and the repository keeps the distributed IDD
 label names (or any other label such an auto-labeler could plausibly
 infer), adopt the guard recipe in
 [Customizing IDD — Reserved-label guard recipe](../customization.md#reserved-label-guard-recipe)
-before relying on unattended discovery or hold semantics.
+before relying on unattended discovery or hold semantics. When a helper
+runtime is available, prefer declaring `labels.untrustedLabelerLogins`
+and running the `idd-onboard` CLI's `--substitute` stage (or the
+`idd-suggest-untrusted-labelers` sweep helper to populate the login
+list) over the manual recipe — both paths, and the trade-offs between
+them, are documented at that same recipe link.
 
 ### Bootstrap execution mode
 


### PR DESCRIPTION
# Summary

Adopters had no documented way to discover the generated
`strip-untrusted-labels.yml` guard (#2671) or the login-sweep helper
(#2670) that shipped in this roadmap's sibling tracks — the Reserved-
label guard recipe still described only the manual copy-paste path.

- Restructure `idd-template/docs/customization.md`'s Reserved-label
  guard recipe into:
  - **Preferred: generated guard** — declare
    `labels.untrustedLabelerLogins`, run `idd-onboard --substitute`,
    populate the login list with `idd-suggest-untrusted-labelers`.
  - **Fallback: manual recipe** — the existing copy-paste path, now
    also the documented route for the `instructions-only` profile and
    for the `issueAuthoring.authoringLabelName` / shared-prefix
    extension the generator doesn't cover.
  - **Advisory: `.coderabbit.yaml` snippet** — a new snippet excluding
    reserved labels from CodeRabbit's issue-labeling instructions, with
    an explicit non-sufficiency caveat so it's never mistaken for a
    substitute for the CI guard.
  - Reframe the "why this file is not shipped" rationale, which the
    new generated path partly supersedes.
- Cross-reference `labels.untrustedLabelerLogins` from
  `idd-template/ONBOARDING.md` Step 1B item 12 and
  `idd-template/docs/onboarding/policy-decisions.md`'s IDD label names
  section.
- `docs/customization.md` regenerated from the edited
  `idd-template/docs/customization.md` via `node scripts/sync-docs.mjs
  --apply`.

## Linked issue

Closes #2672

## Follow-up issues (if any)

- [ ] Consider whether `idd-onboard` should join the
  `package-manager` / `ephemeral-npx` helper command catalog in
  `src/scripts/helper-runtime-manifest.mts` so its `--substitute`
  stage can be documented with a package-manager/`npx` invocation
  form alongside the local-clone form this PR documents. Raised by
  Codex during review; treated as a design decision (catalog
  membership implies a support-level commitment) rather than a docs
  defect, so it's out of scope here.
- [ ] `idd-onboard --substitute --help` doesn't mention that it can
  generate `strip-untrusted-labels.yml` from
  `labels.untrustedLabelerLogins` — surfaced while refining this PR's
  own plan; a `--help` wording fix, not a docs-content defect.
- [ ] This repository's own `.coderabbit.yaml` comment states
  CodeRabbit "never auto-applies" the reserved roadmap label; flagged
  during an earlier sibling PR's (#2671) C1 critique as an overclaim
  worth softening, but out of scope for this documentation-only PR.

## Background / rationale (if material)

Parent roadmap: #2668. This is the last of three sibling tracks off
that roadmap: schema (#2669), generation (#2671), and this
documentation track — sequenced last since it documents shipped
behavior rather than a design still in flux.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191MCYGribBmSeRVTk3AxQ6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified onboarding for configuring untrusted labeler logins and generating reserved-label protection workflows.
  - Documented automated and manual options for handling labels applied by untrusted automation.
  - Added invocation details, configuration requirements, scope limitations, and regeneration behavior.
  - Noted that removing configuration does not remove an existing guard workflow.
  - Added supplemental CodeRabbit label-hygiene guidance while retaining CI protection.
  - Clarified the distinction between suggesting candidates and applying configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
