### PR TITLE
fix(review-fix): give E11 a read-only conflict check

### DIFF
--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -127,9 +127,10 @@ branch-sync check (`idd-review-triage.instructions.md`) and F1
 mergeable,mergeStateStatus` otherwise — reflects the last **pushed**
 head, not unpushed E9 fixes.
 
-Only on a confirmed `content-conflict` (`mergeable` `CONFLICTING`):
-merge `{development-branch}` (resolved in `idd-work.instructions.md`'s
-B1
+On a confirmed `content-conflict` (`mergeable` `CONFLICTING`): first
+pass the **active review gate** (same check as
+`idd-review-triage.instructions.md`'s Sync path step 1), then merge
+`{development-branch}` (resolved in `idd-work.instructions.md`'s B1
 [Resolve the development branch](idd-work.instructions.md#b1--create-worktree-with-branch))
 into the feature branch (`git fetch origin {development-branch} && git
 merge origin/{development-branch}`), resolve conflicts, and complete
@@ -139,14 +140,15 @@ hardware-touch), use the
 for the whole operation — see `idd-review-triage.instructions.md`'s
 Sync path step 2 for the `-m` subject requirement.
 
+On `force-push-exception` (a hold state per
+[IDD policy constants](../../docs/policy-constants.md), like
+`dirty`/`unknown`): stop — post a PR comment documenting the state and
+do not proceed to E12; a maintainer must clear the hold.
+
 Any other read (clean, behind-no-conflict, computing, dirty, unknown)
 skips the merge here — E11 never re-polls a transient read or holds on
 a dirty/unknown one; proceed to E12 and let the post-E12 branch-sync
 check handle those states properly.
-
-**Active review gate**: same check as
-`idd-review-triage.instructions.md`'s Sync path step 1 — only when the
-merge above runs.
 
 ## E12 — Lint, test, push
 

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -120,21 +120,32 @@ recovery.
 
 ## E11 — Resolve conflicts with {development-branch}
 
-Check for conflicts between the feature branch and `{development-branch}`
-(the value resolved in `idd-work.instructions.md`'s B1
-[Resolve the development branch](idd-work.instructions.md#b1--create-worktree-with-branch)
-step). If conflicts exist, merge `{development-branch}` into the feature
-branch (`git fetch origin {development-branch} && git merge
-origin/{development-branch}`), resolve them, and complete the merge. On a
-signed-commit repo with non-interactive-hostile primary signing (GPG
-pinentry / hardware-touch), use the
+Check branch state **read-only** first, same method as the E-phase
+branch-sync check (`idd-review-triage.instructions.md`) and F1
+(`idd-pre-merge.instructions.md`): `idd-branch-conflict-state --pr
+{pr-number}` (helper runtime) or `gh pr view {pr-number} --json
+mergeable,mergeStateStatus` otherwise — reflects the last **pushed**
+head, not unpushed E9 fixes.
+
+Only on an actual conflict (`mergeable` `CONFLICTING` /
+`content-conflict`): merge `{development-branch}` (resolved in
+`idd-work.instructions.md`'s B1
+[Resolve the development branch](idd-work.instructions.md#b1--create-worktree-with-branch))
+into the feature branch (`git fetch origin {development-branch} && git
+merge origin/{development-branch}`), resolve conflicts, and complete
+the merge. On non-interactive-hostile primary signing (GPG pinentry /
+hardware-touch), use the
 [signed-commit merge wrapper](../../docs/idd-helper-scripts.md#signed-commit-merge-wrapper-shared-git-procedure)
-for the whole operation instead of the plain command — see
-`idd-review-triage.instructions.md`'s Sync path step 2 for the
-wrapper's `-m` subject requirement.
+for the whole operation — see `idd-review-triage.instructions.md`'s
+Sync path step 2 for the `-m` subject requirement.
+
+Any other state (clean, behind-no-conflict, computing, dirty, unknown)
+is a **no-op**: proceed to E12 without merging or committing anything —
+E11 never re-polls or holds; the post-E12 branch-sync check owns that.
 
 **Active review gate**: same check as
-`idd-review-triage.instructions.md`'s Sync path step 1.
+`idd-review-triage.instructions.md`'s Sync path step 1 — only when the
+merge above runs.
 
 ## E12 — Lint, test, push
 

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -120,36 +120,23 @@ recovery.
 
 ## E11 — Resolve conflicts with {development-branch}
 
-Check branch state **read-only** first, same method as the E-phase
-branch-sync check (`idd-review-triage.instructions.md`) and F1
-(`idd-pre-merge.instructions.md`): `idd-branch-conflict-state --pr
-{pr-number}` (helper runtime) or `gh pr view {pr-number} --json
-mergeable,mergeStateStatus` otherwise — reflects the last **pushed**
-head, not unpushed E9 fixes.
+Same read-only check as
+`idd-review-triage.instructions.md`'s E-phase branch-sync check and
+`idd-pre-merge.instructions.md`'s F1 (`idd-branch-conflict-state --pr
+{pr-number}` or `gh pr view {pr-number} --json
+mergeable,mergeStateStatus`) — reflects the last pushed head, not
+unpushed E9 fixes.
 
-On a confirmed `content-conflict` (`mergeable` `CONFLICTING`): first
-pass the **active review gate** (same check as
-`idd-review-triage.instructions.md`'s Sync path step 1), then merge
-`{development-branch}` (resolved in `idd-work.instructions.md`'s B1
-[Resolve the development branch](idd-work.instructions.md#b1--create-worktree-with-branch))
-into the feature branch (`git fetch origin {development-branch} && git
-merge origin/{development-branch}`), resolve conflicts, and complete
-the merge. On non-interactive-hostile primary signing (GPG pinentry /
-hardware-touch), use the
-[signed-commit merge wrapper](../../docs/idd-helper-scripts.md#signed-commit-merge-wrapper-shared-git-procedure)
-for the whole operation — see `idd-review-triage.instructions.md`'s
-Sync path step 2 for the `-m` subject requirement.
-
-On `force-push-exception` (a hold state per
-[IDD policy constants](../../docs/policy-constants.md), like
-`dirty`/`unknown`): stop — post a PR comment documenting the state and
-do not proceed to E12; a maintainer must clear the hold.
-
-Any other read (clean, behind-no-conflict, computing, dirty, unknown)
-skips the merge here — E11 never re-polls a transient read or holds on
-a dirty/unknown one; proceed to E12 and let
-`idd-review-triage.instructions.md`'s E-phase branch-sync check handle
-those states properly once PATH A reaches zero.
+- **`content-conflict`** (`mergeable` `CONFLICTING`): pass the active
+  review gate, merge `{development-branch}` into the feature branch
+  (`git fetch origin {development-branch} && git merge
+  origin/{development-branch}`), resolve, complete the merge.
+  Non-interactive-hostile signing: use the
+  [signed-commit merge wrapper](../../docs/idd-helper-scripts.md#signed-commit-merge-wrapper-shared-git-procedure)
+  instead.
+- Otherwise (clean, behind-no-conflict, computing, dirty,
+  force-push-exception, unknown): skip the merge, proceed to E12 —
+  the E-phase branch-sync check and F1 hold on those later.
 
 ## E12 — Lint, test, push
 

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -147,8 +147,9 @@ do not proceed to E12; a maintainer must clear the hold.
 
 Any other read (clean, behind-no-conflict, computing, dirty, unknown)
 skips the merge here — E11 never re-polls a transient read or holds on
-a dirty/unknown one; proceed to E12 and let the post-E12 branch-sync
-check handle those states properly.
+a dirty/unknown one; proceed to E12 and let
+`idd-review-triage.instructions.md`'s E-phase branch-sync check handle
+those states properly once PATH A reaches zero.
 
 ## E12 — Lint, test, push
 

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -136,7 +136,7 @@ unpushed E9 fixes.
   instead.
 - Otherwise (clean, behind-no-conflict, computing, dirty,
   force-push-exception, unknown): skip the merge, proceed to E12 —
-  the E-phase branch-sync check and F1 hold on those later.
+  the E-phase branch-sync check and F1 handle those downstream.
 
 ## E12 — Lint, test, push
 

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -127,9 +127,9 @@ branch-sync check (`idd-review-triage.instructions.md`) and F1
 mergeable,mergeStateStatus` otherwise — reflects the last **pushed**
 head, not unpushed E9 fixes.
 
