### PR TITLE
fix(supersession-detection): anchor check extraction to verdict

### DIFF
--- a/scripts/supersession-detection.mjs
+++ b/scripts/supersession-detection.mjs
@@ -189,6 +189,28 @@ const SUITABILITY_REJECTION_OUTCOME_PATTERN =
 const SUITABILITY_REJECTION_CHECK_PATTERN_GLOBAL = /Check\s+\d+\s*\([^)]+\)/gi;
 const SUITABILITY_REJECTION_FAILURE_VERB_PATTERN = /\bfail(?:s|ed|ing)?\b/gi;
 /**
+ * Distance between two half-open text spans `[aStart, aEnd)` and
+ * `[bStart, bEnd)`: 0 when they overlap or touch, otherwise the gap between
+ * the nearer edges. Codex and CodeRabbit review findings on PR #2732 both
+ * caught that comparing match *start* positions alone (as an earlier
+ * revision of this function did) misattributes a failure verb to the wrong
+ * check once check names have different lengths -- e.g. "Check 4
+ * (Duplicate or Superseded Work) fails, while Check 5 (Actionability)
+ * passes": Check 5's short *start*-to-start gap to "fails" can read as
+ * closer than Check 4's own, immediately-adjacent *span*-to-span gap.
+ * Measuring from the nearer span edge instead of the start alone fixes
+ * this regardless of either match's length.
+ */
+function spanDistance(aStart, aEnd, bStart, bEnd) {
+  if (aEnd <= bStart) {
+    return bStart - aEnd;
+  }
+  if (bEnd <= aStart) {
+    return aStart - bEnd;
+  }
+  return 0;
+}
+/**
  * Extract the `Check N (<Name>)` excerpt describing the comment's actual
  * failed check, not merely an incidentally-mentioned one (#2708). A
  * rejection comment may mention more than one check in the same sentence --
@@ -205,8 +227,10 @@ const SUITABILITY_REJECTION_FAILURE_VERB_PATTERN = /\bfail(?:s|ed|ing)?\b/gi;
  * the failed check is described with a failure verb ("fails"/"failed"/
  * "failing") near its own mention, while a merely-cited check is not. When
  * a failure verb appears anywhere in the body, this returns the `Check N
- * (...)` mention closest to it (character distance; ties keep the earlier
- * mention). When no failure verb appears at all -- the common case: a
+ * (...)` mention closest to it ({@link spanDistance} between the two
+ * matched spans, not merely their start positions -- see that function's
+ * own doc comment for why; ties keep the earlier mention). When no failure
+ * verb appears at all -- the common case: a
  * comment stating its verdict as a headline, "Check N (<Name>): reason",
  * with no other check mentioned, or a comment mentioning a second check
  * only as passing with no failure verb anywhere -- this falls back to the
@@ -234,10 +258,12 @@ function extractSuitabilityVerdictCheckMatch(body) {
   let closest = checkMatches[0] ?? null;
   let closestDistance = Number.POSITIVE_INFINITY;
   for (const checkMatch of checkMatches) {
-    const checkIndex = checkMatch.index ?? 0;
+    const checkStart = checkMatch.index ?? 0;
+    const checkEnd = checkStart + checkMatch[0].length;
     for (const verbMatch of failureVerbMatches) {
-      const verbIndex = verbMatch.index ?? 0;
-      const distance = Math.abs(checkIndex - verbIndex);
+      const verbStart = verbMatch.index ?? 0;
+      const verbEnd = verbStart + verbMatch[0].length;
+      const distance = spanDistance(checkStart, checkEnd, verbStart, verbEnd);
       if (distance < closestDistance) {
         closestDistance = distance;
         closest = checkMatch;

--- a/scripts/supersession-detection.mjs
+++ b/scripts/supersession-detection.mjs
@@ -186,7 +186,29 @@ export const SUITABILITY_REJECTION_PREFIX = 'A4.5 suitability gate rejection';
 // never invents a token the protocol doesn't recognize.
 const SUITABILITY_REJECTION_OUTCOME_PATTERN =
   /outcome:\s*(unclear|needs-decision|blocked-by-human|duplicate|out-of-scope|invalid)\b/i;
-const SUITABILITY_REJECTION_CHECK_PATTERN = /Check\s+\d+\s*\([^)]+\)/i;
+const SUITABILITY_REJECTION_CHECK_PATTERN_GLOBAL = /Check\s+\d+\s*\([^)]+\)/gi;
+/**
+ * Extract the `Check N (<Name>)` excerpt matching the comment's own final
+ * stated verdict (#2708), not merely the first incidental match anywhere in
+ * the body. A rejection comment may cite an earlier check number for
+ * context ("Check 5 (Actionability) was previously cited, but...") before
+ * stating its actual, different final verdict ("...this time it fails
+ * Check 7 (Verifiability)") -- a natural, even encouraged pattern, and one
+ * this repository's own real rejection comments already exhibit in both
+ * relative orderings (check-citation-then-outcome-line, and
+ * outcome-then-check-citation) -- so anchoring to the `outcome:` line's
+ * position is not a reliable signal either way. The last occurrence in
+ * prose reading order is: a single-mention comment (the common case)
+ * returns that one mention unchanged; a multi-mention comment returns the
+ * final, most-recently-stated one, matching how the acceptance criteria's
+ * repro is phrased (earlier context, then a final differing verdict).
+ */
+function extractLatestSuitabilityCheckMatch(body) {
+  const matches = [
+    ...body.matchAll(SUITABILITY_REJECTION_CHECK_PATTERN_GLOBAL),
+  ];
+  return matches.length > 0 ? matches[matches.length - 1] : null;
+}
 /** The four A4.5 outcomes with no dedicated label (#2243): the only values
  * `<!-- {prefix}-triage-verdict: <outcome> -->` may declare.
  * `needs-decision`/`blocked-by-human` are deliberately excluded -- those
@@ -383,7 +405,7 @@ export function findTrustedSuitabilityRejection(
     }
     latestTimestamp = timestamp;
     const outcomeMatch = SUITABILITY_REJECTION_OUTCOME_PATTERN.exec(body);
-    const checkMatch = SUITABILITY_REJECTION_CHECK_PATTERN.exec(body);
+    const checkMatch = extractLatestSuitabilityCheckMatch(body);
     const markerDetection = parseSuitabilityTriageVerdictMarker(
       body,
       markerPrefix,

--- a/scripts/supersession-detection.mjs
+++ b/scripts/supersession-detection.mjs
@@ -187,27 +187,64 @@ export const SUITABILITY_REJECTION_PREFIX = 'A4.5 suitability gate rejection';
 const SUITABILITY_REJECTION_OUTCOME_PATTERN =
   /outcome:\s*(unclear|needs-decision|blocked-by-human|duplicate|out-of-scope|invalid)\b/i;
 const SUITABILITY_REJECTION_CHECK_PATTERN_GLOBAL = /Check\s+\d+\s*\([^)]+\)/gi;
+const SUITABILITY_REJECTION_FAILURE_VERB_PATTERN = /\bfail(?:s|ed|ing)?\b/gi;
 /**
- * Extract the `Check N (<Name>)` excerpt matching the comment's own final
- * stated verdict (#2708), not merely the first incidental match anywhere in
- * the body. A rejection comment may cite an earlier check number for
- * context ("Check 5 (Actionability) was previously cited, but...") before
- * stating its actual, different final verdict ("...this time it fails
- * Check 7 (Verifiability)") -- a natural, even encouraged pattern, and one
- * this repository's own real rejection comments already exhibit in both
- * relative orderings (check-citation-then-outcome-line, and
- * outcome-then-check-citation) -- so anchoring to the `outcome:` line's
- * position is not a reliable signal either way. The last occurrence in
- * prose reading order is: a single-mention comment (the common case)
- * returns that one mention unchanged; a multi-mention comment returns the
- * final, most-recently-stated one, matching how the acceptance criteria's
- * repro is phrased (earlier context, then a final differing verdict).
+ * Extract the `Check N (<Name>)` excerpt describing the comment's actual
+ * failed check, not merely an incidentally-mentioned one (#2708). A
+ * rejection comment may mention more than one check in the same sentence --
+ * one it actually fails, and another cited only for context. Both relative
+ * orderings occur in practice ("Check 5 (Actionability) was previously
+ * cited, but on review this time it fails Check 7 (Verifiability)" vs.
+ * "Check 7 (Verifiability): ... Check 5 (Actionability) passes ... outcome:
+ * ..."), and both place every `Check N (...)` mention before the trailing
+ * `outcome:` line -- so neither "first match", "last match", nor anchoring
+ * to the `outcome:` line's position can discriminate the two shapes; each
+ * of those gets one shape right and the other wrong.
+ *
+ * The signal that actually discriminates them is not position, it is that
+ * the failed check is described with a failure verb ("fails"/"failed"/
+ * "failing") near its own mention, while a merely-cited check is not. When
+ * a failure verb appears anywhere in the body, this returns the `Check N
+ * (...)` mention closest to it (character distance; ties keep the earlier
+ * mention). When no failure verb appears at all -- the common case: a
+ * comment stating its verdict as a headline, "Check N (<Name>): reason",
+ * with no other check mentioned, or a comment mentioning a second check
+ * only as passing with no failure verb anywhere -- this falls back to the
+ * first mention, the documented headline convention (the verdict check is
+ * stated first; anything mentioned afterward is context).
+ *
+ * This is a best-effort heuristic over freely-authored prose, not a
+ * guarantee against every possible phrasing: see {@link
+ * SuitabilityRejectionRecord.check}'s own doc comment for why that is an
+ * acceptable, bounded limitation here.
  */
