### PR TITLE
fix(provider-adapter-github): keep real GraphQL thread IDs in missingThreads

### DIFF
--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -883,17 +883,17 @@ export function normalizeReview(review) {
 /**
  * Normalize a `ProviderPort.listChangeRequestReviewThreadsWithComments`
  * node into the summarizer-shape `ThreadLike`. Exported for direct unit
- * testing (#1708), see {@link normalizeComment}'s doc comment. `id` and
- * `reviewerReopenedAt` are omitted (both `ThreadLike` fields are optional):
- * the pre-migration GraphQL query never selected `reviewerReopenedAt` at
- * all (`inferReviewerReopenedAt` always returned `''`), and the outer
- * thread `id` fed only `ThreadLike`'s own optional diagnostic fields, not
- * any gating decision -- `review-activity-snapshot.mts`'s own
- * `normalizeThread` already dropped both for the identical shared
- * GraphQL query, reviewed and merged without incident.
+ * testing (#1708), see {@link normalizeComment}'s doc comment.
+ * `reviewerReopenedAt` is omitted (`ThreadLike`'s field is optional): the
+ * pre-migration GraphQL query never selected it at all
+ * (`inferReviewerReopenedAt` always returned `''`). `id` (#2696) is
+ * threaded through -- it feeds `dispositionEvidence.missingThreads[].id`,
+ * which a caller reads to identify which live thread to reply to; dropping
+ * it forced a separate positional lookup to recover the real thread.
  */
 export function normalizeThread(thread) {
   return {
+    id: thread.id,
     isResolved: Boolean(thread.isResolved),
     updatedAt: '',
     comments: {

--- a/scripts/provider-adapter-github.mjs
+++ b/scripts/provider-adapter-github.mjs
@@ -1460,6 +1460,7 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
         'body createdAt updatedAt author { login } pullRequestReview { id }',
       );
       return nodes.map((node) => ({
+        id: node.id,
         isResolved: node.isResolved,
         comments: node.comments.map((comment) => ({
           body: String(comment.body ?? ''),

--- a/scripts/review-activity-snapshot.mjs
+++ b/scripts/review-activity-snapshot.mjs
@@ -207,6 +207,7 @@ function normalizeReview(review) {
 }
 function normalizeThread(thread) {
   return {
+    id: thread.id,
     isResolved: Boolean(thread.isResolved),
     updatedAt: '',
     comments: {

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -1119,17 +1119,17 @@ export function normalizeReview(review: ReviewPayload) {
 /**
  * Normalize a `ProviderPort.listChangeRequestReviewThreadsWithComments`
  * node into the summarizer-shape `ThreadLike`. Exported for direct unit
- * testing (#1708), see {@link normalizeComment}'s doc comment. `id` and
- * `reviewerReopenedAt` are omitted (both `ThreadLike` fields are optional):
- * the pre-migration GraphQL query never selected `reviewerReopenedAt` at
- * all (`inferReviewerReopenedAt` always returned `''`), and the outer
- * thread `id` fed only `ThreadLike`'s own optional diagnostic fields, not
- * any gating decision -- `review-activity-snapshot.mts`'s own
- * `normalizeThread` already dropped both for the identical shared
- * GraphQL query, reviewed and merged without incident.
+ * testing (#1708), see {@link normalizeComment}'s doc comment.
+ * `reviewerReopenedAt` is omitted (`ThreadLike`'s field is optional): the
+ * pre-migration GraphQL query never selected it at all
+ * (`inferReviewerReopenedAt` always returned `''`). `id` (#2696) is
+ * threaded through -- it feeds `dispositionEvidence.missingThreads[].id`,
+ * which a caller reads to identify which live thread to reply to; dropping
+ * it forced a separate positional lookup to recover the real thread.
  */
 export function normalizeThread(thread: ProviderReviewThreadWithComments) {
   return {
+    id: thread.id,
     isResolved: Boolean(thread.isResolved),
     updatedAt: '',
     comments: {

--- a/src/scripts/provider-adapter-github.mts
+++ b/src/scripts/provider-adapter-github.mts
@@ -1900,6 +1900,7 @@ export function createGithubProviderAdapter(
         'body createdAt updatedAt author { login } pullRequestReview { id }',
       );
       return nodes.map((node) => ({
+        id: node.id,
         isResolved: node.isResolved,
         comments: node.comments.map((comment) => ({
           body: String(comment.body ?? ''),

--- a/src/scripts/provider-port.mts
+++ b/src/scripts/provider-port.mts
@@ -245,8 +245,12 @@ export interface ProviderReviewThreadComment {
  * (byte-identical GraphQL query in both). Distinct from the minimal
  * {@link ProviderPort.listChangeRequestReviewThreads} (`{isResolved}[]`
  * only, #2266): this one also needs each thread's comment bodies/authors
- * for disposition-evidence matching. */
+ * for disposition-evidence matching. `id` is the thread's real GraphQL
+ * node id (#2696) -- callers thread it into diagnostic output (e.g.
+ * `dispositionEvidence.missingThreads[].id`) so a caller can identify
+ * which thread to reply to without a separate positional lookup. */
 export interface ProviderReviewThreadWithComments {
+  id: string;
   isResolved: boolean | null;
   comments: ProviderReviewThreadComment[];
 }

--- a/src/scripts/review-activity-snapshot.mts
+++ b/src/scripts/review-activity-snapshot.mts
@@ -254,6 +254,7 @@ function normalizeReview(review: ReviewPayload) {
 
 function normalizeThread(thread: ProviderReviewThreadWithComments) {
   return {
+    id: thread.id,
     isResolved: Boolean(thread.isResolved),
     updatedAt: '',
     comments: {

--- a/tests/pre-merge-readiness-collection-smoke.test.mts
+++ b/tests/pre-merge-readiness-collection-smoke.test.mts
@@ -97,6 +97,7 @@ test('normalizeReview maps REST review fields, deriving createdAt from submitted
 test('normalizeThread maps a ProviderPort review-thread node, including nested comments', () => {
   assert.deepEqual(
     normalizeThread({
+      id: 'RT_1',
       isResolved: false,
       comments: [
         {
@@ -109,6 +110,7 @@ test('normalizeThread maps a ProviderPort review-thread node, including nested c
       ],
     }),
     {
+      id: 'RT_1',
       isResolved: false,
       updatedAt: '',
       comments: {
@@ -437,22 +439,19 @@ test('pre-merge-readiness.mjs CLI: clean scenario collects and normalizes raw gh
     },
   ]);
 
-  // normalizeThread: isResolved flows into dispositionEvidence.missingThreads.
-  // #2267: `id` is now the `thread-${index+1}` fallback, not the raw GraphQL
-  // node id -- `ProviderPort.listChangeRequestReviewThreadsWithComments`
-  // (byte-identical query, shared with the already-migrated
-  // review-activity-snapshot.mts) does not surface it, matching that file's
-  // own already-reviewed `normalizeThread`. This id is diagnostic-only in
-  // this report: `advisory-convergence.mts` (the one real id-matching
-  // consumer, `copilotThreadIds.has(thread.id)`) fetches its own,
-  // independent `threads` array via its own port method and never reads
-  // this file's output.
+  // normalizeThread: isResolved and the real thread id both flow into
+  // dispositionEvidence.missingThreads. #2696: the raw GraphQL node's
+  // `id: 'RT_1'` (see `reviewThreadsPayload` above) now survives
+  // `ProviderPort.listChangeRequestReviewThreadsWithComments` and this
+  // file's own `normalizeThread` -- previously both dropped it, forcing
+  // the positional `thread-${index+1}` fallback even though the id was
+  // already fetched and available.
   const threads = report.threads as { unresolvedCount: number };
   assert.equal(threads.unresolvedCount, 0);
   const dispositionEvidence = report.dispositionEvidence as {
     missingThreads: { id: string; isResolved: boolean }[];
   };
-  assert.equal(dispositionEvidence.missingThreads[0]?.id, 'thread-1');
+  assert.equal(dispositionEvidence.missingThreads[0]?.id, 'RT_1');
   assert.equal(dispositionEvidence.missingThreads[0]?.isResolved, true);
 
   // #2042: `fetchReviewsAndHeadCommit`'s own `gh api graphql` call must
@@ -679,6 +678,7 @@ test('collectPreMergeReadiness against a fake provider: unreadable CI governance
       reviewThreadsWithComments: {
         42: [
           {
+            id: 'RT_unresolved',
             isResolved: false,
             comments: [
               {

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -189,6 +189,54 @@ test('reviewCurrency and dispositionEvidence agree a rejection-confirmed-by-main
   );
 });
 
+// #2696: this gate-level function already read `thread.id` correctly before
+// this issue's fix -- the actual bug was upstream (the provider mapping and
+// both `normalizeThread` call sites dropped `id` before it reached here; see
+// those files' own test coverage for the real regression guards). This test
+// pins the AC's explicit requirement directly at this layer: report the real
+// thread id whenever the caller supplies one, and fall back to a positional
+// `thread-${index+1}` label only when it genuinely has none.
+test('summarizeDispositionEvidenceForGate reports the real thread id when present, and the positional fallback only when absent', () => {
+  const threadWithRealId = {
+    id: 'RT_real_123',
+    isResolved: false,
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          author: { login: 'reviewer-a' },
+          body: 'please address this',
+          createdAt: '2026-05-12T00:00:00Z',
+          updatedAt: '2026-05-12T00:00:00Z',
+        },
+      ],
+    },
+  };
+  const threadWithNoId = {
+    isResolved: false,
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          author: { login: 'reviewer-b' },
+          body: 'and this one too',
+          createdAt: '2026-05-12T00:00:00Z',
+          updatedAt: '2026-05-12T00:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const dispositionSummary = summarizeDispositionEvidenceForGate(
+    { comments: [], threads: [threadWithRealId, threadWithNoId] },
+    { iddAgentLogins: [], advisoryBotLogins: [] },
+  );
+
+  assert.equal(dispositionSummary.blockingCount, 2);
+  assert.equal(dispositionSummary.missingThreads[0].id, 'RT_real_123');
+  assert.equal(dispositionSummary.missingThreads[1].id, 'thread-2');
+});
+
 // #2618: `classifyThreadAckOnlyPostDisposition` extracted out of
 // `summarizeDispositionEvidenceForGate` into a standalone export so F4's
 // `audit-pr-cleanup.mts` (no review-snapshot watermark) can share it with

--- a/tests/provider-adapter-github.test.mts
+++ b/tests/provider-adapter-github.test.mts
@@ -914,6 +914,7 @@ test('listChangeRequestReviewThreadsWithComments and listChangeRequestReviewThre
   );
   assert.deepEqual(port.listChangeRequestReviewThreadsWithComments(7), [
     {
+      id: 't1',
       isResolved: true,
       comments: [
         {

--- a/tests/provider-adapter-parity.test.mts
+++ b/tests/provider-adapter-parity.test.mts
@@ -196,6 +196,7 @@ test('listChangeRequestReviewThreadsWithComments: GitHub and fake adapters agree
     reviewThreadsWithComments: {
       42: [
         {
+          id: 'RT_resolved',
           isResolved: true,
           comments: [
             {
@@ -208,6 +209,7 @@ test('listChangeRequestReviewThreadsWithComments: GitHub and fake adapters agree
           ],
         },
         {
+          id: 'RT_open',
           isResolved: false,
           comments: [
             {
@@ -230,6 +232,14 @@ test('listChangeRequestReviewThreadsWithComments: GitHub and fake adapters agree
     githubResult.map((thread) => thread.isResolved),
     [true, false],
     'sanity: one resolved thread, one unresolved',
+  );
+  // #2696: the real GraphQL thread id must survive the port mapping --
+  // downstream diagnostics (dispositionEvidence.missingThreads[].id) key
+  // off this instead of falling back to a positional thread-N label.
+  assert.deepEqual(
+    githubResult.map((thread) => thread.id),
+    ['RT_resolved', 'RT_open'],
+    'the real thread id must flow through, not be dropped',
   );
   assert.deepEqual(fakeResult, githubResult);
 });


### PR DESCRIPTION
# Summary

`listChangeRequestReviewThreadsWithComments` already receives each
thread's real GraphQL node `id` from `fetchReviewThreadsGeneric` (its
own doc comment confirms this), but dropped it before returning. Two
downstream normalizers -- `pre-merge-readiness.mts`'s exported
`normalizeThread` and `review-activity-snapshot.mts`'s own separate,
identical `normalizeThread` -- also dropped it converting to the
summarizer's `ThreadLike` shape, so
`dispositionEvidence.missingThreads[]` fell back to a positional
`thread-N` label even though the real id was fetched and available the
whole time. Recovering which real thread a `thread-N` label referred to
required a second, separate GraphQL query to line comments up by
creation-order position -- expensive, error-prone busywork this fixes.

Adds `id: string` to `ProviderReviewThreadWithComments` and threads it
through all three sites (the provider adapter and both normalizers).

Documentation-scope note: this PR's own draft/refined plan comments on
the issue independently verified (and a critique pass confirmed) that
the issue's own root-cause paragraph named only
`provider-adapter-github.mts` and `protocol-helpers.mts`, but the
actual id-dropping also happens in the two `normalizeThread` functions
-- `protocol-helpers.mts`'s `summarizeDispositionEvidenceForGate` was
already reading `thread.id` correctly whenever one was supplied.

**Side effect**: `report.threads.classifications[].id` (also read from
`thread.id`, via `summarizeReviewThreadsForGate`) is populated for the
first time instead of always being `undefined` -- same root cause, not
a separate change.

## Linked issue

Closes #2696

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

An independent critique pass on the first draft of this diff found two
real gaps before this push:

- `tests/provider-adapter-github.test.mts` (not in the issue's own
  candidate-files list) has its own `listChangeRequestReviewThreadsWithComments`
  fixture/assertion pair that needed the same `id` addition -- missing
  it left `node --test tests/*.test.mts` failing.
- The new `protocol-helpers.test.mts` fixture id
  (`PRRT_kwDOreal123`-shaped) tripped `cspell` on the unrecognized
  `PRRT` token; renamed to the repository's existing `RT_*` convention
  used elsewhere in the same file/suite.

Both are fixed in this push; the full suite (5308 tests), `pnpm run
lint:minimum`, `pnpm run typecheck`, and `pnpm run build:check` all
pass.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed

`provider-adapter-github.mts` and `pre-merge-readiness.mts` are part of
the F2 merge-gate evidence pipeline, so checked for reviewer visibility
-- but this change is diagnostic-only: it does not alter any gating
decision, threshold, or the `blockingCount`/`route` logic, only the
`id` value attached to each already-computed `missingThreads` /
`classifications` entry.

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jz9naVhMefTusdLL9FzLc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Review-thread identifiers are now preserved and surfaced in diagnostic results.
  * Reports identify the actual thread associated with unresolved review feedback, improving reply targeting and traceability.
  * Positional labels remain available as a fallback when an identifier is unavailable.

* **Tests**
  * Added coverage confirming thread identifiers are retained across providers and reporting workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->