### PR TITLE
docs(idd-onboard): warn that a broad --allow-root defeats confinement

### DIFF
--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -514,9 +514,10 @@ allow/deny split, softened as described below.
   helper script under this same allowlisted surface carries its own
   residual: `idd-onboard`'s `--allow-root <dir>` flag accepts any
   existing directory and adds it to the path-confinement boundary list
-  verbatim, with no upper bound. A filesystem root removes the confinement fix #2216
-  shipped entirely; a narrower but still broad value (e.g. a home
-  directory) substantially widens it instead -- either way defeating
+  verbatim, with no upper bound. A filesystem root removes the
+  confinement that issue #2216 fixed entirely; a narrower but still
+  broad value (e.g. a home directory) substantially widens it instead
+  -- either way defeating
   the exact unattended/agent-dispatch threat model that fix's own doc
   comment names (preventive; no observed incident yet). Neither the
   script's own argument validation nor the allowlisted

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -512,10 +512,9 @@ allow/deny split, softened as described below.
   that deny, consistent with also allowing `gh pr merge` under this
   repository's recorded `fully_autonomous_merge` policy. A different
   helper script under this same allowlisted surface carries its own
-  residual: `idd-onboard`'s `--allow-root <dir>` flag
-  (`src/scripts/idd-onboard.mts`) accepts any existing directory and
-  adds it to the path-confinement boundary list verbatim, with no
-  upper bound. A filesystem root removes the confinement fix #2216
+  residual: `idd-onboard`'s `--allow-root <dir>` flag accepts any
+  existing directory and adds it to the path-confinement boundary list
+  verbatim, with no upper bound. A filesystem root removes the confinement fix #2216
   shipped entirely; a narrower but still broad value (e.g. a home
   directory) substantially widens it instead -- either way defeating
   the exact unattended/agent-dispatch threat model that fix's own doc

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -510,7 +510,18 @@ allow/deny split, softened as described below.
   the next section for this deny's actual, more limited reach. This
   repository's own dogfood `.claude/settings.json` does **not** carry
   that deny, consistent with also allowing `gh pr merge` under this
-  repository's recorded `fully_autonomous_merge` policy.
+  repository's recorded `fully_autonomous_merge` policy. A different
+  helper script under this same allowlisted surface carries its own
+  residual: `idd-onboard`'s `--allow-root <dir>` flag
+  (`src/scripts/idd-onboard.mts`) accepts any existing directory and
+  adds it to the path-confinement boundary list verbatim, with no
+  upper bound -- a filesystem root, a home directory, or any ancestor
+  of the intended target all satisfy the same boundary check. A broad
+  value there removes the confinement fix #2216 shipped entirely,
+  defeating the exact unattended/agent-dispatch threat model that
+  fix's own doc comment names. Neither the script's own argument
+  validation nor the allowlisted `Bash(node scripts/*)` pattern treats
+  an overly broad `--allow-root` value as unusual.
 
 ### What the baseline denies
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -515,13 +515,14 @@ allow/deny split, softened as described below.
   residual: `idd-onboard`'s `--allow-root <dir>` flag
   (`src/scripts/idd-onboard.mts`) accepts any existing directory and
   adds it to the path-confinement boundary list verbatim, with no
-  upper bound -- a filesystem root, a home directory, or any ancestor
-  of the intended target all satisfy the same boundary check. A broad
-  value there removes the confinement fix #2216 shipped entirely,
-  defeating the exact unattended/agent-dispatch threat model that
-  fix's own doc comment names. Neither the script's own argument
-  validation nor the allowlisted `Bash(node scripts/*)` pattern treats
-  an overly broad `--allow-root` value as unusual.
+  upper bound. A filesystem root removes the confinement fix #2216
+  shipped entirely; a narrower but still broad value (e.g. a home
+  directory) substantially widens it instead -- either way defeating
+  the exact unattended/agent-dispatch threat model that fix's own doc
+  comment names (preventive; no observed incident yet). Neither the
+  script's own argument validation nor the allowlisted
+  `Bash(node scripts/*)` / `Bash(node bin/*)` patterns above treat an
+  overly broad `--allow-root` value as unusual.
 
 ### What the baseline denies
 

