### PR TITLE
fix(protocol-helpers): recognize CodeRabbit's follow-up ack template

### DIFF
--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1289,8 +1289,28 @@ const CODERABBIT_ACK_OPENING_RE = new RegExp(
 // "I couldn't resolve this review thread on the repository platform..."
 // fallback trailer (the same API call failed, so CodeRabbit reports the
 // attempt instead).
-const CODERABBIT_ACK_CLOSURE_RE =
-  /✅\s*Review thread resolved\.|I couldn't resolve this review thread on the repository platform/i;
+//
+// #2710: a third, distinct courtesy-ack template observed live -- after an
+// IDD agent posts its own disposition reply and resolves a thread itself,
+// CodeRabbit sometimes follows up with an opening matching
+// CODERABBIT_ACK_OPENING_RE (e.g. "`@login`, thanks for confirming...")
+// but NEITHER closure phrase above; instead it carries the "🐇 ✅" emoji
+// pair immediately followed by this HTML-comment marker.
+// CODERABBIT_SKIP_REVIEW_COMMENT_FOLLOW_UP_MARKER is CodeRabbit's own
+// stable, machine-readable marker for this reply shape -- a
+// decision-shaped signal, consistent with this file's existing design
+// principle of matching CodeRabbit's own resolution decision rather than
+// free-form "new concern" phrasing.
+export const CODERABBIT_SKIP_REVIEW_COMMENT_FOLLOW_UP_MARKER =
+  '<!-- coderabbit-skip-review-comment-follow-up -->';
+const CODERABBIT_ACK_CLOSURE_RE = new RegExp(
+  [
+    '✅\\s*Review thread resolved\\.',
+    "I couldn't resolve this review thread on the repository platform",
+    `🐇\\s*✅[\\s\\S]{0,40}?${escapeRegExp(CODERABBIT_SKIP_REVIEW_COMMENT_FOLLOW_UP_MARKER)}`,
+  ].join('|'),
+  'i',
+);
 // Explicit `isCodeRabbitLogin` author check (Copilot review, #2649,
 // round 4): the closure phrase is CodeRabbit's own resolution decision in
 // practice, but it is still literal text a differently-configured

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2063,8 +2063,28 @@ const CODERABBIT_ACK_OPENING_RE = new RegExp(
 // "I couldn't resolve this review thread on the repository platform..."
 // fallback trailer (the same API call failed, so CodeRabbit reports the
 // attempt instead).
-const CODERABBIT_ACK_CLOSURE_RE =
-  /✅\s*Review thread resolved\.|I couldn't resolve this review thread on the repository platform/i;
+//
+// #2710: a third, distinct courtesy-ack template observed live -- after an
+// IDD agent posts its own disposition reply and resolves a thread itself,
+// CodeRabbit sometimes follows up with an opening matching
+// CODERABBIT_ACK_OPENING_RE (e.g. "`@login`, thanks for confirming...")
+// but NEITHER closure phrase above; instead it carries the "🐇 ✅" emoji
+// pair immediately followed by this HTML-comment marker.
+// CODERABBIT_SKIP_REVIEW_COMMENT_FOLLOW_UP_MARKER is CodeRabbit's own
+// stable, machine-readable marker for this reply shape -- a
+// decision-shaped signal, consistent with this file's existing design
+// principle of matching CodeRabbit's own resolution decision rather than
+// free-form "new concern" phrasing.
+export const CODERABBIT_SKIP_REVIEW_COMMENT_FOLLOW_UP_MARKER =
+  '<!-- coderabbit-skip-review-comment-follow-up -->';
+const CODERABBIT_ACK_CLOSURE_RE = new RegExp(
+  [
+    '✅\\s*Review thread resolved\\.',
+    "I couldn't resolve this review thread on the repository platform",
+    `🐇\\s*✅[\\s\\S]{0,40}?${escapeRegExp(CODERABBIT_SKIP_REVIEW_COMMENT_FOLLOW_UP_MARKER)}`,
+  ].join('|'),
+  'i',
+);
 
 // Explicit `isCodeRabbitLogin` author check (Copilot review, #2649,
 // round 4): the closure phrase is CodeRabbit's own resolution decision in

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -437,6 +437,48 @@ test('classifyThreadAckOnlyPostDisposition still recognizes a known-template cou
   assert.equal(classification.ackOnlyPostDisposition, true);
 });
 
+// #2710: a third, distinct CodeRabbit courtesy-ack template observed live
+// after an IDD agent posts its own disposition reply and resolves a
+// thread itself -- an opening matching CODERABBIT_ACK_OPENING_RE followed
+// by the "🐇 ✅" emoji pair and the
+// `coderabbit-skip-review-comment-follow-up` HTML-comment marker, with
+// NEITHER of the two previously-recognized closure phrases anywhere in
+// the body.
+
+test('classifyThreadAckOnlyPostDisposition recognizes the post-disposition courtesy-ack template (#2710)', () => {
+  const thread = {
+    id: 'thread-skip-review-follow-up-ack',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'SF-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'SF-2',
+          author: { login: 'coderabbitai[bot]' },
+          body: '`@kurone-kito`, thanks for confirming.\n\n🐇 ✅ <!-- coderabbit-skip-review-comment-follow-up -->',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, true);
+});
+
 test('classifyThreadAckOnlyPostDisposition rejects a novel substantive reply that merely avoids disposition phrasing (#2641)', () => {
   // A brand-new finding that happens not to be shaped like
   // `**Accepted**`/`**Rejected**` must not misclassify as ack-only just


### PR DESCRIPTION
## Summary

`isKnownAdvisoryAckTemplate` in `src/scripts/protocol-helpers.mts` requires both `CODERABBIT_ACK_OPENING_RE` and `CODERABBIT_ACK_CLOSURE_RE` to match before treating a CodeRabbit reply as a known, safe-to-ignore courtesy acknowledgment. `CODERABBIT_ACK_CLOSURE_RE` recognized only CodeRabbit's two previously-observed self-resolve closure phrasings ("✅ Review thread resolved." / "I couldn't resolve this review thread on the repository platform...").

Observed live: after an IDD agent posts its own disposition reply and resolves a thread itself, CodeRabbit sometimes posts a distinct courtesy follow-up — an opening matching `CODERABBIT_ACK_OPENING_RE` (e.g. "`@login`, thanks for confirming...") followed by "🐇 ✅ `<!-- coderabbit-skip-review-comment-follow-up -->`", with neither closure phrase anywhere. `isKnownAdvisoryAckTemplate` returned `false`, so `dispositionEvidence` reported `missing-fresh-disposition` on an already-correctly-dispositioned, already-`isResolved: true` thread — a narrow autonomy dead end (F2's override-scoping rule correctly declines a self-applied workaround here; an E1 return would livelock since E1 only re-queues unresolved threads).

## Changes

- `src/scripts/protocol-helpers.mts`: widened `CODERABBIT_ACK_CLOSURE_RE` with a third alternative anchored on the "🐇 ✅" emoji pair immediately followed (within a 40-char window) by a new exported `CODERABBIT_SKIP_REVIEW_COMMENT_FOLLOW_UP_MARKER` constant (`<!-- coderabbit-skip-review-comment-follow-up -->`), following this file's existing marker-constant convention. Keeps the file's established design principle (PR #2649 round 3): match CodeRabbit's own resolution-decision signal, not free-form "new concern" phrasing — no enumerated phrase blocklist was reintroduced.
- `tests/protocol-helpers.test.mts`: added a regression test for the exact live-observed template (opening "thanks for confirming" paired with the new marker, no "Review thread resolved." text), and confirmed the existing bare-🐇-emoji-only rejection test (no marker present) still correctly fails.

## Test plan

- [x] `node --test tests/*.test.mts` — 5348/5348 pass
- [x] `pnpm run typecheck` — pass
- [x] `pnpm run build:check` — pass (generated `.mjs` reproducible)
- [x] `npx biome check` on changed files — clean (2 pre-existing, unrelated warnings elsewhere in the same large file)
- [x] Self-critique (C1, forked subagent) found no blocking issues

Closes #2710

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jz9naVhMefTusdLL9FzLc
