### PR TITLE
fix(discover-viability-gate): exclude non-blocking coordination matches

### DIFF
--- a/scripts/discover-viability-gate.mjs
+++ b/scripts/discover-viability-gate.mjs
@@ -107,15 +107,19 @@ const NEGATION_CUE_PATTERN =
 const NEGATION_CUE_WINDOW = 40;
 const NEGATION_CANCELING_CONJUNCTION_PATTERN = /\b(until|unless|without)\b/i;
 // A backward-looking cue (negation or investigative past tense, below)
-// stops governing a match at a period/semicolon/em-dash (HARD_CLAUSE_BREAK_
-// PATTERN, shared with the broad-scope exclusions above), a blank line, or
-// a following list-item marker -- a bullet's own negation must not reach
-// into a SIBLING bullet's independent claim. A bare mid-paragraph newline
-// (a soft-wrapped line) is deliberately not a break here: #2711's own
-// wrapped quotation shows ordinary prose legitimately continuing a clause
-// across one.
+// stops governing a match at a period/semicolon/colon/em-dash, a blank
+// line, or a following list-item marker -- a bullet's own negation must
+// not reach into a SIBLING bullet's independent claim, and a colon
+// introducing an independent requirement ("No workaround: production
+// access is required before shipping" -- Codex review round 3, PR #2757)
+// must not let the preceding negation cross into it. The pattern below
+// (CUE_HARD_BREAK_PATTERN) is a superset of HARD_CLAUSE_BREAK_PATTERN
+// (period/semicolon/em-dash only), which the broad-scope exclusions
+// above use. A bare mid-paragraph newline (a soft-wrapped line) is
+// deliberately not a break here: #2711's own wrapped quotation shows
+// ordinary prose legitimately continuing a clause across one.
 const CUE_HARD_BREAK_PATTERN =
-  /[.;—]|--|\n[ \t]*(?:[-*]\s|\d+[.)]\s)|\n[ \t]*\n/;
+  /[.;:—]|--|\n[ \t]*(?:[-*]\s|\d+[.)]\s)|\n[ \t]*\n/;
 function isGovernedByBackwardCue(
   corpus,
   matchIndex,
@@ -181,16 +185,19 @@ const INVESTIGATIVE_PAST_TENSE_WINDOW = 80;
 //    this issue ("...a least-privilege CI credential pattern..." -- an
 //    incidental background mention in #2716's own real body, distinct
 //    from that same issue's separately negated target phrase), UNLESS a
-//    requirement-assertion cue (must/require/need/shall/...) sits in the
-//    same clause -- `A credential approach MUST be supplied by the
-//    maintainer before implementation` (Codex review, PR #2757) still
-//    imposes a live requirement despite the generic-sounding noun.
+//    requirement-assertion cue (must/require/need/shall/blocked/pending/
+//    ...) sits in the same clause -- `A credential approach MUST be
+//    supplied by the maintainer before implementation` (Codex review, PR
+//    #2757) still imposes a live requirement despite the generic-sounding
+//    noun. `blocked`/`pending` cover emphasis-quoting with no must/require
+//    wording of its own ("Shipping remains BLOCKED PENDING 'production
+//    access'" -- Codex review round 3, PR #2757).
 const GENERIC_MENTION_NOUN_PATTERN =
   /^(pattern|example|scenario|convention|practice|concept|term|approach|precedent|case)$/i;
 const GENERIC_MENTION_LOOKAHEAD_CHARS = 40;
 const GENERIC_MENTION_LOOKAHEAD_TOKENS = 2;
 const REQUIREMENT_ASSERTION_PATTERN =
-  /\b(must|require[sd]?|requiring|needed|needs?|shall|mandatory|essential)\b/i;
+  /\b(must|require[sd]?|requiring|needed|needs?|shall|mandatory|essential|blocked|blocking|pending)\b/i;
 const REQUIREMENT_ASSERTION_WINDOW_CHARS = 80;
 // Flag-spec keys stay the dashed literal on purpose (never bare keys like
 // `issue:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
@@ -312,28 +319,65 @@ export function evaluateA4Viability(issue) {
     criteria,
   };
 }
