### PR TITLE
fix(discover-orphan-filter): exclude a long attributed quote

### DIFF
--- a/scripts/discover-orphan-filter.mjs
+++ b/scripts/discover-orphan-filter.mjs
@@ -103,21 +103,43 @@ const ISSUE_NUMBER_REFERENCE_PATTERN = /#\d+/g;
 const CITED_ISSUE_ATTRIBUTION_COLON_PATTERN = /:\s*$/;
 // Every standard English sentence terminator, not just period/semicolon
 // -- a question or exclamation mark ending an unrelated sentence must
-// also stop an earlier reference from attributing a later quote
-// (Codex review round 3, PR #2760).
-const CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN = /[.;?!\n]|--|—/;
-// No cap: this exclusion exists specifically for quotes that copy a
-// "much longer" excerpt verbatim, so an artificial bound left a real
-// closer -- and any re-adoption cue past it -- unreached (Codex review
-// round 4, PR #2760). The scan is still bounded by the corpus length.
+// also stop an earlier reference from attributing a later quote (Codex
+// review round 3, PR #2760). A bare newline is a Markdown SOFT wrap, not
+// a clause break -- only a blank line (a real paragraph/list boundary)
+// counts, matching `discover-viability-gate.mts`'s own soft-wrap-vs-
+// hard-break distinction; a genuine attribution can wrap between the
+// reference and its colon just as easily as between the colon and the
+// quote (Codex review round 5, PR #2760).
+const CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN = /[.;?!]|--|—|\n[ \t]*\n/;
+// The requirement-assertion lookahead/lookbehind windows stay bounded
+// (40 chars); only the CLOSE-QUOTE search itself is unbounded, since
+// this exclusion exists specifically for quotes that copy a "much
+// longer" excerpt verbatim -- an artificial bound there left a real
+// closer, and any re-adoption cue past it, unreached (Codex review
+// round 4, PR #2760; comment corrected per Copilot review round 5).
 const ATTRIBUTION_REQUIREMENT_LOOKAHEAD_WINDOW = 40;
-// `blocked`/`blocking`/`pending`/`waiting` join the same vocabulary
-// `discover-viability-gate.mts`'s own requirement-assertion pattern
-// already uses, so a re-adopted prerequisite phrased as "remains
-// blocked" is recognized too, not only "remains required" (Codex review
-// round 3, PR #2760).
+// `blocked`/`blocking`/`pending`/`waiting`/`shall`/`essential` join the
+// same vocabulary `discover-viability-gate.mts`'s own requirement-
+// assertion pattern already uses, so a re-adopted prerequisite phrased
+// as "remains blocked" or "shall remain the acceptance gate" is
+// recognized too, not only "remains required" (Codex review rounds 3
+// and 5, PR #2760).
 const ATTRIBUTION_REQUIREMENT_ASSERTION_PATTERN =
-  /\b(required|require[sd]?|requiring|must|needed|needs?|mandatory|necessary|blocked|blocking|pending|waiting)\b/i;
+  /\b(required|require[sd]?|requiring|must|needed|needs?|mandatory|necessary|blocked|blocking|pending|waiting|shall|essential)\b/i;
+// A quoted excerpt's closer must PAIR with its actual opener, not match
+// any member of the flat CLOSE_QUOTE_CHARS set -- otherwise an unrelated
+// apostrophe of a DIFFERENT quote family inside the excerpt (a plural
+// possessive like "operators'", not merely a contraction already
+// guarded above) can still be mistaken for the closer, making the real
+// closer and any re-adoption cue past it unreachable (Codex review
+// round 5, PR #2760). Mirrors `discover-viability-gate.mts`'s own
+// `QUOTE_CHAR_PAIRS`.
+const QUOTE_CHAR_PAIRS = {
+  '"': '"',
+  "'": "'",
+  '‘': '’',
+  '“': '”',
+};
 // A straight/curly apostrophe inside the quoted excerpt itself (a
 // contraction or possessive, e.g. "it's") must not be mistaken for the
 // closing quote -- only a candidate NOT immediately followed by a
