### PR TITLE
fix(deps): guard against the node >=25 corepack gap

### DIFF
--- a/.github/CONTRIBUTING.ja.md
+++ b/.github/CONTRIBUTING.ja.md
@@ -42,6 +42,9 @@ pnpm run lint
 pnpm run test
 ```
 
+Node.js 25 以降は corepack を同梱しません。`corepack enable` が
+失敗する場合は、先に `npm install -g corepack` でインストールしてください。
+
 pre-commit hook は高速・コミット安全なサブセット
 (`pnpm run lint:precommit`: Biome・dprint・markdownlint)を実行し、
 完全な `pnpm run lint:minimum` スイートは CI で実行されます。

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -40,6 +40,9 @@ pnpm run lint
 pnpm run test
 ```
 
+Node.js 25+ no longer bundles corepack; if `corepack enable` fails,
+install it first with `npm install -g corepack`.
+
 The pre-commit hook runs a fast, commit-safe subset
 (`pnpm run lint:precommit`: Biome, dprint, and markdownlint); the full
 `pnpm run lint:minimum` suite runs in CI. The commit message hook

--- a/.github/CONTRIBUTING.zh.md
+++ b/.github/CONTRIBUTING.zh.md
@@ -32,6 +32,9 @@ pnpm run lint
 pnpm run test
 ```
 
+Node.js 25 及以上版本不再内置 corepack。如果 `corepack enable`
+失败,请先运行 `npm install -g corepack` 进行安装。
+
 pre-commit 钩子运行快速且提交安全的子集
 (`pnpm run lint:precommit`: Biome、dprint 和 markdownlint);完整的
 `pnpm run lint:minimum` 套件在 CI 中运行。commit-msg 钩子通过

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
   },
   "packageManager": "pnpm@12.3.4+sha512.961aa41fb077da3a04a441d9f8e15ebc0c96da8ef710b2eb67bf9ee7cb0610eabd48f1fd85f51cffe73846785fa0f87c56a3a872a1d893f8446741b5cce45457",
   "engines": {
-    "node": "^22.23.2 || ^24.2.0 || >=26.0.0"
+    "node": "^22.23.2 || ^24.2.0 || >=26.0.0",
+    "pnpm": "^12.0.0"
   }
 }

--- a/scripts/verify-install-deps.mjs
+++ b/scripts/verify-install-deps.mjs
@@ -145,12 +145,12 @@ function runInstallCommand(installCommand) {
   }
 }
 /**
- * `shell: true` is required, not incidental, for the same reason
- * `runInstallCommand` above needs it: a globally installed `corepack`
- * can be a `.CMD`/`.ps1` shim on Windows that isn't directly
- * executable without a shell (see also `build-ts.mts`'s header on the
- * `tsc`/`biome` shim case) -- omitting it risks a false "missing" read
- * on Windows even when corepack is present.
+ * `shell: true` is required, not incidental: a globally installed
+ * `corepack` can be a `.CMD`/`.ps1` shim on Windows that isn't
+ * directly executable without a shell -- the same class of problem
+ * `build-ts.mts`'s header documents for the `tsc`/`biome` shim case --
+ * omitting it risks a false "missing" read on Windows even when
+ * corepack is present.
  */
 function isCorepackAvailable() {
   try {

--- a/scripts/verify-install-deps.mjs
+++ b/scripts/verify-install-deps.mjs
@@ -31,6 +31,24 @@ export function classifyInstallDepsOutcome(
     ? { status: 'recovered-after-retry' }
     : { status: 'missing-after-retry' };
 }
+/**
+ * Node.js 25+ no longer bundles corepack (nodejs/corepack), so a
+ * pnpm-based install command can fail with no pnpm binary to run on a
+ * bare Node >=25 install. When the key binary is still missing after
+ * the retry, this hint is a possibility to check, not a diagnosis --
+ * corepack being absent isn't necessarily the actual cause.
+ */
+export function describeCorepackGuidance(corepackAvailable) {
+  if (corepackAvailable) {
+    return null;
+  }
+  return (
+    'verify-install-deps: corepack was not found. Node.js 25+ no longer ' +
+    'bundles corepack, which may be why the install above is failing -- ' +
+    'install it separately (for example `npm install -g corepack`) and ' +
+    'retry.\n'
+  );
+}
 // Flag-spec keys stay the dashed literal on purpose (never bare keys like
 // `key-binary:`): tests/flag-name-matrix.test.mts scans this file's
 // *compiled* .mjs source text for quoted flag literals such as the
@@ -77,6 +95,10 @@ function runCli() {
     existsAfterRetry,
   );
   if (outcome.status === 'missing-after-retry') {
+    const corepackHint = describeCorepackGuidance(isCorepackAvailable());
+    if (corepackHint !== null) {
+      process.stderr.write(corepackHint);
+    }
     process.stderr.write(
       `verify-install-deps: ${args.keyBinary} still missing after retrying ` +
         `"${args.installCommand}". The dependency install did not complete ` +
@@ -120,6 +142,22 @@ function runInstallCommand(installCommand) {
     execFileSync(installCommand, [], { shell: true, stdio: 'inherit' });
   } catch {
     // Swallowed intentionally -- see comment above.
+  }
+}
+/**
+ * `shell: true` is required, not incidental, for the same reason
+ * `runInstallCommand` above needs it: a globally installed `corepack`
+ * can be a `.CMD`/`.ps1` shim on Windows that isn't directly
+ * executable without a shell (see also `build-ts.mts`'s header on the
+ * `tsc`/`biome` shim case) -- omitting it risks a false "missing" read
+ * on Windows even when corepack is present.
+ */
+function isCorepackAvailable() {
+  try {
+    execFileSync('corepack', ['--version'], { shell: true, stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
   }
 }
 function parseArgs(argv) {

--- a/src/scripts/verify-install-deps.mts
+++ b/src/scripts/verify-install-deps.mts
@@ -39,6 +39,27 @@ export function classifyInstallDepsOutcome(
     : { status: 'missing-after-retry' };
 }
 
+/**
+ * Node.js 25+ no longer bundles corepack (nodejs/corepack), so a
+ * pnpm-based install command can fail with no pnpm binary to run on a
+ * bare Node >=25 install. When the key binary is still missing after
+ * the retry, this hint is a possibility to check, not a diagnosis --
+ * corepack being absent isn't necessarily the actual cause.
+ */
+export function describeCorepackGuidance(
+  corepackAvailable: boolean,
+): string | null {
+  if (corepackAvailable) {
+    return null;
+  }
+  return (
+    'verify-install-deps: corepack was not found. Node.js 25+ no longer ' +
+    'bundles corepack, which may be why the install above is failing -- ' +
+    'install it separately (for example `npm install -g corepack`) and ' +
+    'retry.\n'
+  );
+}
+
 // Flag-spec keys stay the dashed literal on purpose (never bare keys like
 // `key-binary:`): tests/flag-name-matrix.test.mts scans this file's
 // *compiled* .mjs source text for quoted flag literals such as the
@@ -90,6 +111,10 @@ function runCli(): void {
     existsAfterRetry,
   );
   if (outcome.status === 'missing-after-retry') {
+    const corepackHint = describeCorepackGuidance(isCorepackAvailable());
+    if (corepackHint !== null) {
+      process.stderr.write(corepackHint);
+    }
     process.stderr.write(
       `verify-install-deps: ${args.keyBinary} still missing after retrying ` +
         `"${args.installCommand}". The dependency install did not complete ` +
@@ -134,6 +159,23 @@ function runInstallCommand(installCommand: string): void {
     execFileSync(installCommand, [], { shell: true, stdio: 'inherit' });
   } catch {
     // Swallowed intentionally -- see comment above.
+  }
+}
+
+/**
+ * `shell: true` is required, not incidental, for the same reason
+ * `runInstallCommand` above needs it: a globally installed `corepack`
+ * can be a `.CMD`/`.ps1` shim on Windows that isn't directly
+ * executable without a shell (see also `build-ts.mts`'s header on the
+ * `tsc`/`biome` shim case) -- omitting it risks a false "missing" read
+ * on Windows even when corepack is present.
+ */
+function isCorepackAvailable(): boolean {
+  try {
+    execFileSync('corepack', ['--version'], { shell: true, stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
   }
 }
 

--- a/src/scripts/verify-install-deps.mts
+++ b/src/scripts/verify-install-deps.mts
@@ -163,12 +163,12 @@ function runInstallCommand(installCommand: string): void {
 }
 
 /**
- * `shell: true` is required, not incidental, for the same reason
- * `runInstallCommand` above needs it: a globally installed `corepack`
- * can be a `.CMD`/`.ps1` shim on Windows that isn't directly
- * executable without a shell (see also `build-ts.mts`'s header on the
- * `tsc`/`biome` shim case) -- omitting it risks a false "missing" read
- * on Windows even when corepack is present.
+ * `shell: true` is required, not incidental: a globally installed
+ * `corepack` can be a `.CMD`/`.ps1` shim on Windows that isn't
+ * directly executable without a shell -- the same class of problem
+ * `build-ts.mts`'s header documents for the `tsc`/`biome` shim case --
+ * omitting it risks a false "missing" read on Windows even when
+ * corepack is present.
  */
 function isCorepackAvailable(): boolean {
   try {

--- a/tests/verify-install-deps.test.mts
+++ b/tests/verify-install-deps.test.mts
@@ -6,7 +6,10 @@ import { dirname, join } from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
-import { classifyInstallDepsOutcome } from '../src/scripts/verify-install-deps.mts';
+import {
+  classifyInstallDepsOutcome,
+  describeCorepackGuidance,
+} from '../src/scripts/verify-install-deps.mts';
 
 test('present-after-install when the key binary exists before any retry', () => {
   assert.deepEqual(classifyInstallDepsOutcome(true, false), {
@@ -30,6 +33,16 @@ test('missing-after-retry when the binary is still absent after the retry', () =
   assert.deepEqual(classifyInstallDepsOutcome(false, false), {
     status: 'missing-after-retry',
   });
+});
+
+test('describeCorepackGuidance returns null when corepack is available', () => {
+  assert.equal(describeCorepackGuidance(true), null);
+});
+
+test('describeCorepackGuidance hints at installing corepack when absent', () => {
+  const hint = describeCorepackGuidance(false);
+  assert.match(hint ?? '', /corepack was not found/);
+  assert.match(hint ?? '', /npm install -g corepack/);
 });
 
 // ---------------------------------------------------------------------------
@@ -142,6 +155,10 @@ test('CLI: exits 1 with an actionable message when the binary never appears', ()
   assert.equal(attempts, 2);
   assert.match(stderr, /still missing after retrying/);
   assert.match(stderr, /retry manually/);
+  // This sandbox's dev environment has corepack available, so the
+  // corepack hint must not fire here -- see describeCorepackGuidance's
+  // own unit tests above for the absent-corepack case.
+  assert.doesNotMatch(stderr, /corepack was not found/);
 });
 
 test('CLI: --help prints usage and exits 0 without running any install', () => {

--- a/tests/verify-install-deps.test.mts
+++ b/tests/verify-install-deps.test.mts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { test } from 'node:test';
@@ -89,6 +89,20 @@ function fakeInstallCommand(
   return `node -e "${script}"`;
 }
 
+/**
+ * Same probe the CLI itself runs (`isCorepackAvailable` in
+ * verify-install-deps.mts): whether *this* environment actually has
+ * corepack, so tests can assert against reality instead of assuming a
+ * dev-machine default. `engines.node` supports Node 26.x, which does
+ * not bundle corepack, so this can genuinely be false in CI.
+ */
+function isCorepackOnPath(): boolean {
+  return (
+    spawnSync('corepack', ['--version'], { shell: true, stdio: 'ignore' })
+      .status === 0
+  );
+}
+
 interface CliRun {
   status: number | null;
   stderr: string;
@@ -155,10 +169,54 @@ test('CLI: exits 1 with an actionable message when the binary never appears', ()
   assert.equal(attempts, 2);
   assert.match(stderr, /still missing after retrying/);
   assert.match(stderr, /retry manually/);
-  // This sandbox's dev environment has corepack available, so the
-  // corepack hint must not fire here -- see describeCorepackGuidance's
-  // own unit tests above for the absent-corepack case.
-  assert.doesNotMatch(stderr, /corepack was not found/);
+  // The corepack hint's presence mirrors this environment's own
+  // corepack availability -- asserting a fixed expectation here would
+  // be wrong on a Node >=25 runner with no corepack installed, exactly
+  // the population this issue exists to help. See the isolated-PATH
+  // test below for a deterministic check of the absent-corepack path.
+  if (isCorepackOnPath()) {
+    assert.doesNotMatch(stderr, /corepack was not found/);
+  } else {
+    assert.match(stderr, /corepack was not found/);
+  }
+});
+
+test('CLI: hints at installing corepack when it is absent from PATH', {
+  skip: process.platform === 'win32',
+}, () => {
+  // Deterministic, environment-independent check for the absent-corepack
+  // path: isolate PATH down to a directory containing only a `node`
+  // symlink, so `isCorepackAvailable()`'s `corepack --version` probe
+  // genuinely fails regardless of whether this host has corepack
+  // installed. Skipped on win32: symlinking an executable there needs
+  // elevated privilege or Developer Mode, which CI cannot assume.
+  const cwd = mkdtempSync(join(tmpdir(), 'idd-verify-install-deps-'));
+  const isolatedBin = mkdtempSync(join(tmpdir(), 'idd-no-corepack-bin-'));
+  const callLog = join(cwd, '.call-log');
+  try {
+    symlinkSync(process.execPath, join(isolatedBin, 'node'));
+    const result = spawnSync(
+      'node',
+      [
+        CLI_ENTRY,
+        '--key-binary',
+        KEY_BINARY,
+        '--install-command',
+        fakeInstallCommand(99),
+      ],
+      {
+        cwd,
+        env: { PATH: isolatedBin, CALL_LOG: callLog },
+        encoding: 'utf8',
+      },
+    );
+    assert.equal(result.status, 1);
+    assert.match(result.stderr ?? '', /corepack was not found/);
+    assert.match(result.stderr ?? '', /npm install -g corepack/);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(isolatedBin, { recursive: true, force: true });
+  }
 });
 
 test('CLI: --help prints usage and exits 0 without running any install', () => {


### PR DESCRIPTION
# Summary

Node.js 25+ no longer bundles corepack, which affects contributors and
automation running this repository's local dev tooling on a bare
Node >=25 install. Per the maintainer decision recorded in the issue,
this combines three small, independent, mechanically verifiable
changes:

- Document the gap and the workaround (`npm install -g corepack`) next
  to the existing `corepack enable` step in all three `CONTRIBUTING`
  mirrors (en/ja/zh).
- Add `engines.pnpm: "^12.0.0"` to `package.json`, matching the major
  version already pinned via `packageManager` (#2689/#2693). This is
  enforced by pnpm itself at install time, independent of corepack, so
  it also guards against a stray globally installed pnpm of the wrong
  major version.
- Extend `scripts/verify-install-deps.mjs` (generated from
  `src/scripts/verify-install-deps.mts`) so that when the key binary
  is still missing after its existing retry, it additionally probes
  for a `corepack` binary and, if absent, prints a hint that Node.js
  25+ no longer bundles corepack, framed as a possibility to check
  rather than a diagnosis.

## Linked issue

Closes #2690

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Two independent critique passes (IDD C1) ran against this diff before
submission. The first caught a Windows shim risk for the new
`corepack --version` probe (fixed with `shell: true`, matching this
file's own `runInstallCommand` and `build-ts.mts`'s documented
`.CMD`/`.ps1` shim precedent) and an incorrect `pre-push-validate`
invocation in the draft plan (it is a `.github/idd/config.json`
command-table entry, not a `package.json` script). The second caught
that a new CLI test hard-assumed corepack is present on the test
host — false on exactly the Node >=25 population this issue targets —
which is now a dynamic assertion against the real environment, plus a
new deterministic test that forces the absent-corepack path via an
isolated `PATH` (skipped on win32, where symlinking an executable
needs elevated privilege).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (no docs:sync-managed file touched)
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