-function extractLatestSuitabilityCheckMatch(body) {
-  const matches = [
+function extractSuitabilityVerdictCheckMatch(body) {
+  const checkMatches = [
     ...body.matchAll(SUITABILITY_REJECTION_CHECK_PATTERN_GLOBAL),
   ];
-  return matches.length > 0 ? matches[matches.length - 1] : null;
+  if (checkMatches.length <= 1) {
+    return checkMatches[0] ?? null;
+  }
+  const failureVerbMatches = [
+    ...body.matchAll(SUITABILITY_REJECTION_FAILURE_VERB_PATTERN),
+  ];
+  if (failureVerbMatches.length === 0) {
+    return checkMatches[0] ?? null;
+  }
+  let closest = checkMatches[0] ?? null;
+  let closestDistance = Number.POSITIVE_INFINITY;
+  for (const checkMatch of checkMatches) {
+    const checkIndex = checkMatch.index ?? 0;
+    for (const verbMatch of failureVerbMatches) {
+      const verbIndex = verbMatch.index ?? 0;
+      const distance = Math.abs(checkIndex - verbIndex);
+      if (distance < closestDistance) {
+        closestDistance = distance;
+        closest = checkMatch;
+      }
+    }
+  }
+  return closest;
 }
 /** The four A4.5 outcomes with no dedicated label (#2243): the only values
  * `<!-- {prefix}-triage-verdict: <outcome> -->` may declare.
@@ -405,7 +442,7 @@ export function findTrustedSuitabilityRejection(
     }
     latestTimestamp = timestamp;
     const outcomeMatch = SUITABILITY_REJECTION_OUTCOME_PATTERN.exec(body);
-    const checkMatch = extractLatestSuitabilityCheckMatch(body);
+    const checkMatch = extractSuitabilityVerdictCheckMatch(body);
     const markerDetection = parseSuitabilityTriageVerdictMarker(
       body,
       markerPrefix,

--- a/src/scripts/supersession-detection.mts
+++ b/src/scripts/supersession-detection.mts
@@ -297,6 +297,34 @@ const SUITABILITY_REJECTION_CHECK_PATTERN_GLOBAL = /Check\s+\d+\s*\([^)]+\)/gi;
 const SUITABILITY_REJECTION_FAILURE_VERB_PATTERN = /\bfail(?:s|ed|ing)?\b/gi;
 
 /**
+ * Distance between two half-open text spans `[aStart, aEnd)` and
+ * `[bStart, bEnd)`: 0 when they overlap or touch, otherwise the gap between
+ * the nearer edges. Codex and CodeRabbit review findings on PR #2732 both
+ * caught that comparing match *start* positions alone (as an earlier
+ * revision of this function did) misattributes a failure verb to the wrong
+ * check once check names have different lengths -- e.g. "Check 4
+ * (Duplicate or Superseded Work) fails, while Check 5 (Actionability)
+ * passes": Check 5's short *start*-to-start gap to "fails" can read as
+ * closer than Check 4's own, immediately-adjacent *span*-to-span gap.
+ * Measuring from the nearer span edge instead of the start alone fixes
+ * this regardless of either match's length.
+ */
+function spanDistance(
+  aStart: number,
+  aEnd: number,
+  bStart: number,
+  bEnd: number,
+): number {
+  if (aEnd <= bStart) {
+    return bStart - aEnd;
+  }
+  if (bEnd <= aStart) {
+    return aStart - bEnd;
+  }
+  return 0;
+}
+
+/**
  * Extract the `Check N (<Name>)` excerpt describing the comment's actual
  * failed check, not merely an incidentally-mentioned one (#2708). A
  * rejection comment may mention more than one check in the same sentence --
@@ -313,8 +341,10 @@ const SUITABILITY_REJECTION_FAILURE_VERB_PATTERN = /\bfail(?:s|ed|ing)?\b/gi;
  * the failed check is described with a failure verb ("fails"/"failed"/
  * "failing") near its own mention, while a merely-cited check is not. When
  * a failure verb appears anywhere in the body, this returns the `Check N
- * (...)` mention closest to it (character distance; ties keep the earlier
- * mention). When no failure verb appears at all -- the common case: a
+ * (...)` mention closest to it ({@link spanDistance} between the two
+ * matched spans, not merely their start positions -- see that function's
+ * own doc comment for why; ties keep the earlier mention). When no failure
+ * verb appears at all -- the common case: a
  * comment stating its verdict as a headline, "Check N (<Name>): reason",
  * with no other check mentioned, or a comment mentioning a second check
  * only as passing with no failure verb anywhere -- this falls back to the
@@ -344,10 +374,12 @@ function extractSuitabilityVerdictCheckMatch(
   let closest = checkMatches[0] ?? null;
   let closestDistance = Number.POSITIVE_INFINITY;
   for (const checkMatch of checkMatches) {
-    const checkIndex = checkMatch.index ?? 0;
+    const checkStart = checkMatch.index ?? 0;
+    const checkEnd = checkStart + checkMatch[0].length;
     for (const verbMatch of failureVerbMatches) {
-      const verbIndex = verbMatch.index ?? 0;
-      const distance = Math.abs(checkIndex - verbIndex);
+      const verbStart = verbMatch.index ?? 0;
+      const verbEnd = verbStart + verbMatch[0].length;
+      const distance = spanDistance(checkStart, checkEnd, verbStart, verbEnd);
       if (distance < closestDistance) {
         closestDistance = distance;
         closest = checkMatch;

--- a/src/scripts/supersession-detection.mts
+++ b/src/scripts/supersession-detection.mts
@@ -294,30 +294,67 @@ export const SUITABILITY_REJECTION_PREFIX = 'A4.5 suitability gate rejection';
 const SUITABILITY_REJECTION_OUTCOME_PATTERN =
   /outcome:\s*(unclear|needs-decision|blocked-by-human|duplicate|out-of-scope|invalid)\b/i;
 const SUITABILITY_REJECTION_CHECK_PATTERN_GLOBAL = /Check\s+\d+\s*\([^)]+\)/gi;
+const SUITABILITY_REJECTION_FAILURE_VERB_PATTERN = /\bfail(?:s|ed|ing)?\b/gi;
 
 /**
- * Extract the `Check N (<Name>)` excerpt matching the comment's own final
- * stated verdict (#2708), not merely the first incidental match anywhere in
- * the body. A rejection comment may cite an earlier check number for
- * context ("Check 5 (Actionability) was previously cited, but...") before
- * stating its actual, different final verdict ("...this time it fails
- * Check 7 (Verifiability)") -- a natural, even encouraged pattern, and one
- * this repository's own real rejection comments already exhibit in both
- * relative orderings (check-citation-then-outcome-line, and
- * outcome-then-check-citation) -- so anchoring to the `outcome:` line's
- * position is not a reliable signal either way. The last occurrence in
- * prose reading order is: a single-mention comment (the common case)
- * returns that one mention unchanged; a multi-mention comment returns the
- * final, most-recently-stated one, matching how the acceptance criteria's
- * repro is phrased (earlier context, then a final differing verdict).
+ * Extract the `Check N (<Name>)` excerpt describing the comment's actual
+ * failed check, not merely an incidentally-mentioned one (#2708). A
+ * rejection comment may mention more than one check in the same sentence --
+ * one it actually fails, and another cited only for context. Both relative
+ * orderings occur in practice ("Check 5 (Actionability) was previously
+ * cited, but on review this time it fails Check 7 (Verifiability)" vs.
+ * "Check 7 (Verifiability): ... Check 5 (Actionability) passes ... outcome:
+ * ..."), and both place every `Check N (...)` mention before the trailing
+ * `outcome:` line -- so neither "first match", "last match", nor anchoring
+ * to the `outcome:` line's position can discriminate the two shapes; each
+ * of those gets one shape right and the other wrong.
+ *
+ * The signal that actually discriminates them is not position, it is that
+ * the failed check is described with a failure verb ("fails"/"failed"/
+ * "failing") near its own mention, while a merely-cited check is not. When
+ * a failure verb appears anywhere in the body, this returns the `Check N
+ * (...)` mention closest to it (character distance; ties keep the earlier
+ * mention). When no failure verb appears at all -- the common case: a
+ * comment stating its verdict as a headline, "Check N (<Name>): reason",
+ * with no other check mentioned, or a comment mentioning a second check
+ * only as passing with no failure verb anywhere -- this falls back to the
+ * first mention, the documented headline convention (the verdict check is
+ * stated first; anything mentioned afterward is context).
+ *
+ * This is a best-effort heuristic over freely-authored prose, not a
+ * guarantee against every possible phrasing: see {@link
+ * SuitabilityRejectionRecord.check}'s own doc comment for why that is an
+ * acceptable, bounded limitation here.
  */
-function extractLatestSuitabilityCheckMatch(
+function extractSuitabilityVerdictCheckMatch(
   body: string,
 ): RegExpMatchArray | null {
-  const matches = [
+  const checkMatches = [
     ...body.matchAll(SUITABILITY_REJECTION_CHECK_PATTERN_GLOBAL),
   ];
-  return matches.length > 0 ? matches[matches.length - 1] : null;
+  if (checkMatches.length <= 1) {
+    return checkMatches[0] ?? null;
+  }
+  const failureVerbMatches = [
+    ...body.matchAll(SUITABILITY_REJECTION_FAILURE_VERB_PATTERN),
+  ];
+  if (failureVerbMatches.length === 0) {
+    return checkMatches[0] ?? null;
+  }
+  let closest = checkMatches[0] ?? null;
+  let closestDistance = Number.POSITIVE_INFINITY;
+  for (const checkMatch of checkMatches) {
+    const checkIndex = checkMatch.index ?? 0;
+    for (const verbMatch of failureVerbMatches) {
+      const verbIndex = verbMatch.index ?? 0;
+      const distance = Math.abs(checkIndex - verbIndex);
+      if (distance < closestDistance) {
+        closestDistance = distance;
+        closest = checkMatch;
+      }
+    }
+  }
+  return closest;
 }
 
 /** The four A4.5 outcomes with no dedicated label (#2243): the only values
@@ -502,8 +539,15 @@ export interface SuitabilityRejectionRecord {
    * occurrence; `null` when the comment does not declare one in that
    * recognized form. */
   outcome: string | null;
-  /** Best-effort `Check N (<Name>)` excerpt parsed from the comment body's
-   * own headline convention; `null` when absent. */
+  /** Best-effort `Check N (<Name>)` excerpt parsed from the comment body,
+   * preferring a mention near a failure verb over an incidentally-cited one
+   * (#2708); `null` when absent. Informational only, for human/log
+   * readability -- no routing decision in this codebase branches on it (see
+   * the consumers of {@link findTrustedSuitabilityRejection}, which only
+   * read {@link outcome} and {@link markerOutcome}); freely-authored prose
+   * has no fully reliable mechanical signal for "which check is the real
+   * verdict", so this field accepts a bounded residual failure mode rather
+   * than chasing every possible phrasing. */
   check: string | null;
   /** Outcome declared by the comment's `<!-- {prefix}-triage-verdict:
    * <outcome> -->` marker (#2243), or `null` when absent, malformed, or
@@ -581,7 +625,7 @@ export function findTrustedSuitabilityRejection(
     }
     latestTimestamp = timestamp;
     const outcomeMatch = SUITABILITY_REJECTION_OUTCOME_PATTERN.exec(body);
-    const checkMatch = extractLatestSuitabilityCheckMatch(body);
+    const checkMatch = extractSuitabilityVerdictCheckMatch(body);
     const markerDetection = parseSuitabilityTriageVerdictMarker(
       body,
       markerPrefix,

--- a/src/scripts/supersession-detection.mts
+++ b/src/scripts/supersession-detection.mts
@@ -293,7 +293,32 @@ export const SUITABILITY_REJECTION_PREFIX = 'A4.5 suitability gate rejection';
 // never invents a token the protocol doesn't recognize.
 const SUITABILITY_REJECTION_OUTCOME_PATTERN =
   /outcome:\s*(unclear|needs-decision|blocked-by-human|duplicate|out-of-scope|invalid)\b/i;
-const SUITABILITY_REJECTION_CHECK_PATTERN = /Check\s+\d+\s*\([^)]+\)/i;
+const SUITABILITY_REJECTION_CHECK_PATTERN_GLOBAL = /Check\s+\d+\s*\([^)]+\)/gi;
+
+/**
+ * Extract the `Check N (<Name>)` excerpt matching the comment's own final
+ * stated verdict (#2708), not merely the first incidental match anywhere in
+ * the body. A rejection comment may cite an earlier check number for
+ * context ("Check 5 (Actionability) was previously cited, but...") before
+ * stating its actual, different final verdict ("...this time it fails
+ * Check 7 (Verifiability)") -- a natural, even encouraged pattern, and one
+ * this repository's own real rejection comments already exhibit in both
+ * relative orderings (check-citation-then-outcome-line, and
+ * outcome-then-check-citation) -- so anchoring to the `outcome:` line's
+ * position is not a reliable signal either way. The last occurrence in
+ * prose reading order is: a single-mention comment (the common case)
+ * returns that one mention unchanged; a multi-mention comment returns the
+ * final, most-recently-stated one, matching how the acceptance criteria's
+ * repro is phrased (earlier context, then a final differing verdict).
+ */
+function extractLatestSuitabilityCheckMatch(
+  body: string,
+): RegExpMatchArray | null {
+  const matches = [
+    ...body.matchAll(SUITABILITY_REJECTION_CHECK_PATTERN_GLOBAL),
+  ];
+  return matches.length > 0 ? matches[matches.length - 1] : null;
+}
 
 /** The four A4.5 outcomes with no dedicated label (#2243): the only values
  * `<!-- {prefix}-triage-verdict: <outcome> -->` may declare.
@@ -556,7 +581,7 @@ export function findTrustedSuitabilityRejection(
     }
     latestTimestamp = timestamp;
     const outcomeMatch = SUITABILITY_REJECTION_OUTCOME_PATTERN.exec(body);
-    const checkMatch = SUITABILITY_REJECTION_CHECK_PATTERN.exec(body);
+    const checkMatch = extractLatestSuitabilityCheckMatch(body);
     const markerDetection = parseSuitabilityTriageVerdictMarker(
       body,
       markerPrefix,

--- a/tests/supersession-detection.test.mts
+++ b/tests/supersession-detection.test.mts
@@ -929,9 +929,11 @@ test('findTrustedSuitabilityRejection: a trusted-actor rejection is detected and
 });
 
 // #2708: a comment that cites an earlier check number for context before
-// stating a different final verdict must surface the LATER (final) check,
-// not the first incidental "Check N (...)" substring in the body.
-test('findTrustedSuitabilityRejection: a check cited for context before the final verdict is not returned over the later, real verdict', () => {
+// stating a different, failing final verdict must surface the check
+// actually described as failing (Check 7, next to "fails"), not the
+// earlier-cited, merely-contextual one (Check 5) -- an incidental first
+// match would report the wrong, already-superseded check.
+test('findTrustedSuitabilityRejection: a check cited for context before the real, failing verdict is not returned over the failing check', () => {
   const result = findTrustedSuitabilityRejection(
     [
       makeRejectionComment({
@@ -939,6 +941,28 @@ test('findTrustedSuitabilityRejection: a check cited for context before the fina
           `${SUITABILITY_REJECTION_PREFIX} — Check 5 (Actionability) was ` +
           'previously cited, but on review this time it fails Check 7 ' +
           '(Verifiability).\n\noutcome: needs-decision',
+      }),
+    ],
+    ['kurone-kito'],
+  );
+  assert.equal(result?.outcome, 'needs-decision');
+  assert.equal(result?.check, 'Check 7 (Verifiability)');
+});
+
+// Codex review finding on PR #2732: the opposite ordering -- a comment that
+// states its real, failing verdict FIRST as a headline, then mentions a
+// second check afterward only as passing (no failure verb anywhere in the
+// body) -- must not have a "last match wins" extraction report the later,
+// merely-contextual, passing check over the real, headline verdict.
+test('findTrustedSuitabilityRejection: a passing check mentioned after the headline verdict is not returned over the real verdict', () => {
+  const result = findTrustedSuitabilityRejection(
+    [
+      makeRejectionComment({
+        body:
+          `${SUITABILITY_REJECTION_PREFIX} — Check 7 (Verifiability): the ` +
+          'review evidence does not hold up under scrutiny. Check 5 ' +
+          '(Actionability) passes cleanly on its own.\n\n' +
+          'outcome: needs-decision',
       }),
     ],
     ['kurone-kito'],

--- a/tests/supersession-detection.test.mts
+++ b/tests/supersession-detection.test.mts
@@ -928,6 +928,25 @@ test('findTrustedSuitabilityRejection: a trusted-actor rejection is detected and
   assert.equal(result?.check, 'Check 7 (Verifiability)');
 });
 
+// #2708: a comment that cites an earlier check number for context before
+// stating a different final verdict must surface the LATER (final) check,
+// not the first incidental "Check N (...)" substring in the body.
+test('findTrustedSuitabilityRejection: a check cited for context before the final verdict is not returned over the later, real verdict', () => {
+  const result = findTrustedSuitabilityRejection(
+    [
+      makeRejectionComment({
+        body:
+          `${SUITABILITY_REJECTION_PREFIX} — Check 5 (Actionability) was ` +
+          'previously cited, but on review this time it fails Check 7 ' +
+          '(Verifiability).\n\noutcome: needs-decision',
+      }),
+    ],
+    ['kurone-kito'],
+  );
+  assert.equal(result?.outcome, 'needs-decision');
+  assert.equal(result?.check, 'Check 7 (Verifiability)');
+});
+
 test('findTrustedSuitabilityRejection: the same rejection-shaped comment from an untrusted actor is not surfaced', () => {
   const result = findTrustedSuitabilityRejection(
     [makeRejectionComment({ user: { login: 'random-untrusted-user' } })],

--- a/tests/supersession-detection.test.mts
+++ b/tests/supersession-detection.test.mts
@@ -971,6 +971,27 @@ test('findTrustedSuitabilityRejection: a passing check mentioned after the headl
   assert.equal(result?.check, 'Check 7 (Verifiability)');
 });
 
+// Codex + CodeRabbit review findings on PR #2732: a long check name before
+// its own failure verb must not lose to a short, later, merely-contextual
+// check whose *start* position happens to sit closer to that verb than the
+// long check's own start does -- distance must be measured from the
+// nearer edge of each match's span, not from match starts alone.
+test('findTrustedSuitabilityRejection: a long-named failing check adjacent to "fails" beats a shorter later check whose start is nominally closer', () => {
+  const result = findTrustedSuitabilityRejection(
+    [
+      makeRejectionComment({
+        body:
+          `${SUITABILITY_REJECTION_PREFIX} — Check 4 (Duplicate or ` +
+          'Superseded Work) fails, while Check 5 (Actionability) passes ' +
+          'on its own.\n\noutcome: needs-decision',
+      }),
+    ],
+    ['kurone-kito'],
+  );
+  assert.equal(result?.outcome, 'needs-decision');
+  assert.equal(result?.check, 'Check 4 (Duplicate or Superseded Work)');
+});
+
 test('findTrustedSuitabilityRejection: the same rejection-shaped comment from an untrusted actor is not surfaced', () => {
   const result = findTrustedSuitabilityRejection(
     [makeRejectionComment({ user: { login: 'random-untrusted-user' } })],


### PR DESCRIPTION
# Summary

`findTrustedSuitabilityRejection` in `src/scripts/supersession-detection.mts`
used `SUITABILITY_REJECTION_CHECK_PATTERN` via a single non-`g`-flag
`.exec(body)` call to extract which A4.5 check a rejection comment failed.

Because `.exec` with no `g` flag returns only the first match anywhere in
the comment body, the function returned the FIRST "Check N (...)" substring
in the whole comment -- not the one describing the comment's own stated
verdict. This reproduces whenever a rejection comment cites an earlier
check number for context before stating its actual, different final
verdict ("Check 5 (Actionability) was previously cited, but on review this
time it fails Check 7 (Verifiability)" -- the function returned Check 5,
the wrong and already-superseded reason). This propagates to both
consumers of the function: `discover-readiness-check.mjs` and
`discover-orphan-filter.mjs`.

- An initial revision of this PR replaced the single-match extraction with
  a "last match wins" extractor. A Codex review finding then showed this
  has the exact symmetric failure mode as the original bug: a comment that
  states its real, failing verdict FIRST as a headline, then mentions a
  second check afterward only as passing, would have "last match" report
  the later, merely-contextual, passing check instead of the real verdict.
  Both this shape and the original issue's own repro place every
  "Check N (...)" mention before the trailing `outcome:` line, so no
  purely positional rule (first, last, or anchored-to-outcome) can
  discriminate them.
- The final implementation, `extractSuitabilityVerdictCheckMatch`, uses a
  different signal instead of position: the failed check is described with
  a failure verb ("fails"/"failed"/"failing") near its own mention, while a
  merely-cited check is not. When a failure verb appears anywhere in the
  body, this returns the `Check N (...)` mention closest to it (measured
  between the two matched spans, not merely their start positions -- a
  second round of Codex + CodeRabbit findings caught that start-only
  comparison misattributes the verb once check names have different
  lengths). When no failure verb appears at all, this falls back to the
  first mention, the documented headline convention.
- The `check` field itself is now documented as informational-only, for
  human/log readability: no routing decision in this codebase reads it
  (only `outcome` and the machine-readable `markerOutcome` drive routing),
  since no mechanical prose heuristic can be fully correct against
  arbitrary free-form phrasing.
- Regression tests cover: the issue's own repro (context-check before the
  real, failing verdict), the symmetric counter-example (real verdict
  first, passing check mentioned after), and the span-vs-start-position
  case (a long-named failing check adjacent to "fails" against a shorter,
  later, merely-contextual check).

## Linked issue

Closes #2708

## Follow-up issues (if any)

- [ ] none

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191MCYGribBmSeRVTk3AxQ6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of the specific suitability check associated with a failure when rejection comments mention multiple checks.
  * Preserved fallback behavior when no failure is clearly identified.

* **Tests**
  * Added coverage for comments containing contextual and passing check references alongside the actual failing verdict.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
