### PR TITLE
feat(audit-docs): detect near-ceiling limitBytes ratchet raise

### DIFF
--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -590,10 +590,10 @@ gone.
 
 **Mechanically enforced (#2697).** `node scripts/audit-docs.mjs --check`
 fails when a commit raises a `bundleBudgets` bundle's `limitBytes` while
-that bundle's base-ref utilization was already at or above
-`noticeUtilizationPct` (the same 95% figure above) — the exception is no
-longer prose-only. The check compares against the base ref's own
-`audit/sync-manifest.json` and file contents, so a brand-new bundle (no
+that bundle's base-ref utilization was already at or above the configured
+`noticeUtilizationPct` threshold (95% by default, the same figure above) —
+the exception is no longer prose-only. The check compares against the base
+ref's own `audit/sync-manifest.json` and file contents, so a brand-new bundle (no
 base-ref entry) or a `limitBytes` decrease never trips it.
 
 ### High-contention shared files

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -589,12 +589,16 @@ default while headroom remains, and trim or split once headroom is nearly
 gone.
 
 **Mechanically enforced (#2697).** `node scripts/audit-docs.mjs --check`
-fails when a commit raises a `bundleBudgets` bundle's `limitBytes` while
-that bundle's base-ref utilization was already at or above the configured
-`noticeUtilizationPct` threshold (95% by default, the same figure above) —
-the exception is no longer prose-only. The check compares against the base
-ref's own `audit/sync-manifest.json` and file contents, so a brand-new bundle (no
-base-ref entry) or a `limitBytes` decrease never trips it.
+fails, when the base ref and its manifest are available, when a commit
+raises a `bundleBudgets` bundle's `limitBytes` while that bundle's
+base-ref utilization was already at or above the configured
+`noticeUtilizationPct` threshold (95% by default) — the exception is no
+longer prose-only. The check compares against the base ref's own
+`audit/sync-manifest.json` and file contents, so a brand-new bundle (no
+base-ref entry) or a `limitBytes` decrease never trips it. If the base
+ref or its manifest cannot be read (for example, a shallow checkout),
+the check emits a notice and skips this comparison instead of failing
+closed.
 
 ### High-contention shared files
 

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -588,6 +588,14 @@ budget for smaller-context models. Read the two as one policy: raise by
 default while headroom remains, and trim or split once headroom is nearly
 gone.
 
+**Mechanically enforced (#2697).** `node scripts/audit-docs.mjs --check`
+fails when a commit raises a `bundleBudgets` bundle's `limitBytes` while
+that bundle's base-ref utilization was already at or above
+`noticeUtilizationPct` (the same 95% figure above) — the exception is no
+longer prose-only. The check compares against the base ref's own
+`audit/sync-manifest.json` and file contents, so a brand-new bundle (no
+base-ref entry) or a `limitBytes` decrease never trips it.
+
 ### High-contention shared files
 
 A small set of files concentrates concurrent autopilot edits and therefore

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -594,10 +594,12 @@ raises a `bundleBudgets` bundle's `limitBytes` while that bundle's
 base-ref utilization was already at or above the configured
 `noticeUtilizationPct` threshold (95% by default) — the exception is no
 longer prose-only. The check compares against the base ref's own
-`audit/sync-manifest.json` and file contents, so a brand-new bundle (no
-base-ref entry) or a `limitBytes` decrease never trips it. If the base
-ref or its manifest cannot be read (for example, a shallow checkout),
-the check emits a notice and skips this comparison instead of failing
+`audit/sync-manifest.json` and file contents, so a genuinely new bundle
+(no base-ref entry by id, and no base bundle with an identical file set
+either — an id rename alone does not count as new) or a `limitBytes`
+decrease never trips it. If the base ref or its manifest cannot be read
+(for example, a shallow checkout), the check emits a notice and skips
+this comparison instead of failing
 closed.
 
 ### High-contention shared files

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -590,10 +590,10 @@ gone.
 
 **Mechanically enforced (#2697).** `node scripts/audit-docs.mjs --check`
 fails when a commit raises a `bundleBudgets` bundle's `limitBytes` while
-that bundle's base-ref utilization was already at or above
-`noticeUtilizationPct` (the same 95% figure above) — the exception is no
-longer prose-only. The check compares against the base ref's own
-`audit/sync-manifest.json` and file contents, so a brand-new bundle (no
+that bundle's base-ref utilization was already at or above the configured
+`noticeUtilizationPct` threshold (95% by default, the same figure above) —
+the exception is no longer prose-only. The check compares against the base
+ref's own `audit/sync-manifest.json` and file contents, so a brand-new bundle (no
 base-ref entry) or a `limitBytes` decrease never trips it.
 
 ### High-contention shared files

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -589,12 +589,16 @@ default while headroom remains, and trim or split once headroom is nearly
 gone.
 
 **Mechanically enforced (#2697).** `node scripts/audit-docs.mjs --check`
-fails when a commit raises a `bundleBudgets` bundle's `limitBytes` while
-that bundle's base-ref utilization was already at or above the configured
-`noticeUtilizationPct` threshold (95% by default, the same figure above) —
-the exception is no longer prose-only. The check compares against the base
-ref's own `audit/sync-manifest.json` and file contents, so a brand-new bundle (no
-base-ref entry) or a `limitBytes` decrease never trips it.
+fails, when the base ref and its manifest are available, when a commit
+raises a `bundleBudgets` bundle's `limitBytes` while that bundle's
+base-ref utilization was already at or above the configured
+`noticeUtilizationPct` threshold (95% by default) — the exception is no
+longer prose-only. The check compares against the base ref's own
+`audit/sync-manifest.json` and file contents, so a brand-new bundle (no
+base-ref entry) or a `limitBytes` decrease never trips it. If the base
+ref or its manifest cannot be read (for example, a shallow checkout),
+the check emits a notice and skips this comparison instead of failing
+closed.
 
 ### High-contention shared files
 

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -588,6 +588,14 @@ budget for smaller-context models. Read the two as one policy: raise by
 default while headroom remains, and trim or split once headroom is nearly
 gone.
 
+**Mechanically enforced (#2697).** `node scripts/audit-docs.mjs --check`
+fails when a commit raises a `bundleBudgets` bundle's `limitBytes` while
+that bundle's base-ref utilization was already at or above
+`noticeUtilizationPct` (the same 95% figure above) — the exception is no
+longer prose-only. The check compares against the base ref's own
+`audit/sync-manifest.json` and file contents, so a brand-new bundle (no
+base-ref entry) or a `limitBytes` decrease never trips it.
+
 ### High-contention shared files
 
 A small set of files concentrates concurrent autopilot edits and therefore

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -594,10 +594,12 @@ raises a `bundleBudgets` bundle's `limitBytes` while that bundle's
 base-ref utilization was already at or above the configured
 `noticeUtilizationPct` threshold (95% by default) — the exception is no
 longer prose-only. The check compares against the base ref's own
-`audit/sync-manifest.json` and file contents, so a brand-new bundle (no
-base-ref entry) or a `limitBytes` decrease never trips it. If the base
-ref or its manifest cannot be read (for example, a shallow checkout),
-the check emits a notice and skips this comparison instead of failing
+`audit/sync-manifest.json` and file contents, so a genuinely new bundle
+(no base-ref entry by id, and no base bundle with an identical file set
+either — an id rename alone does not count as new) or a `limitBytes`
+decrease never trips it. If the base ref or its manifest cannot be read
+(for example, a shallow checkout), the check emits a notice and skips
+this comparison instead of failing
 closed.
 
 ### High-contention shared files

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -16,6 +16,7 @@ import {
   collectEnginesRangeMirrorViolations,
   collectGeneratedFromBannerViolations,
   collectInstructionSizeBudgetViolations,
+  collectNearCeilingRatchetViolations,
   collectOkfFrontmatterViolations,
   collectPolicyConfigDrift,
   collectRootMarkdownAllowlistViolations,
@@ -80,10 +81,11 @@ checkShellFileLists(
 checkSyncPairs(manifest.syncPairs ?? []);
 checkGeneratedFromBanners(manifest.syncPairs ?? []);
 checkInstructionSizeBudgets(manifest.instructionSizeBudgets);
-checkContextCeiling(
-  manifest.contextCeiling ?? null,
-  checkBundleBudgets(manifest.bundleBudgets ?? []),
-);
+{
+  const bundleStats = checkBundleBudgets(manifest.bundleBudgets ?? []);
+  checkContextCeiling(manifest.contextCeiling ?? null, bundleStats);
+  checkNearCeilingRatchet(manifest.contextCeiling ?? null, bundleStats);
+}
 checkDocBudgetNumbers();
 checkForbiddenPatterns(manifest.forbiddenPatterns ?? []);
 checkRootMarkdownAllowlist(manifest.rootMarkdownAllowlist ?? null);
@@ -909,6 +911,109 @@ function checkContextCeiling(config, bundleStats) {
   const result = collectContextCeilingViolations(config, bundleStats);
   errors.push(...result.errors);
   notices.push(...result.notices);
+}
+// Near-ceiling ratchet guard (#2697): reads the base ref's own
+// `audit/sync-manifest.json` and its bundle member files via `git show`, so
+// the comparison uses the base ref's OWN file list for a bundle (which may
+// differ from the current manifest's) rather than re-reading current files
+// against an old limit. Degrades to a notice, never an error, when a base
+// ref cannot be resolved or read (e.g. a shallow checkout with no `main`
+// history) -- matching `listChangedFiles`'s own graceful-skip precedent for
+// missing git context, since failing the whole audit closed on an
+// unrelated checkout-depth issue would be worse than skipping this one
+// mechanical guard for that run.
+function resolveNearCeilingBaseRef() {
+  const candidates = [];
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (eventPath) {
+    try {
+      const event = JSON.parse(readFileSync(eventPath, 'utf8'));
+      if (event.pull_request?.base?.sha) {
+        candidates.push(event.pull_request.base.sha);
+      }
+    } catch {
+      // Fall through to the next candidate.
+    }
+  }
+  if (process.env.GITHUB_BASE_REF) {
+    candidates.push(`origin/${process.env.GITHUB_BASE_REF}`);
+  }
+  candidates.push('origin/main');
+  for (const ref of candidates) {
+    try {
+      git(['rev-parse', '--verify', `${ref}^{commit}`]);
+      return ref;
+    } catch {
+      // Try the next candidate.
+    }
+  }
+  return null;
+}
+function readTextAtRef(ref, file) {
+  try {
+    return normalizeText(git(['show', `${ref}:${file}`]));
+  } catch {
+    // File did not exist at the base ref (e.g. newly added in this change);
+    // its base-ref byte contribution is 0, not an error.
+    return null;
+  }
+}
+function computeBaseBundleStats(ref, budgets) {
+  const stats = [];
+  for (const budget of budgets) {
+    const id = budget.id ?? 'bundle-budget';
+    const limitBytes = Number(budget.limitBytes);
+    if (!Number.isFinite(limitBytes) || limitBytes < 0) {
+      // Already reported against the current manifest by checkBundleBudgets.
+      continue;
+    }
+    let totalBytes = 0;
+    for (const file of budget.files ?? []) {
+      const text = readTextAtRef(ref, file);
+      if (text !== null) {
+        totalBytes += Buffer.byteLength(stripGeneratedFromBanner(text), 'utf8');
+      }
+    }
+    stats.push({ id, limitBytes, totalBytes });
+  }
+  return stats;
+}
+function checkNearCeilingRatchet(config, currentBundleStats) {
+  if (!config) {
+    return;
+  }
+  const noticeUtilizationPct = Number(config.noticeUtilizationPct);
+  if (!Number.isFinite(noticeUtilizationPct) || noticeUtilizationPct < 0) {
+    // Already reported by checkContextCeiling.
+    return;
+  }
+  const baseRef = resolveNearCeilingBaseRef();
+  if (!baseRef) {
+    notices.push('near-ceiling-ratchet: could not resolve a base ref; skipped');
+    return;
+  }
+  let baseManifest = null;
+  try {
+    baseManifest = JSON.parse(
+      git(['show', `${baseRef}:audit/sync-manifest.json`]),
+    );
+  } catch {
+    notices.push(
+      `near-ceiling-ratchet: could not read audit/sync-manifest.json at ${baseRef}; skipped`,
+    );
+    return;
+  }
+  const baseBundleStats = computeBaseBundleStats(
+    baseRef,
+    baseManifest.bundleBudgets ?? [],
+  );
+  errors.push(
+    ...collectNearCeilingRatchetViolations(
+      noticeUtilizationPct,
+      currentBundleStats,
+      baseBundleStats,
+    ),
+  );
 }
 function checkDocBudgetNumbers() {
   // Cross-check every hardcoded byte value in the guarded docs against the

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -23,6 +23,7 @@ import {
   collectTypeSuppressionViolations,
   globFiles,
   isBannerScopedInstructionTarget,
+  normalizeNonNegativeNumber,
   parseGeneratedFromBannerSource,
   renderOkfIndexMarkdownTable,
   resolveGeneratedBlockFiles,
@@ -904,7 +905,7 @@ function checkBundleBudgets(budgets) {
         `${id}: bundle total is ${totalBytes} bytes (limit ${limitBytes}); files: ${files.join(', ')}`,
       );
     }
-    stats.push({ id, limitBytes, totalBytes });
+    stats.push({ id, limitBytes, totalBytes, files });
   }
   return stats;
 }
@@ -968,19 +969,20 @@ function computeBaseBundleStats(ref, budgets) {
   const stats = [];
   for (const budget of budgets) {
     const id = budget.id ?? 'bundle-budget';
+    const files = budget.files ?? [];
     const limitBytes = Number(budget.limitBytes);
     if (!Number.isFinite(limitBytes) || limitBytes < 0) {
       // Already reported against the current manifest by checkBundleBudgets.
       continue;
     }
     let totalBytes = 0;
-    for (const file of budget.files ?? []) {
+    for (const file of files) {
       const text = readTextAtRef(ref, file);
       if (text !== null) {
         totalBytes += Buffer.byteLength(stripGeneratedFromBanner(text), 'utf8');
       }
     }
-    stats.push({ id, limitBytes, totalBytes });
+    stats.push({ id, limitBytes, totalBytes, files });
   }
   return stats;
 }
@@ -988,8 +990,15 @@ function checkNearCeilingRatchet(config, currentBundleStats) {
   if (!config) {
     return;
   }
-  const noticeUtilizationPct = Number(config.noticeUtilizationPct);
-  if (!Number.isFinite(noticeUtilizationPct) || noticeUtilizationPct < 0) {
+  // Strict typeof-number gate (Copilot review finding, PR #2736): a bare
+  // Number(...) coercion turns null/''/false into a valid-looking 0, which
+  // would let this function run with an effective 0% threshold instead of
+  // deferring entirely to checkContextCeiling's own error for the same
+  // misconfiguration.
+  const noticeUtilizationPct = normalizeNonNegativeNumber(
+    config.noticeUtilizationPct,
+  );
+  if (noticeUtilizationPct === null) {
     // Already reported by checkContextCeiling.
     return;
   }

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -954,8 +954,13 @@ function readTextAtRef(ref, file) {
   try {
     return normalizeText(git(['show', `${ref}:${file}`]));
   } catch {
-    // File did not exist at the base ref (e.g. newly added in this change);
-    // its base-ref byte contribution is 0, not an error.
+    // Most commonly the file did not exist at the base ref (e.g. newly
+    // added in this change), but any `git show` failure -- a corrupt
+    // object, a path that is a directory at that ref, etc. -- is treated
+    // the same way: there is no usable byte count to add, and
+    // resolveNearCeilingBaseRef already verified the ref itself resolves,
+    // so failing this whole check closed over one file's read error would
+    // be a worse outcome than counting it as a 0-byte contribution.
     return null;
   }
 }

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -26,6 +26,7 @@ import {
   parseGeneratedFromBannerSource,
   renderOkfIndexMarkdownTable,
   resolveGeneratedBlockFiles,
+  selectStricterNoticeUtilizationPct,
   stripGeneratedFromBanner,
   uniqueSorted,
 } from './consistency-helpers.mjs';
@@ -1007,9 +1008,13 @@ function checkNearCeilingRatchet(config, currentBundleStats) {
     baseRef,
     baseManifest.bundleBudgets ?? [],
   );
+  const effectiveNoticeUtilizationPct = selectStricterNoticeUtilizationPct(
+    noticeUtilizationPct,
+    baseManifest.contextCeiling?.noticeUtilizationPct,
+  );
   errors.push(
     ...collectNearCeilingRatchetViolations(
-      noticeUtilizationPct,
+      effectiveNoticeUtilizationPct,
       currentBundleStats,
       baseBundleStats,
     ),

--- a/scripts/consistency-helpers.mjs
+++ b/scripts/consistency-helpers.mjs
@@ -214,7 +214,7 @@ function normalizePositiveIntegerBudget(value, defaultValue) {
   }
   return value;
 }
-function normalizeNonNegativeNumber(value) {
+export function normalizeNonNegativeNumber(value) {
   if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
     return null;
   }
@@ -352,17 +352,32 @@ export function collectContextCeilingViolations(config, bundles) {
  * threshold {@link collectContextCeilingViolations} already surfaces as a
  * notice, so the two checks agree on what "near-ceiling" means.
  *
- * No violation (silently skipped) when: the bundle is absent from
- * `baseBundles` (a brand-new bundle has nothing to compare against); the
- * bundle's `limitBytes` did not increase relative to the base ref (unchanged
- * or decreased); or the base ref's own `limitBytes` is zero or negative
- * (nothing meaningful to ratchet a utilization percentage from). Threshold
- * comparison is cross-multiplied in byte space
- * (`totalBytes * 100` vs. `limitBytes * pct`), matching
- * {@link collectContextCeilingViolations}'s own convention so a bundle
- * sitting exactly at the threshold does not tip over from float rounding;
- * inclusive `>=`, matching that function's own notice-threshold comparison
- * ("reaches ... or more").
+ * No violation (silently skipped) when: the bundle is genuinely new -- no
+ * base-ref entry matches its id, and (see the rename fallback below) no
+ * base bundle has an identical file set either; the bundle's `limitBytes`
+ * did not increase relative to the base ref (unchanged or decreased); or
+ * the base ref's own `limitBytes` is zero or negative (nothing meaningful
+ * to ratchet a utilization percentage from). Threshold comparison is
+ * cross-multiplied in byte space (`totalBytes * 100` vs. `limitBytes *
+ * pct`), matching {@link collectContextCeilingViolations}'s own convention
+ * so a bundle sitting exactly at the threshold does not tip over from
+ * float rounding; inclusive `>=`, matching that function's own
+ * notice-threshold comparison ("reaches ... or more").
+ *
+ * **Bundle-rename fallback** (#2697 Codex review finding on PR #2736): an
+ * id lookup alone would let a PR dodge this guard by renaming an
+ * already-near-ceiling bundle while raising its limit -- the rename reads
+ * as "no base-ref entry", the brand-new-bundle exemption. When a current
+ * bundle's id has no base match, this also looks for a base bundle whose
+ * `files` set is identical (order-independent) to the current bundle's own
+ * -- an id rename with unchanged membership is still the same bundle for
+ * this check's purposes. A file-set shared by two or more base bundles is
+ * ambiguous and is never used as a fallback match. Exact-set match only:
+ * a bundle whose file membership also changed (a split, a merge, a partial
+ * overlap) is treated as genuinely new, the same as before this fallback
+ * existed -- matching membership by name is a much weaker signal than
+ * matching it exactly, and this check's own false-positive cost (blocking
+ * an unrelated, legitimate raise) is why it stops at the exact case.
  */
 export function collectNearCeilingRatchetViolations(
   noticeUtilizationPct,
@@ -370,9 +385,28 @@ export function collectNearCeilingRatchetViolations(
   baseBundles,
 ) {
   const baseById = new Map(baseBundles.map((bundle) => [bundle.id, bundle]));
+  // `null` marks an ambiguous signature (shared by 2+ base bundles) so it is
+  // never mistaken for "no entry" (`undefined`, via a plain Map miss) --
+  // both must resolve to "no fallback match", but for different reasons.
+  const baseByFileSignature = new Map();
+  for (const bundle of baseBundles) {
+    const signature = fileSetSignature(bundle.files);
+    if (signature === null) {
+      continue;
+    }
+    baseByFileSignature.set(
+      signature,
+      baseByFileSignature.has(signature) ? null : bundle,
+    );
+  }
   const errors = [];
   for (const current of currentBundles) {
-    const base = baseById.get(current.id);
+    const currentSignature = fileSetSignature(current.files);
+    const base =
+      baseById.get(current.id) ??
+      (currentSignature !== null
+        ? (baseByFileSignature.get(currentSignature) ?? undefined)
+        : undefined);
     if (
       !base ||
       current.limitBytes <= base.limitBytes ||
@@ -388,6 +422,17 @@ export function collectNearCeilingRatchetViolations(
     }
   }
   return errors;
+}
+/** Order-independent identity for a bundle's file membership, used only by
+ * {@link collectNearCeilingRatchetViolations}'s rename fallback. `null` for
+ * an empty or absent file list -- nothing to key a fallback match on. */
+function fileSetSignature(files) {
+  if (!files || files.length === 0) {
+    return null;
+  }
+  // \n as the join separator, not a space: a file path could
+  // plausibly contain a space, but never a literal newline.
+  return [...files].sort().join('\n');
 }
 /**
  * Pick the effective `noticeUtilizationPct` for

--- a/scripts/consistency-helpers.mjs
+++ b/scripts/consistency-helpers.mjs
@@ -364,32 +364,6 @@ export function collectContextCeilingViolations(config, bundles) {
  * inclusive `>=`, matching that function's own notice-threshold comparison
  * ("reaches ... or more").
  */
-/**
- * Pick the effective `noticeUtilizationPct` for
- * {@link collectNearCeilingRatchetViolations} (#2697 Codex review finding
- * on PR #2736): a PR that raises both a bundle's `limitBytes` and the
- * `noticeUtilizationPct` threshold itself in the same change (e.g. 95 to
- * 97) could otherwise dodge the guard entirely -- a bundle sitting at 96%
- * under the OLD (base-ref) threshold reads as compliant against the NEW,
- * looser threshold, exactly the near-ceiling raise this check exists to
- * catch. Using the stricter (lower) of the base and current thresholds
- * closes that gap in both directions: raising the threshold cannot loosen
- * the check, and a repository that instead LOWERS the threshold in the
- * same PR gets the more conservative (lower) value applied immediately
- * rather than waiting a cycle. Falls back to `currentPct` alone when the
- * base ref's config is missing or not a valid non-negative number (a
- * repository adopting `contextCeiling` for the first time in this PR has
- * no base-ref threshold to compare against).
- */
-export function selectStricterNoticeUtilizationPct(
-  currentPct,
-  baseNoticeUtilizationPct,
-) {
-  const basePct = Number(baseNoticeUtilizationPct);
-  return Number.isFinite(basePct) && basePct >= 0
-    ? Math.min(currentPct, basePct)
-    : currentPct;
-}
 export function collectNearCeilingRatchetViolations(
   noticeUtilizationPct,
   currentBundles,
@@ -414,6 +388,38 @@ export function collectNearCeilingRatchetViolations(
     }
   }
   return errors;
+}
+/**
+ * Pick the effective `noticeUtilizationPct` for
+ * {@link collectNearCeilingRatchetViolations} (#2697 Codex review finding
+ * on PR #2736): a PR that raises both a bundle's `limitBytes` and the
+ * `noticeUtilizationPct` threshold itself in the same change (e.g. 95 to
+ * 97) could otherwise dodge the guard entirely -- a bundle sitting at 96%
+ * under the OLD (base-ref) threshold reads as compliant against the NEW,
+ * looser threshold, exactly the near-ceiling raise this check exists to
+ * catch. Using the stricter (lower) of the base and current thresholds
+ * closes that gap in both directions: raising the threshold cannot loosen
+ * the check, and a repository that instead LOWERS the threshold in the
+ * same PR gets the more conservative (lower) value applied immediately
+ * rather than waiting a cycle. Falls back to `currentPct` alone when the
+ * base ref's config is missing or not a valid non-negative number (a
+ * repository adopting `contextCeiling` for the first time in this PR has
+ * no base-ref threshold to compare against).
+ *
+ * Reuses {@link normalizeNonNegativeNumber}'s strict `typeof === 'number'`
+ * gate rather than a bare `Number(...)` coercion (CodeRabbit review finding
+ * on PR #2736): `Number(null)`, `Number('')`, and `Number(false)` all
+ * coerce to `0`, a valid-looking finite non-negative number that would
+ * silently defeat the documented "missing base value falls back to
+ * currentPct" contract and instead apply an effective 0% threshold --
+ * flagging every raised `limitBytes` regardless of actual utilization.
+ */
+export function selectStricterNoticeUtilizationPct(
+  currentPct,
+  baseNoticeUtilizationPct,
+) {
+  const basePct = normalizeNonNegativeNumber(baseNoticeUtilizationPct);
+  return basePct === null ? currentPct : Math.min(currentPct, basePct);
 }
 // Words after which a `/` must start a regex literal, not division.
 const REGEX_PRECEDING_KEYWORDS = new Set([

--- a/scripts/consistency-helpers.mjs
+++ b/scripts/consistency-helpers.mjs
@@ -338,6 +338,57 @@ export function collectContextCeilingViolations(config, bundles) {
   }
   return { errors, notices };
 }
+/**
+ * Collect "near-ceiling ratchet" violations (#2697): `docs/policy-constants.md`'s
+ * near-ceiling exception says raising a `bundleBudgets` bundle's `limitBytes`
+ * while that bundle was already near its ceiling should be avoided in favor
+ * of trimming or splitting the addition instead -- this mechanically
+ * enforces the exception, which was prose-only before this check existed.
+ *
+ * Pure (no I/O): the audit pipeline supplies the current bundle stats
+ * (`checkBundleBudgets`'s own summation, reused rather than re-measured
+ * here) and the equivalent stats measured from the base ref's manifest and
+ * file contents. `noticeUtilizationPct` reuses the same near-ceiling
+ * threshold {@link collectContextCeilingViolations} already surfaces as a
+ * notice, so the two checks agree on what "near-ceiling" means.
+ *
+ * No violation (silently skipped) when: the bundle is absent from
+ * `baseBundles` (a brand-new bundle has nothing to compare against); the
+ * bundle's `limitBytes` did not increase relative to the base ref (unchanged
+ * or decreased); or the base ref's own `limitBytes` is zero or negative
+ * (nothing meaningful to ratchet a utilization percentage from). Threshold
+ * comparison is cross-multiplied in byte space
+ * (`totalBytes * 100` vs. `limitBytes * pct`), matching
+ * {@link collectContextCeilingViolations}'s own convention so a bundle
+ * sitting exactly at the threshold does not tip over from float rounding;
+ * inclusive `>=`, matching that function's own notice-threshold comparison
+ * ("reaches ... or more").
+ */
+export function collectNearCeilingRatchetViolations(
+  noticeUtilizationPct,
+  currentBundles,
+  baseBundles,
+) {
+  const baseById = new Map(baseBundles.map((bundle) => [bundle.id, bundle]));
+  const errors = [];
+  for (const current of currentBundles) {
+    const base = baseById.get(current.id);
+    if (
+      !base ||
+      current.limitBytes <= base.limitBytes ||
+      base.limitBytes <= 0
+    ) {
+      continue;
+    }
+    if (base.totalBytes * 100 >= base.limitBytes * noticeUtilizationPct) {
+      const baseUtilizationPct = (base.totalBytes / base.limitBytes) * 100;
+      errors.push(
+        `near-ceiling-ratchet: ${current.id} limitBytes raised from ${base.limitBytes} to ${current.limitBytes} while already at ${baseUtilizationPct.toFixed(2)}% utilization at the base ref (${base.totalBytes}/${base.limitBytes} bytes) -- docs/policy-constants.md's near-ceiling exception prefers trimming or splitting the addition over raising here`,
+      );
+    }
+  }
+  return errors;
+}
 // Words after which a `/` must start a regex literal, not division.
 const REGEX_PRECEDING_KEYWORDS = new Set([
   'return',

--- a/scripts/consistency-helpers.mjs
+++ b/scripts/consistency-helpers.mjs
@@ -364,6 +364,32 @@ export function collectContextCeilingViolations(config, bundles) {
  * inclusive `>=`, matching that function's own notice-threshold comparison
  * ("reaches ... or more").
  */
+/**
+ * Pick the effective `noticeUtilizationPct` for
+ * {@link collectNearCeilingRatchetViolations} (#2697 Codex review finding
+ * on PR #2736): a PR that raises both a bundle's `limitBytes` and the
+ * `noticeUtilizationPct` threshold itself in the same change (e.g. 95 to
+ * 97) could otherwise dodge the guard entirely -- a bundle sitting at 96%
+ * under the OLD (base-ref) threshold reads as compliant against the NEW,
+ * looser threshold, exactly the near-ceiling raise this check exists to
+ * catch. Using the stricter (lower) of the base and current thresholds
+ * closes that gap in both directions: raising the threshold cannot loosen
+ * the check, and a repository that instead LOWERS the threshold in the
+ * same PR gets the more conservative (lower) value applied immediately
+ * rather than waiting a cycle. Falls back to `currentPct` alone when the
+ * base ref's config is missing or not a valid non-negative number (a
+ * repository adopting `contextCeiling` for the first time in this PR has
+ * no base-ref threshold to compare against).
+ */
+export function selectStricterNoticeUtilizationPct(
+  currentPct,
+  baseNoticeUtilizationPct,
+) {
+  const basePct = Number(baseNoticeUtilizationPct);
+  return Number.isFinite(basePct) && basePct >= 0
+    ? Math.min(currentPct, basePct)
+    : currentPct;
+}
 export function collectNearCeilingRatchetViolations(
   noticeUtilizationPct,
   currentBundles,

--- a/src/scripts/audit-docs.mts
+++ b/src/scripts/audit-docs.mts
@@ -34,6 +34,7 @@ import {
   collectTypeSuppressionViolations,
   globFiles,
   isBannerScopedInstructionTarget,
+  normalizeNonNegativeNumber,
   parseGeneratedFromBannerSource,
   renderOkfIndexMarkdownTable,
   resolveGeneratedBlockFiles,
@@ -1080,7 +1081,7 @@ function checkBundleBudgets(
         `${id}: bundle total is ${totalBytes} bytes (limit ${limitBytes}); files: ${files.join(', ')}`,
       );
     }
-    stats.push({ id, limitBytes, totalBytes });
+    stats.push({ id, limitBytes, totalBytes, files });
   }
   return stats;
 }
@@ -1156,19 +1157,20 @@ function computeBaseBundleStats(
   const stats: ContextCeilingBundleStat[] = [];
   for (const budget of budgets) {
     const id = budget.id ?? 'bundle-budget';
+    const files = budget.files ?? [];
     const limitBytes = Number(budget.limitBytes);
     if (!Number.isFinite(limitBytes) || limitBytes < 0) {
       // Already reported against the current manifest by checkBundleBudgets.
       continue;
     }
     let totalBytes = 0;
-    for (const file of budget.files ?? []) {
+    for (const file of files) {
       const text = readTextAtRef(ref, file);
       if (text !== null) {
         totalBytes += Buffer.byteLength(stripGeneratedFromBanner(text), 'utf8');
       }
     }
-    stats.push({ id, limitBytes, totalBytes });
+    stats.push({ id, limitBytes, totalBytes, files });
   }
   return stats;
 }
@@ -1180,8 +1182,15 @@ function checkNearCeilingRatchet(
   if (!config) {
     return;
   }
-  const noticeUtilizationPct = Number(config.noticeUtilizationPct);
-  if (!Number.isFinite(noticeUtilizationPct) || noticeUtilizationPct < 0) {
+  // Strict typeof-number gate (Copilot review finding, PR #2736): a bare
+  // Number(...) coercion turns null/''/false into a valid-looking 0, which
+  // would let this function run with an effective 0% threshold instead of
+  // deferring entirely to checkContextCeiling's own error for the same
+  // misconfiguration.
+  const noticeUtilizationPct = normalizeNonNegativeNumber(
+    config.noticeUtilizationPct,
+  );
+  if (noticeUtilizationPct === null) {
     // Already reported by checkContextCeiling.
     return;
   }

--- a/src/scripts/audit-docs.mts
+++ b/src/scripts/audit-docs.mts
@@ -27,6 +27,7 @@ import {
   collectEnginesRangeMirrorViolations,
   collectGeneratedFromBannerViolations,
   collectInstructionSizeBudgetViolations,
+  collectNearCeilingRatchetViolations,
   collectOkfFrontmatterViolations,
   collectPolicyConfigDrift,
   collectRootMarkdownAllowlistViolations,
@@ -180,10 +181,11 @@ checkShellFileLists(
 checkSyncPairs(manifest.syncPairs ?? []);
 checkGeneratedFromBanners(manifest.syncPairs ?? []);
 checkInstructionSizeBudgets(manifest.instructionSizeBudgets);
-checkContextCeiling(
-  manifest.contextCeiling ?? null,
-  checkBundleBudgets(manifest.bundleBudgets ?? []),
-);
+{
+  const bundleStats = checkBundleBudgets(manifest.bundleBudgets ?? []);
+  checkContextCeiling(manifest.contextCeiling ?? null, bundleStats);
+  checkNearCeilingRatchet(manifest.contextCeiling ?? null, bundleStats);
+}
 checkDocBudgetNumbers();
 checkForbiddenPatterns(manifest.forbiddenPatterns ?? []);
 checkRootMarkdownAllowlist(manifest.rootMarkdownAllowlist ?? null);
@@ -1089,6 +1091,121 @@ function checkContextCeiling(
   const result = collectContextCeilingViolations(config, bundleStats);
   errors.push(...result.errors);
   notices.push(...result.notices);
+}
+
+// Near-ceiling ratchet guard (#2697): reads the base ref's own
+// `audit/sync-manifest.json` and its bundle member files via `git show`, so
+// the comparison uses the base ref's OWN file list for a bundle (which may
+// differ from the current manifest's) rather than re-reading current files
+// against an old limit. Degrades to a notice, never an error, when a base
+// ref cannot be resolved or read (e.g. a shallow checkout with no `main`
+// history) -- matching `listChangedFiles`'s own graceful-skip precedent for
+// missing git context, since failing the whole audit closed on an
+// unrelated checkout-depth issue would be worse than skipping this one
+// mechanical guard for that run.
+function resolveNearCeilingBaseRef(): string | null {
+  const candidates: string[] = [];
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (eventPath) {
+    try {
+      const event = JSON.parse(readFileSync(eventPath, 'utf8')) as {
+        pull_request?: { base?: { sha?: string } };
+      };
+      if (event.pull_request?.base?.sha) {
+        candidates.push(event.pull_request.base.sha);
+      }
+    } catch {
+      // Fall through to the next candidate.
+    }
+  }
+  if (process.env.GITHUB_BASE_REF) {
+    candidates.push(`origin/${process.env.GITHUB_BASE_REF}`);
+  }
+  candidates.push('origin/main');
+  for (const ref of candidates) {
+    try {
+      git(['rev-parse', '--verify', `${ref}^{commit}`]);
+      return ref;
+    } catch {
+      // Try the next candidate.
+    }
+  }
+  return null;
+}
+
+function readTextAtRef(ref: string, file: string): string | null {
+  try {
+    return normalizeText(git(['show', `${ref}:${file}`]));
+  } catch {
+    // File did not exist at the base ref (e.g. newly added in this change);
+    // its base-ref byte contribution is 0, not an error.
+    return null;
+  }
+}
+
+function computeBaseBundleStats(
+  ref: string,
+  budgets: BundleBudget[],
+): ContextCeilingBundleStat[] {
+  const stats: ContextCeilingBundleStat[] = [];
+  for (const budget of budgets) {
+    const id = budget.id ?? 'bundle-budget';
+    const limitBytes = Number(budget.limitBytes);
+    if (!Number.isFinite(limitBytes) || limitBytes < 0) {
+      // Already reported against the current manifest by checkBundleBudgets.
+      continue;
+    }
+    let totalBytes = 0;
+    for (const file of budget.files ?? []) {
+      const text = readTextAtRef(ref, file);
+      if (text !== null) {
+        totalBytes += Buffer.byteLength(stripGeneratedFromBanner(text), 'utf8');
+      }
+    }
+    stats.push({ id, limitBytes, totalBytes });
+  }
+  return stats;
+}
+
+function checkNearCeilingRatchet(
+  config: ContextCeilingConfig | null,
+  currentBundleStats: ContextCeilingBundleStat[],
+) {
+  if (!config) {
+    return;
+  }
+  const noticeUtilizationPct = Number(config.noticeUtilizationPct);
+  if (!Number.isFinite(noticeUtilizationPct) || noticeUtilizationPct < 0) {
+    // Already reported by checkContextCeiling.
+    return;
+  }
+  const baseRef = resolveNearCeilingBaseRef();
+  if (!baseRef) {
+    notices.push('near-ceiling-ratchet: could not resolve a base ref; skipped');
+    return;
+  }
+  let baseManifest: AuditManifest | null = null;
+  try {
+    baseManifest = JSON.parse(
+      git(['show', `${baseRef}:audit/sync-manifest.json`]),
+    ) as AuditManifest;
+  } catch {
+    notices.push(
+      `near-ceiling-ratchet: could not read audit/sync-manifest.json at ${baseRef}; skipped`,
+    );
+    return;
+  }
+  const baseBundleStats = computeBaseBundleStats(
+    baseRef,
+    baseManifest.bundleBudgets ?? [],
+  );
+  errors.push(
+    ...collectNearCeilingRatchetViolations(
+      noticeUtilizationPct,
+      currentBundleStats,
+      baseBundleStats,
+    ),
+  );
 }
 
 function checkDocBudgetNumbers() {

--- a/src/scripts/audit-docs.mts
+++ b/src/scripts/audit-docs.mts
@@ -37,6 +37,7 @@ import {
   parseGeneratedFromBannerSource,
   renderOkfIndexMarkdownTable,
   resolveGeneratedBlockFiles,
+  selectStricterNoticeUtilizationPct,
   stripGeneratedFromBanner,
   uniqueSorted,
 } from './consistency-helpers.mts';
@@ -1199,9 +1200,13 @@ function checkNearCeilingRatchet(
     baseRef,
     baseManifest.bundleBudgets ?? [],
   );
+  const effectiveNoticeUtilizationPct = selectStricterNoticeUtilizationPct(
+    noticeUtilizationPct,
+    baseManifest.contextCeiling?.noticeUtilizationPct,
+  );
   errors.push(
     ...collectNearCeilingRatchetViolations(
-      noticeUtilizationPct,
+      effectiveNoticeUtilizationPct,
       currentBundleStats,
       baseBundleStats,
     ),

--- a/src/scripts/audit-docs.mts
+++ b/src/scripts/audit-docs.mts
@@ -1138,8 +1138,13 @@ function readTextAtRef(ref: string, file: string): string | null {
   try {
     return normalizeText(git(['show', `${ref}:${file}`]));
   } catch {
-    // File did not exist at the base ref (e.g. newly added in this change);
-    // its base-ref byte contribution is 0, not an error.
+    // Most commonly the file did not exist at the base ref (e.g. newly
+    // added in this change), but any `git show` failure -- a corrupt
+    // object, a path that is a directory at that ref, etc. -- is treated
+    // the same way: there is no usable byte count to add, and
+    // resolveNearCeilingBaseRef already verified the ref itself resolves,
+    // so failing this whole check closed over one file's read error would
+    // be a worse outcome than counting it as a 0-byte contribution.
     return null;
   }
 }

--- a/src/scripts/consistency-helpers.mts
+++ b/src/scripts/consistency-helpers.mts
@@ -458,6 +458,33 @@ export function collectContextCeilingViolations(
  * inclusive `>=`, matching that function's own notice-threshold comparison
  * ("reaches ... or more").
  */
+/**
+ * Pick the effective `noticeUtilizationPct` for
+ * {@link collectNearCeilingRatchetViolations} (#2697 Codex review finding
+ * on PR #2736): a PR that raises both a bundle's `limitBytes` and the
+ * `noticeUtilizationPct` threshold itself in the same change (e.g. 95 to
+ * 97) could otherwise dodge the guard entirely -- a bundle sitting at 96%
+ * under the OLD (base-ref) threshold reads as compliant against the NEW,
+ * looser threshold, exactly the near-ceiling raise this check exists to
+ * catch. Using the stricter (lower) of the base and current thresholds
+ * closes that gap in both directions: raising the threshold cannot loosen
+ * the check, and a repository that instead LOWERS the threshold in the
+ * same PR gets the more conservative (lower) value applied immediately
+ * rather than waiting a cycle. Falls back to `currentPct` alone when the
+ * base ref's config is missing or not a valid non-negative number (a
+ * repository adopting `contextCeiling` for the first time in this PR has
+ * no base-ref threshold to compare against).
+ */
+export function selectStricterNoticeUtilizationPct(
+  currentPct: number,
+  baseNoticeUtilizationPct: unknown,
+): number {
+  const basePct = Number(baseNoticeUtilizationPct);
+  return Number.isFinite(basePct) && basePct >= 0
+    ? Math.min(currentPct, basePct)
+    : currentPct;
+}
+
 export function collectNearCeilingRatchetViolations(
   noticeUtilizationPct: number,
   currentBundles: readonly ContextCeilingBundleStat[],

--- a/src/scripts/consistency-helpers.mts
+++ b/src/scripts/consistency-helpers.mts
@@ -288,14 +288,19 @@ export interface ContextCeilingConfig {
   exemptBundles?: unknown;
 }
 
-/** One bundle's precomputed byte stats, as measured by `bundleBudgets`. */
+/** One bundle's precomputed byte stats, as measured by `bundleBudgets`.
+ * `files` is optional -- {@link collectContextCeilingViolations} ignores it
+ * entirely; only {@link collectNearCeilingRatchetViolations}'s bundle-rename
+ * fallback (#2697) reads it, to identify a bundle across an id rename by its
+ * unchanged file membership. */
 export interface ContextCeilingBundleStat {
   id: string;
   limitBytes: number;
   totalBytes: number;
+  files?: readonly string[];
 }
 
-function normalizeNonNegativeNumber(value: unknown): number | null {
+export function normalizeNonNegativeNumber(value: unknown): number | null {
   if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
     return null;
   }
@@ -446,17 +451,32 @@ export function collectContextCeilingViolations(
  * threshold {@link collectContextCeilingViolations} already surfaces as a
  * notice, so the two checks agree on what "near-ceiling" means.
  *
- * No violation (silently skipped) when: the bundle is absent from
- * `baseBundles` (a brand-new bundle has nothing to compare against); the
- * bundle's `limitBytes` did not increase relative to the base ref (unchanged
- * or decreased); or the base ref's own `limitBytes` is zero or negative
- * (nothing meaningful to ratchet a utilization percentage from). Threshold
- * comparison is cross-multiplied in byte space
- * (`totalBytes * 100` vs. `limitBytes * pct`), matching
- * {@link collectContextCeilingViolations}'s own convention so a bundle
- * sitting exactly at the threshold does not tip over from float rounding;
- * inclusive `>=`, matching that function's own notice-threshold comparison
- * ("reaches ... or more").
+ * No violation (silently skipped) when: the bundle is genuinely new -- no
+ * base-ref entry matches its id, and (see the rename fallback below) no
+ * base bundle has an identical file set either; the bundle's `limitBytes`
+ * did not increase relative to the base ref (unchanged or decreased); or
+ * the base ref's own `limitBytes` is zero or negative (nothing meaningful
+ * to ratchet a utilization percentage from). Threshold comparison is
+ * cross-multiplied in byte space (`totalBytes * 100` vs. `limitBytes *
+ * pct`), matching {@link collectContextCeilingViolations}'s own convention
+ * so a bundle sitting exactly at the threshold does not tip over from
+ * float rounding; inclusive `>=`, matching that function's own
+ * notice-threshold comparison ("reaches ... or more").
+ *
+ * **Bundle-rename fallback** (#2697 Codex review finding on PR #2736): an
+ * id lookup alone would let a PR dodge this guard by renaming an
+ * already-near-ceiling bundle while raising its limit -- the rename reads
+ * as "no base-ref entry", the brand-new-bundle exemption. When a current
+ * bundle's id has no base match, this also looks for a base bundle whose
+ * `files` set is identical (order-independent) to the current bundle's own
+ * -- an id rename with unchanged membership is still the same bundle for
+ * this check's purposes. A file-set shared by two or more base bundles is
+ * ambiguous and is never used as a fallback match. Exact-set match only:
+ * a bundle whose file membership also changed (a split, a merge, a partial
+ * overlap) is treated as genuinely new, the same as before this fallback
+ * existed -- matching membership by name is a much weaker signal than
+ * matching it exactly, and this check's own false-positive cost (blocking
+ * an unrelated, legitimate raise) is why it stops at the exact case.
  */
 export function collectNearCeilingRatchetViolations(
   noticeUtilizationPct: number,
@@ -464,9 +484,32 @@ export function collectNearCeilingRatchetViolations(
   baseBundles: readonly ContextCeilingBundleStat[],
 ): string[] {
   const baseById = new Map(baseBundles.map((bundle) => [bundle.id, bundle]));
+  // `null` marks an ambiguous signature (shared by 2+ base bundles) so it is
+  // never mistaken for "no entry" (`undefined`, via a plain Map miss) --
+  // both must resolve to "no fallback match", but for different reasons.
+  const baseByFileSignature = new Map<
+    string,
+    ContextCeilingBundleStat | null
+  >();
+  for (const bundle of baseBundles) {
+    const signature = fileSetSignature(bundle.files);
+    if (signature === null) {
+      continue;
+    }
+    baseByFileSignature.set(
+      signature,
+      baseByFileSignature.has(signature) ? null : bundle,
+    );
+  }
+
   const errors: string[] = [];
   for (const current of currentBundles) {
-    const base = baseById.get(current.id);
+    const currentSignature = fileSetSignature(current.files);
+    const base =
+      baseById.get(current.id) ??
+      (currentSignature !== null
+        ? (baseByFileSignature.get(currentSignature) ?? undefined)
+        : undefined);
     if (
       !base ||
       current.limitBytes <= base.limitBytes ||
@@ -482,6 +525,18 @@ export function collectNearCeilingRatchetViolations(
     }
   }
   return errors;
+}
+
+/** Order-independent identity for a bundle's file membership, used only by
+ * {@link collectNearCeilingRatchetViolations}'s rename fallback. `null` for
+ * an empty or absent file list -- nothing to key a fallback match on. */
+function fileSetSignature(files: readonly string[] | undefined): string | null {
+  if (!files || files.length === 0) {
+    return null;
+  }
+  // \n as the join separator, not a space: a file path could
+  // plausibly contain a space, but never a literal newline.
+  return [...files].sort().join('\n');
 }
 
 /**

--- a/src/scripts/consistency-helpers.mts
+++ b/src/scripts/consistency-helpers.mts
@@ -458,33 +458,6 @@ export function collectContextCeilingViolations(
  * inclusive `>=`, matching that function's own notice-threshold comparison
  * ("reaches ... or more").
  */
-/**
- * Pick the effective `noticeUtilizationPct` for
- * {@link collectNearCeilingRatchetViolations} (#2697 Codex review finding
- * on PR #2736): a PR that raises both a bundle's `limitBytes` and the
- * `noticeUtilizationPct` threshold itself in the same change (e.g. 95 to
- * 97) could otherwise dodge the guard entirely -- a bundle sitting at 96%
- * under the OLD (base-ref) threshold reads as compliant against the NEW,
- * looser threshold, exactly the near-ceiling raise this check exists to
- * catch. Using the stricter (lower) of the base and current thresholds
- * closes that gap in both directions: raising the threshold cannot loosen
- * the check, and a repository that instead LOWERS the threshold in the
- * same PR gets the more conservative (lower) value applied immediately
- * rather than waiting a cycle. Falls back to `currentPct` alone when the
- * base ref's config is missing or not a valid non-negative number (a
- * repository adopting `contextCeiling` for the first time in this PR has
- * no base-ref threshold to compare against).
- */
-export function selectStricterNoticeUtilizationPct(
-  currentPct: number,
-  baseNoticeUtilizationPct: unknown,
-): number {
-  const basePct = Number(baseNoticeUtilizationPct);
-  return Number.isFinite(basePct) && basePct >= 0
-    ? Math.min(currentPct, basePct)
-    : currentPct;
-}
-
 export function collectNearCeilingRatchetViolations(
   noticeUtilizationPct: number,
   currentBundles: readonly ContextCeilingBundleStat[],
@@ -509,6 +482,39 @@ export function collectNearCeilingRatchetViolations(
     }
   }
   return errors;
+}
+
+/**
+ * Pick the effective `noticeUtilizationPct` for
+ * {@link collectNearCeilingRatchetViolations} (#2697 Codex review finding
+ * on PR #2736): a PR that raises both a bundle's `limitBytes` and the
+ * `noticeUtilizationPct` threshold itself in the same change (e.g. 95 to
+ * 97) could otherwise dodge the guard entirely -- a bundle sitting at 96%
+ * under the OLD (base-ref) threshold reads as compliant against the NEW,
+ * looser threshold, exactly the near-ceiling raise this check exists to
+ * catch. Using the stricter (lower) of the base and current thresholds
+ * closes that gap in both directions: raising the threshold cannot loosen
+ * the check, and a repository that instead LOWERS the threshold in the
+ * same PR gets the more conservative (lower) value applied immediately
+ * rather than waiting a cycle. Falls back to `currentPct` alone when the
+ * base ref's config is missing or not a valid non-negative number (a
+ * repository adopting `contextCeiling` for the first time in this PR has
+ * no base-ref threshold to compare against).
+ *
+ * Reuses {@link normalizeNonNegativeNumber}'s strict `typeof === 'number'`
+ * gate rather than a bare `Number(...)` coercion (CodeRabbit review finding
+ * on PR #2736): `Number(null)`, `Number('')`, and `Number(false)` all
+ * coerce to `0`, a valid-looking finite non-negative number that would
+ * silently defeat the documented "missing base value falls back to
+ * currentPct" contract and instead apply an effective 0% threshold --
+ * flagging every raised `limitBytes` regardless of actual utilization.
+ */
+export function selectStricterNoticeUtilizationPct(
+  currentPct: number,
+  baseNoticeUtilizationPct: unknown,
+): number {
+  const basePct = normalizeNonNegativeNumber(baseNoticeUtilizationPct);
+  return basePct === null ? currentPct : Math.min(currentPct, basePct);
 }
 
 // Words after which a `/` must start a regex literal, not division.

--- a/src/scripts/consistency-helpers.mts
+++ b/src/scripts/consistency-helpers.mts
@@ -432,6 +432,58 @@ export function collectContextCeilingViolations(
   return { errors, notices };
 }
 
+/**
+ * Collect "near-ceiling ratchet" violations (#2697): `docs/policy-constants.md`'s
+ * near-ceiling exception says raising a `bundleBudgets` bundle's `limitBytes`
+ * while that bundle was already near its ceiling should be avoided in favor
+ * of trimming or splitting the addition instead -- this mechanically
+ * enforces the exception, which was prose-only before this check existed.
+ *
+ * Pure (no I/O): the audit pipeline supplies the current bundle stats
+ * (`checkBundleBudgets`'s own summation, reused rather than re-measured
+ * here) and the equivalent stats measured from the base ref's manifest and
+ * file contents. `noticeUtilizationPct` reuses the same near-ceiling
+ * threshold {@link collectContextCeilingViolations} already surfaces as a
+ * notice, so the two checks agree on what "near-ceiling" means.
+ *
+ * No violation (silently skipped) when: the bundle is absent from
+ * `baseBundles` (a brand-new bundle has nothing to compare against); the
+ * bundle's `limitBytes` did not increase relative to the base ref (unchanged
+ * or decreased); or the base ref's own `limitBytes` is zero or negative
+ * (nothing meaningful to ratchet a utilization percentage from). Threshold
+ * comparison is cross-multiplied in byte space
+ * (`totalBytes * 100` vs. `limitBytes * pct`), matching
+ * {@link collectContextCeilingViolations}'s own convention so a bundle
+ * sitting exactly at the threshold does not tip over from float rounding;
+ * inclusive `>=`, matching that function's own notice-threshold comparison
+ * ("reaches ... or more").
+ */
+export function collectNearCeilingRatchetViolations(
+  noticeUtilizationPct: number,
+  currentBundles: readonly ContextCeilingBundleStat[],
+  baseBundles: readonly ContextCeilingBundleStat[],
+): string[] {
+  const baseById = new Map(baseBundles.map((bundle) => [bundle.id, bundle]));
+  const errors: string[] = [];
+  for (const current of currentBundles) {
+    const base = baseById.get(current.id);
+    if (
+      !base ||
+      current.limitBytes <= base.limitBytes ||
+      base.limitBytes <= 0
+    ) {
+      continue;
+    }
+    if (base.totalBytes * 100 >= base.limitBytes * noticeUtilizationPct) {
+      const baseUtilizationPct = (base.totalBytes / base.limitBytes) * 100;
+      errors.push(
+        `near-ceiling-ratchet: ${current.id} limitBytes raised from ${base.limitBytes} to ${current.limitBytes} while already at ${baseUtilizationPct.toFixed(2)}% utilization at the base ref (${base.totalBytes}/${base.limitBytes} bytes) -- docs/policy-constants.md's near-ceiling exception prefers trimming or splitting the addition over raising here`,
+      );
+    }
+  }
+  return errors;
+}
+
 // Words after which a `/` must start a regex literal, not division.
 const REGEX_PRECEDING_KEYWORDS = new Set([
   'return',

--- a/tests/near-ceiling-ratchet.test.mts
+++ b/tests/near-ceiling-ratchet.test.mts
@@ -1,9 +1,34 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import { collectNearCeilingRatchetViolations } from '../src/scripts/consistency-helpers.mts';
+import {
+  collectNearCeilingRatchetViolations,
+  selectStricterNoticeUtilizationPct,
+} from '../src/scripts/consistency-helpers.mts';
 
 const NOTICE_PCT = 95;
+
+test('selectStricterNoticeUtilizationPct keeps the current value when the base value is missing', () => {
+  assert.equal(selectStricterNoticeUtilizationPct(95, undefined), 95);
+});
+
+test('selectStricterNoticeUtilizationPct keeps the current value when the base value is not a valid number', () => {
+  assert.equal(selectStricterNoticeUtilizationPct(95, 'not-a-number'), 95);
+});
+
+test('selectStricterNoticeUtilizationPct picks the lower base value over a raised current value', () => {
+  // #2697 Codex review finding: raising noticeUtilizationPct in the same PR
+  // that raises a bundle's limitBytes must not loosen the guard.
+  assert.equal(selectStricterNoticeUtilizationPct(97, 95), 95);
+});
+
+test('selectStricterNoticeUtilizationPct picks the lower current value when the base value is higher', () => {
+  assert.equal(selectStricterNoticeUtilizationPct(90, 95), 90);
+});
+
+test('selectStricterNoticeUtilizationPct picks the shared value when base and current match', () => {
+  assert.equal(selectStricterNoticeUtilizationPct(95, 95), 95);
+});
 
 test('a brand-new bundle with no base-ref entry does not error', () => {
   const current = [{ id: 'bundle-new', limitBytes: 10000, totalBytes: 9000 }];

--- a/tests/near-ceiling-ratchet.test.mts
+++ b/tests/near-ceiling-ratchet.test.mts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { collectNearCeilingRatchetViolations } from '../src/scripts/consistency-helpers.mts';
+
+const NOTICE_PCT = 95;
+
+test('a brand-new bundle with no base-ref entry does not error', () => {
+  const current = [{ id: 'bundle-new', limitBytes: 10000, totalBytes: 9000 }];
+  const result = collectNearCeilingRatchetViolations(NOTICE_PCT, current, []);
+  assert.deepEqual(result, []);
+});
+
+test('limitBytes unchanged does not error even at high base utilization', () => {
+  const current = [{ id: 'bundle-a', limitBytes: 1000, totalBytes: 500 }];
+  const base = [{ id: 'bundle-a', limitBytes: 1000, totalBytes: 990 }];
+  const result = collectNearCeilingRatchetViolations(NOTICE_PCT, current, base);
+  assert.deepEqual(result, []);
+});
+
+test('limitBytes decreased does not error even at high base utilization', () => {
+  const current = [{ id: 'bundle-a', limitBytes: 900, totalBytes: 500 }];
+  const base = [{ id: 'bundle-a', limitBytes: 1000, totalBytes: 990 }];
+  const result = collectNearCeilingRatchetViolations(NOTICE_PCT, current, base);
+  assert.deepEqual(result, []);
+});
+
+test('limitBytes raised while base utilization is below the threshold does not error', () => {
+  const current = [{ id: 'bundle-a', limitBytes: 2000, totalBytes: 500 }];
+  const base = [{ id: 'bundle-a', limitBytes: 1000, totalBytes: 900 }];
+  const result = collectNearCeilingRatchetViolations(NOTICE_PCT, current, base);
+  assert.deepEqual(result, []);
+});
+
+test('limitBytes raised while base utilization is at or above the threshold errors', () => {
+  const current = [{ id: 'bundle-a', limitBytes: 2000, totalBytes: 1000 }];
+  const base = [{ id: 'bundle-a', limitBytes: 1000, totalBytes: 950 }];
+  const result = collectNearCeilingRatchetViolations(NOTICE_PCT, current, base);
+  assert.equal(result.length, 1);
+  assert.match(
+    result[0],
+    /bundle-a limitBytes raised from 1000 to 2000 while already at 95\.00% utilization at the base ref \(950\/1000 bytes\)/,
+  );
+});
+
+test('base utilization strictly above the threshold also errors', () => {
+  const current = [{ id: 'bundle-a', limitBytes: 2000, totalBytes: 1000 }];
+  const base = [{ id: 'bundle-a', limitBytes: 1000, totalBytes: 990 }];
+  const result = collectNearCeilingRatchetViolations(NOTICE_PCT, current, base);
+  assert.equal(result.length, 1);
+});
+
+test('a base limitBytes of zero is skipped (nothing to ratchet a percentage from)', () => {
+  const current = [{ id: 'bundle-a', limitBytes: 1000, totalBytes: 500 }];
+  const base = [{ id: 'bundle-a', limitBytes: 0, totalBytes: 0 }];
+  const result = collectNearCeilingRatchetViolations(NOTICE_PCT, current, base);
+  assert.deepEqual(result, []);
+});
+
+test('multiple bundles are evaluated independently', () => {
+  const current = [
+    { id: 'bundle-a', limitBytes: 2000, totalBytes: 1000 },
+    { id: 'bundle-b', limitBytes: 2000, totalBytes: 100 },
+  ];
+  const base = [
+    { id: 'bundle-a', limitBytes: 1000, totalBytes: 950 },
+    { id: 'bundle-b', limitBytes: 1000, totalBytes: 100 },
+  ];
+  const result = collectNearCeilingRatchetViolations(NOTICE_PCT, current, base);
+  assert.equal(result.length, 1);
+  assert.match(result[0], /bundle-a/);
+});

--- a/tests/near-ceiling-ratchet.test.mts
+++ b/tests/near-ceiling-ratchet.test.mts
@@ -30,6 +30,21 @@ test('selectStricterNoticeUtilizationPct picks the shared value when base and cu
   assert.equal(selectStricterNoticeUtilizationPct(95, 95), 95);
 });
 
+// CodeRabbit review finding on PR #2736: a bare `Number(...)` coercion turns
+// each of these into a valid-looking `0`, which would wrongly apply an
+// effective 0% threshold instead of falling back to currentPct.
+test('selectStricterNoticeUtilizationPct falls back to currentPct for null', () => {
+  assert.equal(selectStricterNoticeUtilizationPct(95, null), 95);
+});
+
+test('selectStricterNoticeUtilizationPct falls back to currentPct for an empty string', () => {
+  assert.equal(selectStricterNoticeUtilizationPct(95, ''), 95);
+});
+
+test('selectStricterNoticeUtilizationPct falls back to currentPct for false', () => {
+  assert.equal(selectStricterNoticeUtilizationPct(95, false), 95);
+});
+
 test('a brand-new bundle with no base-ref entry does not error', () => {
   const current = [{ id: 'bundle-new', limitBytes: 10000, totalBytes: 9000 }];
   const result = collectNearCeilingRatchetViolations(NOTICE_PCT, current, []);

--- a/tests/near-ceiling-ratchet.test.mts
+++ b/tests/near-ceiling-ratchet.test.mts
@@ -110,3 +110,81 @@ test('multiple bundles are evaluated independently', () => {
   assert.equal(result.length, 1);
   assert.match(result[0], /bundle-a/);
 });
+
+// Codex review finding on PR #2736: an id rename alone must not exempt an
+// already-near-ceiling bundle from this guard as though it were brand-new.
+test('a bundle renamed with an identical file set is matched by the rename fallback and errors', () => {
+  const files = ['a.md', 'b.md'];
+  const current = [
+    { id: 'bundle-a-v2', limitBytes: 2000, totalBytes: 1000, files },
+  ];
+  const base = [{ id: 'bundle-a', limitBytes: 1000, totalBytes: 950, files }];
+  const result = collectNearCeilingRatchetViolations(NOTICE_PCT, current, base);
+  assert.equal(result.length, 1);
+  assert.match(result[0], /bundle-a-v2 limitBytes raised from 1000 to 2000/);
+});
+
+test('a bundle renamed with an identical file set and an unchanged limitBytes does not error', () => {
+  const files = ['a.md', 'b.md'];
+  const current = [
+    { id: 'bundle-a-v2', limitBytes: 1000, totalBytes: 950, files },
+  ];
+  const base = [{ id: 'bundle-a', limitBytes: 1000, totalBytes: 950, files }];
+  const result = collectNearCeilingRatchetViolations(NOTICE_PCT, current, base);
+  assert.deepEqual(result, []);
+});
+
+test('a bundle renamed with a different file set is treated as genuinely new, not a rename', () => {
+  const current = [
+    {
+      id: 'bundle-a-v2',
+      limitBytes: 2000,
+      totalBytes: 1000,
+      files: ['a.md', 'c.md'],
+    },
+  ];
+  const base = [
+    {
+      id: 'bundle-a',
+      limitBytes: 1000,
+      totalBytes: 950,
+      files: ['a.md', 'b.md'],
+    },
+  ];
+  const result = collectNearCeilingRatchetViolations(NOTICE_PCT, current, base);
+  assert.deepEqual(result, []);
+});
+
+test('two base bundles sharing an identical file set are ambiguous and never used as a rename match', () => {
+  const files = ['a.md', 'b.md'];
+  const current = [
+    { id: 'bundle-a-v2', limitBytes: 2000, totalBytes: 1000, files },
+  ];
+  const base = [
+    { id: 'bundle-a', limitBytes: 1000, totalBytes: 950, files },
+    { id: 'bundle-a-dup', limitBytes: 1000, totalBytes: 950, files },
+  ];
+  const result = collectNearCeilingRatchetViolations(NOTICE_PCT, current, base);
+  assert.deepEqual(result, []);
+});
+
+test('file order does not affect the rename fallback match', () => {
+  const current = [
+    {
+      id: 'bundle-a-v2',
+      limitBytes: 2000,
+      totalBytes: 1000,
+      files: ['b.md', 'a.md'],
+    },
+  ];
+  const base = [
+    {
+      id: 'bundle-a',
+      limitBytes: 1000,
+      totalBytes: 950,
+      files: ['a.md', 'b.md'],
+    },
+  ];
+  const result = collectNearCeilingRatchetViolations(NOTICE_PCT, current, base);
+  assert.equal(result.length, 1);
+});


### PR DESCRIPTION
# Summary

`docs/policy-constants.md`'s near-ceiling exception says once a
`bundleBudgets` bundle is already at roughly 95% or more `limitBytes`
utilization, the convention prefers trimming or splitting the net addition
over another ratchet raise. Nothing enforced this mechanically:
`checkBundleBudgets` only compares the working tree against the current
limit, with no git/base-ref awareness, so it cannot distinguish
"utilization crept up while the limit stayed put" (fine) from "the limit
itself was just raised while already near-ceiling" (a policy violation).
This was not hypothetical: `bundle-review` and `bundle-review-fix-lite`
were both raised past this threshold in an earlier PR this session, caught
only by a Codex review finding, not by lint/`audit-docs` at authoring
time.

- Added `collectNearCeilingRatchetViolations` (`consistency-helpers.mts`):
  a pure comparison between current and base-ref bundle stats, reusing
  `contextCeiling`'s own `noticeUtilizationPct` (95%) so both checks agree
  on what "near-ceiling" means. Skips a brand-new bundle (no base-ref
  entry) and a `limitBytes` decrease/no-change, matching the acceptance
  criteria's pass cases.
- Added `checkNearCeilingRatchet` (`audit-docs.mts`): resolves a base ref
  (PR base sha, `GITHUB_BASE_REF`, then `origin/main`), reads the base
  ref's own `audit/sync-manifest.json` and bundle member files via
  `git show`, and feeds the resulting stats to the pure collector.
  Degrades to a notice (never blocks the whole audit) when a base ref or
  the base manifest cannot be read, matching `listChangedFiles`'s own
  graceful-skip precedent for missing git context.
- Documented the new mechanical enforcement in
  `idd-template/docs/policy-constants.md` (canonical source; synced to
  `docs/policy-constants.md`).
- Unit tests for the pure collector's every branch; manually verified
  end-to-end against this repo's own git history (a temporary `limitBytes`
  bump on an already-96%-utilized bundle correctly failed the check,
  reverted after confirming).

## Linked issue

Closes #2697

## Follow-up issues (if any)

- [x] #2734 (unrelated, discovered during A4.5 triage of this issue: a
      `suitability-triage.mjs` Check 3 false positive on ordinary
      feature-spec prose describing this issue's own proposed check's
      skip condition -- manually overridden with a documented,
      evidence-backed rationale before claiming; not fixed in this PR)

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191MCYGribBmSeRVTk3AxQ6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bundle-budget audits now recognize renamed bundles when their file composition is unchanged.
  * Checks apply the stricter applicable utilization threshold with validated numeric values.

* **Bug Fixes**
  * Audits now skip near-ceiling comparisons with a notice when base revision data cannot be read.
  * ID-only bundle renames are no longer treated as new bundles.

* **Documentation**
  * Clarified bundle-budget enforcement rules and skipped-comparison scenarios.

* **Tests**
  * Added coverage for renamed bundles, ambiguous matches, file composition, thresholds, invalid values, and unavailable base data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->