@@ -189,17 +211,22 @@ function isQuotedMatch(text, start, end) {
 // hard break in between, means the citing issue RE-ADOPTS the quoted
 // prerequisite as its own live requirement rather than merely reporting
 // inert history (Codex review, PR #2760). The close side searches the
-// rest of the corpus for the first close-quote character -- this
-// exclusion exists precisely for "much longer" quotes, so the closer can
-// be arbitrarily far from the match (Codex review round 4, PR #2760) --
-// without requiring it to pair with any specific open-quote character
-// (mirrors this file's existing loose open/close-quote membership
-// checks elsewhere).
-function isFollowedByRequirementAssertion(text, quotedContentStart) {
+// rest of the corpus for the first character that PAIRS with `opener`
+// -- this exclusion exists precisely for "much longer" quotes, so the
+// closer can be arbitrarily far from the match (Codex review round 4,
+// PR #2760) -- rather than any member of CLOSE_QUOTE_CHARS, so an
+// apostrophe of a different quote family inside the excerpt (a plural
+// possessive like "operators'") is never mistaken for the real closer
+// (Codex review round 5, PR #2760).
+function isFollowedByRequirementAssertion(text, quotedContentStart, opener) {
+  const closer = QUOTE_CHAR_PAIRS[opener];
+  if (closer === undefined) {
+    return false;
+  }
   const region = text.slice(quotedContentStart);
   let closeOffset = -1;
   for (let i = 0; i < region.length; i++) {
-    if (!CLOSE_QUOTE_CHARS.has(region[i])) {
+    if (region[i] !== closer) {
       continue;
     }
     if (WORD_CHAR_PATTERN.test(region[i + 1] ?? '')) {
@@ -250,7 +277,11 @@ function isPrecededByRequirementAssertion(text, referenceStart) {
 // motivating shape. Only the open-quote adjacency is required on the
 // open side (unlike `isQuotedMatch`: the whole point of this exclusion
 // is the shape where no nearby closing quote follows the match itself).
-function isAttributedLongQuote(text, start) {
+// `selfIssueNumber`, when given, prevents an issue from attributing a
+// quote to ITSELF: "Issue #122 acceptance criterion: 'X'" inside issue
+// #122's own body is not an external citation, so the cited number must
+// differ from the candidate's own (Codex review round 5, PR #2760).
+function isAttributedLongQuote(text, start, selfIssueNumber) {
   const before = text[start - 1];
   if (before === undefined || !OPEN_QUOTE_CHARS.has(before)) {
     return false;
@@ -266,6 +297,12 @@ function isAttributedLongQuote(text, start) {
   if (!referenceMatch || referenceMatch.index === undefined) {
     return false;
   }
+  if (
+    selfIssueNumber !== undefined &&
+    Number(referenceMatch[0].slice(1)) === selfIssueNumber
+  ) {
+    return false;
+  }
   // Stop at the introducing colon itself -- the whitespace AFTER it
   // (which can include a Markdown soft-wrap newline before the quote,
   // e.g. "Background:\n\"X\"") is not part of the reference-to-colon
@@ -279,7 +316,7 @@ function isAttributedLongQuote(text, start) {
     !CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN.test(
       betweenReferenceAndColon,
     ) &&
-    !isFollowedByRequirementAssertion(text, start) &&
+    !isFollowedByRequirementAssertion(text, start, before) &&
     !isPrecededByRequirementAssertion(text, windowStart + referenceMatch.index)
   );
 }
@@ -287,9 +324,12 @@ function isAttributedLongQuote(text, start) {
  * Detect prose naming a runtime/production-observation precondition
  * (#2467) anywhere in `body`, outside of code regions. Returns `true` on
  * the first match that is neither quoted nor negated -- callers only need a
- * boolean gate, not the matched span.
+ * boolean gate, not the matched span. `selfIssueNumber`, when given, stops
+ * the candidate's own issue number from being treated as an external
+ * citation by {@link isAttributedLongQuote} (Codex review round 5, PR
+ * #2760).
  */
-export function detectRuntimeObservationPrecondition(body) {
+export function detectRuntimeObservationPrecondition(body, selfIssueNumber) {
   const stripped = stripMarkdownCodeRegions(String(body ?? ''));
   for (const pattern of RUNTIME_OBSERVATION_PATTERNS) {
     pattern.lastIndex = 0;
@@ -298,7 +338,7 @@ export function detectRuntimeObservationPrecondition(body) {
       const end = match.index + match[0].length;
       if (
         !isQuotedMatch(stripped, match.index, end) &&
-        !isAttributedLongQuote(stripped, match.index) &&
+        !isAttributedLongQuote(stripped, match.index, selfIssueNumber) &&
         !hasNegationCueBefore(stripped, match.index) &&
         !hasNegationCueAfter(stripped, end)
       ) {
@@ -367,7 +407,7 @@ export function classifyIssue(issue, options) {
   // production-observation precondition has no issue-number reference to
   // resolve, so it must still hold even when every numbered reference below
   // is absent or already closed.
-  if (detectRuntimeObservationPrecondition(body)) {
+  if (detectRuntimeObservationPrecondition(body, Number(issue.number))) {
     return { orphan: false, reason: 'runtime_observation_precondition' };
   }
   // Two independent reference families, matching A3's own dependency check

--- a/scripts/discover-orphan-filter.mjs
+++ b/scripts/discover-orphan-filter.mjs
@@ -83,11 +83,27 @@ const TRAILING_QUOTE_PUNCTUATION_PATTERN = /^[.,!?;:]*/;
 // reference from that colon -- "See #42 for rollout details. Acceptance
 // gate: 'X'" has an unrelated label's colon after a sentence break and
 // must NOT match either, even though a colon does directly precede the
-// quote.
+// quote. When more than one issue reference sits in the window ("See #1.
+// Issue #2 asserted: 'X'"), bind to the LAST one, not the first -- an
+// earlier, unrelated reference must not make a genuine attribution look
+// hard-broken (round-2 Copilot/Codex review, PR #2760).
+//
+// Attribution alone does not prove the quoted text is inert history: an
+// issue can cite another issue's prerequisite and explicitly RE-ADOPT it
+// ("Per issue #42: 'confirmed in production before shipping' remains
+// required" -- Codex review, PR #2760). A requirement-assertion word
+// shortly after the quote closes, with no hard break in between, cancels
+// this exclusion the same way `discover-viability-gate.mts`'s
+// requirement-assertion cancellation already does for its own quote
+// exclusion.
 const CITED_ISSUE_ATTRIBUTION_WINDOW = 80;
-const ISSUE_NUMBER_REFERENCE_PATTERN = /#\d+/;
+const ISSUE_NUMBER_REFERENCE_PATTERN = /#\d+/g;
 const CITED_ISSUE_ATTRIBUTION_COLON_PATTERN = /:\s*$/;
 const CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN = /[.;\n]|--|—/;
+const CLOSE_QUOTE_SEARCH_WINDOW = 300;
+const ATTRIBUTION_REQUIREMENT_LOOKAHEAD_WINDOW = 40;
+const ATTRIBUTION_REQUIREMENT_ASSERTION_PATTERN =
+  /\b(required|require[sd]?|requiring|must|needed|needs?|mandatory|necessary)\b/i;
 if (import.meta.main) {
   await runCli();
 }
@@ -148,12 +164,48 @@ function isQuotedMatch(text, start, end) {
     CLOSE_QUOTE_CHARS.has(after)
   );
 }
+// A requirement-assertion word shortly after the quote closes, with no
+// hard break in between, means the citing issue RE-ADOPTS the quoted
+// prerequisite as its own live requirement rather than merely reporting
+// inert history (Codex review, PR #2760). The close side searches a
+// generous bounded window for the first close-quote character -- this
+// exclusion exists precisely for "much longer" quotes, so the closer can
+// be far from the match -- without requiring it to pair with any
+// specific open-quote character (mirrors this file's existing loose
+// open/close-quote membership checks elsewhere).
+function isFollowedByRequirementAssertion(text, quotedContentStart) {
+  const searchEnd = Math.min(
+    text.length,
+    quotedContentStart + CLOSE_QUOTE_SEARCH_WINDOW,
+  );
+  const region = text.slice(quotedContentStart, searchEnd);
+  let closeOffset = -1;
+  for (let i = 0; i < region.length; i++) {
+    if (CLOSE_QUOTE_CHARS.has(region[i])) {
+      closeOffset = i;
+      break;
+    }
+  }
+  if (closeOffset === -1) {
+    return false;
+  }
+  const afterClose = quotedContentStart + closeOffset + 1;
+  const lookahead = text.slice(
+    afterClose,
+    Math.min(
+      text.length,
+      afterClose + ATTRIBUTION_REQUIREMENT_LOOKAHEAD_WINDOW,
+    ),
+  );
+  const hardBreak = CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN.exec(lookahead);
+  const scoped = hardBreak ? lookahead.slice(0, hardBreak.index) : lookahead;
+  return ATTRIBUTION_REQUIREMENT_ASSERTION_PATTERN.test(scoped);
+}
 // A match that opens a longer quoted excerpt attributed to a different,
 // cited issue by number (#2746) -- see the constants above for the
-// motivating shape. Only the open-quote adjacency is required (the close
-// side is deliberately NOT checked here, unlike `isQuotedMatch`: the
-// whole point of this exclusion is the shape where no nearby closing
-// quote follows).
+// motivating shape. Only the open-quote adjacency is required on the
+// open side (unlike `isQuotedMatch`: the whole point of this exclusion
+// is the shape where no nearby closing quote follows the match itself).
 function isAttributedLongQuote(text, start) {
   const before = text[start - 1];
   if (before === undefined || !OPEN_QUOTE_CHARS.has(before)) {
@@ -164,15 +216,18 @@ function isAttributedLongQuote(text, start) {
   if (!CITED_ISSUE_ATTRIBUTION_COLON_PATTERN.test(window)) {
     return false;
   }
-  const referenceMatch = ISSUE_NUMBER_REFERENCE_PATTERN.exec(window);
-  if (!referenceMatch) {
+  const referenceMatches = [...window.matchAll(ISSUE_NUMBER_REFERENCE_PATTERN)];
+  const referenceMatch = referenceMatches.at(-1);
+  if (!referenceMatch || referenceMatch.index === undefined) {
     return false;
   }
   const betweenReferenceAndColon = window.slice(
     referenceMatch.index + referenceMatch[0].length,
   );
-  return !CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN.test(
-    betweenReferenceAndColon,
+  return (
+    !CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN.test(
+      betweenReferenceAndColon,
+    ) && !isFollowedByRequirementAssertion(text, start)
   );
 }
 /**

--- a/scripts/discover-orphan-filter.mjs
+++ b/scripts/discover-orphan-filter.mjs
@@ -99,11 +99,27 @@ const TRAILING_QUOTE_PUNCTUATION_PATTERN = /^[.,!?;:]*/;
 const CITED_ISSUE_ATTRIBUTION_WINDOW = 80;
 const ISSUE_NUMBER_REFERENCE_PATTERN = /#\d+/g;
 const CITED_ISSUE_ATTRIBUTION_COLON_PATTERN = /:\s*$/;
-const CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN = /[.;\n]|--|—/;
+// Every standard English sentence terminator, not just period/semicolon
+// -- a question or exclamation mark ending an unrelated sentence must
+// also stop an earlier reference from attributing a later quote
+// (Codex review round 3, PR #2760).
+const CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN = /[.;?!\n]|--|—/;
 const CLOSE_QUOTE_SEARCH_WINDOW = 300;
 const ATTRIBUTION_REQUIREMENT_LOOKAHEAD_WINDOW = 40;
+// `blocked`/`blocking`/`pending`/`waiting` join the same vocabulary
+// `discover-viability-gate.mts`'s own requirement-assertion pattern
+// already uses, so a re-adopted prerequisite phrased as "remains
+// blocked" is recognized too, not only "remains required" (Codex review
+// round 3, PR #2760).
 const ATTRIBUTION_REQUIREMENT_ASSERTION_PATTERN =
-  /\b(required|require[sd]?|requiring|must|needed|needs?|mandatory|necessary)\b/i;
+  /\b(required|require[sd]?|requiring|must|needed|needs?|mandatory|necessary|blocked|blocking|pending|waiting)\b/i;
+// A straight/curly apostrophe inside the quoted excerpt itself (a
+// contraction or possessive, e.g. "it's") must not be mistaken for the
+// closing quote -- only a candidate NOT immediately followed by a
+// letter or digit is a plausible closer (Copilot review round 3, PR
+// #2760), mirroring `discover-viability-gate.mts`'s own
+// quote-vs-apostrophe adjacency check.
+const WORD_CHAR_PATTERN = /[A-Za-z0-9]/;
 if (import.meta.main) {
   await runCli();
 }
@@ -181,10 +197,14 @@ function isFollowedByRequirementAssertion(text, quotedContentStart) {
   const region = text.slice(quotedContentStart, searchEnd);
   let closeOffset = -1;
   for (let i = 0; i < region.length; i++) {
-    if (CLOSE_QUOTE_CHARS.has(region[i])) {
-      closeOffset = i;
-      break;
+    if (!CLOSE_QUOTE_CHARS.has(region[i])) {
+      continue;
     }
+    if (WORD_CHAR_PATTERN.test(region[i + 1] ?? '')) {
+      continue;
+    }
+    closeOffset = i;
+    break;
   }
   if (closeOffset === -1) {
     return false;
@@ -213,7 +233,8 @@ function isAttributedLongQuote(text, start) {
   }
   const windowStart = Math.max(0, start - 1 - CITED_ISSUE_ATTRIBUTION_WINDOW);
   const window = text.slice(windowStart, start - 1);
-  if (!CITED_ISSUE_ATTRIBUTION_COLON_PATTERN.test(window)) {
+  const colonMatch = CITED_ISSUE_ATTRIBUTION_COLON_PATTERN.exec(window);
+  if (!colonMatch) {
     return false;
   }
   const referenceMatches = [...window.matchAll(ISSUE_NUMBER_REFERENCE_PATTERN)];
@@ -221,8 +242,14 @@ function isAttributedLongQuote(text, start) {
   if (!referenceMatch || referenceMatch.index === undefined) {
     return false;
   }
+  // Stop at the introducing colon itself -- the whitespace AFTER it
+  // (which can include a Markdown soft-wrap newline before the quote,
+  // e.g. "Background:\n\"X\"") is not part of the reference-to-colon
+  // relationship this hard-break scan is meant to police (Codex review
+  // round 3, PR #2760).
   const betweenReferenceAndColon = window.slice(
     referenceMatch.index + referenceMatch[0].length,
+    colonMatch.index,
   );
   return (
     !CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN.test(

--- a/scripts/discover-orphan-filter.mjs
+++ b/scripts/discover-orphan-filter.mjs
@@ -105,12 +105,16 @@ const CITED_ISSUE_ATTRIBUTION_COLON_PATTERN = /:\s*$/;
 // -- a question or exclamation mark ending an unrelated sentence must
 // also stop an earlier reference from attributing a later quote (Codex
 // review round 3, PR #2760). A bare newline is a Markdown SOFT wrap, not
-// a clause break -- only a blank line (a real paragraph/list boundary)
-// counts, matching `discover-viability-gate.mts`'s own soft-wrap-vs-
-// hard-break distinction; a genuine attribution can wrap between the
-// reference and its colon just as easily as between the colon and the
-// quote (Codex review round 5, PR #2760).
-const CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN = /[.;?!]|--|—|\n[ \t]*\n/;
+// a clause break -- only a blank line OR a following list-item marker
+// (a real paragraph/list boundary) counts, matching
+// `discover-viability-gate.mts`'s own CUE_HARD_BREAK_PATTERN exactly: a
+// genuine attribution can wrap between the reference and its colon just
+// as easily as between the colon and the quote (Codex review round 5,
+// PR #2760), but separate bullets written without a blank line ("-
+// Related issue #42\n- Acceptance gate: 'X'") must not connect through
+// each other either (Codex review round 6, PR #2760).
+const CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN =
+  /[.;?!]|--|—|\n[ \t]*(?:[-*]\s|\d+[.)]\s)|\n[ \t]*\n/;
 // The requirement-assertion lookahead/lookbehind windows stay bounded
 // (40 chars); only the CLOSE-QUOTE search itself is unbounded, since
 // this exclusion exists specifically for quotes that copy a "much
@@ -211,44 +215,57 @@ function isQuotedMatch(text, start, end) {
 // hard break in between, means the citing issue RE-ADOPTS the quoted
 // prerequisite as its own live requirement rather than merely reporting
 // inert history (Codex review, PR #2760). The close side searches the
-// rest of the corpus for the first character that PAIRS with `opener`
-// -- this exclusion exists precisely for "much longer" quotes, so the
-// closer can be arbitrarily far from the match (Codex review round 4,
-// PR #2760) -- rather than any member of CLOSE_QUOTE_CHARS, so an
-// apostrophe of a different quote family inside the excerpt (a plural
-// possessive like "operators'") is never mistaken for the real closer
-// (Codex review round 5, PR #2760).
+// rest of the corpus for a character that PAIRS with `opener` -- this
+// exclusion exists precisely for "much longer" quotes, so the closer can
+// be arbitrarily far from the match (Codex review round 4, PR #2760) --
+// rather than any member of CLOSE_QUOTE_CHARS, so an apostrophe of a
+// DIFFERENT quote family inside the excerpt (a plural possessive like
+// "operators'" inside a double-quoted excerpt) is never mistaken for
+// the real closer (Codex review round 5, PR #2760). Pairing alone still
+// isn't enough for a SINGLE-quoted excerpt: an internal plural
+// possessive apostrophe is the SAME family as the real closer, so every
+// plausible candidate is tried in order (not just the first) until one
+// is followed by a requirement assertion, or none are left (Copilot/
+// Codex review round 6, PR #2760).
 function isFollowedByRequirementAssertion(text, quotedContentStart, opener) {
   const closer = QUOTE_CHAR_PAIRS[opener];
   if (closer === undefined) {
     return false;
   }
   const region = text.slice(quotedContentStart);
-  let closeOffset = -1;
-  for (let i = 0; i < region.length; i++) {
-    if (region[i] !== closer) {
-      continue;
+  let searchFrom = 0;
+  while (searchFrom < region.length) {
+    let closeOffset = -1;
+    for (let i = searchFrom; i < region.length; i++) {
+      if (region[i] !== closer) {
+        continue;
+      }
+      if (WORD_CHAR_PATTERN.test(region[i + 1] ?? '')) {
+        continue;
+      }
+      closeOffset = i;
+      break;
     }
-    if (WORD_CHAR_PATTERN.test(region[i + 1] ?? '')) {
-      continue;
+    if (closeOffset === -1) {
+      return false;
     }
-    closeOffset = i;
-    break;
+    const afterClose = quotedContentStart + closeOffset + 1;
+    const lookahead = text.slice(
+      afterClose,
+      Math.min(
+        text.length,
+        afterClose + ATTRIBUTION_REQUIREMENT_LOOKAHEAD_WINDOW,
+      ),
+    );
+    const hardBreak =
+      CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN.exec(lookahead);
+    const scoped = hardBreak ? lookahead.slice(0, hardBreak.index) : lookahead;
+    if (ATTRIBUTION_REQUIREMENT_ASSERTION_PATTERN.test(scoped)) {
+      return true;
+    }
+    searchFrom = closeOffset + 1;
   }
-  if (closeOffset === -1) {
-    return false;
-  }
-  const afterClose = quotedContentStart + closeOffset + 1;
-  const lookahead = text.slice(
-    afterClose,
-    Math.min(
-      text.length,
-      afterClose + ATTRIBUTION_REQUIREMENT_LOOKAHEAD_WINDOW,
-    ),
-  );
-  const hardBreak = CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN.exec(lookahead);
-  const scoped = hardBreak ? lookahead.slice(0, hardBreak.index) : lookahead;
-  return ATTRIBUTION_REQUIREMENT_ASSERTION_PATTERN.test(scoped);
+  return false;
 }
 // The mirror image of {@link isFollowedByRequirementAssertion}: a
 // requirement-assertion word shortly BEFORE the cited reference, with no

--- a/scripts/discover-orphan-filter.mjs
+++ b/scripts/discover-orphan-filter.mjs
@@ -73,8 +73,21 @@ const TRAILING_QUOTE_PUNCTUATION_PATTERN = /^[.,!?;:]*/;
 // open-quote character immediately before the match (the same adjacency
 // `isQuotedMatch` requires), preceded within a bounded window by an
 // issue-number reference and then a colon introducing the quotation.
+//
+// Two conditions bound the colon to that same attribution, not just any
+// nearby colon (Copilot/Codex/CodeRabbit review, PR #2760): the colon
+// must directly introduce the quote (only whitespace between the colon
+// and the opening quote character -- "Issue #42: prior history. The
+// requirement is 'X'" has no such colon and must NOT match), and no hard
+// clause break (period/semicolon/em-dash) may separate the issue-number
+// reference from that colon -- "See #42 for rollout details. Acceptance
+// gate: 'X'" has an unrelated label's colon after a sentence break and
+// must NOT match either, even though a colon does directly precede the
+// quote.
 const CITED_ISSUE_ATTRIBUTION_WINDOW = 80;
 const ISSUE_NUMBER_REFERENCE_PATTERN = /#\d+/;
+const CITED_ISSUE_ATTRIBUTION_COLON_PATTERN = /:\s*$/;
+const CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN = /[.;\n]|--|—/;
 if (import.meta.main) {
   await runCli();
 }
@@ -148,14 +161,19 @@ function isAttributedLongQuote(text, start) {
   }
   const windowStart = Math.max(0, start - 1 - CITED_ISSUE_ATTRIBUTION_WINDOW);
   const window = text.slice(windowStart, start - 1);
+  if (!CITED_ISSUE_ATTRIBUTION_COLON_PATTERN.test(window)) {
+    return false;
+  }
   const referenceMatch = ISSUE_NUMBER_REFERENCE_PATTERN.exec(window);
   if (!referenceMatch) {
     return false;
   }
-  const afterReference = window.slice(
+  const betweenReferenceAndColon = window.slice(
     referenceMatch.index + referenceMatch[0].length,
   );
-  return afterReference.includes(':');
+  return !CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN.test(
+    betweenReferenceAndColon,
+  );
 }
 /**
  * Detect prose naming a runtime/production-observation precondition

--- a/scripts/discover-orphan-filter.mjs
+++ b/scripts/discover-orphan-filter.mjs
@@ -62,6 +62,19 @@ const NEGATION_HARD_BREAK_PATTERN = /[.;\n]|--|—/g;
 const OPEN_QUOTE_CHARS = new Set(['"', "'", '“', '‘']);
 const CLOSE_QUOTE_CHARS = new Set(['"', "'", '”', '’']);
 const TRAILING_QUOTE_PUNCTUATION_PATTERN = /^[.,!?;:]*/;
+// A match opening a much longer quoted excerpt attributed to a different,
+// cited issue by number ("Issue #2743 asserted in its Background:
+// '<trigger phrase>: ...much more quoted prose...' -- describing a
+// specific event.", #2746) is quoted historical context from another
+// issue, not a live precondition on THIS issue -- even though ordinary
+// sentence punctuation (a colon) continues the quotation right after the
+// match instead of a closing quote character, so `isQuotedMatch` below
+// never recognizes it. Scoped narrowly to the shape this issue found: an
+// open-quote character immediately before the match (the same adjacency
+// `isQuotedMatch` requires), preceded within a bounded window by an
+// issue-number reference and then a colon introducing the quotation.
+const CITED_ISSUE_ATTRIBUTION_WINDOW = 80;
+const ISSUE_NUMBER_REFERENCE_PATTERN = /#\d+/;
 if (import.meta.main) {
   await runCli();
 }
@@ -122,6 +135,28 @@ function isQuotedMatch(text, start, end) {
     CLOSE_QUOTE_CHARS.has(after)
   );
 }
+// A match that opens a longer quoted excerpt attributed to a different,
+// cited issue by number (#2746) -- see the constants above for the
+// motivating shape. Only the open-quote adjacency is required (the close
+// side is deliberately NOT checked here, unlike `isQuotedMatch`: the
+// whole point of this exclusion is the shape where no nearby closing
+// quote follows).
+function isAttributedLongQuote(text, start) {
+  const before = text[start - 1];
+  if (before === undefined || !OPEN_QUOTE_CHARS.has(before)) {
+    return false;
+  }
+  const windowStart = Math.max(0, start - 1 - CITED_ISSUE_ATTRIBUTION_WINDOW);
+  const window = text.slice(windowStart, start - 1);
+  const referenceMatch = ISSUE_NUMBER_REFERENCE_PATTERN.exec(window);
+  if (!referenceMatch) {
+    return false;
+  }
+  const afterReference = window.slice(
+    referenceMatch.index + referenceMatch[0].length,
+  );
+  return afterReference.includes(':');
+}
 /**
  * Detect prose naming a runtime/production-observation precondition
  * (#2467) anywhere in `body`, outside of code regions. Returns `true` on
@@ -137,6 +172,7 @@ export function detectRuntimeObservationPrecondition(body) {
       const end = match.index + match[0].length;
       if (
         !isQuotedMatch(stripped, match.index, end) &&
+        !isAttributedLongQuote(stripped, match.index) &&
         !hasNegationCueBefore(stripped, match.index) &&
         !hasNegationCueAfter(stripped, end)
       ) {

--- a/scripts/discover-orphan-filter.mjs
+++ b/scripts/discover-orphan-filter.mjs
@@ -89,13 +89,15 @@ const TRAILING_QUOTE_PUNCTUATION_PATTERN = /^[.,!?;:]*/;
 // hard-broken (round-2 Copilot/Codex review, PR #2760).
 //
 // Attribution alone does not prove the quoted text is inert history: an
-// issue can cite another issue's prerequisite and explicitly RE-ADOPT it
-// ("Per issue #42: 'confirmed in production before shipping' remains
-// required" -- Codex review, PR #2760). A requirement-assertion word
-// shortly after the quote closes, with no hard break in between, cancels
-// this exclusion the same way `discover-viability-gate.mts`'s
-// requirement-assertion cancellation already does for its own quote
-// exclusion.
+// issue can cite another issue's prerequisite and explicitly RE-ADOPT it,
+// either right after the quote closes ("Per issue #42: 'confirmed in
+// production before shipping' remains required" -- Codex review, PR
+// #2760) or right before the citation opens ("This change still
+// requires issue #42's gate: 'confirmed in production before shipping'"
+// -- Codex review round 4, PR #2760). A requirement-assertion word on
+// EITHER side, with no hard break in between, cancels this exclusion --
+// the same bidirectional shape `discover-viability-gate.mts`'s own
+// requirement-assertion cancellation already uses.
 const CITED_ISSUE_ATTRIBUTION_WINDOW = 80;
 const ISSUE_NUMBER_REFERENCE_PATTERN = /#\d+/g;
 const CITED_ISSUE_ATTRIBUTION_COLON_PATTERN = /:\s*$/;
@@ -104,7 +106,10 @@ const CITED_ISSUE_ATTRIBUTION_COLON_PATTERN = /:\s*$/;
 // also stop an earlier reference from attributing a later quote
 // (Codex review round 3, PR #2760).
 const CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN = /[.;?!\n]|--|—/;
-const CLOSE_QUOTE_SEARCH_WINDOW = 300;
+// No cap: this exclusion exists specifically for quotes that copy a
+// "much longer" excerpt verbatim, so an artificial bound left a real
+// closer -- and any re-adoption cue past it -- unreached (Codex review
+// round 4, PR #2760). The scan is still bounded by the corpus length.
 const ATTRIBUTION_REQUIREMENT_LOOKAHEAD_WINDOW = 40;
 // `blocked`/`blocking`/`pending`/`waiting` join the same vocabulary
 // `discover-viability-gate.mts`'s own requirement-assertion pattern
@@ -183,18 +188,15 @@ function isQuotedMatch(text, start, end) {
 // A requirement-assertion word shortly after the quote closes, with no
 // hard break in between, means the citing issue RE-ADOPTS the quoted
 // prerequisite as its own live requirement rather than merely reporting
-// inert history (Codex review, PR #2760). The close side searches a
-// generous bounded window for the first close-quote character -- this
+// inert history (Codex review, PR #2760). The close side searches the
+// rest of the corpus for the first close-quote character -- this
 // exclusion exists precisely for "much longer" quotes, so the closer can
-// be far from the match -- without requiring it to pair with any
-// specific open-quote character (mirrors this file's existing loose
-// open/close-quote membership checks elsewhere).
+// be arbitrarily far from the match (Codex review round 4, PR #2760) --
+// without requiring it to pair with any specific open-quote character
+// (mirrors this file's existing loose open/close-quote membership
+// checks elsewhere).
 function isFollowedByRequirementAssertion(text, quotedContentStart) {
-  const searchEnd = Math.min(
-    text.length,
-    quotedContentStart + CLOSE_QUOTE_SEARCH_WINDOW,
-  );
-  const region = text.slice(quotedContentStart, searchEnd);
+  const region = text.slice(quotedContentStart);
   let closeOffset = -1;
   for (let i = 0; i < region.length; i++) {
     if (!CLOSE_QUOTE_CHARS.has(region[i])) {
@@ -219,6 +221,28 @@ function isFollowedByRequirementAssertion(text, quotedContentStart) {
   );
   const hardBreak = CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN.exec(lookahead);
   const scoped = hardBreak ? lookahead.slice(0, hardBreak.index) : lookahead;
+  return ATTRIBUTION_REQUIREMENT_ASSERTION_PATTERN.test(scoped);
+}
+// The mirror image of {@link isFollowedByRequirementAssertion}: a
+// requirement-assertion word shortly BEFORE the cited reference, with no
+// hard break in between, means the citing issue already re-adopted the
+// prerequisite before ever citing it ("This change still requires issue
+// #42's gate: 'X'" -- Codex review round 4, PR #2760).
+function isPrecededByRequirementAssertion(text, referenceStart) {
+  const windowStart = Math.max(
+    0,
+    referenceStart - ATTRIBUTION_REQUIREMENT_LOOKAHEAD_WINDOW,
+  );
+  const lookbehind = text.slice(windowStart, referenceStart);
+  const breaks = [
+    ...lookbehind.matchAll(
+      new RegExp(CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN, 'g'),
+    ),
+  ];
+  const lastBreak = breaks.at(-1);
+  const scoped = lastBreak
+    ? lookbehind.slice(lastBreak.index + lastBreak[0].length)
+    : lookbehind;
   return ATTRIBUTION_REQUIREMENT_ASSERTION_PATTERN.test(scoped);
 }
 // A match that opens a longer quoted excerpt attributed to a different,
@@ -254,7 +278,9 @@ function isAttributedLongQuote(text, start) {
   return (
     !CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN.test(
       betweenReferenceAndColon,
-    ) && !isFollowedByRequirementAssertion(text, start)
+    ) &&
+    !isFollowedByRequirementAssertion(text, start) &&
+    !isPrecededByRequirementAssertion(text, windowStart + referenceMatch.index)
   );
 }
 /**

--- a/src/scripts/discover-orphan-filter.mts
+++ b/src/scripts/discover-orphan-filter.mts
@@ -105,11 +105,27 @@ const TRAILING_QUOTE_PUNCTUATION_PATTERN = /^[.,!?;:]*/;
 const CITED_ISSUE_ATTRIBUTION_WINDOW = 80;
 const ISSUE_NUMBER_REFERENCE_PATTERN = /#\d+/g;
 const CITED_ISSUE_ATTRIBUTION_COLON_PATTERN = /:\s*$/;
-const CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN = /[.;\n]|--|—/;
+// Every standard English sentence terminator, not just period/semicolon
+// -- a question or exclamation mark ending an unrelated sentence must
+// also stop an earlier reference from attributing a later quote
+// (Codex review round 3, PR #2760).
+const CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN = /[.;?!\n]|--|—/;
 const CLOSE_QUOTE_SEARCH_WINDOW = 300;
 const ATTRIBUTION_REQUIREMENT_LOOKAHEAD_WINDOW = 40;
+// `blocked`/`blocking`/`pending`/`waiting` join the same vocabulary
+// `discover-viability-gate.mts`'s own requirement-assertion pattern
+// already uses, so a re-adopted prerequisite phrased as "remains
+// blocked" is recognized too, not only "remains required" (Codex review
+// round 3, PR #2760).
 const ATTRIBUTION_REQUIREMENT_ASSERTION_PATTERN =
-  /\b(required|require[sd]?|requiring|must|needed|needs?|mandatory|necessary)\b/i;
+  /\b(required|require[sd]?|requiring|must|needed|needs?|mandatory|necessary|blocked|blocking|pending|waiting)\b/i;
+// A straight/curly apostrophe inside the quoted excerpt itself (a
+// contraction or possessive, e.g. "it's") must not be mistaken for the
+// closing quote -- only a candidate NOT immediately followed by a
+// letter or digit is a plausible closer (Copilot review round 3, PR
+// #2760), mirroring `discover-viability-gate.mts`'s own
+// quote-vs-apostrophe adjacency check.
+const WORD_CHAR_PATTERN = /[A-Za-z0-9]/;
 
 /** Reasons that keep an issue out of the orphan candidate list. */
 export type OrphanFilteredReason =
@@ -365,10 +381,14 @@ function isFollowedByRequirementAssertion(
   const region = text.slice(quotedContentStart, searchEnd);
   let closeOffset = -1;
   for (let i = 0; i < region.length; i++) {
-    if (CLOSE_QUOTE_CHARS.has(region[i])) {
-      closeOffset = i;
-      break;
+    if (!CLOSE_QUOTE_CHARS.has(region[i])) {
+      continue;
     }
+    if (WORD_CHAR_PATTERN.test(region[i + 1] ?? '')) {
+      continue;
+    }
+    closeOffset = i;
+    break;
   }
   if (closeOffset === -1) {
     return false;
@@ -398,7 +418,8 @@ function isAttributedLongQuote(text: string, start: number): boolean {
   }
   const windowStart = Math.max(0, start - 1 - CITED_ISSUE_ATTRIBUTION_WINDOW);
   const window = text.slice(windowStart, start - 1);
-  if (!CITED_ISSUE_ATTRIBUTION_COLON_PATTERN.test(window)) {
+  const colonMatch = CITED_ISSUE_ATTRIBUTION_COLON_PATTERN.exec(window);
+  if (!colonMatch) {
     return false;
   }
   const referenceMatches = [...window.matchAll(ISSUE_NUMBER_REFERENCE_PATTERN)];
@@ -406,8 +427,14 @@ function isAttributedLongQuote(text: string, start: number): boolean {
   if (!referenceMatch || referenceMatch.index === undefined) {
     return false;
   }
+  // Stop at the introducing colon itself -- the whitespace AFTER it
+  // (which can include a Markdown soft-wrap newline before the quote,
+  // e.g. "Background:\n\"X\"") is not part of the reference-to-colon
+  // relationship this hard-break scan is meant to police (Codex review
+  // round 3, PR #2760).
   const betweenReferenceAndColon = window.slice(
     referenceMatch.index + referenceMatch[0].length,
+    colonMatch.index,
   );
   return (
     !CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN.test(

--- a/src/scripts/discover-orphan-filter.mts
+++ b/src/scripts/discover-orphan-filter.mts
@@ -111,12 +111,16 @@ const CITED_ISSUE_ATTRIBUTION_COLON_PATTERN = /:\s*$/;
 // -- a question or exclamation mark ending an unrelated sentence must
 // also stop an earlier reference from attributing a later quote (Codex
 // review round 3, PR #2760). A bare newline is a Markdown SOFT wrap, not
-// a clause break -- only a blank line (a real paragraph/list boundary)
-// counts, matching `discover-viability-gate.mts`'s own soft-wrap-vs-
-// hard-break distinction; a genuine attribution can wrap between the
-// reference and its colon just as easily as between the colon and the
-// quote (Codex review round 5, PR #2760).
-const CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN = /[.;?!]|--|—|\n[ \t]*\n/;
+// a clause break -- only a blank line OR a following list-item marker
+// (a real paragraph/list boundary) counts, matching
+// `discover-viability-gate.mts`'s own CUE_HARD_BREAK_PATTERN exactly: a
+// genuine attribution can wrap between the reference and its colon just
+// as easily as between the colon and the quote (Codex review round 5,
+// PR #2760), but separate bullets written without a blank line ("-
+// Related issue #42\n- Acceptance gate: 'X'") must not connect through
+// each other either (Codex review round 6, PR #2760).
+const CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN =
+  /[.;?!]|--|—|\n[ \t]*(?:[-*]\s|\d+[.)]\s)|\n[ \t]*\n/;
 // The requirement-assertion lookahead/lookbehind windows stay bounded
 // (40 chars); only the CLOSE-QUOTE search itself is unbounded, since
 // this exclusion exists specifically for quotes that copy a "much
@@ -392,13 +396,18 @@ function isQuotedMatch(text: string, start: number, end: number): boolean {
 // hard break in between, means the citing issue RE-ADOPTS the quoted
 // prerequisite as its own live requirement rather than merely reporting
 // inert history (Codex review, PR #2760). The close side searches the
-// rest of the corpus for the first character that PAIRS with `opener`
-// -- this exclusion exists precisely for "much longer" quotes, so the
-// closer can be arbitrarily far from the match (Codex review round 4,
-// PR #2760) -- rather than any member of CLOSE_QUOTE_CHARS, so an
-// apostrophe of a different quote family inside the excerpt (a plural
-// possessive like "operators'") is never mistaken for the real closer
-// (Codex review round 5, PR #2760).
+// rest of the corpus for a character that PAIRS with `opener` -- this
+// exclusion exists precisely for "much longer" quotes, so the closer can
+// be arbitrarily far from the match (Codex review round 4, PR #2760) --
+// rather than any member of CLOSE_QUOTE_CHARS, so an apostrophe of a
+// DIFFERENT quote family inside the excerpt (a plural possessive like
+// "operators'" inside a double-quoted excerpt) is never mistaken for
+// the real closer (Codex review round 5, PR #2760). Pairing alone still
+// isn't enough for a SINGLE-quoted excerpt: an internal plural
+// possessive apostrophe is the SAME family as the real closer, so every
+// plausible candidate is tried in order (not just the first) until one
+// is followed by a requirement assertion, or none are left (Copilot/
+// Codex review round 6, PR #2760).
 function isFollowedByRequirementAssertion(
   text: string,
   quotedContentStart: number,
@@ -409,31 +418,39 @@ function isFollowedByRequirementAssertion(
     return false;
   }
   const region = text.slice(quotedContentStart);
-  let closeOffset = -1;
-  for (let i = 0; i < region.length; i++) {
-    if (region[i] !== closer) {
-      continue;
+  let searchFrom = 0;
+  while (searchFrom < region.length) {
+    let closeOffset = -1;
+    for (let i = searchFrom; i < region.length; i++) {
+      if (region[i] !== closer) {
+        continue;
+      }
+      if (WORD_CHAR_PATTERN.test(region[i + 1] ?? '')) {
+        continue;
+      }
+      closeOffset = i;
+      break;
     }
-    if (WORD_CHAR_PATTERN.test(region[i + 1] ?? '')) {
-      continue;
+    if (closeOffset === -1) {
+      return false;
     }
-    closeOffset = i;
-    break;
+    const afterClose = quotedContentStart + closeOffset + 1;
+    const lookahead = text.slice(
+      afterClose,
+      Math.min(
+        text.length,
+        afterClose + ATTRIBUTION_REQUIREMENT_LOOKAHEAD_WINDOW,
+      ),
+    );
+    const hardBreak =
+      CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN.exec(lookahead);
+    const scoped = hardBreak ? lookahead.slice(0, hardBreak.index) : lookahead;
+    if (ATTRIBUTION_REQUIREMENT_ASSERTION_PATTERN.test(scoped)) {
+      return true;
+    }
+    searchFrom = closeOffset + 1;
   }
-  if (closeOffset === -1) {
-    return false;
-  }
-  const afterClose = quotedContentStart + closeOffset + 1;
-  const lookahead = text.slice(
-    afterClose,
-    Math.min(
-      text.length,
-      afterClose + ATTRIBUTION_REQUIREMENT_LOOKAHEAD_WINDOW,
-    ),
-  );
-  const hardBreak = CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN.exec(lookahead);
-  const scoped = hardBreak ? lookahead.slice(0, hardBreak.index) : lookahead;
-  return ATTRIBUTION_REQUIREMENT_ASSERTION_PATTERN.test(scoped);
+  return false;
 }
 
 // The mirror image of {@link isFollowedByRequirementAssertion}: a

--- a/src/scripts/discover-orphan-filter.mts
+++ b/src/scripts/discover-orphan-filter.mts
@@ -68,6 +68,19 @@ const NEGATION_HARD_BREAK_PATTERN = /[.;\n]|--|—/g;
 const OPEN_QUOTE_CHARS = new Set(['"', "'", '“', '‘']);
 const CLOSE_QUOTE_CHARS = new Set(['"', "'", '”', '’']);
 const TRAILING_QUOTE_PUNCTUATION_PATTERN = /^[.,!?;:]*/;
+// A match opening a much longer quoted excerpt attributed to a different,
+// cited issue by number ("Issue #2743 asserted in its Background:
+// '<trigger phrase>: ...much more quoted prose...' -- describing a
+// specific event.", #2746) is quoted historical context from another
+// issue, not a live precondition on THIS issue -- even though ordinary
+// sentence punctuation (a colon) continues the quotation right after the
+// match instead of a closing quote character, so `isQuotedMatch` below
+// never recognizes it. Scoped narrowly to the shape this issue found: an
+// open-quote character immediately before the match (the same adjacency
+// `isQuotedMatch` requires), preceded within a bounded window by an
+// issue-number reference and then a colon introducing the quotation.
+const CITED_ISSUE_ATTRIBUTION_WINDOW = 80;
+const ISSUE_NUMBER_REFERENCE_PATTERN = /#\d+/;
 
 /** Reasons that keep an issue out of the orphan candidate list. */
 export type OrphanFilteredReason =
@@ -303,6 +316,29 @@ function isQuotedMatch(text: string, start: number, end: number): boolean {
   );
 }
 
+// A match that opens a longer quoted excerpt attributed to a different,
+// cited issue by number (#2746) -- see the constants above for the
+// motivating shape. Only the open-quote adjacency is required (the close
+// side is deliberately NOT checked here, unlike `isQuotedMatch`: the
+// whole point of this exclusion is the shape where no nearby closing
+// quote follows).
+function isAttributedLongQuote(text: string, start: number): boolean {
+  const before = text[start - 1];
+  if (before === undefined || !OPEN_QUOTE_CHARS.has(before)) {
+    return false;
+  }
+  const windowStart = Math.max(0, start - 1 - CITED_ISSUE_ATTRIBUTION_WINDOW);
+  const window = text.slice(windowStart, start - 1);
+  const referenceMatch = ISSUE_NUMBER_REFERENCE_PATTERN.exec(window);
+  if (!referenceMatch) {
+    return false;
+  }
+  const afterReference = window.slice(
+    referenceMatch.index + referenceMatch[0].length,
+  );
+  return afterReference.includes(':');
+}
+
 /**
  * Detect prose naming a runtime/production-observation precondition
  * (#2467) anywhere in `body`, outside of code regions. Returns `true` on
@@ -318,6 +354,7 @@ export function detectRuntimeObservationPrecondition(body: unknown): boolean {
       const end = match.index + match[0].length;
       if (
         !isQuotedMatch(stripped, match.index, end) &&
+        !isAttributedLongQuote(stripped, match.index) &&
         !hasNegationCueBefore(stripped, match.index) &&
         !hasNegationCueAfter(stripped, end)
       ) {

--- a/src/scripts/discover-orphan-filter.mts
+++ b/src/scripts/discover-orphan-filter.mts
@@ -95,13 +95,15 @@ const TRAILING_QUOTE_PUNCTUATION_PATTERN = /^[.,!?;:]*/;
 // hard-broken (round-2 Copilot/Codex review, PR #2760).
 //
 // Attribution alone does not prove the quoted text is inert history: an
-// issue can cite another issue's prerequisite and explicitly RE-ADOPT it
-// ("Per issue #42: 'confirmed in production before shipping' remains
-// required" -- Codex review, PR #2760). A requirement-assertion word
-// shortly after the quote closes, with no hard break in between, cancels
-// this exclusion the same way `discover-viability-gate.mts`'s
-// requirement-assertion cancellation already does for its own quote
-// exclusion.
+// issue can cite another issue's prerequisite and explicitly RE-ADOPT it,
+// either right after the quote closes ("Per issue #42: 'confirmed in
+// production before shipping' remains required" -- Codex review, PR
+// #2760) or right before the citation opens ("This change still
+// requires issue #42's gate: 'confirmed in production before shipping'"
+// -- Codex review round 4, PR #2760). A requirement-assertion word on
+// EITHER side, with no hard break in between, cancels this exclusion --
+// the same bidirectional shape `discover-viability-gate.mts`'s own
+// requirement-assertion cancellation already uses.
 const CITED_ISSUE_ATTRIBUTION_WINDOW = 80;
 const ISSUE_NUMBER_REFERENCE_PATTERN = /#\d+/g;
 const CITED_ISSUE_ATTRIBUTION_COLON_PATTERN = /:\s*$/;
@@ -110,7 +112,10 @@ const CITED_ISSUE_ATTRIBUTION_COLON_PATTERN = /:\s*$/;
 // also stop an earlier reference from attributing a later quote
 // (Codex review round 3, PR #2760).
 const CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN = /[.;?!\n]|--|—/;
-const CLOSE_QUOTE_SEARCH_WINDOW = 300;
+// No cap: this exclusion exists specifically for quotes that copy a
+// "much longer" excerpt verbatim, so an artificial bound left a real
+// closer -- and any re-adoption cue past it -- unreached (Codex review
+// round 4, PR #2760). The scan is still bounded by the corpus length.
 const ATTRIBUTION_REQUIREMENT_LOOKAHEAD_WINDOW = 40;
 // `blocked`/`blocking`/`pending`/`waiting` join the same vocabulary
 // `discover-viability-gate.mts`'s own requirement-assertion pattern
@@ -364,21 +369,18 @@ function isQuotedMatch(text: string, start: number, end: number): boolean {
 // A requirement-assertion word shortly after the quote closes, with no
 // hard break in between, means the citing issue RE-ADOPTS the quoted
 // prerequisite as its own live requirement rather than merely reporting
-// inert history (Codex review, PR #2760). The close side searches a
-// generous bounded window for the first close-quote character -- this
+// inert history (Codex review, PR #2760). The close side searches the
+// rest of the corpus for the first close-quote character -- this
 // exclusion exists precisely for "much longer" quotes, so the closer can
-// be far from the match -- without requiring it to pair with any
-// specific open-quote character (mirrors this file's existing loose
-// open/close-quote membership checks elsewhere).
+// be arbitrarily far from the match (Codex review round 4, PR #2760) --
+// without requiring it to pair with any specific open-quote character
+// (mirrors this file's existing loose open/close-quote membership
+// checks elsewhere).
 function isFollowedByRequirementAssertion(
   text: string,
   quotedContentStart: number,
 ): boolean {
-  const searchEnd = Math.min(
-    text.length,
-    quotedContentStart + CLOSE_QUOTE_SEARCH_WINDOW,
-  );
-  const region = text.slice(quotedContentStart, searchEnd);
+  const region = text.slice(quotedContentStart);
   let closeOffset = -1;
   for (let i = 0; i < region.length; i++) {
     if (!CLOSE_QUOTE_CHARS.has(region[i])) {
@@ -403,6 +405,32 @@ function isFollowedByRequirementAssertion(
   );
   const hardBreak = CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN.exec(lookahead);
   const scoped = hardBreak ? lookahead.slice(0, hardBreak.index) : lookahead;
+  return ATTRIBUTION_REQUIREMENT_ASSERTION_PATTERN.test(scoped);
+}
+
+// The mirror image of {@link isFollowedByRequirementAssertion}: a
+// requirement-assertion word shortly BEFORE the cited reference, with no
+// hard break in between, means the citing issue already re-adopted the
+// prerequisite before ever citing it ("This change still requires issue
+// #42's gate: 'X'" -- Codex review round 4, PR #2760).
+function isPrecededByRequirementAssertion(
+  text: string,
+  referenceStart: number,
+): boolean {
+  const windowStart = Math.max(
+    0,
+    referenceStart - ATTRIBUTION_REQUIREMENT_LOOKAHEAD_WINDOW,
+  );
+  const lookbehind = text.slice(windowStart, referenceStart);
+  const breaks = [
+    ...lookbehind.matchAll(
+      new RegExp(CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN, 'g'),
+    ),
+  ];
+  const lastBreak = breaks.at(-1);
+  const scoped = lastBreak
+    ? lookbehind.slice(lastBreak.index + lastBreak[0].length)
+    : lookbehind;
   return ATTRIBUTION_REQUIREMENT_ASSERTION_PATTERN.test(scoped);
 }
 
@@ -439,7 +467,9 @@ function isAttributedLongQuote(text: string, start: number): boolean {
   return (
     !CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN.test(
       betweenReferenceAndColon,
-    ) && !isFollowedByRequirementAssertion(text, start)
+    ) &&
+    !isFollowedByRequirementAssertion(text, start) &&
+    !isPrecededByRequirementAssertion(text, windowStart + referenceMatch.index)
   );
 }
 

--- a/src/scripts/discover-orphan-filter.mts
+++ b/src/scripts/discover-orphan-filter.mts
@@ -109,21 +109,43 @@ const ISSUE_NUMBER_REFERENCE_PATTERN = /#\d+/g;
 const CITED_ISSUE_ATTRIBUTION_COLON_PATTERN = /:\s*$/;
 // Every standard English sentence terminator, not just period/semicolon
 // -- a question or exclamation mark ending an unrelated sentence must
-// also stop an earlier reference from attributing a later quote
-// (Codex review round 3, PR #2760).
-const CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN = /[.;?!\n]|--|—/;
-// No cap: this exclusion exists specifically for quotes that copy a
-// "much longer" excerpt verbatim, so an artificial bound left a real
-// closer -- and any re-adoption cue past it -- unreached (Codex review
-// round 4, PR #2760). The scan is still bounded by the corpus length.
+// also stop an earlier reference from attributing a later quote (Codex
+// review round 3, PR #2760). A bare newline is a Markdown SOFT wrap, not
+// a clause break -- only a blank line (a real paragraph/list boundary)
+// counts, matching `discover-viability-gate.mts`'s own soft-wrap-vs-
+// hard-break distinction; a genuine attribution can wrap between the
+// reference and its colon just as easily as between the colon and the
+// quote (Codex review round 5, PR #2760).
+const CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN = /[.;?!]|--|—|\n[ \t]*\n/;
+// The requirement-assertion lookahead/lookbehind windows stay bounded
+// (40 chars); only the CLOSE-QUOTE search itself is unbounded, since
+// this exclusion exists specifically for quotes that copy a "much
+// longer" excerpt verbatim -- an artificial bound there left a real
+// closer, and any re-adoption cue past it, unreached (Codex review
+// round 4, PR #2760; comment corrected per Copilot review round 5).
 const ATTRIBUTION_REQUIREMENT_LOOKAHEAD_WINDOW = 40;
-// `blocked`/`blocking`/`pending`/`waiting` join the same vocabulary
-// `discover-viability-gate.mts`'s own requirement-assertion pattern
-// already uses, so a re-adopted prerequisite phrased as "remains
-// blocked" is recognized too, not only "remains required" (Codex review
-// round 3, PR #2760).
+// `blocked`/`blocking`/`pending`/`waiting`/`shall`/`essential` join the
+// same vocabulary `discover-viability-gate.mts`'s own requirement-
+// assertion pattern already uses, so a re-adopted prerequisite phrased
+// as "remains blocked" or "shall remain the acceptance gate" is
+// recognized too, not only "remains required" (Codex review rounds 3
+// and 5, PR #2760).
 const ATTRIBUTION_REQUIREMENT_ASSERTION_PATTERN =
-  /\b(required|require[sd]?|requiring|must|needed|needs?|mandatory|necessary|blocked|blocking|pending|waiting)\b/i;
+  /\b(required|require[sd]?|requiring|must|needed|needs?|mandatory|necessary|blocked|blocking|pending|waiting|shall|essential)\b/i;
+// A quoted excerpt's closer must PAIR with its actual opener, not match
+// any member of the flat CLOSE_QUOTE_CHARS set -- otherwise an unrelated
+// apostrophe of a DIFFERENT quote family inside the excerpt (a plural
+// possessive like "operators'", not merely a contraction already
+// guarded above) can still be mistaken for the closer, making the real
+// closer and any re-adoption cue past it unreachable (Codex review
+// round 5, PR #2760). Mirrors `discover-viability-gate.mts`'s own
+// `QUOTE_CHAR_PAIRS`.
+const QUOTE_CHAR_PAIRS: Record<string, string> = {
+  '"': '"',
+  "'": "'",
+  '‘': '’',
+  '“': '”',
+};
 // A straight/curly apostrophe inside the quoted excerpt itself (a
 // contraction or possessive, e.g. "it's") must not be mistaken for the
 // closing quote -- only a candidate NOT immediately followed by a
@@ -370,20 +392,26 @@ function isQuotedMatch(text: string, start: number, end: number): boolean {
 // hard break in between, means the citing issue RE-ADOPTS the quoted
 // prerequisite as its own live requirement rather than merely reporting
 // inert history (Codex review, PR #2760). The close side searches the
-// rest of the corpus for the first close-quote character -- this
-// exclusion exists precisely for "much longer" quotes, so the closer can
-// be arbitrarily far from the match (Codex review round 4, PR #2760) --
-// without requiring it to pair with any specific open-quote character
-// (mirrors this file's existing loose open/close-quote membership
-// checks elsewhere).
+// rest of the corpus for the first character that PAIRS with `opener`
+// -- this exclusion exists precisely for "much longer" quotes, so the
+// closer can be arbitrarily far from the match (Codex review round 4,
+// PR #2760) -- rather than any member of CLOSE_QUOTE_CHARS, so an
+// apostrophe of a different quote family inside the excerpt (a plural
+// possessive like "operators'") is never mistaken for the real closer
+// (Codex review round 5, PR #2760).
 function isFollowedByRequirementAssertion(
   text: string,
   quotedContentStart: number,
+  opener: string,
 ): boolean {
+  const closer = QUOTE_CHAR_PAIRS[opener];
+  if (closer === undefined) {
+    return false;
+  }
   const region = text.slice(quotedContentStart);
   let closeOffset = -1;
   for (let i = 0; i < region.length; i++) {
-    if (!CLOSE_QUOTE_CHARS.has(region[i])) {
+    if (region[i] !== closer) {
       continue;
     }
     if (WORD_CHAR_PATTERN.test(region[i + 1] ?? '')) {
@@ -439,7 +467,15 @@ function isPrecededByRequirementAssertion(
 // motivating shape. Only the open-quote adjacency is required on the
 // open side (unlike `isQuotedMatch`: the whole point of this exclusion
 // is the shape where no nearby closing quote follows the match itself).
-function isAttributedLongQuote(text: string, start: number): boolean {
+// `selfIssueNumber`, when given, prevents an issue from attributing a
+// quote to ITSELF: "Issue #122 acceptance criterion: 'X'" inside issue
+// #122's own body is not an external citation, so the cited number must
+// differ from the candidate's own (Codex review round 5, PR #2760).
+function isAttributedLongQuote(
+  text: string,
+  start: number,
+  selfIssueNumber?: number,
+): boolean {
   const before = text[start - 1];
   if (before === undefined || !OPEN_QUOTE_CHARS.has(before)) {
     return false;
@@ -455,6 +491,12 @@ function isAttributedLongQuote(text: string, start: number): boolean {
   if (!referenceMatch || referenceMatch.index === undefined) {
     return false;
   }
+  if (
+    selfIssueNumber !== undefined &&
+    Number(referenceMatch[0].slice(1)) === selfIssueNumber
+  ) {
+    return false;
+  }
   // Stop at the introducing colon itself -- the whitespace AFTER it
   // (which can include a Markdown soft-wrap newline before the quote,
   // e.g. "Background:\n\"X\"") is not part of the reference-to-colon
@@ -468,7 +510,7 @@ function isAttributedLongQuote(text: string, start: number): boolean {
     !CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN.test(
       betweenReferenceAndColon,
     ) &&
-    !isFollowedByRequirementAssertion(text, start) &&
+    !isFollowedByRequirementAssertion(text, start, before) &&
     !isPrecededByRequirementAssertion(text, windowStart + referenceMatch.index)
   );
 }
@@ -477,9 +519,15 @@ function isAttributedLongQuote(text: string, start: number): boolean {
  * Detect prose naming a runtime/production-observation precondition
  * (#2467) anywhere in `body`, outside of code regions. Returns `true` on
  * the first match that is neither quoted nor negated -- callers only need a
- * boolean gate, not the matched span.
+ * boolean gate, not the matched span. `selfIssueNumber`, when given, stops
+ * the candidate's own issue number from being treated as an external
+ * citation by {@link isAttributedLongQuote} (Codex review round 5, PR
+ * #2760).
  */
-export function detectRuntimeObservationPrecondition(body: unknown): boolean {
+export function detectRuntimeObservationPrecondition(
+  body: unknown,
+  selfIssueNumber?: number,
+): boolean {
   const stripped = stripMarkdownCodeRegions(String(body ?? ''));
   for (const pattern of RUNTIME_OBSERVATION_PATTERNS) {
     pattern.lastIndex = 0;
@@ -488,7 +536,7 @@ export function detectRuntimeObservationPrecondition(body: unknown): boolean {
       const end = match.index + match[0].length;
       if (
         !isQuotedMatch(stripped, match.index, end) &&
-        !isAttributedLongQuote(stripped, match.index) &&
+        !isAttributedLongQuote(stripped, match.index, selfIssueNumber) &&
         !hasNegationCueBefore(stripped, match.index) &&
         !hasNegationCueAfter(stripped, end)
       ) {
@@ -572,7 +620,7 @@ export function classifyIssue(
   // production-observation precondition has no issue-number reference to
   // resolve, so it must still hold even when every numbered reference below
   // is absent or already closed.
-  if (detectRuntimeObservationPrecondition(body)) {
+  if (detectRuntimeObservationPrecondition(body, Number(issue.number))) {
     return { orphan: false, reason: 'runtime_observation_precondition' };
   }
 

--- a/src/scripts/discover-orphan-filter.mts
+++ b/src/scripts/discover-orphan-filter.mts
@@ -89,11 +89,27 @@ const TRAILING_QUOTE_PUNCTUATION_PATTERN = /^[.,!?;:]*/;
 // reference from that colon -- "See #42 for rollout details. Acceptance
 // gate: 'X'" has an unrelated label's colon after a sentence break and
 // must NOT match either, even though a colon does directly precede the
-// quote.
+// quote. When more than one issue reference sits in the window ("See #1.
+// Issue #2 asserted: 'X'"), bind to the LAST one, not the first -- an
+// earlier, unrelated reference must not make a genuine attribution look
+// hard-broken (round-2 Copilot/Codex review, PR #2760).
+//
+// Attribution alone does not prove the quoted text is inert history: an
+// issue can cite another issue's prerequisite and explicitly RE-ADOPT it
+// ("Per issue #42: 'confirmed in production before shipping' remains
+// required" -- Codex review, PR #2760). A requirement-assertion word
+// shortly after the quote closes, with no hard break in between, cancels
+// this exclusion the same way `discover-viability-gate.mts`'s
+// requirement-assertion cancellation already does for its own quote
+// exclusion.
 const CITED_ISSUE_ATTRIBUTION_WINDOW = 80;
-const ISSUE_NUMBER_REFERENCE_PATTERN = /#\d+/;
+const ISSUE_NUMBER_REFERENCE_PATTERN = /#\d+/g;
 const CITED_ISSUE_ATTRIBUTION_COLON_PATTERN = /:\s*$/;
 const CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN = /[.;\n]|--|—/;
+const CLOSE_QUOTE_SEARCH_WINDOW = 300;
+const ATTRIBUTION_REQUIREMENT_LOOKAHEAD_WINDOW = 40;
+const ATTRIBUTION_REQUIREMENT_ASSERTION_PATTERN =
+  /\b(required|require[sd]?|requiring|must|needed|needs?|mandatory|necessary)\b/i;
 
 /** Reasons that keep an issue out of the orphan candidate list. */
 export type OrphanFilteredReason =
@@ -329,12 +345,52 @@ function isQuotedMatch(text: string, start: number, end: number): boolean {
   );
 }
 
+// A requirement-assertion word shortly after the quote closes, with no
+// hard break in between, means the citing issue RE-ADOPTS the quoted
+// prerequisite as its own live requirement rather than merely reporting
+// inert history (Codex review, PR #2760). The close side searches a
+// generous bounded window for the first close-quote character -- this
+// exclusion exists precisely for "much longer" quotes, so the closer can
+// be far from the match -- without requiring it to pair with any
+// specific open-quote character (mirrors this file's existing loose
+// open/close-quote membership checks elsewhere).
+function isFollowedByRequirementAssertion(
+  text: string,
+  quotedContentStart: number,
+): boolean {
+  const searchEnd = Math.min(
+    text.length,
+    quotedContentStart + CLOSE_QUOTE_SEARCH_WINDOW,
+  );
+  const region = text.slice(quotedContentStart, searchEnd);
+  let closeOffset = -1;
+  for (let i = 0; i < region.length; i++) {
+    if (CLOSE_QUOTE_CHARS.has(region[i])) {
+      closeOffset = i;
+      break;
+    }
+  }
+  if (closeOffset === -1) {
+    return false;
+  }
+  const afterClose = quotedContentStart + closeOffset + 1;
+  const lookahead = text.slice(
+    afterClose,
+    Math.min(
+      text.length,
+      afterClose + ATTRIBUTION_REQUIREMENT_LOOKAHEAD_WINDOW,
+    ),
+  );
+  const hardBreak = CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN.exec(lookahead);
+  const scoped = hardBreak ? lookahead.slice(0, hardBreak.index) : lookahead;
+  return ATTRIBUTION_REQUIREMENT_ASSERTION_PATTERN.test(scoped);
+}
+
 // A match that opens a longer quoted excerpt attributed to a different,
 // cited issue by number (#2746) -- see the constants above for the
-// motivating shape. Only the open-quote adjacency is required (the close
-// side is deliberately NOT checked here, unlike `isQuotedMatch`: the
-// whole point of this exclusion is the shape where no nearby closing
-// quote follows).
+// motivating shape. Only the open-quote adjacency is required on the
+// open side (unlike `isQuotedMatch`: the whole point of this exclusion
+// is the shape where no nearby closing quote follows the match itself).
 function isAttributedLongQuote(text: string, start: number): boolean {
   const before = text[start - 1];
   if (before === undefined || !OPEN_QUOTE_CHARS.has(before)) {
@@ -345,15 +401,18 @@ function isAttributedLongQuote(text: string, start: number): boolean {
   if (!CITED_ISSUE_ATTRIBUTION_COLON_PATTERN.test(window)) {
     return false;
   }
-  const referenceMatch = ISSUE_NUMBER_REFERENCE_PATTERN.exec(window);
-  if (!referenceMatch) {
+  const referenceMatches = [...window.matchAll(ISSUE_NUMBER_REFERENCE_PATTERN)];
+  const referenceMatch = referenceMatches.at(-1);
+  if (!referenceMatch || referenceMatch.index === undefined) {
     return false;
   }
   const betweenReferenceAndColon = window.slice(
     referenceMatch.index + referenceMatch[0].length,
   );
-  return !CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN.test(
-    betweenReferenceAndColon,
+  return (
+    !CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN.test(
+      betweenReferenceAndColon,
+    ) && !isFollowedByRequirementAssertion(text, start)
   );
 }
 

--- a/src/scripts/discover-orphan-filter.mts
+++ b/src/scripts/discover-orphan-filter.mts
@@ -79,8 +79,21 @@ const TRAILING_QUOTE_PUNCTUATION_PATTERN = /^[.,!?;:]*/;
 // open-quote character immediately before the match (the same adjacency
 // `isQuotedMatch` requires), preceded within a bounded window by an
 // issue-number reference and then a colon introducing the quotation.
+//
+// Two conditions bound the colon to that same attribution, not just any
+// nearby colon (Copilot/Codex/CodeRabbit review, PR #2760): the colon
+// must directly introduce the quote (only whitespace between the colon
+// and the opening quote character -- "Issue #42: prior history. The
+// requirement is 'X'" has no such colon and must NOT match), and no hard
+// clause break (period/semicolon/em-dash) may separate the issue-number
+// reference from that colon -- "See #42 for rollout details. Acceptance
+// gate: 'X'" has an unrelated label's colon after a sentence break and
+// must NOT match either, even though a colon does directly precede the
+// quote.
 const CITED_ISSUE_ATTRIBUTION_WINDOW = 80;
 const ISSUE_NUMBER_REFERENCE_PATTERN = /#\d+/;
+const CITED_ISSUE_ATTRIBUTION_COLON_PATTERN = /:\s*$/;
+const CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN = /[.;\n]|--|—/;
 
 /** Reasons that keep an issue out of the orphan candidate list. */
 export type OrphanFilteredReason =
@@ -329,14 +342,19 @@ function isAttributedLongQuote(text: string, start: number): boolean {
   }
   const windowStart = Math.max(0, start - 1 - CITED_ISSUE_ATTRIBUTION_WINDOW);
   const window = text.slice(windowStart, start - 1);
+  if (!CITED_ISSUE_ATTRIBUTION_COLON_PATTERN.test(window)) {
+    return false;
+  }
   const referenceMatch = ISSUE_NUMBER_REFERENCE_PATTERN.exec(window);
   if (!referenceMatch) {
     return false;
   }
-  const afterReference = window.slice(
+  const betweenReferenceAndColon = window.slice(
     referenceMatch.index + referenceMatch[0].length,
   );
-  return afterReference.includes(':');
+  return !CITED_ISSUE_ATTRIBUTION_HARD_BREAK_PATTERN.test(
+    betweenReferenceAndColon,
+  );
 }
 
 /**

--- a/tests/discover-orphan-filter.test.mts
+++ b/tests/discover-orphan-filter.test.mts
@@ -1551,6 +1551,45 @@ test('classifyIssue still trips when a blank line (a real paragraph break) separ
   assert.equal(result.reason, 'runtime_observation_precondition');
 });
 
+test('classifyIssue still trips when an internal plural possessive in a single-quoted excerpt sits before the real closer (Copilot/Codex review round 6, PR #2760)', () => {
+  const result = classifyIssue(
+    {
+      number: 126,
+      title: 't',
+      state: 'OPEN',
+      labels: [],
+      body:
+        "Per issue #42: 'confirmed in production according to the " +
+        "operators' detailed report describing the incident timeline " +
+        "in full' remains required.",
+    },
+    {
+      issueStateByNumber: new Map(),
+      fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    },
+  );
+  assert.equal(result.reason, 'runtime_observation_precondition');
+});
+
+test('classifyIssue still trips when separate Markdown bullets without a blank line connect an unrelated reference to a live gate (Codex review round 6, PR #2760)', () => {
+  const result = classifyIssue(
+    {
+      number: 127,
+      title: 't',
+      state: 'OPEN',
+      labels: [],
+      body:
+        '- Related issue #42\n- Acceptance gate: "confirmed in ' +
+        'production before shipping"',
+    },
+    {
+      issueStateByNumber: new Map(),
+      fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    },
+  );
+  assert.equal(result.reason, 'runtime_observation_precondition');
+});
+
 test('filterOrphanIssues buckets a runtime-observation precondition under filtered.runtime_observation_precondition (#2467)', async () => {
   const issues = [
     {

--- a/tests/discover-orphan-filter.test.mts
+++ b/tests/discover-orphan-filter.test.mts
@@ -1340,6 +1340,83 @@ test('classifyIssue still trips when the citing issue re-adopts the quoted prere
   assert.equal(result.reason, 'runtime_observation_precondition');
 });
 
+test('classifyIssue still detects re-adoption when the quoted excerpt contains a contraction (Copilot review round 3, PR #2760)', () => {
+  const result = classifyIssue(
+    {
+      number: 115,
+      title: 't',
+      state: 'OPEN',
+      labels: [],
+      body:
+        'Per issue #42: "it\'s confirmed in production before shipping" ' +
+        'remains required for this change too.',
+    },
+    {
+      issueStateByNumber: new Map(),
+      fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    },
+  );
+  assert.equal(result.reason, 'runtime_observation_precondition');
+});
+
+test('classifyIssue still trips when the re-adopted requirement is phrased as "remains blocked" (Codex review round 3, PR #2760)', () => {
+  const result = classifyIssue(
+    {
+      number: 116,
+      title: 't',
+      state: 'OPEN',
+      labels: [],
+      body:
+        'Per issue #42: "confirmed in production before shipping" ' +
+        'remains blocked for this change.',
+    },
+    {
+      issueStateByNumber: new Map(),
+      fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    },
+  );
+  assert.equal(result.reason, 'runtime_observation_precondition');
+});
+
+test('classifyIssue still trips when a question mark ends the unrelated sentence containing the earlier reference (Codex review round 3, PR #2760)', () => {
+  const result = classifyIssue(
+    {
+      number: 117,
+      title: 't',
+      state: 'OPEN',
+      labels: [],
+      body:
+        'Did issue #42 ship? Acceptance gate: "confirmed in production ' +
+        'before shipping, per the runbook."',
+    },
+    {
+      issueStateByNumber: new Map(),
+      fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    },
+  );
+  assert.equal(result.reason, 'runtime_observation_precondition');
+});
+
+test('classifyIssue does not trip when a soft-wrap newline sits between the introducing colon and the quote (Codex review round 3, PR #2760)', () => {
+  const result = classifyIssue(
+    {
+      number: 118,
+      title: 't',
+      state: 'OPEN',
+      labels: [],
+      body:
+        'Issue #2743 asserted in its Background:\n"confirmed in ' +
+        'production: the deploy pipeline paused for six hours" -- ' +
+        'describing a specific event.',
+    },
+    {
+      issueStateByNumber: new Map(),
+      fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    },
+  );
+  assert.equal(result.reason, 'orphan');
+});
+
 test('filterOrphanIssues buckets a runtime-observation precondition under filtered.runtime_observation_precondition (#2467)', async () => {
   const issues = [
     {

--- a/tests/discover-orphan-filter.test.mts
+++ b/tests/discover-orphan-filter.test.mts
@@ -1301,6 +1301,45 @@ test('classifyIssue still trips when an unrelated colon follows the cited issue 
   assert.equal(result.reason, 'runtime_observation_precondition');
 });
 
+test('classifyIssue does not trip when the genuine attribution is the LAST reference before an unrelated earlier one (Copilot/Codex review round 2, PR #2760)', () => {
+  const result = classifyIssue(
+    {
+      number: 113,
+      title: 't',
+      state: 'OPEN',
+      labels: [],
+      body:
+        'See #1. Issue #2 asserted: "confirmed in production: the ' +
+        'deploy pipeline paused for six hours" -- describing an ' +
+        'unrelated event.',
+    },
+    {
+      issueStateByNumber: new Map(),
+      fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    },
+  );
+  assert.equal(result.reason, 'orphan');
+});
+
+test('classifyIssue still trips when the citing issue re-adopts the quoted prerequisite as its own requirement (Codex review round 2, PR #2760)', () => {
+  const result = classifyIssue(
+    {
+      number: 114,
+      title: 't',
+      state: 'OPEN',
+      labels: [],
+      body:
+        'Per issue #42: "confirmed in production before shipping" ' +
+        'remains required for this change too.',
+    },
+    {
+      issueStateByNumber: new Map(),
+      fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    },
+  );
+  assert.equal(result.reason, 'runtime_observation_precondition');
+});
+
 test('filterOrphanIssues buckets a runtime-observation precondition under filtered.runtime_observation_precondition (#2467)', async () => {
   const issues = [
     {

--- a/tests/discover-orphan-filter.test.mts
+++ b/tests/discover-orphan-filter.test.mts
@@ -1454,6 +1454,103 @@ test('classifyIssue still trips a re-adoption cue past a quote longer than the o
   assert.equal(result.reason, 'runtime_observation_precondition');
 });
 
+test('classifyIssue still trips when an unrelated apostrophe of a different quote family sits inside the excerpt (Codex review round 5, PR #2760)', () => {
+  const result = classifyIssue(
+    {
+      number: 121,
+      title: 't',
+      state: 'OPEN',
+      labels: [],
+      body:
+        'Per issue #42: "confirmed in production according to the ' +
+        "operators' long excerpt describing the outage window in " +
+        'detail here" remains required.',
+    },
+    {
+      issueStateByNumber: new Map(),
+      fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    },
+  );
+  assert.equal(result.reason, 'runtime_observation_precondition');
+});
+
+test('classifyIssue still trips when the candidate cites its own issue number (Codex review round 5, PR #2760)', () => {
+  const result = classifyIssue(
+    {
+      number: 122,
+      title: 't',
+      state: 'OPEN',
+      labels: [],
+      body:
+        'Issue #122 acceptance criterion: "confirmed in production ' +
+        'before shipping"',
+    },
+    {
+      issueStateByNumber: new Map(),
+      fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    },
+  );
+  assert.equal(result.reason, 'runtime_observation_precondition');
+});
+
+test('classifyIssue still trips when the re-adoption cue is "shall" (Codex review round 5, PR #2760)', () => {
+  const result = classifyIssue(
+    {
+      number: 123,
+      title: 't',
+      state: 'OPEN',
+      labels: [],
+      body:
+        'Per issue #42: "confirmed in production before shipping" ' +
+        'shall remain the acceptance gate.',
+    },
+    {
+      issueStateByNumber: new Map(),
+      fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    },
+  );
+  assert.equal(result.reason, 'runtime_observation_precondition');
+});
+
+test('classifyIssue does not trip when a soft-wrap newline sits between the cited reference and its colon (Codex review round 5, PR #2760)', () => {
+  const result = classifyIssue(
+    {
+      number: 124,
+      title: 't',
+      state: 'OPEN',
+      labels: [],
+      body:
+        'Issue #42 asserted in its\nBackground: "confirmed in ' +
+        'production: the deploy pipeline paused for six hours" -- ' +
+        'describing a specific event.',
+    },
+    {
+      issueStateByNumber: new Map(),
+      fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    },
+  );
+  assert.equal(result.reason, 'orphan');
+});
+
+test('classifyIssue still trips when a blank line (a real paragraph break) separates an unrelated reference from the quote (Codex review round 5, PR #2760)', () => {
+  const result = classifyIssue(
+    {
+      number: 125,
+      title: 't',
+      state: 'OPEN',
+      labels: [],
+      body:
+        'See #42.\n\nAcceptance gate: "confirmed in production before ' +
+        'shipping, per the runbook."',
+    },
+    {
+      issueStateByNumber: new Map(),
+      fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    },
+  );
+  assert.equal(result.reason, 'runtime_observation_precondition');
+});
+
 test('filterOrphanIssues buckets a runtime-observation precondition under filtered.runtime_observation_precondition (#2467)', async () => {
   const issues = [
     {

--- a/tests/discover-orphan-filter.test.mts
+++ b/tests/discover-orphan-filter.test.mts
@@ -1417,6 +1417,43 @@ test('classifyIssue does not trip when a soft-wrap newline sits between the intr
   assert.equal(result.reason, 'orphan');
 });
 
+test('classifyIssue still trips when the re-adoption cue precedes the citation instead of following the quote (Codex review round 4, PR #2760)', () => {
+  const result = classifyIssue(
+    {
+      number: 119,
+      title: 't',
+      state: 'OPEN',
+      labels: [],
+      body:
+        'This change still requires issue #42\'s gate: "confirmed in ' +
+        'production before shipping".',
+    },
+    {
+      issueStateByNumber: new Map(),
+      fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    },
+  );
+  assert.equal(result.reason, 'runtime_observation_precondition');
+});
+
+test('classifyIssue still trips a re-adoption cue past a quote longer than the old 300-char search bound (Codex review round 4, PR #2760)', () => {
+  const longExcerpt = `confirmed in production ${'x'.repeat(320)} end of excerpt`;
+  const result = classifyIssue(
+    {
+      number: 120,
+      title: 't',
+      state: 'OPEN',
+      labels: [],
+      body: `Per issue #42: "${longExcerpt}" remains required.`,
+    },
+    {
+      issueStateByNumber: new Map(),
+      fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    },
+  );
+  assert.equal(result.reason, 'runtime_observation_precondition');
+});
+
 test('filterOrphanIssues buckets a runtime-observation precondition under filtered.runtime_observation_precondition (#2467)', async () => {
   const issues = [
     {

--- a/tests/discover-orphan-filter.test.mts
+++ b/tests/discover-orphan-filter.test.mts
@@ -1263,6 +1263,44 @@ test('classifyIssue still trips a quoted precondition with no cited-issue-number
   assert.equal(result.reason, 'runtime_observation_precondition');
 });
 
+test('classifyIssue still trips when the colon does not directly introduce the quote (CodeRabbit review, PR #2760)', () => {
+  const result = classifyIssue(
+    {
+      number: 111,
+      title: 't',
+      state: 'OPEN',
+      labels: [],
+      body:
+        'Issue #2743: prior history. The requirement is "confirmed in ' +
+        'production before shipping, per the runbook."',
+    },
+    {
+      issueStateByNumber: new Map(),
+      fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    },
+  );
+  assert.equal(result.reason, 'runtime_observation_precondition');
+});
+
+test('classifyIssue still trips when an unrelated colon follows the cited issue reference across a sentence break (Copilot/Codex review, PR #2760)', () => {
+  const result = classifyIssue(
+    {
+      number: 112,
+      title: 't',
+      state: 'OPEN',
+      labels: [],
+      body:
+        'See #42 for rollout details. Acceptance gate: "confirmed in ' +
+        'production before shipping, per the runbook."',
+    },
+    {
+      issueStateByNumber: new Map(),
+      fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    },
+  );
+  assert.equal(result.reason, 'runtime_observation_precondition');
+});
+
 test('filterOrphanIssues buckets a runtime-observation precondition under filtered.runtime_observation_precondition (#2467)', async () => {
   const issues = [
     {

--- a/tests/discover-orphan-filter.test.mts
+++ b/tests/discover-orphan-filter.test.mts
@@ -1223,6 +1223,46 @@ test('classifyIssue does not trip runtime-observation prose negated after the ma
   assert.equal(result.reason, 'orphan');
 });
 
+test('classifyIssue does not trip a trigger phrase opening a longer quote attributed to a different, cited issue by number (#2746)', () => {
+  const result = classifyIssue(
+    {
+      number: 109,
+      title: 't',
+      state: 'OPEN',
+      labels: [],
+      body:
+        'Issue #2743 asserted in its Background: "confirmed in ' +
+        'production: the deploy pipeline paused for six hours" -- ' +
+        'describing a specific event that later turned out to be ' +
+        'unrelated.',
+    },
+    {
+      issueStateByNumber: new Map(),
+      fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    },
+  );
+  assert.equal(result.reason, 'orphan');
+});
+
+test('classifyIssue still trips a quoted precondition with no cited-issue-number attribution nearby (#2746)', () => {
+  const result = classifyIssue(
+    {
+      number: 110,
+      title: 't',
+      state: 'OPEN',
+      labels: [],
+      body:
+        'The team said: "we need this confirmed in production before ' +
+        'shipping."',
+    },
+    {
+      issueStateByNumber: new Map(),
+      fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    },
+  );
+  assert.equal(result.reason, 'runtime_observation_precondition');
+});
+
 test('filterOrphanIssues buckets a runtime-observation precondition under filtered.runtime_observation_precondition (#2467)', async () => {
   const issues = [
     {


### PR DESCRIPTION
# Summary

`isQuotedMatch` in `discover-orphan-filter.mts` only excludes a
runtime-observation trigger phrase (`RUNTIME_OBSERVATION_PATTERNS`,
#2467) when the whole quoted span IS the trigger phrase, closed by a
nearby quote character. It misses a match that merely opens a much
longer quoted excerpt copied verbatim from a different, cited issue's
own body — the character right after the match continues that
quotation as ordinary punctuation (a colon), not a closing quote, so
the match survives and wrongly excludes a startable issue from the
A0-O orphan candidate listing even though `discover-readiness-check.mjs`
and `suitability-triage.mjs` both independently report it `ready`.

Adds a narrow sibling exclusion, `isAttributedLongQuote`: an open-quote
character immediately before the match (the same adjacency the
existing check requires), preceded within an 80-char window by an
issue-number reference and a colon introducing the quotation. Keeps
the existing short-quoted-term, code-span, and negation exclusions
unchanged, and does not broaden into a generic "inside any quotation
mark pair" rule, per the issue's own explicit scoping constraint.

## Linked issue

Closes #2746

## Follow-up issues (if any)

- [ ] none

Across rounds 2-6 of review on this PR, Copilot/Codex identified
several genuine fail-open gaps in the attribution exclusion (a quote
can be attributed to a cited issue yet still be explicitly re-adopted
as a live requirement nearby). Closing those required adding a
bidirectional requirement-assertion cancellation
(`isFollowedByRequirementAssertion` / `isPrecededByRequirementAssertion`)
that mirrors `discover-viability-gate.mts`'s own cancellation shape.
That mechanism, by round 6, already exceeds this issue's own explicit
scope constraint ("does not broaden into a generic 'inside any
quotation mark pair' rule ... a distinct, larger-scoped change needing
its own design discussion, not a side effect of this fix") — it is
now doing bounded-window natural-language cue detection, not just
attribution-adjacency matching. Round 7 (Copilot/Codex) surfaced
further refinements to that same mechanism (punctuation-inside-closer
handling, bounding the candidate-closer scan to the excerpt's own
delimiters); both were rejected with reasoning and left unfixed as
known limitations, since further chasing this shape is exactly the
open-ended semantic quote-parsing design work the issue asked to defer
to its own discussion rather than keep absorbing as review-driven
scope creep on this PR. A follow-up issue should scope that as its own
design discussion if a real (non-constructed) issue body is observed
hitting it.

## Background / rationale (if material)

Reproduced directly against the live function: a drafted issue's own
Background quoted a different, disproven issue's Background claim
verbatim as historical motivating context — a sentence shaped like
"Issue #NNNN asserted in its Background: '<trigger phrase>: ...much
more quoted prose...' -- describing a specific event." The issue was
only discovered and claimed via a manual, evidence-backed override
applied before this fix existed (see kurone-kito/idd-skill#2739's own
triage-note comment).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EycqtGKuWjJMpw2tUav3Tn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of runtime-observation preconditions by excluding trigger phrases found in quoted excerpts attributed to another issue.
  * Preserved classification of unattributed quoted preconditions as runtime-observation preconditions.

* **Tests**
  * Added regression coverage for attributed and unattributed quoted excerpts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