-// CommonMark code spans open and close on a run of backticks of the SAME
-// length (a multi-backtick delimiter, e.g. ``` `` ```, lets literal single
-// backticks appear inside), not on individual-backtick parity -- a run of a
-// different length while a span is open is literal content, not a closer
-// (#2738 Codex review round 2, PR #2757). A fresh regex literal per call
-// (rather than a shared module-level one) sidesteps both the CLI-entry TDZ
-// ordering rule this file's helpers must follow (see the flag-spec comment
-// below) and any `lastIndex` state leaking across calls.
+// CommonMark inline code spans open and close on a run of backticks of the
+// SAME length (a multi-backtick delimiter, e.g. ``` `` ```, lets literal
+// single backticks appear inside), not on individual-backtick parity -- a
+// run of a different length while a span is open is literal content, not a
+// closer (#2738 Codex review round 2, PR #2757). A FENCED code block is
+// different: its opening run sits alone on a line (only leading
+// whitespace before it) and has length >= 3, and CommonMark lets the
+// closing fence be LONGER than the opener, not just equal (a fence opened
+// with ``` and closed with ```` is still a valid, closed block -- Codex
+// review round 3, PR #2757); an exact-length-only rule leaves such a block
+// wrongly "open" for the rest of the corpus. A run only counts as a fence
+// marker when it sits alone on its line; an inline run of 3+ backticks
+// (e.g. all on one line) still requires an exact-length closer. A fresh
+// regex literal per call (rather than a shared module-level one)
+// sidesteps both the CLI-entry TDZ ordering rule this file's helpers must
+// follow (see the flag-spec comment below) and any `lastIndex` state
+// leaking across calls.
+function isAloneOnLine(corpus, runStart, runEnd) {
+  let before = runStart - 1;
+  while (before >= 0 && (corpus[before] === ' ' || corpus[before] === '\t')) {
+    before--;
+  }
+  if (before >= 0 && corpus[before] !== '\n') {
+    return false;
+  }
+  let after = runEnd;
+  while (
+    after < corpus.length &&
+    (corpus[after] === ' ' || corpus[after] === '\t')
+  ) {
+    after++;
+  }
+  return after >= corpus.length || corpus[after] === '\n';
+}
 function isInsideCodeSpan(corpus, index) {
   const runPattern = /`+/g;
-  let openRunLength = null;
+  let open = null;
   let match = runPattern.exec(corpus);
   while (match !== null && match.index < index) {
     const runLength = match[0].length;
-    if (openRunLength === null) {
-      openRunLength = runLength;
-    } else if (runLength === openRunLength) {
-      openRunLength = null;
+    const runEnd = match.index + runLength;
+    if (open === null) {
+      open = {
+        length: runLength,
+        isFence: runLength >= 3 && isAloneOnLine(corpus, match.index, runEnd),
+      };
+    } else if (open.isFence) {
+      if (
+        runLength >= open.length &&
+        isAloneOnLine(corpus, match.index, runEnd)
+      ) {
+        open = null;
+      }
+    } else if (runLength === open.length) {
+      open = null;
     }
     match = runPattern.exec(corpus);
   }
-  return openRunLength !== null;
+  return open !== null;
 }
 function isGovernedByAvoidanceCue(corpus, matchIndex) {
   const windowStart = Math.max(0, matchIndex - AVOIDANCE_CUE_WINDOW);

--- a/scripts/discover-viability-gate.mjs
+++ b/scripts/discover-viability-gate.mjs
@@ -93,15 +93,19 @@ const EXTERNAL_COORDINATION_PATTERN =
 // 1. Negation: the match is governed by a negation cue reaching it with no
 //    hard clause break in between ("no interactive credential minting" --
 //    #2716). `zero` excludes a hyphenated compound ("zero-downtime") so it
-//    is never mistaken for a standalone negation word. A canceling
+//    is never mistaken for a standalone negation word. `without` is a
+//    canceling word, not a cue of its own: "cannot complete this WITHOUT
+//    production access" asserts the access is required, the mirror image
+//    of "no access needed" (Codex review round 2, PR #2757) -- as a
+//    standalone cue it wrongly negated exactly that shape. A canceling
 //    conjunction ("do not proceed UNTIL production access is granted" --
 //    Codex review, PR #2757) flips the negation back to an affirmative
 //    prerequisite: the cue negates the verb before the conjunction, not
 //    the requirement named after it.
 const NEGATION_CUE_PATTERN =
-  /\b(no|not|without|zero(?!-)|never|none|isn'?t|aren'?t|wasn'?t|weren'?t|doesn'?t|don'?t|didn'?t|won'?t|can'?t|cannot)\b/gi;
+  /\b(no|not|zero(?!-)|never|none|isn'?t|aren'?t|wasn'?t|weren'?t|doesn'?t|don'?t|didn'?t|won'?t|can'?t|cannot)\b/gi;
 const NEGATION_CUE_WINDOW = 40;
-const NEGATION_CANCELING_CONJUNCTION_PATTERN = /\b(until|unless)\b/i;
+const NEGATION_CANCELING_CONJUNCTION_PATTERN = /\b(until|unless|without)\b/i;
 // A backward-looking cue (negation or investigative past tense, below)
 // stops governing a match at a period/semicolon/em-dash (HARD_CLAUSE_BREAK_
 // PATTERN, shared with the broad-scope exclusions above), a blank line, or
@@ -136,23 +140,28 @@ function isGovernedByBackwardCue(
 }
 // 2. Quoted example: the match sits on a Markdown blockquote line (an
 //    unambiguous citation on its own), or is bounded by a matching pair of
-//    quote characters within the containing paragraph AND that paragraph
-//    also carries a framing/attribution verb (#2711's inverted-attribution
-//    quotation shape, which soft-wraps the quoted marker across a line
-//    break -- scoped to the paragraph, not the physical line, so that wrap
-//    doesn't defeat the pairing). The framing-verb requirement distinguishes
-//    a genuine cited example from ordinary emphasis-quoting of this issue's
-//    own requirement (`The change requires "production access" before it
-//    can ship` -- Codex review, PR #2757): quote characters alone, with no
-//    reporting/citation cue anywhere in the paragraph, do not exclude. A
-//    plain straight single quote also marks a contraction ("doesn't") or a
-//    possessive after a digit ("2020's"), so a candidate quote character
-//    counts as an opener only when the character right before it is
-//    neither a letter nor a digit, and as a closer only when the character
-//    right after it is neither a letter nor a digit -- a contraction's or
-//    digit-possessive's apostrophe always sits directly adjacent to a
-//    letter or digit on at least one side and fails one of those checks
-//    (Copilot review, PR #2757).
+//    quote characters within the containing paragraph (#2711's
+//    inverted-attribution quotation shape, which soft-wraps the quoted
+//    marker across a line break -- scoped to the paragraph, not the
+//    physical line, so that wrap doesn't defeat the pairing) AND no nearby
+//    requirement-assertion word (4, below) overrides it -- a paired quote
+//    alone does not distinguish a genuine cited example from ordinary
+//    emphasis-quoting of this issue's own requirement (`The change
+//    requires "production access" before it can ship` -- Codex review,
+//    PR #2757); a framing/attribution-verb requirement was tried first but
+//    over-scoped to a whole paragraph (wrongly attributing an unrelated
+//    sentence's own reporting verb) or under-scoped to one sentence
+//    (missing a genuine citation with no reporting verb of its own, as in
+//    #2711's own real body -- Codex review round 2, PR #2757); reusing the
+//    requirement-assertion check already built for generic mentions (4)
+//    avoids both failure modes. A plain straight single quote also marks a
+//    contraction ("doesn't") or a possessive after a digit ("2020's"), so a
+//    candidate quote character counts as an opener only when the character
+//    right before it is neither a letter nor a digit, and as a closer only
+//    when the character right after it is neither a letter nor a digit --
+//    a contraction's or digit-possessive's apostrophe always sits directly
+//    adjacent to a letter or digit on at least one side and fails one of
+//    those checks (Copilot review, PR #2757).
 const QUOTE_CHAR_PAIRS = {
   '"': '"',
   "'": "'",
@@ -160,8 +169,6 @@ const QUOTE_CHAR_PAIRS = {
   '“': '”',
 };
 const QUOTE_ADJACENT_WORD_CHAR_PATTERN = /[A-Za-z0-9]/;
-const QUOTED_EXAMPLE_FRAMING_VERB_PATTERN =
-  /\b(documents?|describes?|says?|states?|explains?|reports?|quotes?|quoted|cites?|cited)\b/i;
 const PARAGRAPH_BREAK_PATTERN = /\n[ \t]*\n/g;
 // 3. Investigative past tense: the match describes an investigation the
 //    issue author already performed while drafting, not remaining work
@@ -305,14 +312,28 @@ export function evaluateA4Viability(issue) {
     criteria,
   };
 }
+// CommonMark code spans open and close on a run of backticks of the SAME
+// length (a multi-backtick delimiter, e.g. ``` `` ```, lets literal single
+// backticks appear inside), not on individual-backtick parity -- a run of a
+// different length while a span is open is literal content, not a closer
+// (#2738 Codex review round 2, PR #2757). A fresh regex literal per call
+// (rather than a shared module-level one) sidesteps both the CLI-entry TDZ
+// ordering rule this file's helpers must follow (see the flag-spec comment
+// below) and any `lastIndex` state leaking across calls.
 function isInsideCodeSpan(corpus, index) {
-  let backtickCount = 0;
-  for (let i = 0; i < index; i += 1) {
-    if (corpus[i] === '`') {
-      backtickCount += 1;
+  const runPattern = /`+/g;
+  let openRunLength = null;
+  let match = runPattern.exec(corpus);
+  while (match !== null && match.index < index) {
+    const runLength = match[0].length;
+    if (openRunLength === null) {
+      openRunLength = runLength;
+    } else if (runLength === openRunLength) {
+      openRunLength = null;
     }
+    match = runPattern.exec(corpus);
   }
-  return backtickCount % 2 === 1;
+  return openRunLength !== null;
 }
 function isGovernedByAvoidanceCue(corpus, matchIndex) {
   const windowStart = Math.max(0, matchIndex - AVOIDANCE_CUE_WINDOW);
@@ -460,10 +481,6 @@ function isInsideQuotedExample(corpus, matchIndex, matchEnd) {
     corpus,
     matchIndex,
   );
-  const paragraph = corpus.slice(paragraphStart, paragraphEnd);
-  if (!QUOTED_EXAMPLE_FRAMING_VERB_PATTERN.test(paragraph)) {
-    return false;
-  }
   const before = corpus.slice(paragraphStart, matchIndex);
   const after = corpus.slice(matchEnd, paragraphEnd);
   for (const [open, close] of Object.entries(QUOTE_CHAR_PAIRS)) {
@@ -481,7 +498,12 @@ function isInsideQuotedExample(corpus, matchIndex, matchEnd) {
     ) {
       continue;
     }
-    return true;
+    // A paired quote alone is not proof of external citation -- a nearby
+    // requirement-assertion word means the quotes are just emphasizing
+    // THIS issue's own live requirement ("The change requires 'production
+    // access' before it can ship" -- Codex review round 2, PR #2757),
+    // regardless of unrelated framing prose elsewhere in the paragraph.
+    return !isNearRequirementAssertion(corpus, matchIndex, matchEnd);
   }
   return false;
 }
@@ -568,7 +590,15 @@ function findUnexcludedExternalCoordinationMatch(corpus) {
   return null;
 }
 export function evaluateAutonomousCompletion(issue) {
-  const corpus = `${issue.title}\n${issue.body}`;
+  // A blank line (not a bare "\n") between title and body, unlike the
+  // other two evaluate* functions' corpus join: CUE_HARD_BREAK_PATTERN
+  // treats "\n[ \t]*\n" as a hard break, so a negation or past-investigation
+  // cue in the title can never govern a match in the body (a short title
+  // like "No credential changes" must not suppress a genuine body blocker
+  // -- Codex review round 2, PR #2757). An ordinary soft-wrapped line
+  // inside the body is still a single "\n" and remains ungoverned by this
+  // rule, per #2711's own wrapped-quotation requirement.
+  const corpus = `${issue.title}\n\n${issue.body}`;
   const match = findUnexcludedExternalCoordinationMatch(corpus);
   if (match !== null) {
     return {

--- a/scripts/discover-viability-gate.mjs
+++ b/scripts/discover-viability-gate.mjs
@@ -81,7 +81,81 @@ const OBJECTIVE_VERIFICATION_PATTERN =
 const SUBJECTIVE_VERIFICATION_PATTERN =
   /\b(feels?|looks? good|opinion|judgement?|ux call|maintainer preference|stakeholder preference|subjective)\b/i;
 const EXTERNAL_COORDINATION_PATTERN =
-  /\b(external coordination|human decision|maintainer decision|stakeholder sign-?off|manual approval|waiting for (?:maintainer|stakeholder)|external system|third-?party access|credential|production access|cross-repo dependency)\b/i;
+  /\b(external coordination|human decision|maintainer decision|stakeholder sign-?off|manual approval|waiting for (?:maintainer|stakeholder)|external system|third-?party access|credential|production access|cross-repo dependency)\b/gi;
+// A trigger phrase inside a phrase describing something other than a live,
+// remaining completion blocker should not count (#2738), mirroring
+// findUnexcludedBroadScopeMatch's per-occurrence shape above: a negated
+// non-requirement, a quoted/cited example of another artifact's own
+// content, a past-tense description of an investigation the issue author
+// already finished while drafting, or a generic mention of a pattern/
+// concept rather than an asserted requirement.
+//
+// 1. Negation: the match is governed by a negation cue reaching it with no
+//    hard clause break in between ("no interactive credential minting" --
+//    #2716). `zero` excludes a hyphenated compound ("zero-downtime") so it
+//    is never mistaken for a standalone negation word.
+const NEGATION_CUE_PATTERN =
+  /\b(no|not|without|zero(?!-)|never|none|isn'?t|aren'?t|wasn'?t|weren'?t|doesn'?t|don'?t|didn'?t|won'?t|can'?t|cannot)\b/gi;
+const NEGATION_CUE_WINDOW = 40;
+// A backward-looking cue (negation or investigative past tense, below)
+// stops governing a match at a period/semicolon/em-dash (HARD_CLAUSE_BREAK_
+// PATTERN, shared with the broad-scope exclusions above), a blank line, or
+// a following list-item marker -- a bullet's own negation must not reach
+// into a SIBLING bullet's independent claim. A bare mid-paragraph newline
+// (a soft-wrapped line) is deliberately not a break here: #2711's own
+// wrapped quotation shows ordinary prose legitimately continuing a clause
+// across one.
+const CUE_HARD_BREAK_PATTERN =
+  /[.;—]|--|\n[ \t]*(?:[-*]\s|\d+[.)]\s)|\n[ \t]*\n/;
+function isGovernedByBackwardCue(corpus, matchIndex, cuePattern, window) {
+  const windowStart = Math.max(0, matchIndex - window);
+  const windowText = corpus.slice(windowStart, matchIndex);
+  for (const cueMatch of windowText.matchAll(cuePattern)) {
+    const linkText = windowText.slice(cueMatch.index + cueMatch[0].length);
+    if (
+      CUE_HARD_BREAK_PATTERN.test(linkText) ||
+      CLAUSE_CONTINUATION_COMMA_PATTERN.test(linkText)
+    ) {
+      continue;
+    }
+    return true;
+  }
+  return false;
+}
+// 2. Quoted example: the match sits on a Markdown blockquote line, or is
+//    bounded by a matching pair of quote characters within the containing
+//    paragraph (#2711's inverted-attribution quotation shape, which soft-
+//    wraps the quoted marker across a line break -- scoped to the
+//    paragraph, not the physical line, so that wrap doesn't defeat the
+//    pairing). A plain straight single quote also marks a contraction
+//    ("doesn't"), so a candidate quote character counts as an opener only
+//    when the character right before it is not a letter, and as a closer
+//    only when the character right after it is not a letter -- a
+//    contraction's apostrophe always sits directly between two letters and
+//    fails both checks.
+const QUOTE_CHAR_PAIRS = {
+  '"': '"',
+  "'": "'",
+  '‘': '’',
+  '“': '”',
+};
+const LETTER_PATTERN = /[A-Za-z]/;
+const PARAGRAPH_BREAK_PATTERN = /\n[ \t]*\n/g;
+// 3. Investigative past tense: the match describes an investigation the
+//    issue author already performed while drafting, not remaining work
+//    (#2697's shape, applied here to EXTERNAL_COORDINATION_PATTERN).
+const INVESTIGATIVE_PAST_TENSE_PATTERN =
+  /\b(?:already|previously)\s+(?:checked|verified|confirmed|investigated|reviewed|searched)\b|\bi\s+(?:already\s+)?checked\b|\ba\s+search\s+(?:already\s+)?found\b|\bconfirmed\s+via\b/gi;
+const INVESTIGATIVE_PAST_TENSE_WINDOW = 80;
+// 4. Generic mention: the match is followed shortly by a noun naming a
+//    general pattern/example rather than asserting a live requirement of
+//    this issue ("...a least-privilege CI credential pattern..." -- an
+//    incidental background mention in #2716's own real body, distinct
+//    from that same issue's separately negated target phrase).
+const GENERIC_MENTION_NOUN_PATTERN =
+  /^(pattern|example|scenario|convention|practice|concept|term|approach|precedent|case)$/i;
+const GENERIC_MENTION_LOOKAHEAD_CHARS = 40;
+const GENERIC_MENTION_LOOKAHEAD_TOKENS = 2;
 // Flag-spec keys stay the dashed literal on purpose (never bare keys like
 // `issue:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
 // .mjs source text for quoted flag literals such as the --issue spec key
@@ -322,12 +396,113 @@ export function evaluateClearVerification(issue) {
     evidence: 'No objective verification signal detected.',
   };
 }
+function isGovernedByNegation(corpus, matchIndex) {
+  return isGovernedByBackwardCue(
+    corpus,
+    matchIndex,
+    NEGATION_CUE_PATTERN,
+    NEGATION_CUE_WINDOW,
+  );
+}
+function isLikelyQuoteOpener(charBefore) {
+  return !LETTER_PATTERN.test(charBefore);
+}
+function isLikelyQuoteCloser(charAfter) {
+  return !LETTER_PATTERN.test(charAfter);
+}
+function findParagraphSpan(corpus, offset) {
+  let start = 0;
+  for (const breakMatch of corpus
+    .slice(0, offset)
+    .matchAll(PARAGRAPH_BREAK_PATTERN)) {
+    start = breakMatch.index + breakMatch[0].length;
+  }
+  const afterBreak = /\n[ \t]*\n/.exec(corpus.slice(offset));
+  const end = afterBreak ? offset + afterBreak.index : corpus.length;
+  return { start, end };
+}
+function isInsideQuotedExample(corpus, matchIndex, matchEnd) {
+  const lineStart = corpus.lastIndexOf('\n', matchIndex - 1) + 1;
+  if (/^[ \t]*>/.test(corpus.slice(lineStart, matchIndex))) {
+    return true;
+  }
+  const { start: paragraphStart, end: paragraphEnd } = findParagraphSpan(
+    corpus,
+    matchIndex,
+  );
+  const before = corpus.slice(paragraphStart, matchIndex);
+  const after = corpus.slice(matchEnd, paragraphEnd);
+  for (const [open, close] of Object.entries(QUOTE_CHAR_PAIRS)) {
+    const openIndex = before.lastIndexOf(open);
+    if (
+      openIndex === -1 ||
+      !isLikelyQuoteOpener(openIndex > 0 ? before[openIndex - 1] : '')
+    ) {
+      continue;
+    }
+    const closeIndex = after.indexOf(close);
+    if (
+      closeIndex === -1 ||
+      !isLikelyQuoteCloser(after[closeIndex + 1] ?? '')
+    ) {
+      continue;
+    }
+    return true;
+  }
+  return false;
+}
+function isDescribedByPastInvestigation(corpus, matchIndex) {
+  return isGovernedByBackwardCue(
+    corpus,
+    matchIndex,
+    INVESTIGATIVE_PAST_TENSE_PATTERN,
+    INVESTIGATIVE_PAST_TENSE_WINDOW,
+  );
+}
+function isFollowedByGenericMentionNoun(corpus, matchEnd) {
+  const rawTail = corpus.slice(
+    matchEnd,
+    matchEnd + GENERIC_MENTION_LOOKAHEAD_CHARS,
+  );
+  const breakMatch = HARD_CLAUSE_BREAK_PATTERN.exec(rawTail);
+  const tail = breakMatch ? rawTail.slice(0, breakMatch.index) : rawTail;
+  const tokens = tail.match(WORD_TOKEN_PATTERN) ?? [];
+  return tokens
+    .slice(0, GENERIC_MENTION_LOOKAHEAD_TOKENS)
+    .some((token) => GENERIC_MENTION_NOUN_PATTERN.test(token));
+}
+/**
+ * Finds the first EXTERNAL_COORDINATION_PATTERN occurrence that survives
+ * every exclusion check (#2738): a match inside a code span, governed by a
+ * negation cue, inside a quoted/cited example, described as an
+ * already-completed investigation, or naming a generic pattern rather than
+ * an asserted requirement does not describe this issue's own remaining
+ * completion blocker and is skipped.
+ */
+function findUnexcludedExternalCoordinationMatch(corpus) {
+  for (const match of corpus.matchAll(EXTERNAL_COORDINATION_PATTERN)) {
+    const index = match.index;
+    const end = index + match[0].length;
+    if (
+      isInsideCodeSpan(corpus, index) ||
+      isInsideQuotedExample(corpus, index, end) ||
+      isGovernedByNegation(corpus, index) ||
+      isDescribedByPastInvestigation(corpus, index) ||
+      isFollowedByGenericMentionNoun(corpus, end)
+    ) {
+      continue;
+    }
+    return match[0];
+  }
+  return null;
+}
 export function evaluateAutonomousCompletion(issue) {
   const corpus = `${issue.title}\n${issue.body}`;
-  if (EXTERNAL_COORDINATION_PATTERN.test(corpus)) {
+  const match = findUnexcludedExternalCoordinationMatch(corpus);
+  if (match !== null) {
     return {
       pass: false,
-      evidence: 'External coordination or manual decision signal detected.',
+      evidence: `External coordination or manual decision signal detected: "${match}".`,
     };
   }
   return {

--- a/scripts/discover-viability-gate.mjs
+++ b/scripts/discover-viability-gate.mjs
@@ -93,10 +93,15 @@ const EXTERNAL_COORDINATION_PATTERN =
 // 1. Negation: the match is governed by a negation cue reaching it with no
 //    hard clause break in between ("no interactive credential minting" --
 //    #2716). `zero` excludes a hyphenated compound ("zero-downtime") so it
-//    is never mistaken for a standalone negation word.
+//    is never mistaken for a standalone negation word. A canceling
+//    conjunction ("do not proceed UNTIL production access is granted" --
+//    Codex review, PR #2757) flips the negation back to an affirmative
+//    prerequisite: the cue negates the verb before the conjunction, not
+//    the requirement named after it.
 const NEGATION_CUE_PATTERN =
   /\b(no|not|without|zero(?!-)|never|none|isn'?t|aren'?t|wasn'?t|weren'?t|doesn'?t|don'?t|didn'?t|won'?t|can'?t|cannot)\b/gi;
 const NEGATION_CUE_WINDOW = 40;
+const NEGATION_CANCELING_CONJUNCTION_PATTERN = /\b(until|unless)\b/i;
 // A backward-looking cue (negation or investigative past tense, below)
 // stops governing a match at a period/semicolon/em-dash (HARD_CLAUSE_BREAK_
 // PATTERN, shared with the broad-scope exclusions above), a blank line, or
@@ -107,14 +112,21 @@ const NEGATION_CUE_WINDOW = 40;
 // across one.
 const CUE_HARD_BREAK_PATTERN =
   /[.;—]|--|\n[ \t]*(?:[-*]\s|\d+[.)]\s)|\n[ \t]*\n/;
-function isGovernedByBackwardCue(corpus, matchIndex, cuePattern, window) {
+function isGovernedByBackwardCue(
+  corpus,
+  matchIndex,
+  cuePattern,
+  window,
+  cancelPattern,
+) {
   const windowStart = Math.max(0, matchIndex - window);
   const windowText = corpus.slice(windowStart, matchIndex);
   for (const cueMatch of windowText.matchAll(cuePattern)) {
     const linkText = windowText.slice(cueMatch.index + cueMatch[0].length);
     if (
       CUE_HARD_BREAK_PATTERN.test(linkText) ||
-      CLAUSE_CONTINUATION_COMMA_PATTERN.test(linkText)
+      CLAUSE_CONTINUATION_COMMA_PATTERN.test(linkText) ||
+      (cancelPattern && cancelPattern.test(linkText))
     ) {
       continue;
     }
@@ -122,24 +134,34 @@ function isGovernedByBackwardCue(corpus, matchIndex, cuePattern, window) {
   }
   return false;
 }
-// 2. Quoted example: the match sits on a Markdown blockquote line, or is
-//    bounded by a matching pair of quote characters within the containing
-//    paragraph (#2711's inverted-attribution quotation shape, which soft-
-//    wraps the quoted marker across a line break -- scoped to the
-//    paragraph, not the physical line, so that wrap doesn't defeat the
-//    pairing). A plain straight single quote also marks a contraction
-//    ("doesn't"), so a candidate quote character counts as an opener only
-//    when the character right before it is not a letter, and as a closer
-//    only when the character right after it is not a letter -- a
-//    contraction's apostrophe always sits directly between two letters and
-//    fails both checks.
+// 2. Quoted example: the match sits on a Markdown blockquote line (an
+//    unambiguous citation on its own), or is bounded by a matching pair of
+//    quote characters within the containing paragraph AND that paragraph
+//    also carries a framing/attribution verb (#2711's inverted-attribution
+//    quotation shape, which soft-wraps the quoted marker across a line
+//    break -- scoped to the paragraph, not the physical line, so that wrap
+//    doesn't defeat the pairing). The framing-verb requirement distinguishes
+//    a genuine cited example from ordinary emphasis-quoting of this issue's
+//    own requirement (`The change requires "production access" before it
+//    can ship` -- Codex review, PR #2757): quote characters alone, with no
+//    reporting/citation cue anywhere in the paragraph, do not exclude. A
+//    plain straight single quote also marks a contraction ("doesn't") or a
+//    possessive after a digit ("2020's"), so a candidate quote character
+//    counts as an opener only when the character right before it is
+//    neither a letter nor a digit, and as a closer only when the character
+//    right after it is neither a letter nor a digit -- a contraction's or
+//    digit-possessive's apostrophe always sits directly adjacent to a
+//    letter or digit on at least one side and fails one of those checks
+//    (Copilot review, PR #2757).
 const QUOTE_CHAR_PAIRS = {
   '"': '"',
   "'": "'",
   '‘': '’',
   '“': '”',
 };
-const LETTER_PATTERN = /[A-Za-z]/;
+const QUOTE_ADJACENT_WORD_CHAR_PATTERN = /[A-Za-z0-9]/;
+const QUOTED_EXAMPLE_FRAMING_VERB_PATTERN =
+  /\b(documents?|describes?|says?|states?|explains?|reports?|quotes?|quoted|cites?|cited)\b/i;
 const PARAGRAPH_BREAK_PATTERN = /\n[ \t]*\n/g;
 // 3. Investigative past tense: the match describes an investigation the
 //    issue author already performed while drafting, not remaining work
@@ -151,11 +173,18 @@ const INVESTIGATIVE_PAST_TENSE_WINDOW = 80;
 //    general pattern/example rather than asserting a live requirement of
 //    this issue ("...a least-privilege CI credential pattern..." -- an
 //    incidental background mention in #2716's own real body, distinct
-//    from that same issue's separately negated target phrase).
+//    from that same issue's separately negated target phrase), UNLESS a
+//    requirement-assertion cue (must/require/need/shall/...) sits in the
+//    same clause -- `A credential approach MUST be supplied by the
+//    maintainer before implementation` (Codex review, PR #2757) still
+//    imposes a live requirement despite the generic-sounding noun.
 const GENERIC_MENTION_NOUN_PATTERN =
   /^(pattern|example|scenario|convention|practice|concept|term|approach|precedent|case)$/i;
 const GENERIC_MENTION_LOOKAHEAD_CHARS = 40;
 const GENERIC_MENTION_LOOKAHEAD_TOKENS = 2;
+const REQUIREMENT_ASSERTION_PATTERN =
+  /\b(must|require[sd]?|requiring|needed|needs?|shall|mandatory|essential)\b/i;
+const REQUIREMENT_ASSERTION_WINDOW_CHARS = 80;
 // Flag-spec keys stay the dashed literal on purpose (never bare keys like
 // `issue:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
 // .mjs source text for quoted flag literals such as the --issue spec key
@@ -402,13 +431,14 @@ function isGovernedByNegation(corpus, matchIndex) {
     matchIndex,
     NEGATION_CUE_PATTERN,
     NEGATION_CUE_WINDOW,
+    NEGATION_CANCELING_CONJUNCTION_PATTERN,
   );
 }
 function isLikelyQuoteOpener(charBefore) {
-  return !LETTER_PATTERN.test(charBefore);
+  return !QUOTE_ADJACENT_WORD_CHAR_PATTERN.test(charBefore);
 }
 function isLikelyQuoteCloser(charAfter) {
-  return !LETTER_PATTERN.test(charAfter);
+  return !QUOTE_ADJACENT_WORD_CHAR_PATTERN.test(charAfter);
 }
 function findParagraphSpan(corpus, offset) {
   let start = 0;
@@ -430,6 +460,10 @@ function isInsideQuotedExample(corpus, matchIndex, matchEnd) {
     corpus,
     matchIndex,
   );
+  const paragraph = corpus.slice(paragraphStart, paragraphEnd);
+  if (!QUOTED_EXAMPLE_FRAMING_VERB_PATTERN.test(paragraph)) {
+    return false;
+  }
   const before = corpus.slice(paragraphStart, matchIndex);
   const after = corpus.slice(matchEnd, paragraphEnd);
   for (const [open, close] of Object.entries(QUOTE_CHAR_PAIRS)) {
@@ -451,15 +485,48 @@ function isInsideQuotedExample(corpus, matchIndex, matchEnd) {
   }
   return false;
 }
-function isDescribedByPastInvestigation(corpus, matchIndex) {
-  return isGovernedByBackwardCue(
-    corpus,
-    matchIndex,
-    INVESTIGATIVE_PAST_TENSE_PATTERN,
-    INVESTIGATIVE_PAST_TENSE_WINDOW,
+function isDescribedByPastInvestigation(corpus, matchIndex, matchEnd) {
+  // The investigation may have CONFIRMED the blocker still holds rather
+  // than resolved it away ("We already verified production access IS
+  // REQUIRED before this can ship" -- Codex review, PR #2757): a nearby
+  // requirement-assertion word means the cited investigation's own
+  // conclusion is that the prerequisite remains live.
+  return (
+    isGovernedByBackwardCue(
+      corpus,
+      matchIndex,
+      INVESTIGATIVE_PAST_TENSE_PATTERN,
+      INVESTIGATIVE_PAST_TENSE_WINDOW,
+    ) && !isNearRequirementAssertion(corpus, matchIndex, matchEnd)
   );
 }
-function isFollowedByGenericMentionNoun(corpus, matchEnd) {
+function isNearRequirementAssertion(corpus, matchIndex, matchEnd) {
+  const forwardRaw = corpus.slice(
+    matchEnd,
+    matchEnd + REQUIREMENT_ASSERTION_WINDOW_CHARS,
+  );
+  const forwardBreak = HARD_CLAUSE_BREAK_PATTERN.exec(forwardRaw);
+  const forwardText = forwardBreak
+    ? forwardRaw.slice(0, forwardBreak.index)
+    : forwardRaw;
+  if (REQUIREMENT_ASSERTION_PATTERN.test(forwardText)) {
+    return true;
+  }
+  const backwardStart = Math.max(
+    0,
+    matchIndex - REQUIREMENT_ASSERTION_WINDOW_CHARS,
+  );
+  const backwardRaw = corpus.slice(backwardStart, matchIndex);
+  const priorBreaks = [
+    ...backwardRaw.matchAll(new RegExp(HARD_CLAUSE_BREAK_PATTERN, 'g')),
+  ];
+  const lastBreak = priorBreaks.at(-1);
+  const backwardText = lastBreak
+    ? backwardRaw.slice(lastBreak.index + lastBreak[0].length)
+    : backwardRaw;
+  return REQUIREMENT_ASSERTION_PATTERN.test(backwardText);
+}
+function isFollowedByGenericMentionNoun(corpus, matchIndex, matchEnd) {
   const rawTail = corpus.slice(
     matchEnd,
     matchEnd + GENERIC_MENTION_LOOKAHEAD_CHARS,
@@ -467,9 +534,13 @@ function isFollowedByGenericMentionNoun(corpus, matchEnd) {
   const breakMatch = HARD_CLAUSE_BREAK_PATTERN.exec(rawTail);
   const tail = breakMatch ? rawTail.slice(0, breakMatch.index) : rawTail;
   const tokens = tail.match(WORD_TOKEN_PATTERN) ?? [];
-  return tokens
+  const namesGenericPattern = tokens
     .slice(0, GENERIC_MENTION_LOOKAHEAD_TOKENS)
     .some((token) => GENERIC_MENTION_NOUN_PATTERN.test(token));
+  return (
+    namesGenericPattern &&
+    !isNearRequirementAssertion(corpus, matchIndex, matchEnd)
+  );
 }
 /**
  * Finds the first EXTERNAL_COORDINATION_PATTERN occurrence that survives
@@ -487,8 +558,8 @@ function findUnexcludedExternalCoordinationMatch(corpus) {
       isInsideCodeSpan(corpus, index) ||
       isInsideQuotedExample(corpus, index, end) ||
       isGovernedByNegation(corpus, index) ||
-      isDescribedByPastInvestigation(corpus, index) ||
-      isFollowedByGenericMentionNoun(corpus, end)
+      isDescribedByPastInvestigation(corpus, index, end) ||
+      isFollowedByGenericMentionNoun(corpus, index, end)
     ) {
       continue;
     }

--- a/scripts/discover-viability-gate.mjs
+++ b/scripts/discover-viability-gate.mjs
@@ -106,6 +106,13 @@ const NEGATION_CUE_PATTERN =
   /\b(no|not|zero(?!-)|never|none|isn'?t|aren'?t|wasn'?t|weren'?t|doesn'?t|don'?t|didn'?t|won'?t|can'?t|cannot)\b/gi;
 const NEGATION_CUE_WINDOW = 40;
 const NEGATION_CANCELING_CONJUNCTION_PATTERN = /\b(until|unless|without)\b/i;
+// "not only X" is an additive idiom that affirms X, not a negation of it
+// ("Not only is production access needed for the rollout" -- Codex review
+// round 4, PR #2757); scoped to an immediately-following "only" right
+// after "not" specifically, not a general requirement-assertion
+// cancellation (which would also wrongly cancel a genuine double negative
+// like "No credential changes are needed").
+const NOT_ONLY_IDIOM_PATTERN = /^\s*only\b/i;
 // A backward-looking cue (negation or investigative past tense, below)
 // stops governing a match at a period/semicolon/colon/em-dash, a blank
 // line, or a following list-item marker -- a bullet's own negation must
@@ -134,7 +141,9 @@ function isGovernedByBackwardCue(
     if (
       CUE_HARD_BREAK_PATTERN.test(linkText) ||
       CLAUSE_CONTINUATION_COMMA_PATTERN.test(linkText) ||
-      (cancelPattern && cancelPattern.test(linkText))
+      (cancelPattern && cancelPattern.test(linkText)) ||
+      (cueMatch[0].toLowerCase() === 'not' &&
+        NOT_ONLY_IDIOM_PATTERN.test(linkText))
     ) {
       continue;
     }
@@ -331,11 +340,16 @@ export function evaluateA4Viability(issue) {
 // review round 3, PR #2757); an exact-length-only rule leaves such a block
 // wrongly "open" for the rest of the corpus. A run only counts as a fence
 // marker when it sits alone on its line; an inline run of 3+ backticks
-// (e.g. all on one line) still requires an exact-length closer. A fresh
-// regex literal per call (rather than a shared module-level one)
-// sidesteps both the CLI-entry TDZ ordering rule this file's helpers must
-// follow (see the flag-spec comment below) and any `lastIndex` state
-// leaking across calls.
+// (e.g. all on one line) still requires an exact-length closer. Finally, a
+// run with NO valid closer anywhere in the corpus (a stray unmatched
+// backtick, e.g. "contains a stray `. Production access is required" --
+// Codex review round 4, PR #2757) never forms a code span at all per
+// CommonMark and must not be treated as an opener -- it is ordinary
+// literal text, and scanning continues past it looking for the next
+// potential opener. A fresh regex literal per call (rather than a shared
+// module-level one) sidesteps both the CLI-entry TDZ ordering rule this
+// file's helpers must follow (see the flag-spec comment below) and any
+// `lastIndex` state leaking across calls.
 function isAloneOnLine(corpus, runStart, runEnd) {
   let before = runStart - 1;
   while (before >= 0 && (corpus[before] === ' ' || corpus[before] === '\t')) {
@@ -353,29 +367,42 @@ function isAloneOnLine(corpus, runStart, runEnd) {
   }
   return after >= corpus.length || corpus[after] === '\n';
 }
+function closesRun(candidate, open) {
+  return open.isFenceCandidate
+    ? candidate.length >= open.length && candidate.isFenceCandidate
+    : candidate.length === open.length;
+}
 function isInsideCodeSpan(corpus, index) {
   const runPattern = /`+/g;
-  let open = null;
+  const runs = [];
   let match = runPattern.exec(corpus);
-  while (match !== null && match.index < index) {
-    const runLength = match[0].length;
-    const runEnd = match.index + runLength;
+  while (match !== null) {
+    const runIndex = match.index;
+    const runEnd = runIndex + match[0].length;
+    runs.push({
+      index: runIndex,
+      end: runEnd,
+      length: match[0].length,
+      isFenceCandidate:
+        match[0].length >= 3 && isAloneOnLine(corpus, runIndex, runEnd),
+    });
+    match = runPattern.exec(corpus);
+  }
+  let open = null;
+  for (const run of runs) {
+    if (run.index >= index) {
+      break;
+    }
     if (open === null) {
-      open = {
-        length: runLength,
-        isFence: runLength >= 3 && isAloneOnLine(corpus, match.index, runEnd),
-      };
-    } else if (open.isFence) {
-      if (
-        runLength >= open.length &&
-        isAloneOnLine(corpus, match.index, runEnd)
-      ) {
-        open = null;
+      const hasCloser = runs.some(
+        (candidate) => candidate.index > run.index && closesRun(candidate, run),
+      );
+      if (hasCloser) {
+        open = run;
       }
-    } else if (runLength === open.length) {
+    } else if (closesRun(run, open)) {
       open = null;
     }
-    match = runPattern.exec(corpus);
   }
   return open !== null;
 }
@@ -519,7 +546,11 @@ function findParagraphSpan(corpus, offset) {
 function isInsideQuotedExample(corpus, matchIndex, matchEnd) {
   const lineStart = corpus.lastIndexOf('\n', matchIndex - 1) + 1;
   if (/^[ \t]*>/.test(corpus.slice(lineStart, matchIndex))) {
-    return true;
+    // Blockquote syntax alone does not establish the cited content is
+    // non-blocking -- the same requirement-assertion safeguard used for a
+    // paired quote below must also apply here ("> Production access is
+    // required before shipping" -- Codex review round 4, PR #2757).
+    return !isNearRequirementAssertion(corpus, matchIndex, matchEnd);
   }
   const { start: paragraphStart, end: paragraphEnd } = findParagraphSpan(
     corpus,

--- a/scripts/discover-viability-gate.mjs
+++ b/scripts/discover-viability-gate.mjs
@@ -200,13 +200,18 @@ const INVESTIGATIVE_PAST_TENSE_WINDOW = 80;
 //    #2757) still imposes a live requirement despite the generic-sounding
 //    noun. `blocked`/`pending` cover emphasis-quoting with no must/require
 //    wording of its own ("Shipping remains BLOCKED PENDING 'production
-//    access'" -- Codex review round 3, PR #2757).
+//    access'" -- Codex review round 3, PR #2757). `waiting` covers an
+//    ongoing dependency the past-investigation exclusion would otherwise
+//    wrongly suppress ("We already checked the reproduction and are now
+//    WAITING ON production access" -- Codex review round 5, PR #2757):
+//    the investigation cue is unrelated to the still-open dependency
+//    named right after it.
 const GENERIC_MENTION_NOUN_PATTERN =
   /^(pattern|example|scenario|convention|practice|concept|term|approach|precedent|case)$/i;
 const GENERIC_MENTION_LOOKAHEAD_CHARS = 40;
 const GENERIC_MENTION_LOOKAHEAD_TOKENS = 2;
 const REQUIREMENT_ASSERTION_PATTERN =
-  /\b(must|require[sd]?|requiring|needed|needs?|shall|mandatory|essential|blocked|blocking|pending)\b/i;
+  /\b(must|require[sd]?|requiring|needed|needs?|shall|mandatory|essential|blocked|blocking|pending|waiting)\b/i;
 const REQUIREMENT_ASSERTION_WINDOW_CHARS = 80;
 // Flag-spec keys stay the dashed literal on purpose (never bare keys like
 // `issue:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
@@ -333,31 +338,33 @@ export function evaluateA4Viability(issue) {
 // single backticks appear inside), not on individual-backtick parity -- a
 // run of a different length while a span is open is literal content, not a
 // closer (#2738 Codex review round 2, PR #2757). A FENCED code block is
-// different: its opening run sits alone on a line (only leading
-// whitespace before it) and has length >= 3, and CommonMark lets the
+// different: its opening run needs only LEADING whitespace on its line
+// (trailing content is a valid info string, e.g. ```ts -- Copilot/Codex
+// review round 5, PR #2757) and has length >= 3, and CommonMark lets the
 // closing fence be LONGER than the opener, not just equal (a fence opened
 // with ``` and closed with ```` is still a valid, closed block -- Codex
 // review round 3, PR #2757); an exact-length-only rule leaves such a block
-// wrongly "open" for the rest of the corpus. A run only counts as a fence
-// marker when it sits alone on its line; an inline run of 3+ backticks
-// (e.g. all on one line) still requires an exact-length closer. Finally, a
-// run with NO valid closer anywhere in the corpus (a stray unmatched
-// backtick, e.g. "contains a stray `. Production access is required" --
-// Codex review round 4, PR #2757) never forms a code span at all per
-// CommonMark and must not be treated as an opener -- it is ordinary
-// literal text, and scanning continues past it looking for the next
-// potential opener. A fresh regex literal per call (rather than a shared
-// module-level one) sidesteps both the CLI-entry TDZ ordering rule this
-// file's helpers must follow (see the flag-spec comment below) and any
-// `lastIndex` state leaking across calls.
-function isAloneOnLine(corpus, runStart, runEnd) {
+// wrongly "open" for the rest of the corpus. A CLOSING fence, unlike the
+// opener, allows no info string: it needs both leading AND trailing
+// whitespace only. An inline run of 3+ backticks (e.g. all on one line,
+// with non-whitespace before it) still requires an exact-length closer.
+// Finally, a run with NO valid closer anywhere in the corpus (a stray
+// unmatched backtick, e.g. "contains a stray `. Production access is
+// required" -- Codex review round 4, PR #2757) never forms a code span at
+// all per CommonMark and must not be treated as an opener -- it is
+// ordinary literal text, and scanning continues past it looking for the
+// next potential opener. A fresh regex literal per call (rather than a
+// shared module-level one) sidesteps both the CLI-entry TDZ ordering rule
+// this file's helpers must follow (see the flag-spec comment below) and
+// any `lastIndex` state leaking across calls.
+function hasOnlyLeadingWhitespace(corpus, runStart) {
   let before = runStart - 1;
   while (before >= 0 && (corpus[before] === ' ' || corpus[before] === '\t')) {
     before--;
   }
-  if (before >= 0 && corpus[before] !== '\n') {
-    return false;
-  }
+  return before < 0 || corpus[before] === '\n';
+}
+function hasOnlyTrailingWhitespace(corpus, runEnd) {
   let after = runEnd;
   while (
     after < corpus.length &&
@@ -368,8 +375,8 @@ function isAloneOnLine(corpus, runStart, runEnd) {
   return after >= corpus.length || corpus[after] === '\n';
 }
 function closesRun(candidate, open) {
-  return open.isFenceCandidate
-    ? candidate.length >= open.length && candidate.isFenceCandidate
+  return open.isFenceOpenerCandidate
+    ? candidate.length >= open.length && candidate.isFenceCloserCandidate
     : candidate.length === open.length;
 }
 function isInsideCodeSpan(corpus, index) {
@@ -379,12 +386,16 @@ function isInsideCodeSpan(corpus, index) {
   while (match !== null) {
     const runIndex = match.index;
     const runEnd = runIndex + match[0].length;
+    const leadingOk = hasOnlyLeadingWhitespace(corpus, runIndex);
     runs.push({
       index: runIndex,
       end: runEnd,
       length: match[0].length,
-      isFenceCandidate:
-        match[0].length >= 3 && isAloneOnLine(corpus, runIndex, runEnd),
+      isFenceOpenerCandidate: match[0].length >= 3 && leadingOk,
+      isFenceCloserCandidate:
+        match[0].length >= 3 &&
+        leadingOk &&
+        hasOnlyTrailingWhitespace(corpus, runEnd),
     });
     match = runPattern.exec(corpus);
   }

--- a/src/scripts/discover-viability-gate.mts
+++ b/src/scripts/discover-viability-gate.mts
@@ -152,15 +152,19 @@ const EXTERNAL_COORDINATION_PATTERN =
 // 1. Negation: the match is governed by a negation cue reaching it with no
 //    hard clause break in between ("no interactive credential minting" --
 //    #2716). `zero` excludes a hyphenated compound ("zero-downtime") so it
-//    is never mistaken for a standalone negation word. A canceling
+//    is never mistaken for a standalone negation word. `without` is a
+//    canceling word, not a cue of its own: "cannot complete this WITHOUT
+//    production access" asserts the access is required, the mirror image
+//    of "no access needed" (Codex review round 2, PR #2757) -- as a
+//    standalone cue it wrongly negated exactly that shape. A canceling
 //    conjunction ("do not proceed UNTIL production access is granted" --
 //    Codex review, PR #2757) flips the negation back to an affirmative
 //    prerequisite: the cue negates the verb before the conjunction, not
 //    the requirement named after it.
 const NEGATION_CUE_PATTERN =
-  /\b(no|not|without|zero(?!-)|never|none|isn'?t|aren'?t|wasn'?t|weren'?t|doesn'?t|don'?t|didn'?t|won'?t|can'?t|cannot)\b/gi;
+  /\b(no|not|zero(?!-)|never|none|isn'?t|aren'?t|wasn'?t|weren'?t|doesn'?t|don'?t|didn'?t|won'?t|can'?t|cannot)\b/gi;
 const NEGATION_CUE_WINDOW = 40;
-const NEGATION_CANCELING_CONJUNCTION_PATTERN = /\b(until|unless)\b/i;
+const NEGATION_CANCELING_CONJUNCTION_PATTERN = /\b(until|unless|without)\b/i;
 // A backward-looking cue (negation or investigative past tense, below)
 // stops governing a match at a period/semicolon/em-dash (HARD_CLAUSE_BREAK_
 // PATTERN, shared with the broad-scope exclusions above), a blank line, or
@@ -195,23 +199,28 @@ function isGovernedByBackwardCue(
 }
 // 2. Quoted example: the match sits on a Markdown blockquote line (an
 //    unambiguous citation on its own), or is bounded by a matching pair of
-//    quote characters within the containing paragraph AND that paragraph
-//    also carries a framing/attribution verb (#2711's inverted-attribution
-//    quotation shape, which soft-wraps the quoted marker across a line
-//    break -- scoped to the paragraph, not the physical line, so that wrap
-//    doesn't defeat the pairing). The framing-verb requirement distinguishes
-//    a genuine cited example from ordinary emphasis-quoting of this issue's
-//    own requirement (`The change requires "production access" before it
-//    can ship` -- Codex review, PR #2757): quote characters alone, with no
-//    reporting/citation cue anywhere in the paragraph, do not exclude. A
-//    plain straight single quote also marks a contraction ("doesn't") or a
-//    possessive after a digit ("2020's"), so a candidate quote character
-//    counts as an opener only when the character right before it is
-//    neither a letter nor a digit, and as a closer only when the character
-//    right after it is neither a letter nor a digit -- a contraction's or
-//    digit-possessive's apostrophe always sits directly adjacent to a
-//    letter or digit on at least one side and fails one of those checks
-//    (Copilot review, PR #2757).
+//    quote characters within the containing paragraph (#2711's
+//    inverted-attribution quotation shape, which soft-wraps the quoted
+//    marker across a line break -- scoped to the paragraph, not the
+//    physical line, so that wrap doesn't defeat the pairing) AND no nearby
+//    requirement-assertion word (4, below) overrides it -- a paired quote
+//    alone does not distinguish a genuine cited example from ordinary
+//    emphasis-quoting of this issue's own requirement (`The change
+//    requires "production access" before it can ship` -- Codex review,
+//    PR #2757); a framing/attribution-verb requirement was tried first but
+//    over-scoped to a whole paragraph (wrongly attributing an unrelated
+//    sentence's own reporting verb) or under-scoped to one sentence
+//    (missing a genuine citation with no reporting verb of its own, as in
+//    #2711's own real body -- Codex review round 2, PR #2757); reusing the
+//    requirement-assertion check already built for generic mentions (4)
+//    avoids both failure modes. A plain straight single quote also marks a
+//    contraction ("doesn't") or a possessive after a digit ("2020's"), so a
+//    candidate quote character counts as an opener only when the character
+//    right before it is neither a letter nor a digit, and as a closer only
+//    when the character right after it is neither a letter nor a digit --
+//    a contraction's or digit-possessive's apostrophe always sits directly
+//    adjacent to a letter or digit on at least one side and fails one of
+//    those checks (Copilot review, PR #2757).
 const QUOTE_CHAR_PAIRS: Record<string, string> = {
   '"': '"',
   "'": "'",
@@ -219,8 +228,6 @@ const QUOTE_CHAR_PAIRS: Record<string, string> = {
   '“': '”',
 };
 const QUOTE_ADJACENT_WORD_CHAR_PATTERN = /[A-Za-z0-9]/;
-const QUOTED_EXAMPLE_FRAMING_VERB_PATTERN =
-  /\b(documents?|describes?|says?|states?|explains?|reports?|quotes?|quoted|cites?|cited)\b/i;
 const PARAGRAPH_BREAK_PATTERN = /\n[ \t]*\n/g;
 // 3. Investigative past tense: the match describes an investigation the
 //    issue author already performed while drafting, not remaining work
@@ -384,14 +391,28 @@ export function evaluateA4Viability(issue: unknown): {
   };
 }
 
+// CommonMark code spans open and close on a run of backticks of the SAME
+// length (a multi-backtick delimiter, e.g. ``` `` ```, lets literal single
+// backticks appear inside), not on individual-backtick parity -- a run of a
+// different length while a span is open is literal content, not a closer
+// (#2738 Codex review round 2, PR #2757). A fresh regex literal per call
+// (rather than a shared module-level one) sidesteps both the CLI-entry TDZ
+// ordering rule this file's helpers must follow (see the flag-spec comment
+// below) and any `lastIndex` state leaking across calls.
 function isInsideCodeSpan(corpus: string, index: number): boolean {
-  let backtickCount = 0;
-  for (let i = 0; i < index; i += 1) {
-    if (corpus[i] === '`') {
-      backtickCount += 1;
+  const runPattern = /`+/g;
+  let openRunLength: number | null = null;
+  let match: RegExpExecArray | null = runPattern.exec(corpus);
+  while (match !== null && match.index < index) {
+    const runLength = match[0].length;
+    if (openRunLength === null) {
+      openRunLength = runLength;
+    } else if (runLength === openRunLength) {
+      openRunLength = null;
     }
+    match = runPattern.exec(corpus);
   }
-  return backtickCount % 2 === 1;
+  return openRunLength !== null;
 }
 
 function isGovernedByAvoidanceCue(corpus: string, matchIndex: number): boolean {
@@ -560,10 +581,6 @@ function isInsideQuotedExample(
     corpus,
     matchIndex,
   );
-  const paragraph = corpus.slice(paragraphStart, paragraphEnd);
-  if (!QUOTED_EXAMPLE_FRAMING_VERB_PATTERN.test(paragraph)) {
-    return false;
-  }
   const before = corpus.slice(paragraphStart, matchIndex);
   const after = corpus.slice(matchEnd, paragraphEnd);
   for (const [open, close] of Object.entries(QUOTE_CHAR_PAIRS)) {
@@ -581,7 +598,12 @@ function isInsideQuotedExample(
     ) {
       continue;
     }
-    return true;
+    // A paired quote alone is not proof of external citation -- a nearby
+    // requirement-assertion word means the quotes are just emphasizing
+    // THIS issue's own live requirement ("The change requires 'production
+    // access' before it can ship" -- Codex review round 2, PR #2757),
+    // regardless of unrelated framing prose elsewhere in the paragraph.
+    return !isNearRequirementAssertion(corpus, matchIndex, matchEnd);
   }
   return false;
 }
@@ -689,7 +711,15 @@ function findUnexcludedExternalCoordinationMatch(
 export function evaluateAutonomousCompletion(
   issue: NormalizedIssue,
 ): EvalResult {
-  const corpus = `${issue.title}\n${issue.body}`;
+  // A blank line (not a bare "\n") between title and body, unlike the
+  // other two evaluate* functions' corpus join: CUE_HARD_BREAK_PATTERN
+  // treats "\n[ \t]*\n" as a hard break, so a negation or past-investigation
+  // cue in the title can never govern a match in the body (a short title
+  // like "No credential changes" must not suppress a genuine body blocker
+  // -- Codex review round 2, PR #2757). An ordinary soft-wrapped line
+  // inside the body is still a single "\n" and remains ungoverned by this
+  // rule, per #2711's own wrapped-quotation requirement.
+  const corpus = `${issue.title}\n\n${issue.body}`;
   const match = findUnexcludedExternalCoordinationMatch(corpus);
   if (match !== null) {
     return {

--- a/src/scripts/discover-viability-gate.mts
+++ b/src/scripts/discover-viability-gate.mts
@@ -152,10 +152,15 @@ const EXTERNAL_COORDINATION_PATTERN =
 // 1. Negation: the match is governed by a negation cue reaching it with no
 //    hard clause break in between ("no interactive credential minting" --
 //    #2716). `zero` excludes a hyphenated compound ("zero-downtime") so it
-//    is never mistaken for a standalone negation word.
+//    is never mistaken for a standalone negation word. A canceling
+//    conjunction ("do not proceed UNTIL production access is granted" --
+//    Codex review, PR #2757) flips the negation back to an affirmative
+//    prerequisite: the cue negates the verb before the conjunction, not
+//    the requirement named after it.
 const NEGATION_CUE_PATTERN =
   /\b(no|not|without|zero(?!-)|never|none|isn'?t|aren'?t|wasn'?t|weren'?t|doesn'?t|don'?t|didn'?t|won'?t|can'?t|cannot)\b/gi;
 const NEGATION_CUE_WINDOW = 40;
+const NEGATION_CANCELING_CONJUNCTION_PATTERN = /\b(until|unless)\b/i;
 // A backward-looking cue (negation or investigative past tense, below)
 // stops governing a match at a period/semicolon/em-dash (HARD_CLAUSE_BREAK_
 // PATTERN, shared with the broad-scope exclusions above), a blank line, or
@@ -171,6 +176,7 @@ function isGovernedByBackwardCue(
   matchIndex: number,
   cuePattern: RegExp,
   window: number,
+  cancelPattern?: RegExp,
 ): boolean {
   const windowStart = Math.max(0, matchIndex - window);
   const windowText = corpus.slice(windowStart, matchIndex);
@@ -178,7 +184,8 @@ function isGovernedByBackwardCue(
     const linkText = windowText.slice(cueMatch.index + cueMatch[0].length);
     if (
       CUE_HARD_BREAK_PATTERN.test(linkText) ||
-      CLAUSE_CONTINUATION_COMMA_PATTERN.test(linkText)
+      CLAUSE_CONTINUATION_COMMA_PATTERN.test(linkText) ||
+      (cancelPattern && cancelPattern.test(linkText))
     ) {
       continue;
     }
@@ -186,24 +193,34 @@ function isGovernedByBackwardCue(
   }
   return false;
 }
-// 2. Quoted example: the match sits on a Markdown blockquote line, or is
-//    bounded by a matching pair of quote characters within the containing
-//    paragraph (#2711's inverted-attribution quotation shape, which soft-
-//    wraps the quoted marker across a line break -- scoped to the
-//    paragraph, not the physical line, so that wrap doesn't defeat the
-//    pairing). A plain straight single quote also marks a contraction
-//    ("doesn't"), so a candidate quote character counts as an opener only
-//    when the character right before it is not a letter, and as a closer
-//    only when the character right after it is not a letter -- a
-//    contraction's apostrophe always sits directly between two letters and
-//    fails both checks.
+// 2. Quoted example: the match sits on a Markdown blockquote line (an
+//    unambiguous citation on its own), or is bounded by a matching pair of
+//    quote characters within the containing paragraph AND that paragraph
+//    also carries a framing/attribution verb (#2711's inverted-attribution
+//    quotation shape, which soft-wraps the quoted marker across a line
+//    break -- scoped to the paragraph, not the physical line, so that wrap
+//    doesn't defeat the pairing). The framing-verb requirement distinguishes
+//    a genuine cited example from ordinary emphasis-quoting of this issue's
+//    own requirement (`The change requires "production access" before it
+//    can ship` -- Codex review, PR #2757): quote characters alone, with no
+//    reporting/citation cue anywhere in the paragraph, do not exclude. A
+//    plain straight single quote also marks a contraction ("doesn't") or a
+//    possessive after a digit ("2020's"), so a candidate quote character
+//    counts as an opener only when the character right before it is
+//    neither a letter nor a digit, and as a closer only when the character
+//    right after it is neither a letter nor a digit -- a contraction's or
+//    digit-possessive's apostrophe always sits directly adjacent to a
+//    letter or digit on at least one side and fails one of those checks
+//    (Copilot review, PR #2757).
 const QUOTE_CHAR_PAIRS: Record<string, string> = {
   '"': '"',
   "'": "'",
   '‘': '’',
   '“': '”',
 };
-const LETTER_PATTERN = /[A-Za-z]/;
+const QUOTE_ADJACENT_WORD_CHAR_PATTERN = /[A-Za-z0-9]/;
+const QUOTED_EXAMPLE_FRAMING_VERB_PATTERN =
+  /\b(documents?|describes?|says?|states?|explains?|reports?|quotes?|quoted|cites?|cited)\b/i;
 const PARAGRAPH_BREAK_PATTERN = /\n[ \t]*\n/g;
 // 3. Investigative past tense: the match describes an investigation the
 //    issue author already performed while drafting, not remaining work
@@ -215,11 +232,18 @@ const INVESTIGATIVE_PAST_TENSE_WINDOW = 80;
 //    general pattern/example rather than asserting a live requirement of
 //    this issue ("...a least-privilege CI credential pattern..." -- an
 //    incidental background mention in #2716's own real body, distinct
-//    from that same issue's separately negated target phrase).
+//    from that same issue's separately negated target phrase), UNLESS a
+//    requirement-assertion cue (must/require/need/shall/...) sits in the
+//    same clause -- `A credential approach MUST be supplied by the
+//    maintainer before implementation` (Codex review, PR #2757) still
+//    imposes a live requirement despite the generic-sounding noun.
 const GENERIC_MENTION_NOUN_PATTERN =
   /^(pattern|example|scenario|convention|practice|concept|term|approach|precedent|case)$/i;
 const GENERIC_MENTION_LOOKAHEAD_CHARS = 40;
 const GENERIC_MENTION_LOOKAHEAD_TOKENS = 2;
+const REQUIREMENT_ASSERTION_PATTERN =
+  /\b(must|require[sd]?|requiring|needed|needs?|shall|mandatory|essential)\b/i;
+const REQUIREMENT_ASSERTION_WINDOW_CHARS = 80;
 
 // Flag-spec keys stay the dashed literal on purpose (never bare keys like
 // `issue:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
@@ -496,15 +520,16 @@ function isGovernedByNegation(corpus: string, matchIndex: number): boolean {
     matchIndex,
     NEGATION_CUE_PATTERN,
     NEGATION_CUE_WINDOW,
+    NEGATION_CANCELING_CONJUNCTION_PATTERN,
   );
 }
 
 function isLikelyQuoteOpener(charBefore: string): boolean {
-  return !LETTER_PATTERN.test(charBefore);
+  return !QUOTE_ADJACENT_WORD_CHAR_PATTERN.test(charBefore);
 }
 
 function isLikelyQuoteCloser(charAfter: string): boolean {
-  return !LETTER_PATTERN.test(charAfter);
+  return !QUOTE_ADJACENT_WORD_CHAR_PATTERN.test(charAfter);
 }
 
 function findParagraphSpan(
@@ -535,6 +560,10 @@ function isInsideQuotedExample(
     corpus,
     matchIndex,
   );
+  const paragraph = corpus.slice(paragraphStart, paragraphEnd);
+  if (!QUOTED_EXAMPLE_FRAMING_VERB_PATTERN.test(paragraph)) {
+    return false;
+  }
   const before = corpus.slice(paragraphStart, matchIndex);
   const after = corpus.slice(matchEnd, paragraphEnd);
   for (const [open, close] of Object.entries(QUOTE_CHAR_PAIRS)) {
@@ -560,17 +589,57 @@ function isInsideQuotedExample(
 function isDescribedByPastInvestigation(
   corpus: string,
   matchIndex: number,
+  matchEnd: number,
 ): boolean {
-  return isGovernedByBackwardCue(
-    corpus,
-    matchIndex,
-    INVESTIGATIVE_PAST_TENSE_PATTERN,
-    INVESTIGATIVE_PAST_TENSE_WINDOW,
+  // The investigation may have CONFIRMED the blocker still holds rather
+  // than resolved it away ("We already verified production access IS
+  // REQUIRED before this can ship" -- Codex review, PR #2757): a nearby
+  // requirement-assertion word means the cited investigation's own
+  // conclusion is that the prerequisite remains live.
+  return (
+    isGovernedByBackwardCue(
+      corpus,
+      matchIndex,
+      INVESTIGATIVE_PAST_TENSE_PATTERN,
+      INVESTIGATIVE_PAST_TENSE_WINDOW,
+    ) && !isNearRequirementAssertion(corpus, matchIndex, matchEnd)
   );
+}
+
+function isNearRequirementAssertion(
+  corpus: string,
+  matchIndex: number,
+  matchEnd: number,
+): boolean {
+  const forwardRaw = corpus.slice(
+    matchEnd,
+    matchEnd + REQUIREMENT_ASSERTION_WINDOW_CHARS,
+  );
+  const forwardBreak = HARD_CLAUSE_BREAK_PATTERN.exec(forwardRaw);
+  const forwardText = forwardBreak
+    ? forwardRaw.slice(0, forwardBreak.index)
+    : forwardRaw;
+  if (REQUIREMENT_ASSERTION_PATTERN.test(forwardText)) {
+    return true;
+  }
+  const backwardStart = Math.max(
+    0,
+    matchIndex - REQUIREMENT_ASSERTION_WINDOW_CHARS,
+  );
+  const backwardRaw = corpus.slice(backwardStart, matchIndex);
+  const priorBreaks = [
+    ...backwardRaw.matchAll(new RegExp(HARD_CLAUSE_BREAK_PATTERN, 'g')),
+  ];
+  const lastBreak = priorBreaks.at(-1);
+  const backwardText = lastBreak
+    ? backwardRaw.slice(lastBreak.index + lastBreak[0].length)
+    : backwardRaw;
+  return REQUIREMENT_ASSERTION_PATTERN.test(backwardText);
 }
 
 function isFollowedByGenericMentionNoun(
   corpus: string,
+  matchIndex: number,
   matchEnd: number,
 ): boolean {
   const rawTail = corpus.slice(
@@ -580,9 +649,13 @@ function isFollowedByGenericMentionNoun(
   const breakMatch = HARD_CLAUSE_BREAK_PATTERN.exec(rawTail);
   const tail = breakMatch ? rawTail.slice(0, breakMatch.index) : rawTail;
   const tokens = tail.match(WORD_TOKEN_PATTERN) ?? [];
-  return tokens
+  const namesGenericPattern = tokens
     .slice(0, GENERIC_MENTION_LOOKAHEAD_TOKENS)
     .some((token) => GENERIC_MENTION_NOUN_PATTERN.test(token));
+  return (
+    namesGenericPattern &&
+    !isNearRequirementAssertion(corpus, matchIndex, matchEnd)
+  );
 }
 
 /**
@@ -603,8 +676,8 @@ function findUnexcludedExternalCoordinationMatch(
       isInsideCodeSpan(corpus, index) ||
       isInsideQuotedExample(corpus, index, end) ||
       isGovernedByNegation(corpus, index) ||
-      isDescribedByPastInvestigation(corpus, index) ||
-      isFollowedByGenericMentionNoun(corpus, end)
+      isDescribedByPastInvestigation(corpus, index, end) ||
+      isFollowedByGenericMentionNoun(corpus, index, end)
     ) {
       continue;
     }

--- a/src/scripts/discover-viability-gate.mts
+++ b/src/scripts/discover-viability-gate.mts
@@ -165,6 +165,13 @@ const NEGATION_CUE_PATTERN =
   /\b(no|not|zero(?!-)|never|none|isn'?t|aren'?t|wasn'?t|weren'?t|doesn'?t|don'?t|didn'?t|won'?t|can'?t|cannot)\b/gi;
 const NEGATION_CUE_WINDOW = 40;
 const NEGATION_CANCELING_CONJUNCTION_PATTERN = /\b(until|unless|without)\b/i;
+// "not only X" is an additive idiom that affirms X, not a negation of it
+// ("Not only is production access needed for the rollout" -- Codex review
+// round 4, PR #2757); scoped to an immediately-following "only" right
+// after "not" specifically, not a general requirement-assertion
+// cancellation (which would also wrongly cancel a genuine double negative
+// like "No credential changes are needed").
+const NOT_ONLY_IDIOM_PATTERN = /^\s*only\b/i;
 // A backward-looking cue (negation or investigative past tense, below)
 // stops governing a match at a period/semicolon/colon/em-dash, a blank
 // line, or a following list-item marker -- a bullet's own negation must
@@ -193,7 +200,9 @@ function isGovernedByBackwardCue(
     if (
       CUE_HARD_BREAK_PATTERN.test(linkText) ||
       CLAUSE_CONTINUATION_COMMA_PATTERN.test(linkText) ||
-      (cancelPattern && cancelPattern.test(linkText))
+      (cancelPattern && cancelPattern.test(linkText)) ||
+      (cueMatch[0].toLowerCase() === 'not' &&
+        NOT_ONLY_IDIOM_PATTERN.test(linkText))
     ) {
       continue;
     }
@@ -410,11 +419,16 @@ export function evaluateA4Viability(issue: unknown): {
 // review round 3, PR #2757); an exact-length-only rule leaves such a block
 // wrongly "open" for the rest of the corpus. A run only counts as a fence
 // marker when it sits alone on its line; an inline run of 3+ backticks
-// (e.g. all on one line) still requires an exact-length closer. A fresh
-// regex literal per call (rather than a shared module-level one)
-// sidesteps both the CLI-entry TDZ ordering rule this file's helpers must
-// follow (see the flag-spec comment below) and any `lastIndex` state
-// leaking across calls.
+// (e.g. all on one line) still requires an exact-length closer. Finally, a
+// run with NO valid closer anywhere in the corpus (a stray unmatched
+// backtick, e.g. "contains a stray `. Production access is required" --
+// Codex review round 4, PR #2757) never forms a code span at all per
+// CommonMark and must not be treated as an opener -- it is ordinary
+// literal text, and scanning continues past it looking for the next
+// potential opener. A fresh regex literal per call (rather than a shared
+// module-level one) sidesteps both the CLI-entry TDZ ordering rule this
+// file's helpers must follow (see the flag-spec comment below) and any
+// `lastIndex` state leaking across calls.
 function isAloneOnLine(
   corpus: string,
   runStart: number,
@@ -436,29 +450,48 @@ function isAloneOnLine(
   }
   return after >= corpus.length || corpus[after] === '\n';
 }
+interface BacktickRun {
+  index: number;
+  end: number;
+  length: number;
+  isFenceCandidate: boolean;
+}
+function closesRun(candidate: BacktickRun, open: BacktickRun): boolean {
+  return open.isFenceCandidate
+    ? candidate.length >= open.length && candidate.isFenceCandidate
+    : candidate.length === open.length;
+}
 function isInsideCodeSpan(corpus: string, index: number): boolean {
   const runPattern = /`+/g;
-  let open: { length: number; isFence: boolean } | null = null;
+  const runs: BacktickRun[] = [];
   let match: RegExpExecArray | null = runPattern.exec(corpus);
-  while (match !== null && match.index < index) {
-    const runLength = match[0].length;
-    const runEnd = match.index + runLength;
+  while (match !== null) {
+    const runIndex = match.index;
+    const runEnd = runIndex + match[0].length;
+    runs.push({
+      index: runIndex,
+      end: runEnd,
+      length: match[0].length,
+      isFenceCandidate:
+        match[0].length >= 3 && isAloneOnLine(corpus, runIndex, runEnd),
+    });
+    match = runPattern.exec(corpus);
+  }
+  let open: BacktickRun | null = null;
+  for (const run of runs) {
+    if (run.index >= index) {
+      break;
+    }
     if (open === null) {
-      open = {
-        length: runLength,
-        isFence: runLength >= 3 && isAloneOnLine(corpus, match.index, runEnd),
-      };
-    } else if (open.isFence) {
-      if (
-        runLength >= open.length &&
-        isAloneOnLine(corpus, match.index, runEnd)
-      ) {
-        open = null;
+      const hasCloser = runs.some(
+        (candidate) => candidate.index > run.index && closesRun(candidate, run),
+      );
+      if (hasCloser) {
+        open = run;
       }
-    } else if (runLength === open.length) {
+    } else if (closesRun(run, open)) {
       open = null;
     }
-    match = runPattern.exec(corpus);
   }
   return open !== null;
 }
@@ -623,7 +656,11 @@ function isInsideQuotedExample(
 ): boolean {
   const lineStart = corpus.lastIndexOf('\n', matchIndex - 1) + 1;
   if (/^[ \t]*>/.test(corpus.slice(lineStart, matchIndex))) {
-    return true;
+    // Blockquote syntax alone does not establish the cited content is
+    // non-blocking -- the same requirement-assertion safeguard used for a
+    // paired quote below must also apply here ("> Production access is
+    // required before shipping" -- Codex review round 4, PR #2757).
+    return !isNearRequirementAssertion(corpus, matchIndex, matchEnd);
   }
   const { start: paragraphStart, end: paragraphEnd } = findParagraphSpan(
     corpus,

--- a/src/scripts/discover-viability-gate.mts
+++ b/src/scripts/discover-viability-gate.mts
@@ -259,13 +259,18 @@ const INVESTIGATIVE_PAST_TENSE_WINDOW = 80;
 //    #2757) still imposes a live requirement despite the generic-sounding
 //    noun. `blocked`/`pending` cover emphasis-quoting with no must/require
 //    wording of its own ("Shipping remains BLOCKED PENDING 'production
-//    access'" -- Codex review round 3, PR #2757).
+//    access'" -- Codex review round 3, PR #2757). `waiting` covers an
+//    ongoing dependency the past-investigation exclusion would otherwise
+//    wrongly suppress ("We already checked the reproduction and are now
+//    WAITING ON production access" -- Codex review round 5, PR #2757):
+//    the investigation cue is unrelated to the still-open dependency
+//    named right after it.
 const GENERIC_MENTION_NOUN_PATTERN =
   /^(pattern|example|scenario|convention|practice|concept|term|approach|precedent|case)$/i;
 const GENERIC_MENTION_LOOKAHEAD_CHARS = 40;
 const GENERIC_MENTION_LOOKAHEAD_TOKENS = 2;
 const REQUIREMENT_ASSERTION_PATTERN =
-  /\b(must|require[sd]?|requiring|needed|needs?|shall|mandatory|essential|blocked|blocking|pending)\b/i;
+  /\b(must|require[sd]?|requiring|needed|needs?|shall|mandatory|essential|blocked|blocking|pending|waiting)\b/i;
 const REQUIREMENT_ASSERTION_WINDOW_CHARS = 80;
 
 // Flag-spec keys stay the dashed literal on purpose (never bare keys like
@@ -412,35 +417,33 @@ export function evaluateA4Viability(issue: unknown): {
 // single backticks appear inside), not on individual-backtick parity -- a
 // run of a different length while a span is open is literal content, not a
 // closer (#2738 Codex review round 2, PR #2757). A FENCED code block is
-// different: its opening run sits alone on a line (only leading
-// whitespace before it) and has length >= 3, and CommonMark lets the
+// different: its opening run needs only LEADING whitespace on its line
+// (trailing content is a valid info string, e.g. ```ts -- Copilot/Codex
+// review round 5, PR #2757) and has length >= 3, and CommonMark lets the
 // closing fence be LONGER than the opener, not just equal (a fence opened
 // with ``` and closed with ```` is still a valid, closed block -- Codex
 // review round 3, PR #2757); an exact-length-only rule leaves such a block
-// wrongly "open" for the rest of the corpus. A run only counts as a fence
-// marker when it sits alone on its line; an inline run of 3+ backticks
-// (e.g. all on one line) still requires an exact-length closer. Finally, a
-// run with NO valid closer anywhere in the corpus (a stray unmatched
-// backtick, e.g. "contains a stray `. Production access is required" --
-// Codex review round 4, PR #2757) never forms a code span at all per
-// CommonMark and must not be treated as an opener -- it is ordinary
-// literal text, and scanning continues past it looking for the next
-// potential opener. A fresh regex literal per call (rather than a shared
-// module-level one) sidesteps both the CLI-entry TDZ ordering rule this
-// file's helpers must follow (see the flag-spec comment below) and any
-// `lastIndex` state leaking across calls.
-function isAloneOnLine(
-  corpus: string,
-  runStart: number,
-  runEnd: number,
-): boolean {
+// wrongly "open" for the rest of the corpus. A CLOSING fence, unlike the
+// opener, allows no info string: it needs both leading AND trailing
+// whitespace only. An inline run of 3+ backticks (e.g. all on one line,
+// with non-whitespace before it) still requires an exact-length closer.
+// Finally, a run with NO valid closer anywhere in the corpus (a stray
+// unmatched backtick, e.g. "contains a stray `. Production access is
+// required" -- Codex review round 4, PR #2757) never forms a code span at
+// all per CommonMark and must not be treated as an opener -- it is
+// ordinary literal text, and scanning continues past it looking for the
+// next potential opener. A fresh regex literal per call (rather than a
+// shared module-level one) sidesteps both the CLI-entry TDZ ordering rule
+// this file's helpers must follow (see the flag-spec comment below) and
+// any `lastIndex` state leaking across calls.
+function hasOnlyLeadingWhitespace(corpus: string, runStart: number): boolean {
   let before = runStart - 1;
   while (before >= 0 && (corpus[before] === ' ' || corpus[before] === '\t')) {
     before--;
   }
-  if (before >= 0 && corpus[before] !== '\n') {
-    return false;
-  }
+  return before < 0 || corpus[before] === '\n';
+}
+function hasOnlyTrailingWhitespace(corpus: string, runEnd: number): boolean {
   let after = runEnd;
   while (
     after < corpus.length &&
@@ -454,11 +457,12 @@ interface BacktickRun {
   index: number;
   end: number;
   length: number;
-  isFenceCandidate: boolean;
+  isFenceOpenerCandidate: boolean;
+  isFenceCloserCandidate: boolean;
 }
 function closesRun(candidate: BacktickRun, open: BacktickRun): boolean {
-  return open.isFenceCandidate
-    ? candidate.length >= open.length && candidate.isFenceCandidate
+  return open.isFenceOpenerCandidate
+    ? candidate.length >= open.length && candidate.isFenceCloserCandidate
     : candidate.length === open.length;
 }
 function isInsideCodeSpan(corpus: string, index: number): boolean {
@@ -468,12 +472,16 @@ function isInsideCodeSpan(corpus: string, index: number): boolean {
   while (match !== null) {
     const runIndex = match.index;
     const runEnd = runIndex + match[0].length;
+    const leadingOk = hasOnlyLeadingWhitespace(corpus, runIndex);
     runs.push({
       index: runIndex,
       end: runEnd,
       length: match[0].length,
-      isFenceCandidate:
-        match[0].length >= 3 && isAloneOnLine(corpus, runIndex, runEnd),
+      isFenceOpenerCandidate: match[0].length >= 3 && leadingOk,
+      isFenceCloserCandidate:
+        match[0].length >= 3 &&
+        leadingOk &&
+        hasOnlyTrailingWhitespace(corpus, runEnd),
     });
     match = runPattern.exec(corpus);
   }

--- a/src/scripts/discover-viability-gate.mts
+++ b/src/scripts/discover-viability-gate.mts
@@ -166,15 +166,19 @@ const NEGATION_CUE_PATTERN =
 const NEGATION_CUE_WINDOW = 40;
 const NEGATION_CANCELING_CONJUNCTION_PATTERN = /\b(until|unless|without)\b/i;
 // A backward-looking cue (negation or investigative past tense, below)
-// stops governing a match at a period/semicolon/em-dash (HARD_CLAUSE_BREAK_
-// PATTERN, shared with the broad-scope exclusions above), a blank line, or
-// a following list-item marker -- a bullet's own negation must not reach
-// into a SIBLING bullet's independent claim. A bare mid-paragraph newline
-// (a soft-wrapped line) is deliberately not a break here: #2711's own
-// wrapped quotation shows ordinary prose legitimately continuing a clause
-// across one.
+// stops governing a match at a period/semicolon/colon/em-dash, a blank
+// line, or a following list-item marker -- a bullet's own negation must
+// not reach into a SIBLING bullet's independent claim, and a colon
+// introducing an independent requirement ("No workaround: production
+// access is required before shipping" -- Codex review round 3, PR #2757)
+// must not let the preceding negation cross into it. The pattern below
+// (CUE_HARD_BREAK_PATTERN) is a superset of HARD_CLAUSE_BREAK_PATTERN
+// (period/semicolon/em-dash only), which the broad-scope exclusions
+// above use. A bare mid-paragraph newline (a soft-wrapped line) is
+// deliberately not a break here: #2711's own wrapped quotation shows
+// ordinary prose legitimately continuing a clause across one.
 const CUE_HARD_BREAK_PATTERN =
-  /[.;—]|--|\n[ \t]*(?:[-*]\s|\d+[.)]\s)|\n[ \t]*\n/;
+  /[.;:—]|--|\n[ \t]*(?:[-*]\s|\d+[.)]\s)|\n[ \t]*\n/;
 function isGovernedByBackwardCue(
   corpus: string,
   matchIndex: number,
@@ -240,16 +244,19 @@ const INVESTIGATIVE_PAST_TENSE_WINDOW = 80;
 //    this issue ("...a least-privilege CI credential pattern..." -- an
 //    incidental background mention in #2716's own real body, distinct
 //    from that same issue's separately negated target phrase), UNLESS a
-//    requirement-assertion cue (must/require/need/shall/...) sits in the
-//    same clause -- `A credential approach MUST be supplied by the
-//    maintainer before implementation` (Codex review, PR #2757) still
-//    imposes a live requirement despite the generic-sounding noun.
+//    requirement-assertion cue (must/require/need/shall/blocked/pending/
+//    ...) sits in the same clause -- `A credential approach MUST be
+//    supplied by the maintainer before implementation` (Codex review, PR
+//    #2757) still imposes a live requirement despite the generic-sounding
+//    noun. `blocked`/`pending` cover emphasis-quoting with no must/require
+//    wording of its own ("Shipping remains BLOCKED PENDING 'production
+//    access'" -- Codex review round 3, PR #2757).
 const GENERIC_MENTION_NOUN_PATTERN =
   /^(pattern|example|scenario|convention|practice|concept|term|approach|precedent|case)$/i;
 const GENERIC_MENTION_LOOKAHEAD_CHARS = 40;
 const GENERIC_MENTION_LOOKAHEAD_TOKENS = 2;
 const REQUIREMENT_ASSERTION_PATTERN =
-  /\b(must|require[sd]?|requiring|needed|needs?|shall|mandatory|essential)\b/i;
+  /\b(must|require[sd]?|requiring|needed|needs?|shall|mandatory|essential|blocked|blocking|pending)\b/i;
 const REQUIREMENT_ASSERTION_WINDOW_CHARS = 80;
 
 // Flag-spec keys stay the dashed literal on purpose (never bare keys like
@@ -391,28 +398,69 @@ export function evaluateA4Viability(issue: unknown): {
   };
 }
 
-// CommonMark code spans open and close on a run of backticks of the SAME
-// length (a multi-backtick delimiter, e.g. ``` `` ```, lets literal single
-// backticks appear inside), not on individual-backtick parity -- a run of a
-// different length while a span is open is literal content, not a closer
-// (#2738 Codex review round 2, PR #2757). A fresh regex literal per call
-// (rather than a shared module-level one) sidesteps both the CLI-entry TDZ
-// ordering rule this file's helpers must follow (see the flag-spec comment
-// below) and any `lastIndex` state leaking across calls.
+// CommonMark inline code spans open and close on a run of backticks of the
+// SAME length (a multi-backtick delimiter, e.g. ``` `` ```, lets literal
+// single backticks appear inside), not on individual-backtick parity -- a
+// run of a different length while a span is open is literal content, not a
+// closer (#2738 Codex review round 2, PR #2757). A FENCED code block is
+// different: its opening run sits alone on a line (only leading
+// whitespace before it) and has length >= 3, and CommonMark lets the
+// closing fence be LONGER than the opener, not just equal (a fence opened
+// with ``` and closed with ```` is still a valid, closed block -- Codex
+// review round 3, PR #2757); an exact-length-only rule leaves such a block
+// wrongly "open" for the rest of the corpus. A run only counts as a fence
+// marker when it sits alone on its line; an inline run of 3+ backticks
+// (e.g. all on one line) still requires an exact-length closer. A fresh
+// regex literal per call (rather than a shared module-level one)
+// sidesteps both the CLI-entry TDZ ordering rule this file's helpers must
+// follow (see the flag-spec comment below) and any `lastIndex` state
+// leaking across calls.
+function isAloneOnLine(
+  corpus: string,
+  runStart: number,
+  runEnd: number,
+): boolean {
+  let before = runStart - 1;
+  while (before >= 0 && (corpus[before] === ' ' || corpus[before] === '\t')) {
+    before--;
+  }
+  if (before >= 0 && corpus[before] !== '\n') {
+    return false;
+  }
+  let after = runEnd;
+  while (
+    after < corpus.length &&
+    (corpus[after] === ' ' || corpus[after] === '\t')
+  ) {
+    after++;
+  }
+  return after >= corpus.length || corpus[after] === '\n';
+}
 function isInsideCodeSpan(corpus: string, index: number): boolean {
   const runPattern = /`+/g;
-  let openRunLength: number | null = null;
+  let open: { length: number; isFence: boolean } | null = null;
   let match: RegExpExecArray | null = runPattern.exec(corpus);
   while (match !== null && match.index < index) {
     const runLength = match[0].length;
-    if (openRunLength === null) {
-      openRunLength = runLength;
-    } else if (runLength === openRunLength) {
-      openRunLength = null;
+    const runEnd = match.index + runLength;
+    if (open === null) {
+      open = {
+        length: runLength,
+        isFence: runLength >= 3 && isAloneOnLine(corpus, match.index, runEnd),
+      };
+    } else if (open.isFence) {
+      if (
+        runLength >= open.length &&
+        isAloneOnLine(corpus, match.index, runEnd)
+      ) {
+        open = null;
+      }
+    } else if (runLength === open.length) {
+      open = null;
     }
     match = runPattern.exec(corpus);
   }
-  return openRunLength !== null;
+  return open !== null;
 }
 
 function isGovernedByAvoidanceCue(corpus: string, matchIndex: number): boolean {

--- a/src/scripts/discover-viability-gate.mts
+++ b/src/scripts/discover-viability-gate.mts
@@ -140,7 +140,86 @@ const OBJECTIVE_VERIFICATION_PATTERN =
 const SUBJECTIVE_VERIFICATION_PATTERN =
   /\b(feels?|looks? good|opinion|judgement?|ux call|maintainer preference|stakeholder preference|subjective)\b/i;
 const EXTERNAL_COORDINATION_PATTERN =
-  /\b(external coordination|human decision|maintainer decision|stakeholder sign-?off|manual approval|waiting for (?:maintainer|stakeholder)|external system|third-?party access|credential|production access|cross-repo dependency)\b/i;
+  /\b(external coordination|human decision|maintainer decision|stakeholder sign-?off|manual approval|waiting for (?:maintainer|stakeholder)|external system|third-?party access|credential|production access|cross-repo dependency)\b/gi;
+// A trigger phrase inside a phrase describing something other than a live,
+// remaining completion blocker should not count (#2738), mirroring
+// findUnexcludedBroadScopeMatch's per-occurrence shape above: a negated
+// non-requirement, a quoted/cited example of another artifact's own
+// content, a past-tense description of an investigation the issue author
+// already finished while drafting, or a generic mention of a pattern/
+// concept rather than an asserted requirement.
+//
+// 1. Negation: the match is governed by a negation cue reaching it with no
+//    hard clause break in between ("no interactive credential minting" --
+//    #2716). `zero` excludes a hyphenated compound ("zero-downtime") so it
+//    is never mistaken for a standalone negation word.
+const NEGATION_CUE_PATTERN =
+  /\b(no|not|without|zero(?!-)|never|none|isn'?t|aren'?t|wasn'?t|weren'?t|doesn'?t|don'?t|didn'?t|won'?t|can'?t|cannot)\b/gi;
+const NEGATION_CUE_WINDOW = 40;
+// A backward-looking cue (negation or investigative past tense, below)
+// stops governing a match at a period/semicolon/em-dash (HARD_CLAUSE_BREAK_
+// PATTERN, shared with the broad-scope exclusions above), a blank line, or
+// a following list-item marker -- a bullet's own negation must not reach
+// into a SIBLING bullet's independent claim. A bare mid-paragraph newline
+// (a soft-wrapped line) is deliberately not a break here: #2711's own
+// wrapped quotation shows ordinary prose legitimately continuing a clause
+// across one.
+const CUE_HARD_BREAK_PATTERN =
+  /[.;—]|--|\n[ \t]*(?:[-*]\s|\d+[.)]\s)|\n[ \t]*\n/;
+function isGovernedByBackwardCue(
+  corpus: string,
+  matchIndex: number,
+  cuePattern: RegExp,
+  window: number,
+): boolean {
+  const windowStart = Math.max(0, matchIndex - window);
+  const windowText = corpus.slice(windowStart, matchIndex);
+  for (const cueMatch of windowText.matchAll(cuePattern)) {
+    const linkText = windowText.slice(cueMatch.index + cueMatch[0].length);
+    if (
+      CUE_HARD_BREAK_PATTERN.test(linkText) ||
+      CLAUSE_CONTINUATION_COMMA_PATTERN.test(linkText)
+    ) {
+      continue;
+    }
+    return true;
+  }
+  return false;
+}
+// 2. Quoted example: the match sits on a Markdown blockquote line, or is
+//    bounded by a matching pair of quote characters within the containing
+//    paragraph (#2711's inverted-attribution quotation shape, which soft-
+//    wraps the quoted marker across a line break -- scoped to the
+//    paragraph, not the physical line, so that wrap doesn't defeat the
+//    pairing). A plain straight single quote also marks a contraction
+//    ("doesn't"), so a candidate quote character counts as an opener only
+//    when the character right before it is not a letter, and as a closer
+//    only when the character right after it is not a letter -- a
+//    contraction's apostrophe always sits directly between two letters and
+//    fails both checks.
+const QUOTE_CHAR_PAIRS: Record<string, string> = {
+  '"': '"',
+  "'": "'",
+  '‘': '’',
+  '“': '”',
+};
+const LETTER_PATTERN = /[A-Za-z]/;
+const PARAGRAPH_BREAK_PATTERN = /\n[ \t]*\n/g;
+// 3. Investigative past tense: the match describes an investigation the
+//    issue author already performed while drafting, not remaining work
+//    (#2697's shape, applied here to EXTERNAL_COORDINATION_PATTERN).
+const INVESTIGATIVE_PAST_TENSE_PATTERN =
+  /\b(?:already|previously)\s+(?:checked|verified|confirmed|investigated|reviewed|searched)\b|\bi\s+(?:already\s+)?checked\b|\ba\s+search\s+(?:already\s+)?found\b|\bconfirmed\s+via\b/gi;
+const INVESTIGATIVE_PAST_TENSE_WINDOW = 80;
+// 4. Generic mention: the match is followed shortly by a noun naming a
+//    general pattern/example rather than asserting a live requirement of
+//    this issue ("...a least-privilege CI credential pattern..." -- an
+//    incidental background mention in #2716's own real body, distinct
+//    from that same issue's separately negated target phrase).
+const GENERIC_MENTION_NOUN_PATTERN =
+  /^(pattern|example|scenario|convention|practice|concept|term|approach|precedent|case)$/i;
+const GENERIC_MENTION_LOOKAHEAD_CHARS = 40;
+const GENERIC_MENTION_LOOKAHEAD_TOKENS = 2;
 
 // Flag-spec keys stay the dashed literal on purpose (never bare keys like
 // `issue:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
@@ -411,14 +490,138 @@ export function evaluateClearVerification(issue: NormalizedIssue): EvalResult {
   };
 }
 
+function isGovernedByNegation(corpus: string, matchIndex: number): boolean {
+  return isGovernedByBackwardCue(
+    corpus,
+    matchIndex,
+    NEGATION_CUE_PATTERN,
+    NEGATION_CUE_WINDOW,
+  );
+}
+
+function isLikelyQuoteOpener(charBefore: string): boolean {
+  return !LETTER_PATTERN.test(charBefore);
+}
+
+function isLikelyQuoteCloser(charAfter: string): boolean {
+  return !LETTER_PATTERN.test(charAfter);
+}
+
+function findParagraphSpan(
+  corpus: string,
+  offset: number,
+): { start: number; end: number } {
+  let start = 0;
+  for (const breakMatch of corpus
+    .slice(0, offset)
+    .matchAll(PARAGRAPH_BREAK_PATTERN)) {
+    start = breakMatch.index + breakMatch[0].length;
+  }
+  const afterBreak = /\n[ \t]*\n/.exec(corpus.slice(offset));
+  const end = afterBreak ? offset + afterBreak.index : corpus.length;
+  return { start, end };
+}
+
+function isInsideQuotedExample(
+  corpus: string,
+  matchIndex: number,
+  matchEnd: number,
+): boolean {
+  const lineStart = corpus.lastIndexOf('\n', matchIndex - 1) + 1;
+  if (/^[ \t]*>/.test(corpus.slice(lineStart, matchIndex))) {
+    return true;
+  }
+  const { start: paragraphStart, end: paragraphEnd } = findParagraphSpan(
+    corpus,
+    matchIndex,
+  );
+  const before = corpus.slice(paragraphStart, matchIndex);
+  const after = corpus.slice(matchEnd, paragraphEnd);
+  for (const [open, close] of Object.entries(QUOTE_CHAR_PAIRS)) {
+    const openIndex = before.lastIndexOf(open);
+    if (
+      openIndex === -1 ||
+      !isLikelyQuoteOpener(openIndex > 0 ? before[openIndex - 1] : '')
+    ) {
+      continue;
+    }
+    const closeIndex = after.indexOf(close);
+    if (
+      closeIndex === -1 ||
+      !isLikelyQuoteCloser(after[closeIndex + 1] ?? '')
+    ) {
+      continue;
+    }
+    return true;
+  }
+  return false;
+}
+
+function isDescribedByPastInvestigation(
+  corpus: string,
+  matchIndex: number,
+): boolean {
+  return isGovernedByBackwardCue(
+    corpus,
+    matchIndex,
+    INVESTIGATIVE_PAST_TENSE_PATTERN,
+    INVESTIGATIVE_PAST_TENSE_WINDOW,
+  );
+}
+
+function isFollowedByGenericMentionNoun(
+  corpus: string,
+  matchEnd: number,
+): boolean {
+  const rawTail = corpus.slice(
+    matchEnd,
+    matchEnd + GENERIC_MENTION_LOOKAHEAD_CHARS,
+  );
+  const breakMatch = HARD_CLAUSE_BREAK_PATTERN.exec(rawTail);
+  const tail = breakMatch ? rawTail.slice(0, breakMatch.index) : rawTail;
+  const tokens = tail.match(WORD_TOKEN_PATTERN) ?? [];
+  return tokens
+    .slice(0, GENERIC_MENTION_LOOKAHEAD_TOKENS)
+    .some((token) => GENERIC_MENTION_NOUN_PATTERN.test(token));
+}
+
+/**
+ * Finds the first EXTERNAL_COORDINATION_PATTERN occurrence that survives
+ * every exclusion check (#2738): a match inside a code span, governed by a
+ * negation cue, inside a quoted/cited example, described as an
+ * already-completed investigation, or naming a generic pattern rather than
+ * an asserted requirement does not describe this issue's own remaining
+ * completion blocker and is skipped.
+ */
+function findUnexcludedExternalCoordinationMatch(
+  corpus: string,
+): string | null {
+  for (const match of corpus.matchAll(EXTERNAL_COORDINATION_PATTERN)) {
+    const index = match.index;
+    const end = index + match[0].length;
+    if (
+      isInsideCodeSpan(corpus, index) ||
+      isInsideQuotedExample(corpus, index, end) ||
+      isGovernedByNegation(corpus, index) ||
+      isDescribedByPastInvestigation(corpus, index) ||
+      isFollowedByGenericMentionNoun(corpus, end)
+    ) {
+      continue;
+    }
+    return match[0];
+  }
+  return null;
+}
+
 export function evaluateAutonomousCompletion(
   issue: NormalizedIssue,
 ): EvalResult {
   const corpus = `${issue.title}\n${issue.body}`;
-  if (EXTERNAL_COORDINATION_PATTERN.test(corpus)) {
+  const match = findUnexcludedExternalCoordinationMatch(corpus);
+  if (match !== null) {
     return {
       pass: false,
-      evidence: 'External coordination or manual decision signal detected.',
+      evidence: `External coordination or manual decision signal detected: "${match}".`,
     };
   }
   return {

--- a/tests/discover-viability-gate.test.mts
+++ b/tests/discover-viability-gate.test.mts
@@ -694,6 +694,68 @@ test('passes autonomous completion when a trigger phrase sits inside a multi-bac
   assert.deepEqual(result.failedCriteria, []);
 });
 
+// --- PR #2757 review round 3 (Copilot/Codex): a colon introducing an
+// independent requirement, "blocked"/"pending" emphasis-quoting with no
+// must/require wording of its own, and a fenced code block whose closer is
+// longer than its opener -------------------------------------------------
+
+test('still fails autonomous completion when a colon introduces an independent requirement after a negation (Codex review round 3, PR #2757)', () => {
+  const result = evaluateA4Viability({
+    number: 51,
+    title: 'wire external approval gate',
+    body:
+      'No workaround: production access is required before shipping. ' +
+      'Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.failedCriteria.includes('autonomous_completion'));
+});
+
+test('still fails autonomous completion when a quoted requirement is emphasized with "blocked"/"pending" instead of must/require (Codex review round 3, PR #2757)', () => {
+  const result = evaluateA4Viability({
+    number: 52,
+    title: 'wire external approval gate',
+    body:
+      'Shipping remains blocked pending "production access". ' +
+      'Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.failedCriteria.includes('autonomous_completion'));
+});
+
+test('still fails autonomous completion when a genuine blocker sits after a fenced code block closed by a longer backtick run (Codex review round 3, PR #2757)', () => {
+  const result = evaluateA4Viability({
+    number: 53,
+    title: 'fix docs example formatting',
+    body:
+      '```\nproduction access\n````\n\n' +
+      'Production access is required before shipping. ' +
+      'Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.failedCriteria.includes('autonomous_completion'));
+});
+
+test('passes autonomous completion when the only trigger phrase sits inside a fenced code block closed by a longer backtick run (Codex review round 3, PR #2757)', () => {
+  const result = evaluateA4Viability({
+    number: 54,
+    title: 'fix docs example formatting',
+    body:
+      '```\nproduction access\n````\n\n' +
+      'Single docs-only change. Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, true);
+  assert.deepEqual(result.failedCriteria, []);
+});
+
 test('evaluateDiscoverViability fails closed when a lookup aborts', async () => {
   // A non-404 gh failure (auth / rate-limit / network) propagates out of
   // loadIssue instead of being swallowed into a silent issue_not_found.

--- a/tests/discover-viability-gate.test.mts
+++ b/tests/discover-viability-gate.test.mts
@@ -557,6 +557,81 @@ test('still fails autonomous completion when a generic-pattern mention coexists 
   assert.ok(result.failedCriteria.includes('autonomous_completion'));
 });
 
+// --- PR #2757 review follow-ups (Copilot + Codex): a digit-adjacent
+// apostrophe, an "until"-canceled negation, unattributed emphasis-quoting,
+// a past investigation that confirms rather than resolves the blocker, and
+// a generic noun paired with an explicit requirement-assertion word -------
+
+test('still fails autonomous completion when a possessive apostrophe follows a digit (Copilot review, PR #2757)', () => {
+  const result = evaluateA4Viability({
+    number: 42,
+    title: 'wire external approval gate',
+    body:
+      "The 2020's external system rollout requires production access " +
+      'before it can ship. Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.failedCriteria.includes('autonomous_completion'));
+});
+
+test('still fails autonomous completion when "not ... until" makes the following phrase a prerequisite (Codex review, PR #2757)', () => {
+  const result = evaluateA4Viability({
+    number: 43,
+    title: 'wire external approval gate',
+    body:
+      'Do not proceed until production access is granted. ' +
+      'Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.failedCriteria.includes('autonomous_completion'));
+});
+
+test("still fails autonomous completion when quotes only emphasize this issue's own requirement, with no citation framing (Codex review, PR #2757)", () => {
+  const result = evaluateA4Viability({
+    number: 44,
+    title: 'wire external approval gate',
+    body:
+      'The change requires "production access" before it can ship. ' +
+      'Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.failedCriteria.includes('autonomous_completion'));
+});
+
+test('still fails autonomous completion when a past investigation confirms the blocker rather than resolving it (Codex review, PR #2757)', () => {
+  const result = evaluateA4Viability({
+    number: 45,
+    title: 'wire external approval gate',
+    body:
+      'We already verified production access is required before this ' +
+      'can ship. Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.failedCriteria.includes('autonomous_completion'));
+});
+
+test('still fails autonomous completion when a generic-sounding noun coexists with an explicit requirement-assertion word (Codex review, PR #2757)', () => {
+  const result = evaluateA4Viability({
+    number: 46,
+    title: 'wire external approval gate',
+    body:
+      'A credential approach must be supplied by the maintainer before ' +
+      'implementation. Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.failedCriteria.includes('autonomous_completion'));
+});
+
 test('evaluateDiscoverViability fails closed when a lookup aborts', async () => {
   // A non-404 gh failure (auth / rate-limit / network) propagates out of
   // loadIssue instead of being swallowed into a silent issue_not_found.

--- a/tests/discover-viability-gate.test.mts
+++ b/tests/discover-viability-gate.test.mts
@@ -632,6 +632,68 @@ test('still fails autonomous completion when a generic-sounding noun coexists wi
   assert.ok(result.failedCriteria.includes('autonomous_completion'));
 });
 
+// --- PR #2757 review round 2 (Codex): "cannot ... without" as a
+// requirement (not a double negation), a negation cue crossing the
+// title/body boundary, an unrelated attribution verb elsewhere in the
+// paragraph, and a multi-backtick code span --------------------------
+
+test('still fails autonomous completion when "cannot ... without" makes the following phrase a prerequisite (Codex review round 2, PR #2757)', () => {
+  const result = evaluateA4Viability({
+    number: 47,
+    title: 'wire external approval gate',
+    body:
+      'We cannot complete this without production access. ' +
+      'Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.failedCriteria.includes('autonomous_completion'));
+});
+
+test('still fails autonomous completion when a negation in the title would otherwise cross into the body (Codex review round 2, PR #2757)', () => {
+  const result = evaluateA4Viability({
+    number: 48,
+    title: 'No credential changes',
+    body:
+      'Production access is required before shipping. ' +
+      'Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.failedCriteria.includes('autonomous_completion'));
+});
+
+test('still fails autonomous completion when an unrelated attribution verb sits elsewhere in the paragraph (Codex review round 2, PR #2757)', () => {
+  const result = evaluateA4Viability({
+    number: 49,
+    title: 'wire external approval gate',
+    body:
+      'The docs describe local setup. This change requires ' +
+      '"production access" before it can ship. Verification: add unit ' +
+      'tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.failedCriteria.includes('autonomous_completion'));
+});
+
+test('passes autonomous completion when a trigger phrase sits inside a multi-backtick code span (Codex review round 2, PR #2757)', () => {
+  const result = evaluateA4Viability({
+    number: 50,
+    title: 'fix docs example formatting',
+    body:
+      'Use ``production access`` as a diagnostic label in the error ' +
+      'message. Single docs-only change. Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, true);
+  assert.deepEqual(result.failedCriteria, []);
+});
+
 test('evaluateDiscoverViability fails closed when a lookup aborts', async () => {
   // A non-404 gh failure (auth / rate-limit / network) propagates out of
   // loadIssue instead of being swallowed into a silent issue_not_found.

--- a/tests/discover-viability-gate.test.mts
+++ b/tests/discover-viability-gate.test.mts
@@ -756,6 +756,66 @@ test('passes autonomous completion when the only trigger phrase sits inside a fe
   assert.deepEqual(result.failedCriteria, []);
 });
 
+// --- PR #2757 review round 4 (Codex): a stray unmatched backtick, the
+// "not only" additive idiom, and an unconditional blockquote exclusion
+// with no requirement-assertion safeguard ---------------------------------
+
+test('still fails autonomous completion when a stray unmatched backtick precedes a genuine blocker (Codex review round 4, PR #2757)', () => {
+  const result = evaluateA4Viability({
+    number: 55,
+    title: 'fix malformed input handling',
+    body:
+      'Malformed input contains a stray `. Production access is ' +
+      'required before shipping. Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.failedCriteria.includes('autonomous_completion'));
+});
+
+test('still fails autonomous completion when "not only" additively affirms the requirement instead of negating it (Codex review round 4, PR #2757)', () => {
+  const result = evaluateA4Viability({
+    number: 56,
+    title: 'wire external approval gate',
+    body:
+      'Not only is production access needed for the rollout, the ' +
+      'timeline also slips. Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.failedCriteria.includes('autonomous_completion'));
+});
+
+test('still fails autonomous completion when a genuine requirement is stated as a blockquote (Codex review round 4, PR #2757)', () => {
+  const result = evaluateA4Viability({
+    number: 57,
+    title: 'wire external approval gate',
+    body:
+      '> Production access is required before shipping.\n\n' +
+      'Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.failedCriteria.includes('autonomous_completion'));
+});
+
+test('passes autonomous completion when a blockquoted example is not a requirement of its own (Codex review round 4, PR #2757)', () => {
+  const result = evaluateA4Viability({
+    number: 58,
+    title: 'fix docs example formatting',
+    body:
+      '> Example: "no production access needed" is the desired end ' +
+      'state.\n\nSingle docs-only change. Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, true);
+  assert.deepEqual(result.failedCriteria, []);
+});
+
 test('evaluateDiscoverViability fails closed when a lookup aborts', async () => {
   // A non-404 gh failure (auth / rate-limit / network) propagates out of
   // loadIssue instead of being swallowed into a silent issue_not_found.

--- a/tests/discover-viability-gate.test.mts
+++ b/tests/discover-viability-gate.test.mts
@@ -816,6 +816,53 @@ test('passes autonomous completion when a blockquoted example is not a requireme
   assert.deepEqual(result.failedCriteria, []);
 });
 
+// --- PR #2757 review round 5 (Copilot/Codex): a fenced-code opener with
+// an info string, and a past-investigation cue unrelated to a later,
+// still-open dependency -----------------------------------------------
+
+test('still fails autonomous completion when a genuine blocker sits after a fenced code block opened with an info string (Copilot/Codex review round 5, PR #2757)', () => {
+  const result = evaluateA4Viability({
+    number: 59,
+    title: 'fix docs example formatting',
+    body:
+      '```ts\nproduction access\n````\n\n' +
+      'Production access is required before shipping. ' +
+      'Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.failedCriteria.includes('autonomous_completion'));
+});
+
+test('passes autonomous completion when the only trigger phrase sits inside a fenced code block opened with an info string (Copilot/Codex review round 5, PR #2757)', () => {
+  const result = evaluateA4Viability({
+    number: 60,
+    title: 'fix docs example formatting',
+    body:
+      '```ts\nproduction access\n````\n\n' +
+      'Single docs-only change. Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, true);
+  assert.deepEqual(result.failedCriteria, []);
+});
+
+test('still fails autonomous completion when a past-investigation cue is unrelated to a later, still-open dependency (Codex review round 5, PR #2757)', () => {
+  const result = evaluateA4Viability({
+    number: 61,
+    title: 'wire external approval gate',
+    body:
+      'We already checked the reproduction and are now waiting on ' +
+      'production access. Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.failedCriteria.includes('autonomous_completion'));
+});
+
 test('evaluateDiscoverViability fails closed when a lookup aborts', async () => {
   // A non-404 gh failure (auth / rate-limit / network) propagates out of
   // loadIssue instead of being swallowed into a silent issue_not_found.

--- a/tests/discover-viability-gate.test.mts
+++ b/tests/discover-viability-gate.test.mts
@@ -361,6 +361,202 @@ test('fails autonomous completion when external coordination is required', () =>
   assert.ok(result.failedCriteria.includes('autonomous_completion'));
 });
 
+// --- #2738: autonomous_completion false positives on negated, quoted, or
+// investigative-past-tense phrasing, not a live remaining blocker --------
+
+test('passes autonomous completion when a trigger phrase is negated nearby (#2716 shape)', () => {
+  const result = evaluateA4Viability({
+    number: 30,
+    title:
+      'verify Contents API permission masking with no interactive credential minting',
+    body:
+      'Perform the empirical test with no interactive credential minting: ' +
+      'create a disposable repository and record the observed status code. ' +
+      'Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, true);
+  assert.deepEqual(result.failedCriteria, []);
+});
+
+test("passes autonomous completion when a trigger phrase is quoted as another artifact's own content (#2711 shape)", () => {
+  const result = evaluateA4Viability({
+    number: 31,
+    title: 'fix quotation masking in checkVerifiability framing-verb scan',
+    body:
+      `An inverted-attribution quotation ("'Maintainer decision (...): ` +
+      `choose A,' reports the referenced tracking issue") is not ` +
+      'recognized as quoted. Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, true);
+  assert.deepEqual(result.failedCriteria, []);
+});
+
+test('passes autonomous completion when a trigger phrase describes an already-completed investigation (#2697 shape, applied to autonomous_completion)', () => {
+  const result = evaluateA4Viability({
+    number: 32,
+    title: 'document the Contents API masking finding',
+    body:
+      'A search already found that the external system does not mask ' +
+      'permission denials as 404. Single docs-only change. ' +
+      'Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, true);
+  assert.deepEqual(result.failedCriteria, []);
+});
+
+test('still fails autonomous completion when negation is cut off by a hard clause break before a later genuine blocker', () => {
+  // Adversarial case: a negation cue must not extend its reach across a
+  // clause boundary and exclude a genuine blocker that follows it.
+  const result = evaluateA4Viability({
+    number: 33,
+    title: 'wire external approval gate',
+    body:
+      'This has no ambiguity here. Waiting for maintainer sign-off is ' +
+      'required before this can ship. Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.failedCriteria.includes('autonomous_completion'));
+});
+
+test('still fails autonomous completion when a quote-like character never closes on the same line', () => {
+  // Adversarial case: a contraction's apostrophe ("customer's") must not
+  // be mistaken for an opening quote and suppress a genuine blocker.
+  const result = evaluateA4Viability({
+    number: 34,
+    title: "wire external approval gate for the customer's workflow",
+    body:
+      "The customer's rollout requires external coordination before this " +
+      'can ship. Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.failedCriteria.includes('autonomous_completion'));
+});
+
+test('still fails autonomous completion when "checked" appears without a past-tense qualifier before a genuine blocker', () => {
+  const result = evaluateA4Viability({
+    number: 35,
+    title: 'add pre-merge external verification step',
+    body:
+      'It must be checked whether production access is required before ' +
+      'this ships. Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.failedCriteria.includes('autonomous_completion'));
+});
+
+// --- Independent critique follow-ups on the exclusions above: a
+// comma/list-boundary guard for negation, paragraph-scoped quote pairing,
+// and a generic-mention exclusion for a trigger word used to describe a
+// pattern rather than assert a requirement -----------------------------
+
+test('passes autonomous completion when a quoted example wraps across a soft line break within the same paragraph (#2711 real-body shape)', () => {
+  const result = evaluateA4Viability({
+    number: 36,
+    title: 'fix quotation masking in checkVerifiability framing-verb scan',
+    body:
+      `An inverted-attribution quotation ("'Maintainer decision\n` +
+      `(...): choose A,' reports the referenced tracking issue") is not ` +
+      'recognized as quoted. Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, true);
+  assert.deepEqual(result.failedCriteria, []);
+});
+
+test('passes autonomous completion when an earlier generic-pattern mention and a later negated occurrence of the same trigger word coexist (#2716 real-body shape)', () => {
+  const result = evaluateA4Viability({
+    number: 37,
+    title: 'verify Contents API permission masking',
+    body:
+      'This would be exploitable for an adopter authenticating with a ' +
+      'fine-grained token (an increasingly common least-privilege CI ' +
+      'credential pattern) that has repository access. Perform the test ' +
+      'with no interactive credential minting: create a disposable ' +
+      'repository. Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, true);
+  assert.deepEqual(result.failedCriteria, []);
+});
+
+test('still fails autonomous completion when negation is cut off by a comma-joined contrastive clause', () => {
+  // Adversarial case (Codex-style independent critique finding): an
+  // unrelated leading negation must not reach across a contrastive comma
+  // clause and exclude a genuine blocker that follows it.
+  const result = evaluateA4Viability({
+    number: 38,
+    title: 'wire external approval gate',
+    body:
+      'No obvious risk here, but production access is still required ' +
+      'before this can ship. Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.failedCriteria.includes('autonomous_completion'));
+});
+
+test('still fails autonomous completion when negation is cut off by a list-item boundary', () => {
+  // Adversarial case: a bullet's own negation must not reach into a
+  // sibling bullet's independent claim.
+  const result = evaluateA4Viability({
+    number: 39,
+    title: 'wire external approval gate',
+    body:
+      '- No new dependencies\n' +
+      '- Requires maintainer decision on naming\n' +
+      '- Add tests\n' +
+      'Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.failedCriteria.includes('autonomous_completion'));
+});
+
+test('still fails autonomous completion when "zero" is part of a hyphenated compound, not a negation cue', () => {
+  const result = evaluateA4Viability({
+    number: 40,
+    title: 'wire external approval gate',
+    body:
+      'Zero-downtime deployment requires production access before this ' +
+      'can ship. Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.failedCriteria.includes('autonomous_completion'));
+});
+
+test('still fails autonomous completion when a generic-pattern mention coexists with a distinct genuine blocker', () => {
+  const result = evaluateA4Viability({
+    number: 41,
+    title: 'wire external approval gate',
+    body:
+      'This describes a common credential pattern used elsewhere. ' +
+      'Waiting for maintainer sign-off is still required before this ' +
+      'can ship. Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.failedCriteria.includes('autonomous_completion'));
+});
+
 test('evaluateDiscoverViability fails closed when a lookup aborts', async () => {
   // A non-404 gh failure (auth / rate-limit / network) propagates out of
   // loadIssue instead of being swallowed into a silent issue_not_found.


### PR DESCRIPTION
# Summary

`evaluateAutonomousCompletion`'s A4 autonomous-completion check tested
`EXTERNAL_COORDINATION_PATTERN` as a single whole-corpus boolean, so a
trigger phrase that was negated ("no interactive credential minting"),
quoted from another artifact's own content, describing an
already-completed investigation, or naming a generic pattern rather than
an asserted requirement still failed the gate.

This walks every pattern occurrence via `matchAll` and skips one that
survives any of those exclusions, mirroring the existing
`findUnexcludedBroadScopeMatch`/`BROAD_SCOPE_PATTERN` per-occurrence shape
in the same file, so the check stays fail-closed only on a genuine
remaining blocker.

Verified against the real bodies of the three issues that motivated this
fix (#2716, #2711, #2697): each previously reproduced a false positive on
`autonomous_completion` and now passes.

## Linked issue

Closes #2738

## Follow-up issues (if any)

None filed yet. Six rounds of Copilot/Codex review left a handful of
known, narrow limitations of this bounded-window heuristic gate,
each rejected in review with reasoning rather than fixed (to keep
the exclusion surface from growing without bound — see
"Rounds 2–6" below). A follow-up issue can pick any of these up if
it is ever observed in a real issue body:

- A postposed negation ("production access is not required") is not
  recognized — only backward-looking negation is handled.
- "No X exists" (absence) vs. "no X is needed" (unnecessity) are not
  distinguished.
- A coordinating conjunction ("but", "yet", "however", ...) does not
  terminate a negation cue's reach.
- An assertion verb governing the act of quoting a phrase vs.
  asserting the quoted phrase itself as a dependency is not
  distinguished.
- The assertion-word vocabulary (`must`/`require`/`blocked`/
  `pending`/`waiting`/...) is not exhaustive (e.g. `prerequisite`,
  `dependency` are not covered).
- A 4+-space-indented backtick run (an indented code block, not a
  fence) is not distinguished from ordinary text.

## Background / rationale (if material)

An independent critique pass on the initial implementation found three
High-severity gaps empirically (by running the checker against the real
issue bodies rather than only the hand-crafted test fixtures):

1. The negation exclusion had no clause-boundary guard, so an unrelated
   negation earlier in a comma-joined or list-separated corpus could wrongly
   exclude a genuine, unrelated later blocker.
2. The quotation exclusion was scoped to a single physical line, so a
   quoted example that soft-wraps across a line break (as #2711's real body
   does) was not recognized as quoted.
3. The "first unexcluded match wins" design had no exclusion for an
   incidental, non-negated mention of a trigger word describing a general
   pattern (as #2716's real body has, alongside its separately negated
   target phrase) — an earlier such mention masked the correctly-excluded
   negated occurrence.

All three are fixed in this PR (comma/list-boundary guard reusing the
existing `CLAUSE_CONTINUATION_COMMA_PATTERN`; paragraph-scoped quote
pairing instead of line-scoped; a new generic-mention-noun exclusion), each
with a regression test reproducing the exact failure mode, plus adversarial
tests confirming genuine blockers still fail (including a `"zero-downtime"`
hyphenated-compound case, since `zero` alone is one of the negation cue
words).

### Rounds 2–6 (Copilot / Codex automated review)

Five more rounds of findings landed after the initial push. Rounds 2–5
each fixed a fail-open gap (a blocked issue wrongly passing the gate),
with a regression test reproducing the exact corpus cited. Round 6
found four more fail-open shapes, all rejected without a code change
(see below and "Follow-up issues" above) once it became clear that
fixing each one was surfacing the next: the loop only converges by
stopping, not by continuing to widen the exclusion surface.

- **Round 2**: `"cannot ... without X"` was wrongly treated as a
  double negation of `X` — `without` moved from the negation-cue list to
  the canceling-conjunction list (a deliberate deviation from the
  original issue's own suggested cue list, since "without" there asserts
  `X` is required, the mirror image of "no `X` needed"); a title/body
  negation crossing the synthetic join boundary (now joined with a blank
  line, a hard break); an unrelated paragraph-wide attribution verb
  wrongly excluding a live quoted requirement (replaced with the same
  requirement-assertion cancellation used elsewhere); a multi-backtick
  code span miscounted via individual-backtick parity instead of
  run-length matching.
- **Round 3**: a colon introducing an independent requirement after a
  negation; `"blocked"`/`"pending"` emphasis-quoting with no
  must/require wording of its own; a fenced code block closed by a
  longer backtick run than its opener (valid per CommonMark) left
  wrongly "open".
- **Round 4**: a stray unmatched backtick (no valid CommonMark closer)
  wrongly hid every later match as "inside code"; the `"not only X"`
  additive idiom wrongly read as a negation of `X`; an unconditional
  blockquote exclusion missing the same requirement-assertion safeguard
  the paired-quote branch already has.

- **Round 5**: a fenced-code opener with an info string (```` ```ts ````)
  was not recognized as a fence candidate (leading/trailing whitespace
  checks split so an opener only needs leading whitespace, a closer
  still needs both); a past-investigation cue reaching across an
  unrelated clause to suppress a later, still-open dependency (`waiting`
  added to `REQUIREMENT_ASSERTION_PATTERN`, reusing the existing
  cancellation mechanism).

Two findings were **rejected** as requiring grammatical/dependency
parsing or an open-ended vocabulary rather than bounded-window string
matching — the gate stays fail-closed on these narrow shapes by
design, consistent with never widening or removing an existing
genuine-blocker match: a round-4 finding on an assertion verb governing
the act of quoting a phrase vs. asserting the quoted phrase itself as a
dependency, and a round-5 finding on a negation stated after the
trigger phrase instead of before it.

**Round 6** found four more fail-open shapes (listed under "Follow-up
issues" above) and all four were rejected without a code change: each
one is either the same semantic-polarity judgment already rejected in
rounds 4–5, or an open-ended vocabulary/boundary-token list that the
round-3 colon fix already showed keeps producing the next finding once
you start enumerating it. Continuing to fix one new shape per round
was not converging — every fix was itself a new push, and every push
triggered a fresh Codex review of the new code. Stopping here (reject
with reasoning, no further push) is what actually ends the loop.

All 26 review threads across the six rounds carry a stamped
`**Accepted**`/`**Rejected**` disposition reply.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EycqtGKuWjJMpw2tUav3Tn