--- a/idd-template/docs/permissions.md
+++ b/idd-template/docs/permissions.md
@@ -514,9 +514,10 @@ allow/deny split, softened as described below.
   helper script under this same allowlisted surface carries its own
   residual: `idd-onboard`'s `--allow-root <dir>` flag accepts any
   existing directory and adds it to the path-confinement boundary list
-  verbatim, with no upper bound. A filesystem root removes the confinement fix #2216
-  shipped entirely; a narrower but still broad value (e.g. a home
-  directory) substantially widens it instead -- either way defeating
+  verbatim, with no upper bound. A filesystem root removes the
+  confinement that issue #2216 fixed entirely; a narrower but still
+  broad value (e.g. a home directory) substantially widens it instead
+  -- either way defeating
   the exact unattended/agent-dispatch threat model that fix's own doc
   comment names (preventive; no observed incident yet). Neither the
   script's own argument validation nor the allowlisted

--- a/idd-template/docs/permissions.md
+++ b/idd-template/docs/permissions.md
@@ -512,10 +512,9 @@ allow/deny split, softened as described below.
   that deny, consistent with also allowing `gh pr merge` under this
   repository's recorded `fully_autonomous_merge` policy. A different
   helper script under this same allowlisted surface carries its own
-  residual: `idd-onboard`'s `--allow-root <dir>` flag
-  (`src/scripts/idd-onboard.mts`) accepts any existing directory and
-  adds it to the path-confinement boundary list verbatim, with no
-  upper bound. A filesystem root removes the confinement fix #2216
+  residual: `idd-onboard`'s `--allow-root <dir>` flag accepts any
+  existing directory and adds it to the path-confinement boundary list
+  verbatim, with no upper bound. A filesystem root removes the confinement fix #2216
   shipped entirely; a narrower but still broad value (e.g. a home
   directory) substantially widens it instead -- either way defeating
   the exact unattended/agent-dispatch threat model that fix's own doc

--- a/idd-template/docs/permissions.md
+++ b/idd-template/docs/permissions.md
@@ -510,7 +510,18 @@ allow/deny split, softened as described below.
   the next section for this deny's actual, more limited reach. This
   repository's own dogfood `.claude/settings.json` does **not** carry
   that deny, consistent with also allowing `gh pr merge` under this
-  repository's recorded `fully_autonomous_merge` policy.
+  repository's recorded `fully_autonomous_merge` policy. A different
+  helper script under this same allowlisted surface carries its own
+  residual: `idd-onboard`'s `--allow-root <dir>` flag
+  (`src/scripts/idd-onboard.mts`) accepts any existing directory and
+  adds it to the path-confinement boundary list verbatim, with no
+  upper bound -- a filesystem root, a home directory, or any ancestor
+  of the intended target all satisfy the same boundary check. A broad
+  value there removes the confinement fix #2216 shipped entirely,
+  defeating the exact unattended/agent-dispatch threat model that
+  fix's own doc comment names. Neither the script's own argument
+  validation nor the allowlisted `Bash(node scripts/*)` pattern treats
+  an overly broad `--allow-root` value as unusual.
 
 ### What the baseline denies
 

--- a/idd-template/docs/permissions.md
+++ b/idd-template/docs/permissions.md
@@ -515,13 +515,14 @@ allow/deny split, softened as described below.
   residual: `idd-onboard`'s `--allow-root <dir>` flag
   (`src/scripts/idd-onboard.mts`) accepts any existing directory and
   adds it to the path-confinement boundary list verbatim, with no
