### PR TITLE
fix(idd-pre-merge): document --claimless, structure missing-arg error

### DIFF
--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -108,14 +108,17 @@ for the full flag reference.
 
 **Polling loop failure mode**: a caller that repeats this invocation
 (directly, or via a delegated worker) until F2 is ready must branch on
-two distinct outcomes: a non-zero exit with a JSON `{ "error": ... }`
-object on stdout (a call-time argument/usage error, e.g. the missing
-`--claim-issue`/`--claimless` case above) is a **call failure** — fix the
-invocation and retry, never keep polling on it — while a zero exit with
-the full readiness report JSON (`ready: false` with `blockers`) is an
-ordinary **not-ready-yet** result to keep polling on. Treating both the
-same way (kurone-kito/idd-skill#2707) turns a fixable invocation mistake
-into a silent stall with no operator-visible error.
+two distinct outcomes: a zero exit with the full readiness report JSON
+(`ready: false` with `blockers`) is an ordinary **not-ready-yet** result
+to keep polling on; a non-zero exit with a JSON `{ "error": ... }` object
+on stdout instead is a **call failure** — this covers both a call-time
+argument/usage error (e.g. the missing `--claim-issue`/`--claimless`
+case above, which also carries a `hint`) and a live `gh`-backed lookup
+failing (no `hint`); fix the invocation before retrying an argument
+error, and use judgment before abandoning the poll on a `hint`-less one
+(a live call can fail transiently). Conflating either kind of `{error}`
+response with an ordinary not-ready-yet result (kurone-kito/idd-skill#2707)
+turns an operator-visible failure into a silent stall.
 
 - **Review currency** (live re-fetch required, freshness gate): read the
   most recent `<!-- review-watermark: {agent-id} {claim-id} … -->`

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -97,6 +97,26 @@ kurone-kito/idd-skill#1529). Omitting `--nonce` silently skips the
 merge-time comparison rather than failing closed, so pass it whenever a
 nonce was recorded for the active claim.
 
+**No claimed issue**: the readiness collector requires either
+`--claim-issue <issue-number>` (with `--claim-id`) or `--claimless`
+(#2017) — pass `--claimless` instead when this PR has no linked issue to
+claim (`closingIssuesReferences` empty); it cannot combine with
+`--claim-issue`/`--claim-id` and fails closed if `closingIssuesReferences`
+is non-empty. See
+[docs/idd-helper-scripts.md's Readiness command](../../docs/idd-helper-scripts.md)
+for the full flag reference.
+
+**Polling loop failure mode**: a caller that repeats this invocation
+(directly, or via a delegated worker) until F2 is ready must branch on
+two distinct outcomes: a non-zero exit with a JSON `{ "error": ... }`
+object on stdout (a call-time argument/usage error, e.g. the missing
+`--claim-issue`/`--claimless` case above) is a **call failure** — fix the
+invocation and retry, never keep polling on it — while a zero exit with
+the full readiness report JSON (`ready: false` with `blockers`) is an
+ordinary **not-ready-yet** result to keep polling on. Treating both the
+same way (kurone-kito/idd-skill#2707) turns a fixable invocation mistake
+into a silent stall with no operator-visible error.
+
 - **Review currency** (live re-fetch required, freshness gate): read the
   most recent `<!-- review-watermark: {agent-id} {claim-id} … -->`
   comment whose embedded `{claim-id}` matches the current active claim

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -92,6 +92,26 @@ kurone-kito/idd-skill#1529). Omitting `--nonce` silently skips the
 merge-time comparison rather than failing closed, so pass it whenever a
 nonce was recorded for the active claim.
 
+**No claimed issue**: the readiness collector requires either
+`--claim-issue <issue-number>` (with `--claim-id`) or `--claimless`
+(#2017) — pass `--claimless` instead when this PR has no linked issue to
+claim (`closingIssuesReferences` empty); it cannot combine with
+`--claim-issue`/`--claim-id` and fails closed if `closingIssuesReferences`
+is non-empty. See
+[docs/idd-helper-scripts.md's Readiness command](../../docs/idd-helper-scripts.md)
+for the full flag reference.
+
+**Polling loop failure mode**: a caller that repeats this invocation
+(directly, or via a delegated worker) until F2 is ready must branch on
+two distinct outcomes: a non-zero exit with a JSON `{ "error": ... }`
+object on stdout (a call-time argument/usage error, e.g. the missing
+`--claim-issue`/`--claimless` case above) is a **call failure** — fix the
+invocation and retry, never keep polling on it — while a zero exit with
+the full readiness report JSON (`ready: false` with `blockers`) is an
+ordinary **not-ready-yet** result to keep polling on. Treating both the
+same way (kurone-kito/idd-skill#2707) turns a fixable invocation mistake
+into a silent stall with no operator-visible error.
+
 - **Review currency** (live re-fetch required, freshness gate): read the
   most recent `<!-- review-watermark: {agent-id} {claim-id} … -->`
   comment whose embedded `{claim-id}` matches the current active claim

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -103,14 +103,17 @@ for the full flag reference.
 
 **Polling loop failure mode**: a caller that repeats this invocation
 (directly, or via a delegated worker) until F2 is ready must branch on
-two distinct outcomes: a non-zero exit with a JSON `{ "error": ... }`
-object on stdout (a call-time argument/usage error, e.g. the missing
-`--claim-issue`/`--claimless` case above) is a **call failure** — fix the
-invocation and retry, never keep polling on it — while a zero exit with
-the full readiness report JSON (`ready: false` with `blockers`) is an
-ordinary **not-ready-yet** result to keep polling on. Treating both the
-same way (kurone-kito/idd-skill#2707) turns a fixable invocation mistake
-into a silent stall with no operator-visible error.
+two distinct outcomes: a zero exit with the full readiness report JSON
+(`ready: false` with `blockers`) is an ordinary **not-ready-yet** result
+to keep polling on; a non-zero exit with a JSON `{ "error": ... }` object
+on stdout instead is a **call failure** — this covers both a call-time
+argument/usage error (e.g. the missing `--claim-issue`/`--claimless`
+case above, which also carries a `hint`) and a live `gh`-backed lookup
+failing (no `hint`); fix the invocation before retrying an argument
+error, and use judgment before abandoning the poll on a `hint`-less one
+(a live call can fail transiently). Conflating either kind of `{error}`
+response with an ordinary not-ready-yet result (kurone-kito/idd-skill#2707)
+turns an operator-visible failure into a silent stall.
 
 - **Review currency** (live re-fetch required, freshness gate): read the
   most recent `<!-- review-watermark: {agent-id} {claim-id} … -->`

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -664,11 +664,39 @@ export function collectPreMergeReadiness(
     trustedMarkerActorsSource,
   };
 }
+// #2707: a caller that repeats this invocation until F2 is ready (directly,
+// or via a delegated worker's polling loop) must be able to distinguish a
+// call-time argument/usage error from an ordinary "not ready yet" readiness
+// report -- both used to be indistinguishable-by-default (an uncaught
+// exception left an unhandled stack trace on stderr and a non-JSON stdout,
+// easy to conflate with a transient not-ready state if the caller only
+// checks the exit code). `hint` is populated only for the specific error
+// this arose from (the missing --claim-issue/--claimless case); other
+// thrown errors surface with `error` alone.
+export function renderCliUsageError(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.includes('missing required --claim-issue')) {
+    return {
+      error: message,
+      hint:
+        'pass --claim-issue <issue-number> (with --claim-id), or --claimless ' +
+        'for a PR with no closingIssuesReferences',
+    };
+  }
+  return { error: message };
+}
 // CLI: emit the readiness report as JSON when invoked directly.
 if (import.meta.main) {
-  process.stdout.write(
-    `${JSON.stringify(collectPreMergeReadiness(process.argv.slice(2)), null, 2)}\n`,
-  );
+  try {
+    process.stdout.write(
+      `${JSON.stringify(collectPreMergeReadiness(process.argv.slice(2)), null, 2)}\n`,
+    );
+  } catch (error) {
+    process.stdout.write(
+      `${JSON.stringify(renderCliUsageError(error), null, 2)}\n`,
+    );
+    process.exitCode = 1;
+  }
 }
 function warnDeprecatedFlag(deprecated, canonical) {
   process.stderr.write(

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -874,11 +874,43 @@ export function collectPreMergeReadiness(
   } as PreMergeReadinessReport;
 }
 
+// #2707: a caller that repeats this invocation until F2 is ready (directly,
+// or via a delegated worker's polling loop) must be able to distinguish a
+// call-time argument/usage error from an ordinary "not ready yet" readiness
+// report -- both used to be indistinguishable-by-default (an uncaught
+// exception left an unhandled stack trace on stderr and a non-JSON stdout,
+// easy to conflate with a transient not-ready state if the caller only
+// checks the exit code). `hint` is populated only for the specific error
+// this arose from (the missing --claim-issue/--claimless case); other
+// thrown errors surface with `error` alone.
+export function renderCliUsageError(error: unknown): {
+  error: string;
+  hint?: string;
+} {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.includes('missing required --claim-issue')) {
+    return {
+      error: message,
+      hint:
+        'pass --claim-issue <issue-number> (with --claim-id), or --claimless ' +
+        'for a PR with no closingIssuesReferences',
+    };
+  }
+  return { error: message };
+}
+
 // CLI: emit the readiness report as JSON when invoked directly.
 if (import.meta.main) {
-  process.stdout.write(
-    `${JSON.stringify(collectPreMergeReadiness(process.argv.slice(2)), null, 2)}\n`,
-  );
+  try {
+    process.stdout.write(
+      `${JSON.stringify(collectPreMergeReadiness(process.argv.slice(2)), null, 2)}\n`,
+    );
+  } catch (error) {
+    process.stdout.write(
+      `${JSON.stringify(renderCliUsageError(error), null, 2)}\n`,
+    );
+    process.exitCode = 1;
+  }
 }
 
 function warnDeprecatedFlag(deprecated: string, canonical: string): void {

--- a/tests/pre-merge-readiness-collection-smoke.test.mts
+++ b/tests/pre-merge-readiness-collection-smoke.test.mts
@@ -610,6 +610,50 @@ test('pre-merge-readiness.mjs CLI: --claimless fails closed when closingIssuesRe
   }
 });
 
+// #2707 (CodeRabbit review on PR #2731): the sibling `renderCliUsageError`
+// unit test in pre-merge-readiness.test.mts covers the hinted shape as a
+// pure function, but not the actual subprocess boundary -- this exercises
+// the real CLI entrypoint end-to-end for the missing-claim-issue case (no
+// gh stub needed: collectPreMergeReadiness throws this before any gh call).
+test('pre-merge-readiness.mjs CLI: neither --claim-issue nor --claimless names --claimless as the fix (#2707)', () => {
+  const cwdRoot = mkdtempSync(
+    join(tmpdir(), 'idd-pre-merge-missing-claim-cwd-'),
+  );
+  try {
+    assert.throws(
+      () =>
+        execFileSync(
+          process.execPath,
+          [
+            join(REPO_ROOT, 'scripts/pre-merge-readiness.mjs'),
+            '--pr',
+            '1',
+            '--owner',
+            OWNER,
+            '--repo',
+            REPO,
+          ],
+          {
+            cwd: cwdRoot,
+            encoding: 'utf8',
+            env: { ...process.env },
+            timeout: 60_000,
+          },
+        ),
+      (error: unknown) => {
+        const stdout = (error as { stdout?: string }).stdout ?? '';
+        const parsed = JSON.parse(stdout) as { error: string; hint?: string };
+        assert.match(parsed.error, /missing required --claim-issue/);
+        assert.match(parsed.hint ?? '', /--claimless/);
+        assert.notEqual((error as { status?: number }).status, 0);
+        return true;
+      },
+    );
+  } finally {
+    rmSync(cwdRoot, { recursive: true, force: true });
+  }
+});
+
 test('pre-merge-readiness.mjs CLI: blocked scenario (one unresolved review thread) surfaces it end-to-end', () => {
   const report = runPreMergeReadinessSmoke(false);
 

--- a/tests/pre-merge-readiness-collection-smoke.test.mts
+++ b/tests/pre-merge-readiness-collection-smoke.test.mts
@@ -556,6 +556,11 @@ test('pre-merge-readiness.mjs CLI: --claimless on an empty-references PR skips c
   }
 });
 
+// #2707: the CLI entrypoint now catches this throw and emits a structured
+// `{ error, hint? }` JSON object on stdout with a non-zero exit code,
+// instead of an uncaught-exception stack trace on stderr -- assert against
+// the parsed stdout JSON (execFileSync still throws on the non-zero exit;
+// only where the error text lives changed).
 test('pre-merge-readiness.mjs CLI: --claimless fails closed when closingIssuesReferences is non-empty (#2017)', () => {
   const cwdRoot = mkdtempSync(
     join(tmpdir(), 'idd-pre-merge-claimless-fail-cwd-'),
@@ -591,7 +596,13 @@ test('pre-merge-readiness.mjs CLI: --claimless fails closed when closingIssuesRe
             timeout: 60_000,
           },
         ),
-      /closingIssuesReferences/,
+      (error: unknown) => {
+        const stdout = (error as { stdout?: string }).stdout ?? '';
+        const parsed = JSON.parse(stdout) as { error: string; hint?: string };
+        assert.match(parsed.error, /closingIssuesReferences/);
+        assert.equal(parsed.hint, undefined);
+        return true;
+      },
     );
   } finally {
     restore();

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -7,10 +7,12 @@ import {
   renderReviewReplyStamp,
 } from '../src/scripts/marker-helpers.mts';
 import {
+  collectPreMergeReadiness,
   fetchBranchRulesets,
   fetchGovernanceJson,
   normalizeStatusCheckRollupEntry,
   parseArgs,
+  renderCliUsageError,
   resolveDeclarationActiveSince,
   resolveEligibleCodeownerUserLogins,
   resolveToleratedGhFailure,
@@ -7096,6 +7098,43 @@ test('parseArgs: a non-positive / non-integer number throws a clear message', ()
     () => parseArgs(['--claim-issue', '0']),
     /invalid --claim-issue value/,
   );
+});
+
+// #2707: neither --claimless nor --claim-issue supplied is still a thrown
+// Error from collectPreMergeReadiness itself (unchanged contract for a
+// direct function caller) -- the CLI entrypoint's own try/catch, tested via
+// renderCliUsageError below, is what turns this into a structured,
+// non-crashing stdout error for a subprocess caller.
+test('collectPreMergeReadiness: neither --claimless nor --claim-issue throws (#2707)', () => {
+  assert.throws(
+    () => collectPreMergeReadiness(['--pr', '1']),
+    /missing required --claim-issue <number> argument/,
+  );
+});
+
+test('renderCliUsageError: names --claimless as the fix for the missing-claim-issue error (#2707)', () => {
+  const result = renderCliUsageError(
+    new Error('missing required --claim-issue <number> argument'),
+  );
+  assert.equal(
+    result.error,
+    'missing required --claim-issue <number> argument',
+  );
+  assert.match(result.hint ?? '', /--claimless/);
+});
+
+test('renderCliUsageError: an unrelated error carries no --claimless hint (#2707)', () => {
+  const result = renderCliUsageError(
+    new Error('missing required --pr <number> argument'),
+  );
+  assert.equal(result.error, 'missing required --pr <number> argument');
+  assert.equal(result.hint, undefined);
+});
+
+test('renderCliUsageError: a non-Error thrown value still renders a string error (#2707)', () => {
+  const result = renderCliUsageError('some non-Error throw');
+  assert.equal(result.error, 'some non-Error throw');
+  assert.equal(result.hint, undefined);
 });
 
 test('buildPreMergeReadinessSummary: claimless emits not-applicable ownership (#2017)', () => {


### PR DESCRIPTION
# Summary

`pre-merge-readiness.mjs`'s `--claimless` flag (added for #2017-class
directly-authorized, unclaimed PRs) is fully documented at
`docs/idd-helper-scripts.md`'s Readiness command bullet, but the actual
F1/F2 phase file that invokes the helper
(`idd-pre-merge.instructions.md`) never mentioned it at all. The CLI
entrypoint also had no error handling: calling it with neither
`--claimless` nor `--claim-issue` threw an uncaught `Error`, exiting with
an unhandled stack trace on stderr instead of structured, parseable
output.

Field evidence from the issue: a delegated worker's polling loop invoked
this helper without a claim argument. Because the failure was an
uncaught exception (non-JSON stderr, not readiness JSON), every poll
iteration hit the same failure with no branch to distinguish "the helper
call itself failed" from "not ready yet" -- a silent ~90 minute stall
with no operator-visible error.

- `idd-pre-merge.instructions.md`'s F2 opening now points to `--claimless`
  for the no-claimed-issue case, linking to `docs/idd-helper-scripts.md`'s
  full flag reference.
- `pre-merge-readiness.mts`'s CLI entrypoint now catches any thrown error
  and emits a structured `{ error, hint? }` JSON object on stdout with a
  non-zero exit code, instead of an uncaught-exception stack trace.
  `hint` names `--claimless` specifically for the missing-claim-issue
  case; `collectPreMergeReadiness`'s own throw contract for a direct
  function caller is unchanged.
- Documented (and, after a C1 self-critique pass caught an overclaim in
  the first draft, corrected) that a polling caller must distinguish the
  hinted argument-error case (fix and retry) from a hint-less `{error}`
  response (a live `gh`-backed lookup can also surface through this same
  catch and may be transient -- use judgment before abandoning the poll)
  from an ordinary not-ready-yet readiness report.
- New tests cover `collectPreMergeReadiness`'s unchanged throw, the new
  `renderCliUsageError` shape for both the hinted and unhinted cases, and
  an existing end-to-end CLI smoke test updated to parse the new
  structured stdout shape instead of the old stderr-derived error text.

## Linked issue

Closes #2707

## Follow-up issues (if any)

- [ ] none

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191MCYGribBmSeRVTk3AxQ6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The pre-merge readiness command now reports failures as structured JSON, with a helpful hint when claim information is missing.
  - Commands that run without a linked issue can now use claimless mode.

- **Bug Fixes**
  - Improved handling of readiness checks that fail due to invalid arguments or temporary lookup issues.
  - Prevented uncaught stack traces from being shown for command errors.

- **Documentation**
  - Clarified claimless usage and how to interpret readiness reports versus command or lookup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->