-Only on an actual conflict (`mergeable` `CONFLICTING` /
-`content-conflict`): merge `{development-branch}` (resolved in
-`idd-work.instructions.md`'s B1
+Only on a confirmed `content-conflict` (`mergeable` `CONFLICTING`):
+merge `{development-branch}` (resolved in `idd-work.instructions.md`'s
+B1
 [Resolve the development branch](idd-work.instructions.md#b1--create-worktree-with-branch))
 into the feature branch (`git fetch origin {development-branch} && git
 merge origin/{development-branch}`), resolve conflicts, and complete
@@ -139,9 +139,10 @@ hardware-touch), use the
 for the whole operation — see `idd-review-triage.instructions.md`'s
 Sync path step 2 for the `-m` subject requirement.
 
-Any other state (clean, behind-no-conflict, computing, dirty, unknown)
-is a **no-op**: proceed to E12 without merging or committing anything —
-E11 never re-polls or holds; the post-E12 branch-sync check owns that.
+Any other read (clean, behind-no-conflict, computing, dirty, unknown)
+skips the merge here — E11 never re-polls a transient read or holds on
+a dirty/unknown one; proceed to E12 and let the post-E12 branch-sync
+check handle those states properly.
 
 **Active review gate**: same check as
 `idd-review-triage.instructions.md`'s Sync path step 1 — only when the

--- a/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -144,8 +144,10 @@ other GitHub side effect, confirm all of the following:
    (helper) or `gh pr view {pr-number} --json mergeable,mergeStateStatus`
    otherwise — reflects the last pushed head, not local unpushed fixes.
 2. Not a confirmed conflict (clean, behind-no-conflict, computing,
-   dirty, unknown)? Skip the merge and continue to E12 — a later check
-   re-polls a transient read and holds on dirty/unknown.
+   dirty, unknown)? Skip the merge and continue to E12 — a dirty or
+   unresolved read isn't this step's problem to fix; F1
+   (`idd-pre-merge-lite.instructions.md`) stops and asks on any
+   non-clean pre-merge branch state.
 3. Conflict reported (`mergeable` `CONFLICTING`)? If the PR has
    unresolved review threads, unreplied comments, or a reviewer's
    latest state is `CHANGES_REQUESTED`, get explicit operator

--- a/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -143,8 +143,9 @@ other GitHub side effect, confirm all of the following:
 1. Check state read-only: `idd-branch-conflict-state --pr {pr-number}`
    (helper) or `gh pr view {pr-number} --json mergeable,mergeStateStatus`
    otherwise — reflects the last pushed head, not local unpushed fixes.
-2. No conflict (clean, behind-no-conflict, computing, dirty, unknown)?
-   Continue to E12 — do not merge; a later check owns re-poll/hold.
+2. Not a confirmed conflict (clean, behind-no-conflict, computing,
+   dirty, unknown)? Skip the merge and continue to E12 — a later check
+   re-polls a transient read and holds on dirty/unknown.
 3. Conflict reported (`mergeable` `CONFLICTING`)? If the PR has
    unresolved review threads, unreplied comments, or a reviewer's
    latest state is `CHANGES_REQUESTED`, get explicit operator

--- a/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -142,38 +142,23 @@ other GitHub side effect, confirm all of the following:
 
 1. Check state read-only: `idd-branch-conflict-state --pr {pr-number}`
    — reflects the last pushed head, not local unpushed fixes. Missing,
-   failing, or disagreeing with live state? Stop and ask per the Helper
-   runtime contract above — do not fall back to a non-helper read here.
-2. `force-push-exception` (a hold state per
-   [IDD policy constants](../../../docs/policy-constants.md), like
-   `dirty`/`unknown`)? Stop here — post a PR comment documenting the
-   state, and do not continue to E12; a maintainer must clear the
-   hold. Otherwise not a confirmed conflict (clean, behind-no-conflict,
-   computing, dirty, unknown)? Skip the merge and continue to E12 — a
-   dirty or unresolved read isn't this step's problem to fix; F1
-   (`idd-pre-merge-lite.instructions.md`) stops and asks on any
-   non-clean pre-merge branch state.
-3. Conflict reported (`mergeable` `CONFLICTING`)? If the PR has
-   unresolved review threads, unreplied comments, or a reviewer's
-   latest state is `CHANGES_REQUESTED`, get explicit operator
-   confirmation before merging — the merge commit will appear in the
-   PR history.
-4. Run `git fetch origin main && git merge origin/main`.
-5. On a signed-commit repo whose primary signing is non-interactive
-   hostile (GPG pinentry or hardware-touch) but that provides a
-   fallback signing wrapper for arbitrary git subcommands (pass
-   `-c gpg.format=ssh -c user.signingkey=<abs-path> -c
-   commit.gpgsign=true` to `git` before the subcommand, plus
-   `-m "chore: merge origin/main into the claimed branch"` on the
-   first `merge` so a commitlint hook accepts the subject — `git -c …
-   merge`, not `git merge -c …`; a commit-only alias like
-   `git commit-ssh` will not run `merge`), run this merge through that
-   wrapper, not the plain command.
-6. Resolve any conflicts and complete the merge.
-7. If the merge needed `--continue`, run it through the same wrapper
-   used in step 5 (`git -c … merge --continue`), never the plain
-   `git merge --continue` — the wrapper must own the whole operation, or
-   the merge commit reverts to the stalling primary signing.
+   failing, or disagreeing? Stop and ask (Helper runtime contract
+   above) — no non-helper fallback here.
+2. Not a confirmed conflict (clean, behind-no-conflict, computing,
+   dirty, force-push-exception, unknown)? Skip the merge, continue to
+   E12 — F1 (`idd-pre-merge-lite.instructions.md`) holds on those
+   later.
+3. Conflict (`mergeable` `CONFLICTING`)? Unresolved review threads,
+   unreplied comments, or reviewer state `CHANGES_REQUESTED`: get
+   explicit operator confirmation first — the merge commit will appear
+   in the PR history.
+4. Run `git fetch origin main && git merge origin/main`. On
+   non-interactive-hostile primary signing (GPG pinentry or
+   hardware-touch) with a fallback wrapper, run the whole merge
+   (including `--continue`) through that wrapper instead — see
+   `docs/idd-helper-scripts.md#signed-commit-merge-wrapper-shared-git-procedure`
+   for the command form and the commitlint `-m` requirement.
+5. Resolve conflicts, complete the merge.
 
 ## E12 — Lint, test, push
 

--- a/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -140,12 +140,16 @@ other GitHub side effect, confirm all of the following:
 
 ## E11 — Resolve conflicts with main
 
-1. Check for conflicts between the feature branch and `main`.
-2. If none exist, continue to E12.
-3. If conflicts exist, and the PR has unresolved review threads,
-   unreplied comments, or a reviewer's latest state is
-   `CHANGES_REQUESTED`, get explicit operator confirmation before
-   merging — the merge commit will appear in the PR history.
+1. Check state read-only: `idd-branch-conflict-state --pr {pr-number}`
+   (helper) or `gh pr view {pr-number} --json mergeable,mergeStateStatus`
+   otherwise — reflects the last pushed head, not local unpushed fixes.
+2. No conflict (clean, behind-no-conflict, computing, dirty, unknown)?
+   Continue to E12 — do not merge; a later check owns re-poll/hold.
+3. Conflict reported (`mergeable` `CONFLICTING`)? If the PR has
+   unresolved review threads, unreplied comments, or a reviewer's
+   latest state is `CHANGES_REQUESTED`, get explicit operator
+   confirmation before merging — the merge commit will appear in the
+   PR history.
 4. Run `git fetch origin main && git merge origin/main`.
 5. On a signed-commit repo whose primary signing is non-interactive
    hostile (GPG pinentry or hardware-touch) but that provides a

--- a/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -149,8 +149,8 @@ other GitHub side effect, confirm all of the following:
    contract above) — no non-helper fallback here.
 2. Not a confirmed conflict (clean, behind-no-conflict, computing,
    dirty, force-push-exception, unknown)? Skip the merge, continue to
