### PR TITLE
docs(idd-workflow): check for a stale clone-lock during resume recovery

### DIFF
--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -757,9 +757,17 @@ Running this variant safely requires:
 - **Resume-specific recovery when a worker dies mid-turn.** Re-verify
   claim ownership and worktree state before continuing; treat any
   uncommitted work found in the worktree as unverified input to check,
-  never as something to trust or silently discard; then delegate a fresh
-  subagent with a resume-specific briefing rather than resuming the dead
-  worker's own context.
+  never as something to trust or silently discard. Also check for a
+  stale clone-scoped lock before redelegating: run
+  `node scripts/clone-lock.mjs --check` (or the profile-selected
+  `idd:clone-lock --check` equivalent -- see
+  [Clone-scoped lock](idd-helper-scripts.md#clone-scoped-lock)) and, if
+  it reports a held lock, follow the existing manual-recovery procedure
+  (independently confirm the recorded holder's pid is actually gone,
+  then remove the lock file by hand and retry -- the same recovery
+  git's own `index.lock` expects on a stale-lock collision) before
+  delegating a fresh subagent with a resume-specific briefing rather
+  than resuming the dead worker's own context.
 - **Independently verify a worker's reported terminal outcome before
   trusting it.** A worker's final-turn text describes what it
   _attempted_, not proof of what actually landed on the forge. Before

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -770,11 +770,13 @@ Running this variant safely requires:
   parseable holder: confirm the whole lock-owning operation -- the
   recorded wrapper and any git process it spawned -- is actually gone,
   not merely that the recorded pid has exited (a dead wrapper can still
-  leave a live git child that still needs the lock --
-  kurone-kito/idd-skill#2223). With `malformed: true` (a truncated or
-  otherwise unparseable lock file carries no holder to check at all):
-  independently confirm no clone-scoped git operation is still running
-  against this repository instead. Either way, only then remove the
+  leave a live git child that still needs the lock -- observed
+  2026-09-01, kurone-kito/idd-skill#2223, kurone-kito/idd-skill#2389).
+  With `malformed: true` (a truncated or otherwise unparseable lock
+  file carries no holder to check at all -- preventive; no observed
+  incident yet): independently confirm no clone-scoped git operation is
+  still running against this repository instead. Either way, only then
+  remove the
   lock file by hand and retry -- the same approach git's own
   `index.lock` takes on a stale-lock collision -- before delegating a
   fresh subagent with a resume-specific briefing rather than resuming

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -760,12 +760,15 @@ Running this variant safely requires:
   never as something to trust or silently discard. Also check for a
   stale clone-scoped lock before redelegating: run
   `node scripts/clone-lock.mjs --check` (or the profile-selected
-  `idd:clone-lock --check` equivalent -- see
-  [Clone-scoped lock](idd-helper-scripts.md#clone-scoped-lock)) and, if
-  it reports a held lock, follow the existing manual-recovery procedure
-  (independently confirm the recorded holder's pid is actually gone,
+  `idd:clone-lock` command with `--check` -- see
+  [Clone-scoped lock](idd-helper-scripts.md#clone-scoped-lock) for the
+  literal per-profile invocation) and, if it reports a held lock, follow
+  the existing manual-recovery procedure: confirm the whole lock-owning
+  operation -- the recorded wrapper and any git process it spawned -- is
+  actually gone, not merely that the recorded pid has exited (a dead
+  wrapper can still leave a live git child that still needs the lock),
   then remove the lock file by hand and retry -- the same recovery
-  git's own `index.lock` expects on a stale-lock collision) before
+  git's own `index.lock` expects on a stale-lock collision -- before
   delegating a fresh subagent with a resume-specific briefing rather
   than resuming the dead worker's own context.
 - **Independently verify a worker's reported terminal outcome before

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -766,11 +766,12 @@ Running this variant safely requires:
   the existing manual-recovery procedure: confirm the whole lock-owning
   operation -- the recorded wrapper and any git process it spawned -- is
   actually gone, not merely that the recorded pid has exited (a dead
-  wrapper can still leave a live git child that still needs the lock),
-  then remove the lock file by hand and retry -- the same recovery
-  git's own `index.lock` expects on a stale-lock collision -- before
-  delegating a fresh subagent with a resume-specific briefing rather
-  than resuming the dead worker's own context.
+  wrapper can still leave a live git child that still needs the lock --
+  kurone-kito/idd-skill#2223), then remove the lock file by hand and
+  retry -- the same approach git's own `index.lock` takes on a
+  stale-lock collision -- before delegating a fresh subagent with a
+  resume-specific briefing rather than resuming the dead worker's own
+  context.
 - **Independently verify a worker's reported terminal outcome before
   trusting it.** A worker's final-turn text describes what it
   _attempted_, not proof of what actually landed on the forge. Before

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -765,15 +765,20 @@ Running this variant safely requires:
   profile's own multi-worker-one-clone caveat: run
   `node scripts/clone-lock.mjs --check` (or the profile-selected
   `idd:clone-lock` command with `--check`, per that same section, for
-  the literal per-profile invocation) and, if it reports a held lock, follow
-  the existing manual-recovery procedure: confirm the whole lock-owning
-  operation -- the recorded wrapper and any git process it spawned -- is
-  actually gone, not merely that the recorded pid has exited (a dead
-  wrapper can still leave a live git child that still needs the lock --
-  kurone-kito/idd-skill#2223), then remove the lock file by hand and
-  retry -- the same approach git's own `index.lock` takes on a
-  stale-lock collision -- before delegating a fresh subagent with a
-  resume-specific briefing rather than resuming the dead worker's own
+  the literal per-profile invocation) and, if it reports the lock
+  present, follow the existing manual-recovery procedure. With a
+  parseable holder: confirm the whole lock-owning operation -- the
+  recorded wrapper and any git process it spawned -- is actually gone,
+  not merely that the recorded pid has exited (a dead wrapper can still
+  leave a live git child that still needs the lock --
+  kurone-kito/idd-skill#2223). With `malformed: true` (a truncated or
+  otherwise unparseable lock file carries no holder to check at all):
+  independently confirm no clone-scoped git operation is still running
+  against this repository instead. Either way, only then remove the
+  lock file by hand and retry -- the same approach git's own
+  `index.lock` takes on a stale-lock collision -- before delegating a
+  fresh subagent with a resume-specific briefing rather than resuming
+  the dead worker's own
   context.
 - **Independently verify a worker's reported terminal outcome before
   trusting it.** A worker's final-turn text describes what it

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -758,11 +758,14 @@ Running this variant safely requires:
   claim ownership and worktree state before continuing; treat any
   uncommitted work found in the worktree as unverified input to check,
   never as something to trust or silently discard. Also check for a
-  stale clone-scoped lock before redelegating: run
+  stale clone-scoped lock before redelegating -- skip this check under
+  `instructions-only` running one worker at a time, which never
+  contends for the lock; see
+  [Clone-scoped lock](idd-helper-scripts.md#clone-scoped-lock) for that
+  profile's own multi-worker-one-clone caveat: run
   `node scripts/clone-lock.mjs --check` (or the profile-selected
-  `idd:clone-lock` command with `--check` -- see
-  [Clone-scoped lock](idd-helper-scripts.md#clone-scoped-lock) for the
-  literal per-profile invocation) and, if it reports a held lock, follow
+  `idd:clone-lock` command with `--check`, per that same section, for
+  the literal per-profile invocation) and, if it reports a held lock, follow
   the existing manual-recovery procedure: confirm the whole lock-owning
   operation -- the recorded wrapper and any git process it spawned -- is
   actually gone, not merely that the recorded pid has exited (a dead

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -766,21 +766,12 @@ Running this variant safely requires:
   `node scripts/clone-lock.mjs --check` (or the profile-selected
   `idd:clone-lock` command with `--check`, per that same section, for
   the literal per-profile invocation) and, if it reports the lock
-  present, follow the existing manual-recovery procedure. With a
-  parseable holder: confirm the whole lock-owning operation -- the
-  recorded wrapper and any git process it spawned -- is actually gone,
-  not merely that the recorded pid has exited (a dead wrapper can still
-  leave a live git child that still needs the lock -- observed
-  2026-09-01, kurone-kito/idd-skill#2223, kurone-kito/idd-skill#2389).
-  With `malformed: true` (a truncated or otherwise unparseable lock
-  file carries no holder to check at all -- preventive; no observed
-  incident yet): independently confirm no clone-scoped git operation is
-  still running against this repository instead. Either way, only then
-  remove the
-  lock file by hand and retry -- the same approach git's own
-  `index.lock` takes on a stale-lock collision -- before delegating a
-  fresh subagent with a resume-specific briefing rather than resuming
-  the dead worker's own
+  present, follow that same section's manual-recovery procedure in
+  full -- by design this lock never auto-recovers a stale holder
+  (observed 2026-09-01, kurone-kito/idd-skill#2223,
+  kurone-kito/idd-skill#2389) -- before delegating a fresh subagent
+  with a resume-specific briefing rather than resuming the dead
+  worker's own
   context.
 - **Independently verify a worker's reported terminal outcome before
   trusting it.** A worker's final-turn text describes what it

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -753,21 +753,12 @@ Running this variant safely requires:
   `node scripts/clone-lock.mjs --check` (or the profile-selected
   `idd:clone-lock` command with `--check`, per that same section, for
   the literal per-profile invocation) and, if it reports the lock
-  present, follow the existing manual-recovery procedure. With a
-  parseable holder: confirm the whole lock-owning operation -- the
-  recorded wrapper and any git process it spawned -- is actually gone,
-  not merely that the recorded pid has exited (a dead wrapper can still
-  leave a live git child that still needs the lock -- observed
-  2026-09-01, kurone-kito/idd-skill#2223, kurone-kito/idd-skill#2389).
-  With `malformed: true` (a truncated or otherwise unparseable lock
-  file carries no holder to check at all -- preventive; no observed
-  incident yet): independently confirm no clone-scoped git operation is
-  still running against this repository instead. Either way, only then
-  remove the
-  lock file by hand and retry -- the same approach git's own
-  `index.lock` takes on a stale-lock collision -- before delegating a
-  fresh subagent with a resume-specific briefing rather than resuming
-  the dead worker's own
+  present, follow that same section's manual-recovery procedure in
+  full -- by design this lock never auto-recovers a stale holder
+  (observed 2026-09-01, kurone-kito/idd-skill#2223,
+  kurone-kito/idd-skill#2389) -- before delegating a fresh subagent
+  with a resume-specific briefing rather than resuming the dead
+  worker's own
   context.
 - **Independently verify a worker's reported terminal outcome before
   trusting it.** A worker's final-turn text describes what it

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -744,9 +744,24 @@ Running this variant safely requires:
 - **Resume-specific recovery when a worker dies mid-turn.** Re-verify
   claim ownership and worktree state before continuing; treat any
   uncommitted work found in the worktree as unverified input to check,
-  never as something to trust or silently discard; then delegate a fresh
-  subagent with a resume-specific briefing rather than resuming the dead
-  worker's own context.
+  never as something to trust or silently discard. Also check for a
+  stale clone-scoped lock before redelegating -- skip this check under
+  `instructions-only` running one worker at a time, which never
+  contends for the lock; see
+  [Clone-scoped lock](idd-helper-scripts.md#clone-scoped-lock) for that
+  profile's own multi-worker-one-clone caveat: run
+  `node scripts/clone-lock.mjs --check` (or the profile-selected
+  `idd:clone-lock` command with `--check`, per that same section, for
+  the literal per-profile invocation) and, if it reports a held lock, follow
+  the existing manual-recovery procedure: confirm the whole lock-owning
+  operation -- the recorded wrapper and any git process it spawned -- is
+  actually gone, not merely that the recorded pid has exited (a dead
+  wrapper can still leave a live git child that still needs the lock --
+  kurone-kito/idd-skill#2223), then remove the lock file by hand and
+  retry -- the same approach git's own `index.lock` takes on a
+  stale-lock collision -- before delegating a fresh subagent with a
+  resume-specific briefing rather than resuming the dead worker's own
+  context.
 - **Independently verify a worker's reported terminal outcome before
   trusting it.** A worker's final-turn text describes what it
   _attempted_, not proof of what actually landed on the forge. Before

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -752,15 +752,20 @@ Running this variant safely requires:
   profile's own multi-worker-one-clone caveat: run
   `node scripts/clone-lock.mjs --check` (or the profile-selected
   `idd:clone-lock` command with `--check`, per that same section, for
-  the literal per-profile invocation) and, if it reports a held lock, follow
-  the existing manual-recovery procedure: confirm the whole lock-owning
-  operation -- the recorded wrapper and any git process it spawned -- is
-  actually gone, not merely that the recorded pid has exited (a dead
-  wrapper can still leave a live git child that still needs the lock --
-  kurone-kito/idd-skill#2223), then remove the lock file by hand and
-  retry -- the same approach git's own `index.lock` takes on a
-  stale-lock collision -- before delegating a fresh subagent with a
-  resume-specific briefing rather than resuming the dead worker's own
+  the literal per-profile invocation) and, if it reports the lock
+  present, follow the existing manual-recovery procedure. With a
+  parseable holder: confirm the whole lock-owning operation -- the
+  recorded wrapper and any git process it spawned -- is actually gone,
+  not merely that the recorded pid has exited (a dead wrapper can still
+  leave a live git child that still needs the lock --
+  kurone-kito/idd-skill#2223). With `malformed: true` (a truncated or
+  otherwise unparseable lock file carries no holder to check at all):
+  independently confirm no clone-scoped git operation is still running
+  against this repository instead. Either way, only then remove the
+  lock file by hand and retry -- the same approach git's own
+  `index.lock` takes on a stale-lock collision -- before delegating a
+  fresh subagent with a resume-specific briefing rather than resuming
+  the dead worker's own
   context.
 - **Independently verify a worker's reported terminal outcome before
   trusting it.** A worker's final-turn text describes what it

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -757,11 +757,13 @@ Running this variant safely requires:
   parseable holder: confirm the whole lock-owning operation -- the
   recorded wrapper and any git process it spawned -- is actually gone,
   not merely that the recorded pid has exited (a dead wrapper can still
-  leave a live git child that still needs the lock --
-  kurone-kito/idd-skill#2223). With `malformed: true` (a truncated or
-  otherwise unparseable lock file carries no holder to check at all):
-  independently confirm no clone-scoped git operation is still running
-  against this repository instead. Either way, only then remove the
+  leave a live git child that still needs the lock -- observed
+  2026-09-01, kurone-kito/idd-skill#2223, kurone-kito/idd-skill#2389).
+  With `malformed: true` (a truncated or otherwise unparseable lock
+  file carries no holder to check at all -- preventive; no observed
+  incident yet): independently confirm no clone-scoped git operation is
+  still running against this repository instead. Either way, only then
+  remove the
   lock file by hand and retry -- the same approach git's own
   `index.lock` takes on a stale-lock collision -- before delegating a
   fresh subagent with a resume-specific briefing rather than resuming


### PR DESCRIPTION
# Summary

Extends the Orchestrator fan-out variant's "Resume-specific recovery
when a worker dies mid-turn" bullet in `docs/idd-workflow.md` (and its
portable mirror, `idd-template/docs/idd-workflow.md`) to also check for
a stale clone-scoped lock before redelegating a fresh subagent. The
bullet defers the actual recovery steps entirely to the existing
Clone-scoped lock section (`idd-helper-scripts.md#clone-scoped-lock`)
rather than re-deriving them inline, after review rounds kept finding
new edge cases (pid-vs-child, malformed lock, publication-window race)
in an earlier inline version -- per this issue's own acceptance
criteria (point at the procedure, don't reproduce it). Docs-only
change; no new recovery mechanism is introduced.

## Linked issue

Closes #2713

## Follow-up issues (if any)

Review raised a possible gap in `docs/idd-helper-scripts.md`'s
Clone-scoped lock section itself (out of this issue's Candidate
files): its manual-recovery wording only asks to confirm the recorded
holder is gone, which does not by itself rule out a still-live git
child the dead wrapper spawned. Worth a separate, focused issue against
that section if a maintainer agrees; not addressed here.

## Background / rationale (if material)

`clone-lock.mts` has no automatic stale-lock recovery, and a worker
dying mid-turn is exactly the scenario that can leave its lock
orphaned -- the resume-recovery bullet was the one place that should
have flagged this but didn't.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed



