### PR TITLE
docs(issue-authoring): anchor today phrasing, resolve dangling ref

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -697,7 +697,8 @@ Validation expectations:
 - the issue stays discoverable under the target repository's
   `issue-scope` setting
 - exactly one autopilot-suitability footer with an integer 1-5
-  marker; a score of `1` carries `status:blocked-by-human`, unless an
+  marker; a score of `1` carries the configured `blocked-by-human` label
+  (default `status:blocked-by-human`), unless an
   `authoring-bucket: needs-decision` marker substitutes the configured
   needs-decision label instead (see
   [Authoring-bucket marker](#authoring-bucket-marker))
@@ -729,7 +730,8 @@ Validation expectations:
 - nested roadmap entries stay identifiable as coordination/audit nodes
   instead of normal execution leaves
 - exactly one autopilot-suitability footer with an integer 1-5
-  marker; a score of `1` carries `status:blocked-by-human`, unless an
+  marker; a score of `1` carries the configured `blocked-by-human` label
+  (default `status:blocked-by-human`), unless an
   `authoring-bucket: needs-decision` marker substitutes the configured
   needs-decision label instead (see
   [Authoring-bucket marker](#authoring-bucket-marker))
@@ -764,7 +766,8 @@ Validation expectations:
   justified
 - the issue can be claimed independently without absorbing sibling work
 - exactly one autopilot-suitability footer with an integer 1-5
-  marker; a score of `1` carries `status:blocked-by-human`, unless an
+  marker; a score of `1` carries the configured `blocked-by-human` label
+  (default `status:blocked-by-human`), unless an
   `authoring-bucket: needs-decision` marker substitutes the configured
   needs-decision label instead (see
   [Authoring-bucket marker](#authoring-bucket-marker))

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -697,8 +697,9 @@ Validation expectations:
 - the issue stays discoverable under the target repository's
   `issue-scope` setting
 - exactly one autopilot-suitability footer with an integer 1-5
-  marker; a score of `1` carries `status:blocked-by-human` unless an
-  `authoring-bucket: needs-decision` marker exempts it (see
+  marker; a score of `1` carries `status:blocked-by-human`, unless an
+  `authoring-bucket: needs-decision` marker substitutes the configured
+  needs-decision label instead (see
   [Authoring-bucket marker](#authoring-bucket-marker))
 - passes the `audit-authored-issue` mechanical pre-publish gate for the
   `orphan` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
@@ -728,8 +729,9 @@ Validation expectations:
 - nested roadmap entries stay identifiable as coordination/audit nodes
   instead of normal execution leaves
 - exactly one autopilot-suitability footer with an integer 1-5
-  marker; a score of `1` carries `status:blocked-by-human` unless an
-  `authoring-bucket: needs-decision` marker exempts it (see
+  marker; a score of `1` carries `status:blocked-by-human`, unless an
+  `authoring-bucket: needs-decision` marker substitutes the configured
+  needs-decision label instead (see
   [Authoring-bucket marker](#authoring-bucket-marker))
 - passes the `audit-authored-issue` mechanical pre-publish gate for the
   `roadmap` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
@@ -762,8 +764,9 @@ Validation expectations:
   justified
 - the issue can be claimed independently without absorbing sibling work
 - exactly one autopilot-suitability footer with an integer 1-5
-  marker; a score of `1` carries `status:blocked-by-human` unless an
-  `authoring-bucket: needs-decision` marker exempts it (see
+  marker; a score of `1` carries `status:blocked-by-human`, unless an
+  `authoring-bucket: needs-decision` marker substitutes the configured
+  needs-decision label instead (see
   [Authoring-bucket marker](#authoring-bucket-marker))
 - passes the `audit-authored-issue` mechanical pre-publish gate for the
   `child` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -697,7 +697,9 @@ Validation expectations:
 - the issue stays discoverable under the target repository's
   `issue-scope` setting
 - exactly one autopilot-suitability footer with an integer 1-5
-  marker; a score of `1` also carries `status:blocked-by-human`
+  marker; a score of `1` carries `status:blocked-by-human` unless an
+  `authoring-bucket: needs-decision` marker exempts it (see
+  [Authoring-bucket marker](#authoring-bucket-marker))
 - passes the `audit-authored-issue` mechanical pre-publish gate for the
   `orphan` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
 
@@ -726,7 +728,9 @@ Validation expectations:
 - nested roadmap entries stay identifiable as coordination/audit nodes
   instead of normal execution leaves
 - exactly one autopilot-suitability footer with an integer 1-5
-  marker; a score of `1` also carries `status:blocked-by-human`
+  marker; a score of `1` carries `status:blocked-by-human` unless an
+  `authoring-bucket: needs-decision` marker exempts it (see
+  [Authoring-bucket marker](#authoring-bucket-marker))
 - passes the `audit-authored-issue` mechanical pre-publish gate for the
   `roadmap` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
 
@@ -758,7 +762,9 @@ Validation expectations:
   justified
 - the issue can be claimed independently without absorbing sibling work
 - exactly one autopilot-suitability footer with an integer 1-5
-  marker; a score of `1` also carries `status:blocked-by-human`
+  marker; a score of `1` carries `status:blocked-by-human` unless an
+  `authoring-bucket: needs-decision` marker exempts it (see
+  [Authoring-bucket marker](#authoring-bucket-marker))
 - passes the `audit-authored-issue` mechanical pre-publish gate for the
   `child` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
 
@@ -774,8 +780,7 @@ A drafted issue's human-readable prose sections — `## Background` (or
   drafted prose use that language.
 - The literal `match-source` matches the operator's live conversational
   language during an interactive/hearing issue-authoring session.
-- An absent field defaults to English, codifying today's actual
-  emergent behavior.
+- An absent field defaults to English.
 
 See `docs/customization.md`'s Authoring Language section for the full
 field definition.
@@ -927,8 +932,9 @@ can never match. A nested/child list item's reference is evaluated
 together with its full ancestor chain's coordination-language text
 instead of being scoped away from it, while a sibling bullet at the same
 indentation — nested or top-level — still starts its own separate scope,
-preserving the tight-list sentence-conflation fix mentioned above. This
-holds for every nested child under a given parent, at any depth — not
+so a tight list (no blank line between sibling items) never reads two
+consecutive bullets' coordination language as one continuous sentence.
+This holds for every nested child under a given parent, at any depth — not
 only the first. A continuation line resuming at an ancestor's own
 indentation, after a deeper child has already opened, is attributed to
 that ancestor rather than the deepest open child. A loose list (a blank
@@ -1110,9 +1116,9 @@ Binding rules:
   gates, and a large (`L`) issue stays fully claimable when it is the only
   ready work.
 - **Fail-safe on absence.** A missing, non-`S|M|L`, or conflicting
-  marker means "no effort hint": selection behaves exactly as it does
-  today (a missing hint sorts as the neutral middle, as-if `M`).
-  Pre-existing issues with no effort footer keep flowing.
+  marker means "no effort hint": it sorts as the neutral middle, as-if
+  `M`, per `idd-discover.instructions.md` A4 Step 2. Pre-existing issues
+  with no effort footer keep flowing.
 
 Backfill is opportunistic and follows the same claim-state precondition
 as the suitability footer.
@@ -1137,8 +1143,8 @@ published before this marker existed.
 
 Binding rules:
 
-- **Two axes only.** Scoped to the two buckets with a real behavioral
-  consequence today (a required label) — `deferred` and `out-of-scope`
+- **Two axes only.** Scoped to the two buckets that require a label
+  (`needs-decision`, `blocked-by-human`) — `deferred` and `out-of-scope`
   have none, so they carry no marker.
 - **Folds the existing suitability-1 check.** When present, this marker
   decides `suitability-blocked-by-human`'s applicability instead of the

--- a/.claude/skills/issue-authoring/references/draft-patterns.md
+++ b/.claude/skills/issue-authoring/references/draft-patterns.md
@@ -145,7 +145,7 @@ that a suitability score of `1` carries the configured
 `blocked-by-human` label (default `status:blocked-by-human`), unless an
 `authoring-bucket: needs-decision` marker substitutes the configured
 needs-decision label instead (see
-[Authoring-bucket marker](https://github.com/kurone-kito/idd-skill/blob/main/skills/issue-authoring/references/contract.md#authoring-bucket-marker));
+[Authoring-bucket marker](contract.md#authoring-bucket-marker));
 use `--config <path>` to point at a policy that overrides the label
 name — this check is also one-directional, it does not flag the
 reverse, a non-`1` score paired with the label. Fix every reported

--- a/.claude/skills/issue-authoring/references/draft-patterns.md
+++ b/.claude/skills/issue-authoring/references/draft-patterns.md
@@ -142,12 +142,15 @@ Use `--shape roadmap` or `--shape child` for those shapes, `--stdin`
 instead of `--body-file` when the draft is not yet on disk, and
 `--label <name>` (repeatable) to pass proposed labels for the check
 that a suitability score of `1` carries the configured
-`blocked-by-human` label (default `status:blocked-by-human`; use
-`--config <path>` to point at a policy that overrides the label name —
-this check is also one-directional, it does not flag the reverse, a
-non-`1` score paired with the label). Fix every reported finding and
-re-run before publishing; a `passed: false` report means the draft is
-not ready yet, regardless of how complete the narrative reads.
+`blocked-by-human` label (default `status:blocked-by-human`) unless an
+`authoring-bucket: needs-decision` marker exempts it (see
+[Authoring-bucket marker](https://github.com/kurone-kito/idd-skill/blob/main/skills/issue-authoring/references/contract.md#authoring-bucket-marker));
+use `--config <path>` to point at a policy that overrides the label
+name — this check is also one-directional, it does not flag the
+reverse, a non-`1` score paired with the label. Fix every reported
+finding and re-run before publishing; a `passed: false` report means
+the draft is not ready yet, regardless of how complete the narrative
+reads.
 
 **No helper runtime available (`instructions-only` profile):** the
 linter cannot run. `instructions-only` is a first-class supported

--- a/.claude/skills/issue-authoring/references/draft-patterns.md
+++ b/.claude/skills/issue-authoring/references/draft-patterns.md
@@ -142,8 +142,9 @@ Use `--shape roadmap` or `--shape child` for those shapes, `--stdin`
 instead of `--body-file` when the draft is not yet on disk, and
 `--label <name>` (repeatable) to pass proposed labels for the check
 that a suitability score of `1` carries the configured
-`blocked-by-human` label (default `status:blocked-by-human`) unless an
-`authoring-bucket: needs-decision` marker exempts it (see
+`blocked-by-human` label (default `status:blocked-by-human`), unless an
+`authoring-bucket: needs-decision` marker substitutes the configured
+needs-decision label instead (see
 [Authoring-bucket marker](https://github.com/kurone-kito/idd-skill/blob/main/skills/issue-authoring/references/contract.md#authoring-bucket-marker));
 use `--config <path>` to point at a policy that overrides the label
 name — this check is also one-directional, it does not flag the

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -198,8 +198,8 @@ rules.
   lowest-issue-number tie-break); it never skips, gates, crosses a score
   band, or bypasses the A4.5/A5 gates, and a large issue stays claimable
   when it is the only ready work.
-- A missing or invalid hint is **fail-safe**: selection behaves exactly
-  as today (a missing hint sorts as the neutral middle, as-if `M`).
+- A missing or invalid hint is **fail-safe**: it sorts as the neutral
+  middle, as-if `M`, per `idd-discover.instructions.md` A4 Step 2.
 
 ### Authoring-bucket marker
 
@@ -216,8 +216,9 @@ the
 [Authoring-bucket marker](https://github.com/kurone-kito/idd-skill/blob/main/skills/issue-authoring/references/contract.md#authoring-bucket-marker)
 section of the contract for the binding rules.
 
-- Scoped to the two buckets with a real behavioral consequence today;
-  `ready`, `deferred`, and `out-of-scope` carry no marker.
+- Scoped to the two buckets that require a label (`needs-decision`,
+  `blocked-by-human`); `ready`, `deferred`, and `out-of-scope` carry no
+  marker.
 - When present, it decides the suitability-1/`blocked-by-human` check's
   applicability instead of the score; absent or malformed, that check
   falls back to its pre-existing suitability-1-only rule (no backfill
@@ -1451,7 +1452,9 @@ Validation expectations:
   the draft includes a post-publication maintainer approval step after
   the final title, body, and generated plan are stable
 - exactly one autopilot-suitability footer with an integer 1-5 marker; a
-  score of `1` also carries `status:blocked-by-human`
+  score of `1` carries `status:blocked-by-human` unless an
+  `authoring-bucket: needs-decision` marker exempts it (see
+  [Authoring-bucket marker](https://github.com/kurone-kito/idd-skill/blob/main/skills/issue-authoring/references/contract.md#authoring-bucket-marker))
 - passes the `audit-authored-issue` mechanical pre-publish gate for the
   `orphan` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
 
@@ -1495,7 +1498,9 @@ Validation expectations:
 - the roadmap can survive multi-session handoffs without relying on
   private session memory
 - exactly one autopilot-suitability footer with an integer 1-5 marker; a
-  score of `1` also carries `status:blocked-by-human`
+  score of `1` carries `status:blocked-by-human` unless an
+  `authoring-bucket: needs-decision` marker exempts it (see
+  [Authoring-bucket marker](https://github.com/kurone-kito/idd-skill/blob/main/skills/issue-authoring/references/contract.md#authoring-bucket-marker))
 - passes the `audit-authored-issue` mechanical pre-publish gate for the
   `roadmap` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
 
@@ -1533,7 +1538,9 @@ Validation expectations:
   justified
 - the issue can be claimed independently without absorbing sibling work
 - exactly one autopilot-suitability footer with an integer 1-5 marker; a
-  score of `1` also carries `status:blocked-by-human`
+  score of `1` carries `status:blocked-by-human` unless an
+  `authoring-bucket: needs-decision` marker exempts it (see
+  [Authoring-bucket marker](https://github.com/kurone-kito/idd-skill/blob/main/skills/issue-authoring/references/contract.md#authoring-bucket-marker))
 - passes the `audit-authored-issue` mechanical pre-publish gate using
   `--shape child` (the linter's shape enum names this schema `child`,
   matching `contract.md`'s "Child issue under a roadmap"; see
@@ -1551,8 +1558,7 @@ A drafted issue's human-readable prose sections — `## Background` (or
   drafted prose use that language.
 - The literal `match-source` matches the operator's live conversational
   language during an interactive/hearing issue-authoring session.
-- An absent field defaults to English, codifying today's actual
-  emergent behavior.
+- An absent field defaults to English.
 
 See
 [Authoring Language](https://github.com/kurone-kito/idd-skill/blob/main/docs/customization.md#authoring-language)

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -1452,8 +1452,9 @@ Validation expectations:
   the draft includes a post-publication maintainer approval step after
   the final title, body, and generated plan are stable
 - exactly one autopilot-suitability footer with an integer 1-5 marker; a
-  score of `1` carries `status:blocked-by-human` unless an
-  `authoring-bucket: needs-decision` marker exempts it (see
+  score of `1` carries `status:blocked-by-human`, unless an
+  `authoring-bucket: needs-decision` marker substitutes the configured
+  needs-decision label instead (see
   [Authoring-bucket marker](https://github.com/kurone-kito/idd-skill/blob/main/skills/issue-authoring/references/contract.md#authoring-bucket-marker))
 - passes the `audit-authored-issue` mechanical pre-publish gate for the
   `orphan` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
@@ -1498,8 +1499,9 @@ Validation expectations:
 - the roadmap can survive multi-session handoffs without relying on
   private session memory
 - exactly one autopilot-suitability footer with an integer 1-5 marker; a
-  score of `1` carries `status:blocked-by-human` unless an
-  `authoring-bucket: needs-decision` marker exempts it (see
+  score of `1` carries `status:blocked-by-human`, unless an
+  `authoring-bucket: needs-decision` marker substitutes the configured
+  needs-decision label instead (see
   [Authoring-bucket marker](https://github.com/kurone-kito/idd-skill/blob/main/skills/issue-authoring/references/contract.md#authoring-bucket-marker))
 - passes the `audit-authored-issue` mechanical pre-publish gate for the
   `roadmap` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
@@ -1538,8 +1540,9 @@ Validation expectations:
   justified
 - the issue can be claimed independently without absorbing sibling work
 - exactly one autopilot-suitability footer with an integer 1-5 marker; a
-  score of `1` carries `status:blocked-by-human` unless an
-  `authoring-bucket: needs-decision` marker exempts it (see
+  score of `1` carries `status:blocked-by-human`, unless an
+  `authoring-bucket: needs-decision` marker substitutes the configured
+  needs-decision label instead (see
   [Authoring-bucket marker](https://github.com/kurone-kito/idd-skill/blob/main/skills/issue-authoring/references/contract.md#authoring-bucket-marker))
 - passes the `audit-authored-issue` mechanical pre-publish gate using
   `--shape child` (the linter's shape enum names this schema `child`,

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -1452,7 +1452,8 @@ Validation expectations:
   the draft includes a post-publication maintainer approval step after
   the final title, body, and generated plan are stable
 - exactly one autopilot-suitability footer with an integer 1-5 marker; a
-  score of `1` carries `status:blocked-by-human`, unless an
+  score of `1` carries the configured `blocked-by-human` label (default
+  `status:blocked-by-human`), unless an
   `authoring-bucket: needs-decision` marker substitutes the configured
   needs-decision label instead (see
   [Authoring-bucket marker](https://github.com/kurone-kito/idd-skill/blob/main/skills/issue-authoring/references/contract.md#authoring-bucket-marker))
@@ -1499,7 +1500,8 @@ Validation expectations:
 - the roadmap can survive multi-session handoffs without relying on
   private session memory
 - exactly one autopilot-suitability footer with an integer 1-5 marker; a
-  score of `1` carries `status:blocked-by-human`, unless an
+  score of `1` carries the configured `blocked-by-human` label (default
+  `status:blocked-by-human`), unless an
   `authoring-bucket: needs-decision` marker substitutes the configured
   needs-decision label instead (see
   [Authoring-bucket marker](https://github.com/kurone-kito/idd-skill/blob/main/skills/issue-authoring/references/contract.md#authoring-bucket-marker))
@@ -1540,7 +1542,8 @@ Validation expectations:
   justified
 - the issue can be claimed independently without absorbing sibling work
 - exactly one autopilot-suitability footer with an integer 1-5 marker; a
-  score of `1` carries `status:blocked-by-human`, unless an
+  score of `1` carries the configured `blocked-by-human` label (default
+  `status:blocked-by-human`), unless an
   `authoring-bucket: needs-decision` marker substitutes the configured
   needs-decision label instead (see
   [Authoring-bucket marker](https://github.com/kurone-kito/idd-skill/blob/main/skills/issue-authoring/references/contract.md#authoring-bucket-marker))

--- a/idd-template/docs/onboarding/issue-mediated-bootstrap.md
+++ b/idd-template/docs/onboarding/issue-mediated-bootstrap.md
@@ -369,12 +369,13 @@ placeholder in
 that value is derived. The suitability score of `1` reflects that
 Discover structurally cannot route this issue pre-import, not a quality
 judgment about the change itself; per the issue-authoring skill's
-contract, a score of `1` carries the `status:blocked-by-human` label
-unless an `authoring-bucket: needs-decision` marker exempts it
-(`skills/issue-authoring/references/contract.md`, "Authoring-bucket
-marker") — here the label applies, correctly signaling that this issue
-needs a human or a narrowly-scoped, pre-authorized agent rather than
-the ordinary autonomous loop. Use the operator-confirmed `labels.blockedByHumanLabelName`
+contract, a score of `1` carries the `status:blocked-by-human` label,
+unless an `authoring-bucket: needs-decision` marker substitutes the
+configured needs-decision label instead (see
+[Authoring-bucket marker](https://github.com/kurone-kito/idd-skill/blob/main/skills/issue-authoring/references/contract.md#authoring-bucket-marker))
+— here the label applies, correctly signaling that this issue needs a
+human or a narrowly-scoped, pre-authorized agent rather than the
+ordinary autonomous loop. Use the operator-confirmed `labels.blockedByHumanLabelName`
 value from Step 1B for both issue publication and label creation below —
 default to `status:blocked-by-human` only when that default was actually
 selected, never unconditionally. A pre-import repository may not have

--- a/idd-template/docs/onboarding/issue-mediated-bootstrap.md
+++ b/idd-template/docs/onboarding/issue-mediated-bootstrap.md
@@ -369,8 +369,9 @@ placeholder in
 that value is derived. The suitability score of `1` reflects that
 Discover structurally cannot route this issue pre-import, not a quality
 judgment about the change itself; per the issue-authoring skill's
-contract, a score of `1` carries the `status:blocked-by-human` label,
-unless an `authoring-bucket: needs-decision` marker substitutes the
+contract, a score of `1` carries the configured `blocked-by-human` label
+(default `status:blocked-by-human`), unless an
+`authoring-bucket: needs-decision` marker substitutes the
 configured needs-decision label instead (see
 [Authoring-bucket marker](https://github.com/kurone-kito/idd-skill/blob/main/skills/issue-authoring/references/contract.md#authoring-bucket-marker))
 — here the label applies, correctly signaling that this issue needs a

--- a/idd-template/docs/onboarding/issue-mediated-bootstrap.md
+++ b/idd-template/docs/onboarding/issue-mediated-bootstrap.md
@@ -369,10 +369,12 @@ placeholder in
 that value is derived. The suitability score of `1` reflects that
 Discover structurally cannot route this issue pre-import, not a quality
 judgment about the change itself; per the issue-authoring skill's
-contract, a score of `1` also carries the `status:blocked-by-human`
-label, which correctly signals that this issue needs a human or a
-narrowly-scoped, pre-authorized agent rather than the ordinary
-autonomous loop. Use the operator-confirmed `labels.blockedByHumanLabelName`
+contract, a score of `1` carries the `status:blocked-by-human` label
+unless an `authoring-bucket: needs-decision` marker exempts it
+(`skills/issue-authoring/references/contract.md`, "Authoring-bucket
+marker") — here the label applies, correctly signaling that this issue
+needs a human or a narrowly-scoped, pre-authorized agent rather than
+the ordinary autonomous loop. Use the operator-confirmed `labels.blockedByHumanLabelName`
 value from Step 1B for both issue publication and label creation below —
 default to `status:blocked-by-human` only when that default was actually
 selected, never unconditionally. A pre-import repository may not have

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -697,7 +697,8 @@ Validation expectations:
 - the issue stays discoverable under the target repository's
   `issue-scope` setting
 - exactly one autopilot-suitability footer with an integer 1-5
-  marker; a score of `1` carries `status:blocked-by-human`, unless an
+  marker; a score of `1` carries the configured `blocked-by-human` label
+  (default `status:blocked-by-human`), unless an
   `authoring-bucket: needs-decision` marker substitutes the configured
   needs-decision label instead (see
   [Authoring-bucket marker](#authoring-bucket-marker))
@@ -729,7 +730,8 @@ Validation expectations:
 - nested roadmap entries stay identifiable as coordination/audit nodes
   instead of normal execution leaves
 - exactly one autopilot-suitability footer with an integer 1-5
-  marker; a score of `1` carries `status:blocked-by-human`, unless an
+  marker; a score of `1` carries the configured `blocked-by-human` label
+  (default `status:blocked-by-human`), unless an
   `authoring-bucket: needs-decision` marker substitutes the configured
   needs-decision label instead (see
   [Authoring-bucket marker](#authoring-bucket-marker))
@@ -764,7 +766,8 @@ Validation expectations:
   justified
 - the issue can be claimed independently without absorbing sibling work
 - exactly one autopilot-suitability footer with an integer 1-5
-  marker; a score of `1` carries `status:blocked-by-human`, unless an
+  marker; a score of `1` carries the configured `blocked-by-human` label
+  (default `status:blocked-by-human`), unless an
   `authoring-bucket: needs-decision` marker substitutes the configured
   needs-decision label instead (see
   [Authoring-bucket marker](#authoring-bucket-marker))

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -697,8 +697,9 @@ Validation expectations:
 - the issue stays discoverable under the target repository's
   `issue-scope` setting
 - exactly one autopilot-suitability footer with an integer 1-5
-  marker; a score of `1` carries `status:blocked-by-human` unless an
-  `authoring-bucket: needs-decision` marker exempts it (see
+  marker; a score of `1` carries `status:blocked-by-human`, unless an
+  `authoring-bucket: needs-decision` marker substitutes the configured
+  needs-decision label instead (see
   [Authoring-bucket marker](#authoring-bucket-marker))
 - passes the `audit-authored-issue` mechanical pre-publish gate for the
   `orphan` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
@@ -728,8 +729,9 @@ Validation expectations:
 - nested roadmap entries stay identifiable as coordination/audit nodes
   instead of normal execution leaves
 - exactly one autopilot-suitability footer with an integer 1-5
-  marker; a score of `1` carries `status:blocked-by-human` unless an
-  `authoring-bucket: needs-decision` marker exempts it (see
+  marker; a score of `1` carries `status:blocked-by-human`, unless an
+  `authoring-bucket: needs-decision` marker substitutes the configured
+  needs-decision label instead (see
   [Authoring-bucket marker](#authoring-bucket-marker))
 - passes the `audit-authored-issue` mechanical pre-publish gate for the
   `roadmap` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
@@ -762,8 +764,9 @@ Validation expectations:
   justified
 - the issue can be claimed independently without absorbing sibling work
 - exactly one autopilot-suitability footer with an integer 1-5
-  marker; a score of `1` carries `status:blocked-by-human` unless an
-  `authoring-bucket: needs-decision` marker exempts it (see
+  marker; a score of `1` carries `status:blocked-by-human`, unless an
+  `authoring-bucket: needs-decision` marker substitutes the configured
+  needs-decision label instead (see
   [Authoring-bucket marker](#authoring-bucket-marker))
 - passes the `audit-authored-issue` mechanical pre-publish gate for the
   `child` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -697,7 +697,9 @@ Validation expectations:
 - the issue stays discoverable under the target repository's
   `issue-scope` setting
 - exactly one autopilot-suitability footer with an integer 1-5
-  marker; a score of `1` also carries `status:blocked-by-human`
+  marker; a score of `1` carries `status:blocked-by-human` unless an
+  `authoring-bucket: needs-decision` marker exempts it (see
+  [Authoring-bucket marker](#authoring-bucket-marker))
 - passes the `audit-authored-issue` mechanical pre-publish gate for the
   `orphan` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
 
@@ -726,7 +728,9 @@ Validation expectations:
 - nested roadmap entries stay identifiable as coordination/audit nodes
   instead of normal execution leaves
 - exactly one autopilot-suitability footer with an integer 1-5
-  marker; a score of `1` also carries `status:blocked-by-human`
+  marker; a score of `1` carries `status:blocked-by-human` unless an
+  `authoring-bucket: needs-decision` marker exempts it (see
+  [Authoring-bucket marker](#authoring-bucket-marker))
 - passes the `audit-authored-issue` mechanical pre-publish gate for the
   `roadmap` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
 
@@ -758,7 +762,9 @@ Validation expectations:
   justified
 - the issue can be claimed independently without absorbing sibling work
 - exactly one autopilot-suitability footer with an integer 1-5
-  marker; a score of `1` also carries `status:blocked-by-human`
+  marker; a score of `1` carries `status:blocked-by-human` unless an
+  `authoring-bucket: needs-decision` marker exempts it (see
+  [Authoring-bucket marker](#authoring-bucket-marker))
 - passes the `audit-authored-issue` mechanical pre-publish gate for the
   `child` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
 
@@ -774,8 +780,7 @@ A drafted issue's human-readable prose sections — `## Background` (or
   drafted prose use that language.
 - The literal `match-source` matches the operator's live conversational
   language during an interactive/hearing issue-authoring session.
-- An absent field defaults to English, codifying today's actual
-  emergent behavior.
+- An absent field defaults to English.
 
 See `docs/customization.md`'s Authoring Language section for the full
 field definition.
@@ -927,8 +932,9 @@ can never match. A nested/child list item's reference is evaluated
 together with its full ancestor chain's coordination-language text
 instead of being scoped away from it, while a sibling bullet at the same
 indentation — nested or top-level — still starts its own separate scope,
-preserving the tight-list sentence-conflation fix mentioned above. This
-holds for every nested child under a given parent, at any depth — not
+so a tight list (no blank line between sibling items) never reads two
+consecutive bullets' coordination language as one continuous sentence.
+This holds for every nested child under a given parent, at any depth — not
 only the first. A continuation line resuming at an ancestor's own
 indentation, after a deeper child has already opened, is attributed to
 that ancestor rather than the deepest open child. A loose list (a blank
@@ -1110,9 +1116,9 @@ Binding rules:
   gates, and a large (`L`) issue stays fully claimable when it is the only
   ready work.
 - **Fail-safe on absence.** A missing, non-`S|M|L`, or conflicting
-  marker means "no effort hint": selection behaves exactly as it does
-  today (a missing hint sorts as the neutral middle, as-if `M`).
-  Pre-existing issues with no effort footer keep flowing.
+  marker means "no effort hint": it sorts as the neutral middle, as-if
+  `M`, per `idd-discover.instructions.md` A4 Step 2. Pre-existing issues
+  with no effort footer keep flowing.
 
 Backfill is opportunistic and follows the same claim-state precondition
 as the suitability footer.
@@ -1137,8 +1143,8 @@ published before this marker existed.
 
 Binding rules:
 
-- **Two axes only.** Scoped to the two buckets with a real behavioral
-  consequence today (a required label) — `deferred` and `out-of-scope`
+- **Two axes only.** Scoped to the two buckets that require a label
+  (`needs-decision`, `blocked-by-human`) — `deferred` and `out-of-scope`
   have none, so they carry no marker.
 - **Folds the existing suitability-1 check.** When present, this marker
   decides `suitability-blocked-by-human`'s applicability instead of the

--- a/skills/issue-authoring/references/draft-patterns.md
+++ b/skills/issue-authoring/references/draft-patterns.md
@@ -145,7 +145,7 @@ that a suitability score of `1` carries the configured
 `blocked-by-human` label (default `status:blocked-by-human`), unless an
 `authoring-bucket: needs-decision` marker substitutes the configured
 needs-decision label instead (see
-[Authoring-bucket marker](https://github.com/kurone-kito/idd-skill/blob/main/skills/issue-authoring/references/contract.md#authoring-bucket-marker));
+[Authoring-bucket marker](contract.md#authoring-bucket-marker));
 use `--config <path>` to point at a policy that overrides the label
 name — this check is also one-directional, it does not flag the
 reverse, a non-`1` score paired with the label. Fix every reported

--- a/skills/issue-authoring/references/draft-patterns.md
+++ b/skills/issue-authoring/references/draft-patterns.md
@@ -142,12 +142,15 @@ Use `--shape roadmap` or `--shape child` for those shapes, `--stdin`
 instead of `--body-file` when the draft is not yet on disk, and
 `--label <name>` (repeatable) to pass proposed labels for the check
 that a suitability score of `1` carries the configured
-`blocked-by-human` label (default `status:blocked-by-human`; use
-`--config <path>` to point at a policy that overrides the label name —
-this check is also one-directional, it does not flag the reverse, a
-non-`1` score paired with the label). Fix every reported finding and
-re-run before publishing; a `passed: false` report means the draft is
-not ready yet, regardless of how complete the narrative reads.
+`blocked-by-human` label (default `status:blocked-by-human`) unless an
+`authoring-bucket: needs-decision` marker exempts it (see
+[Authoring-bucket marker](https://github.com/kurone-kito/idd-skill/blob/main/skills/issue-authoring/references/contract.md#authoring-bucket-marker));
+use `--config <path>` to point at a policy that overrides the label
+name — this check is also one-directional, it does not flag the
+reverse, a non-`1` score paired with the label. Fix every reported
+finding and re-run before publishing; a `passed: false` report means
+the draft is not ready yet, regardless of how complete the narrative
+reads.
 
 **No helper runtime available (`instructions-only` profile):** the
 linter cannot run. `instructions-only` is a first-class supported

--- a/skills/issue-authoring/references/draft-patterns.md
+++ b/skills/issue-authoring/references/draft-patterns.md
@@ -142,8 +142,9 @@ Use `--shape roadmap` or `--shape child` for those shapes, `--stdin`
 instead of `--body-file` when the draft is not yet on disk, and
 `--label <name>` (repeatable) to pass proposed labels for the check
 that a suitability score of `1` carries the configured
-`blocked-by-human` label (default `status:blocked-by-human`) unless an
-`authoring-bucket: needs-decision` marker exempts it (see
+`blocked-by-human` label (default `status:blocked-by-human`), unless an
+`authoring-bucket: needs-decision` marker substitutes the configured
+needs-decision label instead (see
 [Authoring-bucket marker](https://github.com/kurone-kito/idd-skill/blob/main/skills/issue-authoring/references/contract.md#authoring-bucket-marker));
 use `--config <path>` to point at a policy that overrides the label
 name — this check is also one-directional, it does not flag the


### PR DESCRIPTION
## Summary

- Replace three "today"-anchored normative sentences (default authoring language, missing effort hint, authoring-bucket marker scoping) with the concrete rule each one means, in both hand-maintained copies of the issue-authoring contract.
- Rewrite a dangling "the tight-list sentence-conflation fix mentioned above" reference (the word "conflation" only appears once in the file) as a self-contained clause.
- Qualify the score-1 `status:blocked-by-human` label rule (stated unconditionally in five places) to note the existing `authoring-bucket: needs-decision` marker exemption, which the Authoring-bucket marker section already documents as real behavior elsewhere.
- Regenerate the `.claude/skills/issue-authoring/` mirror via `sync-docs.mjs`.

Closes #2779

## Test plan

- [x] `grep -n "today"` in both `docs/issue-authoring-skill.md` and `skills/issue-authoring/references/contract.md` shows only the untouched resync-rule line
- [x] `grep -c "mentioned above" skills/issue-authoring/references/contract.md` → 0
- [x] `grep -n "also carries \`status:blocked-by-human\`"` → empty across all four prose files
- [x] `diff` between the hand-maintained bundle copy and its `.claude/` mirror is empty for `contract.md` and `draft-patterns.md`
- [x] `node scripts/audit-docs.mjs --check` passes
- [x] `npx markdownlint-cli2 "**/*.md"` passes
- [x] `pnpm exec dprint fmt "**/*.md"` produces no additional diff
- [x] `node scripts/audit-code-span-wrap.mjs` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDJpTELrY2SnjHW9m5Aw7i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified issue-authoring rules for suitability scores, including the exemption for `needs-decision` issues.
  - Documented English as the default authoring language when no language is specified.
  - Clarified effort-hint handling, prose-dependency parsing, and required authoring labels.
  - Expanded guidance for blocked-by-human labeling, configuration overrides, and validation behavior.
  - Updated onboarding documentation to reflect the revised suitability-label rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->