### PR TITLE
fix(protocol-helpers): a lone CANCELLED CI check resolves to pending

### DIFF
--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -4495,7 +4495,6 @@ function resolvePresentRunConclusion(normalizedChecks) {
   const unknownChecks = classification.unknown ?? [];
   if (
     classification.status === 'unknown' &&
-    unknownChecks.length > 0 &&
     unknownChecks.every((check) => check.state === 'CANCELLED')
   ) {
     return 'pending';

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -4474,11 +4474,30 @@ function resolvePresentRunConclusion(normalizedChecks) {
   const effective = normalizedChecks.map((check) =>
     check.coveredByWaiver ? { ...check, state: 'SKIPPED' } : check,
   );
-  const { status } = classifyCiChecks(effective);
-  if (status === 'success') {
+  const classification = classifyCiChecks(effective);
+  if (classification.status === 'success') {
     return 'all-passing';
   }
-  if (status === 'pending') {
+  if (classification.status === 'pending') {
+    return 'pending';
+  }
+  // #2714: a lone CANCELLED instance with no same-producer successor to
+  // dedup against lands in classifyCiChecks's residual `unknown` bucket --
+  // CANCELLED is deliberately excluded from both `failed` and `passing`
+  // (see CI_FAILURE_CONCLUSION_STATES's own doc comment). Map that exact
+  // shape to 'pending' -- a cancelled-with-no-successor run is a plausible
+  // rerun candidate -- rather than folding it into 'some-failing', which
+  // reads as terminal/actionable and reproduces through this fallback
+  // exactly the outcome classifyCiChecks's own CANCELLED exclusion exists
+  // to avoid. Scoped to CANCELLED-only `unknown` entries: an `unknown`
+  // bucket containing any other, genuinely unrecognized state stays
+  // 'some-failing', the conservative default.
+  const unknownChecks = classification.unknown ?? [];
+  if (
+    classification.status === 'unknown' &&
+    unknownChecks.length > 0 &&
+    unknownChecks.every((check) => check.state === 'CANCELLED')
+  ) {
     return 'pending';
   }
   return 'some-failing';

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -5678,11 +5678,30 @@ function resolvePresentRunConclusion(
   const effective = normalizedChecks.map((check) =>
     check.coveredByWaiver ? { ...check, state: 'SKIPPED' } : check,
   );
-  const { status } = classifyCiChecks(effective);
-  if (status === 'success') {
+  const classification = classifyCiChecks(effective);
+  if (classification.status === 'success') {
     return 'all-passing';
   }
-  if (status === 'pending') {
+  if (classification.status === 'pending') {
+    return 'pending';
+  }
+  // #2714: a lone CANCELLED instance with no same-producer successor to
+  // dedup against lands in classifyCiChecks's residual `unknown` bucket --
+  // CANCELLED is deliberately excluded from both `failed` and `passing`
+  // (see CI_FAILURE_CONCLUSION_STATES's own doc comment). Map that exact
+  // shape to 'pending' -- a cancelled-with-no-successor run is a plausible
+  // rerun candidate -- rather than folding it into 'some-failing', which
+  // reads as terminal/actionable and reproduces through this fallback
+  // exactly the outcome classifyCiChecks's own CANCELLED exclusion exists
+  // to avoid. Scoped to CANCELLED-only `unknown` entries: an `unknown`
+  // bucket containing any other, genuinely unrecognized state stays
+  // 'some-failing', the conservative default.
+  const unknownChecks = classification.unknown ?? [];
+  if (
+    classification.status === 'unknown' &&
+    unknownChecks.length > 0 &&
+    unknownChecks.every((check) => check.state === 'CANCELLED')
+  ) {
     return 'pending';
   }
   return 'some-failing';

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -5699,7 +5699,6 @@ function resolvePresentRunConclusion(
   const unknownChecks = classification.unknown ?? [];
   if (
     classification.status === 'unknown' &&
-    unknownChecks.length > 0 &&
     unknownChecks.every((check) => check.state === 'CANCELLED')
   ) {
     return 'pending';

--- a/tests/required-checks-summary.test.mts
+++ b/tests/required-checks-summary.test.mts
@@ -30,6 +30,18 @@ test('protected branch with a failing required check: gate does not pass', () =>
   assert.equal(r.requiredChecksPassing, false);
 });
 
+// #2714's fix is deliberately scoped to resolvePresentRunConclusion (the
+// no-required-checks fallback), not classifyCiChecks itself, because a
+// REQUIRED check that is itself CANCELLED with no successor must not
+// silently read as passing. Lock that design intent directly: the
+// required-checks status must stay 'unknown', never 'success'.
+test('protected branch with a lone CANCELLED required check: status stays unknown, gate does not pass', () => {
+  const r = summarize([{ name: 'lint', state: 'CANCELLED' }], protectedRules);
+  assert.equal(r.noRequiredChecksConfigured, false);
+  assert.equal(r.status, 'unknown');
+  assert.equal(r.requiredChecksPassing, false);
+});
+
 test('unprotected + green runs: reported distinctly from a passing required gate', () => {
   const r = summarize([{ name: 'build', state: 'SUCCESS' }], []);
   assert.equal(r.noRequiredChecksConfigured, true);

--- a/tests/required-checks-summary.test.mts
+++ b/tests/required-checks-summary.test.mts
@@ -112,6 +112,23 @@ test('unprotected + an unrecognized non-CANCELLED state: presentRunConclusion st
   assert.equal(r.presentRunConclusion, 'some-failing');
 });
 
+// A mix of CANCELLED and a genuinely unrecognized state in the `unknown`
+// bucket must not be laxly treated as "contains a CANCELLED, so pending" --
+// the `.every()` check exists precisely to require the WHOLE bucket be
+// CANCELLED before relaxing to 'pending'.
+test('unprotected + CANCELLED mixed with an unrecognized state: presentRunConclusion stays some-failing', () => {
+  const r = summarize(
+    [
+      { name: 'lint', state: 'SUCCESS' },
+      { name: 'companion-a', state: 'CANCELLED' },
+      { name: 'companion-b', state: 'SOME_FUTURE_GITHUB_STATE' },
+    ],
+    [],
+  );
+  assert.equal(r.noRequiredChecksConfigured, true);
+  assert.equal(r.presentRunConclusion, 'some-failing');
+});
+
 // A pinned/indeterminate required-check source (workflows rule, or an app-pinned
 // classic check with no enumerable context) must NOT be reported as "no required
 // checks configured" — there may be required checks we cannot enumerate, so F2

--- a/tests/required-checks-summary.test.mts
+++ b/tests/required-checks-summary.test.mts
@@ -56,6 +56,62 @@ test('unprotected + pending runs: presentRunConclusion is pending', () => {
   assert.equal(r.presentRunConclusion, 'pending');
 });
 
+// #2714: a lone CANCELLED instance with no same-producer successor to dedup
+// against is deliberately excluded from both classifyCiChecks's `failed`
+// and `passing` buckets, landing in its residual `unknown` bucket. Before
+// this fix, resolvePresentRunConclusion folded that `unknown` status into
+// 'some-failing' -- reproducing exactly the outcome CANCELLED's exclusion
+// from `failed` exists to avoid. A single genuinely-passing companion check
+// (`lint`) alongside it rules out a passing-run-count coincidence.
+test('unprotected + a lone CANCELLED run with no successor: presentRunConclusion is pending, not some-failing', () => {
+  const r = summarize(
+    [
+      { name: 'lint', state: 'SUCCESS' },
+      { name: 'companion', state: 'CANCELLED' },
+    ],
+    [],
+  );
+  assert.equal(r.noRequiredChecksConfigured, true);
+  assert.equal(r.presentRunConclusion, 'pending');
+});
+
+// A CANCELLED instance that DOES have a same-producer successor is an
+// ordinary, already-handled dedup case (#1471/#1745): selectLatestCheckPerName
+// selects the successor, so the CANCELLED instance never reaches the
+// `unknown` bucket at all. This must stay 'all-passing', not 'pending' --
+// confirms the #2714 fix is scoped to the lone/no-successor shape only.
+test('unprotected + a CANCELLED run superseded by a later SUCCESS for the same name: presentRunConclusion is all-passing', () => {
+  const r = summarize(
+    [
+      {
+        name: 'build',
+        state: 'CANCELLED',
+        completedAt: '2026-01-01T00:00:00Z',
+      },
+      { name: 'build', state: 'SUCCESS', completedAt: '2026-01-01T00:05:00Z' },
+    ],
+    [],
+  );
+  assert.equal(r.noRequiredChecksConfigured, true);
+  assert.equal(r.presentRunConclusion, 'all-passing');
+});
+
+// The #2714 fix is scoped to CANCELLED specifically -- an `unknown` bucket
+// caused by some other, genuinely unrecognized state string stays
+// 'some-failing', the conservative default, rather than being broadened to
+// every `unknown` cause.
+test('unprotected + an unrecognized non-CANCELLED state: presentRunConclusion stays some-failing', () => {
+  const r = summarize(
+    [
+      { name: 'lint', state: 'SUCCESS' },
+      { name: 'companion', state: 'SOME_FUTURE_GITHUB_STATE' },
+    ],
+    [],
+  );
+  assert.equal(r.noRequiredChecksConfigured, true);
+  assert.equal(r.presentRunConclusion, 'some-failing');
+});
+
 // A pinned/indeterminate required-check source (workflows rule, or an app-pinned
 // classic check with no enumerable context) must NOT be reported as "no required
 // checks configured" — there may be required checks we cannot enumerate, so F2


### PR DESCRIPTION
# Summary

`classifyCiChecks` (`src/scripts/protocol-helpers.mts`) deliberately excludes
`CANCELLED` from its `failed` bucket -- its own inline comment states
"CANCELLED is deliberately not included". A lone `CANCELLED` instance with no
same-producer successor to dedup against still lands in the residual
`unknown` bucket though, so `status` becomes `'unknown'` rather than
`'success'`.

`resolvePresentRunConclusion` (used for the F2 fallback when no required
checks are configured) mapped every non-success/non-pending status --
including `'unknown'` -- to `'some-failing'`, reproducing through status
aggregation exactly the outcome CANCELLED's exclusion from `failed` exists to
avoid. Confirmed against `idd-pre-merge.instructions.md`'s own routing table
that `'pending'` means "wait, then re-evaluate F2" while `'some-failing'`
means "hold; never merge" -- so this distinction has real behavioral effect,
not just a label change.

- `resolvePresentRunConclusion` now special-cases the exact shape described
  in the issue: `status === 'unknown'` with every entry in the `unknown`
  bucket specifically `CANCELLED` maps to `'pending'` instead of
  `'some-failing'`.
- Deliberately scoped to `resolvePresentRunConclusion`'s own `unknown` field
  rather than folding CANCELLED handling into `classifyCiChecks` itself,
  which also feeds `summarizeRequiredChecks`'s required-checks `status` -- a
  *required* check that is itself cancelled with no successor should not
  silently read as passing there. A dedicated regression test locks that
  design intent directly (added after a C1 self-critique pass flagged the
  gap).
- New tests added to `tests/required-checks-summary.test.mts` rather than the
  issue's originally-suggested `tests/protocol-helpers.test.mts`: all existing
  coverage of `classifyCiChecks`/`resolvePresentRunConclusion`/
  `summarizeRequiredChecks` already lives in the former file, and
  `protocol-helpers.test.mts` has none, so this follows the established
  convention rather than starting a second location for the same surface.

## Linked issue

Closes #2714

## Merge-behavior note

Marked "Security / credential / merge behavior changed" above: this fix
changes the F2 no-required-checks fallback's routing for the narrow
lone-CANCELLED-with-no-successor shape, from `'some-failing'` (hold; never
merge) to `'pending'` (wait, then re-evaluate F2). It does not loosen the
required-checks (protected-branch) path at all -- a required check that is
itself cancelled with no successor still reports `status: 'unknown'`, locked
by a dedicated regression test.

## Follow-up issues (if any)

- [ ] none

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191MCYGribBmSeRVTk3AxQ6
