### PR TITLE
fix(idd-merge, idd-pr-submit): correct F4 step exits and prose

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -223,16 +223,16 @@ Before any mutating action in F3, apply the
        state of `mergeable: "MERGEABLE"` and `mergeStateStatus` settled
        to `"CLEAN"` or `"BEHIND"` also required.
        `isSafeSoloCodeownerAdminMergeState` still refuses
-       `mergeStateStatus: "BLOCKED"`. On kurone-kito/idd-skill's
-       current `main` ruleset (`require_code_owner_review: false`), the
-       `status: "clear"` trigger never matches, observed `"BLOCKED"`
-       states have not been a confirmed CODEOWNER deadlock, and the
-       remaining escalation on **this topology** is a human `--admin`
-       (or `hold-and-report`). Distributed `auto-admin-retry` is
-       unchanged when `status: "clear"` with a bypass-available
-       `reason`, `prAuthorIsSoleEligibleCodeowner: true`, and
-       `codeownerEligibilityUnreadable: false` hold. See
-       `docs/permissions.md` (kurone-kito/idd-skill#1663).
+       `mergeStateStatus: "BLOCKED"`. When the base ruleset does not
+       require CODEOWNER review, the `status: "clear"` trigger does not
+       match and a `BLOCKED` state is not by itself a CODEOWNER
+       deadlock; the remaining escalation on **this topology** is a
+       human `--admin` (or `hold-and-report`). Distributed
+       `auto-admin-retry` is unchanged when `status: "clear"` with a
+       bypass-available `reason`, `prAuthorIsSoleEligibleCodeowner:
+       true`, and `codeownerEligibilityUnreadable: false` hold. See
+       `docs/permissions.md` (kurone-kito/idd-skill#1663) for this
+       repository's own dated observation.
        `idd-merge-execute.mjs --apply` applies this automatically and
        records the outcome in the verdict's `adminFallbackUsed` field.
 
@@ -349,7 +349,7 @@ Before any mutating action in F3, apply the
    shows `needs-apply`):
 
    - **`clean`**: no candidates and no permission-blocked items.
-     Proceed to step 3.
+     Proceed to step 4.
 
    - **`needs-apply`**: eligible candidates exist and the viewer can
      minimize them. Apply is mandatory. Re-validate the active claim,
@@ -368,7 +368,7 @@ Before any mutating action in F3, apply the
      duplicate-success-record skip rule above; otherwise post the
      evidence comment (`status`, `applied`, `failed`, `skipped`,
      `viewer-cannot-minimize` counts for `applied`, or a converged
-     `clean` record) so this run's work is recorded. Proceed to step 3.
+     `clean` record) so this run's work is recorded. Proceed to step 4.
 
      The helper internally retries a whole scan-and-minimize pass, bounded,
      when a fresh rescan still reports candidates after applying (a
@@ -395,12 +395,12 @@ Before any mutating action in F3, apply the
      convergence was never confirmed) — note that distinction in the
      comment and re-run `--apply` to confirm convergence. Explicit
      evidence, not a merge gate — the merge already succeeded. Proceed
-     to step 3.
+     to step 4.
 
    - **`permission-blocked`**: skipped items exist with
      `viewerCanMinimize: false` and no apply-eligible candidates found.
      Post a cleanup-permission-blocked comment listing the blocked
-     candidates and the count, then proceed to step 3.
+     candidates and the count, then proceed to step 4.
 
    For the GraphQL fallback (helper unavailable): check
    `viewerCanMinimize` and `isMinimized` before minimizing; skip
@@ -490,8 +490,8 @@ Before any mutating action in F3, apply the
      `{development-branch}` is the cause.
 
 6. If GitHub auto-delete is disabled: delete the remote branch too.
-   (WorkTrunk may be used for steps 4–5, the deletion steps —
-   step 3's local `{development-branch}` update is a plain git
+   (WorkTrunk may be used for steps 5–6, the deletion steps —
+   step 4's local `{development-branch}` update is a plain git
    operation, not a WorkTrunk one.)
 7. Re-validate the active claim one final time. If it still uses your
    `{claim-id}`, post `unclaimed-by` for your own `{agent-id}` /

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -510,8 +510,8 @@ confirmed condition above. Delegate polling mechanics to
   `ciWait.rerunPolicy` rerun only reproduces the same red **unless a
   maintainer has since posted a valid external-check waiver for this
   HEAD** — that case still needs the rerun, to make the check reflect
-  the waiver (a pre-existing F2/F3 concern this branch leaves unchanged;
-  see `idd-pre-merge.instructions.md`'s External-check waivers). A
+  the waiver (see `idd-pre-merge.instructions.md`'s External-check
+  waivers for the F2/F3 handling). A
   waiver is effective only once `deadline.passed` is true or
   `terminal.state` reaches `COPILOT_UNAVAILABLE` (check both fields in
   the same run's output); posted earlier, it is valid but inert —

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -218,16 +218,16 @@ Before any mutating action in F3, apply the
        state of `mergeable: "MERGEABLE"` and `mergeStateStatus` settled
        to `"CLEAN"` or `"BEHIND"` also required.
        `isSafeSoloCodeownerAdminMergeState` still refuses
-       `mergeStateStatus: "BLOCKED"`. On kurone-kito/idd-skill's
-       current `main` ruleset (`require_code_owner_review: false`), the
-       `status: "clear"` trigger never matches, observed `"BLOCKED"`
-       states have not been a confirmed CODEOWNER deadlock, and the
-       remaining escalation on **this topology** is a human `--admin`
-       (or `hold-and-report`). Distributed `auto-admin-retry` is
-       unchanged when `status: "clear"` with a bypass-available
-       `reason`, `prAuthorIsSoleEligibleCodeowner: true`, and
-       `codeownerEligibilityUnreadable: false` hold. See
-       `docs/permissions.md` (kurone-kito/idd-skill#1663).
+       `mergeStateStatus: "BLOCKED"`. When the base ruleset does not
+       require CODEOWNER review, the `status: "clear"` trigger does not
+       match and a `BLOCKED` state is not by itself a CODEOWNER
+       deadlock; the remaining escalation on **this topology** is a
+       human `--admin` (or `hold-and-report`). Distributed
+       `auto-admin-retry` is unchanged when `status: "clear"` with a
+       bypass-available `reason`, `prAuthorIsSoleEligibleCodeowner:
+       true`, and `codeownerEligibilityUnreadable: false` hold. See
+       `docs/permissions.md` (kurone-kito/idd-skill#1663) for this
+       repository's own dated observation.
        `idd-merge-execute.mjs --apply` applies this automatically and
        records the outcome in the verdict's `adminFallbackUsed` field.
 
@@ -344,7 +344,7 @@ Before any mutating action in F3, apply the
    shows `needs-apply`):
 
    - **`clean`**: no candidates and no permission-blocked items.
-     Proceed to step 3.
+     Proceed to step 4.
 
    - **`needs-apply`**: eligible candidates exist and the viewer can
      minimize them. Apply is mandatory. Re-validate the active claim,
@@ -363,7 +363,7 @@ Before any mutating action in F3, apply the
      duplicate-success-record skip rule above; otherwise post the
      evidence comment (`status`, `applied`, `failed`, `skipped`,
      `viewer-cannot-minimize` counts for `applied`, or a converged
-     `clean` record) so this run's work is recorded. Proceed to step 3.
+     `clean` record) so this run's work is recorded. Proceed to step 4.
 
      The helper internally retries a whole scan-and-minimize pass, bounded,
      when a fresh rescan still reports candidates after applying (a
@@ -390,12 +390,12 @@ Before any mutating action in F3, apply the
      convergence was never confirmed) — note that distinction in the
      comment and re-run `--apply` to confirm convergence. Explicit
      evidence, not a merge gate — the merge already succeeded. Proceed
-     to step 3.
+     to step 4.
 
    - **`permission-blocked`**: skipped items exist with
      `viewerCanMinimize: false` and no apply-eligible candidates found.
      Post a cleanup-permission-blocked comment listing the blocked
-     candidates and the count, then proceed to step 3.
+     candidates and the count, then proceed to step 4.
 
    For the GraphQL fallback (helper unavailable): check
    `viewerCanMinimize` and `isMinimized` before minimizing; skip
@@ -485,8 +485,8 @@ Before any mutating action in F3, apply the
      `{development-branch}` is the cause.
 
 6. If GitHub auto-delete is disabled: delete the remote branch too.
-   (WorkTrunk may be used for steps 4–5, the deletion steps —
-   step 3's local `{development-branch}` update is a plain git
+   (WorkTrunk may be used for steps 5–6, the deletion steps —
+   step 4's local `{development-branch}` update is a plain git
    operation, not a WorkTrunk one.)
 7. Re-validate the active claim one final time. If it still uses your
    `{claim-id}`, post `unclaimed-by` for your own `{agent-id}` /

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -505,8 +505,8 @@ confirmed condition above. Delegate polling mechanics to
   `ciWait.rerunPolicy` rerun only reproduces the same red **unless a
   maintainer has since posted a valid external-check waiver for this
   HEAD** — that case still needs the rerun, to make the check reflect
-  the waiver (a pre-existing F2/F3 concern this branch leaves unchanged;
-  see `idd-pre-merge.instructions.md`'s External-check waivers). A
+  the waiver (see `idd-pre-merge.instructions.md`'s External-check
+  waivers for the F2/F3 handling). A
   waiver is effective only once `deadline.passed` is true or
   `terminal.state` reaches `COPILOT_UNAVAILABLE` (check both fields in
   the same run's output); posted earlier, it is valid but inert —

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -2618,12 +2618,6 @@ const REVIEW_TRIAGE_ALLOWED_MAIN_LINES = new Set([
   '[design rationale](../../docs/idd-design-rationale.md#merge-main-livelock-under-fast-moving-main)).',
 ]);
 
-const MERGE_ALLOWED_MAIN_LINES = new Set([
-  // A historical, repository-specific ruleset-name reference, not a
-  // synchronization/target instruction.
-  'current `main` ruleset (`require_code_owner_review: false`), the',
-]);
-
 const B1_TRUSTED_CHECKOUT_MAIN_LINES = new Set([
   '1. Ensure the local `main` branch is up to date and has no local',
   'commits. Run this from the primary worktree while on `main`:',
@@ -2664,11 +2658,11 @@ test('idd-review-triage.instructions.md confines its bare `main` mention to the 
   );
 });
 
-test('idd-merge.instructions.md confines its bare `main` mention to the known historical ruleset-name reference (#2274)', () => {
+test('idd-merge.instructions.md carries zero bare `main` branch mentions (#2274, #2775)', () => {
   const text = readText(
     'idd-template/.github/instructions/idd-merge.instructions.md',
   );
-  assert.deepEqual(findUnallowedMainLines(text, MERGE_ALLOWED_MAIN_LINES), []);
+  assert.deepEqual(findUnallowedMainLines(text, NO_MAIN_MENTIONS_ALLOWED), []);
 });
 
 test('idd-work.instructions.md confines every bare `main` mention to the B1 trusted-checkout contract (#2274)', () => {


### PR DESCRIPTION
## Summary
- Fix four F4 step-3 self-referencing exits (should point to step 4) in `idd-merge.instructions.md`, including one line-wrapped occurrence
- Fix F4 step 6's parenthetical to name the correct steps (5-6 for deletion, 4 for the local development-branch update)
- Rewrite F3 step 5's live, undated, repo-specific ruleset assertion as a general conditional rule, pointing at `docs/permissions.md`'s own dated observation instead of restating it inline in a distributed file
- Trim `idd-pr-submit.instructions.md` D4's session-scoped "this branch leaves unchanged" prose to just the durable cross-reference
- Regenerate the `.github/instructions/` mirrors via `sync-docs.mjs --apply`

Closes #2775

## Test plan
- [x] `awk '/^## F4/{f=1} f' .github/instructions/idd-merge.instructions.md | tr '\n' ' ' | grep -o -i -E 'proceed[[:space:]]+to step 3' | wc -l` prints `0`
- [x] `grep -n 'current \`main\` ruleset' .github/instructions/idd-merge.instructions.md` prints nothing
- [x] `grep -n 'this branch leaves' .github/instructions/idd-pr-submit.instructions.md` prints nothing
- [x] `node scripts/audit-docs.mjs --check` passes
- [x] `npx markdownlint-cli2 "**/*.md"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDJpTELrY2SnjHW9m5Aw7i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified merge fallback guidance, including administrator escalation when required and handling when CODEOWNER review is not needed.
  * Updated cleanup instructions to provide clearer outcomes and corrected step references for subsequent local branch actions.
  * Refined pull request submission guidance to direct CI-wait waivers to the appropriate external-check handling instructions.
  * Applied the same workflow guidance updates to the distributed template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->