### PR TITLE
docs(lite): fix idd-review-snapshot-lite's inverted F3 digest carve-out

### DIFF
--- a/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
@@ -173,9 +173,9 @@ different-claim watermark here.
 
 Do not create or edit the PR live status digest after posting this
 watermark unless the next route is back to E1, an F3 blocked reroute
-that returns to F2's restart path, a hold/stop, or post-merge cleanup —
-a digest edit after the watermark counts as new activity and forces a
-fresh E1 snapshot before F2 can pass.
+that leaves the F2 restart path (F1/D4), a hold/stop, or post-merge
+cleanup — a digest edit after the watermark counts as new activity and
+forces a fresh E1 snapshot before F2 can pass.
 
 ### Step 3 — Filter into ReviewItems_snapshot
 

--- a/idd-template/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
@@ -168,9 +168,9 @@ different-claim watermark here.
 
 Do not create or edit the PR live status digest after posting this
 watermark unless the next route is back to E1, an F3 blocked reroute
-that returns to F2's restart path, a hold/stop, or post-merge cleanup —
-a digest edit after the watermark counts as new activity and forces a
-fresh E1 snapshot before F2 can pass.
+that leaves the F2 restart path (F1/D4), a hold/stop, or post-merge
+cleanup — a digest edit after the watermark counts as new activity and
+forces a fresh E1 snapshot before F2 can pass.
 
 ### Step 3 — Filter into ReviewItems_snapshot
 


### PR DESCRIPTION
# Summary

`.github/instructions/lite/idd-review-snapshot-lite.instructions.md`
Step 2's digest carve-out said not to touch the PR live status digest
unless the next route "returns to F2's restart path" — the opposite of
what the standard file it condenses
(`idd-review-snapshot.instructions.md`), `idd-merge.instructions.md`
F3, and `idd-overview-appendix.instructions.md` all say: a blocked F3
reroute that **leaves** the F2 restart path (F1/D4) must not touch the
digest, since a digest edit is PR activity that would invalidate the
review currency the restarted F2 pass is about to check. A lite-profile
session following its own file edits the digest on exactly the path
where that edit self-invalidates the next gate.

Replaces "returns to F2's restart path" with the standard file's
"leaves the F2 restart path (F1/D4)" in the canonical
`idd-template/` source, then syncs the generated
`.github/instructions/lite/` copy to match via
`node scripts/sync-docs.mjs --apply`.

## Linked issue

Closes #2771

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

n/a — the issue body already cites the exact conflicting line ranges in
both the lite and standard files.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EycqtGKuWjJMpw2tUav3Tn
