### PR TITLE
fix(suitability-triage): close ten Check 7 masking/boundary gaps

### DIFF
--- a/scripts/markdown-code.mjs
+++ b/scripts/markdown-code.mjs
@@ -1066,7 +1066,16 @@ export function findFencedCodeRanges(text) {
   }
   return ranges;
 }
-function findIndentedCodeRanges(text, fencedRanges) {
+/**
+ * Blank-line-tolerant ranges of 4-space (or list-content-indent-relative)
+ * indented code blocks, excluding any line already covered by a fenced
+ * range. `fencedRanges` must be in ascending `start` order (as returned by
+ * {@link findFencedCodeRanges}). Exported (#2711) so a caller that needs
+ * fenced + indented masking WITHOUT inline code spans -- {@link
+ * findMarkdownCodeRanges} always includes inline spans too -- can compose
+ * this with {@link findFencedCodeRanges} directly.
+ */
+export function findIndentedCodeRanges(text, fencedRanges) {
   const ranges = [];
   let rangeStart = null;
   let rangeEnd = 0;

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -372,6 +372,14 @@ function isInBlockquotedParagraph(normalizedBody, paragraphSpans, offset) {
 // relative to `normalizedBody` (as `maskMarkdownCodeRegionsPreservingPositions`
 // guarantees) so `paragraphSpans` and `offset`, both computed against
 // `normalizedBody`, stay valid against it.
+//
+// #2711 PR #2735 review round 5 (Codex): a backslash-escaped delimiter
+// (`\~~`) renders as a literal string in CommonMark, not a real
+// strikethrough boundary -- two literal `\~~` examples surrounding a
+// genuine, unstruck "Maintainer decision (...)" must not be paired as if
+// they were real delimiters. A single preceding backslash is enough to
+// treat a `~~` as escaped (soft heuristic, matching this file's existing
+// style; does not attempt full backslash-run parity for `\\~~`).
 function isInStrikethroughSpan(codeMaskedBody, paragraphSpans, offset) {
   const span =
     paragraphSpans.find(
@@ -385,7 +393,9 @@ function isInStrikethroughSpan(codeMaskedBody, paragraphSpans, offset) {
   const delimiterStarts = [];
   let delimiterMatch = delimiterPattern.exec(paragraphText);
   while (delimiterMatch !== null) {
-    delimiterStarts.push(delimiterMatch.index);
+    if (paragraphText[delimiterMatch.index - 1] !== '\\') {
+      delimiterStarts.push(delimiterMatch.index);
+    }
     delimiterPattern.lastIndex = delimiterMatch.index + 2;
     delimiterMatch = delimiterPattern.exec(paragraphText);
   }
@@ -424,15 +434,26 @@ function isInStrikethroughSpan(codeMaskedBody, paragraphSpans, offset) {
 // ranges from consideration entirely; pass fenced + indented + inline
 // ranges (e.g. `findMarkdownCodeRanges`'s result) to cover every code
 // shape, not just fenced blocks.
+//
+// #2711 PR #2735 review round 5 (Codex): a backslash-escaped opener
+// (`\<!--`) renders as a literal string in CommonMark, not a real HTML
+// comment start -- an issue documenting the literal marker syntax (e.g.
+// `Document the literal \<!-- marker`) must not have everything after it
+// masked through EOF. A single preceding backslash is enough to treat it
+// as escaped (soft heuristic, matching this file's existing style; does
+// not attempt full backslash-run parity for a doubly-escaped `\\<!--`).
 function findHtmlCommentRanges(text, ignoredOpenerRanges = []) {
   const ranges = [];
   const openPattern = /<!--/g;
   let openMatch = openPattern.exec(text);
   while (openMatch) {
     const openIndex = openMatch.index;
-    const isIgnored = ignoredOpenerRanges.some(
-      (range) => openIndex >= range.start && openIndex < range.end,
-    );
+    const isEscaped = text[openIndex - 1] === '\\';
+    const isIgnored =
+      isEscaped ||
+      ignoredOpenerRanges.some(
+        (range) => openIndex >= range.start && openIndex < range.end,
+      );
     if (isIgnored) {
       openPattern.lastIndex = openIndex + 4;
       openMatch = openPattern.exec(text);

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -363,14 +363,23 @@ function isInBlockquotedParagraph(normalizedBody, paragraphSpans, offset) {
 // containing paragraph (a soft heuristic, not full CommonMark strikethrough
 // parsing, matching this file's existing style for inline-span detection)
 // and reports whether `offset` falls strictly inside any pair's content.
-function isInStrikethroughSpan(normalizedBody, paragraphSpans, offset) {
+//
+// #2711 PR #2735 review round 3 (Codex): scans `codeMaskedBody` (e.g.
+// `normalizedCodeMaskedBody`), not the raw `normalizedBody`, so a literal
+// "~~" inside an inline/fenced code example demonstrating the syntax --
+// masked to spaces there -- is never mistaken for a real delimiter.
+// `codeMaskedBody` must be the SAME length and position-preserving
+// relative to `normalizedBody` (as `maskMarkdownCodeRegionsPreservingPositions`
+// guarantees) so `paragraphSpans` and `offset`, both computed against
+// `normalizedBody`, stay valid against it.
+function isInStrikethroughSpan(codeMaskedBody, paragraphSpans, offset) {
   const span =
     paragraphSpans.find(
       (candidate) => offset >= candidate.start && offset <= candidate.end,
     ) ?? paragraphSpans[paragraphSpans.length - 1];
   const paragraphStart = span?.start ?? 0;
-  const paragraphEnd = span?.end ?? normalizedBody.length;
-  const paragraphText = normalizedBody.slice(paragraphStart, paragraphEnd);
+  const paragraphEnd = span?.end ?? codeMaskedBody.length;
+  const paragraphText = codeMaskedBody.slice(paragraphStart, paragraphEnd);
   const relativeOffset = offset - paragraphStart;
   const delimiterPattern = /~~/g;
   const delimiterStarts = [];
@@ -2449,9 +2458,17 @@ export function checkVerifiability(context) {
         acHeadingStart + (acceptanceCriteriaMatch[0]?.length ?? 0);
       const acRestOfBody = fenceMaskedBody.slice(acContentStart);
       const acNextHeadingIdx = acRestOfBody.search(NEXT_HEADING_PATTERN);
-      const acContentEnd =
+      const acSectionEnd =
         acContentStart +
         (acNextHeadingIdx === -1 ? acRestOfBody.length : acNextHeadingIdx);
+      // #2711 PR #2735 review round 3 (Codex): the primary section-scoped
+      // scan above only ever examines the first 500 characters after the
+      // heading (`contentAfter`'s own slice window) -- capping the
+      // exclusion at that SAME boundary, not the section's full extent,
+      // so a genuine checklist item past that window (which the primary
+      // scan never saw either) remains available to this fallback instead
+      // of being doubly hidden.
+      const acContentEnd = Math.min(acSectionEnd, acContentStart + 500);
       alternativeScanExclusions.push({
         start: acHeadingStart,
         end: acContentEnd,
@@ -2625,7 +2642,7 @@ export function checkVerifiability(context) {
           inlineMatch.index,
         ) &&
         !isInStrikethroughSpan(
-          normalizedBody,
+          normalizedCodeMaskedBody,
           paragraphSpans,
           inlineMatch.index,
         )

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -2506,7 +2506,29 @@ export function checkVerifiability(context) {
       // so a genuine checklist item past that window (which the primary
       // scan never saw either) remains available to this fallback instead
       // of being doubly hidden.
-      const acContentEnd = Math.min(acSectionEnd, acContentStart + 500);
+      //
+      // #2711 PR #2735 review round 7 (Codex): a single checklist item
+      // that itself straddles the 500-character cutoff -- marker and
+      // explanatory prefix before it, objective clause after -- must not
+      // have its exclusion cut mid-line: char-precise truncation left the
+      // marker excluded while only the suffix reached the fallback, and
+      // the bare suffix text (with no "- [ ]" of its own) never matched
+      // `hasChecklist`'s marker pattern. Snap the cutoff back to the start
+      // of the straddling line so the whole item stays together, either
+      // fully excluded (primary scan's job) or fully visible to the
+      // fallback -- never split across the boundary.
+      const rawCutoff = acContentStart + 500;
+      let acContentEnd;
+      if (rawCutoff >= acSectionEnd) {
+        acContentEnd = acSectionEnd;
+      } else {
+        const straddleLineStart =
+          fenceMaskedBody.lastIndexOf('\n', rawCutoff) + 1;
+        acContentEnd =
+          straddleLineStart <= acContentStart
+            ? acContentStart
+            : straddleLineStart;
+      }
       alternativeScanExclusions.push({
         start: acHeadingStart,
         end: acContentEnd,

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -18,6 +18,7 @@ import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mjs';
 import { loadPolicyConfig } from './idd-config.mjs';
 import {
   findFencedCodeRanges,
+  findIndentedCodeRanges,
   findMarkdownCodeRanges,
   getMarkdownCodeRange,
   maskMarkdownCodeRegionsPreservingPositions,
@@ -242,23 +243,84 @@ function isFramedAsDescriptive(normalizedBody, paragraphSpans, offset) {
 // Maintainer decision (...): choose A" -- must not suppress a genuine
 // decision merely for sharing a paragraph with an unrelated use of the same
 // vocabulary.
+// #2711: the terminal punctuation of a sentence may be immediately
+// followed by a closing Markdown emphasis marker or quote character before
+// the whitespace that ends it -- e.g. a sentence ending `"done."` or
+// `*settled*.`. The previous literal ". "/"! "/"? " scan below found no
+// boundary at such a position (the quote/emphasis character sits between
+// the punctuation and the space) and fell back to an EARLIER, unrelated
+// sentence boundary instead, widening the scan window enough to catch that
+// earlier sentence's own framing verb.
+const SENTENCE_TERMINATOR_PATTERN = /[.!?][)"'*_`\]]*(?=\s|$)/;
+function findLastSentenceBoundaryEnd(scanText) {
+  const pattern = new RegExp(SENTENCE_TERMINATOR_PATTERN.source, 'g');
+  let end = -1;
+  let match = pattern.exec(scanText);
+  while (match !== null) {
+    end = match.index + match[0].length;
+    match = pattern.exec(scanText);
+  }
+  return end;
+}
+function findFirstSentenceBoundaryEnd(scanText) {
+  const match = SENTENCE_TERMINATOR_PATTERN.exec(scanText);
+  return match === null ? scanText.length : match.index + match[0].length;
+}
 function isPrecededByFramingVerb(normalizedBody, paragraphSpans, offset) {
   const span =
     paragraphSpans.find(
       (candidate) => offset >= candidate.start && offset <= candidate.end,
     ) ?? paragraphSpans[paragraphSpans.length - 1];
   const scanText = normalizedBody.slice(span?.start ?? 0, offset);
-  const lastSentenceBoundary = Math.max(
-    scanText.lastIndexOf('. '),
-    scanText.lastIndexOf('! '),
-    scanText.lastIndexOf('? '),
-    scanText.lastIndexOf('.\n'),
-    scanText.lastIndexOf('!\n'),
-    scanText.lastIndexOf('?\n'),
+  const sentenceStart = findLastSentenceBoundaryEnd(scanText);
+  return FRAMING_VERB_PATTERN.test(
+    scanText.slice(sentenceStart === -1 ? 0 : sentenceStart),
   );
-  const sentenceStart =
-    lastSentenceBoundary === -1 ? 0 : lastSentenceBoundary + 2;
-  return FRAMING_VERB_PATTERN.test(scanText.slice(sentenceStart));
+}
+// #2711: an inverted-attribution quotation states the marker FIRST and its
+// reporting verb after it -- "'Maintainer decision (...): choose A,'
+// reports the referenced tracking issue" -- which `isPrecededByFramingVerb`
+// above never sees, since it only scans text BEFORE the match. Mirrors that
+// function's own single-sentence bound, forward instead of backward, so an
+// unrelated LATER sentence's own framing verb doesn't wrongly suppress a
+// genuine decision two sentences later.
+const QUOTE_CHARS = ['"', "'"];
+function isFollowedByFramingVerb(
+  normalizedBody,
+  paragraphSpans,
+  matchStart,
+  matchEnd,
+) {
+  const span =
+    paragraphSpans.find(
+      (candidate) =>
+        matchStart >= candidate.start && matchStart <= candidate.end,
+    ) ?? paragraphSpans[paragraphSpans.length - 1];
+  const paragraphStart = span?.start ?? 0;
+  const paragraphEnd = span?.end ?? normalizedBody.length;
+  // Deliberately narrower than "any framing verb somewhere later in the
+  // sentence": the marker must be immediately preceded by an opening quote
+  // character, closed by that SAME character before the framing verb.
+  // Without this, an ordinary reporting verb inside the marker's OWN
+  // resolution text -- "Maintainer decision (...): the helper reports an
+  // actionable error..." -- would be wrongly read as external framing (PR
+  // #2662 Codex review's own regression coverage for the backward-scan
+  // case; the forward scan needs the identical guard).
+  const precedingChar = normalizedBody[matchStart - 1];
+  if (
+    matchStart <= paragraphStart ||
+    !QUOTE_CHARS.includes(precedingChar ?? '')
+  ) {
+    return false;
+  }
+  const followingText = normalizedBody.slice(matchEnd, paragraphEnd);
+  const closingQuoteIndex = followingText.indexOf(precedingChar);
+  if (closingQuoteIndex === -1) {
+    return false;
+  }
+  const afterQuote = followingText.slice(closingQuoteIndex + 1);
+  const sentenceEnd = findFirstSentenceBoundaryEnd(afterQuote);
+  return FRAMING_VERB_PATTERN.test(afterQuote.slice(0, sentenceEnd));
 }
 // #2661 PR #2662 review round 2 (Codex): a Markdown blockquote ("> Maintainer
 // decision (...): ...") is itself a quoting signal, independent of
@@ -293,6 +355,40 @@ function isInBlockquotedParagraph(normalizedBody, paragraphSpans, offset) {
   );
   return /^[ \t]*>/.test(firstLine);
 }
+// #2711: a GFM strikethrough span ("~~Maintainer decision (...): choose
+// A~~") marks its content as struck through -- rendered convention for
+// "retracted" or "superseded" -- so a decision inside one must not count
+// as this issue's current live resolution, independent of any framing verb
+// or blockquote. Pairs consecutive "~~" delimiters left-to-right within the
+// containing paragraph (a soft heuristic, not full CommonMark strikethrough
+// parsing, matching this file's existing style for inline-span detection)
+// and reports whether `offset` falls strictly inside any pair's content.
+function isInStrikethroughSpan(normalizedBody, paragraphSpans, offset) {
+  const span =
+    paragraphSpans.find(
+      (candidate) => offset >= candidate.start && offset <= candidate.end,
+    ) ?? paragraphSpans[paragraphSpans.length - 1];
+  const paragraphStart = span?.start ?? 0;
+  const paragraphEnd = span?.end ?? normalizedBody.length;
+  const paragraphText = normalizedBody.slice(paragraphStart, paragraphEnd);
+  const relativeOffset = offset - paragraphStart;
+  const delimiterPattern = /~~/g;
+  const delimiterStarts = [];
+  let delimiterMatch = delimiterPattern.exec(paragraphText);
+  while (delimiterMatch !== null) {
+    delimiterStarts.push(delimiterMatch.index);
+    delimiterPattern.lastIndex = delimiterMatch.index + 2;
+    delimiterMatch = delimiterPattern.exec(paragraphText);
+  }
+  for (let index = 0; index + 1 < delimiterStarts.length; index += 2) {
+    const contentStart = (delimiterStarts[index] ?? 0) + 2;
+    const contentEnd = delimiterStarts[index + 1] ?? 0;
+    if (relativeOffset >= contentStart && relativeOffset < contentEnd) {
+      return true;
+    }
+  }
+  return false;
+}
 // #2661 PR #2662 review round 6 (Codex): an issue-template author commonly
 // leaves hidden instructional scaffolding as an HTML comment -- e.g.
 // `<!-- Maintainer decision (Groom hearing, YYYY-MM-DD): <resolution text>
@@ -304,14 +400,33 @@ function isInBlockquotedParagraph(normalizedBody, paragraphSpans, offset) {
 // EOF, so the entire remaining body -- a genuine marker and Acceptance
 // Criteria included -- can be invisible in the rendered issue while still
 // matching this scan if left unmasked (round 7, PR #2662).
-function findHtmlCommentRanges(text) {
+//
+// #2711: an issue that documents this convention's own syntax inside a
+// fenced code example -- e.g. a fence containing a literal, deliberately
+// unterminated `<!--` to illustrate the shape -- must not have that
+// example's opener treated as a REAL unterminated comment: doing so masks
+// through EOF and swallows a genuine later "Maintainer decision (...)"
+// that follows the fence. `fencedRanges` (optional, defaults to none so
+// existing callers with no fenced content to worry about are unaffected)
+// lets a caller exclude any `<!--` whose own opening `<` falls inside a
+// fenced code range from consideration entirely.
+function findHtmlCommentRanges(text, fencedRanges = []) {
   const ranges = [];
   const openPattern = /<!--/g;
   let openMatch = openPattern.exec(text);
   while (openMatch) {
-    const closeIndex = text.indexOf('-->', openMatch.index + 4);
+    const openIndex = openMatch.index;
+    const isInsideFence = fencedRanges.some(
+      (range) => openIndex >= range.start && openIndex < range.end,
+    );
+    if (isInsideFence) {
+      openPattern.lastIndex = openIndex + 4;
+      openMatch = openPattern.exec(text);
+      continue;
+    }
+    const closeIndex = text.indexOf('-->', openIndex + 4);
     const end = closeIndex === -1 ? text.length : closeIndex + 3;
-    ranges.push({ start: openMatch.index, end });
+    ranges.push({ start: openIndex, end });
     openPattern.lastIndex = end;
     openMatch = openPattern.exec(text);
   }
@@ -744,12 +859,36 @@ const CODE_SPAN_STRUCTURE_PATTERN = /[/._:-]/;
 // CODE_SPAN_STRUCTURE_PATTERN.
 const CODE_SPAN_ALNUM_PATTERN = /[a-zA-Z0-9]/;
 const BARE_DOTTED_FILENAME_PATTERN = /\b[\w-]{2,}\.[a-zA-Z]{1,5}\b/;
+// #2711: BARE_DOTTED_FILENAME_PATTERN's own dictionary-word-shaped match
+// also fires on a placeholder domain mentioned in ordinary prose -- an
+// Acceptance Criteria bullet that merely SAYS "update the contact at
+// example.com" or "notify owner@example.com" names no real file. Two
+// independent exclusions, checked per match rather than once over the
+// whole text (so one genuine bare filename elsewhere in the same section
+// still counts even when a placeholder domain also appears):
+// EXAMPLE_PLACEHOLDER_DOMAIN_PATTERN excludes the RFC 2606 reserved
+// example domains (the convention's own go-to placeholder), and a match
+// immediately preceded by "@" is an email address's domain part -- for
+// ANY domain, not just the reserved ones -- never a bare filename.
+const EXAMPLE_PLACEHOLDER_DOMAIN_PATTERN = /^example\.(?:com|org|net|edu)$/i;
 // CodeRabbit review (PR #2602): an ATX heading may carry up to three
 // leading spaces per CommonMark, so the AC-section boundary below must
 // tolerate that indentation or an indented sibling heading (e.g. this
 // repo's own "   ## Candidate files", however it happens to be indented)
 // would not stop the section.
-const NEXT_HEADING_PATTERN = /\n {0,3}#{1,6}\s/;
+// #2711: also matches the boundary immediately before a Setext-style
+// sibling heading's own content line (a text line directly followed, with
+// no blank line between, by a lone run of "=" or "-" characters) -- ATX
+// alone reproduced this same section-boundary leak for that heading
+// style. The lookahead anchors the match at the same "\n before the
+// heading" position as the ATX alternative, so `.slice(0, index)` still
+// excludes the sibling heading's own text either way. Accepted limitation
+// (soft heuristic, matching this file's existing style): a "-" underline
+// immediately following a list-item line is treated as a Setext boundary
+// even where CommonMark itself would keep it inside the list -- full
+// container-aware disambiguation is out of scope for this fix.
+const NEXT_HEADING_PATTERN =
+  /\n(?: {0,3}#{1,6}\s|(?=[ \t]*\S[^\n]*\n {0,3}(?:=+|-+)[ \t]*(?:\n|$)))/;
 // CodeRabbit review (PR #2602): scanning the whole AC section's raw text
 // -- rather than just its list-item lines -- let a placeholder bullet
 // ("- [ ] TODO") followed by unrelated, non-list prose containing a
@@ -758,7 +897,10 @@ const NEXT_HEADING_PATTERN = /\n {0,3}#{1,6}\s/;
 // continuation line is intentionally excluded too, since it cannot be
 // told apart from unrelated trailing prose without full Markdown
 // paragraph parsing) are considered for either check.
-const LIST_ITEM_LINE_PATTERN = /^\s*(?:[-*]|\d+\.)\s+/;
+// #2711: also recognizes the parenthesized ordered-list form ("1)"
+// alongside "1."), which CommonMark treats as an equally valid ordered
+// list marker.
+const LIST_ITEM_LINE_PATTERN = /^\s*(?:[-*]|\d+[.)])\s+/;
 function looksLikePlaceholder(content) {
   return PLACEHOLDER_LEAD_PATTERN.test(content);
 }
@@ -789,7 +931,25 @@ function hasSubstantiveBullet(text) {
       return true;
     }
   }
-  return BARE_DOTTED_FILENAME_PATTERN.test(text);
+  return hasBareDottedFilename(text);
+}
+// #2711: per-match variant of BARE_DOTTED_FILENAME_PATTERN.test(text) --
+// see EXAMPLE_PLACEHOLDER_DOMAIN_PATTERN above for why a single whole-text
+// `.test()` is not enough. Checked per match, not short-circuited by the
+// first one found, so a placeholder domain earlier in the text never
+// hides a genuine bare filename later in the same section.
+function hasBareDottedFilename(text) {
+  const pattern = new RegExp(BARE_DOTTED_FILENAME_PATTERN.source, 'g');
+  let match = pattern.exec(text);
+  while (match !== null) {
+    const matchText = match[0];
+    const precededByAt = text[match.index - 1] === '@';
+    if (!precededByAt && !EXAMPLE_PLACEHOLDER_DOMAIN_PATTERN.test(matchText)) {
+      return true;
+    }
+    match = pattern.exec(text);
+  }
+  return false;
 }
 // A heading line such as "## Decision (resolved 2026-06-27)" records that a
 // human has already ruled on the issue's open question (see Check 7). The
@@ -2196,16 +2356,26 @@ export function checkVerifiability(context) {
   // bullet, or a heading-like line meant only as sample output) must not
   // leak into this scan either way -- as a fake substantive bullet, or as a
   // fake section-boundary heading that truncates the section before a real
-  // bullet after the fence. Mask fence content only (not inline code spans,
+  // bullet after the fence. Mask fence content (not inline code spans,
   // which hasSubstantiveBullet below still needs) over the whole body before
   // any slicing, so a fence that opens inside the eventual 500-char window
   // and closes outside it is still fully masked (E2 critique subagent,
   // #2589 round 6). Masking preserves character positions, so every offset
   // computed below stays valid against the original body.
-  const fenceMaskedBody = maskMarkdownCodeRegionsPreservingPositions(
-    body,
-    findFencedCodeRanges(body),
-  );
+  //
+  // #2711: also masks indented (4-space) code blocks and HTML comments,
+  // neither of which the fenced-only mask above covered -- a keyword-free
+  // example written as an indented block, or hidden template scaffolding
+  // inside an HTML comment, could otherwise leak a fake substantive bullet
+  // or a fake outcome-signal keyword into this same scan. `findHtmlCommentRanges`
+  // is given the fenced ranges too so an unterminated `<!--` used as a
+  // fenced code EXAMPLE of the syntax doesn't mask through EOF.
+  const fencedRangesForVerifiability = findFencedCodeRanges(body);
+  const fenceMaskedBody = maskMarkdownCodeRegionsPreservingPositions(body, [
+    ...fencedRangesForVerifiability,
+    ...findIndentedCodeRanges(body, fencedRangesForVerifiability),
+    ...findHtmlCommentRanges(body, fencedRangesForVerifiability),
+  ]);
   const acceptanceCriteriaMatch = fenceMaskedBody.match(
     ACCEPTANCE_CRITERIA_PATTERN,
   );
@@ -2239,8 +2409,15 @@ export function checkVerifiability(context) {
         OUTCOME_SIGNAL_PATTERN.test(listItemsOnly);
     }
   }
-  // Alternative: check for numbered steps with outcome signals or checklists
-  if (!hasObjectiveCriteria) {
+  // Alternative: check for numbered steps with outcome signals or
+  // checklists. Scoped to a body with NO "Acceptance Criteria" heading at
+  // all (#2711): when one exists, the section-scoped scan above already
+  // gave it a fair, bounded review; letting this whole-body fallback rescan
+  // past that boundary let an unrelated LATER section's own checklist
+  // (e.g. this repo's own "## Candidate files" bullet-list convention)
+  // flip a genuinely placeholder Acceptance Criteria section to "has
+  // objective criteria."
+  if (!hasObjectiveCriteria && !acceptanceCriteriaMatch) {
     const hasNumSteps =
       /^\s*\d+\.\s+/m.test(body) && OUTCOME_SIGNAL_PATTERN.test(body);
     const hasChecklist =
@@ -2279,12 +2456,16 @@ export function checkVerifiability(context) {
   // A` ``) and hidden HTML-comment template scaffolding (round 6:
   // `<!-- Maintainer decision (...): <resolution text> -->`).
   // `findMarkdownCodeRanges` covers both inline and fenced spans, unlike
-  // `findFencedCodeRanges` alone.
+  // `findFencedCodeRanges` alone. `findHtmlCommentRanges` is given the
+  // fenced ranges too (#2711) so an unterminated `<!--` used as a fenced
+  // code EXAMPLE of the HTML-comment-marker syntax isn't treated as a real
+  // unterminated comment masking through EOF.
+  const fencedRangesForCommentMasking = findFencedCodeRanges(normalizedBody);
   const normalizedCodeMaskedBody = maskMarkdownCodeRegionsPreservingPositions(
     normalizedBody,
     [
       ...findMarkdownCodeRanges(normalizedBody),
-      ...findHtmlCommentRanges(normalizedBody),
+      ...findHtmlCommentRanges(normalizedBody, fencedRangesForCommentMasking),
     ],
   );
   const hasSubjectiveApproval = (() => {
@@ -2338,11 +2519,18 @@ export function checkVerifiability(context) {
   // whole-paragraph `isFramedAsDescriptive`) so a genuine resolution whose
   // OWN text happens to use a reporting verb -- "Maintainer decision (...):
   // the helper reports an actionable error" -- is not wrongly excluded
-  // (Codex review, PR #2662). A Markdown blockquote is a second, independent
-  // quoting signal with no reporting verb of its own -- "> Maintainer
-  // decision (...): ..." -- so `isInBlockquotedParagraph` also excludes a
-  // match (Codex review rounds 2 and 4, PR #2662). The heading form has no
-  // equivalent gap: a "## Decision (resolved …)" section is, by
+  // (Codex review, PR #2662). `isFollowedByFramingVerb` (#2711) catches the
+  // inverted-attribution shape of the same quoting problem, where the
+  // reporting verb follows the marker instead of preceding it -- "'Maintainer
+  // decision (...): choose A,' reports the referenced tracking issue". A
+  // Markdown blockquote is a third, independent quoting signal with no
+  // reporting verb of its own -- "> Maintainer decision (...): ..." -- so
+  // `isInBlockquotedParagraph` also excludes a match (Codex review rounds 2
+  // and 4, PR #2662). A GFM strikethrough span (#2711) is a fourth,
+  // independent signal: a struck-through decision reads as retracted/
+  // superseded, not this issue's current live resolution, regardless of
+  // whether any framing verb or blockquote is also present. The heading
+  // form has no equivalent gap: a "## Decision (resolved …)" section is, by
   // construction, this issue's own decision record, never a quoted example
   // of someone else's.
   const hasInlineResolvedDecision = (() => {
@@ -2352,13 +2540,25 @@ export function checkVerifiability(context) {
     );
     let inlineMatch = inlinePattern.exec(normalizedCodeMaskedBody);
     while (inlineMatch) {
+      const matchEnd = inlineMatch.index + inlineMatch[0].length;
       if (
         !isPrecededByFramingVerb(
           normalizedBody,
           paragraphSpans,
           inlineMatch.index,
         ) &&
+        !isFollowedByFramingVerb(
+          normalizedBody,
+          paragraphSpans,
+          inlineMatch.index,
+          matchEnd,
+        ) &&
         !isInBlockquotedParagraph(
+          normalizedBody,
+          paragraphSpans,
+          inlineMatch.index,
+        ) &&
+        !isInStrikethroughSpan(
           normalizedBody,
           paragraphSpans,
           inlineMatch.index,

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -2450,6 +2450,11 @@ export function checkVerifiability(context) {
   // #2735) -- only these two specific, already-recognized
   // non-verification regions are excluded now, not every sibling section.
   // Also accepts the "1)" ordered-list form (matching the fix above).
+  // #2711 PR #2735 review round 4 (Codex): starts from `fenceMaskedBody`
+  // (already fenced/indented/HTML-comment masked), not the raw `body` --
+  // a fenced or indented example demonstrating a "1)" step, or one hidden
+  // in an HTML comment, could otherwise satisfy this fallback on its own
+  // once paired with an unrelated outcome-signal word anywhere else.
   if (!hasObjectiveCriteria) {
     const alternativeScanExclusions = [];
     if (acceptanceCriteriaMatch) {
@@ -2494,10 +2499,10 @@ export function checkVerifiability(context) {
     const bodyForAlternativeScan =
       alternativeScanExclusions.length > 0
         ? maskMarkdownCodeRegionsPreservingPositions(
-            body,
+            fenceMaskedBody,
             alternativeScanExclusions,
           )
-        : body;
+        : fenceMaskedBody;
     const hasNumSteps =
       /^\s*\d+[.)]\s+/m.test(bodyForAlternativeScan) &&
       OUTCOME_SIGNAL_PATTERN.test(bodyForAlternativeScan);

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -2426,6 +2426,16 @@ export function checkVerifiability(context) {
   const acceptanceCriteriaMatch = fenceMaskedBody.match(
     ACCEPTANCE_CRITERIA_PATTERN,
   );
+  // #2711 PR #2735 review round 6 (Codex): tracks whether the primary scan
+  // below actually reached its list-shaped outer gate, so the Alternative
+  // fallback (further down) only treats the AC section as "already fairly
+  // reviewed" -- and excludes it -- when that gate genuinely ran. An AC
+  // section starting with introductory prose before its checklist (e.g.
+  // "The implementation must satisfy:\n- [ ] ...") never enters the gate
+  // here (the section's own text doesn't start with a list marker), so its
+  // real checklist item was never seen by either scan; excluding it from
+  // the fallback too made it doubly invisible instead of falling through.
+  let acListGateReached = false;
   if (acceptanceCriteriaMatch) {
     const indexAfter =
       (acceptanceCriteriaMatch.index ?? 0) +
@@ -2453,6 +2463,7 @@ export function checkVerifiability(context) {
     // form, matching LIST_ITEM_LINE_PATTERN's own fix -- an AC section
     // written entirely with that numbering used to never enter this block.
     if (/^[-*]\s+/.test(listSection) || /^\d+[.)]\s+/.test(listSection)) {
+      acListGateReached = true;
       const listItemsOnly = extractListItemLines(listSection);
       hasObjectiveCriteria =
         hasSubstantiveBullet(listItemsOnly) ||
@@ -2461,9 +2472,10 @@ export function checkVerifiability(context) {
   }
   // Alternative: check for numbered steps with outcome signals or
   // checklists, excluding (a) the Acceptance Criteria section's own
-  // content, already given a fair, bounded review above, and (b) this
-  // repo's own "## Candidate files" convention (#2589) -- a list of files
-  // to EDIT, never a verification signal. A genuine numbered-steps or
+  // content, but ONLY when `acListGateReached` -- i.e. the primary scan
+  // above actually gave it a fair, bounded review -- and (b) this repo's
+  // own "## Candidate files" convention (#2589) -- a list of files to
+  // EDIT, never a verification signal. A genuine numbered-steps or
   // checklist section elsewhere in the body (e.g. "## Expected Behavior",
   // "## Reproduction") still counts: an earlier revision (#2711) instead
   // skipped this whole fallback whenever ANY Acceptance Criteria heading
@@ -2478,7 +2490,7 @@ export function checkVerifiability(context) {
   // once paired with an unrelated outcome-signal word anywhere else.
   if (!hasObjectiveCriteria) {
     const alternativeScanExclusions = [];
-    if (acceptanceCriteriaMatch) {
+    if (acceptanceCriteriaMatch && acListGateReached) {
       const acHeadingStart = acceptanceCriteriaMatch.index ?? 0;
       const acContentStart =
         acHeadingStart + (acceptanceCriteriaMatch[0]?.length ?? 0);

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -406,20 +406,25 @@ function isInStrikethroughSpan(normalizedBody, paragraphSpans, offset) {
 // unterminated `<!--` to illustrate the shape -- must not have that
 // example's opener treated as a REAL unterminated comment: doing so masks
 // through EOF and swallows a genuine later "Maintainer decision (...)"
-// that follows the fence. `fencedRanges` (optional, defaults to none so
-// existing callers with no fenced content to worry about are unaffected)
-// lets a caller exclude any `<!--` whose own opening `<` falls inside a
-// fenced code range from consideration entirely.
-function findHtmlCommentRanges(text, fencedRanges = []) {
+// that follows the fence. The same applies to an INLINE code span
+// demonstrating the same syntax (PR #2735 Codex review round 2) -- e.g.
+// `` `<!--` `` followed by a later bullet naming the real artifact.
+// `ignoredOpenerRanges` (optional, defaults to none so existing callers
+// with no code content to worry about are unaffected) lets a caller
+// exclude any `<!--` whose own opening `<` falls inside one of these
+// ranges from consideration entirely; pass fenced + indented + inline
+// ranges (e.g. `findMarkdownCodeRanges`'s result) to cover every code
+// shape, not just fenced blocks.
+function findHtmlCommentRanges(text, ignoredOpenerRanges = []) {
   const ranges = [];
   const openPattern = /<!--/g;
   let openMatch = openPattern.exec(text);
   while (openMatch) {
     const openIndex = openMatch.index;
-    const isInsideFence = fencedRanges.some(
+    const isIgnored = ignoredOpenerRanges.some(
       (range) => openIndex >= range.start && openIndex < range.end,
     );
-    if (isInsideFence) {
+    if (isIgnored) {
       openPattern.lastIndex = openIndex + 4;
       openMatch = openPattern.exec(text);
       continue;
@@ -806,6 +811,13 @@ function isEnumeratedParentheticalEntry(body, matchIndex, matchLength) {
   return otherEntries.length > 0 && otherEntries.every(looksLikeLabelEntry);
 }
 const ACCEPTANCE_CRITERIA_PATTERN = /^#+\s*Acceptance\s+Criteria\s*$/im;
+// #2711 PR #2735 review (Codex): this repo's own "## Candidate files"
+// convention (#2589) names files to EDIT, never a verification signal --
+// matched here (mirroring ACCEPTANCE_CRITERIA_PATTERN's own shape) so the
+// "Alternative" whole-body fallback below can exclude just this specific,
+// already-recognized non-verification section instead of every sibling
+// section unconditionally.
+const CANDIDATE_FILES_SECTION_PATTERN = /^#+\s*Candidate\s+files\s*$/im;
 // #2589: a bullet under "## Acceptance Criteria" that names something
 // concrete -- an inline-code span (covers a quoted file path, command, or
 // identifier) or a bare dotted filename -- is substantive on its own,
@@ -2368,13 +2380,18 @@ export function checkVerifiability(context) {
   // example written as an indented block, or hidden template scaffolding
   // inside an HTML comment, could otherwise leak a fake substantive bullet
   // or a fake outcome-signal keyword into this same scan. `findHtmlCommentRanges`
-  // is given the fenced ranges too so an unterminated `<!--` used as a
-  // fenced code EXAMPLE of the syntax doesn't mask through EOF.
+  // is given every code range (fenced, indented, AND inline -- PR #2735
+  // Codex review round 2) so an unterminated `<!--` used as a code
+  // EXAMPLE of the syntax, in any of those three shapes, doesn't mask
+  // through EOF; only fenced and indented ranges are actually masked into
+  // `fenceMaskedBody` itself, since inline spans stay unmasked for
+  // hasSubstantiveBullet's own backtick scan below.
   const fencedRangesForVerifiability = findFencedCodeRanges(body);
+  const codeRangesForVerifiability = findMarkdownCodeRanges(body);
   const fenceMaskedBody = maskMarkdownCodeRegionsPreservingPositions(body, [
     ...fencedRangesForVerifiability,
     ...findIndentedCodeRanges(body, fencedRangesForVerifiability),
-    ...findHtmlCommentRanges(body, fencedRangesForVerifiability),
+    ...findHtmlCommentRanges(body, codeRangesForVerifiability),
   ]);
   const acceptanceCriteriaMatch = fenceMaskedBody.match(
     ACCEPTANCE_CRITERIA_PATTERN,
@@ -2402,7 +2419,10 @@ export function checkVerifiability(context) {
     // only the section's own list-item lines, not its full raw text, so a
     // placeholder bullet followed by unrelated non-list prose can't
     // borrow that prose's substance or keywords (#2589 CodeRabbit review).
-    if (/^[-*]\s+/.test(listSection) || /^\d+\.\s+/.test(listSection)) {
+    // #2711 PR #2735 review (Copilot): also accepts the "1)" ordered-list
+    // form, matching LIST_ITEM_LINE_PATTERN's own fix -- an AC section
+    // written entirely with that numbering used to never enter this block.
+    if (/^[-*]\s+/.test(listSection) || /^\d+[.)]\s+/.test(listSection)) {
       const listItemsOnly = extractListItemLines(listSection);
       hasObjectiveCriteria =
         hasSubstantiveBullet(listItemsOnly) ||
@@ -2410,18 +2430,63 @@ export function checkVerifiability(context) {
     }
   }
   // Alternative: check for numbered steps with outcome signals or
-  // checklists. Scoped to a body with NO "Acceptance Criteria" heading at
-  // all (#2711): when one exists, the section-scoped scan above already
-  // gave it a fair, bounded review; letting this whole-body fallback rescan
-  // past that boundary let an unrelated LATER section's own checklist
-  // (e.g. this repo's own "## Candidate files" bullet-list convention)
-  // flip a genuinely placeholder Acceptance Criteria section to "has
-  // objective criteria."
-  if (!hasObjectiveCriteria && !acceptanceCriteriaMatch) {
+  // checklists, excluding (a) the Acceptance Criteria section's own
+  // content, already given a fair, bounded review above, and (b) this
+  // repo's own "## Candidate files" convention (#2589) -- a list of files
+  // to EDIT, never a verification signal. A genuine numbered-steps or
+  // checklist section elsewhere in the body (e.g. "## Expected Behavior",
+  // "## Reproduction") still counts: an earlier revision (#2711) instead
+  // skipped this whole fallback whenever ANY Acceptance Criteria heading
+  // existed, which also suppressed that legitimate case (Codex review, PR
+  // #2735) -- only these two specific, already-recognized
+  // non-verification regions are excluded now, not every sibling section.
+  // Also accepts the "1)" ordered-list form (matching the fix above).
+  if (!hasObjectiveCriteria) {
+    const alternativeScanExclusions = [];
+    if (acceptanceCriteriaMatch) {
+      const acHeadingStart = acceptanceCriteriaMatch.index ?? 0;
+      const acContentStart =
+        acHeadingStart + (acceptanceCriteriaMatch[0]?.length ?? 0);
+      const acRestOfBody = fenceMaskedBody.slice(acContentStart);
+      const acNextHeadingIdx = acRestOfBody.search(NEXT_HEADING_PATTERN);
+      const acContentEnd =
+        acContentStart +
+        (acNextHeadingIdx === -1 ? acRestOfBody.length : acNextHeadingIdx);
+      alternativeScanExclusions.push({
+        start: acHeadingStart,
+        end: acContentEnd,
+      });
+    }
+    const candidateFilesMatch = fenceMaskedBody.match(
+      CANDIDATE_FILES_SECTION_PATTERN,
+    );
+    if (candidateFilesMatch) {
+      const cfHeadingStart = candidateFilesMatch.index ?? 0;
+      const cfContentStart =
+        cfHeadingStart + (candidateFilesMatch[0]?.length ?? 0);
+      const cfRestOfBody = fenceMaskedBody.slice(cfContentStart);
+      const cfNextHeadingIdx = cfRestOfBody.search(NEXT_HEADING_PATTERN);
+      const cfContentEnd =
+        cfContentStart +
+        (cfNextHeadingIdx === -1 ? cfRestOfBody.length : cfNextHeadingIdx);
+      alternativeScanExclusions.push({
+        start: cfHeadingStart,
+        end: cfContentEnd,
+      });
+    }
+    const bodyForAlternativeScan =
+      alternativeScanExclusions.length > 0
+        ? maskMarkdownCodeRegionsPreservingPositions(
+            body,
+            alternativeScanExclusions,
+          )
+        : body;
     const hasNumSteps =
-      /^\s*\d+\.\s+/m.test(body) && OUTCOME_SIGNAL_PATTERN.test(body);
+      /^\s*\d+[.)]\s+/m.test(bodyForAlternativeScan) &&
+      OUTCOME_SIGNAL_PATTERN.test(bodyForAlternativeScan);
     const hasChecklist =
-      /^\s*[-*]\s+\[[ xX]\]/m.test(body) && OUTCOME_SIGNAL_PATTERN.test(body);
+      /^\s*[-*]\s+\[[ xX]\]/m.test(bodyForAlternativeScan) &&
+      OUTCOME_SIGNAL_PATTERN.test(bodyForAlternativeScan);
     hasObjectiveCriteria = hasNumSteps || hasChecklist;
   }
   // Fallback: check for "Output", "Deliverables", or "Verification" keywords with signal words
@@ -2455,17 +2520,18 @@ export function checkVerifiability(context) {
   // syntax with `` `Maintainer decision (Groom hearing, 2026-09-05): choose
   // A` ``) and hidden HTML-comment template scaffolding (round 6:
   // `<!-- Maintainer decision (...): <resolution text> -->`).
-  // `findMarkdownCodeRanges` covers both inline and fenced spans, unlike
-  // `findFencedCodeRanges` alone. `findHtmlCommentRanges` is given the
-  // fenced ranges too (#2711) so an unterminated `<!--` used as a fenced
-  // code EXAMPLE of the HTML-comment-marker syntax isn't treated as a real
-  // unterminated comment masking through EOF.
-  const fencedRangesForCommentMasking = findFencedCodeRanges(normalizedBody);
+  // `findMarkdownCodeRanges` covers fenced, indented, AND inline spans,
+  // unlike `findFencedCodeRanges` alone. `findHtmlCommentRanges` is given
+  // that same superset (#2711; widened to include inline spans too per PR
+  // #2735 Codex review round 2) so an unterminated `<!--` used as a code
+  // EXAMPLE of the HTML-comment-marker syntax, fenced or inline, isn't
+  // treated as a real unterminated comment masking through EOF.
+  const codeRangesForCommentMasking = findMarkdownCodeRanges(normalizedBody);
   const normalizedCodeMaskedBody = maskMarkdownCodeRegionsPreservingPositions(
     normalizedBody,
     [
-      ...findMarkdownCodeRanges(normalizedBody),
-      ...findHtmlCommentRanges(normalizedBody, fencedRangesForCommentMasking),
+      ...codeRangesForCommentMasking,
+      ...findHtmlCommentRanges(normalizedBody, codeRangesForCommentMasking),
     ],
   );
   const hasSubjectiveApproval = (() => {

--- a/src/scripts/markdown-code.mts
+++ b/src/scripts/markdown-code.mts
@@ -1235,7 +1235,16 @@ export function findFencedCodeRanges(text: string): MarkdownCodeRange[] {
   return ranges;
 }
 
-function findIndentedCodeRanges(
+/**
+ * Blank-line-tolerant ranges of 4-space (or list-content-indent-relative)
+ * indented code blocks, excluding any line already covered by a fenced
+ * range. `fencedRanges` must be in ascending `start` order (as returned by
+ * {@link findFencedCodeRanges}). Exported (#2711) so a caller that needs
+ * fenced + indented masking WITHOUT inline code spans -- {@link
+ * findMarkdownCodeRanges} always includes inline spans too -- can compose
+ * this with {@link findFencedCodeRanges} directly.
+ */
+export function findIndentedCodeRanges(
   text: string,
   fencedRanges: MarkdownCodeRange[],
 ): MarkdownCodeRange[] {

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -20,6 +20,7 @@ import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mts';
 import { loadPolicyConfig } from './idd-config.mts';
 import {
   findFencedCodeRanges,
+  findIndentedCodeRanges,
   findMarkdownCodeRanges,
   getMarkdownCodeRange,
   type MarkdownCodeRange,
@@ -371,6 +372,32 @@ function isFramedAsDescriptive(
 // Maintainer decision (...): choose A" -- must not suppress a genuine
 // decision merely for sharing a paragraph with an unrelated use of the same
 // vocabulary.
+// #2711: the terminal punctuation of a sentence may be immediately
+// followed by a closing Markdown emphasis marker or quote character before
+// the whitespace that ends it -- e.g. a sentence ending `"done."` or
+// `*settled*.`. The previous literal ". "/"! "/"? " scan below found no
+// boundary at such a position (the quote/emphasis character sits between
+// the punctuation and the space) and fell back to an EARLIER, unrelated
+// sentence boundary instead, widening the scan window enough to catch that
+// earlier sentence's own framing verb.
+const SENTENCE_TERMINATOR_PATTERN = /[.!?][)"'*_`\]]*(?=\s|$)/;
+
+function findLastSentenceBoundaryEnd(scanText: string): number {
+  const pattern = new RegExp(SENTENCE_TERMINATOR_PATTERN.source, 'g');
+  let end = -1;
+  let match = pattern.exec(scanText);
+  while (match !== null) {
+    end = match.index + match[0].length;
+    match = pattern.exec(scanText);
+  }
+  return end;
+}
+
+function findFirstSentenceBoundaryEnd(scanText: string): number {
+  const match = SENTENCE_TERMINATOR_PATTERN.exec(scanText);
+  return match === null ? scanText.length : match.index + match[0].length;
+}
+
 function isPrecededByFramingVerb(
   normalizedBody: string,
   paragraphSpans: { start: number; end: number }[],
@@ -381,17 +408,58 @@ function isPrecededByFramingVerb(
       (candidate) => offset >= candidate.start && offset <= candidate.end,
     ) ?? paragraphSpans[paragraphSpans.length - 1];
   const scanText = normalizedBody.slice(span?.start ?? 0, offset);
-  const lastSentenceBoundary = Math.max(
-    scanText.lastIndexOf('. '),
-    scanText.lastIndexOf('! '),
-    scanText.lastIndexOf('? '),
-    scanText.lastIndexOf('.\n'),
-    scanText.lastIndexOf('!\n'),
-    scanText.lastIndexOf('?\n'),
+  const sentenceStart = findLastSentenceBoundaryEnd(scanText);
+  return FRAMING_VERB_PATTERN.test(
+    scanText.slice(sentenceStart === -1 ? 0 : sentenceStart),
   );
-  const sentenceStart =
-    lastSentenceBoundary === -1 ? 0 : lastSentenceBoundary + 2;
-  return FRAMING_VERB_PATTERN.test(scanText.slice(sentenceStart));
+}
+
+// #2711: an inverted-attribution quotation states the marker FIRST and its
+// reporting verb after it -- "'Maintainer decision (...): choose A,'
+// reports the referenced tracking issue" -- which `isPrecededByFramingVerb`
+// above never sees, since it only scans text BEFORE the match. Mirrors that
+// function's own single-sentence bound, forward instead of backward, so an
+// unrelated LATER sentence's own framing verb doesn't wrongly suppress a
+// genuine decision two sentences later.
+const QUOTE_CHARS = ['"', "'"];
+
+function isFollowedByFramingVerb(
+  normalizedBody: string,
+  paragraphSpans: { start: number; end: number }[],
+  matchStart: number,
+  matchEnd: number,
+): boolean {
+  const span =
+    paragraphSpans.find(
+      (candidate) =>
+        matchStart >= candidate.start && matchStart <= candidate.end,
+    ) ?? paragraphSpans[paragraphSpans.length - 1];
+  const paragraphStart = span?.start ?? 0;
+  const paragraphEnd = span?.end ?? normalizedBody.length;
+
+  // Deliberately narrower than "any framing verb somewhere later in the
+  // sentence": the marker must be immediately preceded by an opening quote
+  // character, closed by that SAME character before the framing verb.
+  // Without this, an ordinary reporting verb inside the marker's OWN
+  // resolution text -- "Maintainer decision (...): the helper reports an
+  // actionable error..." -- would be wrongly read as external framing (PR
+  // #2662 Codex review's own regression coverage for the backward-scan
+  // case; the forward scan needs the identical guard).
+  const precedingChar = normalizedBody[matchStart - 1];
+  if (
+    matchStart <= paragraphStart ||
+    !QUOTE_CHARS.includes(precedingChar ?? '')
+  ) {
+    return false;
+  }
+  const followingText = normalizedBody.slice(matchEnd, paragraphEnd);
+  const closingQuoteIndex = followingText.indexOf(precedingChar as string);
+  if (closingQuoteIndex === -1) {
+    return false;
+  }
+  const afterQuote = followingText.slice(closingQuoteIndex + 1);
+  const sentenceEnd = findFirstSentenceBoundaryEnd(afterQuote);
+  return FRAMING_VERB_PATTERN.test(afterQuote.slice(0, sentenceEnd));
 }
 
 // #2661 PR #2662 review round 2 (Codex): a Markdown blockquote ("> Maintainer
@@ -432,6 +500,45 @@ function isInBlockquotedParagraph(
   return /^[ \t]*>/.test(firstLine);
 }
 
+// #2711: a GFM strikethrough span ("~~Maintainer decision (...): choose
+// A~~") marks its content as struck through -- rendered convention for
+// "retracted" or "superseded" -- so a decision inside one must not count
+// as this issue's current live resolution, independent of any framing verb
+// or blockquote. Pairs consecutive "~~" delimiters left-to-right within the
+// containing paragraph (a soft heuristic, not full CommonMark strikethrough
+// parsing, matching this file's existing style for inline-span detection)
+// and reports whether `offset` falls strictly inside any pair's content.
+function isInStrikethroughSpan(
+  normalizedBody: string,
+  paragraphSpans: { start: number; end: number }[],
+  offset: number,
+): boolean {
+  const span =
+    paragraphSpans.find(
+      (candidate) => offset >= candidate.start && offset <= candidate.end,
+    ) ?? paragraphSpans[paragraphSpans.length - 1];
+  const paragraphStart = span?.start ?? 0;
+  const paragraphEnd = span?.end ?? normalizedBody.length;
+  const paragraphText = normalizedBody.slice(paragraphStart, paragraphEnd);
+  const relativeOffset = offset - paragraphStart;
+  const delimiterPattern = /~~/g;
+  const delimiterStarts: number[] = [];
+  let delimiterMatch = delimiterPattern.exec(paragraphText);
+  while (delimiterMatch !== null) {
+    delimiterStarts.push(delimiterMatch.index);
+    delimiterPattern.lastIndex = delimiterMatch.index + 2;
+    delimiterMatch = delimiterPattern.exec(paragraphText);
+  }
+  for (let index = 0; index + 1 < delimiterStarts.length; index += 2) {
+    const contentStart = (delimiterStarts[index] ?? 0) + 2;
+    const contentEnd = delimiterStarts[index + 1] ?? 0;
+    if (relativeOffset >= contentStart && relativeOffset < contentEnd) {
+      return true;
+    }
+  }
+  return false;
+}
+
 // #2661 PR #2662 review round 6 (Codex): an issue-template author commonly
 // leaves hidden instructional scaffolding as an HTML comment -- e.g.
 // `<!-- Maintainer decision (Groom hearing, YYYY-MM-DD): <resolution text>
@@ -443,14 +550,36 @@ function isInBlockquotedParagraph(
 // EOF, so the entire remaining body -- a genuine marker and Acceptance
 // Criteria included -- can be invisible in the rendered issue while still
 // matching this scan if left unmasked (round 7, PR #2662).
-function findHtmlCommentRanges(text: string): MarkdownCodeRange[] {
+//
+// #2711: an issue that documents this convention's own syntax inside a
+// fenced code example -- e.g. a fence containing a literal, deliberately
+// unterminated `<!--` to illustrate the shape -- must not have that
+// example's opener treated as a REAL unterminated comment: doing so masks
+// through EOF and swallows a genuine later "Maintainer decision (...)"
+// that follows the fence. `fencedRanges` (optional, defaults to none so
+// existing callers with no fenced content to worry about are unaffected)
+// lets a caller exclude any `<!--` whose own opening `<` falls inside a
+// fenced code range from consideration entirely.
+function findHtmlCommentRanges(
+  text: string,
+  fencedRanges: MarkdownCodeRange[] = [],
+): MarkdownCodeRange[] {
   const ranges: MarkdownCodeRange[] = [];
   const openPattern = /<!--/g;
   let openMatch = openPattern.exec(text);
   while (openMatch) {
-    const closeIndex = text.indexOf('-->', openMatch.index + 4);
+    const openIndex = openMatch.index;
+    const isInsideFence = fencedRanges.some(
+      (range) => openIndex >= range.start && openIndex < range.end,
+    );
+    if (isInsideFence) {
+      openPattern.lastIndex = openIndex + 4;
+      openMatch = openPattern.exec(text);
+      continue;
+    }
+    const closeIndex = text.indexOf('-->', openIndex + 4);
     const end = closeIndex === -1 ? text.length : closeIndex + 3;
-    ranges.push({ start: openMatch.index, end });
+    ranges.push({ start: openIndex, end });
     openPattern.lastIndex = end;
     openMatch = openPattern.exec(text);
   }
@@ -901,12 +1030,36 @@ const CODE_SPAN_STRUCTURE_PATTERN = /[/._:-]/;
 // CODE_SPAN_STRUCTURE_PATTERN.
 const CODE_SPAN_ALNUM_PATTERN = /[a-zA-Z0-9]/;
 const BARE_DOTTED_FILENAME_PATTERN = /\b[\w-]{2,}\.[a-zA-Z]{1,5}\b/;
+// #2711: BARE_DOTTED_FILENAME_PATTERN's own dictionary-word-shaped match
+// also fires on a placeholder domain mentioned in ordinary prose -- an
+// Acceptance Criteria bullet that merely SAYS "update the contact at
+// example.com" or "notify owner@example.com" names no real file. Two
+// independent exclusions, checked per match rather than once over the
+// whole text (so one genuine bare filename elsewhere in the same section
+// still counts even when a placeholder domain also appears):
+// EXAMPLE_PLACEHOLDER_DOMAIN_PATTERN excludes the RFC 2606 reserved
+// example domains (the convention's own go-to placeholder), and a match
+// immediately preceded by "@" is an email address's domain part -- for
+// ANY domain, not just the reserved ones -- never a bare filename.
+const EXAMPLE_PLACEHOLDER_DOMAIN_PATTERN = /^example\.(?:com|org|net|edu)$/i;
 // CodeRabbit review (PR #2602): an ATX heading may carry up to three
 // leading spaces per CommonMark, so the AC-section boundary below must
 // tolerate that indentation or an indented sibling heading (e.g. this
 // repo's own "   ## Candidate files", however it happens to be indented)
 // would not stop the section.
-const NEXT_HEADING_PATTERN = /\n {0,3}#{1,6}\s/;
+// #2711: also matches the boundary immediately before a Setext-style
+// sibling heading's own content line (a text line directly followed, with
+// no blank line between, by a lone run of "=" or "-" characters) -- ATX
+// alone reproduced this same section-boundary leak for that heading
+// style. The lookahead anchors the match at the same "\n before the
+// heading" position as the ATX alternative, so `.slice(0, index)` still
+// excludes the sibling heading's own text either way. Accepted limitation
+// (soft heuristic, matching this file's existing style): a "-" underline
+// immediately following a list-item line is treated as a Setext boundary
+// even where CommonMark itself would keep it inside the list -- full
+// container-aware disambiguation is out of scope for this fix.
+const NEXT_HEADING_PATTERN =
+  /\n(?: {0,3}#{1,6}\s|(?=[ \t]*\S[^\n]*\n {0,3}(?:=+|-+)[ \t]*(?:\n|$)))/;
 // CodeRabbit review (PR #2602): scanning the whole AC section's raw text
 // -- rather than just its list-item lines -- let a placeholder bullet
 // ("- [ ] TODO") followed by unrelated, non-list prose containing a
@@ -915,7 +1068,10 @@ const NEXT_HEADING_PATTERN = /\n {0,3}#{1,6}\s/;
 // continuation line is intentionally excluded too, since it cannot be
 // told apart from unrelated trailing prose without full Markdown
 // paragraph parsing) are considered for either check.
-const LIST_ITEM_LINE_PATTERN = /^\s*(?:[-*]|\d+\.)\s+/;
+// #2711: also recognizes the parenthesized ordered-list form ("1)"
+// alongside "1."), which CommonMark treats as an equally valid ordered
+// list marker.
+const LIST_ITEM_LINE_PATTERN = /^\s*(?:[-*]|\d+[.)])\s+/;
 
 function looksLikePlaceholder(content: string): boolean {
   return PLACEHOLDER_LEAD_PATTERN.test(content);
@@ -949,7 +1105,26 @@ function hasSubstantiveBullet(text: string): boolean {
       return true;
     }
   }
-  return BARE_DOTTED_FILENAME_PATTERN.test(text);
+  return hasBareDottedFilename(text);
+}
+
+// #2711: per-match variant of BARE_DOTTED_FILENAME_PATTERN.test(text) --
+// see EXAMPLE_PLACEHOLDER_DOMAIN_PATTERN above for why a single whole-text
+// `.test()` is not enough. Checked per match, not short-circuited by the
+// first one found, so a placeholder domain earlier in the text never
+// hides a genuine bare filename later in the same section.
+function hasBareDottedFilename(text: string): boolean {
+  const pattern = new RegExp(BARE_DOTTED_FILENAME_PATTERN.source, 'g');
+  let match = pattern.exec(text);
+  while (match !== null) {
+    const matchText = match[0];
+    const precededByAt = text[match.index - 1] === '@';
+    if (!precededByAt && !EXAMPLE_PLACEHOLDER_DOMAIN_PATTERN.test(matchText)) {
+      return true;
+    }
+    match = pattern.exec(text);
+  }
+  return false;
 }
 // A heading line such as "## Decision (resolved 2026-06-27)" records that a
 // human has already ruled on the issue's open question (see Check 7). The
@@ -2435,16 +2610,26 @@ export function checkVerifiability(context: Context): CheckOutcome {
   // bullet, or a heading-like line meant only as sample output) must not
   // leak into this scan either way -- as a fake substantive bullet, or as a
   // fake section-boundary heading that truncates the section before a real
-  // bullet after the fence. Mask fence content only (not inline code spans,
+  // bullet after the fence. Mask fence content (not inline code spans,
   // which hasSubstantiveBullet below still needs) over the whole body before
   // any slicing, so a fence that opens inside the eventual 500-char window
   // and closes outside it is still fully masked (E2 critique subagent,
   // #2589 round 6). Masking preserves character positions, so every offset
   // computed below stays valid against the original body.
-  const fenceMaskedBody = maskMarkdownCodeRegionsPreservingPositions(
-    body,
-    findFencedCodeRanges(body),
-  );
+  //
+  // #2711: also masks indented (4-space) code blocks and HTML comments,
+  // neither of which the fenced-only mask above covered -- a keyword-free
+  // example written as an indented block, or hidden template scaffolding
+  // inside an HTML comment, could otherwise leak a fake substantive bullet
+  // or a fake outcome-signal keyword into this same scan. `findHtmlCommentRanges`
+  // is given the fenced ranges too so an unterminated `<!--` used as a
+  // fenced code EXAMPLE of the syntax doesn't mask through EOF.
+  const fencedRangesForVerifiability = findFencedCodeRanges(body);
+  const fenceMaskedBody = maskMarkdownCodeRegionsPreservingPositions(body, [
+    ...fencedRangesForVerifiability,
+    ...findIndentedCodeRanges(body, fencedRangesForVerifiability),
+    ...findHtmlCommentRanges(body, fencedRangesForVerifiability),
+  ]);
   const acceptanceCriteriaMatch = fenceMaskedBody.match(
     ACCEPTANCE_CRITERIA_PATTERN,
   );
@@ -2479,8 +2664,15 @@ export function checkVerifiability(context: Context): CheckOutcome {
     }
   }
 
-  // Alternative: check for numbered steps with outcome signals or checklists
-  if (!hasObjectiveCriteria) {
+  // Alternative: check for numbered steps with outcome signals or
+  // checklists. Scoped to a body with NO "Acceptance Criteria" heading at
+  // all (#2711): when one exists, the section-scoped scan above already
+  // gave it a fair, bounded review; letting this whole-body fallback rescan
+  // past that boundary let an unrelated LATER section's own checklist
+  // (e.g. this repo's own "## Candidate files" bullet-list convention)
+  // flip a genuinely placeholder Acceptance Criteria section to "has
+  // objective criteria."
+  if (!hasObjectiveCriteria && !acceptanceCriteriaMatch) {
     const hasNumSteps =
       /^\s*\d+\.\s+/m.test(body) && OUTCOME_SIGNAL_PATTERN.test(body);
     const hasChecklist =
@@ -2522,12 +2714,16 @@ export function checkVerifiability(context: Context): CheckOutcome {
   // A` ``) and hidden HTML-comment template scaffolding (round 6:
   // `<!-- Maintainer decision (...): <resolution text> -->`).
   // `findMarkdownCodeRanges` covers both inline and fenced spans, unlike
-  // `findFencedCodeRanges` alone.
+  // `findFencedCodeRanges` alone. `findHtmlCommentRanges` is given the
+  // fenced ranges too (#2711) so an unterminated `<!--` used as a fenced
+  // code EXAMPLE of the HTML-comment-marker syntax isn't treated as a real
+  // unterminated comment masking through EOF.
+  const fencedRangesForCommentMasking = findFencedCodeRanges(normalizedBody);
   const normalizedCodeMaskedBody = maskMarkdownCodeRegionsPreservingPositions(
     normalizedBody,
     [
       ...findMarkdownCodeRanges(normalizedBody),
-      ...findHtmlCommentRanges(normalizedBody),
+      ...findHtmlCommentRanges(normalizedBody, fencedRangesForCommentMasking),
     ],
   );
   const hasSubjectiveApproval = ((): boolean => {
@@ -2583,11 +2779,18 @@ export function checkVerifiability(context: Context): CheckOutcome {
   // whole-paragraph `isFramedAsDescriptive`) so a genuine resolution whose
   // OWN text happens to use a reporting verb -- "Maintainer decision (...):
   // the helper reports an actionable error" -- is not wrongly excluded
-  // (Codex review, PR #2662). A Markdown blockquote is a second, independent
-  // quoting signal with no reporting verb of its own -- "> Maintainer
-  // decision (...): ..." -- so `isInBlockquotedParagraph` also excludes a
-  // match (Codex review rounds 2 and 4, PR #2662). The heading form has no
-  // equivalent gap: a "## Decision (resolved …)" section is, by
+  // (Codex review, PR #2662). `isFollowedByFramingVerb` (#2711) catches the
+  // inverted-attribution shape of the same quoting problem, where the
+  // reporting verb follows the marker instead of preceding it -- "'Maintainer
+  // decision (...): choose A,' reports the referenced tracking issue". A
+  // Markdown blockquote is a third, independent quoting signal with no
+  // reporting verb of its own -- "> Maintainer decision (...): ..." -- so
+  // `isInBlockquotedParagraph` also excludes a match (Codex review rounds 2
+  // and 4, PR #2662). A GFM strikethrough span (#2711) is a fourth,
+  // independent signal: a struck-through decision reads as retracted/
+  // superseded, not this issue's current live resolution, regardless of
+  // whether any framing verb or blockquote is also present. The heading
+  // form has no equivalent gap: a "## Decision (resolved …)" section is, by
   // construction, this issue's own decision record, never a quoted example
   // of someone else's.
   const hasInlineResolvedDecision = ((): boolean => {
@@ -2597,13 +2800,25 @@ export function checkVerifiability(context: Context): CheckOutcome {
     );
     let inlineMatch = inlinePattern.exec(normalizedCodeMaskedBody);
     while (inlineMatch) {
+      const matchEnd = inlineMatch.index + inlineMatch[0].length;
       if (
         !isPrecededByFramingVerb(
           normalizedBody,
           paragraphSpans,
           inlineMatch.index,
         ) &&
+        !isFollowedByFramingVerb(
+          normalizedBody,
+          paragraphSpans,
+          inlineMatch.index,
+          matchEnd,
+        ) &&
         !isInBlockquotedParagraph(
+          normalizedBody,
+          paragraphSpans,
+          inlineMatch.index,
+        ) &&
+        !isInStrikethroughSpan(
           normalizedBody,
           paragraphSpans,
           inlineMatch.index,

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -2705,6 +2705,11 @@ export function checkVerifiability(context: Context): CheckOutcome {
   // #2735) -- only these two specific, already-recognized
   // non-verification regions are excluded now, not every sibling section.
   // Also accepts the "1)" ordered-list form (matching the fix above).
+  // #2711 PR #2735 review round 4 (Codex): starts from `fenceMaskedBody`
+  // (already fenced/indented/HTML-comment masked), not the raw `body` --
+  // a fenced or indented example demonstrating a "1)" step, or one hidden
+  // in an HTML comment, could otherwise satisfy this fallback on its own
+  // once paired with an unrelated outcome-signal word anywhere else.
   if (!hasObjectiveCriteria) {
     const alternativeScanExclusions: MarkdownCodeRange[] = [];
     if (acceptanceCriteriaMatch) {
@@ -2749,10 +2754,10 @@ export function checkVerifiability(context: Context): CheckOutcome {
     const bodyForAlternativeScan =
       alternativeScanExclusions.length > 0
         ? maskMarkdownCodeRegionsPreservingPositions(
-            body,
+            fenceMaskedBody,
             alternativeScanExclusions,
           )
-        : body;
+        : fenceMaskedBody;
     const hasNumSteps =
       /^\s*\d+[.)]\s+/m.test(bodyForAlternativeScan) &&
       OUTCOME_SIGNAL_PATTERN.test(bodyForAlternativeScan);

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -517,6 +517,14 @@ function isInBlockquotedParagraph(
 // relative to `normalizedBody` (as `maskMarkdownCodeRegionsPreservingPositions`
 // guarantees) so `paragraphSpans` and `offset`, both computed against
 // `normalizedBody`, stay valid against it.
+//
+// #2711 PR #2735 review round 5 (Codex): a backslash-escaped delimiter
+// (`\~~`) renders as a literal string in CommonMark, not a real
+// strikethrough boundary -- two literal `\~~` examples surrounding a
+// genuine, unstruck "Maintainer decision (...)" must not be paired as if
+// they were real delimiters. A single preceding backslash is enough to
+// treat a `~~` as escaped (soft heuristic, matching this file's existing
+// style; does not attempt full backslash-run parity for `\\~~`).
 function isInStrikethroughSpan(
   codeMaskedBody: string,
   paragraphSpans: { start: number; end: number }[],
@@ -534,7 +542,9 @@ function isInStrikethroughSpan(
   const delimiterStarts: number[] = [];
   let delimiterMatch = delimiterPattern.exec(paragraphText);
   while (delimiterMatch !== null) {
-    delimiterStarts.push(delimiterMatch.index);
+    if (paragraphText[delimiterMatch.index - 1] !== '\\') {
+      delimiterStarts.push(delimiterMatch.index);
+    }
     delimiterPattern.lastIndex = delimiterMatch.index + 2;
     delimiterMatch = delimiterPattern.exec(paragraphText);
   }
@@ -574,6 +584,14 @@ function isInStrikethroughSpan(
 // ranges from consideration entirely; pass fenced + indented + inline
 // ranges (e.g. `findMarkdownCodeRanges`'s result) to cover every code
 // shape, not just fenced blocks.
+//
+// #2711 PR #2735 review round 5 (Codex): a backslash-escaped opener
+// (`\<!--`) renders as a literal string in CommonMark, not a real HTML
+// comment start -- an issue documenting the literal marker syntax (e.g.
+// `Document the literal \<!-- marker`) must not have everything after it
+// masked through EOF. A single preceding backslash is enough to treat it
+// as escaped (soft heuristic, matching this file's existing style; does
+// not attempt full backslash-run parity for a doubly-escaped `\\<!--`).
 function findHtmlCommentRanges(
   text: string,
   ignoredOpenerRanges: MarkdownCodeRange[] = [],
@@ -583,9 +601,12 @@ function findHtmlCommentRanges(
   let openMatch = openPattern.exec(text);
   while (openMatch) {
     const openIndex = openMatch.index;
-    const isIgnored = ignoredOpenerRanges.some(
-      (range) => openIndex >= range.start && openIndex < range.end,
-    );
+    const isEscaped = text[openIndex - 1] === '\\';
+    const isIgnored =
+      isEscaped ||
+      ignoredOpenerRanges.some(
+        (range) => openIndex >= range.start && openIndex < range.end,
+      );
     if (isIgnored) {
       openPattern.lastIndex = openIndex + 4;
       openMatch = openPattern.exec(text);

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -556,23 +556,28 @@ function isInStrikethroughSpan(
 // unterminated `<!--` to illustrate the shape -- must not have that
 // example's opener treated as a REAL unterminated comment: doing so masks
 // through EOF and swallows a genuine later "Maintainer decision (...)"
-// that follows the fence. `fencedRanges` (optional, defaults to none so
-// existing callers with no fenced content to worry about are unaffected)
-// lets a caller exclude any `<!--` whose own opening `<` falls inside a
-// fenced code range from consideration entirely.
+// that follows the fence. The same applies to an INLINE code span
+// demonstrating the same syntax (PR #2735 Codex review round 2) -- e.g.
+// `` `<!--` `` followed by a later bullet naming the real artifact.
+// `ignoredOpenerRanges` (optional, defaults to none so existing callers
+// with no code content to worry about are unaffected) lets a caller
+// exclude any `<!--` whose own opening `<` falls inside one of these
+// ranges from consideration entirely; pass fenced + indented + inline
+// ranges (e.g. `findMarkdownCodeRanges`'s result) to cover every code
+// shape, not just fenced blocks.
 function findHtmlCommentRanges(
   text: string,
-  fencedRanges: MarkdownCodeRange[] = [],
+  ignoredOpenerRanges: MarkdownCodeRange[] = [],
 ): MarkdownCodeRange[] {
   const ranges: MarkdownCodeRange[] = [];
   const openPattern = /<!--/g;
   let openMatch = openPattern.exec(text);
   while (openMatch) {
     const openIndex = openMatch.index;
-    const isInsideFence = fencedRanges.some(
+    const isIgnored = ignoredOpenerRanges.some(
       (range) => openIndex >= range.start && openIndex < range.end,
     );
-    if (isInsideFence) {
+    if (isIgnored) {
       openPattern.lastIndex = openIndex + 4;
       openMatch = openPattern.exec(text);
       continue;
@@ -977,6 +982,13 @@ function isEnumeratedParentheticalEntry(
   return otherEntries.length > 0 && otherEntries.every(looksLikeLabelEntry);
 }
 const ACCEPTANCE_CRITERIA_PATTERN = /^#+\s*Acceptance\s+Criteria\s*$/im;
+// #2711 PR #2735 review (Codex): this repo's own "## Candidate files"
+// convention (#2589) names files to EDIT, never a verification signal --
+// matched here (mirroring ACCEPTANCE_CRITERIA_PATTERN's own shape) so the
+// "Alternative" whole-body fallback below can exclude just this specific,
+// already-recognized non-verification section instead of every sibling
+// section unconditionally.
+const CANDIDATE_FILES_SECTION_PATTERN = /^#+\s*Candidate\s+files\s*$/im;
 // #2589: a bullet under "## Acceptance Criteria" that names something
 // concrete -- an inline-code span (covers a quoted file path, command, or
 // identifier) or a bare dotted filename -- is substantive on its own,
@@ -2622,13 +2634,18 @@ export function checkVerifiability(context: Context): CheckOutcome {
   // example written as an indented block, or hidden template scaffolding
   // inside an HTML comment, could otherwise leak a fake substantive bullet
   // or a fake outcome-signal keyword into this same scan. `findHtmlCommentRanges`
-  // is given the fenced ranges too so an unterminated `<!--` used as a
-  // fenced code EXAMPLE of the syntax doesn't mask through EOF.
+  // is given every code range (fenced, indented, AND inline -- PR #2735
+  // Codex review round 2) so an unterminated `<!--` used as a code
+  // EXAMPLE of the syntax, in any of those three shapes, doesn't mask
+  // through EOF; only fenced and indented ranges are actually masked into
+  // `fenceMaskedBody` itself, since inline spans stay unmasked for
+  // hasSubstantiveBullet's own backtick scan below.
   const fencedRangesForVerifiability = findFencedCodeRanges(body);
+  const codeRangesForVerifiability = findMarkdownCodeRanges(body);
   const fenceMaskedBody = maskMarkdownCodeRegionsPreservingPositions(body, [
     ...fencedRangesForVerifiability,
     ...findIndentedCodeRanges(body, fencedRangesForVerifiability),
-    ...findHtmlCommentRanges(body, fencedRangesForVerifiability),
+    ...findHtmlCommentRanges(body, codeRangesForVerifiability),
   ]);
   const acceptanceCriteriaMatch = fenceMaskedBody.match(
     ACCEPTANCE_CRITERIA_PATTERN,
@@ -2656,7 +2673,10 @@ export function checkVerifiability(context: Context): CheckOutcome {
     // only the section's own list-item lines, not its full raw text, so a
     // placeholder bullet followed by unrelated non-list prose can't
     // borrow that prose's substance or keywords (#2589 CodeRabbit review).
-    if (/^[-*]\s+/.test(listSection) || /^\d+\.\s+/.test(listSection)) {
+    // #2711 PR #2735 review (Copilot): also accepts the "1)" ordered-list
+    // form, matching LIST_ITEM_LINE_PATTERN's own fix -- an AC section
+    // written entirely with that numbering used to never enter this block.
+    if (/^[-*]\s+/.test(listSection) || /^\d+[.)]\s+/.test(listSection)) {
       const listItemsOnly = extractListItemLines(listSection);
       hasObjectiveCriteria =
         hasSubstantiveBullet(listItemsOnly) ||
@@ -2665,18 +2685,63 @@ export function checkVerifiability(context: Context): CheckOutcome {
   }
 
   // Alternative: check for numbered steps with outcome signals or
-  // checklists. Scoped to a body with NO "Acceptance Criteria" heading at
-  // all (#2711): when one exists, the section-scoped scan above already
-  // gave it a fair, bounded review; letting this whole-body fallback rescan
-  // past that boundary let an unrelated LATER section's own checklist
-  // (e.g. this repo's own "## Candidate files" bullet-list convention)
-  // flip a genuinely placeholder Acceptance Criteria section to "has
-  // objective criteria."
-  if (!hasObjectiveCriteria && !acceptanceCriteriaMatch) {
+  // checklists, excluding (a) the Acceptance Criteria section's own
+  // content, already given a fair, bounded review above, and (b) this
+  // repo's own "## Candidate files" convention (#2589) -- a list of files
+  // to EDIT, never a verification signal. A genuine numbered-steps or
+  // checklist section elsewhere in the body (e.g. "## Expected Behavior",
+  // "## Reproduction") still counts: an earlier revision (#2711) instead
+  // skipped this whole fallback whenever ANY Acceptance Criteria heading
+  // existed, which also suppressed that legitimate case (Codex review, PR
+  // #2735) -- only these two specific, already-recognized
+  // non-verification regions are excluded now, not every sibling section.
+  // Also accepts the "1)" ordered-list form (matching the fix above).
+  if (!hasObjectiveCriteria) {
+    const alternativeScanExclusions: MarkdownCodeRange[] = [];
+    if (acceptanceCriteriaMatch) {
+      const acHeadingStart = acceptanceCriteriaMatch.index ?? 0;
+      const acContentStart =
+        acHeadingStart + (acceptanceCriteriaMatch[0]?.length ?? 0);
+      const acRestOfBody = fenceMaskedBody.slice(acContentStart);
+      const acNextHeadingIdx = acRestOfBody.search(NEXT_HEADING_PATTERN);
+      const acContentEnd =
+        acContentStart +
+        (acNextHeadingIdx === -1 ? acRestOfBody.length : acNextHeadingIdx);
+      alternativeScanExclusions.push({
+        start: acHeadingStart,
+        end: acContentEnd,
+      });
+    }
+    const candidateFilesMatch = fenceMaskedBody.match(
+      CANDIDATE_FILES_SECTION_PATTERN,
+    );
+    if (candidateFilesMatch) {
+      const cfHeadingStart = candidateFilesMatch.index ?? 0;
+      const cfContentStart =
+        cfHeadingStart + (candidateFilesMatch[0]?.length ?? 0);
+      const cfRestOfBody = fenceMaskedBody.slice(cfContentStart);
+      const cfNextHeadingIdx = cfRestOfBody.search(NEXT_HEADING_PATTERN);
+      const cfContentEnd =
+        cfContentStart +
+        (cfNextHeadingIdx === -1 ? cfRestOfBody.length : cfNextHeadingIdx);
+      alternativeScanExclusions.push({
+        start: cfHeadingStart,
+        end: cfContentEnd,
+      });
+    }
+    const bodyForAlternativeScan =
+      alternativeScanExclusions.length > 0
+        ? maskMarkdownCodeRegionsPreservingPositions(
+            body,
+            alternativeScanExclusions,
+          )
+        : body;
     const hasNumSteps =
-      /^\s*\d+\.\s+/m.test(body) && OUTCOME_SIGNAL_PATTERN.test(body);
+      /^\s*\d+[.)]\s+/m.test(bodyForAlternativeScan) &&
+      OUTCOME_SIGNAL_PATTERN.test(bodyForAlternativeScan);
     const hasChecklist =
-      /^\s*[-*]\s+\[[ xX]\]/m.test(body) && OUTCOME_SIGNAL_PATTERN.test(body);
+      /^\s*[-*]\s+\[[ xX]\]/m.test(bodyForAlternativeScan) &&
+      OUTCOME_SIGNAL_PATTERN.test(bodyForAlternativeScan);
     hasObjectiveCriteria = hasNumSteps || hasChecklist;
   }
 
@@ -2713,17 +2778,18 @@ export function checkVerifiability(context: Context): CheckOutcome {
   // syntax with `` `Maintainer decision (Groom hearing, 2026-09-05): choose
   // A` ``) and hidden HTML-comment template scaffolding (round 6:
   // `<!-- Maintainer decision (...): <resolution text> -->`).
-  // `findMarkdownCodeRanges` covers both inline and fenced spans, unlike
-  // `findFencedCodeRanges` alone. `findHtmlCommentRanges` is given the
-  // fenced ranges too (#2711) so an unterminated `<!--` used as a fenced
-  // code EXAMPLE of the HTML-comment-marker syntax isn't treated as a real
-  // unterminated comment masking through EOF.
-  const fencedRangesForCommentMasking = findFencedCodeRanges(normalizedBody);
+  // `findMarkdownCodeRanges` covers fenced, indented, AND inline spans,
+  // unlike `findFencedCodeRanges` alone. `findHtmlCommentRanges` is given
+  // that same superset (#2711; widened to include inline spans too per PR
+  // #2735 Codex review round 2) so an unterminated `<!--` used as a code
+  // EXAMPLE of the HTML-comment-marker syntax, fenced or inline, isn't
+  // treated as a real unterminated comment masking through EOF.
+  const codeRangesForCommentMasking = findMarkdownCodeRanges(normalizedBody);
   const normalizedCodeMaskedBody = maskMarkdownCodeRegionsPreservingPositions(
     normalizedBody,
     [
-      ...findMarkdownCodeRanges(normalizedBody),
-      ...findHtmlCommentRanges(normalizedBody, fencedRangesForCommentMasking),
+      ...codeRangesForCommentMasking,
+      ...findHtmlCommentRanges(normalizedBody, codeRangesForCommentMasking),
     ],
   );
   const hasSubjectiveApproval = ((): boolean => {

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -2680,6 +2680,16 @@ export function checkVerifiability(context: Context): CheckOutcome {
   const acceptanceCriteriaMatch = fenceMaskedBody.match(
     ACCEPTANCE_CRITERIA_PATTERN,
   );
+  // #2711 PR #2735 review round 6 (Codex): tracks whether the primary scan
+  // below actually reached its list-shaped outer gate, so the Alternative
+  // fallback (further down) only treats the AC section as "already fairly
+  // reviewed" -- and excludes it -- when that gate genuinely ran. An AC
+  // section starting with introductory prose before its checklist (e.g.
+  // "The implementation must satisfy:\n- [ ] ...") never enters the gate
+  // here (the section's own text doesn't start with a list marker), so its
+  // real checklist item was never seen by either scan; excluding it from
+  // the fallback too made it doubly invisible instead of falling through.
+  let acListGateReached = false;
   if (acceptanceCriteriaMatch) {
     const indexAfter =
       (acceptanceCriteriaMatch.index ?? 0) +
@@ -2707,6 +2717,7 @@ export function checkVerifiability(context: Context): CheckOutcome {
     // form, matching LIST_ITEM_LINE_PATTERN's own fix -- an AC section
     // written entirely with that numbering used to never enter this block.
     if (/^[-*]\s+/.test(listSection) || /^\d+[.)]\s+/.test(listSection)) {
+      acListGateReached = true;
       const listItemsOnly = extractListItemLines(listSection);
       hasObjectiveCriteria =
         hasSubstantiveBullet(listItemsOnly) ||
@@ -2716,9 +2727,10 @@ export function checkVerifiability(context: Context): CheckOutcome {
 
   // Alternative: check for numbered steps with outcome signals or
   // checklists, excluding (a) the Acceptance Criteria section's own
-  // content, already given a fair, bounded review above, and (b) this
-  // repo's own "## Candidate files" convention (#2589) -- a list of files
-  // to EDIT, never a verification signal. A genuine numbered-steps or
+  // content, but ONLY when `acListGateReached` -- i.e. the primary scan
+  // above actually gave it a fair, bounded review -- and (b) this repo's
+  // own "## Candidate files" convention (#2589) -- a list of files to
+  // EDIT, never a verification signal. A genuine numbered-steps or
   // checklist section elsewhere in the body (e.g. "## Expected Behavior",
   // "## Reproduction") still counts: an earlier revision (#2711) instead
   // skipped this whole fallback whenever ANY Acceptance Criteria heading
@@ -2733,7 +2745,7 @@ export function checkVerifiability(context: Context): CheckOutcome {
   // once paired with an unrelated outcome-signal word anywhere else.
   if (!hasObjectiveCriteria) {
     const alternativeScanExclusions: MarkdownCodeRange[] = [];
-    if (acceptanceCriteriaMatch) {
+    if (acceptanceCriteriaMatch && acListGateReached) {
       const acHeadingStart = acceptanceCriteriaMatch.index ?? 0;
       const acContentStart =
         acHeadingStart + (acceptanceCriteriaMatch[0]?.length ?? 0);

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -508,8 +508,17 @@ function isInBlockquotedParagraph(
 // containing paragraph (a soft heuristic, not full CommonMark strikethrough
 // parsing, matching this file's existing style for inline-span detection)
 // and reports whether `offset` falls strictly inside any pair's content.
+//
+// #2711 PR #2735 review round 3 (Codex): scans `codeMaskedBody` (e.g.
+// `normalizedCodeMaskedBody`), not the raw `normalizedBody`, so a literal
+// "~~" inside an inline/fenced code example demonstrating the syntax --
+// masked to spaces there -- is never mistaken for a real delimiter.
+// `codeMaskedBody` must be the SAME length and position-preserving
+// relative to `normalizedBody` (as `maskMarkdownCodeRegionsPreservingPositions`
+// guarantees) so `paragraphSpans` and `offset`, both computed against
+// `normalizedBody`, stay valid against it.
 function isInStrikethroughSpan(
-  normalizedBody: string,
+  codeMaskedBody: string,
   paragraphSpans: { start: number; end: number }[],
   offset: number,
 ): boolean {
@@ -518,8 +527,8 @@ function isInStrikethroughSpan(
       (candidate) => offset >= candidate.start && offset <= candidate.end,
     ) ?? paragraphSpans[paragraphSpans.length - 1];
   const paragraphStart = span?.start ?? 0;
-  const paragraphEnd = span?.end ?? normalizedBody.length;
-  const paragraphText = normalizedBody.slice(paragraphStart, paragraphEnd);
+  const paragraphEnd = span?.end ?? codeMaskedBody.length;
+  const paragraphText = codeMaskedBody.slice(paragraphStart, paragraphEnd);
   const relativeOffset = offset - paragraphStart;
   const delimiterPattern = /~~/g;
   const delimiterStarts: number[] = [];
@@ -2704,9 +2713,17 @@ export function checkVerifiability(context: Context): CheckOutcome {
         acHeadingStart + (acceptanceCriteriaMatch[0]?.length ?? 0);
       const acRestOfBody = fenceMaskedBody.slice(acContentStart);
       const acNextHeadingIdx = acRestOfBody.search(NEXT_HEADING_PATTERN);
-      const acContentEnd =
+      const acSectionEnd =
         acContentStart +
         (acNextHeadingIdx === -1 ? acRestOfBody.length : acNextHeadingIdx);
+      // #2711 PR #2735 review round 3 (Codex): the primary section-scoped
+      // scan above only ever examines the first 500 characters after the
+      // heading (`contentAfter`'s own slice window) -- capping the
+      // exclusion at that SAME boundary, not the section's full extent,
+      // so a genuine checklist item past that window (which the primary
+      // scan never saw either) remains available to this fallback instead
+      // of being doubly hidden.
+      const acContentEnd = Math.min(acSectionEnd, acContentStart + 500);
       alternativeScanExclusions.push({
         start: acHeadingStart,
         end: acContentEnd,
@@ -2885,7 +2902,7 @@ export function checkVerifiability(context: Context): CheckOutcome {
           inlineMatch.index,
         ) &&
         !isInStrikethroughSpan(
-          normalizedBody,
+          normalizedCodeMaskedBody,
           paragraphSpans,
           inlineMatch.index,
         )

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -2761,7 +2761,29 @@ export function checkVerifiability(context: Context): CheckOutcome {
       // so a genuine checklist item past that window (which the primary
       // scan never saw either) remains available to this fallback instead
       // of being doubly hidden.
-      const acContentEnd = Math.min(acSectionEnd, acContentStart + 500);
+      //
+      // #2711 PR #2735 review round 7 (Codex): a single checklist item
+      // that itself straddles the 500-character cutoff -- marker and
+      // explanatory prefix before it, objective clause after -- must not
+      // have its exclusion cut mid-line: char-precise truncation left the
+      // marker excluded while only the suffix reached the fallback, and
+      // the bare suffix text (with no "- [ ]" of its own) never matched
+      // `hasChecklist`'s marker pattern. Snap the cutoff back to the start
+      // of the straddling line so the whole item stays together, either
+      // fully excluded (primary scan's job) or fully visible to the
+      // fallback -- never split across the boundary.
+      const rawCutoff = acContentStart + 500;
+      let acContentEnd: number;
+      if (rawCutoff >= acSectionEnd) {
+        acContentEnd = acSectionEnd;
+      } else {
+        const straddleLineStart =
+          fenceMaskedBody.lastIndexOf('\n', rawCutoff) + 1;
+        acContentEnd =
+          straddleLineStart <= acContentStart
+            ? acContentStart
+            : straddleLineStart;
+      }
       alternativeScanExclusions.push({
         start: acHeadingStart,
         end: acContentEnd,

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -4570,6 +4570,45 @@ This will produce the expected result.
   assert.equal(result.pass, false);
 });
 
+test('verifiability ignores a backslash-escaped HTML comment opener (PR #2735 Codex review round 5)', () => {
+  // A backslash-escaped "\<!--" renders as a literal string in CommonMark,
+  // not a real HTML comment start. findHtmlCommentRanges previously masked
+  // everything after it through EOF (no matching "-->" ever follows),
+  // hiding a genuine later Acceptance Criteria checklist item.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `Document the literal \\<!-- marker in the README.
+
+## Acceptance Criteria
+- [ ] Ship the fix in src/foo.ts
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('verifiability ignores backslash-escaped strikethrough delimiters (PR #2735 Codex review round 5)', () => {
+  // A backslash-escaped "\~~" renders as a literal string in CommonMark,
+  // not a real strikethrough delimiter. isInStrikethroughSpan previously
+  // paired two such literal, escaped tokens as a real delimiter pair,
+  // wrongly treating the genuine decision marker between them as struck
+  // through / retracted.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `Needs maintainer sign-off on the final approach.
+
+## Acceptance Criteria
+- [ ] tests pass
+
+\\~~ Maintainer decision (Groom hearing, 2026-09-05): proceed as described. \\~~
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
 test('repository fit fails when external system access is required', () => {
   const result = checkRepositoryFit({
     issue: {

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -4629,6 +4629,27 @@ The implementation must satisfy:
   assert.equal(result.pass, true);
 });
 
+test('verifiability keeps a checklist item together when it straddles the 500-char cutoff (PR #2735 Codex review round 7)', () => {
+  // A single checklist item whose marker/prefix sits before the 500-char
+  // cutoff and whose objective clause sits after it was previously split
+  // by char-precise exclusion: the marker was excluded (masked as part of
+  // the "already reviewed" AC section) while only the bare suffix reached
+  // the Alternative fallback -- with no "- [ ]" of its own, the suffix
+  // never matched hasChecklist's marker pattern. Now the cutoff snaps back
+  // to the start of the straddling line, so the whole item either stays
+  // fully excluded or reaches the fallback intact.
+  const filler = 'This section explains context at length. '.repeat(12);
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `## Acceptance Criteria
+- [ ] ${filler}The result is deterministic.
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
 test('repository fit fails when external system access is required', () => {
   const result = checkRepositoryFit({
     issue: {

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -4609,6 +4609,26 @@ test('verifiability ignores backslash-escaped strikethrough delimiters (PR #2735
   assert.equal(result.pass, true);
 });
 
+test('verifiability falls through to the Alternative scan when the AC section opens with introductory prose (PR #2735 Codex review round 6)', () => {
+  // The primary AC scan only enters its list-shaped outer gate when the
+  // section's own trimmed content starts with a list marker -- an
+  // introductory line before the checklist ("The implementation must
+  // satisfy:") never reaches that gate, so hasObjectiveCriteria stays
+  // false without the section ever being fairly reviewed. Excluding the
+  // section from the Alternative fallback regardless made its real
+  // checklist item doubly invisible instead of falling through to it.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `## Acceptance Criteria
+The implementation must satisfy:
+- [ ] The result is deterministic.
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
 test('repository fit fails when external system access is required', () => {
   const result = checkRepositoryFit({
     issue: {

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -4440,6 +4440,67 @@ The doc states "figure it out." Maintainer decision (Groom hearing, 2026-09-05):
   assert.equal(result.pass, true);
 });
 
+test('verifiability recognizes an Acceptance Criteria section written entirely with "1)" numbering (PR #2735 Copilot review)', () => {
+  // The outer "does this section look like a list at all" gate recognized
+  // only "1." ordered-list numbering, not the "1)" form LIST_ITEM_LINE_PATTERN
+  // itself already supports (#2711 gap 5) -- an AC section using ONLY that
+  // numbering style (no "-"/"*" bullet anywhere) never entered the
+  // section-scoped scan at all, regardless of the list-item-line fix.
+  const tick = String.fromCharCode(96);
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `## Acceptance Criteria
+1) TBD
+2) ${tick}scripts/real.mjs${tick} passes
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('verifiability ignores an HTML-comment-marker opener demonstrated in inline code (PR #2735 Codex review round 2)', () => {
+  // findHtmlCommentRanges excluded an unmatched "<!--" only when it was
+  // inside a FENCED code example (#2711 gap 4); the same demonstration
+  // written as an inline code span -- `` `<!--` `` -- was still treated as
+  // a real unterminated comment and masked the rest of the section,
+  // including the following bullet's own concrete artifact, through EOF.
+  const tick = String.fromCharCode(96);
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `## Acceptance Criteria
+- Document the literal ${tick}<!--${tick} marker
+- ${tick}src/parser.mts${tick} is deterministic
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('verifiability still credits a genuine numbered section unrelated to a placeholder Acceptance Criteria heading (PR #2735 Codex review round 2)', () => {
+  // An earlier revision (#2711 gap 2) skipped the whole-body numbered-
+  // steps/checklist fallback entirely whenever ANY Acceptance Criteria
+  // heading existed, over-correcting for the "## Candidate files" leak: a
+  // genuinely separate, later section (here "## Expected Behavior") with
+  // real numbered verification content was wrongly suppressed too. Only
+  // the Acceptance Criteria section's own content and the recognized
+  // "## Candidate files" convention are excluded now, not every sibling
+  // section.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `## Acceptance Criteria
+TBD
+
+## Expected Behavior
+1. The result is deterministic.
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
 test('repository fit fails when external system access is required', () => {
   const result = checkRepositoryFit({
     issue: {

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -4542,6 +4542,34 @@ The syntax \`~~\` is documented. Maintainer decision (Groom hearing, 2026-09-05)
   assert.equal(result.pass, true);
 });
 
+test('verifiability masks fenced/indented code and HTML comments before the Alternative fallback scan (PR #2735 Codex review round 4)', () => {
+  // The Alternative fallback's own body -- after excluding the
+  // Acceptance Criteria and Candidate-files sections -- previously used
+  // raw `body`, unmasked: a "1)" step demonstrated inside a fenced code
+  // example, paired with an unrelated outcome-signal word elsewhere in
+  // the body, wrongly satisfied hasNumSteps. Neither section is present
+  // here (a placeholder AC section and an unrelated "## Notes" section),
+  // isolating the code-masking gap itself from the section-exclusion
+  // fixes above.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `## Acceptance Criteria
+TBD
+
+## Notes
+
+\`\`\`
+1) Placeholder instruction
+\`\`\`
+
+This will produce the expected result.
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
 test('repository fit fails when external system access is required', () => {
   const result = checkRepositoryFit({
     issue: {

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -4501,6 +4501,47 @@ TBD
   assert.equal(result.pass, true);
 });
 
+test("verifiability preserves a checklist item past the primary scan's own 500-char window (PR #2735 Codex review round 3)", () => {
+  // The primary section-scoped scan only ever examines the first 500
+  // characters after the "Acceptance Criteria" heading. An earlier
+  // revision's exclusion masked the section's FULL extent from the
+  // Alternative fallback instead of matching that same 500-char window,
+  // so a genuine checklist item past it -- which the primary scan never
+  // examined either -- was doubly hidden rather than left available.
+  const filler = 'This section explains context at length. '.repeat(15);
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `## Acceptance Criteria
+${filler}
+- [ ] The result is deterministic.
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('verifiability ignores a literal "~~" demonstrated in inline code when pairing strikethrough (PR #2735 Codex review round 3)', () => {
+  // isInStrikethroughSpan previously scanned the raw, unmasked body for
+  // "~~" delimiters -- two literal "~~" tokens quoted in inline code
+  // (documenting the syntax itself) were paired as real strikethrough
+  // delimiters, wrongly treating the genuine decision marker between them
+  // as struck through / retracted.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `Needs maintainer sign-off on the final approach.
+
+## Acceptance Criteria
+- [ ] tests pass
+
+The syntax \`~~\` is documented. Maintainer decision (Groom hearing, 2026-09-05): proceed as described. Keep \`~~\` escaped.
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
 test('repository fit fails when external system access is required', () => {
   const result = checkRepositoryFit({
     issue: {

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -4227,6 +4227,219 @@ test('verifiability does not pair "either" in one bullet with an unrelated "or" 
   assert.equal(result.pass, true);
 });
 
+test('verifiability does not treat a placeholder domain or an email address as a bare filename (#2711 gap 1)', () => {
+  // BARE_DOTTED_FILENAME_PATTERN's own dictionary-word-shaped match also
+  // fires on a placeholder domain mentioned in ordinary prose -- neither
+  // "example.com" (the RFC 2606 reserved placeholder domain) nor
+  // "owner@example.com" (an email address, whose domain part alone also
+  // matches the pattern) names a real file.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `## Acceptance Criteria
+- [ ] Update the contact listed as example.com
+- [ ] Notify owner@example.com when done
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
+test("verifiability does not let an unrelated later section's checklist flip a placeholder Acceptance Criteria section (#2711 gap 2)", () => {
+  // The whole-body numbered-steps/checklist fallback previously had no
+  // section-boundary awareness: this repo's own "## Candidate files"
+  // bullet-list convention (itself a checklist, unrelated to the AC
+  // section) combined with an outcome-signal word anywhere else in the
+  // body wrongly flipped a genuinely placeholder AC section to "has
+  // objective criteria."
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `## Acceptance Criteria
+TBD
+
+## Candidate files
+- [ ] src/scripts/foo.mts
+
+This change should pass on merge.
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
+test('verifiability does not let a hidden HTML comment leak substance into the Acceptance Criteria scan (#2711 gap 3)', () => {
+  // A concrete-looking code span and outcome-signal keyword hidden inside
+  // an HTML comment on the same line as a placeholder bullet is invisible
+  // in the rendered issue and must not count as real content.
+  const tick = String.fromCharCode(96);
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `## Acceptance Criteria
+- [ ] TODO <!-- ${tick}scripts/real.mjs${tick} outputs the result -->
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
+test('verifiability does not let an unmatched fenced-example "<!--" swallow a later genuine decision (#2711 gap 4)', () => {
+  // findHtmlCommentRanges previously scanned for a literal "<!--" with no
+  // awareness of fenced code: an issue documenting the HTML-comment marker
+  // syntax inside a fenced example, with no closing "-->" anywhere in the
+  // body, masked from that position all the way to EOF, swallowing a
+  // genuine "Maintainer decision (...)" that followed the fence.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `Needs maintainer sign-off before merging.
+
+## Acceptance Criteria
+- [ ] tests pass
+
+Example marker syntax:
+\`\`\`
+<!-- unterminated example
+\`\`\`
+
+Maintainer decision (Groom hearing, 2026-09-05): proceed as described above.
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('verifiability recognizes a parenthesized ordered-list marker as a real checklist line (#2711 gap 5)', () => {
+  // LIST_ITEM_LINE_PATTERN previously recognized only "1." numbering, not
+  // the equally valid CommonMark "1)" form -- a substantive bullet written
+  // that way was silently dropped from the AC-section list-item scan,
+  // leaving only the placeholder line and wrongly failing the check. The
+  // placeholder line deliberately avoids checkbox ("- [ ]") syntax so this
+  // fixture isolates LIST_ITEM_LINE_PATTERN's own gap from the unscoped
+  // whole-body checklist fallback (#2711 gap 2, fixed separately) that a
+  // checkbox-shaped placeholder line would otherwise also satisfy.
+  const tick = String.fromCharCode(96);
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `## Acceptance Criteria
+- TODO
+1) ${tick}scripts/real-thing.mjs${tick} passes
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('verifiability does not let a keyword-free indented-code example leak into the Acceptance Criteria scan (#2711 gap 6)', () => {
+  // No indented (4-space) code masking existed before the AC-substance
+  // scan -- a fenced-only mask left an indented Markdown example (here,
+  // one demonstrating the checklist syntax itself) fully visible, so its
+  // own concrete-looking code span was read as a real, substantive bullet.
+  // Two blank lines fully exit the preceding "- [ ] TODO" bullet's own
+  // list-content zone (one blank line alone keeps a list zone active,
+  // which raises the indented-code threshold above 4 columns and would
+  // read this same line as a nested list item instead of a code example).
+  const tick = String.fromCharCode(96);
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `## Acceptance Criteria
+- [ ] TODO
+
+
+    - [ ] ${tick}scripts/real.mjs${tick} passes
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
+test('verifiability bounds the Acceptance Criteria section at a Setext-style sibling heading (#2711 gap 7)', () => {
+  // NEXT_HEADING_PATTERN previously recognized only ATX ("#") headings --
+  // a Setext-style sibling heading (a text line underlined with "---")
+  // reproduced the same section-boundary leak as an unbounded scan: a
+  // trailing "## Candidate files"-shaped section's own bullet leaked into
+  // a genuinely placeholder AC section.
+  const tick = String.fromCharCode(96);
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `## Acceptance Criteria
+- [ ] TODO
+
+Candidate files
+---
+- [ ] ${tick}scripts/real.mjs${tick}
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
+test('verifiability treats a struck-through inline decision as not resolved (#2711 gap 8)', () => {
+  // A GFM strikethrough span ("~~...~~") marks its content as retracted or
+  // superseded -- a struck-through "Maintainer decision (...)" must not
+  // count as this issue's own current live resolution.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `Needs maintainer sign-off on the final approach.
+
+## Acceptance Criteria
+- [ ] tests pass
+
+~~Maintainer decision (Groom hearing, 2026-09-05): proceed as described above.~~ Superseded, see the follow-up discussion for the current plan.
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
+test("verifiability recognizes an inverted-attribution quotation of another issue's decision (#2711 gap 9)", () => {
+  // A reporting verb can follow the quoted marker instead of preceding it
+  // -- "'Maintainer decision (...): choose A,' reports the linked
+  // discussion" -- which the backward-only framing-verb scan never saw,
+  // wrongly treating an externally-reported quotation as this issue's own
+  // resolution.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `Needs maintainer sign-off on the final approach.
+
+## Acceptance Criteria
+- [ ] tests pass
+
+Issue #4321 'Maintainer decision (Groom hearing, 2026-09-05): choose option A,' reports the linked discussion.
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
+test('verifiability does not let an earlier sentence ending in a closing quote widen the framing-verb scan (#2711 gap 10)', () => {
+  // The literal ". "/"! "/"? " sentence-boundary scan found no boundary at
+  // a sentence ending in a closing quote before the space (`out." `) and
+  // fell back to scanning from the paragraph start, wrongly pulling an
+  // earlier, unrelated sentence's own framing verb ("states") into the
+  // window and suppressing this issue's own genuine, later, unrelated
+  // resolution.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `Needs maintainer sign-off on the final approach.
+
+## Acceptance Criteria
+- [ ] tests pass
+
+The doc states "figure it out." Maintainer decision (Groom hearing, 2026-09-05): choose option A.
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
 test('repository fit fails when external system access is required', () => {
   const result = checkRepositoryFit({
     issue: {


### PR DESCRIPTION
# Summary

`checkVerifiability`'s Check 7 (`src/scripts/suitability-triage.mts`)
carried ten independent masking and section-boundary precision gaps, all
re-verified against current `main` before fixing (issue #2711's own
numbering, kept for traceability):

1. `BARE_DOTTED_FILENAME_PATTERN` wrongly classified a placeholder domain
   (`example.com`) or an email address's domain part
   (`owner@example.com`) as a real filename.
2. The whole-body numbered-steps/checklist "Alternative" fallback had no
   section-boundary awareness -- an unrelated later section's own
   checklist (e.g. `## Candidate files`) could flip a genuinely
   placeholder Acceptance Criteria section.
3. HTML comments were never masked before the Acceptance Criteria
   substance scan.
4. `findHtmlCommentRanges` masked an unmatched `<!--` through EOF even
   when it was inside a fenced code example, swallowing a genuine later
   decision marker.
5. `LIST_ITEM_LINE_PATTERN` recognized only `1.` ordered-list numbering,
   not the equally valid CommonMark `1)` form.
6. No indented (4-space) code-block masking existed before the
   Acceptance Criteria substance scan.
7. `NEXT_HEADING_PATTERN` recognized only ATX (`#`) headings, not a
   Setext-style sibling heading.
8. No GFM-strikethrough exclusion existed for the inline
   maintainer-decision pattern.
9. The framing-verb check only scanned text before a marker, missing the
   inverted-attribution shape where the reporting verb follows the
   marker instead.
10. The sentence-boundary scan had no tolerance for a sentence ending in
    a closing quote or emphasis marker before the terminating
    punctuation.

Excludes the issue's own reported 11th gap (parenthesized-ordered-list
support in `isInBlockquotedParagraph`) per its own finding that it does
not apply upstream.

Each gap has its own regression test fixture in
`tests/suitability-triage.test.mts` -- every one independently verified
(via `git stash` of the source changes) to fail against pre-fix behavior
and pass after.

Four review rounds (Copilot and Codex) surfaced six further follow-up
findings against this same batch, all fixed the same way (own regression
test, `git stash`-verified fail-before/pass-after): narrowing the AC-list
outer gate to genuine list markup, excluding a blockquoted decision
sentence, requiring symmetric quote-closing for the inverted framing-verb
check, moving GFM-strikethrough pairing onto the code-masked body instead
of the raw body, widening the `<!--` exclusion to cover inline code spans
(not just fenced/indented), and -- most recently -- rebasing the
Alternative fallback's whole-body scan onto the fully code-masked body
instead of raw `body`, so a fenced or indented "1)" example elsewhere in
the issue can no longer combine with an unrelated outcome-signal word to
falsely satisfy the checklist/numbered-steps heuristic.

## Linked issue

Closes #2711

## Candidate files

- `src/scripts/suitability-triage.mts`
- `src/scripts/markdown-code.mts` (exports the previously-private
  `findIndentedCodeRanges` so the Acceptance Criteria scan can compose
  fenced + indented masking without also masking inline code spans,
  which the same scan still needs)
- `tests/suitability-triage.test.mts`

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm run typecheck`
- [x] `pnpm run build` (regenerated `scripts/suitability-triage.mjs` and
      `scripts/markdown-code.mjs`)
- [x] `node --test tests/*.test.mts` (5391 tests, 0 failures)
- [x] `npx biome check`
- [x] `npx dprint check`
- [x] `pnpm run build:check` (committed `.mjs` matches rebuilt output)
- [x] Each of the 16 new regression tests (10 original + 6 review
      follow-ups) confirmed to fail on pre-fix source (`git stash` of
      `src/scripts/*.mts` + generated `.mjs`) and pass after

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EycqtGKuWjJMpw2tUav3Tn