-   E12 — F1 (`idd-pre-merge-lite.instructions.md`) holds on those
-   later.
+   E12 — F1 (`idd-pre-merge-lite.instructions.md`) handles those
+   downstream.
 3. Conflict (`mergeable` `CONFLICTING`)? Unresolved review threads,
    unreplied comments, or reviewer state `CHANGES_REQUESTED`: get
    explicit operator confirmation first — the merge commit will appear

--- a/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -140,10 +140,13 @@ other GitHub side effect, confirm all of the following:
 
 ## E11 — Resolve conflicts with main
 
-1. Check state read-only: `idd-branch-conflict-state --pr {pr-number}`
-   — reflects the last pushed head, not local unpushed fixes. Missing,
-   failing, or disagreeing? Stop and ask (Helper runtime contract
-   above) — no non-helper fallback here.
+1. Check state with the profile-selected branch-conflict-state helper:
+   `node scripts/branch-conflict-state.mjs --pr {pr-number}`, or the
+   package-manager-profile `idd:branch-conflict-state` command
+   (resolve the exact command from `docs/idd-helper-scripts.md` if
+   unsure) — reflects the last pushed head, not local unpushed fixes.
+   Missing, failing, or disagreeing? Stop and ask (Helper runtime
+   contract above) — no non-helper fallback here.
 2. Not a confirmed conflict (clean, behind-no-conflict, computing,
    dirty, force-push-exception, unknown)? Skip the merge, continue to
    E12 — F1 (`idd-pre-merge-lite.instructions.md`) holds on those