-  upper bound -- a filesystem root, a home directory, or any ancestor
-  of the intended target all satisfy the same boundary check. A broad
-  value there removes the confinement fix #2216 shipped entirely,
-  defeating the exact unattended/agent-dispatch threat model that
-  fix's own doc comment names. Neither the script's own argument
-  validation nor the allowlisted `Bash(node scripts/*)` pattern treats
-  an overly broad `--allow-root` value as unusual.
+  upper bound. A filesystem root removes the confinement fix #2216
+  shipped entirely; a narrower but still broad value (e.g. a home
+  directory) substantially widens it instead -- either way defeating
+  the exact unattended/agent-dispatch threat model that fix's own doc
+  comment names (preventive; no observed incident yet). Neither the
+  script's own argument validation nor the allowlisted
+  `Bash(node scripts/*)` / `Bash(node bin/*)` patterns above treat an
+  overly broad `--allow-root` value as unusual.
 
 ### What the baseline denies
 

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -2910,10 +2910,11 @@ in that case); 2 usage or configuration error.
   --allow-root <dir>   additionally confine --target to this root, on top
                        of the current working directory (#2216); repeat
                        for more than one. Required only when --target
-                       resolves outside the working directory. A broad
-                       value (a filesystem root, a home directory, or
-                       similar) removes this confinement guarantee
-                       entirely, not just widens it.
+                       resolves outside the working directory. A
+                       filesystem root removes this confinement
+                       guarantee entirely; a narrower but still broad
+                       value (e.g. a home directory) substantially
+                       widens it instead.
   --from-transcript <file>
                        read placeholder answers from a confirmed --hear
                        transcript (mapsToPlaceholder items); an explicit
@@ -2948,10 +2949,11 @@ nothing in that case); 2 usage or configuration error.
   --allow-root <dir>                additionally confine --source / --target
                                      to this root, on top of the current
                                      working directory (#2216); repeat for
-                                     more than one. A broad value (a
-                                     filesystem root, a home directory, or
-                                     similar) removes this confinement
-                                     guarantee entirely, not just widens it.
+                                     more than one. A filesystem root
+                                     removes this confinement guarantee
+                                     entirely; a narrower but still
+                                     broad value (e.g. a home directory)
+                                     substantially widens it instead.
   --profile <name>                  ${PROFILE_NAMES.join(' | ')}
   --force                           allow overwriting a differing target file
   --dry-run                         print the plan without writing anything
@@ -2977,10 +2979,11 @@ or placeholder residue); 2 usage or configuration error.
   --allow-root <dir>                 additionally confine --source / --target
                                       to this root, on top of the current
                                       working directory (#2216); repeat for
-                                      more than one. A broad value (a
-                                      filesystem root, a home directory, or
-                                      similar) removes this confinement
-                                      guarantee entirely, not just widens it.
+                                      more than one. A filesystem root
+                                      removes this confinement guarantee
+                                      entirely; a narrower but still
+                                      broad value (e.g. a home directory)
+                                      substantially widens it instead.
   --profile <name>                   ${PROFILE_NAMES.join(' | ')}
   --help, -h                         show this help
 
@@ -3017,10 +3020,11 @@ never writes .github/idd/config.json, never requires --source.
   --target <dir>               target repository (default: current directory)
   --allow-root <dir>           additionally confine --target to this root,
                                on top of the current working directory
-                               (#2216); repeat for more than one. A broad
-                               value (a filesystem root, a home directory,
-                               or similar) removes this confinement
-                               guarantee entirely, not just widens it.
+                               (#2216); repeat for more than one. A
+                               filesystem root removes this confinement
+                               guarantee entirely; a narrower but still
+                               broad value (e.g. a home directory)
+                               substantially widens it instead.
   --answers <file>              path to the --apply answers JSON file
   --help, -h                    show this help
 
@@ -3052,10 +3056,11 @@ AGENTS.md, or GEMINI.md.
   --target <dir>               target repository (default: current directory)
   --allow-root <dir>           additionally confine --target to this root,
                                on top of the current working directory
-                               (#2216); repeat for more than one. A broad
-                               value (a filesystem root, a home directory,
-                               or similar) removes this confinement
-                               guarantee entirely, not just widens it.
+                               (#2216); repeat for more than one. A
+                               filesystem root removes this confinement
+                               guarantee entirely; a narrower but still
+                               broad value (e.g. a home directory)
+                               substantially widens it instead.
   --transcript <file>          path to the confirmed --hear transcript
   --help, -h                    show this help
 `);

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -2910,7 +2910,10 @@ in that case); 2 usage or configuration error.
   --allow-root <dir>   additionally confine --target to this root, on top
                        of the current working directory (#2216); repeat
                        for more than one. Required only when --target
-                       resolves outside both
+                       resolves outside the working directory. A broad
+                       value (a filesystem root, a home directory, or
+                       similar) removes this confinement guarantee
+                       entirely, not just widens it.
   --from-transcript <file>
                        read placeholder answers from a confirmed --hear
                        transcript (mapsToPlaceholder items); an explicit
@@ -2945,7 +2948,10 @@ nothing in that case); 2 usage or configuration error.
   --allow-root <dir>                additionally confine --source / --target
                                      to this root, on top of the current
                                      working directory (#2216); repeat for
-                                     more than one
+                                     more than one. A broad value (a
+                                     filesystem root, a home directory, or
+                                     similar) removes this confinement
+                                     guarantee entirely, not just widens it.
   --profile <name>                  ${PROFILE_NAMES.join(' | ')}
   --force                           allow overwriting a differing target file
   --dry-run                         print the plan without writing anything
@@ -2971,7 +2977,10 @@ or placeholder residue); 2 usage or configuration error.
   --allow-root <dir>                 additionally confine --source / --target
                                       to this root, on top of the current
                                       working directory (#2216); repeat for
-                                      more than one
+                                      more than one. A broad value (a
+                                      filesystem root, a home directory, or
+                                      similar) removes this confinement
+                                      guarantee entirely, not just widens it.
   --profile <name>                   ${PROFILE_NAMES.join(' | ')}
   --help, -h                         show this help
 
@@ -3008,7 +3017,10 @@ never writes .github/idd/config.json, never requires --source.
   --target <dir>               target repository (default: current directory)
   --allow-root <dir>           additionally confine --target to this root,
                                on top of the current working directory
-                               (#2216); repeat for more than one
+                               (#2216); repeat for more than one. A broad
+                               value (a filesystem root, a home directory,
+                               or similar) removes this confinement
+                               guarantee entirely, not just widens it.
   --answers <file>              path to the --apply answers JSON file
   --help, -h                    show this help
 
@@ -3040,7 +3052,10 @@ AGENTS.md, or GEMINI.md.
   --target <dir>               target repository (default: current directory)
   --allow-root <dir>           additionally confine --target to this root,
                                on top of the current working directory
-                               (#2216); repeat for more than one
+                               (#2216); repeat for more than one. A broad
+                               value (a filesystem root, a home directory,
+                               or similar) removes this confinement
+                               guarantee entirely, not just widens it.
   --transcript <file>          path to the confirmed --hear transcript
   --help, -h                    show this help
 `);

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -3491,7 +3491,10 @@ in that case); 2 usage or configuration error.
   --allow-root <dir>   additionally confine --target to this root, on top
                        of the current working directory (#2216); repeat
                        for more than one. Required only when --target
-                       resolves outside both
+                       resolves outside the working directory. A broad
+                       value (a filesystem root, a home directory, or
+                       similar) removes this confinement guarantee
+                       entirely, not just widens it.
   --from-transcript <file>
                        read placeholder answers from a confirmed --hear
                        transcript (mapsToPlaceholder items); an explicit
@@ -3526,7 +3529,10 @@ nothing in that case); 2 usage or configuration error.
   --allow-root <dir>                additionally confine --source / --target
                                      to this root, on top of the current
                                      working directory (#2216); repeat for
-                                     more than one
+                                     more than one. A broad value (a
+                                     filesystem root, a home directory, or
+                                     similar) removes this confinement
+                                     guarantee entirely, not just widens it.
   --profile <name>                  ${PROFILE_NAMES.join(' | ')}
   --force                           allow overwriting a differing target file
   --dry-run                         print the plan without writing anything
@@ -3552,7 +3558,10 @@ or placeholder residue); 2 usage or configuration error.
   --allow-root <dir>                 additionally confine --source / --target
                                       to this root, on top of the current
                                       working directory (#2216); repeat for
-                                      more than one
+                                      more than one. A broad value (a
+                                      filesystem root, a home directory, or
+                                      similar) removes this confinement
+                                      guarantee entirely, not just widens it.
   --profile <name>                   ${PROFILE_NAMES.join(' | ')}
   --help, -h                         show this help
 
@@ -3589,7 +3598,10 @@ never writes .github/idd/config.json, never requires --source.
   --target <dir>               target repository (default: current directory)
   --allow-root <dir>           additionally confine --target to this root,
                                on top of the current working directory
-                               (#2216); repeat for more than one
+                               (#2216); repeat for more than one. A broad
+                               value (a filesystem root, a home directory,
+                               or similar) removes this confinement
+                               guarantee entirely, not just widens it.
   --answers <file>              path to the --apply answers JSON file
   --help, -h                    show this help
 
@@ -3621,7 +3633,10 @@ AGENTS.md, or GEMINI.md.
   --target <dir>               target repository (default: current directory)
   --allow-root <dir>           additionally confine --target to this root,
                                on top of the current working directory
-                               (#2216); repeat for more than one
+                               (#2216); repeat for more than one. A broad
+                               value (a filesystem root, a home directory,
+                               or similar) removes this confinement
+                               guarantee entirely, not just widens it.
   --transcript <file>          path to the confirmed --hear transcript
   --help, -h                    show this help
 `);

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -3491,10 +3491,11 @@ in that case); 2 usage or configuration error.
   --allow-root <dir>   additionally confine --target to this root, on top
                        of the current working directory (#2216); repeat
                        for more than one. Required only when --target
-                       resolves outside the working directory. A broad
-                       value (a filesystem root, a home directory, or
-                       similar) removes this confinement guarantee
-                       entirely, not just widens it.
+                       resolves outside the working directory. A
+                       filesystem root removes this confinement
+                       guarantee entirely; a narrower but still broad
+                       value (e.g. a home directory) substantially
+                       widens it instead.
   --from-transcript <file>
                        read placeholder answers from a confirmed --hear
                        transcript (mapsToPlaceholder items); an explicit
@@ -3529,10 +3530,11 @@ nothing in that case); 2 usage or configuration error.
   --allow-root <dir>                additionally confine --source / --target
                                      to this root, on top of the current
                                      working directory (#2216); repeat for
-                                     more than one. A broad value (a
-                                     filesystem root, a home directory, or
-                                     similar) removes this confinement
-                                     guarantee entirely, not just widens it.
+                                     more than one. A filesystem root
+                                     removes this confinement guarantee
+                                     entirely; a narrower but still
+                                     broad value (e.g. a home directory)
+                                     substantially widens it instead.
   --profile <name>                  ${PROFILE_NAMES.join(' | ')}
   --force                           allow overwriting a differing target file
   --dry-run                         print the plan without writing anything
@@ -3558,10 +3560,11 @@ or placeholder residue); 2 usage or configuration error.
   --allow-root <dir>                 additionally confine --source / --target
                                       to this root, on top of the current
                                       working directory (#2216); repeat for
-                                      more than one. A broad value (a
-                                      filesystem root, a home directory, or
-                                      similar) removes this confinement
-                                      guarantee entirely, not just widens it.
+                                      more than one. A filesystem root
+                                      removes this confinement guarantee
+                                      entirely; a narrower but still
+                                      broad value (e.g. a home directory)
+                                      substantially widens it instead.
   --profile <name>                   ${PROFILE_NAMES.join(' | ')}
   --help, -h                         show this help
 
@@ -3598,10 +3601,11 @@ never writes .github/idd/config.json, never requires --source.
   --target <dir>               target repository (default: current directory)
   --allow-root <dir>           additionally confine --target to this root,
                                on top of the current working directory
-                               (#2216); repeat for more than one. A broad
-                               value (a filesystem root, a home directory,
-                               or similar) removes this confinement
-                               guarantee entirely, not just widens it.
+                               (#2216); repeat for more than one. A
+                               filesystem root removes this confinement
+                               guarantee entirely; a narrower but still
+                               broad value (e.g. a home directory)
+                               substantially widens it instead.
   --answers <file>              path to the --apply answers JSON file
   --help, -h                    show this help
 
@@ -3633,10 +3637,11 @@ AGENTS.md, or GEMINI.md.
   --target <dir>               target repository (default: current directory)
   --allow-root <dir>           additionally confine --target to this root,
                                on top of the current working directory
-                               (#2216); repeat for more than one. A broad
-                               value (a filesystem root, a home directory,
-                               or similar) removes this confinement
-                               guarantee entirely, not just widens it.
+                               (#2216); repeat for more than one. A
+                               filesystem root removes this confinement
+                               guarantee entirely; a narrower but still
+                               broad value (e.g. a home directory)
+                               substantially widens it instead.
   --transcript <file>          path to the confirmed --hear transcript
   --help, -h                    show this help
 `);

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -4854,3 +4854,13 @@ test('bin/idd-onboard.mjs --help documents --allow-root', () => {
   });
   assert.match(help, /--allow-root <dir>/);
 });
+
+test('bin/idd-onboard.mjs --help warns that a broad --allow-root removes confinement', () => {
+  const help = execFileSync(process.execPath, [BIN_PATH, '--help'], {
+    encoding: 'utf8',
+  });
+  const normalized = help.replace(/\s+/g, ' ');
+  const warningCount =
+    normalized.split('removes this confinement guarantee entirely').length - 1;
+  assert.equal(warningCount, 5);
+});

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -4860,7 +4860,18 @@ test('bin/idd-onboard.mjs --help warns that a broad --allow-root removes confine
     encoding: 'utf8',
   });
   const normalized = help.replace(/\s+/g, ' ');
-  const warningCount =
-    normalized.split('removes this confinement guarantee entirely').length - 1;
-  assert.equal(warningCount, 5);
+  const sections = normalized.split(
+    /(?=--(?:substitute \(wave 1\)|import \(wave 2\)|verify \(wave 3\)|hear \(#2281\)|record-policy \(#2282\)):)/,
+  );
+  assert.equal(sections.length, 6);
+  for (const section of sections.slice(1)) {
+    assert.match(
+      section,
+      /filesystem root removes this confinement guarantee entirely/,
+    );
+    assert.match(
+      section,
+      /broad value \(e\.g\. a home directory\) substantially widens it instead/,
+    );
+  }
 });


### PR DESCRIPTION
# Summary

`idd-onboard`'s `--allow-root <dir>` flag accepts any existing
directory and adds it to the path-confinement boundary list verbatim,
with no upper bound: a filesystem root or home directory satisfies the
same `isWithinBoundary` check as a narrow, legitimate value, silently
reopening the confinement that issue #2216 fixed. This PR documents
that residual risk explicitly, in both places it should be visible:

- All five `--help` blocks in `src/scripts/idd-onboard.mts` that
  document `--allow-root` (substitute, import, verify, hear,
  record-policy).
- `docs/permissions.md`, alongside the other command-specific
  residuals the permission baseline already documents (parallel to the
  existing `idd-merge-execute.mjs` entry).

`docs/permissions.md` is generated from `idd-template/docs/permissions.md`
(exact-mode sync pair), so the actual edit lives in the template source
and `docs/permissions.md` was regenerated via `pnpm run docs:sync`.
Docs-only in effect; no new flag, no rejection logic, no behavior
change (both explicitly out of scope per the issue body).

## Linked issue

Closes #2715

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

`resolveConfinedDirectory`'s own doc comment already names unattended
dispatch (an agent, a CI job, a pipeline) as the higher-risk case this
confinement feature protects, but nothing in the flag's interface or
help text warned that a sufficiently broad `--allow-root` value
defeats that protection entirely.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded `--allow-root` help text to clarify how filesystem roots or overly broad directories affect path confinement.
  * Documented the residual security risk of selecting broad allowance directories.

* **Tests**
  * Added coverage verifying the warning appears across all five onboarding modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->