### PR TITLE
feat(marker-helpers): add operational-marker hide-policy guard

### DIFF
--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -319,12 +319,13 @@ verified HEAD within one pass).
 
 After a new `advisory-wait`/`advisory-wait-recovery` marker is verified
 for the current `PR_HEAD_SHA`, minimize every trusted prior marker of
-the `advisory-wait:`/`advisory-wait-recovery:`/`advisory-reroll:`
-family whose embedded HEAD SHA does **not** match, as `OUTDATED` (cuts
-F4 backlog and review-page noise — a stale-HEAD `advisory-reroll:`
-marker is exactly as much operational noise as a stale advisory-wait
-one). Find candidate IDs (trusted markers of that family with a
-differing embedded SHA), then call the minimize-markers command:
+the `advisory-wait:`/`advisory-wait-recovery:`/`<!-- advisory-wait:`/
+`advisory-reroll:` family whose embedded HEAD SHA does **not** match,
+as `OUTDATED` (cuts F4 backlog and review-page noise — a stale-HEAD
+`advisory-reroll:` marker is exactly as much operational noise as a
+stale advisory-wait one). Find candidate IDs (trusted markers of that
+family with a differing embedded SHA), then call the minimize-markers
+command:
 [shell fallback AW3-H](../../docs/idd-advisory-wait-shell-fallback.md#aw3-h).
 
 Skip entirely if the new marker was not verified, the candidate set is

--- a/docs/idd-autonomy-contract.md
+++ b/docs/idd-autonomy-contract.md
@@ -226,14 +226,14 @@ close.
 
 ### Advisory-wait markers (AW1-AW6)
 
-| Mutation                                                                                           | Reversible / Irreversible | Undo path / Governing gate                                                  | Source                                                   |
-| -------------------------------------------------------------------------------------------------- | ------------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------- |
-| Post `advisory-wait:` request marker                                                               | Reversible                | Superseded by the next marker for a later HEAD, or by the SATISFIED outcome | AW3 REQUEST_NEEDED (`idd-advisory-wait.instructions.md`) |
-| Post `advisory-wait-recovery:` marker                                                              | Reversible                | Same as above                                                               | AW3-R (`idd-advisory-wait.instructions.md`)              |
-| Post `advisory-reroll:` marker                                                                     | Reversible                | Same as above                                                               | AW6 (`idd-advisory-wait.instructions.md`)                |
-| Request/remove primary or secondary bot reviewer                                                   | Reversible                | `gh pr edit --remove-reviewer` / re-request                                 | E14 (`idd-review-fix.instructions.md`)                   |
-| Hide superseded `advisory-wait:`/`advisory-wait-recovery:`/`advisory-reroll:` markers (`OUTDATED`) | Irreversible              | See GitHub-minimize convention above                                        | AW3-H (`idd-advisory-wait.instructions.md`)              |
-| Approve a gated Actions run (bot-triggered `action_required`)                                      | Reversible                | Does not destroy state; only unblocks a run                                 | `idd-ci.instructions.md` Rerun mechanics                 |
+| Mutation                                                                                                                 | Reversible / Irreversible | Undo path / Governing gate                                                  | Source                                                   |
+| ------------------------------------------------------------------------------------------------------------------------ | ------------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------- |
+| Post `advisory-wait:` request marker                                                                                     | Reversible                | Superseded by the next marker for a later HEAD, or by the SATISFIED outcome | AW3 REQUEST_NEEDED (`idd-advisory-wait.instructions.md`) |
+| Post `advisory-wait-recovery:` marker                                                                                    | Reversible                | Same as above                                                               | AW3-R (`idd-advisory-wait.instructions.md`)              |
+| Post `advisory-reroll:` marker                                                                                           | Reversible                | Same as above                                                               | AW6 (`idd-advisory-wait.instructions.md`)                |
+| Request/remove primary or secondary bot reviewer                                                                         | Reversible                | `gh pr edit --remove-reviewer` / re-request                                 | E14 (`idd-review-fix.instructions.md`)                   |
+| Hide superseded `advisory-wait:`/`advisory-wait-recovery:`/`<!-- advisory-wait:`/`advisory-reroll:` markers (`OUTDATED`) | Irreversible              | See GitHub-minimize convention above                                        | AW3-H (`idd-advisory-wait.instructions.md`)              |
+| Approve a gated Actions run (bot-triggered `action_required`)                                                            | Reversible                | Does not destroy state; only unblocks a run                                 | `idd-ci.instructions.md` Rerun mechanics                 |
 
 ### Merge execution (F2.5-F3)
 

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -126,19 +126,20 @@ The JSON report includes these fields:
 ## Timing
 
 F4 (merge-gated) cleanup is the default timing for every marker or
-comment kind not explicitly classified `wired` in the hide-policy table
-below. For those, run minimization only after one of these is true:
+comment kind not explicitly classified `wired` in `MARKER_HIDE_POLICY`
+(`src/scripts/marker-helpers.mts`). For those, run minimization only
+after one of these is true:
 
 - the PR has already merged
 - a maintainer explicitly starts a merged-PR audit
 
 **Exception -- hide-at-post-time for `wired` families** (issue #731,
-issue #733, issue #2751). A marker family classified `wired` in `MARKER_HIDE_POLICY`
-(`src/scripts/marker-helpers.mts`) may be minimized immediately after its
-own new instance's POST+verify succeeds, pre-merge, using that family's
-documented supersession/grouping key -- never for any other reason
-during an active E or F gate. Three families ship this today: the claim
-chain (`claimed-by:`/`unclaimed-by:`/`activation-nonce:`, grouped by
+issue #733, issue #2751). A `wired` family may be minimized immediately
+after its own new instance's POST+verify succeeds, pre-merge, using
+that family's documented supersession/grouping key -- never for any
+other reason during an active E or F gate. Three families ship this
+today: the claim chain
+(`claimed-by:`/`unclaimed-by:`/`activation-nonce:`, grouped by
 `supersedes:` lineage, `idd-claim.instructions.md`), `review-watermark:`/
 `review-baseline:` (grouped by same claim-id,
 `idd-review-snapshot.instructions.md`), and the `advisory-wait` family

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -140,23 +140,35 @@ that family's documented supersession/grouping key -- never for any
 other reason during an active E or F gate. Three families ship this
 today: the claim chain
 (`claimed-by:`/`unclaimed-by:`, grouped by
-`supersedes:` lineage, `idd-claim.instructions.md` -- `activation-nonce:`
-is a related marker in the same claim exchange but is not itself
-minimized by this wiring, so it stays `f4-only`), `review-watermark:`/
+`supersedes:` lineage, `idd-claim.instructions.md`), `review-watermark:`/
 `review-baseline:` (grouped by same claim-id,
 `idd-review-snapshot.instructions.md`), and the `advisory-wait` family
 (`advisory-wait:`/`advisory-wait-recovery:`/`<!-- advisory-wait:`/
 `advisory-reroll:`, grouped by embedded HEAD SHA mismatch, AW3-H,
 `idd-advisory-wait.instructions.md`). A family classified `f4-only` has
 no such wiring yet and follows the default F4-only timing above until a
-future track adds it. A third `MARKER_HIDE_POLICY` kind, `excluded`,
-covers markers deliberately kept out of both groupings (each for the
-reason on its own entry in `MARKER_HIDE_POLICY`) -- one of those,
-`<!-- forced-handoff:`, also carries its own permanent F4 exemption
-(`audit-pr-cleanup.mts` hardcodes a skip for that prefix regardless of
-merge state); the other `excluded` entries have no such exemption and
-are swept by F4's generic stale-marker rule like an ordinary `f4-only`
-family.
+future track adds it -- concretely, the post-merge F4 batch means
+`audit-pr-cleanup.mts`'s generic marker-prefix match
+(`operationalMarkerPrefix`) against comments on the merged PR itself,
+which recognizes the full `OPERATIONAL_MARKERS` set. That is broader than
+the specific prefix list under this document's Candidate Rules section
+below: that list predates several `f4-only`-classified families added
+since, and is stale documentation rather than a deliberately narrower
+second path -- both the vendored helper's own dry run and the manual
+GraphQL fallback read the same Candidate Rules list, so the gap affects
+an adopter following either path, not only the manual fallback (tracked
+as issue #2778). A third `MARKER_HIDE_POLICY` kind, `excluded`, covers markers
+deliberately kept out of both groupings (each for the reason on its own
+entry in `MARKER_HIDE_POLICY`). Two of those are permanently outside F4's
+reach for different reasons: `<!-- forced-handoff:` carries its own
+explicit F4 exemption (`audit-pr-cleanup.mts` hardcodes a skip for that
+prefix regardless of merge state), and `<!-- activation-nonce:` is a
+related marker in the same claim exchange as the wired claim chain above
+but is posted to the claim **issue**, not the PR -- F4's PR-scoped
+`audit-pr-cleanup.mts` structurally never sees it, so it has no F4
+cleanup path even though it is not `wired` either. The remaining
+`excluded` entries carry no such exemption; whether F4's generic rule
+actually reaches each of them depends on where that family is posted.
 
 Do not minimize comments during active E or F gates for any other
 reason. In particular, do not minimize comments that still determine

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -125,15 +125,35 @@ The JSON report includes these fields:
 
 ## Timing
 
-Run minimization only after one of these is true:
+F4 (merge-gated) cleanup is the default timing for every marker or
+comment kind not explicitly classified `wired` in the hide-policy table
+below. For those, run minimization only after one of these is true:
 
 - the PR has already merged
 - a maintainer explicitly starts a merged-PR audit
 
-Do not minimize comments during active E or F gates. In particular, do
-not minimize comments that still determine review currency, advisory
-wait state, unresolved-thread state, unreplied-comment state, hold
-state, or a pending maintainer decision.
+**Exception -- hide-at-post-time for `wired` families** (issue #731,
+issue #733, issue #2751). A marker family classified `wired` in `MARKER_HIDE_POLICY`
+(`src/scripts/marker-helpers.mts`) may be minimized immediately after its
+own new instance's POST+verify succeeds, pre-merge, using that family's
+documented supersession/grouping key -- never for any other reason
+during an active E or F gate. Three families ship this today: the claim
+chain (`claimed-by:`/`unclaimed-by:`/`activation-nonce:`, grouped by
+`supersedes:` lineage, `idd-claim.instructions.md`), `review-watermark:`/
+`review-baseline:` (grouped by same claim-id,
+`idd-review-snapshot.instructions.md`), and the `advisory-wait` family
+(`advisory-wait:`/`advisory-wait-recovery:`/`<!-- advisory-wait:`/
+`advisory-reroll:`, grouped by embedded HEAD SHA mismatch, AW3-H,
+`idd-advisory-wait.instructions.md`). A family classified `f4-only` has
+no such wiring yet and follows the default F4-only timing above until a
+future track adds it.
+
+Do not minimize comments during active E or F gates for any other
+reason. In particular, do not minimize comments that still determine
+review currency, advisory wait state, unresolved-thread state,
+unreplied-comment state, hold state, or a pending maintainer decision --
+including a `wired` family's own comment outside the narrow
+POST+verify-triggered exception above.
 
 ### Server-side fallback (optional)
 

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -139,15 +139,24 @@ after its own new instance's POST+verify succeeds, pre-merge, using
 that family's documented supersession/grouping key -- never for any
 other reason during an active E or F gate. Three families ship this
 today: the claim chain
-(`claimed-by:`/`unclaimed-by:`/`activation-nonce:`, grouped by
-`supersedes:` lineage, `idd-claim.instructions.md`), `review-watermark:`/
+(`claimed-by:`/`unclaimed-by:`, grouped by
+`supersedes:` lineage, `idd-claim.instructions.md` -- `activation-nonce:`
+is a related marker in the same claim exchange but is not itself
+minimized by this wiring, so it stays `f4-only`), `review-watermark:`/
 `review-baseline:` (grouped by same claim-id,
 `idd-review-snapshot.instructions.md`), and the `advisory-wait` family
 (`advisory-wait:`/`advisory-wait-recovery:`/`<!-- advisory-wait:`/
 `advisory-reroll:`, grouped by embedded HEAD SHA mismatch, AW3-H,
 `idd-advisory-wait.instructions.md`). A family classified `f4-only` has
 no such wiring yet and follows the default F4-only timing above until a
-future track adds it.
+future track adds it. A third `MARKER_HIDE_POLICY` kind, `excluded`,
+covers markers deliberately kept out of both groupings (each for the
+reason on its own entry in `MARKER_HIDE_POLICY`) -- one of those,
+`<!-- forced-handoff:`, also carries its own permanent F4 exemption
+(`audit-pr-cleanup.mts` hardcodes a skip for that prefix regardless of
+merge state); the other `excluded` entries have no such exemption and
+are swept by F4's generic stale-marker rule like an ordinary `f4-only`
+family.
 
 Do not minimize comments during active E or F gates for any other
 reason. In particular, do not minimize comments that still determine

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -150,15 +150,15 @@ no such wiring yet and follows the default F4-only timing above until a
 future track adds it -- concretely, the post-merge F4 batch means
 `audit-pr-cleanup.mts`'s generic marker-prefix match
 (`operationalMarkerPrefix`) against comments on the merged PR itself,
-which recognizes the full `OPERATIONAL_MARKERS` set. That is broader than
-the specific prefix list under this document's Candidate Rules section
-below: that list predates several `f4-only`-classified families added
-since, and is stale documentation rather than a deliberately narrower
-second path -- both the vendored helper's own dry run and the manual
-GraphQL fallback read the same Candidate Rules list, so the gap affects
-an adopter following either path, not only the manual fallback (tracked
-as issue #2778). A third `MARKER_HIDE_POLICY` kind, `excluded`, covers markers
-deliberately kept out of both groupings (each for the reason on its own
+which recognizes the full `OPERATIONAL_MARKERS` set directly. The
+running code never parses this document, so the vendored helper's own
+dry run is unaffected by the Candidate Rules section below being stale
+(that list predates several `f4-only`-classified families added since).
+Only the manual GraphQL fallback, which has no code behind it and uses
+that list as its literal operating procedure, is actually narrowed by
+the gap (tracked as issue #2778). A third `MARKER_HIDE_POLICY` kind,
+`excluded`, covers markers deliberately kept out of both groupings
+(each for the reason on its own
 entry in `MARKER_HIDE_POLICY`). Two of those are permanently outside F4's
 reach for different reasons: `<!-- forced-handoff:` carries its own
 explicit F4 exemption (`audit-pr-cleanup.mts` hardcodes a skip for that

--- a/docs/idd-concept-ownership.md
+++ b/docs/idd-concept-ownership.md
@@ -84,7 +84,7 @@ matrix's general "who mutates" column above.
 | Branch and worktree | Deleted | Worker or merge-capable session, F4 — only after F3 merge succeeds |
 | Review thread | Resolved | Worker session, immediately after posting a disposition reply (E6/E13) — **except** an `**Awaiting maintainer decision**` reply, which leaves the thread unresolved until a maintainer responds (F2's unresolved-threads gate relies on this); or a human reviewer resolving their own thread |
 | PR | Merged | Merge-capable session, F3, only once the full F2/F2.5 gate checklist holds |
-| `review-watermark` / `review-baseline` / `advisory-wait:` / `advisory-wait-recovery:` / `advisory-reroll:` markers | Superseded / minimized as `OUTDATED` | Worker session, after a newer valid marker of the same kind exists for the same claim or HEAD |
+| `review-watermark` / `review-baseline` / `advisory-wait:` / `advisory-wait-recovery:` / `<!-- advisory-wait:` / `advisory-reroll:` markers | Superseded / minimized as `OUTDATED` | Worker session, after a newer valid marker of the same kind exists for the same claim or HEAD |
 | Claim-marker chain (`claimed-by`/`unclaimed-by`/heartbeat) | Superseded / minimized as `OUTDATED` | Worker session, but **only** the prior claim-id's chain after a verified `supersedes: <prior-id>` takeover — a same-claim heartbeat chain must never be hidden; it is the active-claim audit trail |
 | External-check waiver | Expired, or consumed | Worker session, rerunning the waived check so it reflects the waiver; expiry itself is a time-driven transition (`expiresAt`) that needs no actor |
 | `status:blocked-by-human` label | Removed | Human maintainer only, after resolving the underlying blocker |

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -314,12 +314,13 @@ verified HEAD within one pass).
 
 After a new `advisory-wait`/`advisory-wait-recovery` marker is verified
 for the current `PR_HEAD_SHA`, minimize every trusted prior marker of
-the `advisory-wait:`/`advisory-wait-recovery:`/`advisory-reroll:`
-family whose embedded HEAD SHA does **not** match, as `OUTDATED` (cuts
-F4 backlog and review-page noise — a stale-HEAD `advisory-reroll:`
-marker is exactly as much operational noise as a stale advisory-wait
-one). Find candidate IDs (trusted markers of that family with a
-differing embedded SHA), then call the minimize-markers command:
+the `advisory-wait:`/`advisory-wait-recovery:`/`<!-- advisory-wait:`/
+`advisory-reroll:` family whose embedded HEAD SHA does **not** match,
+as `OUTDATED` (cuts F4 backlog and review-page noise — a stale-HEAD
+`advisory-reroll:` marker is exactly as much operational noise as a
+stale advisory-wait one). Find candidate IDs (trusted markers of that
+family with a differing embedded SHA), then call the minimize-markers
+command:
 [shell fallback AW3-H](../../docs/idd-advisory-wait-shell-fallback.md#aw3-h).
 
 Skip entirely if the new marker was not verified, the candidate set is

--- a/idd-template/docs/idd-autonomy-contract.md
+++ b/idd-template/docs/idd-autonomy-contract.md
@@ -226,14 +226,14 @@ close.
 
 ### Advisory-wait markers (AW1-AW6)
 
-| Mutation                                                                                           | Reversible / Irreversible | Undo path / Governing gate                                                  | Source                                                   |
-| -------------------------------------------------------------------------------------------------- | ------------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------- |
-| Post `advisory-wait:` request marker                                                               | Reversible                | Superseded by the next marker for a later HEAD, or by the SATISFIED outcome | AW3 REQUEST_NEEDED (`idd-advisory-wait.instructions.md`) |
-| Post `advisory-wait-recovery:` marker                                                              | Reversible                | Same as above                                                               | AW3-R (`idd-advisory-wait.instructions.md`)              |
-| Post `advisory-reroll:` marker                                                                     | Reversible                | Same as above                                                               | AW6 (`idd-advisory-wait.instructions.md`)                |
-| Request/remove primary or secondary bot reviewer                                                   | Reversible                | `gh pr edit --remove-reviewer` / re-request                                 | E14 (`idd-review-fix.instructions.md`)                   |
-| Hide superseded `advisory-wait:`/`advisory-wait-recovery:`/`advisory-reroll:` markers (`OUTDATED`) | Irreversible              | See GitHub-minimize convention above                                        | AW3-H (`idd-advisory-wait.instructions.md`)              |
-| Approve a gated Actions run (bot-triggered `action_required`)                                      | Reversible                | Does not destroy state; only unblocks a run                                 | `idd-ci.instructions.md` Rerun mechanics                 |
+| Mutation                                                                                                                 | Reversible / Irreversible | Undo path / Governing gate                                                  | Source                                                   |
+| ------------------------------------------------------------------------------------------------------------------------ | ------------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------- |
+| Post `advisory-wait:` request marker                                                                                     | Reversible                | Superseded by the next marker for a later HEAD, or by the SATISFIED outcome | AW3 REQUEST_NEEDED (`idd-advisory-wait.instructions.md`) |
+| Post `advisory-wait-recovery:` marker                                                                                    | Reversible                | Same as above                                                               | AW3-R (`idd-advisory-wait.instructions.md`)              |
+| Post `advisory-reroll:` marker                                                                                           | Reversible                | Same as above                                                               | AW6 (`idd-advisory-wait.instructions.md`)                |
+| Request/remove primary or secondary bot reviewer                                                                         | Reversible                | `gh pr edit --remove-reviewer` / re-request                                 | E14 (`idd-review-fix.instructions.md`)                   |
+| Hide superseded `advisory-wait:`/`advisory-wait-recovery:`/`<!-- advisory-wait:`/`advisory-reroll:` markers (`OUTDATED`) | Irreversible              | See GitHub-minimize convention above                                        | AW3-H (`idd-advisory-wait.instructions.md`)              |
+| Approve a gated Actions run (bot-triggered `action_required`)                                                            | Reversible                | Does not destroy state; only unblocks a run                                 | `idd-ci.instructions.md` Rerun mechanics                 |
 
 ### Merge execution (F2.5-F3)
 

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -126,19 +126,20 @@ The JSON report includes these fields:
 ## Timing
 
 F4 (merge-gated) cleanup is the default timing for every marker or
-comment kind not explicitly classified `wired` in the hide-policy table
-below. For those, run minimization only after one of these is true:
+comment kind not explicitly classified `wired` in `MARKER_HIDE_POLICY`
+(`src/scripts/marker-helpers.mts`). For those, run minimization only
+after one of these is true:
 
 - the PR has already merged
 - a maintainer explicitly starts a merged-PR audit
 
 **Exception -- hide-at-post-time for `wired` families** (issue #731,
-issue #733, issue #2751). A marker family classified `wired` in `MARKER_HIDE_POLICY`
-(`src/scripts/marker-helpers.mts`) may be minimized immediately after its
-own new instance's POST+verify succeeds, pre-merge, using that family's
-documented supersession/grouping key -- never for any other reason
-during an active E or F gate. Three families ship this today: the claim
-chain (`claimed-by:`/`unclaimed-by:`/`activation-nonce:`, grouped by
+issue #733, issue #2751). A `wired` family may be minimized immediately
+after its own new instance's POST+verify succeeds, pre-merge, using
+that family's documented supersession/grouping key -- never for any
+other reason during an active E or F gate. Three families ship this
+today: the claim chain
+(`claimed-by:`/`unclaimed-by:`/`activation-nonce:`, grouped by
 `supersedes:` lineage, `idd-claim.instructions.md`), `review-watermark:`/
 `review-baseline:` (grouped by same claim-id,
 `idd-review-snapshot.instructions.md`), and the `advisory-wait` family

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -140,23 +140,35 @@ that family's documented supersession/grouping key -- never for any
 other reason during an active E or F gate. Three families ship this
 today: the claim chain
 (`claimed-by:`/`unclaimed-by:`, grouped by
-`supersedes:` lineage, `idd-claim.instructions.md` -- `activation-nonce:`
-is a related marker in the same claim exchange but is not itself
-minimized by this wiring, so it stays `f4-only`), `review-watermark:`/
+`supersedes:` lineage, `idd-claim.instructions.md`), `review-watermark:`/
 `review-baseline:` (grouped by same claim-id,
 `idd-review-snapshot.instructions.md`), and the `advisory-wait` family
 (`advisory-wait:`/`advisory-wait-recovery:`/`<!-- advisory-wait:`/
 `advisory-reroll:`, grouped by embedded HEAD SHA mismatch, AW3-H,
 `idd-advisory-wait.instructions.md`). A family classified `f4-only` has
 no such wiring yet and follows the default F4-only timing above until a
-future track adds it. A third `MARKER_HIDE_POLICY` kind, `excluded`,
-covers markers deliberately kept out of both groupings (each for the
-reason on its own entry in `MARKER_HIDE_POLICY`) -- one of those,
-`<!-- forced-handoff:`, also carries its own permanent F4 exemption
-(`audit-pr-cleanup.mts` hardcodes a skip for that prefix regardless of
-merge state); the other `excluded` entries have no such exemption and
-are swept by F4's generic stale-marker rule like an ordinary `f4-only`
-family.
+future track adds it -- concretely, the post-merge F4 batch means
+`audit-pr-cleanup.mts`'s generic marker-prefix match
+(`operationalMarkerPrefix`) against comments on the merged PR itself,
+which recognizes the full `OPERATIONAL_MARKERS` set. That is broader than
+the specific prefix list under this document's Candidate Rules section
+below: that list predates several `f4-only`-classified families added
+since, and is stale documentation rather than a deliberately narrower
+second path -- both the vendored helper's own dry run and the manual
+GraphQL fallback read the same Candidate Rules list, so the gap affects
+an adopter following either path, not only the manual fallback (tracked
+as issue #2778). A third `MARKER_HIDE_POLICY` kind, `excluded`, covers markers
+deliberately kept out of both groupings (each for the reason on its own
+entry in `MARKER_HIDE_POLICY`). Two of those are permanently outside F4's
+reach for different reasons: `<!-- forced-handoff:` carries its own
+explicit F4 exemption (`audit-pr-cleanup.mts` hardcodes a skip for that
+prefix regardless of merge state), and `<!-- activation-nonce:` is a
+related marker in the same claim exchange as the wired claim chain above
+but is posted to the claim **issue**, not the PR -- F4's PR-scoped
+`audit-pr-cleanup.mts` structurally never sees it, so it has no F4
+cleanup path even though it is not `wired` either. The remaining
+`excluded` entries carry no such exemption; whether F4's generic rule
+actually reaches each of them depends on where that family is posted.
 
 Do not minimize comments during active E or F gates for any other
 reason. In particular, do not minimize comments that still determine

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -125,15 +125,35 @@ The JSON report includes these fields:
 
 ## Timing
 
-Run minimization only after one of these is true:
+F4 (merge-gated) cleanup is the default timing for every marker or
+comment kind not explicitly classified `wired` in the hide-policy table
+below. For those, run minimization only after one of these is true:
 
 - the PR has already merged
 - a maintainer explicitly starts a merged-PR audit
 
-Do not minimize comments during active E or F gates. In particular, do
-not minimize comments that still determine review currency, advisory
-wait state, unresolved-thread state, unreplied-comment state, hold
-state, or a pending maintainer decision.
+**Exception -- hide-at-post-time for `wired` families** (issue #731,
+issue #733, issue #2751). A marker family classified `wired` in `MARKER_HIDE_POLICY`
+(`src/scripts/marker-helpers.mts`) may be minimized immediately after its
+own new instance's POST+verify succeeds, pre-merge, using that family's
+documented supersession/grouping key -- never for any other reason
+during an active E or F gate. Three families ship this today: the claim
+chain (`claimed-by:`/`unclaimed-by:`/`activation-nonce:`, grouped by
+`supersedes:` lineage, `idd-claim.instructions.md`), `review-watermark:`/
+`review-baseline:` (grouped by same claim-id,
+`idd-review-snapshot.instructions.md`), and the `advisory-wait` family
+(`advisory-wait:`/`advisory-wait-recovery:`/`<!-- advisory-wait:`/
+`advisory-reroll:`, grouped by embedded HEAD SHA mismatch, AW3-H,
+`idd-advisory-wait.instructions.md`). A family classified `f4-only` has
+no such wiring yet and follows the default F4-only timing above until a
+future track adds it.
+
+Do not minimize comments during active E or F gates for any other
+reason. In particular, do not minimize comments that still determine
+review currency, advisory wait state, unresolved-thread state,
+unreplied-comment state, hold state, or a pending maintainer decision --
+including a `wired` family's own comment outside the narrow
+POST+verify-triggered exception above.
 
 ### Server-side fallback (optional)
 

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -139,15 +139,24 @@ after its own new instance's POST+verify succeeds, pre-merge, using
 that family's documented supersession/grouping key -- never for any
 other reason during an active E or F gate. Three families ship this
 today: the claim chain
-(`claimed-by:`/`unclaimed-by:`/`activation-nonce:`, grouped by
-`supersedes:` lineage, `idd-claim.instructions.md`), `review-watermark:`/
+(`claimed-by:`/`unclaimed-by:`, grouped by
+`supersedes:` lineage, `idd-claim.instructions.md` -- `activation-nonce:`
+is a related marker in the same claim exchange but is not itself
+minimized by this wiring, so it stays `f4-only`), `review-watermark:`/
 `review-baseline:` (grouped by same claim-id,
 `idd-review-snapshot.instructions.md`), and the `advisory-wait` family
 (`advisory-wait:`/`advisory-wait-recovery:`/`<!-- advisory-wait:`/
 `advisory-reroll:`, grouped by embedded HEAD SHA mismatch, AW3-H,
 `idd-advisory-wait.instructions.md`). A family classified `f4-only` has
 no such wiring yet and follows the default F4-only timing above until a
-future track adds it.
+future track adds it. A third `MARKER_HIDE_POLICY` kind, `excluded`,
+covers markers deliberately kept out of both groupings (each for the
+reason on its own entry in `MARKER_HIDE_POLICY`) -- one of those,
+`<!-- forced-handoff:`, also carries its own permanent F4 exemption
+(`audit-pr-cleanup.mts` hardcodes a skip for that prefix regardless of
+merge state); the other `excluded` entries have no such exemption and
+are swept by F4's generic stale-marker rule like an ordinary `f4-only`
+family.
 
 Do not minimize comments during active E or F gates for any other
 reason. In particular, do not minimize comments that still determine

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -150,15 +150,15 @@ no such wiring yet and follows the default F4-only timing above until a
 future track adds it -- concretely, the post-merge F4 batch means
 `audit-pr-cleanup.mts`'s generic marker-prefix match
 (`operationalMarkerPrefix`) against comments on the merged PR itself,
-which recognizes the full `OPERATIONAL_MARKERS` set. That is broader than
-the specific prefix list under this document's Candidate Rules section
-below: that list predates several `f4-only`-classified families added
-since, and is stale documentation rather than a deliberately narrower
-second path -- both the vendored helper's own dry run and the manual
-GraphQL fallback read the same Candidate Rules list, so the gap affects
-an adopter following either path, not only the manual fallback (tracked
-as issue #2778). A third `MARKER_HIDE_POLICY` kind, `excluded`, covers markers
-deliberately kept out of both groupings (each for the reason on its own
+which recognizes the full `OPERATIONAL_MARKERS` set directly. The
+running code never parses this document, so the vendored helper's own
+dry run is unaffected by the Candidate Rules section below being stale
+(that list predates several `f4-only`-classified families added since).
+Only the manual GraphQL fallback, which has no code behind it and uses
+that list as its literal operating procedure, is actually narrowed by
+the gap (tracked as issue #2778). A third `MARKER_HIDE_POLICY` kind,
+`excluded`, covers markers deliberately kept out of both groupings
+(each for the reason on its own
 entry in `MARKER_HIDE_POLICY`). Two of those are permanently outside F4's
 reach for different reasons: `<!-- forced-handoff:` carries its own
 explicit F4 exemption (`audit-pr-cleanup.mts` hardcodes a skip for that

--- a/idd-template/docs/idd-concept-ownership.md
+++ b/idd-template/docs/idd-concept-ownership.md
@@ -84,7 +84,7 @@ matrix's general "who mutates" column above.
 | Branch and worktree | Deleted | Worker or merge-capable session, F4 — only after F3 merge succeeds |
 | Review thread | Resolved | Worker session, immediately after posting a disposition reply (E6/E13) — **except** an `**Awaiting maintainer decision**` reply, which leaves the thread unresolved until a maintainer responds (F2's unresolved-threads gate relies on this); or a human reviewer resolving their own thread |
 | PR | Merged | Merge-capable session, F3, only once the full F2/F2.5 gate checklist holds |
-| `review-watermark` / `review-baseline` / `advisory-wait:` / `advisory-wait-recovery:` / `advisory-reroll:` markers | Superseded / minimized as `OUTDATED` | Worker session, after a newer valid marker of the same kind exists for the same claim or HEAD |
+| `review-watermark` / `review-baseline` / `advisory-wait:` / `advisory-wait-recovery:` / `<!-- advisory-wait:` / `advisory-reroll:` markers | Superseded / minimized as `OUTDATED` | Worker session, after a newer valid marker of the same kind exists for the same claim or HEAD |
 | Claim-marker chain (`claimed-by`/`unclaimed-by`/heartbeat) | Superseded / minimized as `OUTDATED` | Worker session, but **only** the prior claim-id's chain after a verified `supersedes: <prior-id>` takeover — a same-claim heartbeat chain must never be hidden; it is the active-claim audit trail |
 | External-check waiver | Expired, or consumed | Worker session, rerunning the waived check so it reflects the waiver; expiry itself is a time-driven transition (`expiresAt`) that needs no actor |
 | `status:blocked-by-human` label | Removed | Human maintainer only, after resolving the underlying blocker |

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -316,45 +316,81 @@ const MARKER_HIDE_POLICY_ENTRIES = [
   },
 ];
 /**
- * Wraps `map` so every mutating call (`set`/`delete`/`clear`) throws instead
- * of silently succeeding. Unlike an array or a plain object, `Object.freeze`
- * on a `Map` instance does not stop `Map#set`/`#delete`/`#clear` -- those
- * mutate internal slots the freeze does not cover, so a `ReadonlyMap<K, V>`
- * type alone is a compile-time-only guard that a JS caller (or a TS call
- * site that casts around the type) can bypass at runtime. Read methods
- * (`get`/`has`/`keys`/`entries`/iteration/etc.) are passed through to the
- * real `Map`, bound to it rather than the proxy, since `Map.prototype`'s own
- * methods require a genuine `Map` internal slot to operate on. `forEach` is
- * special-cased rather than simply bound: `Map#forEach`'s native
- * implementation passes its *own receiver* as the callback's third
- * argument, so a plain bind would hand callers the real, mutable `target`
- * map as `forEach`'s third callback argument -- an escape hatch around the
- * freeze this function exists to enforce -- so this substitutes the
- * returned proxy itself for that argument instead (caught by
- * chatgpt-codex-connector review on PR #2759; the `forEach` escape found
- * during this fix's own E10 self-critique).
+ * Wraps `map` in a brand-new, closure-backed object exposing only the
+ * `ReadonlyMap<K, V>` surface -- no mutating method, and no reference to
+ * `map` ever reaches the returned object's own property graph. This
+ * function went through two narrower attempts first, both a `Proxy` over
+ * the real `Map`, before landing here; both attempts are recorded so the
+ * next reader does not retry them:
+ *
+ * 1. A `Proxy` whose `get` trap rejected `set`/`delete`/`clear` and bound
+ *    every other method to the real underlying `map` (`Map.prototype`'s
+ *    own methods require a genuine `Map` internal slot as `this`, and
+ *    `Object.freeze` on a `Map` instance does not stop `#set`/`#delete`/
+ *    `#clear` -- those mutate the `[[MapData]]` internal slot, not an
+ *    ordinary object property, so freezing the `Map` itself was never a
+ *    workable option). `forEach` needed special-casing even within this
+ *    approach: `Map#forEach`'s native implementation passes its *own
+ *    receiver* as the callback's third argument, so a plain bind would
+ *    hand callers the real, mutable map as that argument (caught by
+ *    chatgpt-codex-connector review on PR #2759; found during this fix's
+ *    own E10 self-critique).
+ * 2. Adding `Object.preventExtensions(map)` to close a further reflective
+ *    escape from attempt 1: a `Proxy` with no `defineProperty`/`set` trap
+ *    still forwards a brand-new own-property assignment straight to
+ *    `target`, so a caller could define `MARKER_HIDE_POLICY.leak =
+ *    function () { return this; }` and read it back through the generic
+ *    function-binding `get` path, which bound it to `target` and handed
+ *    back the raw, mutable map (caught by chatgpt-codex-connector review
+ *    on PR #2759, a second round).
+ *
+ * Both attempts still shared the same flaw: the generic function-binding
+ * path (`typeof value === 'function' ? value.bind(target) : value`) binds
+ * *any* inherited function property to `target`, not just the ones this
+ * function intended to expose. `Object.prototype.valueOf` is one such
+ * property -- it is a function, it is inherited by every `Map`, and it
+ * returns `this` -- so `MARKER_HIDE_POLICY.valueOf()` bound `valueOf` to
+ * `target` and simply handed back the raw, mutable map, and neither
+ * `preventExtensions` nor the `mutators` denylist touched it (caught by
+ * `advisor()` review during this fix's own verification pass, a third
+ * round). A denylist over inherited `Object.prototype` methods would be
+ * a fourth patch on the same mechanism -- every fix so far has been
+ * "enumerate what's dangerous," and each round found something the
+ * previous enumeration missed. This rewrite instead removes the
+ * mechanism the escapes have in common: there is no `target` for any
+ * trap or bind call to leak, because the returned object has no relation
+ * to `map` other than the closures below capturing it by reference. The
+ * eight members below are exactly `ReadonlyMap<K, V>`'s interface --
+ * `get`/`has`/`size`/`keys`/`values`/`entries`/`forEach`/
+ * `[Symbol.iterator]` -- so nothing else is reachable to bind or leak in
+ * the first place. `forEach` still substitutes the returned object for
+ * its own third callback argument, matching `Map#forEach`'s documented
+ * shape without the third-argument leak the earlier `Proxy` attempts had
+ * to special-case. `Object.freeze` on the returned object blocks adding
+ * new properties (the injection escape from attempt 2), since this is now
+ * a plain object, not a `Map` -- `Object.freeze` is fully effective here.
+ * The result deliberately does not satisfy `instanceof Map`; nothing in
+ * this codebase relies on that, and a lookup that only ever exposes
+ * `ReadonlyMap` behavior should not also claim to be a `Map` it isn't.
  */
 function freezeMap(map) {
-  const mutators = new Set(['set', 'delete', 'clear']);
-  const proxy = new Proxy(map, {
-    get(target, prop, _receiver) {
-      if (typeof prop === 'string' && mutators.has(prop)) {
-        return () => {
-          throw new TypeError(`this frozen map does not allow ${prop}()`);
-        };
-      }
-      if (prop === 'forEach') {
-        return (callbackFn, thisArg) => {
-          target.forEach((value, key) => {
-            callbackFn.call(thisArg, value, key, proxy);
-          });
-        };
-      }
-      const value = Reflect.get(target, prop, target);
-      return typeof value === 'function' ? value.bind(target) : value;
+  const readOnlyMap = {
+    get: (key) => map.get(key),
+    has: (key) => map.has(key),
+    get size() {
+      return map.size;
     },
-  });
-  return proxy;
+    keys: () => map.keys(),
+    values: () => map.values(),
+    entries: () => map.entries(),
+    forEach(callbackFn, thisArg) {
+      map.forEach((value, key) => {
+        callbackFn.call(thisArg, value, key, readOnlyMap);
+      });
+    },
+    [Symbol.iterator]: () => map.entries(),
+  };
+  return Object.freeze(readOnlyMap);
 }
 /**
  * Builds the frozen {@link MARKER_HIDE_POLICY} lookup from `entries`,
@@ -385,7 +421,8 @@ export function buildMarkerHidePolicyMap(entries) {
  * matches `OPERATIONAL_MARKERS`' labels, so a future new marker family with
  * no entry here fails that test instead of silently drifting the way issue
  * #1705 did. See {@link buildMarkerHidePolicyMap} for the duplicate-label
- * guard and {@link freezeMap} for why this is a `Proxy`, not a plain `Map`.
+ * guard and {@link freezeMap} for why this is a closure-backed object
+ * exposing only the `ReadonlyMap<K, V>` surface, not a `Map` itself.
  */
 export const MARKER_HIDE_POLICY = buildMarkerHidePolicyMap(
   MARKER_HIDE_POLICY_ENTRIES,

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -225,9 +225,12 @@ const MARKER_HIDE_POLICY_ENTRIES = [
   },
   {
     label: '<!-- activation-nonce:',
-    policy: 'wired',
+    policy: 'f4-only',
     reason:
-      'Claim chain, grouped by supersedes: claim-id lineage (idd-claim.instructions.md).',
+      "No hide-at-post-time wiring yet: idd-claim.instructions.md's takeover " +
+      'minimization only targets claimed-by/unclaimed-by/heartbeat comments, ' +
+      'not activation-nonce -- only the post-merge F4 cleanup batch cleans it ' +
+      'up today (caught by Copilot review on PR #2759).',
   },
   {
     label: '<!-- review-watermark:',

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -210,6 +210,122 @@ const OPERATIONAL_MARKER_ENTRIES = [
 export const OPERATIONAL_MARKERS = Object.freeze(
   OPERATIONAL_MARKER_ENTRIES.map((marker) => Object.freeze(marker)),
 );
+const MARKER_HIDE_POLICY_ENTRIES = [
+  {
+    label: '<!-- claimed-by:',
+    policy: 'wired',
+    reason:
+      'Claim chain, grouped by supersedes: claim-id lineage (idd-claim.instructions.md).',
+  },
+  {
+    label: '<!-- unclaimed-by:',
+    policy: 'wired',
+    reason:
+      'Claim chain, grouped by supersedes: claim-id lineage (idd-claim.instructions.md).',
+  },
+  {
+    label: '<!-- activation-nonce:',
+    policy: 'wired',
+    reason:
+      'Claim chain, grouped by supersedes: claim-id lineage (idd-claim.instructions.md).',
+  },
+  {
+    label: '<!-- review-watermark:',
+    policy: 'wired',
+    reason: 'Grouped by same claim-id (idd-review-snapshot.instructions.md).',
+  },
+  {
+    label: '<!-- review-baseline:',
+    policy: 'wired',
+    reason: 'Grouped by same claim-id (idd-review-snapshot.instructions.md).',
+  },
+  {
+    label: 'advisory-wait:',
+    policy: 'wired',
+    reason:
+      'Advisory-wait family, grouped by embedded HEAD SHA mismatch, AW3-H (idd-advisory-wait.instructions.md).',
+  },
+  {
+    label: 'advisory-wait-recovery:',
+    policy: 'wired',
+    reason:
+      'Advisory-wait family, grouped by embedded HEAD SHA mismatch, AW3-H (idd-advisory-wait.instructions.md).',
+  },
+  {
+    label: '<!-- advisory-wait:',
+    policy: 'wired',
+    reason:
+      'Advisory-wait family (HTML-comment form), grouped by embedded HEAD SHA mismatch, AW3-H (idd-advisory-wait.instructions.md).',
+  },
+  {
+    label: 'advisory-reroll:',
+    policy: 'wired',
+    reason:
+      'Advisory-wait family, grouped by embedded HEAD SHA mismatch, AW3-H (idd-advisory-wait.instructions.md).',
+  },
+  {
+    label: 'review-ack:',
+    policy: 'f4-only',
+    reason:
+      'No hide-at-post-time wiring yet; only the post-merge F4 cleanup batch cleans it up today. Flipped to wired by roadmap #2751 Track 2 (#2754).',
+  },
+  {
+    label: 'copilot-unavailable:',
+    policy: 'f4-only',
+    reason:
+      'No hide-at-post-time wiring yet; only the post-merge F4 cleanup batch cleans it up today. Flipped to wired by roadmap #2751 Track 2 (#2754).',
+  },
+  {
+    label: '<!-- forced-handoff:',
+    policy: 'excluded',
+    reason:
+      'Permanent maintainer-authority audit record of a claim transfer; never listed in any documented F4 minimization candidate-prefix list and never minimized.',
+  },
+  {
+    label: '<!-- idd-external-check-waiver:',
+    policy: 'excluded',
+    reason:
+      'Maintainer-authority marker; a correct grouping key needs the embedded check: selector, and hiding a still-relevant waiver for a different check would hide live authorization (roadmap #2751 Background).',
+  },
+  {
+    label: '<!-- idd-provider-outage-declaration:',
+    policy: 'excluded',
+    reason:
+      'Issue-scoped, cross-PR declare/advance protocol with no clean single-PR grouping key (roadmap #2751 Background).',
+  },
+  {
+    label: '<!-- idd-provider-outage-advanced:',
+    policy: 'excluded',
+    reason:
+      'Issue-scoped, cross-PR declare/advance protocol with no clean single-PR grouping key (roadmap #2751 Background).',
+  },
+  {
+    label: '<!-- idd-provider-outage-park:',
+    policy: 'excluded',
+    reason:
+      'Supersession would need to track claim lineage the way the claim chain does, but the marker carries no supersedes: reference back to it -- a same-claim-only rule risks leaving a park marker for an already-superseded claim visible, while a lineage-aware rule risks the reverse; needs its own design pass (roadmap #2751 Background).',
+  },
+  {
+    label: '<!-- idd-local-validation-evidence:',
+    policy: 'f4-only',
+    reason:
+      'No hide-at-post-time wiring yet; only the post-merge F4 cleanup batch cleans it up today. Flipped to wired by roadmap #2751 Track 3 (#2755).',
+  },
+];
+/**
+ * Frozen, exported lookup from an `OPERATIONAL_MARKERS` entry's `label` to
+ * its hide-at-post-time classification (#2751/#2752).
+ * `tests/marker-helpers-facade.test.mts` asserts this map's key set exactly
+ * matches `OPERATIONAL_MARKERS`' labels, so a future new marker family with
+ * no entry here fails that test instead of silently drifting the way issue
+ * #1705 did.
+ */
+export const MARKER_HIDE_POLICY = new Map(
+  MARKER_HIDE_POLICY_ENTRIES.map((entry) => [
+    entry.label,
+    Object.freeze(entry),
+  ]),
+);
 export const IDD_AGENT_DERIVED_MARKERS = new Set([
   '<!-- claimed-by:',
   '<!-- unclaimed-by:',

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -316,18 +316,79 @@ const MARKER_HIDE_POLICY_ENTRIES = [
   },
 ];
 /**
+ * Wraps `map` so every mutating call (`set`/`delete`/`clear`) throws instead
+ * of silently succeeding. Unlike an array or a plain object, `Object.freeze`
+ * on a `Map` instance does not stop `Map#set`/`#delete`/`#clear` -- those
+ * mutate internal slots the freeze does not cover, so a `ReadonlyMap<K, V>`
+ * type alone is a compile-time-only guard that a JS caller (or a TS call
+ * site that casts around the type) can bypass at runtime. Read methods
+ * (`get`/`has`/`keys`/`entries`/iteration/etc.) are passed through to the
+ * real `Map`, bound to it rather than the proxy, since `Map.prototype`'s own
+ * methods require a genuine `Map` internal slot to operate on. `forEach` is
+ * special-cased rather than simply bound: `Map#forEach`'s native
+ * implementation passes its *own receiver* as the callback's third
+ * argument, so a plain bind would hand callers the real, mutable `target`
+ * map as `forEach`'s third callback argument -- an escape hatch around the
+ * freeze this function exists to enforce -- so this substitutes the
+ * returned proxy itself for that argument instead (caught by
+ * chatgpt-codex-connector review on PR #2759; the `forEach` escape found
+ * during this fix's own E10 self-critique).
+ */
+function freezeMap(map) {
+  const mutators = new Set(['set', 'delete', 'clear']);
+  const proxy = new Proxy(map, {
+    get(target, prop, _receiver) {
+      if (typeof prop === 'string' && mutators.has(prop)) {
+        return () => {
+          throw new TypeError(`this frozen map does not allow ${prop}()`);
+        };
+      }
+      if (prop === 'forEach') {
+        return (callbackFn, thisArg) => {
+          target.forEach((value, key) => {
+            callbackFn.call(thisArg, value, key, proxy);
+          });
+        };
+      }
+      const value = Reflect.get(target, prop, target);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+  return proxy;
+}
+/**
+ * Builds the frozen {@link MARKER_HIDE_POLICY} lookup from `entries`,
+ * throwing if two entries share a `label` -- plain `new Map(...)`
+ * construction would otherwise let the later entry silently win, hiding a
+ * copy-paste mistake (a duplicate row that still names every required
+ * label passes the "exactly one classification per marker" coverage test
+ * in `tests/marker-helpers-facade.test.mts`, since that test only checks
+ * label-set membership, not per-label uniqueness in the source array).
+ * Exported so that test can also exercise the duplicate-detection path
+ * directly, without needing to corrupt the real production entries (caught
+ * by chatgpt-codex-connector review on PR #2759).
+ */
+export function buildMarkerHidePolicyMap(entries) {
+  const map = new Map();
+  for (const entry of entries) {
+    if (map.has(entry.label)) {
+      throw new Error(`duplicate hide-policy label: ${entry.label}`);
+    }
+    map.set(entry.label, Object.freeze(entry));
+  }
+  return freezeMap(map);
+}
+/**
  * Frozen, exported lookup from an `OPERATIONAL_MARKERS` entry's `label` to
  * its hide-at-post-time classification (#2751/#2752).
  * `tests/marker-helpers-facade.test.mts` asserts this map's key set exactly
  * matches `OPERATIONAL_MARKERS`' labels, so a future new marker family with
  * no entry here fails that test instead of silently drifting the way issue
- * #1705 did.
+ * #1705 did. See {@link buildMarkerHidePolicyMap} for the duplicate-label
+ * guard and {@link freezeMap} for why this is a `Proxy`, not a plain `Map`.
  */
-export const MARKER_HIDE_POLICY = new Map(
-  MARKER_HIDE_POLICY_ENTRIES.map((entry) => [
-    entry.label,
-    Object.freeze(entry),
-  ]),
+export const MARKER_HIDE_POLICY = buildMarkerHidePolicyMap(
+  MARKER_HIDE_POLICY_ENTRIES,
 );
 export const IDD_AGENT_DERIVED_MARKERS = new Set([
   '<!-- claimed-by:',

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -232,7 +232,7 @@ const MARKER_HIDE_POLICY_ENTRIES = [
       'not activation-nonce (caught by Copilot review on PR #2759). Also ' +
       'issue-scoped, not PR-scoped (posted via `post-idd-marker --type ' +
       'activation-nonce --target issue`), so unlike an ordinary f4-only ' +
-      "family it has no F4 cleanup path either: audit-pr-cleanup.mjs's " +
+      "family it has no F4 cleanup path either: audit-pr-cleanup.mts's " +
       'GraphQL fetch is bound to the merged PR number and never sees a ' +
       'comment on the separate issue (caught by chatgpt-codex-connector ' +
       'review, second round).',

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -279,7 +279,7 @@ const MARKER_HIDE_POLICY_ENTRIES = [
     label: '<!-- forced-handoff:',
     policy: 'excluded',
     reason:
-      'Permanent maintainer-authority audit record of a claim transfer; never listed in any documented F4 minimization candidate-prefix list and never minimized.',
+      'Permanent maintainer-authority audit record of a claim transfer. The only excluded family with a matching F4 exemption today: audit-pr-cleanup.mts hardcodes a skip for this prefix.',
   },
   {
     label: '<!-- idd-external-check-waiver:',

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -225,12 +225,17 @@ const MARKER_HIDE_POLICY_ENTRIES = [
   },
   {
     label: '<!-- activation-nonce:',
-    policy: 'f4-only',
+    policy: 'excluded',
     reason:
       "No hide-at-post-time wiring yet: idd-claim.instructions.md's takeover " +
       'minimization only targets claimed-by/unclaimed-by/heartbeat comments, ' +
-      'not activation-nonce -- only the post-merge F4 cleanup batch cleans it ' +
-      'up today (caught by Copilot review on PR #2759).',
+      'not activation-nonce (caught by Copilot review on PR #2759). Also ' +
+      'issue-scoped, not PR-scoped (posted via `post-idd-marker --type ' +
+      'activation-nonce --target issue`), so unlike an ordinary f4-only ' +
+      "family it has no F4 cleanup path either: audit-pr-cleanup.mjs's " +
+      'GraphQL fetch is bound to the merged PR number and never sees a ' +
+      'comment on the separate issue (caught by chatgpt-codex-connector ' +
+      'review, second round).',
   },
   {
     label: '<!-- review-watermark:',

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -583,48 +583,81 @@ const MARKER_HIDE_POLICY_ENTRIES: readonly MarkerHidePolicyEntry[] = [
 ];
 
 /**
- * Wraps `map` so every mutating call (`set`/`delete`/`clear`) throws instead
- * of silently succeeding. Unlike an array or a plain object, `Object.freeze`
- * on a `Map` instance does not stop `Map#set`/`#delete`/`#clear` -- those
- * mutate internal slots the freeze does not cover, so a `ReadonlyMap<K, V>`
- * type alone is a compile-time-only guard that a JS caller (or a TS call
- * site that casts around the type) can bypass at runtime. Read methods
- * (`get`/`has`/`keys`/`entries`/iteration/etc.) are passed through to the
- * real `Map`, bound to it rather than the proxy, since `Map.prototype`'s own
- * methods require a genuine `Map` internal slot to operate on. `forEach` is
- * special-cased rather than simply bound: `Map#forEach`'s native
- * implementation passes its *own receiver* as the callback's third
- * argument, so a plain bind would hand callers the real, mutable `target`
- * map as `forEach`'s third callback argument -- an escape hatch around the
- * freeze this function exists to enforce -- so this substitutes the
- * returned proxy itself for that argument instead (caught by
- * chatgpt-codex-connector review on PR #2759; the `forEach` escape found
- * during this fix's own E10 self-critique).
+ * Wraps `map` in a brand-new, closure-backed object exposing only the
+ * `ReadonlyMap<K, V>` surface -- no mutating method, and no reference to
+ * `map` ever reaches the returned object's own property graph. This
+ * function went through two narrower attempts first, both a `Proxy` over
+ * the real `Map`, before landing here; both attempts are recorded so the
+ * next reader does not retry them:
+ *
+ * 1. A `Proxy` whose `get` trap rejected `set`/`delete`/`clear` and bound
+ *    every other method to the real underlying `map` (`Map.prototype`'s
+ *    own methods require a genuine `Map` internal slot as `this`, and
+ *    `Object.freeze` on a `Map` instance does not stop `#set`/`#delete`/
+ *    `#clear` -- those mutate the `[[MapData]]` internal slot, not an
+ *    ordinary object property, so freezing the `Map` itself was never a
+ *    workable option). `forEach` needed special-casing even within this
+ *    approach: `Map#forEach`'s native implementation passes its *own
+ *    receiver* as the callback's third argument, so a plain bind would
+ *    hand callers the real, mutable map as that argument (caught by
+ *    chatgpt-codex-connector review on PR #2759; found during this fix's
+ *    own E10 self-critique).
+ * 2. Adding `Object.preventExtensions(map)` to close a further reflective
+ *    escape from attempt 1: a `Proxy` with no `defineProperty`/`set` trap
+ *    still forwards a brand-new own-property assignment straight to
+ *    `target`, so a caller could define `MARKER_HIDE_POLICY.leak =
+ *    function () { return this; }` and read it back through the generic
+ *    function-binding `get` path, which bound it to `target` and handed
+ *    back the raw, mutable map (caught by chatgpt-codex-connector review
+ *    on PR #2759, a second round).
+ *
+ * Both attempts still shared the same flaw: the generic function-binding
+ * path (`typeof value === 'function' ? value.bind(target) : value`) binds
+ * *any* inherited function property to `target`, not just the ones this
+ * function intended to expose. `Object.prototype.valueOf` is one such
+ * property -- it is a function, it is inherited by every `Map`, and it
+ * returns `this` -- so `MARKER_HIDE_POLICY.valueOf()` bound `valueOf` to
+ * `target` and simply handed back the raw, mutable map, and neither
+ * `preventExtensions` nor the `mutators` denylist touched it (caught by
+ * `advisor()` review during this fix's own verification pass, a third
+ * round). A denylist over inherited `Object.prototype` methods would be
+ * a fourth patch on the same mechanism -- every fix so far has been
+ * "enumerate what's dangerous," and each round found something the
+ * previous enumeration missed. This rewrite instead removes the
+ * mechanism the escapes have in common: there is no `target` for any
+ * trap or bind call to leak, because the returned object has no relation
+ * to `map` other than the closures below capturing it by reference. The
+ * eight members below are exactly `ReadonlyMap<K, V>`'s interface --
+ * `get`/`has`/`size`/`keys`/`values`/`entries`/`forEach`/
+ * `[Symbol.iterator]` -- so nothing else is reachable to bind or leak in
+ * the first place. `forEach` still substitutes the returned object for
+ * its own third callback argument, matching `Map#forEach`'s documented
+ * shape without the third-argument leak the earlier `Proxy` attempts had
+ * to special-case. `Object.freeze` on the returned object blocks adding
+ * new properties (the injection escape from attempt 2), since this is now
+ * a plain object, not a `Map` -- `Object.freeze` is fully effective here.
+ * The result deliberately does not satisfy `instanceof Map`; nothing in
+ * this codebase relies on that, and a lookup that only ever exposes
+ * `ReadonlyMap` behavior should not also claim to be a `Map` it isn't.
  */
 function freezeMap<K, V>(map: Map<K, V>): ReadonlyMap<K, V> {
-  const mutators = new Set(['set', 'delete', 'clear']);
-  const proxy: ReadonlyMap<K, V> = new Proxy(map, {
-    get(target, prop, _receiver) {
-      if (typeof prop === 'string' && mutators.has(prop)) {
-        return () => {
-          throw new TypeError(`this frozen map does not allow ${prop}()`);
-        };
-      }
-      if (prop === 'forEach') {
-        return (
-          callbackFn: (value: V, key: K, map: ReadonlyMap<K, V>) => void,
-          thisArg?: unknown,
-        ) => {
-          target.forEach((value, key) => {
-            callbackFn.call(thisArg, value, key, proxy);
-          });
-        };
-      }
-      const value = Reflect.get(target, prop, target);
-      return typeof value === 'function' ? value.bind(target) : value;
+  const readOnlyMap: ReadonlyMap<K, V> = {
+    get: (key) => map.get(key),
+    has: (key) => map.has(key),
+    get size() {
+      return map.size;
     },
-  }) as ReadonlyMap<K, V>;
-  return proxy;
+    keys: () => map.keys(),
+    values: () => map.values(),
+    entries: () => map.entries(),
+    forEach(callbackFn, thisArg) {
+      map.forEach((value, key) => {
+        callbackFn.call(thisArg, value, key, readOnlyMap);
+      });
+    },
+    [Symbol.iterator]: () => map.entries(),
+  };
+  return Object.freeze(readOnlyMap);
 }
 
 /**
@@ -659,7 +692,8 @@ export function buildMarkerHidePolicyMap(
  * matches `OPERATIONAL_MARKERS`' labels, so a future new marker family with
  * no entry here fails that test instead of silently drifting the way issue
  * #1705 did. See {@link buildMarkerHidePolicyMap} for the duplicate-label
- * guard and {@link freezeMap} for why this is a `Proxy`, not a plain `Map`.
+ * guard and {@link freezeMap} for why this is a closure-backed object
+ * exposing only the `ReadonlyMap<K, V>` surface, not a `Map` itself.
  */
 export const MARKER_HIDE_POLICY: ReadonlyMap<string, MarkerHidePolicyEntry> =
   buildMarkerHidePolicyMap(MARKER_HIDE_POLICY_ENTRIES);

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -456,8 +456,16 @@ export const OPERATIONAL_MARKERS: readonly OperationalMarker[] = Object.freeze(
  * (see `docs/idd-comment-minimization.md`'s "## Timing" section); `f4-only`
  * families have no hide-at-post-time wiring yet, so the post-merge F4
  * cleanup batch (`docs/idd-comment-minimization.md`'s Candidate Rules) is
- * their only cleanup path today; `excluded` families are deliberately never
- * minimized, each for the reason recorded on its own entry below.
+ * their only cleanup path today; `excluded` families are deliberately kept
+ * out of the `wired` pre-merge grouping, each for the reason recorded on
+ * its own entry below. This classification alone does not guarantee F4
+ * protection too: only `<!-- forced-handoff:` also carries a matching F4
+ * exemption today (`audit-pr-cleanup.mts`'s `evaluateOperationalComment`
+ * hardcodes a skip for that one prefix). The other four `excluded` entries
+ * have no equivalent exemption yet and are swept by F4's generic
+ * stale-marker rule exactly like an ordinary `f4-only` family -- a real
+ * gap their own reasons argue against, flagged for a follow-up rather than
+ * fixed by this classification pass.
  */
 export type MarkerHidePolicyKind = 'wired' | 'f4-only' | 'excluded';
 
@@ -537,7 +545,7 @@ const MARKER_HIDE_POLICY_ENTRIES: readonly MarkerHidePolicyEntry[] = [
     label: '<!-- forced-handoff:',
     policy: 'excluded',
     reason:
-      'Permanent maintainer-authority audit record of a claim transfer; never listed in any documented F4 minimization candidate-prefix list and never minimized.',
+      'Permanent maintainer-authority audit record of a claim transfer. The only excluded family with a matching F4 exemption today: audit-pr-cleanup.mts hardcodes a skip for this prefix.',
   },
   {
     label: '<!-- idd-external-check-waiver:',

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -454,18 +454,30 @@ export const OPERATIONAL_MARKERS: readonly OperationalMarker[] = Object.freeze(
  * keyed by that entry's `label` (#2751/#2752). `wired` marker families
  * already have a documented pre-merge hide-at-post-time supersession rule
  * (see `docs/idd-comment-minimization.md`'s "## Timing" section); `f4-only`
- * families have no hide-at-post-time wiring yet, so the post-merge F4
- * cleanup batch (`docs/idd-comment-minimization.md`'s Candidate Rules) is
- * their only cleanup path today; `excluded` families are deliberately kept
- * out of the `wired` pre-merge grouping, each for the reason recorded on
- * its own entry below. This classification alone does not guarantee F4
- * protection too: only `<!-- forced-handoff:` also carries a matching F4
- * exemption today (`audit-pr-cleanup.mts`'s `evaluateOperationalComment`
- * hardcodes a skip for that one prefix). The other four `excluded` entries
- * have no equivalent exemption yet and are swept by F4's generic
- * stale-marker rule exactly like an ordinary `f4-only` family -- a real
- * gap their own reasons argue against, flagged for a follow-up rather than
- * fixed by this classification pass.
+ * families have no such pre-merge wiring, so the post-merge F4 cleanup
+ * batch is their only cleanup path today -- concretely,
+ * `audit-pr-cleanup.mts`'s generic `operationalMarkerPrefix` match against
+ * comments on the merged PR, which recognizes the full
+ * `OPERATIONAL_MARKERS` set. That is broader than the specific prefix
+ * list under `docs/idd-comment-minimization.md`'s "## Candidate Rules"
+ * heading: that list predates several `f4-only`-classified families
+ * (including the three this pass added) and is stale documentation, not
+ * a deliberately narrower second path -- both the vendored helper's own
+ * dry run and the manual GraphQL fallback read that same list, so the
+ * gap is not adopter-fallback-only (tracked as issue #2778); `excluded`
+ * families are deliberately kept out of the `wired` pre-merge grouping,
+ * each for the reason recorded on its own entry below. This
+ * classification alone does not guarantee an F4 cleanup
+ * path either: `<!-- forced-handoff:` carries an explicit F4 skip
+ * (`evaluateOperationalComment` hardcodes it for that one prefix), and
+ * `<!-- activation-nonce:` is issue-scoped, so F4's PR-scoped
+ * `audit-pr-cleanup.mts` structurally never even sees that comment --
+ * both permanently outside F4's reach, for different reasons. The
+ * remaining `excluded` entries carry no explicit exemption; whether F4's
+ * generic rule actually reaches each of them depends on where that family
+ * is posted -- a gap their own reasons argue against, flagged for a
+ * follow-up rather than fully audited or fixed by this classification
+ * pass.
  */
 export type MarkerHidePolicyKind = 'wired' | 'f4-only' | 'excluded';
 
@@ -491,12 +503,17 @@ const MARKER_HIDE_POLICY_ENTRIES: readonly MarkerHidePolicyEntry[] = [
   },
   {
     label: '<!-- activation-nonce:',
-    policy: 'f4-only',
+    policy: 'excluded',
     reason:
       "No hide-at-post-time wiring yet: idd-claim.instructions.md's takeover " +
       'minimization only targets claimed-by/unclaimed-by/heartbeat comments, ' +
-      'not activation-nonce -- only the post-merge F4 cleanup batch cleans it ' +
-      'up today (caught by Copilot review on PR #2759).',
+      'not activation-nonce (caught by Copilot review on PR #2759). Also ' +
+      'issue-scoped, not PR-scoped (posted via `post-idd-marker --type ' +
+      'activation-nonce --target issue`), so unlike an ordinary f4-only ' +
+      "family it has no F4 cleanup path either: audit-pr-cleanup.mjs's " +
+      'GraphQL fetch is bound to the merged PR number and never sees a ' +
+      'comment on the separate issue (caught by chatgpt-codex-connector ' +
+      'review, second round).',
   },
   {
     label: '<!-- review-watermark:',

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -491,9 +491,12 @@ const MARKER_HIDE_POLICY_ENTRIES: readonly MarkerHidePolicyEntry[] = [
   },
   {
     label: '<!-- activation-nonce:',
-    policy: 'wired',
+    policy: 'f4-only',
     reason:
-      'Claim chain, grouped by supersedes: claim-id lineage (idd-claim.instructions.md).',
+      "No hide-at-post-time wiring yet: idd-claim.instructions.md's takeover " +
+      'minimization only targets claimed-by/unclaimed-by/heartbeat comments, ' +
+      'not activation-nonce -- only the post-merge F4 cleanup batch cleans it ' +
+      'up today (caught by Copilot review on PR #2759).',
   },
   {
     label: '<!-- review-watermark:',

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -583,20 +583,86 @@ const MARKER_HIDE_POLICY_ENTRIES: readonly MarkerHidePolicyEntry[] = [
 ];
 
 /**
+ * Wraps `map` so every mutating call (`set`/`delete`/`clear`) throws instead
+ * of silently succeeding. Unlike an array or a plain object, `Object.freeze`
+ * on a `Map` instance does not stop `Map#set`/`#delete`/`#clear` -- those
+ * mutate internal slots the freeze does not cover, so a `ReadonlyMap<K, V>`
+ * type alone is a compile-time-only guard that a JS caller (or a TS call
+ * site that casts around the type) can bypass at runtime. Read methods
+ * (`get`/`has`/`keys`/`entries`/iteration/etc.) are passed through to the
+ * real `Map`, bound to it rather than the proxy, since `Map.prototype`'s own
+ * methods require a genuine `Map` internal slot to operate on. `forEach` is
+ * special-cased rather than simply bound: `Map#forEach`'s native
+ * implementation passes its *own receiver* as the callback's third
+ * argument, so a plain bind would hand callers the real, mutable `target`
+ * map as `forEach`'s third callback argument -- an escape hatch around the
+ * freeze this function exists to enforce -- so this substitutes the
+ * returned proxy itself for that argument instead (caught by
+ * chatgpt-codex-connector review on PR #2759; the `forEach` escape found
+ * during this fix's own E10 self-critique).
+ */
+function freezeMap<K, V>(map: Map<K, V>): ReadonlyMap<K, V> {
+  const mutators = new Set(['set', 'delete', 'clear']);
+  const proxy: ReadonlyMap<K, V> = new Proxy(map, {
+    get(target, prop, _receiver) {
+      if (typeof prop === 'string' && mutators.has(prop)) {
+        return () => {
+          throw new TypeError(`this frozen map does not allow ${prop}()`);
+        };
+      }
+      if (prop === 'forEach') {
+        return (
+          callbackFn: (value: V, key: K, map: ReadonlyMap<K, V>) => void,
+          thisArg?: unknown,
+        ) => {
+          target.forEach((value, key) => {
+            callbackFn.call(thisArg, value, key, proxy);
+          });
+        };
+      }
+      const value = Reflect.get(target, prop, target);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  }) as ReadonlyMap<K, V>;
+  return proxy;
+}
+
+/**
+ * Builds the frozen {@link MARKER_HIDE_POLICY} lookup from `entries`,
+ * throwing if two entries share a `label` -- plain `new Map(...)`
+ * construction would otherwise let the later entry silently win, hiding a
+ * copy-paste mistake (a duplicate row that still names every required
+ * label passes the "exactly one classification per marker" coverage test
+ * in `tests/marker-helpers-facade.test.mts`, since that test only checks
+ * label-set membership, not per-label uniqueness in the source array).
+ * Exported so that test can also exercise the duplicate-detection path
+ * directly, without needing to corrupt the real production entries (caught
+ * by chatgpt-codex-connector review on PR #2759).
+ */
+export function buildMarkerHidePolicyMap(
+  entries: readonly MarkerHidePolicyEntry[],
+): ReadonlyMap<string, MarkerHidePolicyEntry> {
+  const map = new Map<string, MarkerHidePolicyEntry>();
+  for (const entry of entries) {
+    if (map.has(entry.label)) {
+      throw new Error(`duplicate hide-policy label: ${entry.label}`);
+    }
+    map.set(entry.label, Object.freeze(entry));
+  }
+  return freezeMap(map);
+}
+
+/**
  * Frozen, exported lookup from an `OPERATIONAL_MARKERS` entry's `label` to
  * its hide-at-post-time classification (#2751/#2752).
  * `tests/marker-helpers-facade.test.mts` asserts this map's key set exactly
  * matches `OPERATIONAL_MARKERS`' labels, so a future new marker family with
  * no entry here fails that test instead of silently drifting the way issue
- * #1705 did.
+ * #1705 did. See {@link buildMarkerHidePolicyMap} for the duplicate-label
+ * guard and {@link freezeMap} for why this is a `Proxy`, not a plain `Map`.
  */
 export const MARKER_HIDE_POLICY: ReadonlyMap<string, MarkerHidePolicyEntry> =
-  new Map(
-    MARKER_HIDE_POLICY_ENTRIES.map((entry) => [
-      entry.label,
-      Object.freeze(entry),
-    ]),
-  );
+  buildMarkerHidePolicyMap(MARKER_HIDE_POLICY_ENTRIES);
 
 export const IDD_AGENT_DERIVED_MARKERS: ReadonlySet<string> = new Set([
   '<!-- claimed-by:',

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -458,14 +458,17 @@ export const OPERATIONAL_MARKERS: readonly OperationalMarker[] = Object.freeze(
  * batch is their only cleanup path today -- concretely,
  * `audit-pr-cleanup.mts`'s generic `operationalMarkerPrefix` match against
  * comments on the merged PR, which recognizes the full
- * `OPERATIONAL_MARKERS` set. That is broader than the specific prefix
- * list under `docs/idd-comment-minimization.md`'s "## Candidate Rules"
- * heading: that list predates several `f4-only`-classified families
- * (including the three this pass added) and is stale documentation, not
- * a deliberately narrower second path -- both the vendored helper's own
- * dry run and the manual GraphQL fallback read that same list, so the
- * gap is not adopter-fallback-only (tracked as issue #2778); `excluded`
- * families are deliberately kept out of the `wired` pre-merge grouping,
+ * `OPERATIONAL_MARKERS` set directly -- the running code never parses
+ * `docs/idd-comment-minimization.md`, so its own dry run is unaffected by
+ * that document's "## Candidate Rules" heading being stale (that list
+ * predates several `f4-only`-classified families, including the three
+ * this pass added). Only the manual GraphQL fallback, which has no code
+ * behind it and uses that list as its literal operating procedure, is
+ * actually narrowed by the gap (tracked as issue #2778; caught by
+ * chatgpt-codex-connector review on PR #2759, a fresh round after this
+ * fix's own docs correction introduced the overclaim that both paths
+ * were affected); `excluded` families are deliberately kept out of the
+ * `wired` pre-merge grouping,
  * each for the reason recorded on its own entry below. This
  * classification alone does not guarantee an F4 cleanup
  * path either: `<!-- forced-handoff:` carries an explicit F4 skip
@@ -510,7 +513,7 @@ const MARKER_HIDE_POLICY_ENTRIES: readonly MarkerHidePolicyEntry[] = [
       'not activation-nonce (caught by Copilot review on PR #2759). Also ' +
       'issue-scoped, not PR-scoped (posted via `post-idd-marker --type ' +
       'activation-nonce --target issue`), so unlike an ordinary f4-only ' +
-      "family it has no F4 cleanup path either: audit-pr-cleanup.mjs's " +
+      "family it has no F4 cleanup path either: audit-pr-cleanup.mts's " +
       'GraphQL fetch is bound to the merged PR number and never sees a ' +
       'comment on the separate issue (caught by chatgpt-codex-connector ' +
       'review, second round).',

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -449,6 +449,144 @@ export const OPERATIONAL_MARKERS: readonly OperationalMarker[] = Object.freeze(
   OPERATIONAL_MARKER_ENTRIES.map((marker) => Object.freeze(marker)),
 );
 
+/**
+ * Hide-at-post-time classification for one `OPERATIONAL_MARKERS` entry,
+ * keyed by that entry's `label` (#2751/#2752). `wired` marker families
+ * already have a documented pre-merge hide-at-post-time supersession rule
+ * (see `docs/idd-comment-minimization.md`'s "## Timing" section); `f4-only`
+ * families have no hide-at-post-time wiring yet, so the post-merge F4
+ * cleanup batch (`docs/idd-comment-minimization.md`'s Candidate Rules) is
+ * their only cleanup path today; `excluded` families are deliberately never
+ * minimized, each for the reason recorded on its own entry below.
+ */
+export type MarkerHidePolicyKind = 'wired' | 'f4-only' | 'excluded';
+
+/** One {@link MARKER_HIDE_POLICY} row: see {@link MarkerHidePolicyKind}. */
+export interface MarkerHidePolicyEntry {
+  readonly label: string;
+  readonly policy: MarkerHidePolicyKind;
+  readonly reason: string;
+}
+
+const MARKER_HIDE_POLICY_ENTRIES: readonly MarkerHidePolicyEntry[] = [
+  {
+    label: '<!-- claimed-by:',
+    policy: 'wired',
+    reason:
+      'Claim chain, grouped by supersedes: claim-id lineage (idd-claim.instructions.md).',
+  },
+  {
+    label: '<!-- unclaimed-by:',
+    policy: 'wired',
+    reason:
+      'Claim chain, grouped by supersedes: claim-id lineage (idd-claim.instructions.md).',
+  },
+  {
+    label: '<!-- activation-nonce:',
+    policy: 'wired',
+    reason:
+      'Claim chain, grouped by supersedes: claim-id lineage (idd-claim.instructions.md).',
+  },
+  {
+    label: '<!-- review-watermark:',
+    policy: 'wired',
+    reason: 'Grouped by same claim-id (idd-review-snapshot.instructions.md).',
+  },
+  {
+    label: '<!-- review-baseline:',
+    policy: 'wired',
+    reason: 'Grouped by same claim-id (idd-review-snapshot.instructions.md).',
+  },
+  {
+    label: 'advisory-wait:',
+    policy: 'wired',
+    reason:
+      'Advisory-wait family, grouped by embedded HEAD SHA mismatch, AW3-H (idd-advisory-wait.instructions.md).',
+  },
+  {
+    label: 'advisory-wait-recovery:',
+    policy: 'wired',
+    reason:
+      'Advisory-wait family, grouped by embedded HEAD SHA mismatch, AW3-H (idd-advisory-wait.instructions.md).',
+  },
+  {
+    label: '<!-- advisory-wait:',
+    policy: 'wired',
+    reason:
+      'Advisory-wait family (HTML-comment form), grouped by embedded HEAD SHA mismatch, AW3-H (idd-advisory-wait.instructions.md).',
+  },
+  {
+    label: 'advisory-reroll:',
+    policy: 'wired',
+    reason:
+      'Advisory-wait family, grouped by embedded HEAD SHA mismatch, AW3-H (idd-advisory-wait.instructions.md).',
+  },
+  {
+    label: 'review-ack:',
+    policy: 'f4-only',
+    reason:
+      'No hide-at-post-time wiring yet; only the post-merge F4 cleanup batch cleans it up today. Flipped to wired by roadmap #2751 Track 2 (#2754).',
+  },
+  {
+    label: 'copilot-unavailable:',
+    policy: 'f4-only',
+    reason:
+      'No hide-at-post-time wiring yet; only the post-merge F4 cleanup batch cleans it up today. Flipped to wired by roadmap #2751 Track 2 (#2754).',
+  },
+  {
+    label: '<!-- forced-handoff:',
+    policy: 'excluded',
+    reason:
+      'Permanent maintainer-authority audit record of a claim transfer; never listed in any documented F4 minimization candidate-prefix list and never minimized.',
+  },
+  {
+    label: '<!-- idd-external-check-waiver:',
+    policy: 'excluded',
+    reason:
+      'Maintainer-authority marker; a correct grouping key needs the embedded check: selector, and hiding a still-relevant waiver for a different check would hide live authorization (roadmap #2751 Background).',
+  },
+  {
+    label: '<!-- idd-provider-outage-declaration:',
+    policy: 'excluded',
+    reason:
+      'Issue-scoped, cross-PR declare/advance protocol with no clean single-PR grouping key (roadmap #2751 Background).',
+  },
+  {
+    label: '<!-- idd-provider-outage-advanced:',
+    policy: 'excluded',
+    reason:
+      'Issue-scoped, cross-PR declare/advance protocol with no clean single-PR grouping key (roadmap #2751 Background).',
+  },
+  {
+    label: '<!-- idd-provider-outage-park:',
+    policy: 'excluded',
+    reason:
+      'Supersession would need to track claim lineage the way the claim chain does, but the marker carries no supersedes: reference back to it -- a same-claim-only rule risks leaving a park marker for an already-superseded claim visible, while a lineage-aware rule risks the reverse; needs its own design pass (roadmap #2751 Background).',
+  },
+  {
+    label: '<!-- idd-local-validation-evidence:',
+    policy: 'f4-only',
+    reason:
+      'No hide-at-post-time wiring yet; only the post-merge F4 cleanup batch cleans it up today. Flipped to wired by roadmap #2751 Track 3 (#2755).',
+  },
+];
+
+/**
+ * Frozen, exported lookup from an `OPERATIONAL_MARKERS` entry's `label` to
+ * its hide-at-post-time classification (#2751/#2752).
+ * `tests/marker-helpers-facade.test.mts` asserts this map's key set exactly
+ * matches `OPERATIONAL_MARKERS`' labels, so a future new marker family with
+ * no entry here fails that test instead of silently drifting the way issue
+ * #1705 did.
+ */
+export const MARKER_HIDE_POLICY: ReadonlyMap<string, MarkerHidePolicyEntry> =
+  new Map(
+    MARKER_HIDE_POLICY_ENTRIES.map((entry) => [
+      entry.label,
+      Object.freeze(entry),
+    ]),
+  );
+
 export const IDD_AGENT_DERIVED_MARKERS: ReadonlySet<string> = new Set([
   '<!-- claimed-by:',
   '<!-- unclaimed-by:',

--- a/tests/marker-helpers-facade.test.mts
+++ b/tests/marker-helpers-facade.test.mts
@@ -128,9 +128,13 @@ test('buildMarkerHidePolicyMap throws on a duplicate label', () => {
 });
 
 // #2759 (chatgpt-codex-connector review): `ReadonlyMap<K, V>` is a
-// compile-time-only guard -- `Object.freeze` on a `Map` instance does not
-// stop `Map#set`/`#delete`/`#clear` at runtime, so this asserts the actual
-// exported object rejects mutation, not just its declared type.
+// compile-time-only guard, so this asserts the actual exported object
+// rejects mutation, not just its declared type. `MARKER_HIDE_POLICY` is a
+// closure-backed plain object exposing only the `ReadonlyMap` surface (see
+// `freezeMap` in marker-helpers.mts), so `set`/`delete`/`clear` are not
+// merely rejected -- they do not exist on it at all, and calling a
+// property that is `undefined` throws `TypeError` for that reason on its
+// own.
 test('MARKER_HIDE_POLICY rejects runtime mutation', () => {
   const mutable = direct.MARKER_HIDE_POLICY as unknown as Map<string, unknown>;
   const sizeBefore = direct.MARKER_HIDE_POLICY.size;
@@ -150,13 +154,14 @@ test('MARKER_HIDE_POLICY rejects runtime mutation', () => {
   );
 });
 
-// #2759 E10 self-critique: `Map#forEach`'s native implementation invokes the
-// callback with its own receiver as the third argument, so naively binding
-// `forEach` to the real underlying `Map` (as every other read method is
-// bound) would hand callers that mutable `Map` as `forEach`'s third
-// argument -- an escape hatch around the freeze above. Asserts the third
-// argument is the frozen lookup itself, not the raw map, and that trying to
-// mutate through it still throws.
+// #2759 E10 self-critique: an earlier `Proxy`-based implementation of
+// `freezeMap` bound `forEach` to the real underlying `Map`, whose native
+// implementation invokes the callback with its own receiver as the third
+// argument -- handing callers that mutable `Map` as `forEach`'s third
+// argument, an escape hatch around the freeze. The current closure-backed
+// implementation substitutes the frozen lookup itself for that argument.
+// Asserts the third argument is the frozen lookup, not a mutable map, and
+// that there is no mutating method to call through it.
 test('MARKER_HIDE_POLICY.forEach never exposes the underlying mutable map', () => {
   let sawThirdArg = false;
   direct.MARKER_HIDE_POLICY.forEach((_value, _key, mapArg) => {
@@ -173,4 +178,74 @@ test('MARKER_HIDE_POLICY.forEach never exposes the underlying mutable map', () =
     );
   });
   assert.ok(sawThirdArg, 'forEach must invoke its callback at least once');
+});
+
+// #2759 (chatgpt-codex-connector review, second round): an earlier
+// `Proxy`-based `freezeMap` forwarded a brand-new own-property assignment
+// straight to its underlying `Map` target (no `defineProperty`/`set` trap
+// intercepted it), so a caller could define
+// `MARKER_HIDE_POLICY.leak = function () { return this; }` and read it back
+// bound to the mutable target. The current closure-backed implementation is
+// a plain frozen object, so `Object.freeze` is fully effective against new
+// own-property definition -- this asserts that path stays closed.
+test('MARKER_HIDE_POLICY refuses reflective property injection', () => {
+  const mutable = direct.MARKER_HIDE_POLICY as unknown as Record<
+    string,
+    unknown
+  >;
+  // This test file is an ES module, which is always strict mode, so the
+  // assignment below throws directly rather than silently no-op'ing the
+  // way it would in a sloppy-mode caller.
+  assert.throws(() => {
+    mutable.leak = function (this: unknown) {
+      return this;
+    };
+  }, TypeError);
+  assert.strictEqual(
+    mutable.leak,
+    undefined,
+    'the injected property must never actually attach to the frozen map',
+  );
+  assert.throws(
+    () =>
+      Object.defineProperty(mutable, 'leak2', {
+        value: function (this: unknown) {
+          return this;
+        },
+        configurable: true,
+      }),
+    TypeError,
+  );
+});
+
+// #2759 (advisor review, third round): an earlier `freezeMap` implementation
+// bound *any* inherited function property read off the underlying `Map` to
+// that same mutable target, not just the methods it intended to expose.
+// `Object.prototype.valueOf` is one such property -- every object inherits
+// it, and it returns `this` -- so `MARKER_HIDE_POLICY.valueOf()` handed back
+// the raw, mutable `Map`, bypassing both the mutator denylist and
+// `Object.preventExtensions` from the two prior rounds. The current
+// closure-backed implementation has no `target` for `valueOf` (inherited
+// from `Object.prototype`) to be bound to: it returns the frozen lookup
+// itself, which is what this asserts, alongside `toString` staying a
+// harmless primitive rather than exposing anything mutable.
+test('MARKER_HIDE_POLICY does not leak the underlying map through inherited Object.prototype methods', () => {
+  const leaked = (
+    direct.MARKER_HIDE_POLICY as unknown as { valueOf(): unknown }
+  ).valueOf();
+  assert.strictEqual(
+    leaked,
+    direct.MARKER_HIDE_POLICY,
+    'valueOf() must return the frozen lookup itself, never a distinct mutable object',
+  );
+  assert.strictEqual(
+    typeof (leaked as unknown as Record<string, unknown>).set,
+    'undefined',
+    'whatever valueOf() returns must not expose a set() method',
+  );
+  assert.strictEqual(
+    typeof direct.MARKER_HIDE_POLICY.toString(),
+    'string',
+    'toString() must stay a harmless primitive, not expose the underlying map',
+  );
 });

--- a/tests/marker-helpers-facade.test.mts
+++ b/tests/marker-helpers-facade.test.mts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import * as direct from '../src/scripts/marker-helpers.mts';
+import {
+  MARKER_HIDE_POLICY,
+  OPERATIONAL_MARKERS,
+} from '../src/scripts/marker-helpers.mts';
 import * as facade from '../src/scripts/protocol-helpers.mts';
 
 // Wave 1 of the protocol-helpers split (#1209) moved every operational-marker
@@ -64,6 +68,44 @@ test('protocol-helpers re-exports every sampled marker-helpers name by identity'
       viaFacade,
       viaDirect,
       `protocol-helpers.mts's ${name} must be the same binding as marker-helpers.mts's (re-export, not a copy)`,
+    );
+  }
+});
+
+// #2752: guards against the drift issue #1705 hit -- a new marker family
+// shipped with zero hide-at-post-time wiring and zero record of that gap,
+// so F4 cleanup silently missed it. This asserts every OPERATIONAL_MARKERS
+// entry has exactly one MARKER_HIDE_POLICY classification: a future new
+// entry with no classification fails this test instead of drifting quietly.
+test('MARKER_HIDE_POLICY classifies every OPERATIONAL_MARKERS entry exactly once', () => {
+  const markerLabels = OPERATIONAL_MARKERS.map((marker) => marker.label);
+  const policyLabels = [...MARKER_HIDE_POLICY.keys()];
+
+  assert.strictEqual(
+    policyLabels.length,
+    new Set(policyLabels).size,
+    'MARKER_HIDE_POLICY must not carry duplicate labels',
+  );
+  assert.deepStrictEqual(
+    new Set(policyLabels),
+    new Set(markerLabels),
+    'MARKER_HIDE_POLICY must classify exactly the OPERATIONAL_MARKERS label set (no missing, no stale, no extra entries)',
+  );
+
+  for (const marker of OPERATIONAL_MARKERS) {
+    const entry = MARKER_HIDE_POLICY.get(marker.label);
+    assert.ok(
+      entry,
+      `MARKER_HIDE_POLICY is missing a classification for ${marker.label}`,
+    );
+    assert.match(
+      entry.policy,
+      /^(wired|f4-only|excluded)$/,
+      `${marker.label}: unexpected hide-policy kind "${entry.policy}"`,
+    );
+    assert.ok(
+      entry.reason.trim().length > 0,
+      `${marker.label}: hide-policy entry must carry a non-empty reason`,
     );
   }
 });

--- a/tests/marker-helpers-facade.test.mts
+++ b/tests/marker-helpers-facade.test.mts
@@ -76,9 +76,13 @@ test('protocol-helpers re-exports every sampled marker-helpers name by identity'
 // (A `policyLabels.length === new Set(policyLabels).size` duplicate check
 // was considered here and dropped: `MARKER_HIDE_POLICY.keys()` can never
 // contain a duplicate -- Map key sets are unique by construction -- so
-// that comparison could never fail. A source-array label collision instead
-// shrinks the map below OPERATIONAL_MARKERS' label count, which the
-// deepStrictEqual set-equality check below already catches.)
+// that comparison could never fail here. A duplicate label in the *source*
+// array is instead caught at construction time by
+// `buildMarkerHidePolicyMap` throwing, exercised directly below -- a
+// duplicate that still names every required label would otherwise pass
+// this coverage check silently, since it only verifies label-set
+// membership, not per-label uniqueness in the source array. Caught by
+// chatgpt-codex-connector review on PR #2759.)
 test('MARKER_HIDE_POLICY classifies every OPERATIONAL_MARKERS entry exactly once', () => {
   const markerLabels = direct.OPERATIONAL_MARKERS.map((marker) => marker.label);
   const policyLabels = [...direct.MARKER_HIDE_POLICY.keys()];
@@ -105,4 +109,68 @@ test('MARKER_HIDE_POLICY classifies every OPERATIONAL_MARKERS entry exactly once
       `${marker.label}: hide-policy entry must carry a non-empty reason`,
     );
   }
+});
+
+// #2759 (chatgpt-codex-connector review): a duplicate `label` in the source
+// entries must fail loudly at construction time, not silently let the later
+// row win. Exercises `buildMarkerHidePolicyMap` directly with a synthetic
+// duplicate so this does not require corrupting the real production entries.
+test('buildMarkerHidePolicyMap throws on a duplicate label', () => {
+  assert.throws(
+    () =>
+      direct.buildMarkerHidePolicyMap([
+        { label: '<!-- dup:', policy: 'f4-only', reason: 'first' },
+        { label: '<!-- dup:', policy: 'wired', reason: 'second' },
+      ]),
+    /duplicate.*label/i,
+    'buildMarkerHidePolicyMap must reject two entries sharing the same label',
+  );
+});
+
+// #2759 (chatgpt-codex-connector review): `ReadonlyMap<K, V>` is a
+// compile-time-only guard -- `Object.freeze` on a `Map` instance does not
+// stop `Map#set`/`#delete`/`#clear` at runtime, so this asserts the actual
+// exported object rejects mutation, not just its declared type.
+test('MARKER_HIDE_POLICY rejects runtime mutation', () => {
+  const mutable = direct.MARKER_HIDE_POLICY as unknown as Map<string, unknown>;
+  const sizeBefore = direct.MARKER_HIDE_POLICY.size;
+
+  assert.throws(() => mutable.set('<!-- injected:', {}), TypeError);
+  assert.throws(() => mutable.delete('<!-- claimed-by:'), TypeError);
+  assert.throws(() => mutable.clear(), TypeError);
+  assert.strictEqual(
+    direct.MARKER_HIDE_POLICY.size,
+    sizeBefore,
+    'a failed mutation attempt must not change the map contents',
+  );
+  assert.strictEqual(
+    direct.MARKER_HIDE_POLICY.get('<!-- claimed-by:')?.policy,
+    'wired',
+    'read access must keep working after rejected mutation attempts',
+  );
+});
+
+// #2759 E10 self-critique: `Map#forEach`'s native implementation invokes the
+// callback with its own receiver as the third argument, so naively binding
+// `forEach` to the real underlying `Map` (as every other read method is
+// bound) would hand callers that mutable `Map` as `forEach`'s third
+// argument -- an escape hatch around the freeze above. Asserts the third
+// argument is the frozen lookup itself, not the raw map, and that trying to
+// mutate through it still throws.
+test('MARKER_HIDE_POLICY.forEach never exposes the underlying mutable map', () => {
+  let sawThirdArg = false;
+  direct.MARKER_HIDE_POLICY.forEach((_value, _key, mapArg) => {
+    sawThirdArg = true;
+    assert.strictEqual(
+      mapArg,
+      direct.MARKER_HIDE_POLICY,
+      "forEach's third argument must be the frozen lookup, not the raw map",
+    );
+    const mutableArg = mapArg as unknown as Map<string, unknown>;
+    assert.throws(
+      () => mutableArg.set('<!-- injected-via-forEach:', {}),
+      TypeError,
+    );
+  });
+  assert.ok(sawThirdArg, 'forEach must invoke its callback at least once');
 });

--- a/tests/marker-helpers-facade.test.mts
+++ b/tests/marker-helpers-facade.test.mts
@@ -1,10 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import * as direct from '../src/scripts/marker-helpers.mts';
-import {
-  MARKER_HIDE_POLICY,
-  OPERATIONAL_MARKERS,
-} from '../src/scripts/marker-helpers.mts';
 import * as facade from '../src/scripts/protocol-helpers.mts';
 
 // Wave 1 of the protocol-helpers split (#1209) moved every operational-marker
@@ -77,23 +73,24 @@ test('protocol-helpers re-exports every sampled marker-helpers name by identity'
 // so F4 cleanup silently missed it. This asserts every OPERATIONAL_MARKERS
 // entry has exactly one MARKER_HIDE_POLICY classification: a future new
 // entry with no classification fails this test instead of drifting quietly.
+// (A `policyLabels.length === new Set(policyLabels).size` duplicate check
+// was considered here and dropped: `MARKER_HIDE_POLICY.keys()` can never
+// contain a duplicate -- Map key sets are unique by construction -- so
+// that comparison could never fail. A source-array label collision instead
+// shrinks the map below OPERATIONAL_MARKERS' label count, which the
+// deepStrictEqual set-equality check below already catches.)
 test('MARKER_HIDE_POLICY classifies every OPERATIONAL_MARKERS entry exactly once', () => {
-  const markerLabels = OPERATIONAL_MARKERS.map((marker) => marker.label);
-  const policyLabels = [...MARKER_HIDE_POLICY.keys()];
+  const markerLabels = direct.OPERATIONAL_MARKERS.map((marker) => marker.label);
+  const policyLabels = [...direct.MARKER_HIDE_POLICY.keys()];
 
-  assert.strictEqual(
-    policyLabels.length,
-    new Set(policyLabels).size,
-    'MARKER_HIDE_POLICY must not carry duplicate labels',
-  );
   assert.deepStrictEqual(
     new Set(policyLabels),
     new Set(markerLabels),
     'MARKER_HIDE_POLICY must classify exactly the OPERATIONAL_MARKERS label set (no missing, no stale, no extra entries)',
   );
 
-  for (const marker of OPERATIONAL_MARKERS) {
-    const entry = MARKER_HIDE_POLICY.get(marker.label);
+  for (const marker of direct.OPERATIONAL_MARKERS) {
+    const entry = direct.MARKER_HIDE_POLICY.get(marker.label);
     assert.ok(
       entry,
       `MARKER_HIDE_POLICY is missing a classification for ${marker.label}`,


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Track 1 of roadmap #2751. Adds `MARKER_HIDE_POLICY` to
`src/scripts/marker-helpers.mts`, classifying every one of the 17
`OPERATIONAL_MARKERS` entries as `wired` (already has a documented
pre-merge hide-at-post-time supersession rule), `f4-only` (cleaned up
only by the post-merge F4 batch today), or `excluded` (deliberately
kept out of the `wired` grouping, each for a recorded reason). Adds a
coverage test in `tests/marker-helpers-facade.test.mts` that fails
(not skips) whenever a marker family has no classification, guarding
against the exact drift issue #1705 hit (`advisory-reroll:` shipped
with zero hide-at-post-time wiring and zero record of the gap).

Also fixes `docs/idd-comment-minimization.md`'s "## Timing" section
(and its `idd-template/` canonical source), which claimed
minimization only ever runs post-merge -- already contradicted by the
three `wired` families' shipped pre-merge behavior -- and, per an
independent C1 critique pass on this branch, two accuracy issues the
new prose surfaced:

- The `excluded` policy kind's doc comment overclaimed "deliberately
  never minimized" for all five excluded families, but
  `audit-pr-cleanup.mts`'s `evaluateOperationalComment()` only
  hardcodes an F4 exemption for `<!-- forced-handoff:`. The other
  four excluded prefixes have no matching exemption and are swept by
  F4's generic stale-marker rule today. Corrected the doc comment and
  the `forced-handoff` entry's own reason to say what's actually true
  now.
- The new Timing prose listed the wired advisory-wait family as four
  forms (including the `<!-- advisory-wait:` HTML-comment variant),
  but `idd-advisory-wait.instructions.md`'s own AW3-H paragraph named
  only three. Aligned AW3-H's paragraph to the four-form grouping
  already used by the existing F4 candidate-prefix lists
  (`idd-comment-minimization.md`, `idd-merge.instructions.md`) and the
  `advisoryWaitMarkerMatchesHead()` head-matching logic, rather than
  narrowing the new prose to disagree with those. Widening AW3-H's own
  paragraph then surfaced two more pages that cite AW3-H by name with
  the stale three-form list -- `idd-autonomy-contract.md`'s mutation
  table and `idd-concept-ownership.md`'s ownership-transition table --
  updated in a follow-up commit so every page describing AW3-H's scope
  agrees.

Track 2 (#2754) and Track 3 (#2755) wire the three `f4-only` families
to `wired` next; both are currently blocked on this PR merging.

## Linked issue

Closes #2752

## Follow-up issues (if any)

- [ ] `audit-pr-cleanup.mts`'s F4 candidate detection has no exemption
      for `<!-- idd-external-check-waiver:`,
      `<!-- idd-provider-outage-declaration:`,
      `<!-- idd-provider-outage-advanced:`, or
      `<!-- idd-provider-outage-park:` -- unlike `forced-handoff:`,
      these four are swept as ordinary stale markers on a merged PR
      today, which undercuts the safety rationale recorded for
      excluding `idd-external-check-waiver:` from `wired` grouping in
      the first place. Flagged here rather than fixed in this PR to
      keep Track 1 scoped to classification + docs only; recommend a
      follow-up issue to add the matching F4 exemptions.

## Background / rationale (if material)

`src/scripts/marker-helpers.mts` defines 17 `OPERATIONAL_MARKERS`
entries; only three families (claim chain, review-watermark/baseline,
advisory-wait) had hide-at-post-time wiring before this roadmap, added
by issue #731/issue #733 (PR #735). All "what counts as superseded"
logic lived in prose split across separate instruction files, invoked
as a documented follow-up step after `post-idd-marker --apply` rather
than tracked anywhere machine-checkable -- this PR adds that tracking
without changing any shipped hide-at-post-time behavior.

Two independent `Agent(subagent_type="general-purpose")` critique
rounds (IDD C1) reviewed this branch. Round 1 found the two Medium
accuracy issues described above plus two Low test nits (a tautological
duplicate-label assertion that could never fail, and a redundant
import) -- all four fixed in a follow-up commit, which itself surfaced
the AW3-H family-list drift in two more pages, fixed in a further
commit. Round 2 independently re-verified all four round-1 findings
resolved against the fix commits, re-ran the full validation chain
(5438/5438 tests, `build:check`, `audit-docs.mjs --check`,
`lint:minimum`), and repo-grepped for any other stale 3-form
advisory-wait enumeration. It found two more Low findings, both
rejected (Accept count 0, C1 floor passed): an unrelated, pre-existing
abbreviated marker list in `docs/idd-helper-scripts.md` that predates
this branch and has no behavioral bearing (`minimize-superseded-markers.mts`
is generic and hardcodes no prefixes), and a minor wording-precision
nit in this PR's own test comment.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (passing: biome, dprint, markdownlint, typecheck,
      build:check, docs audit, workshop integrity, cspell)
- [x] `pnpm test` (5438/5438 passing)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passed, 3 pre-existing warnings
      unrelated to this change)
- [x] `pnpm run build:check`
- [x] `node scripts/audit-code-span-wrap.mjs`
- [x] `npx cspell lint "**" --no-progress`

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdQ5SPdFLaDGus5PNdBUhw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent classification for operational markers, including those eligible for pre-merge cleanup and those requiring merge-gated cleanup.
  * Stale advisory-reroll markers are now hidden when they reference an outdated pull request revision.

* **Documentation**
  * Updated cleanup policies and terminal-state guidance to cover advisory-reroll markers and HTML-comment advisory-wait markers.
  * Clarified exceptions, timing rules, and protected workflow comments.

* **Tests**
  * Added coverage for policy completeness, duplicate detection, immutability, and safe read-only behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->