--- a/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -141,11 +141,16 @@ other GitHub side effect, confirm all of the following:
 ## E11 — Resolve conflicts with main
 
 1. Check state read-only: `idd-branch-conflict-state --pr {pr-number}`
-   (helper) or `gh pr view {pr-number} --json mergeable,mergeStateStatus`
-   otherwise — reflects the last pushed head, not local unpushed fixes.
-2. Not a confirmed conflict (clean, behind-no-conflict, computing,
-   dirty, unknown)? Skip the merge and continue to E12 — a dirty or
-   unresolved read isn't this step's problem to fix; F1
+   — reflects the last pushed head, not local unpushed fixes. Missing,
+   failing, or disagreeing with live state? Stop and ask per the Helper
+   runtime contract above — do not fall back to a non-helper read here.
+2. `force-push-exception` (a hold state per
+   [IDD policy constants](../../../docs/policy-constants.md), like
+   `dirty`/`unknown`)? Stop here — post a PR comment documenting the
+   state, and do not continue to E12; a maintainer must clear the
+   hold. Otherwise not a confirmed conflict (clean, behind-no-conflict,
+   computing, dirty, unknown)? Skip the merge and continue to E12 — a
+   dirty or unresolved read isn't this step's problem to fix; F1
    (`idd-pre-merge-lite.instructions.md`) stops and asks on any
    non-clean pre-merge branch state.
 3. Conflict reported (`mergeable` `CONFLICTING`)? If the PR has

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -351,7 +351,7 @@
         ".github/instructions/lite/idd-ci-lite.instructions.md",
         ".github/instructions/lite/idd-review-fix-lite.instructions.md"
       ],
-      "limitBytes": 39500
+      "limitBytes": 40000
     },
     {
       "id": "bundle-review-snapshot-lite",
@@ -374,7 +374,7 @@
         ".github/instructions/idd-review-snapshot.instructions.md",
         ".github/instructions/idd-review-triage.instructions.md"
       ],
-      "limitBytes": 138000
+      "limitBytes": 140000
     },
     {
       "id": "bundle-merge",

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -351,7 +351,7 @@
         ".github/instructions/lite/idd-ci-lite.instructions.md",
         ".github/instructions/lite/idd-review-fix-lite.instructions.md"
       ],
-      "limitBytes": 40000
+      "limitBytes": 41000
     },
     {
       "id": "bundle-review-snapshot-lite",

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -351,7 +351,7 @@
         ".github/instructions/lite/idd-ci-lite.instructions.md",
         ".github/instructions/lite/idd-review-fix-lite.instructions.md"
       ],
-      "limitBytes": 41000
+      "limitBytes": 39500
     },
     {
       "id": "bundle-review-snapshot-lite",
@@ -374,7 +374,7 @@
         ".github/instructions/idd-review-snapshot.instructions.md",
         ".github/instructions/idd-review-triage.instructions.md"
       ],
