### PR TITLE
docs(issue-authoring): require a permalink/artifact citation for live-observed Background claims

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -513,6 +513,25 @@ Ask these checks:
    default (observed 2026-08-12/13 on an adopter repository,
    `setup.ubuntu`, kurone-kito/idd-skill#2012).
 
+## Live-observed claim citation
+
+When a drafted issue's Background section asserts a "live observed"
+runtime behavior claim (as opposed to a claim verifiable by reading
+static source), cite a concrete, checkable artifact for it — a
+permalink, a PR/comment/run ID, or an inline reproduction snippet —
+rather than only a prose description of the observed event. A drafting
+session that already has the artifact in hand (a PR review thread, a
+workflow run, an adopter's own report) should cite it directly instead
+of paraphrasing from memory; a worked example already exists elsewhere
+in this file: "(observed 2026-08-12/13 on an adopter repository,
+`setup.ubuntu`, kurone-kito/idd-skill#2012)".
+
+This is not a mechanical `audit-authored-issue` gate check: a
+live-observed claim is prose-level and not reliably machine-detectable
+without a high false-positive risk. Apply this discipline at drafting
+time instead, before an unsupported claim ships in a Background section
+another session or reviewer cannot independently re-verify.
+
 ## Dependency minimization
 
 Encode a dependency edge only when it reflects a true correctness,

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -515,9 +515,10 @@ Ask these checks:
 
 ## Live-observed claim citation
 
-When a drafted issue's Background section asserts a "live observed"
-runtime behavior claim (as opposed to a claim verifiable by reading
-static source), cite a concrete, checkable artifact for it — a
+When a drafted issue's Background section (or its `## Goal` / `## Why
+this matters` equivalent, per the schema in use) asserts a "live
+observed" runtime behavior claim (as opposed to a claim verifiable by
+reading static source), cite a concrete, checkable artifact for it — a
 permalink, a PR/comment/run ID, or an inline reproduction snippet —
 rather than only a prose description of the observed event. A drafting
 session that already has the artifact in hand (a PR review thread, a
@@ -529,8 +530,9 @@ in this file: "(observed 2026-08-12/13 on an adopter repository,
 This is not a mechanical `audit-authored-issue` gate check: a
 live-observed claim is prose-level and not reliably machine-detectable
 without a high false-positive risk. Apply this discipline at drafting
-time instead, before an unsupported claim ships in a Background section
-another session or reviewer cannot independently re-verify.
+time instead, before an unsupported claim ships in one of these
+sections that another session or reviewer cannot independently
+re-verify.
 
 ## Dependency minimization
 

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -552,9 +552,10 @@ Ask these checks:
 
 ## Live-observed claim citation
 
-When a drafted issue's Background section asserts a "live observed"
-runtime behavior claim (as opposed to a claim verifiable by reading
-static source), cite a concrete, checkable artifact for it — a
+When a drafted issue's Background section (or its `## Goal` / `## Why
+this matters` equivalent, per the schema in use) asserts a "live
+observed" runtime behavior claim (as opposed to a claim verifiable by
+reading static source), cite a concrete, checkable artifact for it — a
 permalink, a PR/comment/run ID, or an inline reproduction snippet —
 rather than only a prose description of the observed event. A drafting
 session that already has the artifact in hand (a PR review thread, a
@@ -566,8 +567,9 @@ in this file: "(observed 2026-08-12/13 on an adopter repository,
 This is not a mechanical `audit-authored-issue` gate check: a
 live-observed claim is prose-level and not reliably machine-detectable
 without a high false-positive risk. Apply this discipline at drafting
-time instead, before an unsupported claim ships in a Background section
-another session or reviewer cannot independently re-verify.
+time instead, before an unsupported claim ships in one of these
+sections that another session or reviewer cannot independently
+re-verify.
 
 ## Alignment with A4.5 Suitability Gate
 

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -550,6 +550,25 @@ Ask these checks:
    default (observed 2026-08-12/13 on an adopter repository,
    `setup.ubuntu`, kurone-kito/idd-skill#2012).
 
+## Live-observed claim citation
+
+When a drafted issue's Background section asserts a "live observed"
+runtime behavior claim (as opposed to a claim verifiable by reading
+static source), cite a concrete, checkable artifact for it — a
+permalink, a PR/comment/run ID, or an inline reproduction snippet —
+rather than only a prose description of the observed event. A drafting
+session that already has the artifact in hand (a PR review thread, a
+workflow run, an adopter's own report) should cite it directly instead
+of paraphrasing from memory; a worked example already exists elsewhere
+in this file: "(observed 2026-08-12/13 on an adopter repository,
+`setup.ubuntu`, kurone-kito/idd-skill#2012)".
+
+This is not a mechanical `audit-authored-issue` gate check: a
+live-observed claim is prose-level and not reliably machine-detectable
+without a high false-positive risk. Apply this discipline at drafting
+time instead, before an unsupported claim ships in a Background section
+another session or reviewer cannot independently re-verify.
+
 ## Alignment with A4.5 Suitability Gate
 
 The IDD discover phase uses an A4.5 pre-claim suitability gate that

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -513,6 +513,25 @@ Ask these checks:
    default (observed 2026-08-12/13 on an adopter repository,
    `setup.ubuntu`, kurone-kito/idd-skill#2012).
 
+## Live-observed claim citation
+
+When a drafted issue's Background section asserts a "live observed"
+runtime behavior claim (as opposed to a claim verifiable by reading
+static source), cite a concrete, checkable artifact for it — a
+permalink, a PR/comment/run ID, or an inline reproduction snippet —
+rather than only a prose description of the observed event. A drafting
+session that already has the artifact in hand (a PR review thread, a
+workflow run, an adopter's own report) should cite it directly instead
+of paraphrasing from memory; a worked example already exists elsewhere
+in this file: "(observed 2026-08-12/13 on an adopter repository,
+`setup.ubuntu`, kurone-kito/idd-skill#2012)".
+
+This is not a mechanical `audit-authored-issue` gate check: a
+live-observed claim is prose-level and not reliably machine-detectable
+without a high false-positive risk. Apply this discipline at drafting
+time instead, before an unsupported claim ships in a Background section
+another session or reviewer cannot independently re-verify.
+
 ## Dependency minimization
 
 Encode a dependency edge only when it reflects a true correctness,

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -515,9 +515,10 @@ Ask these checks:
 
 ## Live-observed claim citation
 
-When a drafted issue's Background section asserts a "live observed"
-runtime behavior claim (as opposed to a claim verifiable by reading
-static source), cite a concrete, checkable artifact for it — a
+When a drafted issue's Background section (or its `## Goal` / `## Why
+this matters` equivalent, per the schema in use) asserts a "live
+observed" runtime behavior claim (as opposed to a claim verifiable by
+reading static source), cite a concrete, checkable artifact for it — a
 permalink, a PR/comment/run ID, or an inline reproduction snippet —
 rather than only a prose description of the observed event. A drafting
 session that already has the artifact in hand (a PR review thread, a
@@ -529,8 +530,9 @@ in this file: "(observed 2026-08-12/13 on an adopter repository,
 This is not a mechanical `audit-authored-issue` gate check: a
 live-observed claim is prose-level and not reliably machine-detectable
 without a high false-positive risk. Apply this discipline at drafting
-time instead, before an unsupported claim ships in a Background section
-another session or reviewer cannot independently re-verify.
+time instead, before an unsupported claim ships in one of these
+sections that another session or reviewer cannot independently
+re-verify.
 
 ## Dependency minimization
 


### PR DESCRIPTION
# Summary

Issue #2710 (closed, unmerged) asserted in its Background: "Observed
live: after an IDD agent posts its own disposition reply and resolves a
thread itself, CodeRabbit sometimes posts a distinct courtesy
follow-up..." -- describing a specific live GitHub event, with no
permalink, comment ID, PR number, or timestamp attached. A fix was
implemented against that premise; a subsequent empirical search across
this repository's real PR history found zero occurrences of the
asserted marker appearing without the pre-existing, already-recognized
closure phrase -- the premise did not hold. The PR was closed unmerged
after re-verification. This was a legitimate empirical process working
as intended, but it consumed a full implement-review-revert cycle that
a cheaper up-front citation check could plausibly have caught.

Neither `skills/issue-authoring/references/contract.md` (the canonical
bundled contract) nor `docs/issue-authoring-skill.md` (its independent
maintenance-doc counterpart) previously stated a citation requirement
for a drafted issue's own live-observed runtime claims, even though a
worked example elsewhere in both files already models good practice
organically (a citation with date, repository, and issue reference).

- Added a "Live-observed claim citation" section to both files: a
  Background section asserting a "live observed" runtime behavior claim
  must cite a concrete, checkable artifact for it -- a permalink,
  PR/comment/run ID, or an inline reproduction snippet -- rather than
  only a prose description of the observed event.
- Deliberately scoped as a drafting-time discipline, not a new
  mechanical `audit-authored-issue.mjs` gate check: a live-observed
  claim is prose-level and not reliably machine-detectable without a
  high false-positive risk.
- `docs/issue-authoring-skill.md` independently restates this content
  (its own "Codebase-fidelity validation" section exists separately
  from the canonical file's, not merely as a link), so it was updated
  in the same commit per the issue's own acceptance criteria.

## A4.5 note

This issue's own body quotes "Observed live:" as a past-tense excerpt
of issue #2710's disproven claim (historical motivating context), not a
precondition this issue's own scope needs before starting. The A0-O
`discover-orphan-filter.mjs` convenience listing mechanically excludes
it as `runtime_observation_precondition` (a phrase-list match, #2467) --
a false positive on manual re-reading against the written A3 rule.
`discover-readiness-check.mjs` (A3's own canonical readiness check) and
`suitability-triage.mjs` (the full A4.5 seven-check gate) both report
`ready`. Documented as a triage note on the issue before claiming; see
Follow-up issues below for the filter gap itself.

## Linked issue

Closes #2739

## Follow-up issues (if any)

- [ ] `discover-orphan-filter.mjs`'s `runtime_observation_precondition`
      detection (#2467) is a bare phrase-list match with no exclusion
      for a match that appears only as a quoted excerpt of a different,
      referenced issue's claim. Worth narrowing so a documentation issue
      *about* live-observation citation discipline (like this one) does
      not itself get excluded from the A0-O orphan listing.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191MCYGribBmSeRVTk3AxQ6
