### PR TITLE
docs(idd-config): verify Contents API 403/404 masking for loadTrustedIddConfig

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -88,6 +88,37 @@ posting), which does not affect `status`; `resolve-review-thread.mjs`
 returns `mode` (`dry-run`/`apply`) alongside its own separate
 `status?` (`applied`/`failed`).
 
+## Contents API permission-masking probe (#2716)
+
+`loadTrustedIddConfig` (`src/scripts/idd-config.mts`) fetches
+`.github/idd/config.json` at a trusted `ref` via the GitHub Contents API
+and returns `null` (documented-defaults fallback) only on a confirmed
+404; any other failure, including a permission denial, throws instead of
+guessing. Whether GitHub's Contents API masks a `403` (permission denied)
+as a `404` for a token lacking Contents read access was an open empirical
+question -- a related masking pattern is already documented for the
+branch-protection/ruleset endpoints specifically (`trustEmptyProtectionReads`,
+see `docs/policy-constants.md`).
+
+**Verified 2026-09-08**: no masking observed for the Contents API. A
+disposable **private** repository
+(`kurone-kito/idd-skill-issue-2716-contents-api-probe`, intentionally
+retained rather than deleted -- see the linked issue) ran a GitHub
+Actions workflow declaring `permissions: { contents: none }` at the job
+level, then used the workflow's own ephemeral `GITHUB_TOKEN` to request
+an existing file at a valid ref via
+`GET /repos/{owner}/{repo}/contents/{path}?ref={sha}`. Response:
+`403` with body `{"message": "Resource not accessible by integration"}`
+-- a genuine, unambiguous permission denial, not a `404`. The repo is
+**private** deliberately: a public repo's `contents: none` token can
+still read publicly-visible content and return `200`, which would prove
+nothing about masking.
+
+`loadTrustedIddConfig`'s existing fail-closed `deriveGhHttpStatus(error)
+=== 404` check is therefore correct as written and needs no change for
+this finding. See the function's own JSDoc for the same note attached
+directly to its contract.
+
 ## Decision
 
 In the idd-skill source repository, the following optional helpers were adopted:

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -88,7 +88,7 @@ posting), which does not affect `status`; `resolve-review-thread.mjs`
 returns `mode` (`dry-run`/`apply`) alongside its own separate
 `status?` (`applied`/`failed`).
 
-## Contents API permission-masking probe (#2716)
+## Contents API permission-masking probe (kurone-kito/idd-skill#2716)
 
 `loadTrustedIddConfig` (`src/scripts/idd-config.mts`) fetches
 `.github/idd/config.json` at a trusted `ref` via the GitHub Contents API
@@ -103,7 +103,7 @@ see `docs/policy-constants.md`).
 **Verified 2026-09-08**: no masking observed for the Contents API. A
 disposable **private** repository
 (`kurone-kito/idd-skill-issue-2716-contents-api-probe`, intentionally
-retained rather than deleted -- see the linked issue) ran a GitHub
+retained rather than deleted -- see kurone-kito/idd-skill#2716) ran a GitHub
 Actions workflow declaring `permissions: { contents: none }` at the job
 level, then used the workflow's own ephemeral `GITHUB_TOKEN` to request
 an existing file at a valid ref via

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -88,6 +88,37 @@ posting), which does not affect `status`; `resolve-review-thread.mjs`
 returns `mode` (`dry-run`/`apply`) alongside its own separate
 `status?` (`applied`/`failed`).
 
+## Contents API permission-masking probe (#2716)
+
+`loadTrustedIddConfig` (`src/scripts/idd-config.mts`) fetches
+`.github/idd/config.json` at a trusted `ref` via the GitHub Contents API
+and returns `null` (documented-defaults fallback) only on a confirmed
+404; any other failure, including a permission denial, throws instead of
+guessing. Whether GitHub's Contents API masks a `403` (permission denied)
+as a `404` for a token lacking Contents read access was an open empirical
+question -- a related masking pattern is already documented for the
+branch-protection/ruleset endpoints specifically (`trustEmptyProtectionReads`,
+see `docs/policy-constants.md`).
+
+**Verified 2026-09-08**: no masking observed for the Contents API. A
+disposable **private** repository
+(`kurone-kito/idd-skill-issue-2716-contents-api-probe`, intentionally
+retained rather than deleted -- see the linked issue) ran a GitHub
+Actions workflow declaring `permissions: { contents: none }` at the job
+level, then used the workflow's own ephemeral `GITHUB_TOKEN` to request
+an existing file at a valid ref via
+`GET /repos/{owner}/{repo}/contents/{path}?ref={sha}`. Response:
+`403` with body `{"message": "Resource not accessible by integration"}`
+-- a genuine, unambiguous permission denial, not a `404`. The repo is
+**private** deliberately: a public repo's `contents: none` token can
+still read publicly-visible content and return `200`, which would prove
+nothing about masking.
+
+`loadTrustedIddConfig`'s existing fail-closed `deriveGhHttpStatus(error)
+=== 404` check is therefore correct as written and needs no change for
+this finding. See the function's own JSDoc for the same note attached
+directly to its contract.
+
 ## Decision
 
 In the idd-skill source repository, the following optional helpers were adopted:

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -88,7 +88,7 @@ posting), which does not affect `status`; `resolve-review-thread.mjs`
 returns `mode` (`dry-run`/`apply`) alongside its own separate
 `status?` (`applied`/`failed`).
 
-## Contents API permission-masking probe (#2716)
+## Contents API permission-masking probe (kurone-kito/idd-skill#2716)
 
 `loadTrustedIddConfig` (`src/scripts/idd-config.mts`) fetches
 `.github/idd/config.json` at a trusted `ref` via the GitHub Contents API
@@ -103,7 +103,7 @@ see `docs/policy-constants.md`).
 **Verified 2026-09-08**: no masking observed for the Contents API. A
 disposable **private** repository
 (`kurone-kito/idd-skill-issue-2716-contents-api-probe`, intentionally
-retained rather than deleted -- see the linked issue) ran a GitHub
+retained rather than deleted -- see kurone-kito/idd-skill#2716) ran a GitHub
 Actions workflow declaring `permissions: { contents: none }` at the job
 level, then used the workflow's own ephemeral `GITHUB_TOKEN` to request
 an existing file at a valid ref via

--- a/scripts/idd-config.mjs
+++ b/scripts/idd-config.mjs
@@ -123,6 +123,18 @@ export function buildIddConfigContentsArgs(owner, repo, ref) {
  * {@link ghText}) so a caller like `collectPreMergeReadiness` can pass a
  * fake in tests without spawning a `gh` process, mirroring
  * `idd-merge-execute.mts`'s `resolveRemoteSoloCodeownerAdminFallbackMode`.
+ *
+ * **Verified 2026-09-08 (#2716)**: GitHub's Contents API does NOT mask a
+ * permission denial as a 404 for this endpoint. A disposable private repo
+ * (`kurone-kito/idd-skill-issue-2716-contents-api-probe`, intentionally
+ * retained) ran a GitHub Actions workflow declaring `permissions: {
+ * contents: none }` at the job level and read an existing file at a valid
+ * ref via the workflow's own ephemeral `GITHUB_TOKEN`. Observed response:
+ * `403` with `{"message": "Resource not accessible by integration"}` --
+ * a genuine, unambiguous permission denial, distinguishable from a real
+ * 404. `deriveGhHttpStatus(error) === 404` above correctly fails closed
+ * (throws) for this case rather than misclassifying it as absence. See
+ * `docs/idd-helper-scripts.md` for the full test methodology.
  */
 export function loadTrustedIddConfig(
   owner,

--- a/scripts/idd-config.mjs
+++ b/scripts/idd-config.mjs
@@ -132,8 +132,9 @@ export function buildIddConfigContentsArgs(owner, repo, ref) {
  * ref via the workflow's own ephemeral `GITHUB_TOKEN`. Observed response:
  * `403` with `{"message": "Resource not accessible by integration"}` --
  * a genuine, unambiguous permission denial, distinguishable from a real
- * 404. `deriveGhHttpStatus(error) === 404` above correctly fails closed
- * (throws) for this case rather than misclassifying it as absence. See
+ * 404. The `deriveGhHttpStatus(error) === 404` guard in the function body
+ * below correctly evaluates false for a 403, so this case falls through
+ * to the throw branch instead of being misclassified as absence. See
  * `docs/idd-helper-scripts.md` for the full test methodology.
  */
 export function loadTrustedIddConfig(

--- a/src/scripts/idd-config.mts
+++ b/src/scripts/idd-config.mts
@@ -167,8 +167,9 @@ export function buildIddConfigContentsArgs(
  * ref via the workflow's own ephemeral `GITHUB_TOKEN`. Observed response:
  * `403` with `{"message": "Resource not accessible by integration"}` --
  * a genuine, unambiguous permission denial, distinguishable from a real
- * 404. `deriveGhHttpStatus(error) === 404` above correctly fails closed
- * (throws) for this case rather than misclassifying it as absence. See
+ * 404. The `deriveGhHttpStatus(error) === 404` guard in the function body
+ * below correctly evaluates false for a 403, so this case falls through
+ * to the throw branch instead of being misclassified as absence. See
  * `docs/idd-helper-scripts.md` for the full test methodology.
  */
 export function loadTrustedIddConfig(

--- a/src/scripts/idd-config.mts
+++ b/src/scripts/idd-config.mts
@@ -158,6 +158,18 @@ export function buildIddConfigContentsArgs(
  * {@link ghText}) so a caller like `collectPreMergeReadiness` can pass a
  * fake in tests without spawning a `gh` process, mirroring
  * `idd-merge-execute.mts`'s `resolveRemoteSoloCodeownerAdminFallbackMode`.
+ *
+ * **Verified 2026-09-08 (#2716)**: GitHub's Contents API does NOT mask a
+ * permission denial as a 404 for this endpoint. A disposable private repo
+ * (`kurone-kito/idd-skill-issue-2716-contents-api-probe`, intentionally
+ * retained) ran a GitHub Actions workflow declaring `permissions: {
+ * contents: none }` at the job level and read an existing file at a valid
+ * ref via the workflow's own ephemeral `GITHUB_TOKEN`. Observed response:
+ * `403` with `{"message": "Resource not accessible by integration"}` --
+ * a genuine, unambiguous permission denial, distinguishable from a real
+ * 404. `deriveGhHttpStatus(error) === 404` above correctly fails closed
+ * (throws) for this case rather than misclassifying it as absence. See
+ * `docs/idd-helper-scripts.md` for the full test methodology.
  */
 export function loadTrustedIddConfig(
   owner: string,


### PR DESCRIPTION
## Summary

`loadTrustedIddConfig` (`src/scripts/idd-config.mts`) fetches `.github/idd/config.json` at a trusted `ref` via the GitHub Contents API and returns `null` (documented-defaults fallback) only on a confirmed 404; any other failure, including a permission denial, throws instead of guessing. Whether GitHub's Contents API masks a `403` (permission denied) as a `404` for a token lacking Contents read access was an open empirical question — a related masking pattern is already documented for the branch-protection/ruleset endpoints specifically (`trustEmptyProtectionReads`).

## Test performed

Created a disposable **private** repo (`kurone-kito/idd-skill-issue-2716-contents-api-probe`) and added a GitHub Actions workflow declaring `permissions: { contents: none }` at the job level, then used the workflow's own ephemeral `GITHUB_TOKEN` to request an existing file at a valid ref via the Contents API (`GET /repos/{owner}/{repo}/contents/{path}?ref={sha}`).

Private, not public: on a public repo a `contents: none` token can still read publicly-visible content and return `200`, which would prove nothing about masking. The production scenario this issue cares about (a fine-grained PAT or GitHub App installation token lacking Contents read) only produces a denial on a private repo.

**Result: HTTP 403** with body `{"message": "Resource not accessible by integration"}` — a genuine, unambiguous permission denial, not masked as a 404.

The probe repo is **intentionally retained** (not deleted): the `gh` CLI token used to create it lacks the `delete_repo` scope. Marked as such in the repo's own description and README, per this issue's acceptance criteria's explicit alternative to deletion.

## Changes

- `src/scripts/idd-config.mts`: added a "Verified 2026-09-08" note to `loadTrustedIddConfig`'s JSDoc recording the finding directly on the function's own contract.
- `idd-template/docs/idd-helper-scripts.md` (canonical source) / `docs/idd-helper-scripts.md` (generated mirror, re-synced via `sync-docs.mjs --apply`, byte-identical verified with `diff`): added a "Contents API permission-masking probe (#2716)" section with the full test methodology, the observed status code, and the verification date.
- No code-logic change: the finding confirms `loadTrustedIddConfig`'s existing fail-closed `deriveGhHttpStatus(error) === 404` check is already correct as written, per this issue's own acceptance criteria ("if the test confirms the response is a genuine 403 (no masking), no code change is needed").

## Test plan

- [x] `node --test tests/*.test.mts` — 5375/5375 pass
- [x] `pnpm run typecheck` — pass
- [x] `pnpm run build:check` — pass (generated `.mjs` reproducible)
- [x] `node scripts/audit-docs.mjs --check` — documentation audit passed
- [x] `npx markdownlint-cli2 "**/*.md"` — pass
- [x] Self-critique (C1, forked subagent) found no blocking issues, including independently verifying the probe repo's actual contents match this PR's claims

Closes #2716

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jz9naVhMefTusdLL9FzLc