-      "limitBytes": 140000
+      "limitBytes": 138000
     },
     {
       "id": "bundle-merge",

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -122,9 +122,9 @@ branch-sync check (`idd-review-triage.instructions.md`) and F1
 mergeable,mergeStateStatus` otherwise — reflects the last **pushed**
 head, not unpushed E9 fixes.
 
-Only on an actual conflict (`mergeable` `CONFLICTING` /
-`content-conflict`): merge `{development-branch}` (resolved in
-`idd-work.instructions.md`'s B1
+Only on a confirmed `content-conflict` (`mergeable` `CONFLICTING`):
+merge `{development-branch}` (resolved in `idd-work.instructions.md`'s
+B1
 [Resolve the development branch](idd-work.instructions.md#b1--create-worktree-with-branch))
 into the feature branch (`git fetch origin {development-branch} && git
 merge origin/{development-branch}`), resolve conflicts, and complete
@@ -134,9 +134,10 @@ hardware-touch), use the
 for the whole operation — see `idd-review-triage.instructions.md`'s
 Sync path step 2 for the `-m` subject requirement.
 
-Any other state (clean, behind-no-conflict, computing, dirty, unknown)
-is a **no-op**: proceed to E12 without merging or committing anything —
-E11 never re-polls or holds; the post-E12 branch-sync check owns that.
+Any other read (clean, behind-no-conflict, computing, dirty, unknown)
+skips the merge here — E11 never re-polls a transient read or holds on
+a dirty/unknown one; proceed to E12 and let the post-E12 branch-sync
+check handle those states properly.
 
 **Active review gate**: same check as
 `idd-review-triage.instructions.md`'s Sync path step 1 — only when the

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -131,7 +131,7 @@ unpushed E9 fixes.
   instead.
 - Otherwise (clean, behind-no-conflict, computing, dirty,
   force-push-exception, unknown): skip the merge, proceed to E12 —
-  the E-phase branch-sync check and F1 hold on those later.
+  the E-phase branch-sync check and F1 handle those downstream.
 
 ## E12 — Lint, test, push
 

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -115,21 +115,32 @@ recovery.
 
 ## E11 — Resolve conflicts with {development-branch}
 
-Check for conflicts between the feature branch and `{development-branch}`
-(the value resolved in `idd-work.instructions.md`'s B1
-[Resolve the development branch](idd-work.instructions.md#b1--create-worktree-with-branch)
-step). If conflicts exist, merge `{development-branch}` into the feature
-branch (`git fetch origin {development-branch} && git merge
-origin/{development-branch}`), resolve them, and complete the merge. On a
-signed-commit repo with non-interactive-hostile primary signing (GPG
-pinentry / hardware-touch), use the
+Check branch state **read-only** first, same method as the E-phase
+branch-sync check (`idd-review-triage.instructions.md`) and F1
+(`idd-pre-merge.instructions.md`): `idd-branch-conflict-state --pr
+{pr-number}` (helper runtime) or `gh pr view {pr-number} --json
+mergeable,mergeStateStatus` otherwise — reflects the last **pushed**
+head, not unpushed E9 fixes.
+
+Only on an actual conflict (`mergeable` `CONFLICTING` /
+`content-conflict`): merge `{development-branch}` (resolved in
+`idd-work.instructions.md`'s B1
+[Resolve the development branch](idd-work.instructions.md#b1--create-worktree-with-branch))
+into the feature branch (`git fetch origin {development-branch} && git
+merge origin/{development-branch}`), resolve conflicts, and complete
+the merge. On non-interactive-hostile primary signing (GPG pinentry /
+hardware-touch), use the
 [signed-commit merge wrapper](../../docs/idd-helper-scripts.md#signed-commit-merge-wrapper-shared-git-procedure)
-for the whole operation instead of the plain command — see
-`idd-review-triage.instructions.md`'s Sync path step 2 for the
-wrapper's `-m` subject requirement.
+for the whole operation — see `idd-review-triage.instructions.md`'s
+Sync path step 2 for the `-m` subject requirement.
+
+Any other state (clean, behind-no-conflict, computing, dirty, unknown)
+is a **no-op**: proceed to E12 without merging or committing anything —
+E11 never re-polls or holds; the post-E12 branch-sync check owns that.
 
 **Active review gate**: same check as
-`idd-review-triage.instructions.md`'s Sync path step 1.
+`idd-review-triage.instructions.md`'s Sync path step 1 — only when the
+merge above runs.
 
 ## E12 — Lint, test, push
 

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -122,9 +122,10 @@ branch-sync check (`idd-review-triage.instructions.md`) and F1
 mergeable,mergeStateStatus` otherwise — reflects the last **pushed**
 head, not unpushed E9 fixes.
 
-Only on a confirmed `content-conflict` (`mergeable` `CONFLICTING`):
-merge `{development-branch}` (resolved in `idd-work.instructions.md`'s
-B1
+On a confirmed `content-conflict` (`mergeable` `CONFLICTING`): first
+pass the **active review gate** (same check as
+`idd-review-triage.instructions.md`'s Sync path step 1), then merge
+`{development-branch}` (resolved in `idd-work.instructions.md`'s B1
 [Resolve the development branch](idd-work.instructions.md#b1--create-worktree-with-branch))
 into the feature branch (`git fetch origin {development-branch} && git
 merge origin/{development-branch}`), resolve conflicts, and complete
@@ -134,14 +135,15 @@ hardware-touch), use the
 for the whole operation — see `idd-review-triage.instructions.md`'s
 Sync path step 2 for the `-m` subject requirement.
 
+On `force-push-exception` (a hold state per
+[IDD policy constants](../../docs/policy-constants.md), like
+`dirty`/`unknown`): stop — post a PR comment documenting the state and
+do not proceed to E12; a maintainer must clear the hold.
+
 Any other read (clean, behind-no-conflict, computing, dirty, unknown)
 skips the merge here — E11 never re-polls a transient read or holds on
 a dirty/unknown one; proceed to E12 and let the post-E12 branch-sync
 check handle those states properly.
-
-**Active review gate**: same check as
-`idd-review-triage.instructions.md`'s Sync path step 1 — only when the
-merge above runs.
 
 ## E12 — Lint, test, push
 

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -115,36 +115,23 @@ recovery.
 
 ## E11 — Resolve conflicts with {development-branch}
 
-Check branch state **read-only** first, same method as the E-phase
-branch-sync check (`idd-review-triage.instructions.md`) and F1
-(`idd-pre-merge.instructions.md`): `idd-branch-conflict-state --pr
-{pr-number}` (helper runtime) or `gh pr view {pr-number} --json
-mergeable,mergeStateStatus` otherwise — reflects the last **pushed**
-head, not unpushed E9 fixes.
+Same read-only check as
+`idd-review-triage.instructions.md`'s E-phase branch-sync check and
+`idd-pre-merge.instructions.md`'s F1 (`idd-branch-conflict-state --pr
+{pr-number}` or `gh pr view {pr-number} --json
+mergeable,mergeStateStatus`) — reflects the last pushed head, not
+unpushed E9 fixes.
 
-On a confirmed `content-conflict` (`mergeable` `CONFLICTING`): first
-pass the **active review gate** (same check as
-`idd-review-triage.instructions.md`'s Sync path step 1), then merge
-`{development-branch}` (resolved in `idd-work.instructions.md`'s B1
-[Resolve the development branch](idd-work.instructions.md#b1--create-worktree-with-branch))
-into the feature branch (`git fetch origin {development-branch} && git
-merge origin/{development-branch}`), resolve conflicts, and complete
-the merge. On non-interactive-hostile primary signing (GPG pinentry /
-hardware-touch), use the
-[signed-commit merge wrapper](../../docs/idd-helper-scripts.md#signed-commit-merge-wrapper-shared-git-procedure)
-for the whole operation — see `idd-review-triage.instructions.md`'s
-Sync path step 2 for the `-m` subject requirement.
-
-On `force-push-exception` (a hold state per
-[IDD policy constants](../../docs/policy-constants.md), like
-`dirty`/`unknown`): stop — post a PR comment documenting the state and
-do not proceed to E12; a maintainer must clear the hold.
-
-Any other read (clean, behind-no-conflict, computing, dirty, unknown)
-skips the merge here — E11 never re-polls a transient read or holds on
-a dirty/unknown one; proceed to E12 and let
-`idd-review-triage.instructions.md`'s E-phase branch-sync check handle
-those states properly once PATH A reaches zero.
+- **`content-conflict`** (`mergeable` `CONFLICTING`): pass the active
+  review gate, merge `{development-branch}` into the feature branch
+  (`git fetch origin {development-branch} && git merge
+  origin/{development-branch}`), resolve, complete the merge.
+  Non-interactive-hostile signing: use the
+  [signed-commit merge wrapper](../../docs/idd-helper-scripts.md#signed-commit-merge-wrapper-shared-git-procedure)
+  instead.
+- Otherwise (clean, behind-no-conflict, computing, dirty,
+  force-push-exception, unknown): skip the merge, proceed to E12 —
+  the E-phase branch-sync check and F1 hold on those later.
 
 ## E12 — Lint, test, push
 

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -142,8 +142,9 @@ do not proceed to E12; a maintainer must clear the hold.
 
 Any other read (clean, behind-no-conflict, computing, dirty, unknown)
 skips the merge here — E11 never re-polls a transient read or holds on
-a dirty/unknown one; proceed to E12 and let the post-E12 branch-sync
-check handle those states properly.
+a dirty/unknown one; proceed to E12 and let
+`idd-review-triage.instructions.md`'s E-phase branch-sync check handle
+those states properly once PATH A reaches zero.
 
 ## E12 — Lint, test, push
 

--- a/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -139,8 +139,10 @@ other GitHub side effect, confirm all of the following:
    (helper) or `gh pr view {pr-number} --json mergeable,mergeStateStatus`
    otherwise — reflects the last pushed head, not local unpushed fixes.
 2. Not a confirmed conflict (clean, behind-no-conflict, computing,
-   dirty, unknown)? Skip the merge and continue to E12 — a later check
-   re-polls a transient read and holds on dirty/unknown.
+   dirty, unknown)? Skip the merge and continue to E12 — a dirty or
+   unresolved read isn't this step's problem to fix; F1
+   (`idd-pre-merge-lite.instructions.md`) stops and asks on any
+   non-clean pre-merge branch state.
 3. Conflict reported (`mergeable` `CONFLICTING`)? If the PR has
    unresolved review threads, unreplied comments, or a reviewer's
    latest state is `CHANGES_REQUESTED`, get explicit operator

--- a/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -135,10 +135,13 @@ other GitHub side effect, confirm all of the following:
 
 ## E11 — Resolve conflicts with main
 
-1. Check state read-only: `idd-branch-conflict-state --pr {pr-number}`
-   — reflects the last pushed head, not local unpushed fixes. Missing,
-   failing, or disagreeing? Stop and ask (Helper runtime contract
-   above) — no non-helper fallback here.
+1. Check state with the profile-selected branch-conflict-state helper:
+   `node scripts/branch-conflict-state.mjs --pr {pr-number}`, or the
+   package-manager-profile `idd:branch-conflict-state` command
+   (resolve the exact command from `docs/idd-helper-scripts.md` if
+   unsure) — reflects the last pushed head, not local unpushed fixes.
+   Missing, failing, or disagreeing? Stop and ask (Helper runtime
+   contract above) — no non-helper fallback here.
 2. Not a confirmed conflict (clean, behind-no-conflict, computing,
    dirty, force-push-exception, unknown)? Skip the merge, continue to
    E12 — F1 (`idd-pre-merge-lite.instructions.md`) holds on those

--- a/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -144,8 +144,8 @@ other GitHub side effect, confirm all of the following:
    contract above) — no non-helper fallback here.
 2. Not a confirmed conflict (clean, behind-no-conflict, computing,
    dirty, force-push-exception, unknown)? Skip the merge, continue to
-   E12 — F1 (`idd-pre-merge-lite.instructions.md`) holds on those
-   later.
+   E12 — F1 (`idd-pre-merge-lite.instructions.md`) handles those
+   downstream.
 3. Conflict (`mergeable` `CONFLICTING`)? Unresolved review threads,
    unreplied comments, or reviewer state `CHANGES_REQUESTED`: get
    explicit operator confirmation first — the merge commit will appear

--- a/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -138,8 +138,9 @@ other GitHub side effect, confirm all of the following:
 1. Check state read-only: `idd-branch-conflict-state --pr {pr-number}`
    (helper) or `gh pr view {pr-number} --json mergeable,mergeStateStatus`
    otherwise — reflects the last pushed head, not local unpushed fixes.
-2. No conflict (clean, behind-no-conflict, computing, dirty, unknown)?
-   Continue to E12 — do not merge; a later check owns re-poll/hold.
+2. Not a confirmed conflict (clean, behind-no-conflict, computing,
+   dirty, unknown)? Skip the merge and continue to E12 — a later check
+   re-polls a transient read and holds on dirty/unknown.
 3. Conflict reported (`mergeable` `CONFLICTING`)? If the PR has
    unresolved review threads, unreplied comments, or a reviewer's
    latest state is `CHANGES_REQUESTED`, get explicit operator

--- a/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -135,12 +135,16 @@ other GitHub side effect, confirm all of the following:
 
 ## E11 — Resolve conflicts with main
 
-1. Check for conflicts between the feature branch and `main`.
-2. If none exist, continue to E12.
-3. If conflicts exist, and the PR has unresolved review threads,
-   unreplied comments, or a reviewer's latest state is
-   `CHANGES_REQUESTED`, get explicit operator confirmation before
-   merging — the merge commit will appear in the PR history.
+1. Check state read-only: `idd-branch-conflict-state --pr {pr-number}`
+   (helper) or `gh pr view {pr-number} --json mergeable,mergeStateStatus`
+   otherwise — reflects the last pushed head, not local unpushed fixes.
+2. No conflict (clean, behind-no-conflict, computing, dirty, unknown)?
+   Continue to E12 — do not merge; a later check owns re-poll/hold.
+3. Conflict reported (`mergeable` `CONFLICTING`)? If the PR has
+   unresolved review threads, unreplied comments, or a reviewer's
+   latest state is `CHANGES_REQUESTED`, get explicit operator
+   confirmation before merging — the merge commit will appear in the
+   PR history.
 4. Run `git fetch origin main && git merge origin/main`.
 5. On a signed-commit repo whose primary signing is non-interactive
    hostile (GPG pinentry or hardware-touch) but that provides a

--- a/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -136,11 +136,16 @@ other GitHub side effect, confirm all of the following:
 ## E11 — Resolve conflicts with main
 
 1. Check state read-only: `idd-branch-conflict-state --pr {pr-number}`
-   (helper) or `gh pr view {pr-number} --json mergeable,mergeStateStatus`
-   otherwise — reflects the last pushed head, not local unpushed fixes.
-2. Not a confirmed conflict (clean, behind-no-conflict, computing,
-   dirty, unknown)? Skip the merge and continue to E12 — a dirty or
-   unresolved read isn't this step's problem to fix; F1
+   — reflects the last pushed head, not local unpushed fixes. Missing,
+   failing, or disagreeing with live state? Stop and ask per the Helper
+   runtime contract above — do not fall back to a non-helper read here.
+2. `force-push-exception` (a hold state per
+   [IDD policy constants](../../../docs/policy-constants.md), like
+   `dirty`/`unknown`)? Stop here — post a PR comment documenting the
+   state, and do not continue to E12; a maintainer must clear the
+   hold. Otherwise not a confirmed conflict (clean, behind-no-conflict,
+   computing, dirty, unknown)? Skip the merge and continue to E12 — a
+   dirty or unresolved read isn't this step's problem to fix; F1
    (`idd-pre-merge-lite.instructions.md`) stops and asks on any
    non-clean pre-merge branch state.
 3. Conflict reported (`mergeable` `CONFLICTING`)? If the PR has

--- a/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -137,38 +137,23 @@ other GitHub side effect, confirm all of the following:
 
 1. Check state read-only: `idd-branch-conflict-state --pr {pr-number}`
    — reflects the last pushed head, not local unpushed fixes. Missing,
-   failing, or disagreeing with live state? Stop and ask per the Helper
-   runtime contract above — do not fall back to a non-helper read here.
-2. `force-push-exception` (a hold state per
-   [IDD policy constants](../../../docs/policy-constants.md), like
-   `dirty`/`unknown`)? Stop here — post a PR comment documenting the
-   state, and do not continue to E12; a maintainer must clear the
-   hold. Otherwise not a confirmed conflict (clean, behind-no-conflict,
-   computing, dirty, unknown)? Skip the merge and continue to E12 — a
-   dirty or unresolved read isn't this step's problem to fix; F1
-   (`idd-pre-merge-lite.instructions.md`) stops and asks on any
-   non-clean pre-merge branch state.
-3. Conflict reported (`mergeable` `CONFLICTING`)? If the PR has
-   unresolved review threads, unreplied comments, or a reviewer's
-   latest state is `CHANGES_REQUESTED`, get explicit operator
-   confirmation before merging — the merge commit will appear in the
-   PR history.
-4. Run `git fetch origin main && git merge origin/main`.
-5. On a signed-commit repo whose primary signing is non-interactive
-   hostile (GPG pinentry or hardware-touch) but that provides a
-   fallback signing wrapper for arbitrary git subcommands (pass
-   `-c gpg.format=ssh -c user.signingkey=<abs-path> -c
-   commit.gpgsign=true` to `git` before the subcommand, plus
-   `-m "chore: merge origin/main into the claimed branch"` on the
-   first `merge` so a commitlint hook accepts the subject — `git -c …
-   merge`, not `git merge -c …`; a commit-only alias like
-   `git commit-ssh` will not run `merge`), run this merge through that
-   wrapper, not the plain command.
-6. Resolve any conflicts and complete the merge.
-7. If the merge needed `--continue`, run it through the same wrapper
-   used in step 5 (`git -c … merge --continue`), never the plain
-   `git merge --continue` — the wrapper must own the whole operation, or
-   the merge commit reverts to the stalling primary signing.
+   failing, or disagreeing? Stop and ask (Helper runtime contract
+   above) — no non-helper fallback here.
+2. Not a confirmed conflict (clean, behind-no-conflict, computing,
+   dirty, force-push-exception, unknown)? Skip the merge, continue to
+   E12 — F1 (`idd-pre-merge-lite.instructions.md`) holds on those
+   later.
+3. Conflict (`mergeable` `CONFLICTING`)? Unresolved review threads,
+   unreplied comments, or reviewer state `CHANGES_REQUESTED`: get
+   explicit operator confirmation first — the merge commit will appear
+   in the PR history.
+4. Run `git fetch origin main && git merge origin/main`. On
+   non-interactive-hostile primary signing (GPG pinentry or
+   hardware-touch) with a fallback wrapper, run the whole merge
+   (including `--continue`) through that wrapper instead — see
+   `docs/idd-helper-scripts.md#signed-commit-merge-wrapper-shared-git-procedure`
+   for the command form and the commitlint `-m` requirement.
+5. Resolve conflicts, complete the merge.
 
 ## E12 — Lint, test, push
 


### PR DESCRIPTION
# Summary

E11 ("Resolve conflicts with `{development-branch}`") ran a plain
`git merge origin/{development-branch}` unconditionally at the end of
every review-fix round. That is not a dry run: on a clean merge it
commits a merge commit as a side effect. Unlike E11, both the E-phase
branch-sync check and F1 already gate the same sync decision behind a
read-only `idd-branch-conflict-state` / `gh pr view` read first.
Sampling this repository's own merge-commit history found 28 of 37
non-"Merge pull request" merges since 2026-08-06 were clean — no
textual conflict existed at merge time — several landing minutes after
a fix commit with no intervening conflict, each costing an unnecessary
Copilot re-review round.

- Give E11 the same read-only pre-check as its siblings: only merge on
  an actual reported conflict (`mergeable` `CONFLICTING` /
  `content-conflict`); any other state (clean, behind-no-conflict,
  computing, dirty, force-push-exception, unknown) is a no-op that
  proceeds straight to E12 — those states are the E-phase
  branch-sync check's and F1's decision, not E11's. The existing
  conflict-resolution mechanics (merge command, signed-commit wrapper
  reference, never-squash/rebase note) are unchanged for the
  actual-conflict path.
- Apply the identical fix to the lite (weak-model condensed) profile's
  E11 (`idd-review-fix-lite.instructions.md`), which had the same
  unconditional-check gap in its own wording — same underlying defect,
  found during B2 planning; not in the issue's original candidate file
  list but the same fix.
- `bundle-review` and `bundle-review-fix-lite` were already at ~98% of
  their `audit/sync-manifest.json` context-ceiling limit before this
  change. An earlier commit on this branch wrongly raised both limits
  instead of trimming, which Codex correctly flagged as violating
  `docs/policy-constants.md`'s own near-ceiling exception (prefer
  trim/split once a bundle is already at ~95%+ utilization). That
  commit's effective change is reverted: both `limitBytes` are back at
  their original values (39500, 138000), and the E11 text is trimmed
  instead — moving the force-push-exception hold out of E11 (see
  below) and tightening prose (the lite profile's signed-commit
  wrapper mechanics now point at the shared doc section instead of
  repeating it) closed the gap without any limit increase. Both
  bundles finish this PR at 97.44% / 97.98% utilization — unchanged
  from before this PR's fix, not loosened.
- `idd-review-triage.instructions.md`'s E-phase branch-sync check and
  `idd-pre-merge.instructions.md`'s F1 are unchanged.

## Linked issue

Closes #2675

## Follow-up issues (if any)

- [ ] E11's read-only conflict check reflects the PR's last **pushed**
  head, not local unpushed E9 fixes — a genuine, disclosed limitation.
  If an E9 fix changes the exact conflicting hunk so local HEAD would
  merge cleanly, E11 still attempts (and commits) a merge based on the
  stale pushed-head conflict read. Raised by Codex during review;
  fixing it properly means adding a local-HEAD-aware read-only check
  (e.g. `git merge-tree --write-tree HEAD origin/{development-branch}`,
  the technique this issue's own investigation used), a third method
  beyond the two this issue's acceptance criteria names — out of scope
  here, but still a strict improvement over the pre-fix unconditional
  merge.
- [ ] `force-push-exception` is a documented hold state
  (`docs/policy-constants.md`) but neither
  `idd-review-triage.instructions.md`'s E-phase branch-sync check nor
  `idd-pre-merge.instructions.md`'s F1 (both out of scope for this
  issue's acceptance criteria) currently name it as a hold explicitly
  the way they do `dirty`/`unknown`. Raised by Codex during review;
  E11 now routes it (along with every other non-conflict state)
  straight to those two checks rather than holding on it itself, which
  is consistent with E11's narrow "merge or don't" scope, but the gap
  in the two downstream checks' own wording is real and belongs in a
  separate issue against those files.

## Background / rationale (if material)

Parent investigation: this issue's own body documents the merge-commit
history sampling methodology (`git merge-tree --write-tree` re-derivation
against 37 sampled merges) that motivated this fix.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [x] Config schema changed
- [x] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191MCYGribBmSeRVTk3AxQ6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch-state handling so only confirmed content conflicts trigger a merge.
  * Non-conflicting, uncertain, or exceptional states now proceed to later validation steps instead of merging prematurely.
  * Added validation that the selected branch-state check is available, succeeds, and matches the live state.
  * Preserved operator confirmation before conflict resolution.
  * Ensured signed merge procedures remain consistent when a merge must continue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->