### PR TITLE
docs(advisory-wait): consult AW3-S for elapsed-window SATISFIED

### DIFF
--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -554,13 +554,24 @@ confirmed condition above. Delegate polling mechanics to
   mechanics) and resume D4. `SATISFIED` splits on `lastCopilotCommit`:
   when it already matches this HEAD SHA, Copilot's review already
   covers it — request nothing and take the same rerun-and-resume-D4
-  action as `WAIT` above. When it does **not** match this HEAD SHA,
-  `SATISFIED` instead means a same-head request's elapsed window ran
-  out with no review ever landing for this HEAD (see
-  `idd-advisory-wait.instructions.md`'s AW3 elapsed-window rows);
-  `idd-advisory-convergence` stays `pending: true` for this HEAD
-  regardless, so rerunning and resuming D4 would only reproduce the
-  same wait indefinitely — treat it like `CAP_EXHAUSTED`/
+  action as `WAIT` above (this proven-coverage sub-case is unchanged;
+  it never consults **AW3-S**). When it does **not** match this HEAD SHA,
+  `SATISFIED` may reflect either `COPILOT_PENDING` state (see
+  `idd-advisory-wait.instructions.md`'s AW3 elapsed-window rows):
+  `"true"`, settled by `PENDING_WINDOW_MINUTES` alone; or `"false"` — a
+  same-head request's elapsed window ran out with no review ever
+  landing for this HEAD, the settled-window (non-pending) sub-case E14
+  step 4 already consults **AW3-S** for. Consult **AW3-S**'s
+  `staleRequestRecovery` before exiting either way — its non-pending
+  entry requires `COPILOT_PENDING` `"false"`, so the `"true"` sub-case
+  reports `"not-applicable"` and falls through as a safe no-op:
+  `"attempt"` runs the bounded cycle (skip **Remove**, start at
+  **Request**; a proven failure-to-register completes the cycle per
+  the entry's inverted step 4/5 disposition); `"cap-exhausted"` handles
+  like **CAP_EXHAUSTED** below. Either way, `idd-advisory-convergence`
+  stays `pending: true` for this HEAD regardless, so rerunning and
+  resuming D4 would only reproduce the same wait indefinitely — treat
+  it like `CAP_EXHAUSTED`/
   `RECOVERY_NEEDED` below instead. `CAP_EXHAUSTED` (the request cap is
   already spent) or `RECOVERY_NEEDED` (a proven same-head request
   exists but needs its marker, not a new request) both need the fuller

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -214,15 +214,19 @@ turns an operator-visible failure into a silent stall.
      - **SATISFIED**, `COPILOT_PENDING` `"false"`, `COPILOT_PENDING_COVERS_HEAD`
        `"false"` (settled by elapsed time alone, never proven the
        request reached Copilot — `#2327`): consult **AW3-S**'s
-       `staleRequestRecovery` first, the same way E14 step 4 does.
-       `"attempt"` runs its bounded cycle (non-pending entry: skip
-       **Remove**, start at **Request**; a proven failure-to-register
-       completes the cycle per the entry's inverted step 4/5
-       disposition); `"cap-exhausted"` handles like **CAP_EXHAUSTED**
-       below; `"not-applicable"` falls through unchanged. Either way,
-       continue to the CI check afterward (this accumulates
-       recovery-cycle evidence toward `COPILOT_UNAVAILABLE`; the
-       check's own satisfied status is unaffected).
+       `staleRequestRecovery.action` first, the same way E14 step 4
+       does. `"attempt"` runs its bounded cycle (non-pending entry:
+       skip **Remove**, start at **Request**; a proven
+       failure-to-register completes the cycle per the entry's
+       inverted step 4/5 disposition), **then** continue to the CI
+       check (this accumulates recovery-cycle evidence toward
+       `COPILOT_UNAVAILABLE`; the check's own satisfied status is
+       unaffected). `"cap-exhausted"` handles like **CAP_EXHAUSTED**
+       below instead — post the hold and **stop**; do not continue to
+       the CI check for this action (the mandatory stop from
+       **CAP_EXHAUSTED** below still applies; this recovery-cap
+       exhaustion does not waive it). `"not-applicable"` falls through
+       unchanged and continues to the CI check.
      - **SATISFIED** (otherwise) → this check is **satisfied**;
        continue to the CI check.
      - **HOLD** → post the hold comment from **AW4** and stop.

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -205,11 +205,26 @@ turns an operator-visible failure into a silent stall.
   (`idd-advisory-wait.instructions.md`):
 
   1. Run **AW1**. If **SATISFIED** → this check is **satisfied**;
-     continue to the **CI** check.
+     continue to the **CI** check. (This short circuit is always the
+     proven-coverage case — `LAST_COPILOT_COMMIT == PR_HEAD_SHA` —
+     since AW1 alone has no marker data to evaluate the settled-window
+     sub-case below; it never consults **AW3-S**.)
   2. Run **AW2** to fetch markers.
   3. Apply the **AW3** decision table:
-     - **SATISFIED** → this check is **satisfied**; continue to the CI
-       check.
+     - **SATISFIED**, `COPILOT_PENDING` `"false"`, `COPILOT_PENDING_COVERS_HEAD`
+       `"false"` (settled by elapsed time alone, never proven the
+       request reached Copilot — `#2327`): consult **AW3-S**'s
+       `staleRequestRecovery` first, the same way E14 step 4 does.
+       `"attempt"` runs its bounded cycle (non-pending entry: skip
+       **Remove**, start at **Request**; a proven failure-to-register
+       completes the cycle per the entry's inverted step 4/5
+       disposition); `"cap-exhausted"` handles like **CAP_EXHAUSTED**
+       below; `"not-applicable"` falls through unchanged. Either way,
+       continue to the CI check afterward (this accumulates
+       recovery-cycle evidence toward `COPILOT_UNAVAILABLE`; the
+       check's own satisfied status is unaffected).
+     - **SATISFIED** (otherwise) → this check is **satisfied**;
+       continue to the CI check.
      - **HOLD** → post the hold comment from **AW4** and stop.
      - **RECOVERY_NEEDED** → post the recovery marker from **AW3-R**
        without requesting another Copilot review, then enter the normal

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -546,8 +546,8 @@ zero Accepted PATH A items **and** at least one PATH B item got a
 _completed-review_ disposition (never a notice-only rejection — see
 the E6 non-review-notice rule); or (b) the current HEAD is eligible
 for **AW3-S**'s settled-window (non-pending) entry (running
-`advisory-wait-state` reports `staleRequestRecovery.action ==
-"attempt"` for that entry) — D4 and F2 each already consult **AW3-S**
+`advisory-wait-state` reports `staleRequestRecovery.action` as
+`"attempt"` for that entry) — D4 and F2 each already consult **AW3-S**
 independently for this same settled-window entry (`#2726`), but a
 true-virgin empty snapshot otherwise never runs E14 through this gate
 specifically; condition (b) is a defense-in-depth backstop that

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -544,19 +544,20 @@ Applies only from the branch-sync check's no-sync-required `clean` /
 (a) the last non-empty `ReviewItems_snapshot` pass this episode had
 zero Accepted PATH A items **and** at least one PATH B item got a
 _completed-review_ disposition (never a notice-only rejection — see
-the E6 non-review-notice rule); or (b) the current HEAD is **AW3-S**
--eligible under its settled-window (non-pending) entry (running
-`advisory-wait-state` reports `staleRequestRecovery: "attempt"` for
-that entry) — D4 and F2 each already consult **AW3-S** independently
-for this same settled-window entry (`#2726`), but a true-virgin empty
-snapshot otherwise never runs E14 through this gate specifically;
-condition (b) is a defense-in-depth backstop that guarantees this
-path also reaches the stale-request recovery cycle (and its route to
-`COPILOT_UNAVAILABLE`), rather than depending solely on D4/F2 revisits
-eventually accumulating enough AW3-S cycles on their own. Otherwise a
-no-op: a true-virgin empty snapshot with no
-AW3-S-eligible settled-window entry (no PATH B ever dispositioned this
-episode, and no stale same-head request either) never fires it; a
+the E6 non-review-notice rule); or (b) the current HEAD is eligible
+for **AW3-S**'s settled-window (non-pending) entry (running
+`advisory-wait-state` reports `staleRequestRecovery.action ==
+"attempt"` for that entry) — D4 and F2 each already consult **AW3-S**
+independently for this same settled-window entry (`#2726`), but a
+true-virgin empty snapshot otherwise never runs E14 through this gate
+specifically; condition (b) is a defense-in-depth backstop that
+guarantees this path also reaches the stale-request recovery cycle
+(and its route to `COPILOT_UNAVAILABLE`), rather than depending
+solely on D4/F2 revisits eventually accumulating enough AW3-S cycles
+on their own. Otherwise a no-op: a true-virgin empty snapshot with no
+entry eligible for AW3-S's settled-window (no PATH B ever
+dispositioned this episode, and no stale same-head request either)
+never fires it; a
 later-pass empty snapshot after a sync loop-back still fires via (a),
 since the lookback still finds the prior non-empty pass. (Rationale
 for the gap condition (a) closes:

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -540,14 +540,26 @@ rollup: see [rerun mechanics](idd-ci.instructions.md#rerun-mechanics).
 ## Zero-Accepted-PATH-A advisory re-review gate
 
 Applies only from the branch-sync check's no-sync-required `clean` /
-`behind-no-conflict` exit, and only when the last non-empty
-`ReviewItems_snapshot` pass this episode had zero Accepted PATH A items
-**and** at least one PATH B item got a _completed-review_ disposition
-(never a notice-only rejection — see the E6 non-review-notice rule).
-Otherwise a no-op: a true-virgin empty snapshot (no PATH B ever
-dispositioned this episode) never fires it; a later-pass empty snapshot
-after a sync loop-back still does, since the lookback still finds the
-prior non-empty pass. (Rationale for the gap this closes:
+`behind-no-conflict` exit, and fires under either of two conditions:
+(a) the last non-empty `ReviewItems_snapshot` pass this episode had
+zero Accepted PATH A items **and** at least one PATH B item got a
+_completed-review_ disposition (never a notice-only rejection — see
+the E6 non-review-notice rule); or (b) the current HEAD is **AW3-S**
+-eligible under its settled-window (non-pending) entry (running
+`advisory-wait-state` reports `staleRequestRecovery: "attempt"` for
+that entry) — D4 and F2 each already consult **AW3-S** independently
+for this same settled-window entry (`#2726`), but a true-virgin empty
+snapshot otherwise never runs E14 through this gate specifically;
+condition (b) is a defense-in-depth backstop that guarantees this
+path also reaches the stale-request recovery cycle (and its route to
+`COPILOT_UNAVAILABLE`), rather than depending solely on D4/F2 revisits
+eventually accumulating enough AW3-S cycles on their own. Otherwise a
+no-op: a true-virgin empty snapshot with no
+AW3-S-eligible settled-window entry (no PATH B ever dispositioned this
+episode, and no stale same-head request either) never fires it; a
+later-pass empty snapshot after a sync loop-back still fires via (a),
+since the lookback still finds the prior non-empty pass. (Rationale
+for the gap condition (a) closes:
 [design rationale](../../docs/idd-design-rationale.md#zero-accepted-path-a-advisory-re-review-gate).)
 Run this gate **after** any branch-sync merge settles — requesting
 first would let a later merge invalidate the review just obtained.

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -549,13 +549,24 @@ confirmed condition above. Delegate polling mechanics to
   mechanics) and resume D4. `SATISFIED` splits on `lastCopilotCommit`:
   when it already matches this HEAD SHA, Copilot's review already
   covers it — request nothing and take the same rerun-and-resume-D4
-  action as `WAIT` above. When it does **not** match this HEAD SHA,
-  `SATISFIED` instead means a same-head request's elapsed window ran
-  out with no review ever landing for this HEAD (see
-  `idd-advisory-wait.instructions.md`'s AW3 elapsed-window rows);
-  `idd-advisory-convergence` stays `pending: true` for this HEAD
-  regardless, so rerunning and resuming D4 would only reproduce the
-  same wait indefinitely — treat it like `CAP_EXHAUSTED`/
+  action as `WAIT` above (this proven-coverage sub-case is unchanged;
+  it never consults **AW3-S**). When it does **not** match this HEAD SHA,
+  `SATISFIED` may reflect either `COPILOT_PENDING` state (see
+  `idd-advisory-wait.instructions.md`'s AW3 elapsed-window rows):
+  `"true"`, settled by `PENDING_WINDOW_MINUTES` alone; or `"false"` — a
+  same-head request's elapsed window ran out with no review ever
+  landing for this HEAD, the settled-window (non-pending) sub-case E14
+  step 4 already consults **AW3-S** for. Consult **AW3-S**'s
+  `staleRequestRecovery` before exiting either way — its non-pending
+  entry requires `COPILOT_PENDING` `"false"`, so the `"true"` sub-case
+  reports `"not-applicable"` and falls through as a safe no-op:
+  `"attempt"` runs the bounded cycle (skip **Remove**, start at
+  **Request**; a proven failure-to-register completes the cycle per
+  the entry's inverted step 4/5 disposition); `"cap-exhausted"` handles
+  like **CAP_EXHAUSTED** below. Either way, `idd-advisory-convergence`
+  stays `pending: true` for this HEAD regardless, so rerunning and
+  resuming D4 would only reproduce the same wait indefinitely — treat
+  it like `CAP_EXHAUSTED`/
   `RECOVERY_NEEDED` below instead. `CAP_EXHAUSTED` (the request cap is
   already spent) or `RECOVERY_NEEDED` (a proven same-head request
   exists but needs its marker, not a new request) both need the fuller

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -200,11 +200,26 @@ turns an operator-visible failure into a silent stall.
   (`idd-advisory-wait.instructions.md`):
 
   1. Run **AW1**. If **SATISFIED** → this check is **satisfied**;
-     continue to the **CI** check.
+     continue to the **CI** check. (This short circuit is always the
+     proven-coverage case — `LAST_COPILOT_COMMIT == PR_HEAD_SHA` —
+     since AW1 alone has no marker data to evaluate the settled-window
+     sub-case below; it never consults **AW3-S**.)
   2. Run **AW2** to fetch markers.
   3. Apply the **AW3** decision table:
-     - **SATISFIED** → this check is **satisfied**; continue to the CI
-       check.
+     - **SATISFIED**, `COPILOT_PENDING` `"false"`, `COPILOT_PENDING_COVERS_HEAD`
+       `"false"` (settled by elapsed time alone, never proven the
+       request reached Copilot — `#2327`): consult **AW3-S**'s
+       `staleRequestRecovery` first, the same way E14 step 4 does.
+       `"attempt"` runs its bounded cycle (non-pending entry: skip
+       **Remove**, start at **Request**; a proven failure-to-register
+       completes the cycle per the entry's inverted step 4/5
+       disposition); `"cap-exhausted"` handles like **CAP_EXHAUSTED**
+       below; `"not-applicable"` falls through unchanged. Either way,
+       continue to the CI check afterward (this accumulates
+       recovery-cycle evidence toward `COPILOT_UNAVAILABLE`; the
+       check's own satisfied status is unaffected).
+     - **SATISFIED** (otherwise) → this check is **satisfied**;
+       continue to the CI check.
      - **HOLD** → post the hold comment from **AW4** and stop.
      - **RECOVERY_NEEDED** → post the recovery marker from **AW3-R**
        without requesting another Copilot review, then enter the normal

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -209,15 +209,19 @@ turns an operator-visible failure into a silent stall.
      - **SATISFIED**, `COPILOT_PENDING` `"false"`, `COPILOT_PENDING_COVERS_HEAD`
        `"false"` (settled by elapsed time alone, never proven the
        request reached Copilot — `#2327`): consult **AW3-S**'s
-       `staleRequestRecovery` first, the same way E14 step 4 does.
-       `"attempt"` runs its bounded cycle (non-pending entry: skip
-       **Remove**, start at **Request**; a proven failure-to-register
-       completes the cycle per the entry's inverted step 4/5
-       disposition); `"cap-exhausted"` handles like **CAP_EXHAUSTED**
-       below; `"not-applicable"` falls through unchanged. Either way,
-       continue to the CI check afterward (this accumulates
-       recovery-cycle evidence toward `COPILOT_UNAVAILABLE`; the
-       check's own satisfied status is unaffected).
+       `staleRequestRecovery.action` first, the same way E14 step 4
+       does. `"attempt"` runs its bounded cycle (non-pending entry:
+       skip **Remove**, start at **Request**; a proven
+       failure-to-register completes the cycle per the entry's
+       inverted step 4/5 disposition), **then** continue to the CI
+       check (this accumulates recovery-cycle evidence toward
+       `COPILOT_UNAVAILABLE`; the check's own satisfied status is
+       unaffected). `"cap-exhausted"` handles like **CAP_EXHAUSTED**
+       below instead — post the hold and **stop**; do not continue to
+       the CI check for this action (the mandatory stop from
+       **CAP_EXHAUSTED** below still applies; this recovery-cap
+       exhaustion does not waive it). `"not-applicable"` falls through
+       unchanged and continues to the CI check.
      - **SATISFIED** (otherwise) → this check is **satisfied**;
        continue to the CI check.
      - **HOLD** → post the hold comment from **AW4** and stop.

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -535,14 +535,26 @@ rollup: see [rerun mechanics](idd-ci.instructions.md#rerun-mechanics).
 ## Zero-Accepted-PATH-A advisory re-review gate
 
 Applies only from the branch-sync check's no-sync-required `clean` /
-`behind-no-conflict` exit, and only when the last non-empty
-`ReviewItems_snapshot` pass this episode had zero Accepted PATH A items
-**and** at least one PATH B item got a _completed-review_ disposition
-(never a notice-only rejection — see the E6 non-review-notice rule).
-Otherwise a no-op: a true-virgin empty snapshot (no PATH B ever
-dispositioned this episode) never fires it; a later-pass empty snapshot
-after a sync loop-back still does, since the lookback still finds the
-prior non-empty pass. (Rationale for the gap this closes:
+`behind-no-conflict` exit, and fires under either of two conditions:
+(a) the last non-empty `ReviewItems_snapshot` pass this episode had
+zero Accepted PATH A items **and** at least one PATH B item got a
+_completed-review_ disposition (never a notice-only rejection — see
+the E6 non-review-notice rule); or (b) the current HEAD is **AW3-S**
+-eligible under its settled-window (non-pending) entry (running
+`advisory-wait-state` reports `staleRequestRecovery: "attempt"` for
+that entry) — D4 and F2 each already consult **AW3-S** independently
+for this same settled-window entry (`#2726`), but a true-virgin empty
+snapshot otherwise never runs E14 through this gate specifically;
+condition (b) is a defense-in-depth backstop that guarantees this
+path also reaches the stale-request recovery cycle (and its route to
+`COPILOT_UNAVAILABLE`), rather than depending solely on D4/F2 revisits
+eventually accumulating enough AW3-S cycles on their own. Otherwise a
+no-op: a true-virgin empty snapshot with no
+AW3-S-eligible settled-window entry (no PATH B ever dispositioned this
+episode, and no stale same-head request either) never fires it; a
+later-pass empty snapshot after a sync loop-back still fires via (a),
+since the lookback still finds the prior non-empty pass. (Rationale
+for the gap condition (a) closes:
 [design rationale](../../docs/idd-design-rationale.md#zero-accepted-path-a-advisory-re-review-gate).)
 Run this gate **after** any branch-sync merge settles — requesting
 first would let a later merge invalidate the review just obtained.

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -541,8 +541,8 @@ zero Accepted PATH A items **and** at least one PATH B item got a
 _completed-review_ disposition (never a notice-only rejection — see
 the E6 non-review-notice rule); or (b) the current HEAD is eligible
 for **AW3-S**'s settled-window (non-pending) entry (running
-`advisory-wait-state` reports `staleRequestRecovery.action ==
-"attempt"` for that entry) — D4 and F2 each already consult **AW3-S**
+`advisory-wait-state` reports `staleRequestRecovery.action` as
+`"attempt"` for that entry) — D4 and F2 each already consult **AW3-S**
 independently for this same settled-window entry (`#2726`), but a
 true-virgin empty snapshot otherwise never runs E14 through this gate
 specifically; condition (b) is a defense-in-depth backstop that

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -539,19 +539,20 @@ Applies only from the branch-sync check's no-sync-required `clean` /
 (a) the last non-empty `ReviewItems_snapshot` pass this episode had
 zero Accepted PATH A items **and** at least one PATH B item got a
 _completed-review_ disposition (never a notice-only rejection — see
-the E6 non-review-notice rule); or (b) the current HEAD is **AW3-S**
--eligible under its settled-window (non-pending) entry (running
-`advisory-wait-state` reports `staleRequestRecovery: "attempt"` for
-that entry) — D4 and F2 each already consult **AW3-S** independently
-for this same settled-window entry (`#2726`), but a true-virgin empty
-snapshot otherwise never runs E14 through this gate specifically;
-condition (b) is a defense-in-depth backstop that guarantees this
-path also reaches the stale-request recovery cycle (and its route to
-`COPILOT_UNAVAILABLE`), rather than depending solely on D4/F2 revisits
-eventually accumulating enough AW3-S cycles on their own. Otherwise a
-no-op: a true-virgin empty snapshot with no
-AW3-S-eligible settled-window entry (no PATH B ever dispositioned this
-episode, and no stale same-head request either) never fires it; a
+the E6 non-review-notice rule); or (b) the current HEAD is eligible
+for **AW3-S**'s settled-window (non-pending) entry (running
+`advisory-wait-state` reports `staleRequestRecovery.action ==
+"attempt"` for that entry) — D4 and F2 each already consult **AW3-S**
+independently for this same settled-window entry (`#2726`), but a
+true-virgin empty snapshot otherwise never runs E14 through this gate
+specifically; condition (b) is a defense-in-depth backstop that
+guarantees this path also reaches the stale-request recovery cycle
+(and its route to `COPILOT_UNAVAILABLE`), rather than depending
+solely on D4/F2 revisits eventually accumulating enough AW3-S cycles
+on their own. Otherwise a no-op: a true-virgin empty snapshot with no
+entry eligible for AW3-S's settled-window (no PATH B ever
+dispositioned this episode, and no stale same-head request either)
+never fires it; a
 later-pass empty snapshot after a sync loop-back still fires via (a),
 since the lookback still finds the prior non-empty pass. (Rationale
 for the gap condition (a) closes:


### PR DESCRIPTION
# Summary

`D4` (`idd-pr-submit.instructions.md`) and `F2`
(`idd-pre-merge.instructions.md`) both treated an advisory-wait
`SATISFIED` outcome as unconditionally satisfied, but `E14`
(`idd-review-fix.instructions.md`) already special-cases the
settled-window sub-case (`COPILOT_PENDING` `"false"`,
`COPILOT_PENDING_COVERS_HEAD` `"false"`, settled by elapsed time alone
with no proof the request ever reached Copilot) by consulting **AW3-S**
first. Because D4/F2 skipped that consult, a PR hitting this window
could cycle D4 → F2 → CI Exception 3 → D4 indefinitely without ever
posting the bounded recovery markers needed to reach a terminal
`COPILOT_UNAVAILABLE` state.

Ports the same AW3-S consult into D4's elapsed-window `SATISFIED`
branch and F2's AW3-decision-table `SATISFIED` row, and adds a
carve-out to `idd-review-triage.instructions.md`'s Zero-Accepted-PATH-A
gate so a true-virgin empty `ReviewItems_snapshot` still runs E14 (as a
defense-in-depth backstop) when the HEAD is AW3-S-eligible under this
same entry.

**One deviation from the issue's literal wording**: the issue asked for
the AW3-S consult "on both the AW1 SATISFIED short circuit and the AW3
SATISFIED row" in F2. I traced `evaluateAdvisoryWaitOutcome()`
(`src/scripts/protocol-helpers.mts:3460`) and confirmed AW1 alone (no
marker data — just `lastCopilotCommit`/`copilotPending`/
`copilotPendingCoversHead`) can only reach `SATISFIED` via the
proven-coverage branch (`lastCopilotCommit === prHeadSha`); the
settled-window branch structurally requires AW2 marker data. E14's own
reference implementation confirms this split (its AW1-only step is
unconditional; the AW3-S consult only appears at its full-decision-table
step). So F2's AW1 short circuit gets an explanatory note instead of a
structurally-unreachable consult, matching E14's real behavior rather
than the issue's imprecise phrasing.

An independent critique pass (agent) verified the AW3-S mechanics port
against the canonical AW3-S section and E14's reference steps, traced
`evaluateAdvisoryWaitOutcome()` directly, and flagged two Medium wording
concerns (D4's branch could correspond to either of two AW3 rows;
review-triage's carve-out justification could overstate necessity given
D4/F2 also self-heal) — both addressed in follow-up revisions before
this PR (see issue comments for the full critique and the fixes).

## Linked issue

Closes #2726

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

See the issue body's own "Background" section for the full D4/F2/CI
Exception 3 cycle this closes, and issue comments for the critique-pass
findings and the wording revisions they prompted.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDJpTELrY2SnjHW9m5Aw7i
