### PR TITLE
fix(suitability-triage): fail Check 6 on blocked-by-human signals

### DIFF
--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -709,7 +709,7 @@ function parseUpstreamCandidateMarker(text, markerPrefix) {
  * matches regardless of value, so comparing the two counts recovers the
  * distinction.
  */
-function parseAuthoringBucketMarker(text, markerPrefix) {
+export function parseAuthoringBucketMarker(text, markerPrefix) {
   const rawCount = countMarkerOccurrences(
     text,
     markerPrefix,

--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -1746,7 +1746,7 @@ function extractHeadings(text) {
   }
   return headings;
 }
-function normalizeMarkerPrefix(prefix) {
+export function normalizeMarkerPrefix(prefix) {
   // Trim first: a config value or CLI input with accidental leading/
   // trailing whitespace (e.g. "idd-skill ") would otherwise become a
   // distinct prefix that never matches any real marker, producing

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -2436,7 +2436,10 @@ export function checkAutonomy(context) {
       };
     }
   }
-  const markerPrefix = context.markerPrefix ?? DEFAULT_MARKER_PREFIX;
+  // #2737 review, Copilot: checkAutonomy is itself exported and called
+  // directly with a raw Context (including in tests) -- normalize here too
+  // rather than relying solely on the Context-construction call sites.
+  const markerPrefix = normalizeMarkerPrefix(context.markerPrefix);
   const bucketMarker = parseAuthoringBucketMarker(
     stripMarkdownCodeRegions(body),
     markerPrefix,

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -26,7 +26,6 @@ import {
   findMarkdownCodeRanges,
   getMarkdownCodeRange,
   maskMarkdownCodeRegionsPreservingPositions,
-  stripMarkdownCodeRegions,
 } from './markdown-code.mjs';
 import { escapeRegex } from './marker-regex.mjs';
 import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mjs';
@@ -2440,8 +2439,32 @@ export function checkAutonomy(context) {
   // directly with a raw Context (including in tests) -- normalize here too
   // rather than relying solely on the Context-construction call sites.
   const markerPrefix = normalizeMarkerPrefix(context.markerPrefix);
+  // #2761 review (Codex): a naive fenced/inline-only mask (the earlier
+  // `stripMarkdownCodeRegions(body)`) leaves an indented (4-space) code
+  // block untouched, so a documentation example written that way is
+  // wrongly treated as a real marker. It also has no notion of an HTML
+  // comment boundary at all, so it cannot distinguish a genuine marker from
+  // a backslash-escaped `\<!--` opener (literal text, not a real comment)
+  // or correctly recover a genuine marker sitting between backslash-escaped
+  // backticks (`` \` <!-- ... --> \` ``, which `findInlineCodeRanges`
+  // itself already treats as not forming a real inline code span, unlike
+  // the plain regex behind `stripMarkdownCodeRegions`). Scanning only the
+  // real (non-code-example, non-escaped) HTML comment ranges --
+  // `findHtmlCommentRanges`'s own established fenced/indented/inline
+  // code-example exclusion and escaped-opener handling, already used the
+  // same way elsewhere in this function (the objective-criteria
+  // `fenceMaskedBody` scan below) and in checkVerifiability's
+  // `hasSubjectiveApproval` scan -- gets all three right at once.
+  const codeRangesForAutonomy = findMarkdownCodeRanges(body);
+  const commentRangesForAutonomy = findHtmlCommentRanges(
+    body,
+    codeRangesForAutonomy,
+  );
+  const authoringBucketScanText = commentRangesForAutonomy
+    .map((range) => body.slice(range.start, range.end))
+    .join('\n');
   const bucketMarker = parseAuthoringBucketMarker(
-    stripMarkdownCodeRegions(body),
+    authoringBucketScanText,
     markerPrefix,
   );
   if (

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -6,6 +6,7 @@
 // the generated .mjs. See docs/typescript-sources.md.
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { parseAuthoringBucketMarker } from './audit-authored-issue.mjs';
 import { computeBranchName } from './branch-name.mjs';
 import { parseCliArgs } from './cli-args.mjs';
 import {
@@ -22,7 +23,9 @@ import {
   findMarkdownCodeRanges,
   getMarkdownCodeRange,
   maskMarkdownCodeRegionsPreservingPositions,
+  stripMarkdownCodeRegions,
 } from './markdown-code.mjs';
+import { escapeRegex } from './marker-regex.mjs';
 import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mjs';
 import { resolveTrustedMarkerActors } from './protocol-helpers.mjs';
 import {
@@ -59,6 +62,13 @@ const MERGED_PR_SCAN_DEADLINE_MS = 2 * 60 * 1000;
 // marks, so it cannot itself satisfy the scan if the real key is ever
 // renamed -- see #1446's PR description for why that matters.)
 //
+// #2737: the default marker prefix Check 6 (Autonomy) uses to detect an
+// `authoring-bucket: blocked-by-human` marker when the caller does not
+// configure `markerPrefix`. Same TDZ hazard and same fallback value as
+// every other file's own local `DEFAULT_MARKER_PREFIX` constant (see
+// discover-readiness-check.mts, audit-authored-issue.mts, etc.) -- not
+// shared/exported centrally by convention in this codebase.
+const DEFAULT_MARKER_PREFIX = 'idd-skill';
 // Declared here, above the import.meta.main trigger below, rather than
 // alongside parseArgs further down: the trigger calls runCli() ->
 // parseArgs() synchronously at module-evaluation time, and a `const`
@@ -1990,6 +2000,10 @@ export function evaluateSuitability(issue, options = {}) {
       options.needsDecisionLabelName,
       POLICY_DEFAULTS.labels.needsDecisionLabelName,
     ),
+    markerPrefix: normalizeConfiguredLabelName(
+      options.markerPrefix,
+      DEFAULT_MARKER_PREFIX,
+    ),
     highConfidenceDuplicate: normalizeHighConfidenceDuplicateInput(
       options.highConfidenceDuplicate,
     ),
@@ -2361,11 +2375,12 @@ export function checkAutonomy(context) {
   const { issue } = context;
   const labels = new Set(issue.labels);
   const body = issue.body;
+  const blockedByHumanLabelName = normalizeConfiguredLabelName(
+    context.blockedByHumanLabelName,
+    POLICY_DEFAULTS.labels.blockedByHumanLabelName,
+  );
   const blockedLabels = new Set([
-    normalizeConfiguredLabelName(
-      context.blockedByHumanLabelName,
-      POLICY_DEFAULTS.labels.blockedByHumanLabelName,
-    ),
+    blockedByHumanLabelName,
     normalizeConfiguredLabelName(
       context.needsDecisionLabelName,
       POLICY_DEFAULTS.labels.needsDecisionLabelName,
@@ -2378,6 +2393,47 @@ export function checkAutonomy(context) {
         evidence: `Blocking label present: ${label}`,
       };
     }
+  }
+  // #2737: the configured blockedByHumanLabelName label (default
+  // status:blocked-by-human) can be absent even when the issue is
+  // genuinely human-gated -- issue #2657 mechanically passed all seven
+  // A4.5 checks while still carrying a `blocked-by-human:` title prefix
+  // and a hidden authoring-bucket marker, neither of which the label
+  // check above reads. Both are mechanical, pre-label signals the
+  // issue-authoring contract pairs with that label, so this check must
+  // also honor them. The title-prefix stem is derived from the
+  // configured label's own local name (the part after its `status:`-style
+  // namespace) rather than a hardcoded literal, so a repository that
+  // renames the label keeps both signals in sync.
+  const blockedByHumanStem = blockedByHumanLabelName.includes(':')
+    ? blockedByHumanLabelName.slice(
+        blockedByHumanLabelName.lastIndexOf(':') + 1,
+      )
+    : blockedByHumanLabelName;
+  const titlePrefixPattern = new RegExp(
+    `^${escapeRegex(blockedByHumanStem)}:\\s*`,
+    'i',
+  );
+  if (titlePrefixPattern.test(issue.title)) {
+    return {
+      pass: false,
+      evidence: `Title carries the ${blockedByHumanStem}: prefix.`,
+    };
+  }
+  const markerPrefix = context.markerPrefix ?? DEFAULT_MARKER_PREFIX;
+  const bucketMarker = parseAuthoringBucketMarker(
+    stripMarkdownCodeRegions(body),
+    markerPrefix,
+  );
+  if (
+    bucketMarker.present &&
+    !bucketMarker.malformed &&
+    bucketMarker.value === 'blocked-by-human'
+  ) {
+    return {
+      pass: false,
+      evidence: `<!-- ${markerPrefix}-authoring-bucket: blocked-by-human --> marker present.`,
+    };
   }
   // #2219: an either/or acceptance-criterion shape naming two mutually
   // exclusive implementation paths without saying which one to take.
@@ -3330,6 +3386,7 @@ function runCli() {
     duplicateCandidates,
     blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
     needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
+    markerPrefix: resolveMarkerPrefix(policyConfig),
     highConfidenceDuplicate,
     highConfidenceCollectionDegraded: collectionWarnings.length > 0,
   });
@@ -3420,6 +3477,10 @@ export function evaluateSuitabilityLocal(bodyText, options = {}) {
       options.needsDecisionLabelName,
       POLICY_DEFAULTS.labels.needsDecisionLabelName,
     ),
+    markerPrefix: normalizeConfiguredLabelName(
+      options.markerPrefix,
+      DEFAULT_MARKER_PREFIX,
+    ),
   };
   const checks = CHECKS.map((check) => {
     if (check.id === 'duplicate_or_superseded') {
@@ -3451,6 +3512,7 @@ function runLocalCli(args) {
   const result = evaluateSuitabilityLocal(bodyText, {
     blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
     needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
+    markerPrefix: resolveMarkerPrefix(policyConfig),
   });
   const output = {
     mode: result.mode,
@@ -3784,6 +3846,16 @@ function normalizeConfiguredLabelName(labelName, fallback) {
   return typeof labelName === 'string' && labelName.length > 0
     ? labelName
     : fallback;
+}
+// #2737: mirrors discover-readiness-check.mts's `resolveMarkerPrefix` --
+// `normalizePolicyConfig`/`labelsPolicy` has no `markerPrefix` field, so
+// this reads the raw loaded config directly, same as every other
+// consumer of the top-level `markerPrefix` config key.
+function resolveMarkerPrefix(config) {
+  const prefix = config?.markerPrefix;
+  return typeof prefix === 'string' && prefix.length > 0
+    ? prefix
+    : DEFAULT_MARKER_PREFIX;
 }
 function normalizeRepository(repository) {
   if (!repository || typeof repository !== 'object') {

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -2401,24 +2401,40 @@ export function checkAutonomy(context) {
   // and a hidden authoring-bucket marker, neither of which the label
   // check above reads. Both are mechanical, pre-label signals the
   // issue-authoring contract pairs with that label, so this check must
-  // also honor them. The title-prefix stem is derived from the
-  // configured label's own local name (the part after its `status:`-style
-  // namespace) rather than a hardcoded literal, so a repository that
-  // renames the label keeps both signals in sync.
-  const blockedByHumanStem = blockedByHumanLabelName.includes(':')
+  // also honor them.
+  //
+  // The title-prefix convention itself is the same stable
+  // `blocked-by-human` value the authoring-bucket marker below uses
+  // (AuthoringBucketMarkerValue is a fixed enum, never configurable) --
+  // renaming the GitHub label is a repo-local UI concern and must not
+  // silently change which title prefix an issue author is expected to
+  // write, or a legacy/adopter issue titled `blocked-by-human: ...`
+  // would stop being recognized the moment a repository customizes the
+  // label name, reopening the exact pre-label gap this check exists to
+  // close (#2737 review, Codex). So the canonical stem is always
+  // checked; the configured label's own local name (the part after its
+  // `status:`-style namespace) is checked too, as a secondary alias for
+  // a repository that has already standardized its own title
+  // convention around a renamed label. A label misconfigured to end in
+  // `:` (empty local-name stem) contributes no alias rather than
+  // matching every title (#2737 review, Copilot).
+  const CANONICAL_BLOCKED_BY_HUMAN_STEM = 'blocked-by-human';
+  const configuredStem = blockedByHumanLabelName.includes(':')
     ? blockedByHumanLabelName.slice(
         blockedByHumanLabelName.lastIndexOf(':') + 1,
       )
     : blockedByHumanLabelName;
-  const titlePrefixPattern = new RegExp(
-    `^${escapeRegex(blockedByHumanStem)}:\\s*`,
-    'i',
-  );
-  if (titlePrefixPattern.test(issue.title)) {
-    return {
-      pass: false,
-      evidence: `Title carries the ${blockedByHumanStem}: prefix.`,
-    };
+  const titlePrefixStems = new Set([CANONICAL_BLOCKED_BY_HUMAN_STEM]);
+  if (configuredStem.length > 0) {
+    titlePrefixStems.add(configuredStem);
+  }
+  for (const stem of titlePrefixStems) {
+    if (new RegExp(`^${escapeRegex(stem)}:\\s*`, 'i').test(issue.title)) {
+      return {
+        pass: false,
+        evidence: `Title carries the ${stem}: prefix.`,
+      };
+    }
   }
   const markerPrefix = context.markerPrefix ?? DEFAULT_MARKER_PREFIX;
   const bucketMarker = parseAuthoringBucketMarker(

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -6,7 +6,10 @@
 // the generated .mjs. See docs/typescript-sources.md.
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { parseAuthoringBucketMarker } from './audit-authored-issue.mjs';
+import {
+  normalizeMarkerPrefix,
+  parseAuthoringBucketMarker,
+} from './audit-authored-issue.mjs';
 import { computeBranchName } from './branch-name.mjs';
 import { parseCliArgs } from './cli-args.mjs';
 import {
@@ -2000,10 +2003,7 @@ export function evaluateSuitability(issue, options = {}) {
       options.needsDecisionLabelName,
       POLICY_DEFAULTS.labels.needsDecisionLabelName,
     ),
-    markerPrefix: normalizeConfiguredLabelName(
-      options.markerPrefix,
-      DEFAULT_MARKER_PREFIX,
-    ),
+    markerPrefix: normalizeMarkerPrefix(options.markerPrefix),
     highConfidenceDuplicate: normalizeHighConfidenceDuplicateInput(
       options.highConfidenceDuplicate,
     ),
@@ -3493,10 +3493,7 @@ export function evaluateSuitabilityLocal(bodyText, options = {}) {
       options.needsDecisionLabelName,
       POLICY_DEFAULTS.labels.needsDecisionLabelName,
     ),
-    markerPrefix: normalizeConfiguredLabelName(
-      options.markerPrefix,
-      DEFAULT_MARKER_PREFIX,
-    ),
+    markerPrefix: normalizeMarkerPrefix(options.markerPrefix),
   };
   const checks = CHECKS.map((check) => {
     if (check.id === 'duplicate_or_superseded') {

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -2078,7 +2078,7 @@ function extractHeadings(text: string): Set<string> {
   return headings;
 }
 
-function normalizeMarkerPrefix(prefix: unknown): string {
+export function normalizeMarkerPrefix(prefix: unknown): string {
   // Trim first: a config value or CLI input with accidental leading/
   // trailing whitespace (e.g. "idd-skill ") would otherwise become a
   // distinct prefix that never matches any real marker, producing

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -107,7 +107,7 @@ export type AuthoringBucketMarkerValue = 'needs-decision' | 'blocked-by-human';
  * the two recognized tokens (including a value-less marker with no token
  * at all), or it is repeated with a disagreeing value.
  */
-interface AuthoringBucketMarkerDetection {
+export interface AuthoringBucketMarkerDetection {
   present: boolean;
   value: AuthoringBucketMarkerValue | null;
   malformed: boolean;
@@ -943,7 +943,7 @@ function parseUpstreamCandidateMarker(
  * matches regardless of value, so comparing the two counts recovers the
  * distinction.
  */
-function parseAuthoringBucketMarker(
+export function parseAuthoringBucketMarker(
   text: string,
   markerPrefix: string,
 ): AuthoringBucketMarkerDetection {

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -8,7 +8,10 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-import { parseAuthoringBucketMarker } from './audit-authored-issue.mts';
+import {
+  normalizeMarkerPrefix,
+  parseAuthoringBucketMarker,
+} from './audit-authored-issue.mts';
 import { computeBranchName } from './branch-name.mts';
 import { parseCliArgs } from './cli-args.mts';
 import {
@@ -2220,10 +2223,7 @@ export function evaluateSuitability(
       options.needsDecisionLabelName,
       POLICY_DEFAULTS.labels.needsDecisionLabelName,
     ),
-    markerPrefix: normalizeConfiguredLabelName(
-      options.markerPrefix,
-      DEFAULT_MARKER_PREFIX,
-    ),
+    markerPrefix: normalizeMarkerPrefix(options.markerPrefix),
     highConfidenceDuplicate: normalizeHighConfidenceDuplicateInput(
       options.highConfidenceDuplicate,
     ),
@@ -3816,10 +3816,7 @@ export function evaluateSuitabilityLocal(
       options.needsDecisionLabelName,
       POLICY_DEFAULTS.labels.needsDecisionLabelName,
     ),
-    markerPrefix: normalizeConfiguredLabelName(
-      options.markerPrefix,
-      DEFAULT_MARKER_PREFIX,
-    ),
+    markerPrefix: normalizeMarkerPrefix(options.markerPrefix),
   };
 
   const checks: CheckResult[] = CHECKS.map((check) => {

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -8,6 +8,7 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
+import { parseAuthoringBucketMarker } from './audit-authored-issue.mts';
 import { computeBranchName } from './branch-name.mts';
 import { parseCliArgs } from './cli-args.mts';
 import {
@@ -25,7 +26,9 @@ import {
   getMarkdownCodeRange,
   type MarkdownCodeRange,
   maskMarkdownCodeRegionsPreservingPositions,
+  stripMarkdownCodeRegions,
 } from './markdown-code.mts';
+import { escapeRegex } from './marker-regex.mts';
 import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mts';
 import { resolveTrustedMarkerActors } from './protocol-helpers.mts';
 import {
@@ -92,6 +95,14 @@ interface SuitabilityTriageArgs {
 // marks, so it cannot itself satisfy the scan if the real key is ever
 // renamed -- see #1446's PR description for why that matters.)
 //
+// #2737: the default marker prefix Check 6 (Autonomy) uses to detect an
+// `authoring-bucket: blocked-by-human` marker when the caller does not
+// configure `markerPrefix`. Same TDZ hazard and same fallback value as
+// every other file's own local `DEFAULT_MARKER_PREFIX` constant (see
+// discover-readiness-check.mts, audit-authored-issue.mts, etc.) -- not
+// shared/exported centrally by convention in this codebase.
+const DEFAULT_MARKER_PREFIX = 'idd-skill';
+
 // Declared here, above the import.meta.main trigger below, rather than
 // alongside parseArgs further down: the trigger calls runCli() ->
 // parseArgs() synchronously at module-evaluation time, and a `const`
@@ -144,6 +155,10 @@ interface Context {
   blockedByHumanLabelName?: string;
   /** Configured `labels.needsDecisionLabelName` (#1273). */
   needsDecisionLabelName?: string;
+  /** #2737: configured `markerPrefix`, resolved to `DEFAULT_MARKER_PREFIX`
+   * when absent -- read by Check 6 (Autonomy) to detect an
+   * `authoring-bucket: blocked-by-human` marker. */
+  markerPrefix?: string;
   /** #1484: high-confidence duplicate/superseded mechanical evidence. */
   highConfidenceDuplicate?: HighConfidenceDuplicateInput;
   /**
@@ -186,6 +201,8 @@ interface SuitabilityOptions {
   trustSafetyAmbiguous?: unknown;
   blockedByHumanLabelName?: unknown;
   needsDecisionLabelName?: unknown;
+  /** #2737 */
+  markerPrefix?: unknown;
   /** #1484 */
   highConfidenceDuplicate?: unknown;
   /** #1484 */
@@ -2203,6 +2220,10 @@ export function evaluateSuitability(
       options.needsDecisionLabelName,
       POLICY_DEFAULTS.labels.needsDecisionLabelName,
     ),
+    markerPrefix: normalizeConfiguredLabelName(
+      options.markerPrefix,
+      DEFAULT_MARKER_PREFIX,
+    ),
     highConfidenceDuplicate: normalizeHighConfidenceDuplicateInput(
       options.highConfidenceDuplicate,
     ),
@@ -2602,11 +2623,12 @@ export function checkAutonomy(context: Context): CheckOutcome {
   const { issue } = context;
   const labels = new Set(issue.labels);
   const body = issue.body;
+  const blockedByHumanLabelName = normalizeConfiguredLabelName(
+    context.blockedByHumanLabelName,
+    POLICY_DEFAULTS.labels.blockedByHumanLabelName,
+  );
   const blockedLabels = new Set([
-    normalizeConfiguredLabelName(
-      context.blockedByHumanLabelName,
-      POLICY_DEFAULTS.labels.blockedByHumanLabelName,
-    ),
+    blockedByHumanLabelName,
     normalizeConfiguredLabelName(
       context.needsDecisionLabelName,
       POLICY_DEFAULTS.labels.needsDecisionLabelName,
@@ -2620,6 +2642,49 @@ export function checkAutonomy(context: Context): CheckOutcome {
         evidence: `Blocking label present: ${label}`,
       };
     }
+  }
+
+  // #2737: the configured blockedByHumanLabelName label (default
+  // status:blocked-by-human) can be absent even when the issue is
+  // genuinely human-gated -- issue #2657 mechanically passed all seven
+  // A4.5 checks while still carrying a `blocked-by-human:` title prefix
+  // and a hidden authoring-bucket marker, neither of which the label
+  // check above reads. Both are mechanical, pre-label signals the
+  // issue-authoring contract pairs with that label, so this check must
+  // also honor them. The title-prefix stem is derived from the
+  // configured label's own local name (the part after its `status:`-style
+  // namespace) rather than a hardcoded literal, so a repository that
+  // renames the label keeps both signals in sync.
+  const blockedByHumanStem = blockedByHumanLabelName.includes(':')
+    ? blockedByHumanLabelName.slice(
+        blockedByHumanLabelName.lastIndexOf(':') + 1,
+      )
+    : blockedByHumanLabelName;
+  const titlePrefixPattern = new RegExp(
+    `^${escapeRegex(blockedByHumanStem)}:\\s*`,
+    'i',
+  );
+  if (titlePrefixPattern.test(issue.title)) {
+    return {
+      pass: false,
+      evidence: `Title carries the ${blockedByHumanStem}: prefix.`,
+    };
+  }
+
+  const markerPrefix = context.markerPrefix ?? DEFAULT_MARKER_PREFIX;
+  const bucketMarker = parseAuthoringBucketMarker(
+    stripMarkdownCodeRegions(body),
+    markerPrefix,
+  );
+  if (
+    bucketMarker.present &&
+    !bucketMarker.malformed &&
+    bucketMarker.value === 'blocked-by-human'
+  ) {
+    return {
+      pass: false,
+      evidence: `<!-- ${markerPrefix}-authoring-bucket: blocked-by-human --> marker present.`,
+    };
   }
 
   // #2219: an either/or acceptance-criterion shape naming two mutually
@@ -3624,6 +3689,7 @@ function runCli(): void {
     duplicateCandidates,
     blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
     needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
+    markerPrefix: resolveMarkerPrefix(policyConfig),
     highConfidenceDuplicate,
     highConfidenceCollectionDegraded: collectionWarnings.length > 0,
   });
@@ -3671,6 +3737,7 @@ interface LocalSuitabilityResult {
 interface LocalSuitabilityOptions {
   blockedByHumanLabelName?: string;
   needsDecisionLabelName?: string;
+  markerPrefix?: string;
 }
 
 /**
@@ -3733,6 +3800,10 @@ export function evaluateSuitabilityLocal(
       options.needsDecisionLabelName,
       POLICY_DEFAULTS.labels.needsDecisionLabelName,
     ),
+    markerPrefix: normalizeConfiguredLabelName(
+      options.markerPrefix,
+      DEFAULT_MARKER_PREFIX,
+    ),
   };
 
   const checks: CheckResult[] = CHECKS.map((check) => {
@@ -3768,6 +3839,7 @@ function runLocalCli(args: SuitabilityTriageArgs): void {
   const result = evaluateSuitabilityLocal(bodyText, {
     blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
     needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
+    markerPrefix: resolveMarkerPrefix(policyConfig),
   });
 
   const output = {
@@ -4155,6 +4227,17 @@ function normalizeConfiguredLabelName(
   return typeof labelName === 'string' && labelName.length > 0
     ? labelName
     : fallback;
+}
+
+// #2737: mirrors discover-readiness-check.mts's `resolveMarkerPrefix` --
+// `normalizePolicyConfig`/`labelsPolicy` has no `markerPrefix` field, so
+// this reads the raw loaded config directly, same as every other
+// consumer of the top-level `markerPrefix` config key.
+function resolveMarkerPrefix(config: unknown): string {
+  const prefix = (config as { markerPrefix?: unknown } | null)?.markerPrefix;
+  return typeof prefix === 'string' && prefix.length > 0
+    ? prefix
+    : DEFAULT_MARKER_PREFIX;
 }
 
 function normalizeRepository(repository: unknown): Repository | null {

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -29,7 +29,6 @@ import {
   getMarkdownCodeRange,
   type MarkdownCodeRange,
   maskMarkdownCodeRegionsPreservingPositions,
-  stripMarkdownCodeRegions,
 } from './markdown-code.mts';
 import { escapeRegex } from './marker-regex.mts';
 import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mts';
@@ -2691,8 +2690,32 @@ export function checkAutonomy(context: Context): CheckOutcome {
   // directly with a raw Context (including in tests) -- normalize here too
   // rather than relying solely on the Context-construction call sites.
   const markerPrefix = normalizeMarkerPrefix(context.markerPrefix);
+  // #2761 review (Codex): a naive fenced/inline-only mask (the earlier
+  // `stripMarkdownCodeRegions(body)`) leaves an indented (4-space) code
+  // block untouched, so a documentation example written that way is
+  // wrongly treated as a real marker. It also has no notion of an HTML
+  // comment boundary at all, so it cannot distinguish a genuine marker from
+  // a backslash-escaped `\<!--` opener (literal text, not a real comment)
+  // or correctly recover a genuine marker sitting between backslash-escaped
+  // backticks (`` \` <!-- ... --> \` ``, which `findInlineCodeRanges`
+  // itself already treats as not forming a real inline code span, unlike
+  // the plain regex behind `stripMarkdownCodeRegions`). Scanning only the
+  // real (non-code-example, non-escaped) HTML comment ranges --
+  // `findHtmlCommentRanges`'s own established fenced/indented/inline
+  // code-example exclusion and escaped-opener handling, already used the
+  // same way elsewhere in this function (the objective-criteria
+  // `fenceMaskedBody` scan below) and in checkVerifiability's
+  // `hasSubjectiveApproval` scan -- gets all three right at once.
+  const codeRangesForAutonomy = findMarkdownCodeRanges(body);
+  const commentRangesForAutonomy = findHtmlCommentRanges(
+    body,
+    codeRangesForAutonomy,
+  );
+  const authoringBucketScanText = commentRangesForAutonomy
+    .map((range) => body.slice(range.start, range.end))
+    .join('\n');
   const bucketMarker = parseAuthoringBucketMarker(
-    stripMarkdownCodeRegions(body),
+    authoringBucketScanText,
     markerPrefix,
   );
   if (

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -2651,24 +2651,40 @@ export function checkAutonomy(context: Context): CheckOutcome {
   // and a hidden authoring-bucket marker, neither of which the label
   // check above reads. Both are mechanical, pre-label signals the
   // issue-authoring contract pairs with that label, so this check must
-  // also honor them. The title-prefix stem is derived from the
-  // configured label's own local name (the part after its `status:`-style
-  // namespace) rather than a hardcoded literal, so a repository that
-  // renames the label keeps both signals in sync.
-  const blockedByHumanStem = blockedByHumanLabelName.includes(':')
+  // also honor them.
+  //
+  // The title-prefix convention itself is the same stable
+  // `blocked-by-human` value the authoring-bucket marker below uses
+  // (AuthoringBucketMarkerValue is a fixed enum, never configurable) --
+  // renaming the GitHub label is a repo-local UI concern and must not
+  // silently change which title prefix an issue author is expected to
+  // write, or a legacy/adopter issue titled `blocked-by-human: ...`
+  // would stop being recognized the moment a repository customizes the
+  // label name, reopening the exact pre-label gap this check exists to
+  // close (#2737 review, Codex). So the canonical stem is always
+  // checked; the configured label's own local name (the part after its
+  // `status:`-style namespace) is checked too, as a secondary alias for
+  // a repository that has already standardized its own title
+  // convention around a renamed label. A label misconfigured to end in
+  // `:` (empty local-name stem) contributes no alias rather than
+  // matching every title (#2737 review, Copilot).
+  const CANONICAL_BLOCKED_BY_HUMAN_STEM = 'blocked-by-human';
+  const configuredStem = blockedByHumanLabelName.includes(':')
     ? blockedByHumanLabelName.slice(
         blockedByHumanLabelName.lastIndexOf(':') + 1,
       )
     : blockedByHumanLabelName;
-  const titlePrefixPattern = new RegExp(
-    `^${escapeRegex(blockedByHumanStem)}:\\s*`,
-    'i',
-  );
-  if (titlePrefixPattern.test(issue.title)) {
-    return {
-      pass: false,
-      evidence: `Title carries the ${blockedByHumanStem}: prefix.`,
-    };
+  const titlePrefixStems = new Set([CANONICAL_BLOCKED_BY_HUMAN_STEM]);
+  if (configuredStem.length > 0) {
+    titlePrefixStems.add(configuredStem);
+  }
+  for (const stem of titlePrefixStems) {
+    if (new RegExp(`^${escapeRegex(stem)}:\\s*`, 'i').test(issue.title)) {
+      return {
+        pass: false,
+        evidence: `Title carries the ${stem}: prefix.`,
+      };
+    }
   }
 
   const markerPrefix = context.markerPrefix ?? DEFAULT_MARKER_PREFIX;

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -2687,7 +2687,10 @@ export function checkAutonomy(context: Context): CheckOutcome {
     }
   }
 
-  const markerPrefix = context.markerPrefix ?? DEFAULT_MARKER_PREFIX;
+  // #2737 review, Copilot: checkAutonomy is itself exported and called
+  // directly with a raw Context (including in tests) -- normalize here too
+  // rather than relying solely on the Context-construction call sites.
+  const markerPrefix = normalizeMarkerPrefix(context.markerPrefix);
   const bucketMarker = parseAuthoringBucketMarker(
     stripMarkdownCodeRegions(body),
     markerPrefix,

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -6142,6 +6142,36 @@ test('evaluateSuitabilityLocal reports duplicate_or_superseded as not_evaluated 
   );
 });
 
+test('evaluateSuitabilityLocal trims whitespace from a configured markerPrefix before matching (#2761 review, Copilot)', () => {
+  const draftWithMarker = `# feat: add deterministic helper
+
+<!-- idd-skill-authoring-bucket: blocked-by-human -->
+
+## Purpose
+Add a deterministic helper function.
+
+## Scope
+Implement helper behavior in a single file.
+
+## Acceptance Criteria
+- [ ] tests pass
+- [ ] lint passes
+`;
+
+  // An untrimmed prefix (accidental leading/trailing whitespace in config)
+  // must still resolve to the same "idd-skill" prefix as the trimmed form,
+  // not silently fail to match every real marker.
+  const result = evaluateSuitabilityLocal(draftWithMarker, {
+    markerPrefix: '  idd-skill  ',
+  });
+  const autonomyCheck = result.checks.find((check) => check.id === 'autonomy');
+  assert.equal(autonomyCheck?.result, 'fail');
+  assert.match(
+    autonomyCheck?.evidence ?? '',
+    /authoring-bucket: blocked-by-human/,
+  );
+});
+
 test('evaluateSuitabilityLocal honors configured blocked/needs-decision label names (moot for labels, but exercised for parity)', () => {
   // The synthetic local issue always has an empty labels array, so a
   // configured blockedByHumanLabelName can never match -- this just

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -4895,6 +4895,128 @@ test('checkAutonomy resolves configured blocked-label names (#1273)', () => {
   );
 });
 
+// --- #2737: title-prefix and authoring-bucket marker signals ---
+
+test('checkAutonomy fails on a blocked-by-human: title prefix even without the configured label', () => {
+  const result = checkAutonomy({
+    issue: {
+      ...BASE_ISSUE,
+      title: 'blocked-by-human: needs a maintainer decision',
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+  assert.match(result.evidence, /blocked-by-human: prefix/);
+});
+
+test('checkAutonomy title-prefix match is case-insensitive and tolerates extra whitespace after the colon', () => {
+  const result = checkAutonomy({
+    issue: {
+      ...BASE_ISSUE,
+      title: 'Blocked-By-Human:    needs a maintainer decision',
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
+test('checkAutonomy title-prefix stem follows a reconfigured blockedByHumanLabelName', () => {
+  // Default stem ("blocked-by-human") no longer matches once the label
+  // is reconfigured to a different local name.
+  assert.equal(
+    checkAutonomy({
+      issue: {
+        ...BASE_ISSUE,
+        title: 'blocked-by-human: needs a maintainer decision',
+      },
+      blockedByHumanLabelName: 'triage:human-gate',
+    } as Context).pass,
+    true,
+  );
+
+  // The reconfigured stem ("human-gate") matches instead.
+  assert.equal(
+    checkAutonomy({
+      issue: {
+        ...BASE_ISSUE,
+        title: 'human-gate: needs a maintainer decision',
+      },
+      blockedByHumanLabelName: 'triage:human-gate',
+    } as Context).pass,
+    false,
+  );
+});
+
+test('checkAutonomy does not false-positive on a title merely containing "blocked-by-human" mid-sentence', () => {
+  const result = checkAutonomy({
+    issue: {
+      ...BASE_ISSUE,
+      title: 'fix: the blocked-by-human label check has a gap',
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('checkAutonomy fails on a well-formed authoring-bucket: blocked-by-human marker', () => {
+  const result = checkAutonomy({
+    issue: {
+      ...BASE_ISSUE,
+      body: `<!-- idd-skill-authoring-bucket: blocked-by-human -->\n\n${BASE_ISSUE.body}`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+  assert.match(result.evidence, /authoring-bucket: blocked-by-human/);
+});
+
+test('checkAutonomy authoring-bucket marker check honors a configured markerPrefix', () => {
+  assert.equal(
+    checkAutonomy({
+      issue: {
+        ...BASE_ISSUE,
+        body: `<!-- custom-authoring-bucket: blocked-by-human -->\n\n${BASE_ISSUE.body}`,
+      },
+    } as Context).pass,
+    true,
+    'the default idd-skill prefix must not match a custom-prefixed marker',
+  );
+
+  assert.equal(
+    checkAutonomy({
+      issue: {
+        ...BASE_ISSUE,
+        body: `<!-- custom-authoring-bucket: blocked-by-human -->\n\n${BASE_ISSUE.body}`,
+      },
+      markerPrefix: 'custom',
+    } as Context).pass,
+    false,
+  );
+});
+
+test('checkAutonomy passes an authoring-bucket: needs-decision marker (Autonomy is blocked-by-human-specific)', () => {
+  const result = checkAutonomy({
+    issue: {
+      ...BASE_ISSUE,
+      body: `<!-- idd-skill-authoring-bucket: needs-decision -->\n\n${BASE_ISSUE.body}`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('checkAutonomy passes a malformed authoring-bucket marker (fail-safe: no bucket, not blocked-by-human)', () => {
+  const result = checkAutonomy({
+    issue: {
+      ...BASE_ISSUE,
+      body: `<!-- idd-skill-authoring-bucket: not-a-real-value -->\n\n${BASE_ISSUE.body}`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('checkAutonomy passes a body/title with none of the three blocked-by-human signals', () => {
+  const result = checkAutonomy({
+    issue: BASE_ISSUE,
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
 test('evaluateSuitability threads configured blocked-label options through to Autonomy', () => {
   const result = evaluateSuitability(
     { ...BASE_ISSUE, labels: ['triage:needs-call'] },

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -5034,6 +5034,21 @@ test('checkAutonomy authoring-bucket marker check honors a configured markerPref
   );
 });
 
+test('checkAutonomy trims a whitespace-padded markerPrefix when called directly with a raw Context (#2761 review, Copilot)', () => {
+  // checkAutonomy is itself exported and directly callable with a raw
+  // Context (as every test here does) -- it must not rely solely on
+  // evaluateSuitability/evaluateSuitabilityLocal's own trimming.
+  const result = checkAutonomy({
+    issue: {
+      ...BASE_ISSUE,
+      body: `<!-- idd-skill-authoring-bucket: blocked-by-human -->\n\n${BASE_ISSUE.body}`,
+    },
+    markerPrefix: '  idd-skill  ',
+  } as Context);
+  assert.equal(result.pass, false);
+  assert.match(result.evidence, /authoring-bucket: blocked-by-human/);
+});
+
 test('checkAutonomy passes an authoring-bucket: needs-decision marker (Autonomy is blocked-by-human-specific)', () => {
   const result = checkAutonomy({
     issue: {

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -5069,6 +5069,40 @@ test('checkAutonomy passes a malformed authoring-bucket marker (fail-safe: no bu
   assert.equal(result.pass, true);
 });
 
+test('checkAutonomy ignores an authoring-bucket marker documented inside an indented code block (#2761 review, Codex)', () => {
+  const result = checkAutonomy({
+    issue: {
+      ...BASE_ISSUE,
+      body:
+        'Document the marker syntax:\n\n' +
+        '    <!-- idd-skill-authoring-bucket: blocked-by-human -->\n\n' +
+        BASE_ISSUE.body,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('checkAutonomy ignores a backslash-escaped authoring-bucket marker opener (#2761 review, Codex)', () => {
+  const result = checkAutonomy({
+    issue: {
+      ...BASE_ISSUE,
+      body: `Document the literal syntax: \\<!-- idd-skill-authoring-bucket: blocked-by-human -->\n\n${BASE_ISSUE.body}`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('checkAutonomy still detects a genuine authoring-bucket marker sitting between escaped backticks (#2761 review, Codex)', () => {
+  const result = checkAutonomy({
+    issue: {
+      ...BASE_ISSUE,
+      body: `\\\`<!-- idd-skill-authoring-bucket: blocked-by-human -->\\\`\n\n${BASE_ISSUE.body}`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+  assert.match(result.evidence, /authoring-bucket: blocked-by-human/);
+});
+
 test('checkAutonomy passes a body/title with none of the three blocked-by-human signals', () => {
   const result = checkAutonomy({
     issue: BASE_ISSUE,

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -4918,9 +4918,11 @@ test('checkAutonomy title-prefix match is case-insensitive and tolerates extra w
   assert.equal(result.pass, false);
 });
 
-test('checkAutonomy title-prefix stem follows a reconfigured blockedByHumanLabelName', () => {
-  // Default stem ("blocked-by-human") no longer matches once the label
-  // is reconfigured to a different local name.
+test('checkAutonomy title-prefix check recognizes both the canonical stem and a reconfigured blockedByHumanLabelName as aliases (#2737 review, Codex)', () => {
+  // The canonical "blocked-by-human:" stem always matches -- it is the
+  // stable authoring-bucket contract value, not the configurable label
+  // name, so a legacy/adopter issue keeps being recognized even after
+  // the label is renamed.
   assert.equal(
     checkAutonomy({
       issue: {
@@ -4929,10 +4931,12 @@ test('checkAutonomy title-prefix stem follows a reconfigured blockedByHumanLabel
       },
       blockedByHumanLabelName: 'triage:human-gate',
     } as Context).pass,
-    true,
+    false,
   );
 
-  // The reconfigured stem ("human-gate") matches instead.
+  // The reconfigured stem ("human-gate") also matches, as a secondary
+  // alias for a repository that standardized its own title convention
+  // around the renamed label.
   assert.equal(
     checkAutonomy({
       issue: {
@@ -4940,6 +4944,46 @@ test('checkAutonomy title-prefix stem follows a reconfigured blockedByHumanLabel
         title: 'human-gate: needs a maintainer decision',
       },
       blockedByHumanLabelName: 'triage:human-gate',
+    } as Context).pass,
+    false,
+  );
+
+  // An unrelated title matches neither stem.
+  assert.equal(
+    checkAutonomy({
+      issue: {
+        ...BASE_ISSUE,
+        title: 'feat: add deterministic helper',
+      },
+      blockedByHumanLabelName: 'triage:human-gate',
+    } as Context).pass,
+    true,
+  );
+});
+
+test('checkAutonomy title-prefix check tolerates a misconfigured label ending in ":" (empty alias stem contributes no match, #2737 review, Copilot)', () => {
+  // The empty alias is never added to the stem set, so only the
+  // canonical "blocked-by-human:" stem is checked -- a title that
+  // merely starts with a bare colon must not be flagged.
+  assert.equal(
+    checkAutonomy({
+      issue: {
+        ...BASE_ISSUE,
+        title: ': needs a maintainer decision',
+      },
+      blockedByHumanLabelName: 'status:',
+    } as Context).pass,
+    true,
+  );
+
+  // The canonical stem still fires even under the same misconfiguration.
+  assert.equal(
+    checkAutonomy({
+      issue: {
+        ...BASE_ISSUE,
+        title: 'blocked-by-human: needs a maintainer decision',
+      },
+      blockedByHumanLabelName: 'status:',
     } as Context).pass,
     false,
   );


### PR DESCRIPTION
# Summary

`checkAutonomy` (A4.5 Check 6) only failed on the configured blocking
label (default `status:blocked-by-human` / `status:needs-decision`).
Issue #2657 mechanically passed all seven A4.5 checks while still
carrying a `blocked-by-human:` title prefix and a hidden
`authoring-bucket: blocked-by-human` marker, neither of which the
label check reads — both are mechanical, pre-label signals the
issue-authoring contract pairs with that label.

Adds two checks between the label check and the existing either/or
scan:

- A `blocked-by-human:` title prefix (ASCII, case-insensitive,
  optional whitespace after the colon), derived from the configured
  `blockedByHumanLabelName`'s own local-name stem (the part after its
  `status:`-style namespace) so a renamed label keeps both signals in
  sync.
- A well-formed `<!-- {markerPrefix}-authoring-bucket:
  blocked-by-human -->` body marker, parsed with
  `parseAuthoringBucketMarker` (now exported from
  `audit-authored-issue.mts`) rather than a one-off regex. Threads a
  new `Context.markerPrefix` through `evaluateSuitability`/
  `evaluateSuitabilityLocal`, resolved from the loaded policy config
  the same way `discover-readiness-check.mts` already does.

An independent critique pass (agent) traced the diff end-to-end
(stem derivation, regex correctness, marker parsing, `markerPrefix`
threading through both the live and local/dry-run CLI paths, test
coverage) and found no High/Medium issues — only two Low nitpicks
(an edge-case empty stem when the configured label ends in `:`, and a
redundant guard clause), both explicitly noted as harmless.

## Linked issue

Closes #2737

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

See the issue body's own "Background" section for the #2657
reproduction this closes.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDJpTELrY2SnjHW9m5Aw7i
