### PR TITLE
feat(post-idd-marker): hide review-ack/copilot-unavailable at post time

### DIFF
--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -134,18 +134,38 @@ after one of these is true:
 - a maintainer explicitly starts a merged-PR audit
 
 **Exception -- hide-at-post-time for `wired` families** (issue #731,
-issue #733, issue #2751). A `wired` family may be minimized immediately
-after its own new instance's POST+verify succeeds, pre-merge, using
-that family's documented supersession/grouping key -- never for any
-other reason during an active E or F gate. Three families ship this
-today: the claim chain
-(`claimed-by:`/`unclaimed-by:`, grouped by
-`supersedes:` lineage, `idd-claim.instructions.md`), `review-watermark:`/
-`review-baseline:` (grouped by same claim-id,
-`idd-review-snapshot.instructions.md`), and the `advisory-wait` family
-(`advisory-wait:`/`advisory-wait-recovery:`/`<!-- advisory-wait:`/
-`advisory-reroll:`, grouped by embedded HEAD SHA mismatch, AW3-H,
-`idd-advisory-wait.instructions.md`). A family classified `f4-only` has
+issue #733, issue #2751, issue #2754). A `wired` family may be minimized
+immediately after its own new instance's POST+verify succeeds, pre-merge,
+using that family's documented supersession/grouping key -- never for any
+other reason during an active E or F gate. Five families ship this
+today, in two different mechanisms:
+
+- **Agent-followed instruction step** -- the calling phase's own
+  instructions direct the agent to run the minimize step by hand
+  (`node scripts/minimize-superseded-markers.mjs ... --apply`) after
+  posting: the claim chain
+  (`claimed-by:`/`unclaimed-by:`, grouped by
+  `supersedes:` lineage, `idd-claim.instructions.md`), `review-watermark:`/
+  `review-baseline:` (grouped by same claim-id,
+  `idd-review-snapshot.instructions.md`), and the `advisory-wait` family
+  (`advisory-wait:`/`advisory-wait-recovery:`/`<!-- advisory-wait:`/
+  `advisory-reroll:`, grouped by embedded HEAD SHA mismatch, AW3-H,
+  `idd-advisory-wait.instructions.md`).
+- **Code-automated inside `post-idd-marker.mts` itself** (#2754) -- no
+  agent-followed instruction step exists or is needed for these two,
+  since their grouping keys are purely mechanical: `review-ack:`
+  (grouped by embedded HEAD SHA mismatch) and `copilot-unavailable:`
+  (grouped by the same `claim:` value, differing `attempt:` numbers).
+  `post-idd-marker.mts --apply --type review-ack` /
+  `--type copilot-unavailable` scans the target's other comments right
+  after its own new marker POSTs successfully, finds same-family
+  comments the new one supersedes, and reuses
+  `minimize-superseded-markers.mts`'s `runMinimize` for the actual
+  mutation -- best-effort: any failure there (a permission error, an
+  unreadable comment list) is swallowed and never blocks or retries the
+  marker post that already succeeded.
+
+A family classified `f4-only` has
 no such wiring yet and follows the default F4-only timing above until a
 future track adds it -- concretely, the post-merge F4 batch means
 `audit-pr-cleanup.mts`'s generic marker-prefix match

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -171,7 +171,8 @@ mechanisms:
   `scripts/minimize-superseded-markers.mjs`'s `runMinimize` for the
   actual mutation -- best-effort: any failure there (a permission
   error, an unreadable comment list) is swallowed and never blocks or
-  retries the marker post that already succeeded. This mechanism lives
+  retries the marker post that already succeeded (preventive; no
+  observed incident yet — #2788). This mechanism lives
   inside the built `.mjs` helpers, so it only runs where a helper
   runtime is configured (`vendored-node`, `package-manager`, or
   `ephemeral-npx`); under `instructions-only` (or wherever the helper

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -156,14 +156,14 @@ today, in two different mechanisms:
   since their grouping keys are purely mechanical: `review-ack:`
   (grouped by embedded HEAD SHA mismatch) and `copilot-unavailable:`
   (grouped by the same `claim:` value, differing `attempt:` numbers).
-  `post-idd-marker.mts --apply --type review-ack` /
+  `node scripts/post-idd-marker.mjs --apply --type review-ack` /
   `--type copilot-unavailable` scans the target's other comments right
   after its own new marker POSTs successfully, finds same-family
   comments the new one supersedes, and reuses
-  `minimize-superseded-markers.mts`'s `runMinimize` for the actual
-  mutation -- best-effort: any failure there (a permission error, an
-  unreadable comment list) is swallowed and never blocks or retries the
-  marker post that already succeeded.
+  `scripts/minimize-superseded-markers.mjs`'s `runMinimize` for the
+  actual mutation -- best-effort: any failure there (a permission
+  error, an unreadable comment list) is swallowed and never blocks or
+  retries the marker post that already succeeded.
 
 A family classified `f4-only` has
 no such wiring yet and follows the default F4-only timing above until a

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -151,7 +151,7 @@ today, in two different mechanisms:
   (`advisory-wait:`/`advisory-wait-recovery:`/`<!-- advisory-wait:`/
   `advisory-reroll:`, grouped by embedded HEAD SHA mismatch, AW3-H,
   `idd-advisory-wait.instructions.md`).
-- **Code-automated inside `post-idd-marker.mts` itself** (#2754) -- no
+- **Code-automated inside `post-idd-marker.mjs` itself** (#2754) -- no
   agent-followed instruction step exists or is needed for these two,
   since their grouping keys are purely mechanical: `review-ack:`
   (grouped by embedded HEAD SHA mismatch) and `copilot-unavailable:`
@@ -163,7 +163,16 @@ today, in two different mechanisms:
   `scripts/minimize-superseded-markers.mjs`'s `runMinimize` for the
   actual mutation -- best-effort: any failure there (a permission
   error, an unreadable comment list) is swallowed and never blocks or
-  retries the marker post that already succeeded.
+  retries the marker post that already succeeded. This mechanism lives
+  inside the built `.mjs` helper, so it only runs where a helper
+  runtime is configured (`vendored-node`, `package-manager`, or
+  `ephemeral-npx`); under `instructions-only` (or wherever the helper
+  is otherwise unavailable), an agent posts this pair's plain-text
+  marker body by hand instead, and no equivalent manual minimize step
+  exists yet for them the way the agent-followed instruction step
+  above already gives the claim chain / review-watermark-baseline /
+  advisory-wait families -- these two markers accumulate like an
+  `f4-only` family until a future track adds one.
 
 A family classified `f4-only` has
 no such wiring yet and follows the default F4-only timing above until a

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -156,8 +156,9 @@ mechanisms:
   agent-followed instruction step exists or is needed for these
   three, since their grouping keys are purely mechanical:
   `review-ack:` (grouped by embedded HEAD SHA mismatch) and
-  `copilot-unavailable:` (grouped by the same `claim:` value,
-  differing `attempt:` numbers) are both hidden by
+  `copilot-unavailable:` (grouped by the same `claim:` value and a
+  strictly lower `attempt:` number -- a same-or-higher attempt is left
+  alone) are both hidden by
   `post-idd-marker.mjs` itself right after its own new marker POSTs
   successfully (`--apply --type review-ack` / `--type
   copilot-unavailable`); `<!-- idd-local-validation-evidence:`

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -134,18 +134,38 @@ after one of these is true:
 - a maintainer explicitly starts a merged-PR audit
 
 **Exception -- hide-at-post-time for `wired` families** (issue #731,
-issue #733, issue #2751). A `wired` family may be minimized immediately
-after its own new instance's POST+verify succeeds, pre-merge, using
-that family's documented supersession/grouping key -- never for any
-other reason during an active E or F gate. Three families ship this
-today: the claim chain
-(`claimed-by:`/`unclaimed-by:`, grouped by
-`supersedes:` lineage, `idd-claim.instructions.md`), `review-watermark:`/
-`review-baseline:` (grouped by same claim-id,
-`idd-review-snapshot.instructions.md`), and the `advisory-wait` family
-(`advisory-wait:`/`advisory-wait-recovery:`/`<!-- advisory-wait:`/
-`advisory-reroll:`, grouped by embedded HEAD SHA mismatch, AW3-H,
-`idd-advisory-wait.instructions.md`). A family classified `f4-only` has
+issue #733, issue #2751, issue #2754). A `wired` family may be minimized
+immediately after its own new instance's POST+verify succeeds, pre-merge,
+using that family's documented supersession/grouping key -- never for any
+other reason during an active E or F gate. Five families ship this
+today, in two different mechanisms:
+
+- **Agent-followed instruction step** -- the calling phase's own
+  instructions direct the agent to run the minimize step by hand
+  (`node scripts/minimize-superseded-markers.mjs ... --apply`) after
+  posting: the claim chain
+  (`claimed-by:`/`unclaimed-by:`, grouped by
+  `supersedes:` lineage, `idd-claim.instructions.md`), `review-watermark:`/
+  `review-baseline:` (grouped by same claim-id,
+  `idd-review-snapshot.instructions.md`), and the `advisory-wait` family
+  (`advisory-wait:`/`advisory-wait-recovery:`/`<!-- advisory-wait:`/
+  `advisory-reroll:`, grouped by embedded HEAD SHA mismatch, AW3-H,
+  `idd-advisory-wait.instructions.md`).
+- **Code-automated inside `post-idd-marker.mts` itself** (#2754) -- no
+  agent-followed instruction step exists or is needed for these two,
+  since their grouping keys are purely mechanical: `review-ack:`
+  (grouped by embedded HEAD SHA mismatch) and `copilot-unavailable:`
+  (grouped by the same `claim:` value, differing `attempt:` numbers).
+  `post-idd-marker.mts --apply --type review-ack` /
+  `--type copilot-unavailable` scans the target's other comments right
+  after its own new marker POSTs successfully, finds same-family
+  comments the new one supersedes, and reuses
+  `minimize-superseded-markers.mts`'s `runMinimize` for the actual
+  mutation -- best-effort: any failure there (a permission error, an
+  unreadable comment list) is swallowed and never blocks or retries the
+  marker post that already succeeded.
+
+A family classified `f4-only` has
 no such wiring yet and follows the default F4-only timing above until a
 future track adds it -- concretely, the post-merge F4 batch means
 `audit-pr-cleanup.mts`'s generic marker-prefix match

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -171,7 +171,8 @@ mechanisms:
   `scripts/minimize-superseded-markers.mjs`'s `runMinimize` for the
   actual mutation -- best-effort: any failure there (a permission
   error, an unreadable comment list) is swallowed and never blocks or
-  retries the marker post that already succeeded. This mechanism lives
+  retries the marker post that already succeeded (preventive; no
+  observed incident yet — #2788). This mechanism lives
   inside the built `.mjs` helpers, so it only runs where a helper
   runtime is configured (`vendored-node`, `package-manager`, or
   `ephemeral-npx`); under `instructions-only` (or wherever the helper

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -156,14 +156,14 @@ today, in two different mechanisms:
   since their grouping keys are purely mechanical: `review-ack:`
   (grouped by embedded HEAD SHA mismatch) and `copilot-unavailable:`
   (grouped by the same `claim:` value, differing `attempt:` numbers).
-  `post-idd-marker.mts --apply --type review-ack` /
+  `node scripts/post-idd-marker.mjs --apply --type review-ack` /
   `--type copilot-unavailable` scans the target's other comments right
   after its own new marker POSTs successfully, finds same-family
   comments the new one supersedes, and reuses
-  `minimize-superseded-markers.mts`'s `runMinimize` for the actual
-  mutation -- best-effort: any failure there (a permission error, an
-  unreadable comment list) is swallowed and never blocks or retries the
-  marker post that already succeeded.
+  `scripts/minimize-superseded-markers.mjs`'s `runMinimize` for the
+  actual mutation -- best-effort: any failure there (a permission
+  error, an unreadable comment list) is swallowed and never blocks or
+  retries the marker post that already succeeded.
 
 A family classified `f4-only` has
 no such wiring yet and follows the default F4-only timing above until a

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -151,7 +151,7 @@ today, in two different mechanisms:
   (`advisory-wait:`/`advisory-wait-recovery:`/`<!-- advisory-wait:`/
   `advisory-reroll:`, grouped by embedded HEAD SHA mismatch, AW3-H,
   `idd-advisory-wait.instructions.md`).
-- **Code-automated inside `post-idd-marker.mts` itself** (#2754) -- no
+- **Code-automated inside `post-idd-marker.mjs` itself** (#2754) -- no
   agent-followed instruction step exists or is needed for these two,
   since their grouping keys are purely mechanical: `review-ack:`
   (grouped by embedded HEAD SHA mismatch) and `copilot-unavailable:`
@@ -163,7 +163,16 @@ today, in two different mechanisms:
   `scripts/minimize-superseded-markers.mjs`'s `runMinimize` for the
   actual mutation -- best-effort: any failure there (a permission
   error, an unreadable comment list) is swallowed and never blocks or
-  retries the marker post that already succeeded.
+  retries the marker post that already succeeded. This mechanism lives
+  inside the built `.mjs` helper, so it only runs where a helper
+  runtime is configured (`vendored-node`, `package-manager`, or
+  `ephemeral-npx`); under `instructions-only` (or wherever the helper
+  is otherwise unavailable), an agent posts this pair's plain-text
+  marker body by hand instead, and no equivalent manual minimize step
+  exists yet for them the way the agent-followed instruction step
+  above already gives the claim chain / review-watermark-baseline /
+  advisory-wait families -- these two markers accumulate like an
+  `f4-only` family until a future track adds one.
 
 A family classified `f4-only` has
 no such wiring yet and follows the default F4-only timing above until a

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -156,8 +156,9 @@ mechanisms:
   agent-followed instruction step exists or is needed for these
   three, since their grouping keys are purely mechanical:
   `review-ack:` (grouped by embedded HEAD SHA mismatch) and
-  `copilot-unavailable:` (grouped by the same `claim:` value,
-  differing `attempt:` numbers) are both hidden by
+  `copilot-unavailable:` (grouped by the same `claim:` value and a
+  strictly lower `attempt:` number -- a same-or-higher attempt is left
+  alone) are both hidden by
   `post-idd-marker.mjs` itself right after its own new marker POSTs
   successfully (`--apply --type review-ack` / `--type
   copilot-unavailable`); `<!-- idd-local-validation-evidence:`

--- a/idd-template/scripts/minimize-superseded-markers.mjs
+++ b/idd-template/scripts/minimize-superseded-markers.mjs
@@ -253,6 +253,30 @@ export function runMinimize({
       });
       continue;
     }
+    // Second deadline check, immediately before the mutation call itself
+    // (#2754, chatgpt-codex-connector review on PR #2788): the entry check
+    // above only bounds how many candidates this pass STARTS probing --
+    // once a candidate is already in flight (including the very first,
+    // which the entry check always lets through), its own `probeSubject`
+    // call can still cost up to `GH_TIMEOUT_MS`. Without a check here too,
+    // that candidate would still reach `applyMinimize` and cost up to
+    // ANOTHER full `GH_TIMEOUT_MS`, so a single candidate's own probe+apply
+    // pair -- not just the between-candidates gap -- could blow well past
+    // `deadlineMs` before this pass ever returns. Checked for every index
+    // (including 0): unlike the entry check, this one never needs an
+    // exemption to guarantee forward progress, since the candidate's own
+    // probe has already run either way -- only the MUTATION is skipped.
+    if (deadlineMs !== undefined && Date.now() - startedAt >= deadlineMs) {
+      report.items.push({
+        subjectId,
+        url,
+        typename,
+        status: 'skipped',
+        reason: 'deadline-exceeded',
+      });
+      report.counts.deadlineSkipped = (report.counts.deadlineSkipped ?? 0) + 1;
+      continue;
+    }
     const mutation = applyMinimize(subjectId, classifier);
     if (mutation.ok) {
       report.items.push({

--- a/idd-template/scripts/minimize-superseded-markers.mjs
+++ b/idd-template/scripts/minimize-superseded-markers.mjs
@@ -174,11 +174,18 @@ export function runMinimize({
   const startedAt = Date.now();
   const remaining = () => (deadlineMs ?? 0) - (Date.now() - startedAt);
   for (const [index, subjectId] of subjectIds.entries()) {
-    if (
-      deadlineMs !== undefined &&
-      index > 0 &&
-      Date.now() - startedAt >= deadlineMs
-    ) {
+    // #2754, copilot-pull-request-reviewer review on PR #2788 (round 6):
+    // read `remaining()` exactly ONCE per candidate and reuse that SAME
+    // value for both the skip decision and the timeout passed to
+    // probeSubject -- the entry check and the timeoutMs computation used
+    // to call `remaining()` (i.e. `Date.now()`) separately, a few lines
+    // apart; if the budget expired in that gap, a non-first candidate
+    // could still fall through to probeSubject with `undefined` (the 30s
+    // default) instead of being skipped, silently reopening the exact
+    // "runs for a full untouched GH_TIMEOUT_MS regardless of how little
+    // budget is left" gap round 5 closed for the common case.
+    const enteredRemaining = deadlineMs === undefined ? undefined : remaining();
+    if (deadlineMs !== undefined && index > 0 && enteredRemaining <= 0) {
       for (const remainingId of subjectIds.slice(index)) {
         report.items.push({
           subjectId: remainingId,
@@ -190,21 +197,19 @@ export function runMinimize({
         (report.counts.deadlineSkipped ?? 0) + (subjectIds.length - index);
       break;
     }
-    // #2754, chatgpt-codex-connector review on PR #2788 (round 5): thread
-    // the REMAINING budget into probeSubject itself, not just the entry
-    // check above -- otherwise a candidate let through by the entry check
-    // (including the always-exempt index 0) could still let its own probe
-    // run for a full untouched `GH_TIMEOUT_MS` regardless of how little
-    // budget is actually left. `r > 0` guards the one case that check
-    // cannot rule out (index 0 when `deadlineMs` is already exhausted at
-    // entry): never pass a non-positive number here (gh-exec.mts and
+    // Past the check above, `enteredRemaining` is guaranteed > 0 for every
+    // index > 0 -- reused as-is, no second `remaining()` read. Index 0 is
+    // exempt from the skip (the pass always attempts at least one
+    // candidate) and can still be non-positive here; falling back to
+    // probeSubject's own default in that one case is deliberate, not a
+    // gap: never pass a non-positive number through (gh-exec.mts and
     // execFileSync both read `timeout: 0` as "no timeout", the opposite of
-    // "budget already exhausted") -- fall back to probeSubject's own
-    // default instead.
-    const probeR = deadlineMs === undefined ? undefined : remaining();
+    // "budget already exhausted").
     const probe = probeSubject(
       subjectId,
-      probeR !== undefined && probeR > 0 ? probeR : undefined,
+      enteredRemaining !== undefined && enteredRemaining > 0
+        ? enteredRemaining
+        : undefined,
     );
     if (!probe.ok) {
       report.items.push({ subjectId, status: 'failed', reason: probe.reason });
@@ -282,7 +287,18 @@ export function runMinimize({
     // (including 0): unlike the entry check, this one never needs an
     // exemption to guarantee forward progress, since the candidate's own
     // probe has already run either way -- only the MUTATION is skipped.
-    if (deadlineMs !== undefined && Date.now() - startedAt >= deadlineMs) {
+    //
+    // #2754, copilot-pull-request-reviewer review on PR #2788 (round 6):
+    // read `remaining()` exactly ONCE here and reuse that SAME value for
+    // both the skip decision and applyMinimize's own timeout -- round 5
+    // read it a second time a few lines below, so a budget that expired in
+    // that gap could still fall through to `undefined` (the 30s default)
+    // instead of being skipped, silently reopening the exact
+    // "applyMinimize costs up to another full GH_TIMEOUT_MS regardless of
+    // budget" gap this check exists to close.
+    const preApplyRemaining =
+      deadlineMs === undefined ? undefined : remaining();
+    if (deadlineMs !== undefined && preApplyRemaining <= 0) {
       report.items.push({
         subjectId,
         url,
@@ -293,16 +309,11 @@ export function runMinimize({
       report.counts.deadlineSkipped = (report.counts.deadlineSkipped ?? 0) + 1;
       continue;
     }
-    // #2754, chatgpt-codex-connector review on PR #2788 (round 5): thread
-    // the remaining budget into applyMinimize's own `gh` call too -- the
-    // check just above guarantees `remaining() > 0` whenever `deadlineMs`
-    // is set, so this never risks passing a non-positive timeout.
-    const applyR = deadlineMs === undefined ? undefined : remaining();
-    const mutation = applyMinimize(
-      subjectId,
-      classifier,
-      applyR !== undefined && applyR > 0 ? applyR : undefined,
-    );
+    // Past the check above, `preApplyRemaining` is guaranteed > 0 whenever
+    // `deadlineMs` is set (no index exemption here, unlike the probe
+    // check) -- reused as-is, no second `remaining()` read, so this never
+    // risks passing a non-positive timeout.
+    const mutation = applyMinimize(subjectId, classifier, preApplyRemaining);
     if (mutation.ok) {
       report.items.push({
         subjectId,

--- a/idd-template/scripts/minimize-superseded-markers.mjs
+++ b/idd-template/scripts/minimize-superseded-markers.mjs
@@ -34,6 +34,32 @@ function loadIddConfig() {
 // in the temporal dead zone when the trigger fires (see
 // discover-readiness-check.mts's / ci-wait-policy.mts's identical note).
 const GH_TIMEOUT_MS = 30_000;
+// #2754 (caught by chatgpt-codex-connector review on PR #2788): same
+// self-containment constraint as the two constants above -- cannot import
+// gh-exec.mts's resolveGhApiHostname, so duplicate the same GHES-hostname
+// resolution logic locally. Without this, every `runGh` call below always
+// targets github.com even on a GitHub Enterprise Server host where
+// GITHUB_SERVER_URL names the GHES instance but GH_HOST is unset (`gh`
+// itself never reads GITHUB_SERVER_URL), so a GHES-hosted repository's
+// probe/mutate GraphQL calls would silently fail to resolve any node id --
+// exactly the risk `post-idd-marker.mts`'s new hide-at-post-time step
+// (#2754) introduced by calling `runMinimize` from inside a GitHub Actions
+// job, where GITHUB_SERVER_URL is always set by the runtime but GH_HOST is
+// not set by default.
+export function resolveGhHostnameArgs(env = process.env) {
+  if (env.GH_HOST?.trim()) {
+    return [];
+  }
+  const serverUrl = env.GITHUB_SERVER_URL?.trim();
+  if (!serverUrl) {
+    return [];
+  }
+  const host = serverUrl
+    .replace(/^[a-z][a-z0-9+.-]*:\/\//i, '')
+    .replace(/\/+$/, '')
+    .toLowerCase();
+  return host && host !== 'github.com' ? ['--hostname', host] : [];
+}
 const ALLOWED_CLASSIFIERS = new Set(['OUTDATED', 'RESOLVED']);
 const ALLOWED_FORMATS = new Set(['json', 'table']);
 const MINIMIZABLE_TYPENAMES = new Set([
@@ -261,6 +287,7 @@ function isUnresolvableRestShapedId(subjectId, errorText) {
 export function probeSubject(subjectId) {
   const result = runGh([
     'api',
+    ...resolveGhHostnameArgs(),
     'graphql',
     '-f',
     `query=query($id:ID!){
@@ -323,6 +350,7 @@ export function probeSubject(subjectId) {
 export function applyMinimize(subjectId, classifier) {
   const result = runGh([
     'api',
+    ...resolveGhHostnameArgs(),
     'graphql',
     '-f',
     `query=mutation($id:ID!,$classifier:ReportedContentClassifiers!){

--- a/idd-template/scripts/minimize-superseded-markers.mjs
+++ b/idd-template/scripts/minimize-superseded-markers.mjs
@@ -172,6 +172,7 @@ export function runMinimize({
     items: [],
   };
   const startedAt = Date.now();
+  const remaining = () => (deadlineMs ?? 0) - (Date.now() - startedAt);
   for (const [index, subjectId] of subjectIds.entries()) {
     if (
       deadlineMs !== undefined &&
@@ -189,7 +190,22 @@ export function runMinimize({
         (report.counts.deadlineSkipped ?? 0) + (subjectIds.length - index);
       break;
     }
-    const probe = probeSubject(subjectId);
+    // #2754, chatgpt-codex-connector review on PR #2788 (round 5): thread
+    // the REMAINING budget into probeSubject itself, not just the entry
+    // check above -- otherwise a candidate let through by the entry check
+    // (including the always-exempt index 0) could still let its own probe
+    // run for a full untouched `GH_TIMEOUT_MS` regardless of how little
+    // budget is actually left. `r > 0` guards the one case that check
+    // cannot rule out (index 0 when `deadlineMs` is already exhausted at
+    // entry): never pass a non-positive number here (gh-exec.mts and
+    // execFileSync both read `timeout: 0` as "no timeout", the opposite of
+    // "budget already exhausted") -- fall back to probeSubject's own
+    // default instead.
+    const probeR = deadlineMs === undefined ? undefined : remaining();
+    const probe = probeSubject(
+      subjectId,
+      probeR !== undefined && probeR > 0 ? probeR : undefined,
+    );
     if (!probe.ok) {
       report.items.push({ subjectId, status: 'failed', reason: probe.reason });
       report.counts.failed += 1;
@@ -277,7 +293,16 @@ export function runMinimize({
       report.counts.deadlineSkipped = (report.counts.deadlineSkipped ?? 0) + 1;
       continue;
     }
-    const mutation = applyMinimize(subjectId, classifier);
+    // #2754, chatgpt-codex-connector review on PR #2788 (round 5): thread
+    // the remaining budget into applyMinimize's own `gh` call too -- the
+    // check just above guarantees `remaining() > 0` whenever `deadlineMs`
+    // is set, so this never risks passing a non-positive timeout.
+    const applyR = deadlineMs === undefined ? undefined : remaining();
+    const mutation = applyMinimize(
+      subjectId,
+      classifier,
+      applyR !== undefined && applyR > 0 ? applyR : undefined,
+    );
     if (mutation.ok) {
       report.items.push({
         subjectId,
@@ -327,13 +352,14 @@ function isUnresolvableRestShapedId(subjectId, errorText) {
     UNRESOLVABLE_NODE_ID_PATTERN.test(errorText)
   );
 }
-export function probeSubject(subjectId) {
-  const result = runGh([
-    'api',
-    ...resolveGhHostnameArgs(),
-    'graphql',
-    '-f',
-    `query=query($id:ID!){
+export function probeSubject(subjectId, timeoutMs) {
+  const result = runGh(
+    [
+      'api',
+      ...resolveGhHostnameArgs(),
+      'graphql',
+      '-f',
+      `query=query($id:ID!){
         node(id:$id){
           __typename
           ... on IssueComment{id url isMinimized minimizedReason viewerCanMinimize author{login}}
@@ -341,9 +367,11 @@ export function probeSubject(subjectId) {
           ... on PullRequestReviewComment{id url isMinimized minimizedReason viewerCanMinimize author{login}}
         }
       }`,
-    '-f',
-    `id=${subjectId}`,
-  ]);
+      '-f',
+      `id=${subjectId}`,
+    ],
+    timeoutMs,
+  );
   if (!result.ok) {
     if (isUnresolvableRestShapedId(subjectId, result.stderr)) {
       return { ok: false, reason: unresolvableNodeIdReason(subjectId) };
@@ -390,13 +418,14 @@ export function probeSubject(subjectId) {
     },
   };
 }
-export function applyMinimize(subjectId, classifier) {
-  const result = runGh([
-    'api',
-    ...resolveGhHostnameArgs(),
-    'graphql',
-    '-f',
-    `query=mutation($id:ID!,$classifier:ReportedContentClassifiers!){
+export function applyMinimize(subjectId, classifier, timeoutMs) {
+  const result = runGh(
+    [
+      'api',
+      ...resolveGhHostnameArgs(),
+      'graphql',
+      '-f',
+      `query=mutation($id:ID!,$classifier:ReportedContentClassifiers!){
       minimizeComment(input:{subjectId:$id,classifier:$classifier}){
         minimizedComment{
           __typename
@@ -406,11 +435,13 @@ export function applyMinimize(subjectId, classifier) {
         }
       }
     }`,
-    '-f',
-    `id=${subjectId}`,
-    '-f',
-    `classifier=${classifier}`,
-  ]);
+      '-f',
+      `id=${subjectId}`,
+      '-f',
+      `classifier=${classifier}`,
+    ],
+    timeoutMs,
+  );
   if (!result.ok) {
     return {
       ok: false,
@@ -511,11 +542,11 @@ function printTable(report) {
     console.log(`  [${item.status}] ${item.subjectId}  ${url}  ${reason}`);
   }
 }
-function runGh(argv) {
+function runGh(argv, timeoutMs = GH_TIMEOUT_MS) {
   try {
     const stdout = execFileSync('gh', argv, {
       encoding: 'utf8',
-      timeout: GH_TIMEOUT_MS,
+      timeout: timeoutMs,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
     return { ok: true, stdout };

--- a/idd-template/scripts/minimize-superseded-markers.mjs
+++ b/idd-template/scripts/minimize-superseded-markers.mjs
@@ -154,6 +154,7 @@ export function runMinimize({
   trustedSet,
   apply,
   allowUntrusted,
+  deadlineMs,
 }) {
   const report = {
     mode: apply ? 'apply' : 'dry-run',
@@ -166,10 +167,28 @@ export function runMinimize({
       unsupportedType: 0,
       applied: 0,
       failed: 0,
+      deadlineSkipped: 0,
     },
     items: [],
   };
-  for (const subjectId of subjectIds) {
+  const startedAt = Date.now();
+  for (const [index, subjectId] of subjectIds.entries()) {
+    if (
+      deadlineMs !== undefined &&
+      index > 0 &&
+      Date.now() - startedAt >= deadlineMs
+    ) {
+      for (const remainingId of subjectIds.slice(index)) {
+        report.items.push({
+          subjectId: remainingId,
+          status: 'skipped',
+          reason: 'deadline-exceeded',
+        });
+      }
+      report.counts.deadlineSkipped =
+        (report.counts.deadlineSkipped ?? 0) + (subjectIds.length - index);
+      break;
+    }
     const probe = probeSubject(subjectId);
     if (!probe.ok) {
       report.items.push({ subjectId, status: 'failed', reason: probe.reason });

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -275,13 +275,13 @@ const MARKER_HIDE_POLICY_ENTRIES = [
     label: 'review-ack:',
     policy: 'wired',
     reason:
-      'review-ack family, grouped by embedded HEAD SHA mismatch. Hidden at post time by post-idd-marker.mts itself (code-automated, not an agent-followed instruction step, unlike the other wired families above) -- roadmap #2751 Track 2 (#2754).',
+      'review-ack family, grouped by embedded HEAD SHA mismatch. Hidden at post time by post-idd-marker.mjs itself (code-automated, not an agent-followed instruction step, unlike the other wired families above); requires a helper runtime, so an instructions-only manual post gets no equivalent hide step yet -- roadmap #2751 Track 2 (#2754).',
   },
   {
     label: 'copilot-unavailable:',
     policy: 'wired',
     reason:
-      'copilot-unavailable family, grouped by same claim: value (differing attempt: numbers). Hidden at post time by post-idd-marker.mts itself (code-automated, not an agent-followed instruction step, unlike the other wired families above) -- roadmap #2751 Track 2 (#2754).',
+      'copilot-unavailable family, grouped by same claim: value (differing attempt: numbers). Hidden at post time by post-idd-marker.mjs itself (code-automated, not an agent-followed instruction step, unlike the other wired families above); requires a helper runtime, so an instructions-only manual post gets no equivalent hide step yet -- roadmap #2751 Track 2 (#2754).',
   },
   {
     label: '<!-- forced-handoff:',

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -281,7 +281,7 @@ const MARKER_HIDE_POLICY_ENTRIES = [
     label: 'copilot-unavailable:',
     policy: 'wired',
     reason:
-      'copilot-unavailable family, grouped by same claim: value (differing attempt: numbers). Hidden at post time by post-idd-marker.mjs itself (code-automated, not an agent-followed instruction step, unlike the other wired families above); requires a helper runtime, so an instructions-only manual post gets no equivalent hide step yet -- roadmap #2751 Track 2 (#2754).',
+      'copilot-unavailable family, grouped by same claim: value and a strictly lower attempt: number (a same-or-higher attempt is left alone). Hidden at post time by post-idd-marker.mjs itself (code-automated, not an agent-followed instruction step, unlike the other wired families above); requires a helper runtime, so an instructions-only manual post gets no equivalent hide step yet -- roadmap #2751 Track 2 (#2754).',
   },
   {
     label: '<!-- forced-handoff:',

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -273,15 +273,15 @@ const MARKER_HIDE_POLICY_ENTRIES = [
   },
   {
     label: 'review-ack:',
-    policy: 'f4-only',
+    policy: 'wired',
     reason:
-      'No hide-at-post-time wiring yet; only the post-merge F4 cleanup batch cleans it up today. Flipped to wired by roadmap #2751 Track 2 (#2754).',
+      'review-ack family, grouped by embedded HEAD SHA mismatch. Hidden at post time by post-idd-marker.mts itself (code-automated, not an agent-followed instruction step, unlike the other wired families above) -- roadmap #2751 Track 2 (#2754).',
   },
   {
     label: 'copilot-unavailable:',
-    policy: 'f4-only',
+    policy: 'wired',
     reason:
-      'No hide-at-post-time wiring yet; only the post-merge F4 cleanup batch cleans it up today. Flipped to wired by roadmap #2751 Track 2 (#2754).',
+      'copilot-unavailable family, grouped by same claim: value (differing attempt: numbers). Hidden at post time by post-idd-marker.mts itself (code-automated, not an agent-followed instruction step, unlike the other wired families above) -- roadmap #2751 Track 2 (#2754).',
   },
   {
     label: '<!-- forced-handoff:',
@@ -1666,6 +1666,29 @@ export function renderReviewAckMarker(payload) {
     );
   }
   return `review-ack: ${agentId} ${headSha} ${timestamp}`;
+}
+/**
+ * Parse a `review-ack:` marker (#2754). Returns `null` on any structural
+ * mismatch (including a `copilot-unavailable:`-shaped bound body, which this
+ * plain 3-field pattern never matches). Used by `post-idd-marker.mts`'s
+ * hide-at-post-time step to find prior `review-ack:` comments whose
+ * embedded HEAD SHA differs from a freshly posted one.
+ */
+export function parseReviewAckComment(body, createdAt) {
+  const match = body
+    .trimEnd()
+    .match(
+      /^review-ack:\s+(\S+)\s+([0-9a-f]{40})\s+(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)\s*$/,
+    );
+  if (!match) {
+    return null;
+  }
+  return {
+    agentId: match[1],
+    headSha: match[2].toLowerCase(),
+    timestamp: match[3],
+    createdAt: isValidIsoTimestamp(createdAt) ? createdAt : 'none',
+  };
 }
 // #1905: the grammar's positional claim-id field
 // (`{agent-id} {claim-id|none} {head-sha} ...`) already accepts an

--- a/scripts/minimize-superseded-markers.mjs
+++ b/scripts/minimize-superseded-markers.mjs
@@ -253,6 +253,30 @@ export function runMinimize({
       });
       continue;
     }
+    // Second deadline check, immediately before the mutation call itself
+    // (#2754, chatgpt-codex-connector review on PR #2788): the entry check
+    // above only bounds how many candidates this pass STARTS probing --
+    // once a candidate is already in flight (including the very first,
+    // which the entry check always lets through), its own `probeSubject`
+    // call can still cost up to `GH_TIMEOUT_MS`. Without a check here too,
+    // that candidate would still reach `applyMinimize` and cost up to
+    // ANOTHER full `GH_TIMEOUT_MS`, so a single candidate's own probe+apply
+    // pair -- not just the between-candidates gap -- could blow well past
+    // `deadlineMs` before this pass ever returns. Checked for every index
+    // (including 0): unlike the entry check, this one never needs an
+    // exemption to guarantee forward progress, since the candidate's own
+    // probe has already run either way -- only the MUTATION is skipped.
+    if (deadlineMs !== undefined && Date.now() - startedAt >= deadlineMs) {
+      report.items.push({
+        subjectId,
+        url,
+        typename,
+        status: 'skipped',
+        reason: 'deadline-exceeded',
+      });
+      report.counts.deadlineSkipped = (report.counts.deadlineSkipped ?? 0) + 1;
+      continue;
+    }
     const mutation = applyMinimize(subjectId, classifier);
     if (mutation.ok) {
       report.items.push({

--- a/scripts/minimize-superseded-markers.mjs
+++ b/scripts/minimize-superseded-markers.mjs
@@ -174,11 +174,18 @@ export function runMinimize({
   const startedAt = Date.now();
   const remaining = () => (deadlineMs ?? 0) - (Date.now() - startedAt);
   for (const [index, subjectId] of subjectIds.entries()) {
-    if (
-      deadlineMs !== undefined &&
-      index > 0 &&
-      Date.now() - startedAt >= deadlineMs
-    ) {
+    // #2754, copilot-pull-request-reviewer review on PR #2788 (round 6):
+    // read `remaining()` exactly ONCE per candidate and reuse that SAME
+    // value for both the skip decision and the timeout passed to
+    // probeSubject -- the entry check and the timeoutMs computation used
+    // to call `remaining()` (i.e. `Date.now()`) separately, a few lines
+    // apart; if the budget expired in that gap, a non-first candidate
+    // could still fall through to probeSubject with `undefined` (the 30s
+    // default) instead of being skipped, silently reopening the exact
+    // "runs for a full untouched GH_TIMEOUT_MS regardless of how little
+    // budget is left" gap round 5 closed for the common case.
+    const enteredRemaining = deadlineMs === undefined ? undefined : remaining();
+    if (deadlineMs !== undefined && index > 0 && enteredRemaining <= 0) {
       for (const remainingId of subjectIds.slice(index)) {
         report.items.push({
           subjectId: remainingId,
@@ -190,21 +197,19 @@ export function runMinimize({
         (report.counts.deadlineSkipped ?? 0) + (subjectIds.length - index);
       break;
     }
-    // #2754, chatgpt-codex-connector review on PR #2788 (round 5): thread
-    // the REMAINING budget into probeSubject itself, not just the entry
-    // check above -- otherwise a candidate let through by the entry check
-    // (including the always-exempt index 0) could still let its own probe
-    // run for a full untouched `GH_TIMEOUT_MS` regardless of how little
-    // budget is actually left. `r > 0` guards the one case that check
-    // cannot rule out (index 0 when `deadlineMs` is already exhausted at
-    // entry): never pass a non-positive number here (gh-exec.mts and
+    // Past the check above, `enteredRemaining` is guaranteed > 0 for every
+    // index > 0 -- reused as-is, no second `remaining()` read. Index 0 is
+    // exempt from the skip (the pass always attempts at least one
+    // candidate) and can still be non-positive here; falling back to
+    // probeSubject's own default in that one case is deliberate, not a
+    // gap: never pass a non-positive number through (gh-exec.mts and
     // execFileSync both read `timeout: 0` as "no timeout", the opposite of
-    // "budget already exhausted") -- fall back to probeSubject's own
-    // default instead.
-    const probeR = deadlineMs === undefined ? undefined : remaining();
+    // "budget already exhausted").
     const probe = probeSubject(
       subjectId,
-      probeR !== undefined && probeR > 0 ? probeR : undefined,
+      enteredRemaining !== undefined && enteredRemaining > 0
+        ? enteredRemaining
+        : undefined,
     );
     if (!probe.ok) {
       report.items.push({ subjectId, status: 'failed', reason: probe.reason });
@@ -282,7 +287,18 @@ export function runMinimize({
     // (including 0): unlike the entry check, this one never needs an
     // exemption to guarantee forward progress, since the candidate's own
     // probe has already run either way -- only the MUTATION is skipped.
-    if (deadlineMs !== undefined && Date.now() - startedAt >= deadlineMs) {
+    //
+    // #2754, copilot-pull-request-reviewer review on PR #2788 (round 6):
+    // read `remaining()` exactly ONCE here and reuse that SAME value for
+    // both the skip decision and applyMinimize's own timeout -- round 5
+    // read it a second time a few lines below, so a budget that expired in
+    // that gap could still fall through to `undefined` (the 30s default)
+    // instead of being skipped, silently reopening the exact
+    // "applyMinimize costs up to another full GH_TIMEOUT_MS regardless of
+    // budget" gap this check exists to close.
+    const preApplyRemaining =
+      deadlineMs === undefined ? undefined : remaining();
+    if (deadlineMs !== undefined && preApplyRemaining <= 0) {
       report.items.push({
         subjectId,
         url,
@@ -293,16 +309,11 @@ export function runMinimize({
       report.counts.deadlineSkipped = (report.counts.deadlineSkipped ?? 0) + 1;
       continue;
     }
-    // #2754, chatgpt-codex-connector review on PR #2788 (round 5): thread
-    // the remaining budget into applyMinimize's own `gh` call too -- the
-    // check just above guarantees `remaining() > 0` whenever `deadlineMs`
-    // is set, so this never risks passing a non-positive timeout.
-    const applyR = deadlineMs === undefined ? undefined : remaining();
-    const mutation = applyMinimize(
-      subjectId,
-      classifier,
-      applyR !== undefined && applyR > 0 ? applyR : undefined,
-    );
+    // Past the check above, `preApplyRemaining` is guaranteed > 0 whenever
+    // `deadlineMs` is set (no index exemption here, unlike the probe
+    // check) -- reused as-is, no second `remaining()` read, so this never
+    // risks passing a non-positive timeout.
+    const mutation = applyMinimize(subjectId, classifier, preApplyRemaining);
     if (mutation.ok) {
       report.items.push({
         subjectId,

--- a/scripts/minimize-superseded-markers.mjs
+++ b/scripts/minimize-superseded-markers.mjs
@@ -34,6 +34,32 @@ function loadIddConfig() {
 // in the temporal dead zone when the trigger fires (see
 // discover-readiness-check.mts's / ci-wait-policy.mts's identical note).
 const GH_TIMEOUT_MS = 30_000;
+// #2754 (caught by chatgpt-codex-connector review on PR #2788): same
+// self-containment constraint as the two constants above -- cannot import
+// gh-exec.mts's resolveGhApiHostname, so duplicate the same GHES-hostname
+// resolution logic locally. Without this, every `runGh` call below always
+// targets github.com even on a GitHub Enterprise Server host where
+// GITHUB_SERVER_URL names the GHES instance but GH_HOST is unset (`gh`
+// itself never reads GITHUB_SERVER_URL), so a GHES-hosted repository's
+// probe/mutate GraphQL calls would silently fail to resolve any node id --
+// exactly the risk `post-idd-marker.mts`'s new hide-at-post-time step
+// (#2754) introduced by calling `runMinimize` from inside a GitHub Actions
+// job, where GITHUB_SERVER_URL is always set by the runtime but GH_HOST is
+// not set by default.
+export function resolveGhHostnameArgs(env = process.env) {
+  if (env.GH_HOST?.trim()) {
+    return [];
+  }
+  const serverUrl = env.GITHUB_SERVER_URL?.trim();
+  if (!serverUrl) {
+    return [];
+  }
+  const host = serverUrl
+    .replace(/^[a-z][a-z0-9+.-]*:\/\//i, '')
+    .replace(/\/+$/, '')
+    .toLowerCase();
+  return host && host !== 'github.com' ? ['--hostname', host] : [];
+}
 const ALLOWED_CLASSIFIERS = new Set(['OUTDATED', 'RESOLVED']);
 const ALLOWED_FORMATS = new Set(['json', 'table']);
 const MINIMIZABLE_TYPENAMES = new Set([
@@ -261,6 +287,7 @@ function isUnresolvableRestShapedId(subjectId, errorText) {
 export function probeSubject(subjectId) {
   const result = runGh([
     'api',
+    ...resolveGhHostnameArgs(),
     'graphql',
     '-f',
     `query=query($id:ID!){
@@ -323,6 +350,7 @@ export function probeSubject(subjectId) {
 export function applyMinimize(subjectId, classifier) {
   const result = runGh([
     'api',
+    ...resolveGhHostnameArgs(),
     'graphql',
     '-f',
     `query=mutation($id:ID!,$classifier:ReportedContentClassifiers!){

--- a/scripts/minimize-superseded-markers.mjs
+++ b/scripts/minimize-superseded-markers.mjs
@@ -172,6 +172,7 @@ export function runMinimize({
     items: [],
   };
   const startedAt = Date.now();
+  const remaining = () => (deadlineMs ?? 0) - (Date.now() - startedAt);
   for (const [index, subjectId] of subjectIds.entries()) {
     if (
       deadlineMs !== undefined &&
@@ -189,7 +190,22 @@ export function runMinimize({
         (report.counts.deadlineSkipped ?? 0) + (subjectIds.length - index);
       break;
     }
-    const probe = probeSubject(subjectId);
+    // #2754, chatgpt-codex-connector review on PR #2788 (round 5): thread
+    // the REMAINING budget into probeSubject itself, not just the entry
+    // check above -- otherwise a candidate let through by the entry check
+    // (including the always-exempt index 0) could still let its own probe
+    // run for a full untouched `GH_TIMEOUT_MS` regardless of how little
+    // budget is actually left. `r > 0` guards the one case that check
+    // cannot rule out (index 0 when `deadlineMs` is already exhausted at
+    // entry): never pass a non-positive number here (gh-exec.mts and
+    // execFileSync both read `timeout: 0` as "no timeout", the opposite of
+    // "budget already exhausted") -- fall back to probeSubject's own
+    // default instead.
+    const probeR = deadlineMs === undefined ? undefined : remaining();
+    const probe = probeSubject(
+      subjectId,
+      probeR !== undefined && probeR > 0 ? probeR : undefined,
+    );
     if (!probe.ok) {
       report.items.push({ subjectId, status: 'failed', reason: probe.reason });
       report.counts.failed += 1;
@@ -277,7 +293,16 @@ export function runMinimize({
       report.counts.deadlineSkipped = (report.counts.deadlineSkipped ?? 0) + 1;
       continue;
     }
-    const mutation = applyMinimize(subjectId, classifier);
+    // #2754, chatgpt-codex-connector review on PR #2788 (round 5): thread
+    // the remaining budget into applyMinimize's own `gh` call too -- the
+    // check just above guarantees `remaining() > 0` whenever `deadlineMs`
+    // is set, so this never risks passing a non-positive timeout.
+    const applyR = deadlineMs === undefined ? undefined : remaining();
+    const mutation = applyMinimize(
+      subjectId,
+      classifier,
+      applyR !== undefined && applyR > 0 ? applyR : undefined,
+    );
     if (mutation.ok) {
       report.items.push({
         subjectId,
@@ -327,13 +352,14 @@ function isUnresolvableRestShapedId(subjectId, errorText) {
     UNRESOLVABLE_NODE_ID_PATTERN.test(errorText)
   );
 }
-export function probeSubject(subjectId) {
-  const result = runGh([
-    'api',
-    ...resolveGhHostnameArgs(),
-    'graphql',
-    '-f',
-    `query=query($id:ID!){
+export function probeSubject(subjectId, timeoutMs) {
+  const result = runGh(
+    [
+      'api',
+      ...resolveGhHostnameArgs(),
+      'graphql',
+      '-f',
+      `query=query($id:ID!){
         node(id:$id){
           __typename
           ... on IssueComment{id url isMinimized minimizedReason viewerCanMinimize author{login}}
@@ -341,9 +367,11 @@ export function probeSubject(subjectId) {
           ... on PullRequestReviewComment{id url isMinimized minimizedReason viewerCanMinimize author{login}}
         }
       }`,
-    '-f',
-    `id=${subjectId}`,
-  ]);
+      '-f',
+      `id=${subjectId}`,
+    ],
+    timeoutMs,
+  );
   if (!result.ok) {
     if (isUnresolvableRestShapedId(subjectId, result.stderr)) {
       return { ok: false, reason: unresolvableNodeIdReason(subjectId) };
@@ -390,13 +418,14 @@ export function probeSubject(subjectId) {
     },
   };
 }
-export function applyMinimize(subjectId, classifier) {
-  const result = runGh([
-    'api',
-    ...resolveGhHostnameArgs(),
-    'graphql',
-    '-f',
-    `query=mutation($id:ID!,$classifier:ReportedContentClassifiers!){
+export function applyMinimize(subjectId, classifier, timeoutMs) {
+  const result = runGh(
+    [
+      'api',
+      ...resolveGhHostnameArgs(),
+      'graphql',
+      '-f',
+      `query=mutation($id:ID!,$classifier:ReportedContentClassifiers!){
       minimizeComment(input:{subjectId:$id,classifier:$classifier}){
         minimizedComment{
           __typename
@@ -406,11 +435,13 @@ export function applyMinimize(subjectId, classifier) {
         }
       }
     }`,
-    '-f',
-    `id=${subjectId}`,
-    '-f',
-    `classifier=${classifier}`,
-  ]);
+      '-f',
+      `id=${subjectId}`,
+      '-f',
+      `classifier=${classifier}`,
+    ],
+    timeoutMs,
+  );
   if (!result.ok) {
     return {
       ok: false,
@@ -511,11 +542,11 @@ function printTable(report) {
     console.log(`  [${item.status}] ${item.subjectId}  ${url}  ${reason}`);
   }
 }
-function runGh(argv) {
+function runGh(argv, timeoutMs = GH_TIMEOUT_MS) {
   try {
     const stdout = execFileSync('gh', argv, {
       encoding: 'utf8',
-      timeout: GH_TIMEOUT_MS,
+      timeout: timeoutMs,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
     return { ok: true, stdout };

--- a/scripts/minimize-superseded-markers.mjs
+++ b/scripts/minimize-superseded-markers.mjs
@@ -154,6 +154,7 @@ export function runMinimize({
   trustedSet,
   apply,
   allowUntrusted,
+  deadlineMs,
 }) {
   const report = {
     mode: apply ? 'apply' : 'dry-run',
@@ -166,10 +167,28 @@ export function runMinimize({
       unsupportedType: 0,
       applied: 0,
       failed: 0,
+      deadlineSkipped: 0,
     },
     items: [],
   };
-  for (const subjectId of subjectIds) {
+  const startedAt = Date.now();
+  for (const [index, subjectId] of subjectIds.entries()) {
+    if (
+      deadlineMs !== undefined &&
+      index > 0 &&
+      Date.now() - startedAt >= deadlineMs
+    ) {
+      for (const remainingId of subjectIds.slice(index)) {
+        report.items.push({
+          subjectId: remainingId,
+          status: 'skipped',
+          reason: 'deadline-exceeded',
+        });
+      }
+      report.counts.deadlineSkipped =
+        (report.counts.deadlineSkipped ?? 0) + (subjectIds.length - index);
+      break;
+    }
     const probe = probeSubject(subjectId);
     if (!probe.ok) {
       report.items.push({ subjectId, status: 'failed', reason: probe.reason });

--- a/scripts/post-idd-marker.mjs
+++ b/scripts/post-idd-marker.mjs
@@ -627,13 +627,25 @@ export function findSupersededReviewAckSubjects(comments, newHeadSha) {
  * comment.
  */
 export function findSupersededCopilotUnavailableSubjects(comments, newClaimId) {
+  // Trim before comparing (caught by Copilot review on PR #2788):
+  // renderCopilotUnavailableMarker normalizes claimId via
+  // normalizeNonWhitespaceToken() (trim + reject internal whitespace)
+  // before posting, so by the time this runs -- strictly after that POST
+  // already succeeded -- newClaimId can only ever carry leading/trailing
+  // whitespace relative to what was actually posted (internal whitespace
+  // would have failed that render-time validation and never reached
+  // here). Comparing the untrimmed CLI flag value against parsed.claimId
+  // (already whitespace-free, matched via `\S+`) would otherwise never
+  // match a same-claim prior comment when the caller passed the flag with
+  // surrounding whitespace, silently leaving it un-hidden.
+  const target = newClaimId.trim();
   const subjects = [];
   for (const comment of comments) {
     if (!comment.nodeId) {
       continue;
     }
     const parsed = parseCopilotUnavailableComment(comment.body, 'none');
-    if (!parsed || parsed.claimId !== newClaimId) {
+    if (!parsed || parsed.claimId !== target) {
       continue;
     }
     subjects.push(comment.nodeId);

--- a/scripts/post-idd-marker.mjs
+++ b/scripts/post-idd-marker.mjs
@@ -732,36 +732,42 @@ const HIDE_STEP_DEADLINE_MS = 45_000;
  * excludes it structurally, independent of what its embedded HEAD SHA or
  * `claim:` value happens to be.
  *
- * For BOTH types, this also re-reads the target PR's LIVE head SHA and
- * bails out (no scan, no mutation) unless it still matches
- * `fields['head-sha']` (caught by chatgpt-codex-connector review on PR
- * #2788, two rounds): `review-ack`'s usual `--from-pr` reads HEAD once
- * before composing and POSTing the marker body, so on a slow POST the
- * branch can advance and a concurrent session can already have posted a
- * genuine, current-HEAD acknowledgement by the time this step runs. The
- * `id <` restriction above only orders candidates by creation time -- it
- * cannot tell a stale marker from a fresh one once both are "prior" by id,
- * so without this check a stale-HEAD post could minimize that valid newer
- * acknowledgement while leaving its own, now-superseded one visible:
- * destroying the correct evidence instead of the stale evidence.
- * `copilot-unavailable` never derives `--head-sha` from `--from-pr` (its
- * supersession key, `claim-id`, always comes from an explicit CLI flag),
- * but that only rules out THIS caller's own embedded value going stale
- * between observation and POST -- it does nothing about a genuinely
- * different, concurrent same-claim poster (e.g. a stalled pre-handoff
- * session finally completing its retry against a claim a handoff already
- * moved on from): `findSupersededCopilotUnavailableSubjects` matches
- * purely on `claim:` equality, with no HEAD comparison of its own, so a
- * STALE same-claim post could still treat an earlier, CURRENT-HEAD
- * same-claim post as "superseded" purely by virtue of posting later
- * (round 2 review, initially missed: the check below was `review-ack`-only
- * until this). Applying the same live-HEAD gate to both types closes that
- * gap without needing a HEAD-aware rewrite of the claim-based finder
- * itself: a poster who is observably stale relative to current HEAD
- * simply never gets to run its own scan/hide judgment at all, regardless
- * of which family it belongs to. A failed re-read (not a PR, `gh` error,
- * anything else) falls through to the outer catch below and skips the
- * whole pass, same as any other best-effort failure.
+ * For BOTH types, this also re-reads the target PR's LIVE head SHA and, when
+ * it no longer matches `fields['head-sha']`, SELF-MINIMIZES the marker this
+ * call itself just posted instead of scanning for prior candidates (caught
+ * by chatgpt-codex-connector review on PR #2788, three rounds -- rounds 3-4
+ * bailed out entirely here; round 5 found that abandoning the just-posted
+ * marker left it expanded forever with no later invocation guaranteed to
+ * sweep it, mirroring the self-minimize sibling #2755 shipped for
+ * `idd-local-validation-evidence:` after the same finding there): `review-
+ * ack`'s usual `--from-pr` reads HEAD once before composing and POSTing the
+ * marker body, so on a slow POST the branch can advance and a concurrent
+ * session can already have posted a genuine, current-HEAD acknowledgement by
+ * the time this step runs. The `id <` restriction above only orders
+ * candidates by creation time -- it cannot tell a stale marker from a fresh
+ * one once both are "prior" by id, so scanning for prior candidates while
+ * stale could minimize that valid newer acknowledgement while leaving this
+ * call's own, now-superseded one visible: destroying the correct evidence
+ * instead of the stale evidence. `copilot-unavailable` never derives
+ * `--head-sha` from `--from-pr` (its supersession key, `claim-id`, always
+ * comes from an explicit CLI flag), but that only rules out THIS caller's
+ * own embedded value going stale between observation and POST -- it does
+ * nothing about a genuinely different, concurrent same-claim poster (e.g. a
+ * stalled pre-handoff session finally completing its retry against a claim a
+ * handoff already moved on from): `findSupersededCopilotUnavailableSubjects`
+ * matches purely on `claim:` equality, with no HEAD comparison of its own,
+ * so a STALE same-claim post could still treat an earlier, CURRENT-HEAD
+ * same-claim post as "superseded" purely by virtue of posting later (round 2
+ * review, initially missed: the check below was `review-ack`-only until
+ * round 4). Applying the same live-HEAD gate to both types closes that gap
+ * without needing a HEAD-aware rewrite of the claim-based finder itself: a
+ * poster who is observably stale relative to current HEAD never scans for
+ * OTHER candidates, regardless of which family it belongs to -- it only ever
+ * minimizes its own just-posted comment. The trust gate below (on
+ * `postedComment` itself) still applies either way, so an untrusted post
+ * never triggers even its own self-minimize. A failed re-read (not a PR,
+ * `gh` error, anything else) falls through to the outer catch below and
+ * skips the whole pass, same as any other best-effort failure.
  *
  * This step ALSO requires `postedCommentId`'s own author to be in the same
  * `trustedSet` `runMinimize` already gates candidates on (caught by
@@ -800,6 +806,16 @@ export function hideSupersededPostTimeMarkers(
   const startedAt = Date.now();
   const remaining = () => deadlineMs - (Date.now() - startedAt);
   try {
+    // #2754, chatgpt-codex-connector review round 5 on PR #2788: a stale
+    // live-HEAD no longer means "abandon this step entirely" -- it means
+    // "the marker this call just posted is ITSELF the superseded one".
+    // `stale` is recorded (no early return) so the trust gate below still
+    // runs on the shared `postedComment` read either way, and the subject
+    // set further down switches to self-minimizing that one comment
+    // instead of scanning for prior candidates. Sibling #2755 shipped this
+    // exact self-minimize behavior for `idd-local-validation-evidence:`
+    // after Codex found the same gap there first.
+    let stale = false;
     {
       const r = remaining();
       // Never pass `timeout: 0` to a `gh` call below -- gh-exec.mts (like
@@ -813,12 +829,9 @@ export function hideSupersededPostTimeMarkers(
         owner,
         repo,
       ).getChangeRequestHeadSha(number, { timeoutMs: r });
-      if (
+      stale =
         liveHeadSha.trim().toLowerCase() !==
-        fields['head-sha'].trim().toLowerCase()
-      ) {
-        return;
-      }
+        fields['head-sha'].trim().toLowerCase();
     }
     const { actors } = resolveTrustedActors({
       flagValue: trustedMarkerLoginsFlag,
@@ -845,7 +858,8 @@ export function hideSupersededPostTimeMarkers(
     ) {
       // The marker this call just posted is itself untrusted (or its own
       // record could not be re-read) -- never let an untrusted post drive
-      // this step to minimize an older, TRUSTED candidate. Downstream
+      // this step to minimize an older, TRUSTED candidate, or to
+      // self-minimize on ITS OWN say-so when stale. Downstream
       // trust-filtered consumers already ignore an untrusted marker as if
       // it never existed; letting it collapse the trusted terminal marker
       // it claims to supersede would erase the only copy those consumers
@@ -853,17 +867,22 @@ export function hideSupersededPostTimeMarkers(
       // #2788).
       return;
     }
-    const comments = allComments.filter(
-      (comment) => comment.id < postedCommentId,
-    );
-    const subjectIds =
-      type === 'review-ack'
-        ? findSupersededReviewAckSubjects(comments, fields['head-sha'])
-        : findSupersededCopilotUnavailableSubjects(
-            comments,
-            fields['claim-id'],
-            Number(fields.attempt),
+    const subjectIds = stale
+      ? postedComment.nodeId
+        ? [postedComment.nodeId]
+        : []
+      : (() => {
+          const comments = allComments.filter(
+            (comment) => comment.id < postedCommentId,
           );
+          return type === 'review-ack'
+            ? findSupersededReviewAckSubjects(comments, fields['head-sha'])
+            : findSupersededCopilotUnavailableSubjects(
+                comments,
+                fields['claim-id'],
+                Number(fields.attempt),
+              );
+        })();
     if (subjectIds.length === 0) {
       return;
     }

--- a/scripts/post-idd-marker.mjs
+++ b/scripts/post-idd-marker.mjs
@@ -709,23 +709,36 @@ const HIDE_STEP_DEADLINE_MS = 45_000;
  * excludes it structurally, independent of what its embedded HEAD SHA or
  * `claim:` value happens to be.
  *
- * For `review-ack` specifically, this also re-reads the target PR's LIVE
- * head SHA and bails out (no scan, no mutation) unless it still matches
+ * For BOTH types, this also re-reads the target PR's LIVE head SHA and
+ * bails out (no scan, no mutation) unless it still matches
  * `fields['head-sha']` (caught by chatgpt-codex-connector review on PR
- * #2788): `--from-pr` reads HEAD once before composing and POSTing the
- * marker body, so on a slow POST the branch can advance and a concurrent
- * session can already have posted a genuine, current-HEAD acknowledgement
- * by the time this step runs. The `id <` restriction above only orders
- * candidates by creation time -- it cannot tell a stale marker from a fresh
- * one once both are "prior" by id, so without this check a stale-HEAD
- * post could minimize that valid newer acknowledgement while leaving its
- * own, now-superseded one visible: destroying the correct evidence instead
- * of the stale evidence. `copilot-unavailable` carries no live-derived
- * field (its supersession key, `claim-id`, always comes from an explicit
- * CLI flag, never `--from-pr`), so no equivalent drift is possible there
- * and this check is skipped for that type. A failed re-read (not a PR, `gh`
- * error, anything else) falls through to the outer catch below and skips
- * the whole pass, same as any other best-effort failure.
+ * #2788, two rounds): `review-ack`'s usual `--from-pr` reads HEAD once
+ * before composing and POSTing the marker body, so on a slow POST the
+ * branch can advance and a concurrent session can already have posted a
+ * genuine, current-HEAD acknowledgement by the time this step runs. The
+ * `id <` restriction above only orders candidates by creation time -- it
+ * cannot tell a stale marker from a fresh one once both are "prior" by id,
+ * so without this check a stale-HEAD post could minimize that valid newer
+ * acknowledgement while leaving its own, now-superseded one visible:
+ * destroying the correct evidence instead of the stale evidence.
+ * `copilot-unavailable` never derives `--head-sha` from `--from-pr` (its
+ * supersession key, `claim-id`, always comes from an explicit CLI flag),
+ * but that only rules out THIS caller's own embedded value going stale
+ * between observation and POST -- it does nothing about a genuinely
+ * different, concurrent same-claim poster (e.g. a stalled pre-handoff
+ * session finally completing its retry against a claim a handoff already
+ * moved on from): `findSupersededCopilotUnavailableSubjects` matches
+ * purely on `claim:` equality, with no HEAD comparison of its own, so a
+ * STALE same-claim post could still treat an earlier, CURRENT-HEAD
+ * same-claim post as "superseded" purely by virtue of posting later
+ * (round 2 review, initially missed: the check below was `review-ack`-only
+ * until this). Applying the same live-HEAD gate to both types closes that
+ * gap without needing a HEAD-aware rewrite of the claim-based finder
+ * itself: a poster who is observably stale relative to current HEAD
+ * simply never gets to run its own scan/hide judgment at all, regardless
+ * of which family it belongs to. A failed re-read (not a PR, `gh` error,
+ * anything else) falls through to the outer catch below and skips the
+ * whole pass, same as any other best-effort failure.
  *
  * This step ALSO requires `postedCommentId`'s own author to be in the same
  * `trustedSet` `runMinimize` already gates candidates on (caught by
@@ -764,7 +777,7 @@ export function hideSupersededPostTimeMarkers(
   const startedAt = Date.now();
   const remaining = () => deadlineMs - (Date.now() - startedAt);
   try {
-    if (type === 'review-ack') {
+    {
       const r = remaining();
       // Never pass `timeout: 0` to a `gh` call below -- gh-exec.mts (like
       // Node's own `execFileSync`) treats that as "no timeout", the exact

--- a/scripts/post-idd-marker.mjs
+++ b/scripts/post-idd-marker.mjs
@@ -655,17 +655,20 @@ export function findSupersededCopilotUnavailableSubjects(comments, newClaimId) {
   return subjects;
 }
 /**
- * Overall time budget (#2754, chatgpt-codex-connector review on PR #2788)
- * for {@link hideSupersededPostTimeMarkers}'s best-effort mutation pass.
- * `minimize-superseded-markers.mts`'s `runGh` bounds each individual `gh`
- * call to `GH_TIMEOUT_MS` (30s), but that alone does not bound the PASS: a
- * PR with several superseded markers can chain multiple 30s-timeout probes
- * and mutations back to back with no overall cap, stalling the caller's
- * envelope output for a multiple of 30s after the marker it is hiding *for*
- * has already posted successfully. `runMinimize`'s optional `deadlineMs`
- * stops issuing new `gh` calls once this budget is exhausted (always
- * finishing the first candidate it starts) and marks the remainder
- * `skipped` / `deadline-exceeded` instead of leaving the pass unbounded.
+ * Overall time budget (#2754, chatgpt-codex-connector review on PR #2788,
+ * two rounds) for {@link hideSupersededPostTimeMarkers}'s best-effort
+ * mutation pass. `minimize-superseded-markers.mts`'s `runGh` bounds each
+ * individual `gh` call to `GH_TIMEOUT_MS` (30s), but that alone does not
+ * bound the PASS: a PR with several superseded markers can chain multiple
+ * 30s-timeout probes and mutations back to back with no overall cap,
+ * stalling the caller's envelope output well beyond this budget after the
+ * marker it is hiding *for* has already posted successfully. `runMinimize`'s
+ * optional `deadlineMs` checks this budget at two points per candidate
+ * (before starting a new one, and again before mutating it) so no SECOND
+ * candidate can ever reach its own mutation once the budget is spent --
+ * see `runMinimize`'s own `deadlineMs` doc comment for the exact bound
+ * (`deadlineMs + GH_TIMEOUT_MS` worst case for the one candidate already
+ * in flight when the budget runs out, not `deadlineMs` alone).
  */
 const HIDE_STEP_DEADLINE_MS = 45_000;
 /**

--- a/scripts/post-idd-marker.mjs
+++ b/scripts/post-idd-marker.mjs
@@ -631,7 +631,11 @@ export function findSupersededReviewAckSubjects(comments, newHeadSha) {
  * (foreign-claim protection) or an unparseable / non-`copilot-unavailable:`
  * comment.
  */
-export function findSupersededCopilotUnavailableSubjects(comments, newClaimId) {
+export function findSupersededCopilotUnavailableSubjects(
+  comments,
+  newClaimId,
+  newAttempt,
+) {
   // Trim before comparing (caught by Copilot review on PR #2788):
   // renderCopilotUnavailableMarker normalizes claimId via
   // normalizeNonWhitespaceToken() (trim + reject internal whitespace)
@@ -651,6 +655,24 @@ export function findSupersededCopilotUnavailableSubjects(comments, newClaimId) {
     }
     const parsed = parseCopilotUnavailableComment(comment.body, 'none');
     if (!parsed || parsed.claimId !== target) {
+      continue;
+    }
+    // Only a STRICTLY LOWER attempt number is ever superseded (caught by
+    // chatgpt-codex-connector review on PR #2788, round 5): claim:
+    // equality alone says nothing about which attempt is actually more
+    // advanced. Two same-claim sessions racing on the SAME HEAD (no HEAD
+    // drift needed -- the live-HEAD gate above cannot catch this) can
+    // still POST out of attempt order -- e.g. attempt 2 lands with a
+    // LOWER REST id while a stalled attempt 1 lands with the next one --
+    // and an attempt-blind filter would let that delayed, regressive
+    // attempt 1 hide the more advanced attempt 2, leaving the regressive
+    // marker as the only one expanded. A same-attempt candidate (a bare
+    // retry of this exact attempt number, e.g. re-POSTing after a failed
+    // hide step) is deliberately left alone rather than guessing whether
+    // it is a true duplicate: current-attempt protection, the same
+    // conservative "when ambiguous, never hide" policy the live-HEAD gate
+    // above already applies to a same-embedded-HEAD review-ack.
+    if (!(parsed.attempt < newAttempt)) {
       continue;
     }
     subjects.push(comment.nodeId);
@@ -839,6 +861,7 @@ export function hideSupersededPostTimeMarkers(
         : findSupersededCopilotUnavailableSubjects(
             comments,
             fields['claim-id'],
+            Number(fields.attempt),
           );
     if (subjectIds.length === 0) {
       return;

--- a/scripts/post-idd-marker.mjs
+++ b/scripts/post-idd-marker.mjs
@@ -19,7 +19,14 @@
 import { execFileSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import { requireFlag, stripLeadingArgumentSeparator } from './cli-args.mjs';
+import { loadIddConfig } from './idd-config.mjs';
 import {
+  resolveTrustedActors,
+  runMinimize,
+} from './minimize-superseded-markers.mjs';
+import {
+  parseCopilotUnavailableComment,
+  parseReviewAckComment,
   renderActivationNonceMarker,
   renderAdvisoryRerollMarker,
   renderAdvisoryWaitMarker,
@@ -35,6 +42,24 @@ import {
   createGithubProviderAdapter,
   resolveCurrentGithubRepository,
 } from './provider-adapter-github.mjs';
+/**
+ * Marker types whose prior same-family comments this module automatically
+ * hides (classifier `OUTDATED`) immediately after a fresh instance POSTs
+ * successfully under `--apply` -- the hide-at-post-time exception
+ * documented in `docs/idd-comment-minimization.md`'s "## Timing" section
+ * (#2754). Unlike the other `wired` families there (claim chain,
+ * review-watermark/baseline, advisory-wait), which are agent-followed
+ * instruction steps, this pair's grouping keys are purely mechanical
+ * (embedded HEAD SHA mismatch; same `claim:` value), so the hide step is
+ * code-automated directly inside this CLI's own `--apply` path instead.
+ */
+export const HIDE_AT_POST_TIME_MARKER_TYPES = [
+  'review-ack',
+  'copilot-unavailable',
+];
+export function isHideAtPostTimeMarkerType(type) {
+  return HIDE_AT_POST_TIME_MARKER_TYPES.includes(type);
+}
 export const MARKER_TYPES = [
   'claim',
   'unclaim',
@@ -448,6 +473,17 @@ review-activity-snapshot path.
 --expected-head-sha pins a --type watermark --from-pr to the Step 1 stored
 HEAD and fails closed (no post) on drift instead of silently posting a newer
 HEAD than Step 1 saw.
+
+--apply --type review-ack / --type copilot-unavailable (#2754): after the
+new marker POSTs successfully, this command also hides (classifier
+OUTDATED, via minimize-superseded-markers.mts) prior same-family comments
+it supersedes -- a review-ack: whose embedded HEAD SHA differs from the one
+just posted, or a copilot-unavailable: carrying the same claim: value.
+--trusted-marker-logins gates that hide step's trusted-author check too
+(falls back to IDD_TRUSTED_MARKER_ACTORS / the config trustedMarkerActors
+list, same ladder as minimize-superseded-markers.mjs). Best-effort: a
+permission error or any other failure here is swallowed and never blocks
+or retries the marker post that already succeeded.
 `;
 /**
  * POST the marker body as a JSON document (`{"body": …}`) read from stdin via
@@ -537,6 +573,126 @@ function runReviewActivitySnapshot(
     encoding: 'utf8',
   });
   return JSON.parse(out);
+}
+/**
+ * List every comment on `number` (issue or PR -- same comments endpoint),
+ * shaped for the hide-at-post-time candidate scan. Routed through
+ * {@link createGithubProviderAdapter} (`listWorkItemComments`), like every
+ * other read in this migrated file (#2266) -- `post-idd-marker.mts` must
+ * never construct a `gh` call of its own
+ * (`tests/provider-port-migration-guard.test.mts`). A comment missing a
+ * `nodeId` (defensive: the real adapter always populates it from REST's
+ * `node_id`) normalizes to `''`, which the finder functions below already
+ * skip.
+ */
+function listMarkerCandidateComments(owner, repo, number) {
+  return createGithubProviderAdapter(owner, repo)
+    .listWorkItemComments(number)
+    .map((comment) => ({
+      id: comment.id,
+      nodeId: comment.nodeId ?? '',
+      body: comment.body,
+    }));
+}
+/**
+ * Find prior `review-ack:` comments (among `comments`, already excluding the
+ * marker just posted) whose embedded HEAD SHA differs from `newHeadSha` --
+ * the candidates a fresh `review-ack` post should minimize as `OUTDATED`,
+ * mirroring the shipped `advisory-wait` AW3-H rule. Never returns a
+ * candidate matching `newHeadSha` (current-HEAD protection) or an
+ * unparseable / non-`review-ack:` comment.
+ */
+export function findSupersededReviewAckSubjects(comments, newHeadSha) {
+  const target = newHeadSha.trim().toLowerCase();
+  const subjects = [];
+  for (const comment of comments) {
+    if (!comment.nodeId) {
+      continue;
+    }
+    const parsed = parseReviewAckComment(comment.body, 'none');
+    if (!parsed || parsed.headSha === target) {
+      continue;
+    }
+    subjects.push(comment.nodeId);
+  }
+  return subjects;
+}
+/**
+ * Find prior `copilot-unavailable:` comments (among `comments`, already
+ * excluding the marker just posted) carrying the SAME `claim:` value as
+ * `newClaimId` -- the candidates a fresh `copilot-unavailable` post should
+ * minimize as `OUTDATED`, mirroring the shipped watermark/claim-chain
+ * supersession rule. Never returns a candidate whose `claim:` value differs
+ * (foreign-claim protection) or an unparseable / non-`copilot-unavailable:`
+ * comment.
+ */
+export function findSupersededCopilotUnavailableSubjects(comments, newClaimId) {
+  const subjects = [];
+  for (const comment of comments) {
+    if (!comment.nodeId) {
+      continue;
+    }
+    const parsed = parseCopilotUnavailableComment(comment.body, 'none');
+    if (!parsed || parsed.claimId !== newClaimId) {
+      continue;
+    }
+    subjects.push(comment.nodeId);
+  }
+  return subjects;
+}
+/**
+ * Best-effort hide-at-post-time step for {@link HIDE_AT_POST_TIME_MARKER_TYPES}
+ * (#2754). Runs only after `postedCommentId`'s own POST already succeeded
+ * (the caller invokes this strictly afterward, never before or interleaved),
+ * scans the target's OTHER comments for same-family markers superseded by
+ * the one just posted, and reuses `minimize-superseded-markers.mts`'s
+ * `runMinimize` for the actual mutation -- the same trusted-author gate,
+ * already-`isMinimized` skip, and `viewerCanMinimize` check that helper
+ * already implements, so this call site adds no new mutation logic of its
+ * own. Every failure (an unreadable comment list, a `gh` permission error, a
+ * malformed GraphQL response, anything else) is swallowed here: this step
+ * must never retry-loop or throw back into the caller, since the marker it
+ * is hiding *for* has already posted successfully by the time this runs.
+ */
+function hideSupersededPostTimeMarkers(
+  type,
+  fields,
+  owner,
+  repo,
+  number,
+  postedCommentId,
+  trustedMarkerLoginsFlag,
+) {
+  try {
+    const comments = listMarkerCandidateComments(owner, repo, number).filter(
+      (comment) => comment.id !== postedCommentId,
+    );
+    const subjectIds =
+      type === 'review-ack'
+        ? findSupersededReviewAckSubjects(comments, fields['head-sha'])
+        : findSupersededCopilotUnavailableSubjects(
+            comments,
+            fields['claim-id'],
+          );
+    if (subjectIds.length === 0) {
+      return;
+    }
+    const { actors } = resolveTrustedActors({
+      flagValue: trustedMarkerLoginsFlag,
+      envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
+      config: loadIddConfig(),
+    });
+    runMinimize({
+      subjectIds,
+      classifier: 'OUTDATED',
+      trustedSet: new Set(actors),
+      apply: true,
+      allowUntrusted: false,
+    });
+  } catch {
+    // Best-effort only (#2754) -- never block or retry-loop the marker post
+    // that already succeeded above.
+  }
 }
 if (import.meta.main) {
   let args;
@@ -733,6 +889,17 @@ if (import.meta.main) {
   const owner = args.owner || applyCurrentRepo?.owner || '';
   const repo = args.repo || applyCurrentRepo?.repo || '';
   const posted = postMarker(owner, repo, number, body);
+  if (isHideAtPostTimeMarkerType(args.type)) {
+    hideSupersededPostTimeMarkers(
+      args.type,
+      args.fields,
+      owner,
+      repo,
+      number,
+      posted.id,
+      args.trustedMarkerLogins,
+    );
+  }
   const result = {
     mode: 'apply',
     type: args.type,

--- a/scripts/post-idd-marker.mjs
+++ b/scripts/post-idd-marker.mjs
@@ -653,6 +653,18 @@ export function findSupersededCopilotUnavailableSubjects(comments, newClaimId) {
  * malformed GraphQL response, anything else) is swallowed here: this step
  * must never retry-loop or throw back into the caller, since the marker it
  * is hiding *for* has already posted successfully by the time this runs.
+ *
+ * Candidates are restricted to comments **older** than `postedCommentId`
+ * (`comment.id < postedCommentId`, REST issue-comment ids are assigned
+ * sequentially at creation) rather than merely excluding an exact id match
+ * (caught by chatgpt-codex-connector review on PR #2788): the comments scan
+ * runs after this marker's own POST, so a concurrent session's marker
+ * created in that window can already appear in the listing with a HIGHER
+ * id. An inequality-only filter would treat that genuinely newer marker as
+ * "prior" and hide it as `OUTDATED` -- exactly backwards, since it is this
+ * call's own marker that is older by comparison. The `<` restriction
+ * excludes it structurally, independent of what its embedded HEAD SHA or
+ * `claim:` value happens to be.
  */
 function hideSupersededPostTimeMarkers(
   type,
@@ -665,7 +677,7 @@ function hideSupersededPostTimeMarkers(
 ) {
   try {
     const comments = listMarkerCandidateComments(owner, repo, number).filter(
-      (comment) => comment.id !== postedCommentId,
+      (comment) => comment.id < postedCommentId,
     );
     const subjectIds =
       type === 'review-ack'

--- a/scripts/post-idd-marker.mjs
+++ b/scripts/post-idd-marker.mjs
@@ -586,9 +586,12 @@ function runReviewActivitySnapshot(
  * `node_id`) normalizes to `''`, which the finder functions below already
  * skip.
  */
-function listMarkerCandidateComments(owner, repo, number) {
+function listMarkerCandidateComments(owner, repo, number, timeoutMs) {
   return createGithubProviderAdapter(owner, repo)
-    .listWorkItemComments(number)
+    .listWorkItemComments(
+      number,
+      timeoutMs !== undefined ? { timeoutMs } : undefined,
+    )
     .map((comment) => ({
       id: comment.id,
       nodeId: comment.nodeId ?? '',
@@ -656,19 +659,28 @@ export function findSupersededCopilotUnavailableSubjects(comments, newClaimId) {
 }
 /**
  * Overall time budget (#2754, chatgpt-codex-connector review on PR #2788,
- * two rounds) for {@link hideSupersededPostTimeMarkers}'s best-effort
- * mutation pass. `minimize-superseded-markers.mts`'s `runGh` bounds each
- * individual `gh` call to `GH_TIMEOUT_MS` (30s), but that alone does not
- * bound the PASS: a PR with several superseded markers can chain multiple
- * 30s-timeout probes and mutations back to back with no overall cap,
- * stalling the caller's envelope output well beyond this budget after the
- * marker it is hiding *for* has already posted successfully. `runMinimize`'s
- * optional `deadlineMs` checks this budget at two points per candidate
- * (before starting a new one, and again before mutating it) so no SECOND
- * candidate can ever reach its own mutation once the budget is spent --
- * see `runMinimize`'s own `deadlineMs` doc comment for the exact bound
- * (`deadlineMs + GH_TIMEOUT_MS` worst case for the one candidate already
- * in flight when the budget runs out, not `deadlineMs` alone).
+ * three rounds) for the ENTIRE {@link hideSupersededPostTimeMarkers} step,
+ * from its own first line to its return -- not just `runMinimize`'s
+ * mutation pass. Round 2 gave `runMinimize` an internal `deadlineMs`, but
+ * that clock only started at ITS OWN entry, leaving every network call
+ * BEFORE it (the `review-ack` live-HEAD re-check, and the comments listing
+ * every type makes) outside the budget entirely -- the comments listing
+ * alone defaults to `DEFAULT_GH_PAGINATED_TIMEOUT_MS` (120s, gh-exec.mts)
+ * when not told otherwise, already larger than this whole step's intended
+ * budget. `hideSupersededPostTimeMarkers` now starts its own clock first
+ * and re-checks the REMAINING budget before each of its three network
+ * stages (the optional HEAD re-check, the comments listing, and the
+ * `runMinimize` pass), passing that remainder as each stage's own timeout
+ * (or `deadlineMs`, for `runMinimize`) instead of a fixed constant, and
+ * bailing out (never with a `0`/no-op timeout, which `gh-exec.mts` and
+ * `execFileSync` both read as "unbounded") the instant the remainder is
+ * non-positive. The true worst case for the one stage already in flight
+ * when the budget runs out is that stage's own default timeout beyond
+ * `HIDE_STEP_DEADLINE_MS` (up to `DEFAULT_GH_TIMEOUT_MS` for the HEAD
+ * re-check, `DEFAULT_GH_PAGINATED_TIMEOUT_MS` for the comments listing, or
+ * `GH_TIMEOUT_MS` for `runMinimize`'s own in-flight candidate -- see that
+ * function's `deadlineMs` doc comment) -- but no stage can ever START once
+ * the budget is already spent.
  */
 const HIDE_STEP_DEADLINE_MS = 45_000;
 /**
@@ -731,7 +743,7 @@ const HIDE_STEP_DEADLINE_MS = 45_000;
  * fail-closed the same way an unreadable comment list already fails
  * closed elsewhere in this function.
  */
-function hideSupersededPostTimeMarkers(
+export function hideSupersededPostTimeMarkers(
   type,
   fields,
   owner,
@@ -739,13 +751,32 @@ function hideSupersededPostTimeMarkers(
   number,
   postedCommentId,
   trustedMarkerLoginsFlag,
+  deadlineMs,
 ) {
+  // Clock starts here, before ANY network call this step makes (#2754,
+  // chatgpt-codex-connector review round 3 on PR #2788) -- round 2's
+  // deadlineMs only bounded runMinimize's OWN pass, timed from ITS entry,
+  // which left every read before that call (the review-ack live-HEAD
+  // re-check, and the comments listing every type makes) outside the
+  // budget entirely. The comments listing in particular defaults to
+  // `DEFAULT_GH_PAGINATED_TIMEOUT_MS` (120s, gh-exec.mts) when not told
+  // otherwise -- alone larger than this whole step's intended budget.
+  const startedAt = Date.now();
+  const remaining = () => deadlineMs - (Date.now() - startedAt);
   try {
     if (type === 'review-ack') {
+      const r = remaining();
+      // Never pass `timeout: 0` to a `gh` call below -- gh-exec.mts (like
+      // Node's own `execFileSync`) treats that as "no timeout", the exact
+      // opposite of "budget already exhausted". Bailing out here instead
+      // is what makes a non-positive remainder safe.
+      if (r <= 0) {
+        return;
+      }
       const liveHeadSha = createGithubProviderAdapter(
         owner,
         repo,
-      ).getChangeRequestHeadSha(number);
+      ).getChangeRequestHeadSha(number, { timeoutMs: r });
       if (
         liveHeadSha.trim().toLowerCase() !==
         fields['head-sha'].trim().toLowerCase()
@@ -759,7 +790,16 @@ function hideSupersededPostTimeMarkers(
       config: loadIddConfig(),
     });
     const trustedSet = new Set(actors);
-    const allComments = listMarkerCandidateComments(owner, repo, number);
+    const commentsListR = remaining();
+    if (commentsListR <= 0) {
+      return;
+    }
+    const allComments = listMarkerCandidateComments(
+      owner,
+      repo,
+      number,
+      commentsListR,
+    );
     const postedComment = allComments.find(
       (comment) => comment.id === postedCommentId,
     );
@@ -790,13 +830,17 @@ function hideSupersededPostTimeMarkers(
     if (subjectIds.length === 0) {
       return;
     }
+    const mutationPassR = remaining();
+    if (mutationPassR <= 0) {
+      return;
+    }
     runMinimize({
       subjectIds,
       classifier: 'OUTDATED',
       trustedSet,
       apply: true,
       allowUntrusted: false,
-      deadlineMs: HIDE_STEP_DEADLINE_MS,
+      deadlineMs: mutationPassR,
     });
   } catch {
     // Best-effort only (#2754) -- never block or retry-loop the marker post
@@ -1007,6 +1051,7 @@ if (import.meta.main) {
       number,
       posted.id,
       args.trustedMarkerLogins,
+      HIDE_STEP_DEADLINE_MS,
     );
   }
   const result = {

--- a/scripts/post-idd-marker.mjs
+++ b/scripts/post-idd-marker.mjs
@@ -653,6 +653,20 @@ export function findSupersededCopilotUnavailableSubjects(comments, newClaimId) {
   return subjects;
 }
 /**
+ * Overall time budget (#2754, chatgpt-codex-connector review on PR #2788)
+ * for {@link hideSupersededPostTimeMarkers}'s best-effort mutation pass.
+ * `minimize-superseded-markers.mts`'s `runGh` bounds each individual `gh`
+ * call to `GH_TIMEOUT_MS` (30s), but that alone does not bound the PASS: a
+ * PR with several superseded markers can chain multiple 30s-timeout probes
+ * and mutations back to back with no overall cap, stalling the caller's
+ * envelope output for a multiple of 30s after the marker it is hiding *for*
+ * has already posted successfully. `runMinimize`'s optional `deadlineMs`
+ * stops issuing new `gh` calls once this budget is exhausted (always
+ * finishing the first candidate it starts) and marks the remainder
+ * `skipped` / `deadline-exceeded` instead of leaving the pass unbounded.
+ */
+const HIDE_STEP_DEADLINE_MS = 45_000;
+/**
  * Best-effort hide-at-post-time step for {@link HIDE_AT_POST_TIME_MARKER_TYPES}
  * (#2754). Runs only after `postedCommentId`'s own POST already succeeded
  * (the caller invokes this strictly afterward, never before or interleaved),
@@ -677,6 +691,24 @@ export function findSupersededCopilotUnavailableSubjects(comments, newClaimId) {
  * call's own marker that is older by comparison. The `<` restriction
  * excludes it structurally, independent of what its embedded HEAD SHA or
  * `claim:` value happens to be.
+ *
+ * For `review-ack` specifically, this also re-reads the target PR's LIVE
+ * head SHA and bails out (no scan, no mutation) unless it still matches
+ * `fields['head-sha']` (caught by chatgpt-codex-connector review on PR
+ * #2788): `--from-pr` reads HEAD once before composing and POSTing the
+ * marker body, so on a slow POST the branch can advance and a concurrent
+ * session can already have posted a genuine, current-HEAD acknowledgement
+ * by the time this step runs. The `id <` restriction above only orders
+ * candidates by creation time -- it cannot tell a stale marker from a fresh
+ * one once both are "prior" by id, so without this check a stale-HEAD
+ * post could minimize that valid newer acknowledgement while leaving its
+ * own, now-superseded one visible: destroying the correct evidence instead
+ * of the stale evidence. `copilot-unavailable` carries no live-derived
+ * field (its supersession key, `claim-id`, always comes from an explicit
+ * CLI flag, never `--from-pr`), so no equivalent drift is possible there
+ * and this check is skipped for that type. A failed re-read (not a PR, `gh`
+ * error, anything else) falls through to the outer catch below and skips
+ * the whole pass, same as any other best-effort failure.
  */
 function hideSupersededPostTimeMarkers(
   type,
@@ -688,6 +720,18 @@ function hideSupersededPostTimeMarkers(
   trustedMarkerLoginsFlag,
 ) {
   try {
+    if (type === 'review-ack') {
+      const liveHeadSha = createGithubProviderAdapter(
+        owner,
+        repo,
+      ).getChangeRequestHeadSha(number);
+      if (
+        liveHeadSha.trim().toLowerCase() !==
+        fields['head-sha'].trim().toLowerCase()
+      ) {
+        return;
+      }
+    }
     const comments = listMarkerCandidateComments(owner, repo, number).filter(
       (comment) => comment.id < postedCommentId,
     );
@@ -712,6 +756,7 @@ function hideSupersededPostTimeMarkers(
       trustedSet: new Set(actors),
       apply: true,
       allowUntrusted: false,
+      deadlineMs: HIDE_STEP_DEADLINE_MS,
     });
   } catch {
     // Best-effort only (#2754) -- never block or retry-loop the marker post

--- a/scripts/post-idd-marker.mjs
+++ b/scripts/post-idd-marker.mjs
@@ -21,6 +21,7 @@ import { resolve } from 'node:path';
 import { requireFlag, stripLeadingArgumentSeparator } from './cli-args.mjs';
 import { loadIddConfig } from './idd-config.mjs';
 import {
+  isTrustedAuthor,
   resolveTrustedActors,
   runMinimize,
 } from './minimize-superseded-markers.mjs';
@@ -592,6 +593,7 @@ function listMarkerCandidateComments(owner, repo, number) {
       id: comment.id,
       nodeId: comment.nodeId ?? '',
       body: comment.body,
+      authorLogin: comment.authorLogin ?? '',
     }));
 }
 /**
@@ -709,6 +711,22 @@ const HIDE_STEP_DEADLINE_MS = 45_000;
  * and this check is skipped for that type. A failed re-read (not a PR, `gh`
  * error, anything else) falls through to the outer catch below and skips
  * the whole pass, same as any other best-effort failure.
+ *
+ * This step ALSO requires `postedCommentId`'s own author to be in the same
+ * `trustedSet` `runMinimize` already gates candidates on (caught by
+ * chatgpt-codex-connector review on PR #2788): `post-idd-marker.mjs`
+ * performs no author gating of its own -- anyone with `gh` credentials can
+ * invoke `--apply` -- so downstream trust-filtered consumers already
+ * ignore an untrusted marker as if it never existed. Without this check,
+ * that untrusted post's mere presence would still drive this scan, and an
+ * older TRUSTED candidate sharing its supersession key (a same-claim
+ * `copilot-unavailable`, or a same-HEAD `review-ack`) would still get
+ * minimized purely because ITS OWN author is trusted -- collapsing the one
+ * copy of the marker downstream consumers actually rely on, leaving only
+ * the ignored untrusted replacement expanded. Bails out (no scan, no
+ * mutation) when `postedCommentId`'s own comment cannot be re-read at all,
+ * fail-closed the same way an unreadable comment list already fails
+ * closed elsewhere in this function.
  */
 function hideSupersededPostTimeMarkers(
   type,
@@ -732,7 +750,31 @@ function hideSupersededPostTimeMarkers(
         return;
       }
     }
-    const comments = listMarkerCandidateComments(owner, repo, number).filter(
+    const { actors } = resolveTrustedActors({
+      flagValue: trustedMarkerLoginsFlag,
+      envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
+      config: loadIddConfig(),
+    });
+    const trustedSet = new Set(actors);
+    const allComments = listMarkerCandidateComments(owner, repo, number);
+    const postedComment = allComments.find(
+      (comment) => comment.id === postedCommentId,
+    );
+    if (
+      !postedComment ||
+      !isTrustedAuthor(postedComment.authorLogin, trustedSet)
+    ) {
+      // The marker this call just posted is itself untrusted (or its own
+      // record could not be re-read) -- never let an untrusted post drive
+      // this step to minimize an older, TRUSTED candidate. Downstream
+      // trust-filtered consumers already ignore an untrusted marker as if
+      // it never existed; letting it collapse the trusted terminal marker
+      // it claims to supersede would erase the only copy those consumers
+      // actually rely on (#2754, chatgpt-codex-connector review on PR
+      // #2788).
+      return;
+    }
+    const comments = allComments.filter(
       (comment) => comment.id < postedCommentId,
     );
     const subjectIds =
@@ -745,15 +787,10 @@ function hideSupersededPostTimeMarkers(
     if (subjectIds.length === 0) {
       return;
     }
-    const { actors } = resolveTrustedActors({
-      flagValue: trustedMarkerLoginsFlag,
-      envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
-      config: loadIddConfig(),
-    });
     runMinimize({
       subjectIds,
       classifier: 'OUTDATED',
-      trustedSet: new Set(actors),
+      trustedSet,
       apply: true,
       allowUntrusted: false,
       deadlineMs: HIDE_STEP_DEADLINE_MS,

--- a/scripts/post-idd-marker.mjs
+++ b/scripts/post-idd-marker.mjs
@@ -479,7 +479,8 @@ HEAD than Step 1 saw.
 new marker POSTs successfully, this command also hides (classifier
 OUTDATED, via minimize-superseded-markers.mjs) prior same-family comments
 it supersedes -- a review-ack: whose embedded HEAD SHA differs from the one
-just posted, or a copilot-unavailable: carrying the same claim: value.
+just posted, or a copilot-unavailable: carrying the same claim: value and a
+STRICTLY LOWER attempt: number (a same-or-higher attempt is left alone).
 --trusted-marker-logins gates that hide step's trusted-author check too
 (falls back to IDD_TRUSTED_MARKER_ACTORS / the config trustedMarkerActors
 list, same ladder as minimize-superseded-markers.mjs). Best-effort: a

--- a/scripts/post-idd-marker.mjs
+++ b/scripts/post-idd-marker.mjs
@@ -476,7 +476,7 @@ HEAD than Step 1 saw.
 
 --apply --type review-ack / --type copilot-unavailable (#2754): after the
 new marker POSTs successfully, this command also hides (classifier
-OUTDATED, via minimize-superseded-markers.mts) prior same-family comments
+OUTDATED, via minimize-superseded-markers.mjs) prior same-family comments
 it supersedes -- a review-ack: whose embedded HEAD SHA differs from the one
 just posted, or a copilot-unavailable: carrying the same claim: value.
 --trusted-marker-logins gates that hide step's trusted-author check too

--- a/scripts/provider-adapter-github.mjs
+++ b/scripts/provider-adapter-github.mjs
@@ -775,6 +775,7 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
       });
       return rows.map((row) => ({
         id: Number(row.id),
+        nodeId: String(row.node_id ?? ''),
         body: String(row.body ?? ''),
         createdAt: String(row.created_at ?? ''),
         updatedAt: String(row.updated_at ?? row.created_at ?? ''),

--- a/scripts/provider-adapter-github.mjs
+++ b/scripts/provider-adapter-github.mjs
@@ -769,9 +769,12 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
       );
       return refs.map((entry) => String(entry.ref ?? ''));
     },
-    listWorkItemComments(number) {
+    listWorkItemComments(number, options) {
       const rows = deps.ghApiJson(`${repoPath}/issues/${number}/comments`, {
         paginate: true,
+        ...(options?.timeoutMs !== undefined
+          ? { timeout: options.timeoutMs }
+          : {}),
       });
       return rows.map((row) => ({
         id: Number(row.id),
@@ -847,18 +850,21 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
         throw error;
       }
     },
-    getChangeRequestHeadSha(number) {
-      return deps.ghText([
-        'pr',
-        'view',
-        String(number),
-        '-R',
-        `${owner}/${repo}`,
-        '--json',
-        'headRefOid',
-        '--jq',
-        '.headRefOid',
-      ]);
+    getChangeRequestHeadSha(number, options) {
+      return deps.ghText(
+        [
+          'pr',
+          'view',
+          String(number),
+          '-R',
+          `${owner}/${repo}`,
+          '--json',
+          'headRefOid',
+          '--jq',
+          '.headRefOid',
+        ],
+        options?.timeoutMs !== undefined ? { timeout: options.timeoutMs } : {},
+      );
     },
     listRequiredChecks(number) {
       const args = [

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -242,6 +242,18 @@ export interface ParsedAdvisoryRecoveryMarker {
 }
 
 /**
+ * Parsed `review-ack: ...` marker (#2050/#2754). Plain 3-field shape
+ * (agent, HEAD SHA, timestamp) -- same family shape as `advisory-wait:` /
+ * `advisory-reroll:`, no claim/attempt binding.
+ */
+export interface ParsedReviewAckMarker {
+  agentId: string;
+  headSha: string;
+  timestamp: string;
+  createdAt: string;
+}
+
+/**
  * Parsed `copilot-unavailable: ...` terminal marker (#1572). Same bound
  * shape as {@link ParsedAdvisoryRecoveryMarker} (agent, claim, HEAD, attempt
  * number) -- this marker has no legacy unbound form, so every field is
@@ -554,15 +566,15 @@ const MARKER_HIDE_POLICY_ENTRIES: readonly MarkerHidePolicyEntry[] = [
   },
   {
     label: 'review-ack:',
-    policy: 'f4-only',
+    policy: 'wired',
     reason:
-      'No hide-at-post-time wiring yet; only the post-merge F4 cleanup batch cleans it up today. Flipped to wired by roadmap #2751 Track 2 (#2754).',
+      'review-ack family, grouped by embedded HEAD SHA mismatch. Hidden at post time by post-idd-marker.mts itself (code-automated, not an agent-followed instruction step, unlike the other wired families above) -- roadmap #2751 Track 2 (#2754).',
   },
   {
     label: 'copilot-unavailable:',
-    policy: 'f4-only',
+    policy: 'wired',
     reason:
-      'No hide-at-post-time wiring yet; only the post-merge F4 cleanup batch cleans it up today. Flipped to wired by roadmap #2751 Track 2 (#2754).',
+      'copilot-unavailable family, grouped by same claim: value (differing attempt: numbers). Hidden at post time by post-idd-marker.mts itself (code-automated, not an agent-followed instruction step, unlike the other wired families above) -- roadmap #2751 Track 2 (#2754).',
   },
   {
     label: '<!-- forced-handoff:',
@@ -2228,6 +2240,33 @@ export function renderReviewAckMarker(payload: {
     );
   }
   return `review-ack: ${agentId} ${headSha} ${timestamp}`;
+}
+
+/**
+ * Parse a `review-ack:` marker (#2754). Returns `null` on any structural
+ * mismatch (including a `copilot-unavailable:`-shaped bound body, which this
+ * plain 3-field pattern never matches). Used by `post-idd-marker.mts`'s
+ * hide-at-post-time step to find prior `review-ack:` comments whose
+ * embedded HEAD SHA differs from a freshly posted one.
+ */
+export function parseReviewAckComment(
+  body: string,
+  createdAt: string,
+): ParsedReviewAckMarker | null {
+  const match = body
+    .trimEnd()
+    .match(
+      /^review-ack:\s+(\S+)\s+([0-9a-f]{40})\s+(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)\s*$/,
+    );
+  if (!match) {
+    return null;
+  }
+  return {
+    agentId: match[1],
+    headSha: match[2].toLowerCase(),
+    timestamp: match[3],
+    createdAt: isValidIsoTimestamp(createdAt) ? createdAt : 'none',
+  };
 }
 
 // #1905: the grammar's positional claim-id field

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -568,13 +568,13 @@ const MARKER_HIDE_POLICY_ENTRIES: readonly MarkerHidePolicyEntry[] = [
     label: 'review-ack:',
     policy: 'wired',
     reason:
-      'review-ack family, grouped by embedded HEAD SHA mismatch. Hidden at post time by post-idd-marker.mts itself (code-automated, not an agent-followed instruction step, unlike the other wired families above) -- roadmap #2751 Track 2 (#2754).',
+      'review-ack family, grouped by embedded HEAD SHA mismatch. Hidden at post time by post-idd-marker.mjs itself (code-automated, not an agent-followed instruction step, unlike the other wired families above); requires a helper runtime, so an instructions-only manual post gets no equivalent hide step yet -- roadmap #2751 Track 2 (#2754).',
   },
   {
     label: 'copilot-unavailable:',
     policy: 'wired',
     reason:
-      'copilot-unavailable family, grouped by same claim: value (differing attempt: numbers). Hidden at post time by post-idd-marker.mts itself (code-automated, not an agent-followed instruction step, unlike the other wired families above) -- roadmap #2751 Track 2 (#2754).',
+      'copilot-unavailable family, grouped by same claim: value (differing attempt: numbers). Hidden at post time by post-idd-marker.mjs itself (code-automated, not an agent-followed instruction step, unlike the other wired families above); requires a helper runtime, so an instructions-only manual post gets no equivalent hide step yet -- roadmap #2751 Track 2 (#2754).',
   },
   {
     label: '<!-- forced-handoff:',

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -574,7 +574,7 @@ const MARKER_HIDE_POLICY_ENTRIES: readonly MarkerHidePolicyEntry[] = [
     label: 'copilot-unavailable:',
     policy: 'wired',
     reason:
-      'copilot-unavailable family, grouped by same claim: value (differing attempt: numbers). Hidden at post time by post-idd-marker.mjs itself (code-automated, not an agent-followed instruction step, unlike the other wired families above); requires a helper runtime, so an instructions-only manual post gets no equivalent hide step yet -- roadmap #2751 Track 2 (#2754).',
+      'copilot-unavailable family, grouped by same claim: value and a strictly lower attempt: number (a same-or-higher attempt is left alone). Hidden at post time by post-idd-marker.mjs itself (code-automated, not an agent-followed instruction step, unlike the other wired families above); requires a helper runtime, so an instructions-only manual post gets no equivalent hide step yet -- roadmap #2751 Track 2 (#2754).',
   },
   {
     label: '<!-- forced-handoff:',

--- a/src/scripts/minimize-superseded-markers.mts
+++ b/src/scripts/minimize-superseded-markers.mts
@@ -287,10 +287,21 @@ export function runMinimize({
   const startedAt = Date.now();
   const remaining = (): number => (deadlineMs ?? 0) - (Date.now() - startedAt);
   for (const [index, subjectId] of subjectIds.entries()) {
+    // #2754, copilot-pull-request-reviewer review on PR #2788 (round 6):
+    // read `remaining()` exactly ONCE per candidate and reuse that SAME
+    // value for both the skip decision and the timeout passed to
+    // probeSubject -- the entry check and the timeoutMs computation used
+    // to call `remaining()` (i.e. `Date.now()`) separately, a few lines
+    // apart; if the budget expired in that gap, a non-first candidate
+    // could still fall through to probeSubject with `undefined` (the 30s
+    // default) instead of being skipped, silently reopening the exact
+    // "runs for a full untouched GH_TIMEOUT_MS regardless of how little
+    // budget is left" gap round 5 closed for the common case.
+    const enteredRemaining = deadlineMs === undefined ? undefined : remaining();
     if (
       deadlineMs !== undefined &&
       index > 0 &&
-      Date.now() - startedAt >= deadlineMs
+      (enteredRemaining as number) <= 0
     ) {
       for (const remainingId of subjectIds.slice(index)) {
         report.items.push({
@@ -303,21 +314,19 @@ export function runMinimize({
         (report.counts.deadlineSkipped ?? 0) + (subjectIds.length - index);
       break;
     }
-    // #2754, chatgpt-codex-connector review on PR #2788 (round 5): thread
-    // the REMAINING budget into probeSubject itself, not just the entry
-    // check above -- otherwise a candidate let through by the entry check
-    // (including the always-exempt index 0) could still let its own probe
-    // run for a full untouched `GH_TIMEOUT_MS` regardless of how little
-    // budget is actually left. `r > 0` guards the one case that check
-    // cannot rule out (index 0 when `deadlineMs` is already exhausted at
-    // entry): never pass a non-positive number here (gh-exec.mts and
+    // Past the check above, `enteredRemaining` is guaranteed > 0 for every
+    // index > 0 -- reused as-is, no second `remaining()` read. Index 0 is
+    // exempt from the skip (the pass always attempts at least one
+    // candidate) and can still be non-positive here; falling back to
+    // probeSubject's own default in that one case is deliberate, not a
+    // gap: never pass a non-positive number through (gh-exec.mts and
     // execFileSync both read `timeout: 0` as "no timeout", the opposite of
-    // "budget already exhausted") -- fall back to probeSubject's own
-    // default instead.
-    const probeR = deadlineMs === undefined ? undefined : remaining();
+    // "budget already exhausted").
     const probe = probeSubject(
       subjectId,
-      probeR !== undefined && probeR > 0 ? probeR : undefined,
+      enteredRemaining !== undefined && enteredRemaining > 0
+        ? enteredRemaining
+        : undefined,
     );
     if (!probe.ok) {
       report.items.push({ subjectId, status: 'failed', reason: probe.reason });
@@ -403,7 +412,18 @@ export function runMinimize({
     // (including 0): unlike the entry check, this one never needs an
     // exemption to guarantee forward progress, since the candidate's own
     // probe has already run either way -- only the MUTATION is skipped.
-    if (deadlineMs !== undefined && Date.now() - startedAt >= deadlineMs) {
+    //
+    // #2754, copilot-pull-request-reviewer review on PR #2788 (round 6):
+    // read `remaining()` exactly ONCE here and reuse that SAME value for
+    // both the skip decision and applyMinimize's own timeout -- round 5
+    // read it a second time a few lines below, so a budget that expired in
+    // that gap could still fall through to `undefined` (the 30s default)
+    // instead of being skipped, silently reopening the exact
+    // "applyMinimize costs up to another full GH_TIMEOUT_MS regardless of
+    // budget" gap this check exists to close.
+    const preApplyRemaining =
+      deadlineMs === undefined ? undefined : remaining();
+    if (deadlineMs !== undefined && (preApplyRemaining as number) <= 0) {
       report.items.push({
         subjectId,
         url,
@@ -415,16 +435,11 @@ export function runMinimize({
       continue;
     }
 
-    // #2754, chatgpt-codex-connector review on PR #2788 (round 5): thread
-    // the remaining budget into applyMinimize's own `gh` call too -- the
-    // check just above guarantees `remaining() > 0` whenever `deadlineMs`
-    // is set, so this never risks passing a non-positive timeout.
-    const applyR = deadlineMs === undefined ? undefined : remaining();
-    const mutation = applyMinimize(
-      subjectId,
-      classifier,
-      applyR !== undefined && applyR > 0 ? applyR : undefined,
-    );
+    // Past the check above, `preApplyRemaining` is guaranteed > 0 whenever
+    // `deadlineMs` is set (no index exemption here, unlike the probe
+    // check) -- reused as-is, no second `remaining()` read, so this never
+    // risks passing a non-positive timeout.
+    const mutation = applyMinimize(subjectId, classifier, preApplyRemaining);
     if (mutation.ok) {
       report.items.push({
         subjectId,

--- a/src/scripts/minimize-superseded-markers.mts
+++ b/src/scripts/minimize-superseded-markers.mts
@@ -238,18 +238,30 @@ export function runMinimize({
   allowUntrusted: boolean;
   /**
    * Optional overall wall-clock budget in milliseconds for this whole pass
-   * (#2754, chatgpt-codex-connector review on PR #2788). `probeSubject` and
-   * `applyMinimize` each bound a SINGLE `gh` call to `GH_TIMEOUT_MS` (30s),
-   * but a caller chaining several subjects through this function has no
-   * cap on the pass as a whole: a transport outage can make every
-   * candidate individually time out in sequence, each adding another 30s
-   * (or 60s, once a candidate reaches `applyMinimize`) before this function
-   * returns. Passing `deadlineMs` stops issuing new `gh` calls once the
-   * budget (measured from this function's own entry) is exhausted --
-   * always finishing whichever candidate is already in flight -- and marks
-   * every remaining subject `skipped` / `deadline-exceeded` instead of
-   * probing or mutating it. Omit it (the CLI entry point below does) to
-   * keep the pre-existing unbounded behavior.
+   * (#2754, chatgpt-codex-connector review on PR #2788, two rounds).
+   * `probeSubject` and `applyMinimize` each bound a SINGLE `gh` call to
+   * `GH_TIMEOUT_MS` (30s), but a caller chaining several subjects through
+   * this function has no cap on the pass as a whole: a transport outage
+   * can make every candidate individually time out in sequence, each
+   * costing up to 60s (both calls) before this function returns. Passing
+   * `deadlineMs` checks the budget (measured from this function's own
+   * entry) at TWO points per candidate: before starting a NEW candidate's
+   * own `probeSubject` (skipped for the very first candidate, so the pass
+   * always makes at least one attempt even when the budget is already
+   * exhausted at entry), and again immediately before `applyMinimize`,
+   * for every candidate including the first -- closing the gap the first
+   * check alone left (an in-flight candidate's own probe+apply pair could
+   * still cost a full extra `GH_TIMEOUT_MS` beyond the budget, and a
+   * second candidate starting just under the wire could add nearly
+   * another full pair on top of that). Either check failing marks that
+   * subject (and, at the entry check, every remaining one) `skipped` /
+   * `deadline-exceeded` instead of probing or mutating it. The
+   * `applyMinimize` skip cannot undo the probe already spent reaching it,
+   * so the true worst case for a single unlucky candidate is bounded by
+   * `deadlineMs + GH_TIMEOUT_MS`, not `deadlineMs` alone -- but no SECOND
+   * candidate can ever reach its own mutation once the budget is spent.
+   * Omit `deadlineMs` (the CLI entry point below does) to keep the
+   * pre-existing unbounded behavior.
    */
   deadlineMs?: number;
 }): MinimizeReport {
@@ -356,6 +368,31 @@ export function runMinimize({
         status: 'would-apply',
         author,
       });
+      continue;
+    }
+
+    // Second deadline check, immediately before the mutation call itself
+    // (#2754, chatgpt-codex-connector review on PR #2788): the entry check
+    // above only bounds how many candidates this pass STARTS probing --
+    // once a candidate is already in flight (including the very first,
+    // which the entry check always lets through), its own `probeSubject`
+    // call can still cost up to `GH_TIMEOUT_MS`. Without a check here too,
+    // that candidate would still reach `applyMinimize` and cost up to
+    // ANOTHER full `GH_TIMEOUT_MS`, so a single candidate's own probe+apply
+    // pair -- not just the between-candidates gap -- could blow well past
+    // `deadlineMs` before this pass ever returns. Checked for every index
+    // (including 0): unlike the entry check, this one never needs an
+    // exemption to guarantee forward progress, since the candidate's own
+    // probe has already run either way -- only the MUTATION is skipped.
+    if (deadlineMs !== undefined && Date.now() - startedAt >= deadlineMs) {
+      report.items.push({
+        subjectId,
+        url,
+        typename,
+        status: 'skipped',
+        reason: 'deadline-exceeded',
+      });
+      report.counts.deadlineSkipped = (report.counts.deadlineSkipped ?? 0) + 1;
       continue;
     }
 

--- a/src/scripts/minimize-superseded-markers.mts
+++ b/src/scripts/minimize-superseded-markers.mts
@@ -238,30 +238,33 @@ export function runMinimize({
   allowUntrusted: boolean;
   /**
    * Optional overall wall-clock budget in milliseconds for this whole pass
-   * (#2754, chatgpt-codex-connector review on PR #2788, two rounds).
+   * (#2754, chatgpt-codex-connector review on PR #2788, three rounds).
    * `probeSubject` and `applyMinimize` each bound a SINGLE `gh` call to
-   * `GH_TIMEOUT_MS` (30s), but a caller chaining several subjects through
-   * this function has no cap on the pass as a whole: a transport outage
-   * can make every candidate individually time out in sequence, each
-   * costing up to 60s (both calls) before this function returns. Passing
-   * `deadlineMs` checks the budget (measured from this function's own
-   * entry) at TWO points per candidate: before starting a NEW candidate's
-   * own `probeSubject` (skipped for the very first candidate, so the pass
-   * always makes at least one attempt even when the budget is already
-   * exhausted at entry), and again immediately before `applyMinimize`,
-   * for every candidate including the first -- closing the gap the first
-   * check alone left (an in-flight candidate's own probe+apply pair could
-   * still cost a full extra `GH_TIMEOUT_MS` beyond the budget, and a
-   * second candidate starting just under the wire could add nearly
-   * another full pair on top of that). Either check failing marks that
-   * subject (and, at the entry check, every remaining one) `skipped` /
-   * `deadline-exceeded` instead of probing or mutating it. The
-   * `applyMinimize` skip cannot undo the probe already spent reaching it,
-   * so the true worst case for a single unlucky candidate is bounded by
+   * `GH_TIMEOUT_MS` (30s) by default, but a caller chaining several
+   * subjects through this function has no cap on the pass as a whole: a
+   * transport outage can make every candidate individually time out in
+   * sequence, each costing up to 60s (both calls) before this function
+   * returns. Passing `deadlineMs` checks the budget (measured from this
+   * function's own entry) at TWO points per candidate: before starting a
+   * NEW candidate's own `probeSubject` (skipped for the very first
+   * candidate, so the pass always makes at least one attempt even when
+   * the budget is already exhausted at entry), and again immediately
+   * before `applyMinimize`, for every candidate including the first --
+   * closing the gap the first check alone left. Round 3 (this round)
+   * additionally THREADS the actual remaining budget into both calls'
+   * own `timeoutMs` (rather than leaving each bound to the flat
+   * `GH_TIMEOUT_MS` regardless of how little is actually left): a
+   * non-positive remainder is never passed through (gh-exec.mts and
+   * execFileSync both read `timeout: 0` as "no timeout", the opposite of
+   * "budget already exhausted") -- that one case (the always-exempt
+   * index-0 probe when `deadlineMs` is already exhausted at entry) falls
+   * back to the 30s default instead, which is also why the true worst
+   * case for a single unlucky candidate is still bounded by
    * `deadlineMs + GH_TIMEOUT_MS`, not `deadlineMs` alone -- but no SECOND
-   * candidate can ever reach its own mutation once the budget is spent.
-   * Omit `deadlineMs` (the CLI entry point below does) to keep the
-   * pre-existing unbounded behavior.
+   * candidate can ever reach its own mutation once the budget is spent,
+   * and every other in-budget call is now capped far tighter than the
+   * flat constant in practice. Omit `deadlineMs` (the CLI entry point
+   * below does) to keep the pre-existing unbounded behavior.
    */
   deadlineMs?: number;
 }): MinimizeReport {
@@ -282,6 +285,7 @@ export function runMinimize({
   };
 
   const startedAt = Date.now();
+  const remaining = (): number => (deadlineMs ?? 0) - (Date.now() - startedAt);
   for (const [index, subjectId] of subjectIds.entries()) {
     if (
       deadlineMs !== undefined &&
@@ -299,7 +303,22 @@ export function runMinimize({
         (report.counts.deadlineSkipped ?? 0) + (subjectIds.length - index);
       break;
     }
-    const probe = probeSubject(subjectId);
+    // #2754, chatgpt-codex-connector review on PR #2788 (round 5): thread
+    // the REMAINING budget into probeSubject itself, not just the entry
+    // check above -- otherwise a candidate let through by the entry check
+    // (including the always-exempt index 0) could still let its own probe
+    // run for a full untouched `GH_TIMEOUT_MS` regardless of how little
+    // budget is actually left. `r > 0` guards the one case that check
+    // cannot rule out (index 0 when `deadlineMs` is already exhausted at
+    // entry): never pass a non-positive number here (gh-exec.mts and
+    // execFileSync both read `timeout: 0` as "no timeout", the opposite of
+    // "budget already exhausted") -- fall back to probeSubject's own
+    // default instead.
+    const probeR = deadlineMs === undefined ? undefined : remaining();
+    const probe = probeSubject(
+      subjectId,
+      probeR !== undefined && probeR > 0 ? probeR : undefined,
+    );
     if (!probe.ok) {
       report.items.push({ subjectId, status: 'failed', reason: probe.reason });
       report.counts.failed += 1;
@@ -396,7 +415,16 @@ export function runMinimize({
       continue;
     }
 
-    const mutation = applyMinimize(subjectId, classifier);
+    // #2754, chatgpt-codex-connector review on PR #2788 (round 5): thread
+    // the remaining budget into applyMinimize's own `gh` call too -- the
+    // check just above guarantees `remaining() > 0` whenever `deadlineMs`
+    // is set, so this never risks passing a non-positive timeout.
+    const applyR = deadlineMs === undefined ? undefined : remaining();
+    const mutation = applyMinimize(
+      subjectId,
+      classifier,
+      applyR !== undefined && applyR > 0 ? applyR : undefined,
+    );
     if (mutation.ok) {
       report.items.push({
         subjectId,
@@ -453,13 +481,17 @@ function isUnresolvableRestShapedId(
   );
 }
 
-export function probeSubject(subjectId: string): ProbeResult {
-  const result = runGh([
-    'api',
-    ...resolveGhHostnameArgs(),
-    'graphql',
-    '-f',
-    `query=query($id:ID!){
+export function probeSubject(
+  subjectId: string,
+  timeoutMs?: number,
+): ProbeResult {
+  const result = runGh(
+    [
+      'api',
+      ...resolveGhHostnameArgs(),
+      'graphql',
+      '-f',
+      `query=query($id:ID!){
         node(id:$id){
           __typename
           ... on IssueComment{id url isMinimized minimizedReason viewerCanMinimize author{login}}
@@ -467,9 +499,11 @@ export function probeSubject(subjectId: string): ProbeResult {
           ... on PullRequestReviewComment{id url isMinimized minimizedReason viewerCanMinimize author{login}}
         }
       }`,
-    '-f',
-    `id=${subjectId}`,
-  ]);
+      '-f',
+      `id=${subjectId}`,
+    ],
+    timeoutMs,
+  );
   if (!result.ok) {
     if (isUnresolvableRestShapedId(subjectId, result.stderr)) {
       return { ok: false, reason: unresolvableNodeIdReason(subjectId) };
@@ -531,13 +565,15 @@ export function probeSubject(subjectId: string): ProbeResult {
 export function applyMinimize(
   subjectId: string,
   classifier: string,
+  timeoutMs?: number,
 ): MutationResult {
-  const result = runGh([
-    'api',
-    ...resolveGhHostnameArgs(),
-    'graphql',
-    '-f',
-    `query=mutation($id:ID!,$classifier:ReportedContentClassifiers!){
+  const result = runGh(
+    [
+      'api',
+      ...resolveGhHostnameArgs(),
+      'graphql',
+      '-f',
+      `query=mutation($id:ID!,$classifier:ReportedContentClassifiers!){
       minimizeComment(input:{subjectId:$id,classifier:$classifier}){
         minimizedComment{
           __typename
@@ -547,11 +583,13 @@ export function applyMinimize(
         }
       }
     }`,
-    '-f',
-    `id=${subjectId}`,
-    '-f',
-    `classifier=${classifier}`,
-  ]);
+      '-f',
+      `id=${subjectId}`,
+      '-f',
+      `classifier=${classifier}`,
+    ],
+    timeoutMs,
+  );
   if (!result.ok) {
     return {
       ok: false,
@@ -672,11 +710,11 @@ function printTable(report: MinimizeReport): void {
   }
 }
 
-function runGh(argv: string[]): GhResult {
+function runGh(argv: string[], timeoutMs: number = GH_TIMEOUT_MS): GhResult {
   try {
     const stdout = execFileSync('gh', argv, {
       encoding: 'utf8',
-      timeout: GH_TIMEOUT_MS,
+      timeout: timeoutMs,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
     return { ok: true, stdout };

--- a/src/scripts/minimize-superseded-markers.mts
+++ b/src/scripts/minimize-superseded-markers.mts
@@ -132,6 +132,14 @@ interface MinimizeReport {
     unsupportedType: number;
     applied: number;
     failed: number;
+    /**
+     * Candidates left unprocessed because {@link runMinimize}'s optional
+     * `deadlineMs` budget ran out first (#2754). Optional -- and always
+     * initialized to `0` by `runMinimize` itself -- purely so existing
+     * fixtures elsewhere that widen `MinimizeReport` from a partial object
+     * literal (e.g. `computeExitCode`'s own tests) do not need updating.
+     */
+    deadlineSkipped?: number;
   };
   items: ReportItem[];
   trustedMarkerActors?: string[];
@@ -221,12 +229,29 @@ export function runMinimize({
   trustedSet,
   apply,
   allowUntrusted,
+  deadlineMs,
 }: {
   subjectIds: string[];
   classifier: string;
   trustedSet: Set<string>;
   apply: boolean;
   allowUntrusted: boolean;
+  /**
+   * Optional overall wall-clock budget in milliseconds for this whole pass
+   * (#2754, chatgpt-codex-connector review on PR #2788). `probeSubject` and
+   * `applyMinimize` each bound a SINGLE `gh` call to `GH_TIMEOUT_MS` (30s),
+   * but a caller chaining several subjects through this function has no
+   * cap on the pass as a whole: a transport outage can make every
+   * candidate individually time out in sequence, each adding another 30s
+   * (or 60s, once a candidate reaches `applyMinimize`) before this function
+   * returns. Passing `deadlineMs` stops issuing new `gh` calls once the
+   * budget (measured from this function's own entry) is exhausted --
+   * always finishing whichever candidate is already in flight -- and marks
+   * every remaining subject `skipped` / `deadline-exceeded` instead of
+   * probing or mutating it. Omit it (the CLI entry point below does) to
+   * keep the pre-existing unbounded behavior.
+   */
+  deadlineMs?: number;
 }): MinimizeReport {
   const report: MinimizeReport = {
     mode: apply ? 'apply' : 'dry-run',
@@ -239,11 +264,29 @@ export function runMinimize({
       unsupportedType: 0,
       applied: 0,
       failed: 0,
+      deadlineSkipped: 0,
     },
     items: [],
   };
 
-  for (const subjectId of subjectIds) {
+  const startedAt = Date.now();
+  for (const [index, subjectId] of subjectIds.entries()) {
+    if (
+      deadlineMs !== undefined &&
+      index > 0 &&
+      Date.now() - startedAt >= deadlineMs
+    ) {
+      for (const remainingId of subjectIds.slice(index)) {
+        report.items.push({
+          subjectId: remainingId,
+          status: 'skipped',
+          reason: 'deadline-exceeded',
+        });
+      }
+      report.counts.deadlineSkipped =
+        (report.counts.deadlineSkipped ?? 0) + (subjectIds.length - index);
+      break;
+    }
     const probe = probeSubject(subjectId);
     if (!probe.ok) {
       report.items.push({ subjectId, status: 'failed', reason: probe.reason });

--- a/src/scripts/minimize-superseded-markers.mts
+++ b/src/scripts/minimize-superseded-markers.mts
@@ -37,6 +37,35 @@ function loadIddConfig(): unknown {
 // discover-readiness-check.mts's / ci-wait-policy.mts's identical note).
 const GH_TIMEOUT_MS = 30_000;
 
+// #2754 (caught by chatgpt-codex-connector review on PR #2788): same
+// self-containment constraint as the two constants above -- cannot import
+// gh-exec.mts's resolveGhApiHostname, so duplicate the same GHES-hostname
+// resolution logic locally. Without this, every `runGh` call below always
+// targets github.com even on a GitHub Enterprise Server host where
+// GITHUB_SERVER_URL names the GHES instance but GH_HOST is unset (`gh`
+// itself never reads GITHUB_SERVER_URL), so a GHES-hosted repository's
+// probe/mutate GraphQL calls would silently fail to resolve any node id --
+// exactly the risk `post-idd-marker.mts`'s new hide-at-post-time step
+// (#2754) introduced by calling `runMinimize` from inside a GitHub Actions
+// job, where GITHUB_SERVER_URL is always set by the runtime but GH_HOST is
+// not set by default.
+export function resolveGhHostnameArgs(
+  env: NodeJS.ProcessEnv = process.env,
+): string[] {
+  if (env.GH_HOST?.trim()) {
+    return [];
+  }
+  const serverUrl = env.GITHUB_SERVER_URL?.trim();
+  if (!serverUrl) {
+    return [];
+  }
+  const host = serverUrl
+    .replace(/^[a-z][a-z0-9+.-]*:\/\//i, '')
+    .replace(/\/+$/, '')
+    .toLowerCase();
+  return host && host !== 'github.com' ? ['--hostname', host] : [];
+}
+
 const ALLOWED_CLASSIFIERS = new Set(['OUTDATED', 'RESOLVED']);
 const ALLOWED_FORMATS = new Set(['json', 'table']);
 const MINIMIZABLE_TYPENAMES = new Set([
@@ -347,6 +376,7 @@ function isUnresolvableRestShapedId(
 export function probeSubject(subjectId: string): ProbeResult {
   const result = runGh([
     'api',
+    ...resolveGhHostnameArgs(),
     'graphql',
     '-f',
     `query=query($id:ID!){
@@ -424,6 +454,7 @@ export function applyMinimize(
 ): MutationResult {
   const result = runGh([
     'api',
+    ...resolveGhHostnameArgs(),
     'graphql',
     '-f',
     `query=mutation($id:ID!,$classifier:ReportedContentClassifiers!){

--- a/src/scripts/post-idd-marker.mts
+++ b/src/scripts/post-idd-marker.mts
@@ -781,6 +781,21 @@ export function findSupersededCopilotUnavailableSubjects(
 }
 
 /**
+ * Overall time budget (#2754, chatgpt-codex-connector review on PR #2788)
+ * for {@link hideSupersededPostTimeMarkers}'s best-effort mutation pass.
+ * `minimize-superseded-markers.mts`'s `runGh` bounds each individual `gh`
+ * call to `GH_TIMEOUT_MS` (30s), but that alone does not bound the PASS: a
+ * PR with several superseded markers can chain multiple 30s-timeout probes
+ * and mutations back to back with no overall cap, stalling the caller's
+ * envelope output for a multiple of 30s after the marker it is hiding *for*
+ * has already posted successfully. `runMinimize`'s optional `deadlineMs`
+ * stops issuing new `gh` calls once this budget is exhausted (always
+ * finishing the first candidate it starts) and marks the remainder
+ * `skipped` / `deadline-exceeded` instead of leaving the pass unbounded.
+ */
+const HIDE_STEP_DEADLINE_MS = 45_000;
+
+/**
  * Best-effort hide-at-post-time step for {@link HIDE_AT_POST_TIME_MARKER_TYPES}
  * (#2754). Runs only after `postedCommentId`'s own POST already succeeded
  * (the caller invokes this strictly afterward, never before or interleaved),
@@ -805,6 +820,24 @@ export function findSupersededCopilotUnavailableSubjects(
  * call's own marker that is older by comparison. The `<` restriction
  * excludes it structurally, independent of what its embedded HEAD SHA or
  * `claim:` value happens to be.
+ *
+ * For `review-ack` specifically, this also re-reads the target PR's LIVE
+ * head SHA and bails out (no scan, no mutation) unless it still matches
+ * `fields['head-sha']` (caught by chatgpt-codex-connector review on PR
+ * #2788): `--from-pr` reads HEAD once before composing and POSTing the
+ * marker body, so on a slow POST the branch can advance and a concurrent
+ * session can already have posted a genuine, current-HEAD acknowledgement
+ * by the time this step runs. The `id <` restriction above only orders
+ * candidates by creation time -- it cannot tell a stale marker from a fresh
+ * one once both are "prior" by id, so without this check a stale-HEAD
+ * post could minimize that valid newer acknowledgement while leaving its
+ * own, now-superseded one visible: destroying the correct evidence instead
+ * of the stale evidence. `copilot-unavailable` carries no live-derived
+ * field (its supersession key, `claim-id`, always comes from an explicit
+ * CLI flag, never `--from-pr`), so no equivalent drift is possible there
+ * and this check is skipped for that type. A failed re-read (not a PR, `gh`
+ * error, anything else) falls through to the outer catch below and skips
+ * the whole pass, same as any other best-effort failure.
  */
 function hideSupersededPostTimeMarkers(
   type: HideAtPostTimeMarkerType,
@@ -816,6 +849,18 @@ function hideSupersededPostTimeMarkers(
   trustedMarkerLoginsFlag: string,
 ): void {
   try {
+    if (type === 'review-ack') {
+      const liveHeadSha = createGithubProviderAdapter(
+        owner,
+        repo,
+      ).getChangeRequestHeadSha(number);
+      if (
+        liveHeadSha.trim().toLowerCase() !==
+        fields['head-sha'].trim().toLowerCase()
+      ) {
+        return;
+      }
+    }
     const comments = listMarkerCandidateComments(owner, repo, number).filter(
       (comment) => comment.id < postedCommentId,
     );
@@ -840,6 +885,7 @@ function hideSupersededPostTimeMarkers(
       trustedSet: new Set(actors),
       apply: true,
       allowUntrusted: false,
+      deadlineMs: HIDE_STEP_DEADLINE_MS,
     });
   } catch {
     // Best-effort only (#2754) -- never block or retry-loop the marker post

--- a/src/scripts/post-idd-marker.mts
+++ b/src/scripts/post-idd-marker.mts
@@ -570,7 +570,8 @@ HEAD than Step 1 saw.
 new marker POSTs successfully, this command also hides (classifier
 OUTDATED, via minimize-superseded-markers.mjs) prior same-family comments
 it supersedes -- a review-ack: whose embedded HEAD SHA differs from the one
-just posted, or a copilot-unavailable: carrying the same claim: value.
+just posted, or a copilot-unavailable: carrying the same claim: value and a
+STRICTLY LOWER attempt: number (a same-or-higher attempt is left alone).
 --trusted-marker-logins gates that hide step's trusted-author check too
 (falls back to IDD_TRUSTED_MARKER_ACTORS / the config trustedMarkerActors
 list, same ladder as minimize-superseded-markers.mjs). Best-effort: a

--- a/src/scripts/post-idd-marker.mts
+++ b/src/scripts/post-idd-marker.mts
@@ -21,7 +21,14 @@ import { execFileSync } from 'node:child_process';
 import { resolve } from 'node:path';
 
 import { requireFlag, stripLeadingArgumentSeparator } from './cli-args.mts';
+import { loadIddConfig } from './idd-config.mts';
 import {
+  resolveTrustedActors,
+  runMinimize,
+} from './minimize-superseded-markers.mts';
+import {
+  parseCopilotUnavailableComment,
+  parseReviewAckComment,
   renderActivationNonceMarker,
   renderAdvisoryRerollMarker,
   renderAdvisoryWaitMarker,
@@ -37,6 +44,31 @@ import {
   createGithubProviderAdapter,
   resolveCurrentGithubRepository,
 } from './provider-adapter-github.mts';
+
+/**
+ * Marker types whose prior same-family comments this module automatically
+ * hides (classifier `OUTDATED`) immediately after a fresh instance POSTs
+ * successfully under `--apply` -- the hide-at-post-time exception
+ * documented in `docs/idd-comment-minimization.md`'s "## Timing" section
+ * (#2754). Unlike the other `wired` families there (claim chain,
+ * review-watermark/baseline, advisory-wait), which are agent-followed
+ * instruction steps, this pair's grouping keys are purely mechanical
+ * (embedded HEAD SHA mismatch; same `claim:` value), so the hide step is
+ * code-automated directly inside this CLI's own `--apply` path instead.
+ */
+export const HIDE_AT_POST_TIME_MARKER_TYPES = [
+  'review-ack',
+  'copilot-unavailable',
+] as const;
+
+export type HideAtPostTimeMarkerType =
+  (typeof HIDE_AT_POST_TIME_MARKER_TYPES)[number];
+
+export function isHideAtPostTimeMarkerType(
+  type: string,
+): type is HideAtPostTimeMarkerType {
+  return (HIDE_AT_POST_TIME_MARKER_TYPES as readonly string[]).includes(type);
+}
 
 export const MARKER_TYPES = [
   'claim',
@@ -532,6 +564,17 @@ review-activity-snapshot path.
 --expected-head-sha pins a --type watermark --from-pr to the Step 1 stored
 HEAD and fails closed (no post) on drift instead of silently posting a newer
 HEAD than Step 1 saw.
+
+--apply --type review-ack / --type copilot-unavailable (#2754): after the
+new marker POSTs successfully, this command also hides (classifier
+OUTDATED, via minimize-superseded-markers.mts) prior same-family comments
+it supersedes -- a review-ack: whose embedded HEAD SHA differs from the one
+just posted, or a copilot-unavailable: carrying the same claim: value.
+--trusted-marker-logins gates that hide step's trusted-author check too
+(falls back to IDD_TRUSTED_MARKER_ACTORS / the config trustedMarkerActors
+list, same ladder as minimize-superseded-markers.mjs). Best-effort: a
+permission error or any other failure here is swallowed and never blocks
+or retries the marker post that already succeeded.
 `;
 
 /**
@@ -629,6 +672,155 @@ function runReviewActivitySnapshot(
     encoding: 'utf8',
   });
   return JSON.parse(out);
+}
+
+// ---------------------------------------------------------------------------
+// Hide-at-post-time (#2754): review-ack / copilot-unavailable
+// ---------------------------------------------------------------------------
+
+/** One comment shaped for the candidate scan below -- REST `id` (to exclude
+ * the marker this call just posted) plus the GraphQL `nodeId`
+ * `minimizeComment` needs. Narrowed from {@link ProviderComment} (which
+ * carries `nodeId` as an OPTIONAL field, #2754) down to the two fields this
+ * module's pure finder functions actually read. */
+export interface MarkerCandidateComment {
+  id: number;
+  nodeId: string;
+  body: string;
+}
+
+/**
+ * List every comment on `number` (issue or PR -- same comments endpoint),
+ * shaped for the hide-at-post-time candidate scan. Routed through
+ * {@link createGithubProviderAdapter} (`listWorkItemComments`), like every
+ * other read in this migrated file (#2266) -- `post-idd-marker.mts` must
+ * never construct a `gh` call of its own
+ * (`tests/provider-port-migration-guard.test.mts`). A comment missing a
+ * `nodeId` (defensive: the real adapter always populates it from REST's
+ * `node_id`) normalizes to `''`, which the finder functions below already
+ * skip.
+ */
+function listMarkerCandidateComments(
+  owner: string,
+  repo: string,
+  number: number,
+): MarkerCandidateComment[] {
+  return createGithubProviderAdapter(owner, repo)
+    .listWorkItemComments(number)
+    .map((comment) => ({
+      id: comment.id,
+      nodeId: comment.nodeId ?? '',
+      body: comment.body,
+    }));
+}
+
+/**
+ * Find prior `review-ack:` comments (among `comments`, already excluding the
+ * marker just posted) whose embedded HEAD SHA differs from `newHeadSha` --
+ * the candidates a fresh `review-ack` post should minimize as `OUTDATED`,
+ * mirroring the shipped `advisory-wait` AW3-H rule. Never returns a
+ * candidate matching `newHeadSha` (current-HEAD protection) or an
+ * unparseable / non-`review-ack:` comment.
+ */
+export function findSupersededReviewAckSubjects(
+  comments: readonly MarkerCandidateComment[],
+  newHeadSha: string,
+): string[] {
+  const target = newHeadSha.trim().toLowerCase();
+  const subjects: string[] = [];
+  for (const comment of comments) {
+    if (!comment.nodeId) {
+      continue;
+    }
+    const parsed = parseReviewAckComment(comment.body, 'none');
+    if (!parsed || parsed.headSha === target) {
+      continue;
+    }
+    subjects.push(comment.nodeId);
+  }
+  return subjects;
+}
+
+/**
+ * Find prior `copilot-unavailable:` comments (among `comments`, already
+ * excluding the marker just posted) carrying the SAME `claim:` value as
+ * `newClaimId` -- the candidates a fresh `copilot-unavailable` post should
+ * minimize as `OUTDATED`, mirroring the shipped watermark/claim-chain
+ * supersession rule. Never returns a candidate whose `claim:` value differs
+ * (foreign-claim protection) or an unparseable / non-`copilot-unavailable:`
+ * comment.
+ */
+export function findSupersededCopilotUnavailableSubjects(
+  comments: readonly MarkerCandidateComment[],
+  newClaimId: string,
+): string[] {
+  const subjects: string[] = [];
+  for (const comment of comments) {
+    if (!comment.nodeId) {
+      continue;
+    }
+    const parsed = parseCopilotUnavailableComment(comment.body, 'none');
+    if (!parsed || parsed.claimId !== newClaimId) {
+      continue;
+    }
+    subjects.push(comment.nodeId);
+  }
+  return subjects;
+}
+
+/**
+ * Best-effort hide-at-post-time step for {@link HIDE_AT_POST_TIME_MARKER_TYPES}
+ * (#2754). Runs only after `postedCommentId`'s own POST already succeeded
+ * (the caller invokes this strictly afterward, never before or interleaved),
+ * scans the target's OTHER comments for same-family markers superseded by
+ * the one just posted, and reuses `minimize-superseded-markers.mts`'s
+ * `runMinimize` for the actual mutation -- the same trusted-author gate,
+ * already-`isMinimized` skip, and `viewerCanMinimize` check that helper
+ * already implements, so this call site adds no new mutation logic of its
+ * own. Every failure (an unreadable comment list, a `gh` permission error, a
+ * malformed GraphQL response, anything else) is swallowed here: this step
+ * must never retry-loop or throw back into the caller, since the marker it
+ * is hiding *for* has already posted successfully by the time this runs.
+ */
+function hideSupersededPostTimeMarkers(
+  type: HideAtPostTimeMarkerType,
+  fields: MarkerFields,
+  owner: string,
+  repo: string,
+  number: number,
+  postedCommentId: number,
+  trustedMarkerLoginsFlag: string,
+): void {
+  try {
+    const comments = listMarkerCandidateComments(owner, repo, number).filter(
+      (comment) => comment.id !== postedCommentId,
+    );
+    const subjectIds =
+      type === 'review-ack'
+        ? findSupersededReviewAckSubjects(comments, fields['head-sha'])
+        : findSupersededCopilotUnavailableSubjects(
+            comments,
+            fields['claim-id'],
+          );
+    if (subjectIds.length === 0) {
+      return;
+    }
+    const { actors } = resolveTrustedActors({
+      flagValue: trustedMarkerLoginsFlag,
+      envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
+      config: loadIddConfig(),
+    });
+    runMinimize({
+      subjectIds,
+      classifier: 'OUTDATED',
+      trustedSet: new Set(actors),
+      apply: true,
+      allowUntrusted: false,
+    });
+  } catch {
+    // Best-effort only (#2754) -- never block or retry-loop the marker post
+    // that already succeeded above.
+  }
 }
 
 if (import.meta.main) {
@@ -833,6 +1025,17 @@ if (import.meta.main) {
   const repo = args.repo || applyCurrentRepo?.repo || '';
 
   const posted = postMarker(owner, repo, number, body);
+  if (isHideAtPostTimeMarkerType(args.type)) {
+    hideSupersededPostTimeMarkers(
+      args.type,
+      args.fields,
+      owner,
+      repo,
+      number,
+      posted.id,
+      args.trustedMarkerLogins,
+    );
+  }
   const result: PostIddMarkerResult = {
     mode: 'apply',
     type: args.type as MarkerType,

--- a/src/scripts/post-idd-marker.mts
+++ b/src/scripts/post-idd-marker.mts
@@ -866,36 +866,42 @@ const HIDE_STEP_DEADLINE_MS = 45_000;
  * excludes it structurally, independent of what its embedded HEAD SHA or
  * `claim:` value happens to be.
  *
- * For BOTH types, this also re-reads the target PR's LIVE head SHA and
- * bails out (no scan, no mutation) unless it still matches
- * `fields['head-sha']` (caught by chatgpt-codex-connector review on PR
- * #2788, two rounds): `review-ack`'s usual `--from-pr` reads HEAD once
- * before composing and POSTing the marker body, so on a slow POST the
- * branch can advance and a concurrent session can already have posted a
- * genuine, current-HEAD acknowledgement by the time this step runs. The
- * `id <` restriction above only orders candidates by creation time -- it
- * cannot tell a stale marker from a fresh one once both are "prior" by id,
- * so without this check a stale-HEAD post could minimize that valid newer
- * acknowledgement while leaving its own, now-superseded one visible:
- * destroying the correct evidence instead of the stale evidence.
- * `copilot-unavailable` never derives `--head-sha` from `--from-pr` (its
- * supersession key, `claim-id`, always comes from an explicit CLI flag),
- * but that only rules out THIS caller's own embedded value going stale
- * between observation and POST -- it does nothing about a genuinely
- * different, concurrent same-claim poster (e.g. a stalled pre-handoff
- * session finally completing its retry against a claim a handoff already
- * moved on from): `findSupersededCopilotUnavailableSubjects` matches
- * purely on `claim:` equality, with no HEAD comparison of its own, so a
- * STALE same-claim post could still treat an earlier, CURRENT-HEAD
- * same-claim post as "superseded" purely by virtue of posting later
- * (round 2 review, initially missed: the check below was `review-ack`-only
- * until this). Applying the same live-HEAD gate to both types closes that
- * gap without needing a HEAD-aware rewrite of the claim-based finder
- * itself: a poster who is observably stale relative to current HEAD
- * simply never gets to run its own scan/hide judgment at all, regardless
- * of which family it belongs to. A failed re-read (not a PR, `gh` error,
- * anything else) falls through to the outer catch below and skips the
- * whole pass, same as any other best-effort failure.
+ * For BOTH types, this also re-reads the target PR's LIVE head SHA and, when
+ * it no longer matches `fields['head-sha']`, SELF-MINIMIZES the marker this
+ * call itself just posted instead of scanning for prior candidates (caught
+ * by chatgpt-codex-connector review on PR #2788, three rounds -- rounds 3-4
+ * bailed out entirely here; round 5 found that abandoning the just-posted
+ * marker left it expanded forever with no later invocation guaranteed to
+ * sweep it, mirroring the self-minimize sibling #2755 shipped for
+ * `idd-local-validation-evidence:` after the same finding there): `review-
+ * ack`'s usual `--from-pr` reads HEAD once before composing and POSTing the
+ * marker body, so on a slow POST the branch can advance and a concurrent
+ * session can already have posted a genuine, current-HEAD acknowledgement by
+ * the time this step runs. The `id <` restriction above only orders
+ * candidates by creation time -- it cannot tell a stale marker from a fresh
+ * one once both are "prior" by id, so scanning for prior candidates while
+ * stale could minimize that valid newer acknowledgement while leaving this
+ * call's own, now-superseded one visible: destroying the correct evidence
+ * instead of the stale evidence. `copilot-unavailable` never derives
+ * `--head-sha` from `--from-pr` (its supersession key, `claim-id`, always
+ * comes from an explicit CLI flag), but that only rules out THIS caller's
+ * own embedded value going stale between observation and POST -- it does
+ * nothing about a genuinely different, concurrent same-claim poster (e.g. a
+ * stalled pre-handoff session finally completing its retry against a claim a
+ * handoff already moved on from): `findSupersededCopilotUnavailableSubjects`
+ * matches purely on `claim:` equality, with no HEAD comparison of its own,
+ * so a STALE same-claim post could still treat an earlier, CURRENT-HEAD
+ * same-claim post as "superseded" purely by virtue of posting later (round 2
+ * review, initially missed: the check below was `review-ack`-only until
+ * round 4). Applying the same live-HEAD gate to both types closes that gap
+ * without needing a HEAD-aware rewrite of the claim-based finder itself: a
+ * poster who is observably stale relative to current HEAD never scans for
+ * OTHER candidates, regardless of which family it belongs to -- it only ever
+ * minimizes its own just-posted comment. The trust gate below (on
+ * `postedComment` itself) still applies either way, so an untrusted post
+ * never triggers even its own self-minimize. A failed re-read (not a PR,
+ * `gh` error, anything else) falls through to the outer catch below and
+ * skips the whole pass, same as any other best-effort failure.
  *
  * This step ALSO requires `postedCommentId`'s own author to be in the same
  * `trustedSet` `runMinimize` already gates candidates on (caught by
@@ -934,6 +940,16 @@ export function hideSupersededPostTimeMarkers(
   const startedAt = Date.now();
   const remaining = (): number => deadlineMs - (Date.now() - startedAt);
   try {
+    // #2754, chatgpt-codex-connector review round 5 on PR #2788: a stale
+    // live-HEAD no longer means "abandon this step entirely" -- it means
+    // "the marker this call just posted is ITSELF the superseded one".
+    // `stale` is recorded (no early return) so the trust gate below still
+    // runs on the shared `postedComment` read either way, and the subject
+    // set further down switches to self-minimizing that one comment
+    // instead of scanning for prior candidates. Sibling #2755 shipped this
+    // exact self-minimize behavior for `idd-local-validation-evidence:`
+    // after Codex found the same gap there first.
+    let stale = false;
     {
       const r = remaining();
       // Never pass `timeout: 0` to a `gh` call below -- gh-exec.mts (like
@@ -947,12 +963,9 @@ export function hideSupersededPostTimeMarkers(
         owner,
         repo,
       ).getChangeRequestHeadSha(number, { timeoutMs: r });
-      if (
+      stale =
         liveHeadSha.trim().toLowerCase() !==
-        fields['head-sha'].trim().toLowerCase()
-      ) {
-        return;
-      }
+        fields['head-sha'].trim().toLowerCase();
     }
     const { actors } = resolveTrustedActors({
       flagValue: trustedMarkerLoginsFlag,
@@ -979,7 +992,8 @@ export function hideSupersededPostTimeMarkers(
     ) {
       // The marker this call just posted is itself untrusted (or its own
       // record could not be re-read) -- never let an untrusted post drive
-      // this step to minimize an older, TRUSTED candidate. Downstream
+      // this step to minimize an older, TRUSTED candidate, or to
+      // self-minimize on ITS OWN say-so when stale. Downstream
       // trust-filtered consumers already ignore an untrusted marker as if
       // it never existed; letting it collapse the trusted terminal marker
       // it claims to supersede would erase the only copy those consumers
@@ -987,17 +1001,22 @@ export function hideSupersededPostTimeMarkers(
       // #2788).
       return;
     }
-    const comments = allComments.filter(
-      (comment) => comment.id < postedCommentId,
-    );
-    const subjectIds =
-      type === 'review-ack'
-        ? findSupersededReviewAckSubjects(comments, fields['head-sha'])
-        : findSupersededCopilotUnavailableSubjects(
-            comments,
-            fields['claim-id'],
-            Number(fields.attempt),
+    const subjectIds = stale
+      ? postedComment.nodeId
+        ? [postedComment.nodeId]
+        : []
+      : (() => {
+          const comments = allComments.filter(
+            (comment) => comment.id < postedCommentId,
           );
+          return type === 'review-ack'
+            ? findSupersededReviewAckSubjects(comments, fields['head-sha'])
+            : findSupersededCopilotUnavailableSubjects(
+                comments,
+                fields['claim-id'],
+                Number(fields.attempt),
+              );
+        })();
     if (subjectIds.length === 0) {
       return;
     }

--- a/src/scripts/post-idd-marker.mts
+++ b/src/scripts/post-idd-marker.mts
@@ -23,6 +23,7 @@ import { resolve } from 'node:path';
 import { requireFlag, stripLeadingArgumentSeparator } from './cli-args.mts';
 import { loadIddConfig } from './idd-config.mts';
 import {
+  isTrustedAuthor,
   resolveTrustedActors,
   runMinimize,
 } from './minimize-superseded-markers.mts';
@@ -682,14 +683,18 @@ function runReviewActivitySnapshot(
  * caller's own `comment.id < postedCommentId` ordering filter, never by the
  * finder functions themselves), the GraphQL `nodeId` `minimizeComment`
  * needs, and `body` to parse. Narrowed from {@link ProviderComment} (which
- * carries `nodeId` as an OPTIONAL field, #2754) down to the three fields
+ * carries `nodeId` as an OPTIONAL field, #2754) down to the four fields
  * this module actually reads -- `findSupersededReviewAckSubjects` /
  * `findSupersededCopilotUnavailableSubjects` themselves only read `nodeId`
- * and `body`. */
+ * and `body`; `authorLogin` is read by `hideSupersededPostTimeMarkers`
+ * itself, to confirm the just-posted marker's OWN author is trusted before
+ * scanning for anything to hide (#2754, chatgpt-codex-connector review on
+ * PR #2788). */
 export interface MarkerCandidateComment {
   id: number;
   nodeId: string;
   body: string;
+  authorLogin: string;
 }
 
 /**
@@ -714,6 +719,7 @@ function listMarkerCandidateComments(
       id: comment.id,
       nodeId: comment.nodeId ?? '',
       body: comment.body,
+      authorLogin: comment.authorLogin ?? '',
     }));
 }
 
@@ -841,6 +847,22 @@ const HIDE_STEP_DEADLINE_MS = 45_000;
  * and this check is skipped for that type. A failed re-read (not a PR, `gh`
  * error, anything else) falls through to the outer catch below and skips
  * the whole pass, same as any other best-effort failure.
+ *
+ * This step ALSO requires `postedCommentId`'s own author to be in the same
+ * `trustedSet` `runMinimize` already gates candidates on (caught by
+ * chatgpt-codex-connector review on PR #2788): `post-idd-marker.mjs`
+ * performs no author gating of its own -- anyone with `gh` credentials can
+ * invoke `--apply` -- so downstream trust-filtered consumers already
+ * ignore an untrusted marker as if it never existed. Without this check,
+ * that untrusted post's mere presence would still drive this scan, and an
+ * older TRUSTED candidate sharing its supersession key (a same-claim
+ * `copilot-unavailable`, or a same-HEAD `review-ack`) would still get
+ * minimized purely because ITS OWN author is trusted -- collapsing the one
+ * copy of the marker downstream consumers actually rely on, leaving only
+ * the ignored untrusted replacement expanded. Bails out (no scan, no
+ * mutation) when `postedCommentId`'s own comment cannot be re-read at all,
+ * fail-closed the same way an unreadable comment list already fails
+ * closed elsewhere in this function.
  */
 function hideSupersededPostTimeMarkers(
   type: HideAtPostTimeMarkerType,
@@ -864,7 +886,31 @@ function hideSupersededPostTimeMarkers(
         return;
       }
     }
-    const comments = listMarkerCandidateComments(owner, repo, number).filter(
+    const { actors } = resolveTrustedActors({
+      flagValue: trustedMarkerLoginsFlag,
+      envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
+      config: loadIddConfig(),
+    });
+    const trustedSet = new Set(actors);
+    const allComments = listMarkerCandidateComments(owner, repo, number);
+    const postedComment = allComments.find(
+      (comment) => comment.id === postedCommentId,
+    );
+    if (
+      !postedComment ||
+      !isTrustedAuthor(postedComment.authorLogin, trustedSet)
+    ) {
+      // The marker this call just posted is itself untrusted (or its own
+      // record could not be re-read) -- never let an untrusted post drive
+      // this step to minimize an older, TRUSTED candidate. Downstream
+      // trust-filtered consumers already ignore an untrusted marker as if
+      // it never existed; letting it collapse the trusted terminal marker
+      // it claims to supersede would erase the only copy those consumers
+      // actually rely on (#2754, chatgpt-codex-connector review on PR
+      // #2788).
+      return;
+    }
+    const comments = allComments.filter(
       (comment) => comment.id < postedCommentId,
     );
     const subjectIds =
@@ -877,15 +923,10 @@ function hideSupersededPostTimeMarkers(
     if (subjectIds.length === 0) {
       return;
     }
-    const { actors } = resolveTrustedActors({
-      flagValue: trustedMarkerLoginsFlag,
-      envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
-      config: loadIddConfig(),
-    });
     runMinimize({
       subjectIds,
       classifier: 'OUTDATED',
-      trustedSet: new Set(actors),
+      trustedSet,
       apply: true,
       allowUntrusted: false,
       deadlineMs: HIDE_STEP_DEADLINE_MS,

--- a/src/scripts/post-idd-marker.mts
+++ b/src/scripts/post-idd-marker.mts
@@ -712,9 +712,13 @@ function listMarkerCandidateComments(
   owner: string,
   repo: string,
   number: number,
+  timeoutMs?: number,
 ): MarkerCandidateComment[] {
   return createGithubProviderAdapter(owner, repo)
-    .listWorkItemComments(number)
+    .listWorkItemComments(
+      number,
+      timeoutMs !== undefined ? { timeoutMs } : undefined,
+    )
     .map((comment) => ({
       id: comment.id,
       nodeId: comment.nodeId ?? '',
@@ -791,19 +795,28 @@ export function findSupersededCopilotUnavailableSubjects(
 
 /**
  * Overall time budget (#2754, chatgpt-codex-connector review on PR #2788,
- * two rounds) for {@link hideSupersededPostTimeMarkers}'s best-effort
- * mutation pass. `minimize-superseded-markers.mts`'s `runGh` bounds each
- * individual `gh` call to `GH_TIMEOUT_MS` (30s), but that alone does not
- * bound the PASS: a PR with several superseded markers can chain multiple
- * 30s-timeout probes and mutations back to back with no overall cap,
- * stalling the caller's envelope output well beyond this budget after the
- * marker it is hiding *for* has already posted successfully. `runMinimize`'s
- * optional `deadlineMs` checks this budget at two points per candidate
- * (before starting a new one, and again before mutating it) so no SECOND
- * candidate can ever reach its own mutation once the budget is spent --
- * see `runMinimize`'s own `deadlineMs` doc comment for the exact bound
- * (`deadlineMs + GH_TIMEOUT_MS` worst case for the one candidate already
- * in flight when the budget runs out, not `deadlineMs` alone).
+ * three rounds) for the ENTIRE {@link hideSupersededPostTimeMarkers} step,
+ * from its own first line to its return -- not just `runMinimize`'s
+ * mutation pass. Round 2 gave `runMinimize` an internal `deadlineMs`, but
+ * that clock only started at ITS OWN entry, leaving every network call
+ * BEFORE it (the `review-ack` live-HEAD re-check, and the comments listing
+ * every type makes) outside the budget entirely -- the comments listing
+ * alone defaults to `DEFAULT_GH_PAGINATED_TIMEOUT_MS` (120s, gh-exec.mts)
+ * when not told otherwise, already larger than this whole step's intended
+ * budget. `hideSupersededPostTimeMarkers` now starts its own clock first
+ * and re-checks the REMAINING budget before each of its three network
+ * stages (the optional HEAD re-check, the comments listing, and the
+ * `runMinimize` pass), passing that remainder as each stage's own timeout
+ * (or `deadlineMs`, for `runMinimize`) instead of a fixed constant, and
+ * bailing out (never with a `0`/no-op timeout, which `gh-exec.mts` and
+ * `execFileSync` both read as "unbounded") the instant the remainder is
+ * non-positive. The true worst case for the one stage already in flight
+ * when the budget runs out is that stage's own default timeout beyond
+ * `HIDE_STEP_DEADLINE_MS` (up to `DEFAULT_GH_TIMEOUT_MS` for the HEAD
+ * re-check, `DEFAULT_GH_PAGINATED_TIMEOUT_MS` for the comments listing, or
+ * `GH_TIMEOUT_MS` for `runMinimize`'s own in-flight candidate -- see that
+ * function's `deadlineMs` doc comment) -- but no stage can ever START once
+ * the budget is already spent.
  */
 const HIDE_STEP_DEADLINE_MS = 45_000;
 
@@ -867,7 +880,7 @@ const HIDE_STEP_DEADLINE_MS = 45_000;
  * fail-closed the same way an unreadable comment list already fails
  * closed elsewhere in this function.
  */
-function hideSupersededPostTimeMarkers(
+export function hideSupersededPostTimeMarkers(
   type: HideAtPostTimeMarkerType,
   fields: MarkerFields,
   owner: string,
@@ -875,13 +888,32 @@ function hideSupersededPostTimeMarkers(
   number: number,
   postedCommentId: number,
   trustedMarkerLoginsFlag: string,
+  deadlineMs: number,
 ): void {
+  // Clock starts here, before ANY network call this step makes (#2754,
+  // chatgpt-codex-connector review round 3 on PR #2788) -- round 2's
+  // deadlineMs only bounded runMinimize's OWN pass, timed from ITS entry,
+  // which left every read before that call (the review-ack live-HEAD
+  // re-check, and the comments listing every type makes) outside the
+  // budget entirely. The comments listing in particular defaults to
+  // `DEFAULT_GH_PAGINATED_TIMEOUT_MS` (120s, gh-exec.mts) when not told
+  // otherwise -- alone larger than this whole step's intended budget.
+  const startedAt = Date.now();
+  const remaining = (): number => deadlineMs - (Date.now() - startedAt);
   try {
     if (type === 'review-ack') {
+      const r = remaining();
+      // Never pass `timeout: 0` to a `gh` call below -- gh-exec.mts (like
+      // Node's own `execFileSync`) treats that as "no timeout", the exact
+      // opposite of "budget already exhausted". Bailing out here instead
+      // is what makes a non-positive remainder safe.
+      if (r <= 0) {
+        return;
+      }
       const liveHeadSha = createGithubProviderAdapter(
         owner,
         repo,
-      ).getChangeRequestHeadSha(number);
+      ).getChangeRequestHeadSha(number, { timeoutMs: r });
       if (
         liveHeadSha.trim().toLowerCase() !==
         fields['head-sha'].trim().toLowerCase()
@@ -895,7 +927,16 @@ function hideSupersededPostTimeMarkers(
       config: loadIddConfig(),
     });
     const trustedSet = new Set(actors);
-    const allComments = listMarkerCandidateComments(owner, repo, number);
+    const commentsListR = remaining();
+    if (commentsListR <= 0) {
+      return;
+    }
+    const allComments = listMarkerCandidateComments(
+      owner,
+      repo,
+      number,
+      commentsListR,
+    );
     const postedComment = allComments.find(
       (comment) => comment.id === postedCommentId,
     );
@@ -926,13 +967,17 @@ function hideSupersededPostTimeMarkers(
     if (subjectIds.length === 0) {
       return;
     }
+    const mutationPassR = remaining();
+    if (mutationPassR <= 0) {
+      return;
+    }
     runMinimize({
       subjectIds,
       classifier: 'OUTDATED',
       trustedSet,
       apply: true,
       allowUntrusted: false,
-      deadlineMs: HIDE_STEP_DEADLINE_MS,
+      deadlineMs: mutationPassR,
     });
   } catch {
     // Best-effort only (#2754) -- never block or retry-loop the marker post
@@ -1151,6 +1196,7 @@ if (import.meta.main) {
       number,
       posted.id,
       args.trustedMarkerLogins,
+      HIDE_STEP_DEADLINE_MS,
     );
   }
   const result: PostIddMarkerResult = {

--- a/src/scripts/post-idd-marker.mts
+++ b/src/scripts/post-idd-marker.mts
@@ -846,23 +846,36 @@ const HIDE_STEP_DEADLINE_MS = 45_000;
  * excludes it structurally, independent of what its embedded HEAD SHA or
  * `claim:` value happens to be.
  *
- * For `review-ack` specifically, this also re-reads the target PR's LIVE
- * head SHA and bails out (no scan, no mutation) unless it still matches
+ * For BOTH types, this also re-reads the target PR's LIVE head SHA and
+ * bails out (no scan, no mutation) unless it still matches
  * `fields['head-sha']` (caught by chatgpt-codex-connector review on PR
- * #2788): `--from-pr` reads HEAD once before composing and POSTing the
- * marker body, so on a slow POST the branch can advance and a concurrent
- * session can already have posted a genuine, current-HEAD acknowledgement
- * by the time this step runs. The `id <` restriction above only orders
- * candidates by creation time -- it cannot tell a stale marker from a fresh
- * one once both are "prior" by id, so without this check a stale-HEAD
- * post could minimize that valid newer acknowledgement while leaving its
- * own, now-superseded one visible: destroying the correct evidence instead
- * of the stale evidence. `copilot-unavailable` carries no live-derived
- * field (its supersession key, `claim-id`, always comes from an explicit
- * CLI flag, never `--from-pr`), so no equivalent drift is possible there
- * and this check is skipped for that type. A failed re-read (not a PR, `gh`
- * error, anything else) falls through to the outer catch below and skips
- * the whole pass, same as any other best-effort failure.
+ * #2788, two rounds): `review-ack`'s usual `--from-pr` reads HEAD once
+ * before composing and POSTing the marker body, so on a slow POST the
+ * branch can advance and a concurrent session can already have posted a
+ * genuine, current-HEAD acknowledgement by the time this step runs. The
+ * `id <` restriction above only orders candidates by creation time -- it
+ * cannot tell a stale marker from a fresh one once both are "prior" by id,
+ * so without this check a stale-HEAD post could minimize that valid newer
+ * acknowledgement while leaving its own, now-superseded one visible:
+ * destroying the correct evidence instead of the stale evidence.
+ * `copilot-unavailable` never derives `--head-sha` from `--from-pr` (its
+ * supersession key, `claim-id`, always comes from an explicit CLI flag),
+ * but that only rules out THIS caller's own embedded value going stale
+ * between observation and POST -- it does nothing about a genuinely
+ * different, concurrent same-claim poster (e.g. a stalled pre-handoff
+ * session finally completing its retry against a claim a handoff already
+ * moved on from): `findSupersededCopilotUnavailableSubjects` matches
+ * purely on `claim:` equality, with no HEAD comparison of its own, so a
+ * STALE same-claim post could still treat an earlier, CURRENT-HEAD
+ * same-claim post as "superseded" purely by virtue of posting later
+ * (round 2 review, initially missed: the check below was `review-ack`-only
+ * until this). Applying the same live-HEAD gate to both types closes that
+ * gap without needing a HEAD-aware rewrite of the claim-based finder
+ * itself: a poster who is observably stale relative to current HEAD
+ * simply never gets to run its own scan/hide judgment at all, regardless
+ * of which family it belongs to. A failed re-read (not a PR, `gh` error,
+ * anything else) falls through to the outer catch below and skips the
+ * whole pass, same as any other best-effort failure.
  *
  * This step ALSO requires `postedCommentId`'s own author to be in the same
  * `trustedSet` `runMinimize` already gates candidates on (caught by
@@ -901,7 +914,7 @@ export function hideSupersededPostTimeMarkers(
   const startedAt = Date.now();
   const remaining = (): number => deadlineMs - (Date.now() - startedAt);
   try {
-    if (type === 'review-ack') {
+    {
       const r = remaining();
       // Never pass `timeout: 0` to a `gh` call below -- gh-exec.mts (like
       // Node's own `execFileSync`) treats that as "no timeout", the exact

--- a/src/scripts/post-idd-marker.mts
+++ b/src/scripts/post-idd-marker.mts
@@ -781,6 +781,18 @@ export function findSupersededCopilotUnavailableSubjects(
  * malformed GraphQL response, anything else) is swallowed here: this step
  * must never retry-loop or throw back into the caller, since the marker it
  * is hiding *for* has already posted successfully by the time this runs.
+ *
+ * Candidates are restricted to comments **older** than `postedCommentId`
+ * (`comment.id < postedCommentId`, REST issue-comment ids are assigned
+ * sequentially at creation) rather than merely excluding an exact id match
+ * (caught by chatgpt-codex-connector review on PR #2788): the comments scan
+ * runs after this marker's own POST, so a concurrent session's marker
+ * created in that window can already appear in the listing with a HIGHER
+ * id. An inequality-only filter would treat that genuinely newer marker as
+ * "prior" and hide it as `OUTDATED` -- exactly backwards, since it is this
+ * call's own marker that is older by comparison. The `<` restriction
+ * excludes it structurally, independent of what its embedded HEAD SHA or
+ * `claim:` value happens to be.
  */
 function hideSupersededPostTimeMarkers(
   type: HideAtPostTimeMarkerType,
@@ -793,7 +805,7 @@ function hideSupersededPostTimeMarkers(
 ): void {
   try {
     const comments = listMarkerCandidateComments(owner, repo, number).filter(
-      (comment) => comment.id !== postedCommentId,
+      (comment) => comment.id < postedCommentId,
     );
     const subjectIds =
       type === 'review-ack'

--- a/src/scripts/post-idd-marker.mts
+++ b/src/scripts/post-idd-marker.mts
@@ -754,13 +754,25 @@ export function findSupersededCopilotUnavailableSubjects(
   comments: readonly MarkerCandidateComment[],
   newClaimId: string,
 ): string[] {
+  // Trim before comparing (caught by Copilot review on PR #2788):
+  // renderCopilotUnavailableMarker normalizes claimId via
+  // normalizeNonWhitespaceToken() (trim + reject internal whitespace)
+  // before posting, so by the time this runs -- strictly after that POST
+  // already succeeded -- newClaimId can only ever carry leading/trailing
+  // whitespace relative to what was actually posted (internal whitespace
+  // would have failed that render-time validation and never reached
+  // here). Comparing the untrimmed CLI flag value against parsed.claimId
+  // (already whitespace-free, matched via `\S+`) would otherwise never
+  // match a same-claim prior comment when the caller passed the flag with
+  // surrounding whitespace, silently leaving it un-hidden.
+  const target = newClaimId.trim();
   const subjects: string[] = [];
   for (const comment of comments) {
     if (!comment.nodeId) {
       continue;
     }
     const parsed = parseCopilotUnavailableComment(comment.body, 'none');
-    if (!parsed || parsed.claimId !== newClaimId) {
+    if (!parsed || parsed.claimId !== target) {
       continue;
     }
     subjects.push(comment.nodeId);

--- a/src/scripts/post-idd-marker.mts
+++ b/src/scripts/post-idd-marker.mts
@@ -567,7 +567,7 @@ HEAD than Step 1 saw.
 
 --apply --type review-ack / --type copilot-unavailable (#2754): after the
 new marker POSTs successfully, this command also hides (classifier
-OUTDATED, via minimize-superseded-markers.mts) prior same-family comments
+OUTDATED, via minimize-superseded-markers.mjs) prior same-family comments
 it supersedes -- a review-ack: whose embedded HEAD SHA differs from the one
 just posted, or a copilot-unavailable: carrying the same claim: value.
 --trusted-marker-logins gates that hide step's trusted-author check too
@@ -678,11 +678,14 @@ function runReviewActivitySnapshot(
 // Hide-at-post-time (#2754): review-ack / copilot-unavailable
 // ---------------------------------------------------------------------------
 
-/** One comment shaped for the candidate scan below -- REST `id` (to exclude
- * the marker this call just posted) plus the GraphQL `nodeId`
- * `minimizeComment` needs. Narrowed from {@link ProviderComment} (which
- * carries `nodeId` as an OPTIONAL field, #2754) down to the two fields this
- * module's pure finder functions actually read. */
+/** One comment shaped for the candidate scan below -- REST `id` (read by the
+ * caller's own `comment.id < postedCommentId` ordering filter, never by the
+ * finder functions themselves), the GraphQL `nodeId` `minimizeComment`
+ * needs, and `body` to parse. Narrowed from {@link ProviderComment} (which
+ * carries `nodeId` as an OPTIONAL field, #2754) down to the three fields
+ * this module actually reads -- `findSupersededReviewAckSubjects` /
+ * `findSupersededCopilotUnavailableSubjects` themselves only read `nodeId`
+ * and `body`. */
 export interface MarkerCandidateComment {
   id: number;
   nodeId: string;

--- a/src/scripts/post-idd-marker.mts
+++ b/src/scripts/post-idd-marker.mts
@@ -790,17 +790,20 @@ export function findSupersededCopilotUnavailableSubjects(
 }
 
 /**
- * Overall time budget (#2754, chatgpt-codex-connector review on PR #2788)
- * for {@link hideSupersededPostTimeMarkers}'s best-effort mutation pass.
- * `minimize-superseded-markers.mts`'s `runGh` bounds each individual `gh`
- * call to `GH_TIMEOUT_MS` (30s), but that alone does not bound the PASS: a
- * PR with several superseded markers can chain multiple 30s-timeout probes
- * and mutations back to back with no overall cap, stalling the caller's
- * envelope output for a multiple of 30s after the marker it is hiding *for*
- * has already posted successfully. `runMinimize`'s optional `deadlineMs`
- * stops issuing new `gh` calls once this budget is exhausted (always
- * finishing the first candidate it starts) and marks the remainder
- * `skipped` / `deadline-exceeded` instead of leaving the pass unbounded.
+ * Overall time budget (#2754, chatgpt-codex-connector review on PR #2788,
+ * two rounds) for {@link hideSupersededPostTimeMarkers}'s best-effort
+ * mutation pass. `minimize-superseded-markers.mts`'s `runGh` bounds each
+ * individual `gh` call to `GH_TIMEOUT_MS` (30s), but that alone does not
+ * bound the PASS: a PR with several superseded markers can chain multiple
+ * 30s-timeout probes and mutations back to back with no overall cap,
+ * stalling the caller's envelope output well beyond this budget after the
+ * marker it is hiding *for* has already posted successfully. `runMinimize`'s
+ * optional `deadlineMs` checks this budget at two points per candidate
+ * (before starting a new one, and again before mutating it) so no SECOND
+ * candidate can ever reach its own mutation once the budget is spent --
+ * see `runMinimize`'s own `deadlineMs` doc comment for the exact bound
+ * (`deadlineMs + GH_TIMEOUT_MS` worst case for the one candidate already
+ * in flight when the budget runs out, not `deadlineMs` alone).
  */
 const HIDE_STEP_DEADLINE_MS = 45_000;
 

--- a/src/scripts/post-idd-marker.mts
+++ b/src/scripts/post-idd-marker.mts
@@ -766,6 +766,7 @@ export function findSupersededReviewAckSubjects(
 export function findSupersededCopilotUnavailableSubjects(
   comments: readonly MarkerCandidateComment[],
   newClaimId: string,
+  newAttempt: number,
 ): string[] {
   // Trim before comparing (caught by Copilot review on PR #2788):
   // renderCopilotUnavailableMarker normalizes claimId via
@@ -786,6 +787,24 @@ export function findSupersededCopilotUnavailableSubjects(
     }
     const parsed = parseCopilotUnavailableComment(comment.body, 'none');
     if (!parsed || parsed.claimId !== target) {
+      continue;
+    }
+    // Only a STRICTLY LOWER attempt number is ever superseded (caught by
+    // chatgpt-codex-connector review on PR #2788, round 5): claim:
+    // equality alone says nothing about which attempt is actually more
+    // advanced. Two same-claim sessions racing on the SAME HEAD (no HEAD
+    // drift needed -- the live-HEAD gate above cannot catch this) can
+    // still POST out of attempt order -- e.g. attempt 2 lands with a
+    // LOWER REST id while a stalled attempt 1 lands with the next one --
+    // and an attempt-blind filter would let that delayed, regressive
+    // attempt 1 hide the more advanced attempt 2, leaving the regressive
+    // marker as the only one expanded. A same-attempt candidate (a bare
+    // retry of this exact attempt number, e.g. re-POSTing after a failed
+    // hide step) is deliberately left alone rather than guessing whether
+    // it is a true duplicate: current-attempt protection, the same
+    // conservative "when ambiguous, never hide" policy the live-HEAD gate
+    // above already applies to a same-embedded-HEAD review-ack.
+    if (!(parsed.attempt < newAttempt)) {
       continue;
     }
     subjects.push(comment.nodeId);
@@ -976,6 +995,7 @@ export function hideSupersededPostTimeMarkers(
         : findSupersededCopilotUnavailableSubjects(
             comments,
             fields['claim-id'],
+            Number(fields.attempt),
           );
     if (subjectIds.length === 0) {
       return;

--- a/src/scripts/provider-adapter-github.mts
+++ b/src/scripts/provider-adapter-github.mts
@@ -1020,6 +1020,7 @@ export function createGithubProviderAdapter(
         paginate: true,
       }) as {
         id?: unknown;
+        node_id?: unknown;
         body?: unknown;
         created_at?: unknown;
         updated_at?: unknown;
@@ -1027,6 +1028,7 @@ export function createGithubProviderAdapter(
       }[];
       return rows.map((row) => ({
         id: Number(row.id),
+        nodeId: String(row.node_id ?? ''),
         body: String(row.body ?? ''),
         createdAt: String(row.created_at ?? ''),
         updatedAt: String(row.updated_at ?? row.created_at ?? ''),

--- a/src/scripts/provider-adapter-github.mts
+++ b/src/scripts/provider-adapter-github.mts
@@ -1015,9 +1015,15 @@ export function createGithubProviderAdapter(
       return refs.map((entry) => String(entry.ref ?? ''));
     },
 
-    listWorkItemComments(number: number): ProviderComment[] {
+    listWorkItemComments(
+      number: number,
+      options?: { timeoutMs?: number },
+    ): ProviderComment[] {
       const rows = deps.ghApiJson(`${repoPath}/issues/${number}/comments`, {
         paginate: true,
+        ...(options?.timeoutMs !== undefined
+          ? { timeout: options.timeoutMs }
+          : {}),
       }) as {
         id?: unknown;
         node_id?: unknown;
@@ -1112,18 +1118,24 @@ export function createGithubProviderAdapter(
       }
     },
 
-    getChangeRequestHeadSha(number: number): string {
-      return deps.ghText([
-        'pr',
-        'view',
-        String(number),
-        '-R',
-        `${owner}/${repo}`,
-        '--json',
-        'headRefOid',
-        '--jq',
-        '.headRefOid',
-      ]);
+    getChangeRequestHeadSha(
+      number: number,
+      options?: { timeoutMs?: number },
+    ): string {
+      return deps.ghText(
+        [
+          'pr',
+          'view',
+          String(number),
+          '-R',
+          `${owner}/${repo}`,
+          '--json',
+          'headRefOid',
+          '--jq',
+          '.headRefOid',
+        ],
+        options?.timeoutMs !== undefined ? { timeout: options.timeoutMs } : {},
+      );
     },
 
     listRequiredChecks(number: number): ProviderRequiredCheck[] {

--- a/src/scripts/provider-port.mts
+++ b/src/scripts/provider-port.mts
@@ -75,13 +75,22 @@ export interface ProviderWorkItem {
  * shared shape rather than adding a competing method -- every #2266
  * consumer that ignores it is unaffected. `review-activity-snapshot.mts`
  * and `pre-merge-readiness.mts`'s disposition-evidence comment
- * normalization need it for their most-recent-activity computation. */
+ * normalization need it for their most-recent-activity computation.
+ * `nodeId` (#2754) is additive too, and OPTIONAL unlike `updatedAt`: the
+ * real adapter always populates it (REST also returns `node_id` on every
+ * comment response), but it stays optional on the type itself so the many
+ * existing test fixtures that construct a `ProviderComment` literal
+ * without it keep compiling unchanged. `post-idd-marker.mts`'s
+ * hide-at-post-time step is the one consumer that needs it, to pass a
+ * candidate comment's GraphQL node id to
+ * `minimize-superseded-markers.mts`'s `minimizeComment` mutation. */
 export interface ProviderComment {
   id: number;
   body: string;
   createdAt: string;
   updatedAt: string;
   authorLogin: string;
+  nodeId?: string;
 }
 
 /** Result of {@link ProviderPort.postWorkItemComment}. */

--- a/src/scripts/provider-port.mts
+++ b/src/scripts/provider-port.mts
@@ -511,8 +511,18 @@ export interface ProviderPort {
   /** work-items. Issue-branch ref scan (`git/matching-refs/heads/issue/`). */
   listIssueBranchRefs(): string[];
 
-  /** comments-and-labels. Paginated; the most repeated existing operation. */
-  listWorkItemComments(number: number): ProviderComment[];
+  /**
+   * comments-and-labels. Paginated; the most repeated existing operation.
+   *
+   * `options.timeoutMs`, when supplied, overrides the default paginated
+   * `gh --paginate` timeout (#2754, chatgpt-codex-connector review on PR
+   * #2788) -- same rationale as {@link ProviderPort.getChangeRequestHeadSha}'s
+   * own `options.timeoutMs`. Omit it to keep that default unchanged.
+   */
+  listWorkItemComments(
+    number: number,
+    options?: { timeoutMs?: number },
+  ): ProviderComment[];
 
   /**
    * comments-and-labels, write. Adapter posts via stdin-JSON (`--input -`),
@@ -543,8 +553,18 @@ export interface ProviderPort {
    * (this one throws on ANY failure, no 404-to-null mapping) -- pins
    * `headShaFromPr`'s existing no-try/catch-here contract. SHA-format
    * validation stays in the domain.
+   *
+   * `options.timeoutMs`, when supplied, overrides the default single-call
+   * `gh` timeout (#2754, chatgpt-codex-connector review on PR #2788) --
+   * lets a caller budgeting a larger best-effort step (e.g. a hide-at-
+   * post-time pass with its own overall deadline) bound this one call to
+   * whatever time remains, rather than always consuming the port's own
+   * default. Omit it to keep that default unchanged.
    */
-  getChangeRequestHeadSha(number: number): string;
+  getChangeRequestHeadSha(
+    number: number,
+    options?: { timeoutMs?: number },
+  ): string;
 
   /**
    * change-requests (minimal surface for resume-route-selection.mts). Two

--- a/tests/minimize-superseded-markers.test.mts
+++ b/tests/minimize-superseded-markers.test.mts
@@ -13,6 +13,7 @@ import {
   probeSubject,
   resolveGhHostnameArgs,
   resolveTrustedActors,
+  runMinimize,
 } from '../src/scripts/minimize-superseded-markers.mts';
 import { stubExecutable } from './test-utils.mts';
 
@@ -525,4 +526,98 @@ process.exit(1);
       restore();
     }
   });
+});
+
+// --- #2754: runMinimize's optional overall deadlineMs budget --------------
+// (chatgpt-codex-connector review on PR #2788) -- probeSubject/applyMinimize
+// each bound a SINGLE gh call, but chaining several subjects through
+// runMinimize had no cap on the pass as a whole.
+
+/** Stub `gh` so every `graphql` probe call for any subject id resolves
+ * instantly and eligibly (not minimized, viewer can minimize, trusted
+ * author) -- isolates the deadline bookkeeping in `runMinimize` itself from
+ * probe/mutation timing, which `probeSubject`'s own tests already cover. */
+function withInstantEligibleProbeGhStub(): () => void {
+  return stubExecutable(
+    'gh',
+    `const fs = require('node:fs');
+const args = process.argv.slice(2);
+const fValues = [];
+for (let i = 0; i < args.length; i += 1) {
+  if (args[i] === '-f') fValues.push(args[i + 1]);
+}
+const idEntry = fValues.find((v) => v.indexOf('id=') === 0);
+const id = idEntry ? idEntry.slice('id='.length) : '';
+if (args[0] === 'api' && args[1] === 'graphql') {
+  process.stdout.write(JSON.stringify({ data: { node: { __typename: 'IssueComment', url: 'https://github.com/o/r/issues/1#issuecomment-' + id, isMinimized: false, viewerCanMinimize: true, author: { login: 'kurone-kito' } } } }));
+  process.exit(0);
+}
+fs.writeSync(2, 'unexpected gh invocation: ' + args.join(' '));
+process.exit(1);
+`,
+  );
+}
+
+test('runMinimize always finishes the first candidate even when deadlineMs is already 0, then marks the rest deadline-exceeded', () => {
+  const restore = withInstantEligibleProbeGhStub();
+  try {
+    const report = runMinimize({
+      subjectIds: ['IC_a', 'IC_b', 'IC_c'],
+      classifier: 'OUTDATED',
+      trustedSet: new Set(['kurone-kito']),
+      apply: false,
+      allowUntrusted: false,
+      deadlineMs: 0,
+    });
+    // The first candidate is always attempted regardless of the deadline
+    // (probed here, reported eligible/would-apply in dry-run mode) --
+    // never zero candidates processed just because the budget is already
+    // exhausted at entry.
+    assert.deepEqual(
+      report.items.map((item) => ({
+        subjectId: item.subjectId,
+        status: item.status,
+        reason: item.reason,
+      })),
+      [
+        { subjectId: 'IC_a', status: 'would-apply', reason: undefined },
+        {
+          subjectId: 'IC_b',
+          status: 'skipped',
+          reason: 'deadline-exceeded',
+        },
+        {
+          subjectId: 'IC_c',
+          status: 'skipped',
+          reason: 'deadline-exceeded',
+        },
+      ],
+    );
+    assert.equal(report.counts.eligible, 1);
+    assert.equal(report.counts.deadlineSkipped, 2);
+    // No count bucket double-charges a deadline-skipped subject as a
+    // transport failure.
+    assert.equal(report.counts.failed, 0);
+  } finally {
+    restore();
+  }
+});
+
+test('runMinimize processes every subject normally when deadlineMs is omitted (pre-existing unbounded behavior)', () => {
+  const restore = withInstantEligibleProbeGhStub();
+  try {
+    const report = runMinimize({
+      subjectIds: ['IC_a', 'IC_b', 'IC_c'],
+      classifier: 'OUTDATED',
+      trustedSet: new Set(['kurone-kito']),
+      apply: false,
+      allowUntrusted: false,
+    });
+    assert.equal(report.items.length, 3);
+    assert.ok(report.items.every((item) => item.status === 'would-apply'));
+    assert.equal(report.counts.eligible, 3);
+    assert.equal(report.counts.deadlineSkipped, 0);
+  } finally {
+    restore();
+  }
 });

--- a/tests/minimize-superseded-markers.test.mts
+++ b/tests/minimize-superseded-markers.test.mts
@@ -688,6 +688,49 @@ test('runMinimize never reaches applyMinimize for a candidate whose OWN probe al
   }
 });
 
+test("runMinimize threads the actual remaining budget into probeSubject's own gh call, not just GH_TIMEOUT_MS (#2754, chatgpt-codex-connector review round 5)", () => {
+  // The stub's probe response sleeps a full real second (via a blocking
+  // Atomics.wait, portable to Windows unlike execSync('sleep 1')) before
+  // answering -- a correctly-threaded ~150ms remainder passed all the way
+  // down to execFileSync's own `timeout` option must kill that call long
+  // before the sleep completes, proving runMinimize no longer leaves each
+  // candidate's own probe bound to the flat 30s GH_TIMEOUT_MS default
+  // regardless of how little of `deadlineMs` is actually left.
+  const restore = stubExecutable(
+    'gh',
+    `const args = process.argv.slice(2);
+if (args[0] === 'api' && args[1] === 'graphql') {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1000);
+  process.stdout.write(JSON.stringify({ data: { node: { __typename: 'IssueComment', url: 'https://github.com/o/r/issues/1#issuecomment-1', isMinimized: false, viewerCanMinimize: true, author: { login: 'kurone-kito' } } } }));
+  process.exit(0);
+}
+process.exit(1);
+`,
+  );
+  const start = Date.now();
+  try {
+    const report = runMinimize({
+      subjectIds: ['IC_a'],
+      classifier: 'OUTDATED',
+      trustedSet: new Set(['kurone-kito']),
+      apply: false,
+      allowUntrusted: false,
+      deadlineMs: 150,
+    });
+    const elapsed = Date.now() - start;
+    assert.ok(
+      elapsed < 900,
+      `expected the ~150ms timeout to cut off the 1s stub sleep, took ${elapsed}ms`,
+    );
+    // The probe call itself was killed by the timeout, so it surfaces as a
+    // transport failure -- not a clean eligible/would-apply result.
+    assert.equal(report.items[0]?.status, 'failed');
+    assert.equal(report.counts.eligible, 0);
+  } finally {
+    restore();
+  }
+});
+
 // A generous (or omitted) deadlineMs still reaching a real, successful
 // applyMinimize mutation is already covered end-to-end by
 // tests/post-idd-marker.test.mts's hide-step integration tests, which

--- a/tests/minimize-superseded-markers.test.mts
+++ b/tests/minimize-superseded-markers.test.mts
@@ -621,3 +621,76 @@ test('runMinimize processes every subject normally when deadlineMs is omitted (p
     restore();
   }
 });
+
+/**
+ * Stub `gh` for an `apply: true` deadline test where the mutation call
+ * itself must never happen (#2754, chatgpt-codex-connector review round 2
+ * on PR #2788): answers a plain probe (`graphql` with no `classifier=`
+ * `-f` value) the same way {@link withInstantEligibleProbeGhStub} does,
+ * but FAILS LOUDLY on any call that carries `classifier=` -- proving a
+ * skipped-before-mutate candidate never reaches `applyMinimize`'s own `gh`
+ * call, not just that the reported status happens to read `skipped`.
+ */
+function withProbeOnlyGhStub(): () => void {
+  return stubExecutable(
+    'gh',
+    `const fs = require('node:fs');
+const args = process.argv.slice(2);
+const fValues = [];
+for (let i = 0; i < args.length; i += 1) {
+  if (args[i] === '-f') fValues.push(args[i + 1]);
+}
+const idEntry = fValues.find((v) => v.indexOf('id=') === 0);
+const classifierEntry = fValues.find((v) => v.indexOf('classifier=') === 0);
+const id = idEntry ? idEntry.slice('id='.length) : '';
+if (args[0] === 'api' && args[1] === 'graphql' && !classifierEntry) {
+  process.stdout.write(JSON.stringify({ data: { node: { __typename: 'IssueComment', url: 'https://github.com/o/r/issues/1#issuecomment-' + id, isMinimized: false, viewerCanMinimize: true, author: { login: 'kurone-kito' } } } }));
+  process.exit(0);
+}
+fs.writeSync(2, 'unexpected gh invocation (mutation attempted after deadline): ' + args.join(' '));
+process.exit(1);
+`,
+  );
+}
+
+test('runMinimize never reaches applyMinimize for a candidate whose OWN probe already exhausted the deadline (#2754, chatgpt-codex-connector review round 2)', () => {
+  // deadlineMs: 0 means the budget is exhausted the instant ANY wall-clock
+  // time has passed -- true by the time the (real, subprocess-spawning)
+  // probe call for this single candidate returns. The entry check exempts
+  // the very first candidate (so the probe itself is always allowed to
+  // run), but the SEPARATE pre-mutate check must still catch it here,
+  // since without that second check this candidate -- already probed
+  // eligible -- would proceed straight to a real mutation call.
+  const restore = withProbeOnlyGhStub();
+  try {
+    const report = runMinimize({
+      subjectIds: ['IC_a'],
+      classifier: 'OUTDATED',
+      trustedSet: new Set(['kurone-kito']),
+      apply: true,
+      allowUntrusted: false,
+      deadlineMs: 0,
+    });
+    assert.deepEqual(
+      report.items.map((item) => ({
+        subjectId: item.subjectId,
+        status: item.status,
+        reason: item.reason,
+      })),
+      [{ subjectId: 'IC_a', status: 'skipped', reason: 'deadline-exceeded' }],
+    );
+    assert.equal(report.counts.eligible, 1);
+    assert.equal(report.counts.deadlineSkipped, 1);
+    assert.equal(report.counts.applied, 0);
+    assert.equal(report.counts.failed, 0);
+  } finally {
+    restore();
+  }
+});
+
+// A generous (or omitted) deadlineMs still reaching a real, successful
+// applyMinimize mutation is already covered end-to-end by
+// tests/post-idd-marker.test.mts's hide-step integration tests, which
+// invoke this same runMinimize call site with deadlineMs:
+// HIDE_STEP_DEADLINE_MS (45s, never exhausted in-test) and assert the
+// mutation actually ran via readMutatedSubjectIds.

--- a/tests/minimize-superseded-markers.test.mts
+++ b/tests/minimize-superseded-markers.test.mts
@@ -7,11 +7,54 @@ import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import {
+  applyMinimize,
   computeExitCode,
   isTrustedAuthor,
+  probeSubject,
+  resolveGhHostnameArgs,
   resolveTrustedActors,
 } from '../src/scripts/minimize-superseded-markers.mts';
 import { stubExecutable } from './test-utils.mts';
+
+/**
+ * Save/restore `GH_HOST` and `GITHUB_SERVER_URL` around a test body,
+ * mirroring `tests/gh-exec.test.mts`'s `withGhHostEnv` -- `probeSubject` /
+ * `applyMinimize` read `process.env` implicitly (via
+ * `resolveGhHostnameArgs`'s default parameter), so a test exercising that
+ * default path must mutate and restore the real environment rather than
+ * passing an explicit `env` object. CI itself defines
+ * `GITHUB_SERVER_URL=https://github.com` in the runner environment
+ * (#1962), so both variables are cleared first regardless of overrides.
+ */
+function withGhHostEnv(
+  overrides: { GH_HOST?: string; GITHUB_SERVER_URL?: string },
+  run: () => void,
+): void {
+  const savedGhHost = process.env.GH_HOST;
+  const savedServerUrl = process.env.GITHUB_SERVER_URL;
+  delete process.env.GH_HOST;
+  delete process.env.GITHUB_SERVER_URL;
+  if (overrides.GH_HOST !== undefined) {
+    process.env.GH_HOST = overrides.GH_HOST;
+  }
+  if (overrides.GITHUB_SERVER_URL !== undefined) {
+    process.env.GITHUB_SERVER_URL = overrides.GITHUB_SERVER_URL;
+  }
+  try {
+    run();
+  } finally {
+    if (savedGhHost === undefined) {
+      delete process.env.GH_HOST;
+    } else {
+      process.env.GH_HOST = savedGhHost;
+    }
+    if (savedServerUrl === undefined) {
+      delete process.env.GITHUB_SERVER_URL;
+    } else {
+      process.env.GITHUB_SERVER_URL = savedServerUrl;
+    }
+  }
+}
 
 // computeExitCode only reads counts.failed; the partial reports are
 // widened structurally instead of fabricating unused report fields.
@@ -359,4 +402,127 @@ test('a zero / leading-zero --subject-ids value keeps the raw gh passthrough (no
     assert.equal(item.status, 'failed');
     assert.match(item.reason, /^gh-graphql-error:/);
   }
+});
+
+// --- #2754: GHES-hostname routing (caught by chatgpt-codex-connector
+// review on PR #2788) -----------------------------------------------------
+
+test('resolveGhHostnameArgs returns [] with no GH_HOST / GITHUB_SERVER_URL signal', () => {
+  assert.deepEqual(resolveGhHostnameArgs({}), []);
+});
+
+test('resolveGhHostnameArgs returns [] when GH_HOST is set, even alongside a GHES GITHUB_SERVER_URL', () => {
+  // gh already reads GH_HOST itself; a --hostname override here would be
+  // redundant at best and could disagree with an operator's explicit
+  // choice at worst -- mirrors gh-exec.mts's resolveGhApiHostname (#1962).
+  assert.deepEqual(
+    resolveGhHostnameArgs({
+      GH_HOST: 'ghes.example.com',
+      GITHUB_SERVER_URL: 'https://other-ghes.example.com',
+    }),
+    [],
+  );
+});
+
+test('resolveGhHostnameArgs returns [] for GITHUB_SERVER_URL=https://github.com (no behavior change on github.com)', () => {
+  assert.deepEqual(
+    resolveGhHostnameArgs({ GITHUB_SERVER_URL: 'https://github.com' }),
+    [],
+  );
+});
+
+test('resolveGhHostnameArgs returns [] for an empty GITHUB_SERVER_URL', () => {
+  assert.deepEqual(resolveGhHostnameArgs({ GITHUB_SERVER_URL: '' }), []);
+});
+
+test('resolveGhHostnameArgs strips scheme and trailing slash for a GHES GITHUB_SERVER_URL', () => {
+  assert.deepEqual(
+    resolveGhHostnameArgs({ GITHUB_SERVER_URL: 'https://ghes.example.com/' }),
+    ['--hostname', 'ghes.example.com'],
+  );
+});
+
+test('resolveGhHostnameArgs lowercases a mixed-case GHES host and tolerates http scheme', () => {
+  assert.deepEqual(
+    resolveGhHostnameArgs({ GITHUB_SERVER_URL: 'http://GHES.Example.com' }),
+    ['--hostname', 'ghes.example.com'],
+  );
+});
+
+test('probeSubject passes --hostname through to gh on a GHES GITHUB_SERVER_URL with GH_HOST unset', () => {
+  withGhHostEnv({ GITHUB_SERVER_URL: 'https://ghes.example.com' }, () => {
+    const restore = stubExecutable(
+      'gh',
+      `const fs = require('node:fs');
+const args = process.argv.slice(2);
+if (args[0] === 'api' && args[1] === '--hostname' && args[2] === 'ghes.example.com' && args[3] === 'graphql') {
+  process.stdout.write(JSON.stringify({ data: { node: { __typename: 'IssueComment', url: 'u', isMinimized: false, viewerCanMinimize: true, author: { login: 'kurone-kito' } } } }));
+  process.exit(0);
+}
+fs.writeSync(2, 'unexpected gh invocation: ' + args.join(' '));
+process.exit(1);
+`,
+    );
+    try {
+      const result = probeSubject('IC_test');
+      assert.deepEqual(result, {
+        ok: true,
+        node: {
+          typename: 'IssueComment',
+          url: 'u',
+          isMinimized: false,
+          viewerCanMinimize: true,
+          author: 'kurone-kito',
+        },
+      });
+    } finally {
+      restore();
+    }
+  });
+});
+
+test('probeSubject omits --hostname on plain github.com (GH_HOST and GITHUB_SERVER_URL both unset)', () => {
+  withGhHostEnv({}, () => {
+    const restore = stubExecutable(
+      'gh',
+      `const fs = require('node:fs');
+const args = process.argv.slice(2);
+if (args[0] === 'api' && args[1] === 'graphql') {
+  process.stdout.write(JSON.stringify({ data: { node: { __typename: 'IssueComment', url: 'u', isMinimized: false, viewerCanMinimize: true, author: { login: 'kurone-kito' } } } }));
+  process.exit(0);
+}
+fs.writeSync(2, 'unexpected gh invocation: ' + args.join(' '));
+process.exit(1);
+`,
+    );
+    try {
+      const result = probeSubject('IC_test');
+      assert.equal(result.ok, true);
+    } finally {
+      restore();
+    }
+  });
+});
+
+test('applyMinimize passes --hostname through to gh on a GHES GITHUB_SERVER_URL with GH_HOST unset', () => {
+  withGhHostEnv({ GITHUB_SERVER_URL: 'https://ghes.example.com' }, () => {
+    const restore = stubExecutable(
+      'gh',
+      `const fs = require('node:fs');
+const args = process.argv.slice(2);
+if (args[0] === 'api' && args[1] === '--hostname' && args[2] === 'ghes.example.com' && args[3] === 'graphql') {
+  process.stdout.write(JSON.stringify({ data: { minimizeComment: { minimizedComment: { __typename: 'IssueComment', isMinimized: true } } } }));
+  process.exit(0);
+}
+fs.writeSync(2, 'unexpected gh invocation: ' + args.join(' '));
+process.exit(1);
+`,
+    );
+    try {
+      const result = applyMinimize('IC_test', 'OUTDATED');
+      assert.deepEqual(result, { ok: true });
+    } finally {
+      restore();
+    }
+  });
 });

--- a/tests/post-idd-marker.test.mts
+++ b/tests/post-idd-marker.test.mts
@@ -2044,6 +2044,22 @@ test('findSupersededCopilotUnavailableSubjects never hides a comment whose claim
   );
 });
 
+test('findSupersededCopilotUnavailableSubjects trims newClaimId before comparing (#2754, Copilot review on PR #2788)', () => {
+  // renderCopilotUnavailableMarker trims claimId before posting, so a
+  // caller passing --claim-id with surrounding whitespace still posts the
+  // trimmed form -- this finder must trim its own newClaimId the same way,
+  // or it would never match the very comment it just posted's own claim.
+  const sameClaim = candidateComment({
+    id: 5,
+    nodeId: 'IC_same_claim_untrimmed',
+    body: `copilot-unavailable: a ${SHA} ${TS} claim:${CLAIM_A} attempt:1`,
+  });
+  assert.deepEqual(
+    findSupersededCopilotUnavailableSubjects([sameClaim], `  ${CLAIM_A}  `),
+    ['IC_same_claim_untrimmed'],
+  );
+});
+
 test('findSupersededCopilotUnavailableSubjects ignores a non-copilot-unavailable comment and one with no node id', () => {
   const unrelated = candidateComment({
     id: 7,

--- a/tests/post-idd-marker.test.mts
+++ b/tests/post-idd-marker.test.mts
@@ -10,6 +10,10 @@ import {
   buildMarkerBody,
   describeUnaddressedActivity,
   FROM_PR_MARKER_TYPES,
+  findSupersededCopilotUnavailableSubjects,
+  findSupersededReviewAckSubjects,
+  HIDE_AT_POST_TIME_MARKER_TYPES,
+  isHideAtPostTimeMarkerType,
   MARKER_TYPES,
   parseArgs,
   watermarkFieldsFromSnapshot,
@@ -21,6 +25,7 @@ import {
   parseClaimComment,
   parseCopilotUnavailableComment,
   parseReleaseComment,
+  parseReviewAckComment,
   parseReviewWatermarkComment,
 } from '../src/scripts/protocol-helpers.mts';
 import {
@@ -1912,4 +1917,542 @@ test('--help marks every REQUIRED_FIELDS_BY_TYPE field as required and every del
     output,
     /watermark\s+--agent-id --claim-id --head-sha \[--max-activity-at] --total-item-count \[--ci-completed-at]/,
   );
+});
+
+test('parseReviewAckComment round-trips renderReviewAckMarker output', () => {
+  const body = buildMarkerBody('review-ack', {
+    'agent-id': 'a',
+    'head-sha': SHA,
+    timestamp: TS,
+  });
+  assert.deepEqual(parseReviewAckComment(body, TS), {
+    agentId: 'a',
+    headSha: SHA,
+    timestamp: TS,
+    createdAt: TS,
+  });
+});
+
+test('parseReviewAckComment returns null for a non-review-ack / malformed body', () => {
+  assert.equal(parseReviewAckComment('not a marker', TS), null);
+  assert.equal(
+    parseReviewAckComment(
+      `copilot-unavailable: a ${SHA} ${TS} claim:c attempt:1`,
+      TS,
+    ),
+    null,
+  );
+});
+
+// --- #2754: hide-at-post-time for review-ack / copilot-unavailable --------
+
+test('HIDE_AT_POST_TIME_MARKER_TYPES lists exactly review-ack and copilot-unavailable', () => {
+  assert.deepEqual(HIDE_AT_POST_TIME_MARKER_TYPES, [
+    'review-ack',
+    'copilot-unavailable',
+  ]);
+});
+
+test('isHideAtPostTimeMarkerType recognizes only the two hide-at-post-time types', () => {
+  assert.equal(isHideAtPostTimeMarkerType('review-ack'), true);
+  assert.equal(isHideAtPostTimeMarkerType('copilot-unavailable'), true);
+  assert.equal(isHideAtPostTimeMarkerType('claim'), false);
+  assert.equal(isHideAtPostTimeMarkerType('advisory-wait'), false);
+});
+
+function candidateComment(
+  overrides: Partial<{
+    id: number;
+    nodeId: string;
+    body: string;
+    authorLogin: string;
+  }> = {},
+) {
+  return {
+    id: 1,
+    nodeId: 'IC_default',
+    body: '',
+    authorLogin: 'kurone-kito',
+    ...overrides,
+  };
+}
+
+const OTHER_SHA = 'fedcba9876543210fedcba9876543210fedcba90';
+
+test('findSupersededReviewAckSubjects hides a prior review-ack whose HEAD SHA differs from the new one', () => {
+  const stale = candidateComment({
+    id: 1,
+    nodeId: 'IC_stale',
+    body: `review-ack: a ${OTHER_SHA} ${TS}`,
+  });
+  assert.deepEqual(findSupersededReviewAckSubjects([stale], SHA), ['IC_stale']);
+});
+
+test('findSupersededReviewAckSubjects never hides a review-ack matching the new HEAD SHA (current-HEAD protection)', () => {
+  const current = candidateComment({
+    id: 2,
+    nodeId: 'IC_current',
+    body: `review-ack: a ${SHA} ${TS}`,
+  });
+  assert.deepEqual(findSupersededReviewAckSubjects([current], SHA), []);
+});
+
+test('findSupersededReviewAckSubjects ignores a non-review-ack comment and one with no node id', () => {
+  const unrelated = candidateComment({
+    id: 3,
+    nodeId: 'IC_unrelated',
+    body: 'just a regular comment',
+  });
+  const noNodeId = candidateComment({
+    id: 4,
+    nodeId: '',
+    body: `review-ack: a ${OTHER_SHA} ${TS}`,
+  });
+  assert.deepEqual(
+    findSupersededReviewAckSubjects([unrelated, noNodeId], SHA),
+    [],
+  );
+});
+
+const CLAIM_A = 'claim-aaaa';
+const CLAIM_B = 'claim-bbbb';
+
+test('findSupersededCopilotUnavailableSubjects hides a prior comment carrying the SAME claim: value (differing attempt)', () => {
+  const sameClaimEarlierAttempt = candidateComment({
+    id: 5,
+    nodeId: 'IC_same_claim',
+    body: `copilot-unavailable: a ${SHA} ${TS} claim:${CLAIM_A} attempt:1`,
+  });
+  assert.deepEqual(
+    findSupersededCopilotUnavailableSubjects(
+      [sameClaimEarlierAttempt],
+      CLAIM_A,
+    ),
+    ['IC_same_claim'],
+  );
+});
+
+test('findSupersededCopilotUnavailableSubjects never hides a comment whose claim: value differs (foreign-claim protection)', () => {
+  const foreignClaim = candidateComment({
+    id: 6,
+    nodeId: 'IC_foreign_claim',
+    body: `copilot-unavailable: a ${SHA} ${TS} claim:${CLAIM_B} attempt:1`,
+  });
+  assert.deepEqual(
+    findSupersededCopilotUnavailableSubjects([foreignClaim], CLAIM_A),
+    [],
+  );
+});
+
+test('findSupersededCopilotUnavailableSubjects ignores a non-copilot-unavailable comment and one with no node id', () => {
+  const unrelated = candidateComment({
+    id: 7,
+    nodeId: 'IC_unrelated2',
+    body: 'just a regular comment',
+  });
+  const noNodeId = candidateComment({
+    id: 8,
+    nodeId: '',
+    body: `copilot-unavailable: a ${SHA} ${TS} claim:${CLAIM_A} attempt:1`,
+  });
+  assert.deepEqual(
+    findSupersededCopilotUnavailableSubjects([unrelated, noNodeId], CLAIM_A),
+    [],
+  );
+});
+
+/**
+ * Stub `gh` on PATH so a full `--apply --type review-ack` or
+ * `--apply --type copilot-unavailable` run resolves offline (#2754):
+ * dispatches on argv shape across the four distinct `gh` calls this path
+ * can issue -- the prior-comments listing (`api .../comments --paginate`),
+ * the new marker's own POST (`api --method POST ... --input -`), the
+ * minimize-superseded-markers.mts GraphQL probe (`api graphql` with an
+ * `id=` variable and no `classifier=`), and its GraphQL mutation (`api
+ * graphql` with both `id=` and `classifier=`). `priorComments` seeds the
+ * first call's NDJSON response; `probeIndex` (keyed by node id) seeds the
+ * probe's per-subject `isMinimized` / `viewerCanMinimize` / `author`
+ * fields; `failMutationFor` names node ids whose mutation call exits
+ * non-zero (simulating a permission failure) instead of succeeding.
+ *
+ * Every `graphql` call (probe or mutation) appends one `{id, mutation}`
+ * JSON line to `mutationLogFile`, so a test can assert the EXACT set of
+ * node ids the mutation actually ran for -- proving a spared or
+ * already-minimized candidate never reached `minimizeComment`, not just
+ * that the CLI happened to exit 0.
+ */
+function withHideAtPostTimeGhStub(options: {
+  priorComments: {
+    id: number;
+    node_id: string;
+    body: string;
+    user: { login: string };
+  }[];
+  probeIndex: Record<
+    string,
+    { isMinimized?: boolean; viewerCanMinimize?: boolean; author?: string }
+  >;
+  mutationLogFile: string;
+  failMutationFor?: string[];
+  newCommentId?: number;
+}): () => void {
+  const failMutationFor = options.failMutationFor ?? [];
+  return stubExecutable(
+    'gh',
+    `const fs = require('node:fs');
+const args = process.argv.slice(2);
+const priorComments = ${JSON.stringify(options.priorComments)};
+const probeIndex = ${JSON.stringify(options.probeIndex)};
+const failMutationFor = ${JSON.stringify(failMutationFor)};
+const newCommentId = ${JSON.stringify(options.newCommentId ?? 9999)};
+const mutationLogFile = ${JSON.stringify(options.mutationLogFile)};
+function out(s) { fs.writeSync(1, s); process.exit(0); }
+function fail(s) { fs.writeSync(2, s); process.exit(1); }
+if (args[0] === 'api' && typeof args[1] === 'string' && args[1].indexOf('/comments') !== -1 && args.indexOf('--paginate') !== -1) {
+  out(priorComments.map((c) => JSON.stringify(c)).join('\\n') + '\\n');
+} else if (args[0] === 'api' && args[1] === '--method' && args[2] === 'POST') {
+  fs.readFileSync(0, 'utf8');
+  out(JSON.stringify({ id: newCommentId, html_url: 'https://github.com/o/r/issues/1#issuecomment-' + newCommentId }));
+} else if (args[0] === 'api' && args[1] === 'graphql') {
+  const fValues = [];
+  for (let i = 0; i < args.length; i += 1) {
+    if (args[i] === '-f') fValues.push(args[i + 1]);
+  }
+  const idEntry = fValues.find((v) => v.indexOf('id=') === 0);
+  const classifierEntry = fValues.find((v) => v.indexOf('classifier=') === 0);
+  const id = idEntry ? idEntry.slice('id='.length) : '';
+  fs.appendFileSync(mutationLogFile, JSON.stringify({ id, mutation: Boolean(classifierEntry) }) + '\\n');
+  if (classifierEntry) {
+    if (failMutationFor.indexOf(id) !== -1) {
+      fail('mutation-error: permission denied');
+    }
+    out(JSON.stringify({ data: { minimizeComment: { minimizedComment: { __typename: 'IssueComment', isMinimized: true } } } }));
+  } else {
+    const info = probeIndex[id];
+    if (!info) {
+      out(JSON.stringify({ data: { node: null } }));
+    } else {
+      out(JSON.stringify({ data: { node: { __typename: 'IssueComment', url: 'https://github.com/o/r/issues/1#issuecomment-' + id, isMinimized: info.isMinimized || false, viewerCanMinimize: info.viewerCanMinimize !== false, author: { login: info.author || 'kurone-kito' } } } }));
+    }
+  }
+} else {
+  fail('unexpected gh invocation: ' + args.join(' '));
+}
+`,
+  );
+}
+
+/** Read `logFile`'s `{id, mutation}` JSONL lines and return the SET of node
+ * ids that actually reached a `minimizeComment` mutation call (`mutation:
+ * true`), deduplicated. Missing file (no `graphql` call at all) reads as
+ * empty rather than throwing. */
+function readMutatedSubjectIds(logFile: string): string[] {
+  let raw: string;
+  try {
+    raw = readFileSync(logFile, 'utf8');
+  } catch {
+    return [];
+  }
+  const ids = new Set<string>();
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) {
+      continue;
+    }
+    const entry = JSON.parse(line) as { id: string; mutation: boolean };
+    if (entry.mutation) {
+      ids.add(entry.id);
+    }
+  }
+  return [...ids].sort();
+}
+
+test('--apply --type review-ack hides a stale prior review-ack and spares the current-HEAD one (#2754)', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'idd-hide-at-post-review-ack-'));
+  const mutationLogFile = join(tempRoot, 'mutations.jsonl');
+  const restore = withHideAtPostTimeGhStub({
+    priorComments: [
+      {
+        id: 100,
+        node_id: 'IC_stale_review_ack',
+        body: `review-ack: a ${OTHER_SHA} ${TS}`,
+        user: { login: 'kurone-kito' },
+      },
+      {
+        id: 101,
+        node_id: 'IC_current_review_ack',
+        body: `review-ack: a ${SHA} ${TS}`,
+        user: { login: 'kurone-kito' },
+      },
+    ],
+    probeIndex: {
+      IC_stale_review_ack: { author: 'kurone-kito' },
+      IC_current_review_ack: { author: 'kurone-kito' },
+    },
+    mutationLogFile,
+    newCommentId: 9500,
+  });
+  try {
+    const output = execFileSync(
+      process.execPath,
+      [
+        join(REPO_ROOT, 'scripts/post-idd-marker.mjs'),
+        '--type',
+        'review-ack',
+        '--target',
+        'pr',
+        '1200',
+        '--owner',
+        'o',
+        '--repo',
+        'r',
+        '--agent-id',
+        'a',
+        '--head-sha',
+        SHA,
+        '--timestamp',
+        TS,
+        '--trusted-marker-logins',
+        'kurone-kito',
+        '--apply',
+      ],
+      { cwd: REPO_ROOT, encoding: 'utf8', env: { ...process.env } },
+    );
+    // The marker's own POST result is unaffected by the hide step -- it
+    // still succeeds and reports the newly created comment.
+    assert.deepEqual(JSON.parse(output), {
+      mode: 'apply',
+      type: 'review-ack',
+      target: 'pr',
+      number: 1200,
+      commentId: 9500,
+      url: 'https://github.com/o/r/issues/1#issuecomment-9500',
+    });
+    // The GraphQL mutation actually ran ONLY for the stale (differing-HEAD)
+    // comment -- IC_current_review_ack (current-HEAD protection) was never
+    // fed to minimizeComment, even though it has a probeIndex entry and
+    // would otherwise happily minimize.
+    assert.deepEqual(readMutatedSubjectIds(mutationLogFile), [
+      'IC_stale_review_ack',
+    ]);
+  } finally {
+    restore();
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('--apply --type copilot-unavailable hides a prior same-claim comment, spares a foreign-claim one, and is idempotent on an already-minimized candidate (#2754)', () => {
+  const tempRoot = mkdtempSync(
+    join(tmpdir(), 'idd-hide-at-post-copilot-unavailable-'),
+  );
+  const mutationLogFile = join(tempRoot, 'mutations.jsonl');
+  const restore = withHideAtPostTimeGhStub({
+    priorComments: [
+      {
+        id: 200,
+        node_id: 'IC_same_claim_attempt1',
+        body: `copilot-unavailable: a ${SHA} ${TS} claim:${CLAIM_A} attempt:1`,
+        user: { login: 'kurone-kito' },
+      },
+      {
+        id: 201,
+        node_id: 'IC_already_minimized',
+        body: `copilot-unavailable: a ${SHA} ${TS} claim:${CLAIM_A} attempt:2`,
+        user: { login: 'kurone-kito' },
+      },
+      {
+        id: 202,
+        node_id: 'IC_foreign_claim',
+        body: `copilot-unavailable: a ${SHA} ${TS} claim:${CLAIM_B} attempt:1`,
+        user: { login: 'kurone-kito' },
+      },
+    ],
+    probeIndex: {
+      IC_same_claim_attempt1: { author: 'kurone-kito' },
+      // Already minimized: runMinimize's own probe reports isMinimized
+      // true, so this candidate must be skipped (idempotent) -- probed, but
+      // never reaches the actual minimizeComment mutation.
+      IC_already_minimized: { author: 'kurone-kito', isMinimized: true },
+      IC_foreign_claim: { author: 'kurone-kito' },
+    },
+    mutationLogFile,
+    newCommentId: 9600,
+  });
+  try {
+    const output = execFileSync(
+      process.execPath,
+      [
+        join(REPO_ROOT, 'scripts/post-idd-marker.mjs'),
+        '--type',
+        'copilot-unavailable',
+        '--target',
+        'pr',
+        '1200',
+        '--owner',
+        'o',
+        '--repo',
+        'r',
+        '--agent-id',
+        'a',
+        '--claim-id',
+        CLAIM_A,
+        '--head-sha',
+        SHA,
+        '--attempt',
+        '3',
+        '--timestamp',
+        TS,
+        '--trusted-marker-logins',
+        'kurone-kito',
+        '--apply',
+      ],
+      { cwd: REPO_ROOT, encoding: 'utf8', env: { ...process.env } },
+    );
+    assert.deepEqual(JSON.parse(output), {
+      mode: 'apply',
+      type: 'copilot-unavailable',
+      target: 'pr',
+      number: 1200,
+      commentId: 9600,
+      url: 'https://github.com/o/r/issues/1#issuecomment-9600',
+    });
+    // The mutation actually ran ONLY for the same-claim, not-yet-minimized
+    // candidate -- IC_already_minimized was probed (its isMinimized: true
+    // is how runMinimize decides to skip it) but never reached
+    // minimizeComment, and IC_foreign_claim (differing claim:) was never a
+    // candidate at all.
+    assert.deepEqual(readMutatedSubjectIds(mutationLogFile), [
+      'IC_same_claim_attempt1',
+    ]);
+  } finally {
+    restore();
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('--apply --type review-ack: a minimize-mutation permission failure never blocks the marker post itself (#2754)', () => {
+  const tempRoot = mkdtempSync(
+    join(tmpdir(), 'idd-hide-at-post-permission-failure-'),
+  );
+  const mutationLogFile = join(tempRoot, 'mutations.jsonl');
+  const restore = withHideAtPostTimeGhStub({
+    priorComments: [
+      {
+        id: 300,
+        node_id: 'IC_permission_denied',
+        body: `review-ack: a ${OTHER_SHA} ${TS}`,
+        user: { login: 'kurone-kito' },
+      },
+    ],
+    probeIndex: {
+      IC_permission_denied: { author: 'kurone-kito' },
+    },
+    mutationLogFile,
+    failMutationFor: ['IC_permission_denied'],
+    newCommentId: 9700,
+  });
+  try {
+    const output = execFileSync(
+      process.execPath,
+      [
+        join(REPO_ROOT, 'scripts/post-idd-marker.mjs'),
+        '--type',
+        'review-ack',
+        '--target',
+        'pr',
+        '1200',
+        '--owner',
+        'o',
+        '--repo',
+        'r',
+        '--agent-id',
+        'a',
+        '--head-sha',
+        SHA,
+        '--timestamp',
+        TS,
+        '--trusted-marker-logins',
+        'kurone-kito',
+        '--apply',
+      ],
+      { cwd: REPO_ROOT, encoding: 'utf8', env: { ...process.env } },
+    );
+    // The mutation "failed" (simulated permission denial) inside the
+    // best-effort hide step, but the CLI still exits 0 and reports the
+    // marker's own successful POST -- proving the failure never propagated.
+    assert.deepEqual(JSON.parse(output), {
+      mode: 'apply',
+      type: 'review-ack',
+      target: 'pr',
+      number: 1200,
+      commentId: 9700,
+      url: 'https://github.com/o/r/issues/1#issuecomment-9700',
+    });
+    // The mutation was genuinely attempted (and failed) for the candidate --
+    // proving this is a real permission-failure path, not a candidate list
+    // that silently came back empty.
+    const mutationAttempts = readFileSync(mutationLogFile, 'utf8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as { id: string; mutation: boolean });
+    assert.deepEqual(
+      mutationAttempts.filter((entry) => entry.mutation),
+      [{ id: 'IC_permission_denied', mutation: true }],
+    );
+  } finally {
+    restore();
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('--apply for a marker type outside HIDE_AT_POST_TIME_MARKER_TYPES never lists prior comments (#2754)', () => {
+  // A `claim` POST must not trigger the hide-at-post-time comment scan at
+  // all -- proven by never invoking the `--paginate` branch this stub would
+  // otherwise need to answer (any comments-listing call here falls through
+  // to the catch-all "unexpected gh invocation" failure).
+  const restore = stubExecutable(
+    'gh',
+    `const fs = require('node:fs');
+const args = process.argv.slice(2);
+function out(s) { fs.writeSync(1, s); process.exit(0); }
+function fail(s) { fs.writeSync(2, s); process.exit(1); }
+if (args[0] === 'api' && args[1] === '--method' && args[2] === 'POST') {
+  fs.readFileSync(0, 'utf8');
+  out(JSON.stringify({ id: 9800, html_url: 'https://github.com/o/r/issues/1#issuecomment-9800' }));
+} else {
+  fail('unexpected gh invocation: ' + args.join(' '));
+}
+`,
+  );
+  try {
+    const output = execFileSync(
+      process.execPath,
+      [
+        join(REPO_ROOT, 'scripts/post-idd-marker.mjs'),
+        '--type',
+        'claim',
+        '--target',
+        'issue',
+        '1200',
+        '--owner',
+        'o',
+        '--repo',
+        'r',
+        '--agent-id',
+        'a',
+        '--claim-id',
+        'c',
+        '--supersedes',
+        'none',
+        '--timestamp',
+        TS,
+        '--branch',
+        'issue/1200-foo',
+        '--apply',
+      ],
+      { cwd: REPO_ROOT, encoding: 'utf8', env: { ...process.env } },
+    );
+    assert.equal(JSON.parse(output).commentId, 9800);
+  } finally {
+    restore();
+  }
 });

--- a/tests/post-idd-marker.test.mts
+++ b/tests/post-idd-marker.test.mts
@@ -2111,6 +2111,16 @@ function withHideAtPostTimeGhStub(options: {
   mutationLogFile: string;
   failMutationFor?: string[];
   newCommentId?: number;
+  /**
+   * The `headRefOid` a `gh pr view --json headRefOid --jq .headRefOid` call
+   * resolves to (#2754, chatgpt-codex-connector review on PR #2788) --
+   * `hideSupersededPostTimeMarkers`'s pre-scan live-HEAD re-read for
+   * `review-ack`. Defaults to `SHA` (matching every review-ack test's own
+   * `--head-sha`), so existing callers exercising the hide-and-spare /
+   * race-condition / permission-failure paths keep passing without a
+   * mismatch short-circuiting them.
+   */
+  liveHeadSha?: string;
 }): () => void {
   const failMutationFor = options.failMutationFor ?? [];
   return stubExecutable(
@@ -2122,9 +2132,12 @@ const probeIndex = ${JSON.stringify(options.probeIndex)};
 const failMutationFor = ${JSON.stringify(failMutationFor)};
 const newCommentId = ${JSON.stringify(options.newCommentId ?? 9999)};
 const mutationLogFile = ${JSON.stringify(options.mutationLogFile)};
+const liveHeadSha = ${JSON.stringify(options.liveHeadSha ?? SHA)};
 function out(s) { fs.writeSync(1, s); process.exit(0); }
 function fail(s) { fs.writeSync(2, s); process.exit(1); }
-if (args[0] === 'api' && typeof args[1] === 'string' && args[1].indexOf('/comments') !== -1 && args.indexOf('--paginate') !== -1) {
+if (args[0] === 'pr' && args[1] === 'view' && args.includes('headRefOid') && args.includes('.headRefOid')) {
+  out(liveHeadSha + '\\n');
+} else if (args[0] === 'api' && typeof args[1] === 'string' && args[1].indexOf('/comments') !== -1 && args.indexOf('--paginate') !== -1) {
   out(priorComments.map((c) => JSON.stringify(c)).join('\\n') + '\\n');
 } else if (args[0] === 'api' && args[1] === '--method' && args[2] === 'POST') {
   fs.readFileSync(0, 'utf8');
@@ -2318,6 +2331,75 @@ test('--apply --type review-ack never hides a differing-HEAD-SHA comment created
   } finally {
     restore();
     rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('--apply --type review-ack skips the whole hide pass when the live PR HEAD no longer matches the just-posted marker (#2754, delayed-POST race)', () => {
+  // Simulates the branch advancing between --from-pr's own headRefOid read
+  // (embedded in the marker body as SHA) and this call reaching the
+  // hide-at-post-time step: a live re-read now reports OTHER_SHA. The
+  // `id <` ordering restriction alone cannot tell a stale marker from a
+  // fresh one once both are "prior" by id, so the step must bail out
+  // BEFORE ever listing comments, rather than risk minimizing a
+  // genuinely newer, current-HEAD acknowledgement while leaving this
+  // stale one visible. Any `--paginate` comments-listing or `graphql`
+  // call here falls through to the catch-all "unexpected gh invocation"
+  // failure, proving the scan itself never runs.
+  const restore = stubExecutable(
+    'gh',
+    `const fs = require('node:fs');
+const args = process.argv.slice(2);
+function out(s) { fs.writeSync(1, s); process.exit(0); }
+function fail(s) { fs.writeSync(2, s); process.exit(1); }
+if (args[0] === 'pr' && args[1] === 'view' && args.includes('headRefOid') && args.includes('.headRefOid')) {
+  out('${OTHER_SHA}\\n');
+} else if (args[0] === 'api' && args[1] === '--method' && args[2] === 'POST') {
+  fs.readFileSync(0, 'utf8');
+  out(JSON.stringify({ id: 9550, html_url: 'https://github.com/o/r/issues/1#issuecomment-9550' }));
+} else {
+  fail('unexpected gh invocation: ' + args.join(' '));
+}
+`,
+  );
+  try {
+    const output = execFileSync(
+      process.execPath,
+      [
+        join(REPO_ROOT, 'scripts/post-idd-marker.mjs'),
+        '--type',
+        'review-ack',
+        '--target',
+        'pr',
+        '1200',
+        '--owner',
+        'o',
+        '--repo',
+        'r',
+        '--agent-id',
+        'a',
+        '--head-sha',
+        SHA,
+        '--timestamp',
+        TS,
+        '--trusted-marker-logins',
+        'kurone-kito',
+        '--apply',
+      ],
+      { cwd: REPO_ROOT, encoding: 'utf8', env: { ...process.env } },
+    );
+    // The marker's own POST result is unaffected: it still succeeds and
+    // reports the newly created comment, even though the hide step bailed
+    // out entirely (best-effort, #2754).
+    assert.deepEqual(JSON.parse(output), {
+      mode: 'apply',
+      type: 'review-ack',
+      target: 'pr',
+      number: 1200,
+      commentId: 9550,
+      url: 'https://github.com/o/r/issues/1#issuecomment-9550',
+    });
+  } finally {
+    restore();
   }
 });
 

--- a/tests/post-idd-marker.test.mts
+++ b/tests/post-idd-marker.test.mts
@@ -2018,7 +2018,7 @@ test('findSupersededReviewAckSubjects ignores a non-review-ack comment and one w
 const CLAIM_A = 'claim-aaaa';
 const CLAIM_B = 'claim-bbbb';
 
-test('findSupersededCopilotUnavailableSubjects hides a prior comment carrying the SAME claim: value (differing attempt)', () => {
+test('findSupersededCopilotUnavailableSubjects hides a prior comment carrying the SAME claim: value and a LOWER attempt', () => {
   const sameClaimEarlierAttempt = candidateComment({
     id: 5,
     nodeId: 'IC_same_claim',
@@ -2028,6 +2028,7 @@ test('findSupersededCopilotUnavailableSubjects hides a prior comment carrying th
     findSupersededCopilotUnavailableSubjects(
       [sameClaimEarlierAttempt],
       CLAIM_A,
+      2,
     ),
     ['IC_same_claim'],
   );
@@ -2040,7 +2041,37 @@ test('findSupersededCopilotUnavailableSubjects never hides a comment whose claim
     body: `copilot-unavailable: a ${SHA} ${TS} claim:${CLAIM_B} attempt:1`,
   });
   assert.deepEqual(
-    findSupersededCopilotUnavailableSubjects([foreignClaim], CLAIM_A),
+    findSupersededCopilotUnavailableSubjects([foreignClaim], CLAIM_A, 2),
+    [],
+  );
+});
+
+test('findSupersededCopilotUnavailableSubjects never hides a same-claim comment whose attempt is >= the new one (#2754, round 5: attempt-ordering protection)', () => {
+  // Two same-claim sessions racing on the SAME HEAD (no HEAD drift needed)
+  // can still POST out of attempt order -- e.g. attempt 2 lands with a
+  // LOWER REST id while a stalled attempt 1 lands with the next one. An
+  // attempt-blind filter would let that delayed, regressive attempt 1
+  // hide the more advanced attempt 2. A same-attempt candidate (a bare
+  // retry of this exact attempt number) is also left alone rather than
+  // guessing whether it is a true duplicate -- current-attempt protection,
+  // mirroring the live-HEAD gate's own "when ambiguous, never hide" policy
+  // for a same-embedded-HEAD review-ack.
+  const higherAttempt = candidateComment({
+    id: 9,
+    nodeId: 'IC_higher_attempt',
+    body: `copilot-unavailable: a ${SHA} ${TS} claim:${CLAIM_A} attempt:3`,
+  });
+  const sameAttempt = candidateComment({
+    id: 10,
+    nodeId: 'IC_same_attempt',
+    body: `copilot-unavailable: a ${SHA} ${TS} claim:${CLAIM_A} attempt:2`,
+  });
+  assert.deepEqual(
+    findSupersededCopilotUnavailableSubjects(
+      [higherAttempt, sameAttempt],
+      CLAIM_A,
+      2,
+    ),
     [],
   );
 });
@@ -2056,7 +2087,7 @@ test('findSupersededCopilotUnavailableSubjects trims newClaimId before comparing
     body: `copilot-unavailable: a ${SHA} ${TS} claim:${CLAIM_A} attempt:1`,
   });
   assert.deepEqual(
-    findSupersededCopilotUnavailableSubjects([sameClaim], `  ${CLAIM_A}  `),
+    findSupersededCopilotUnavailableSubjects([sameClaim], `  ${CLAIM_A}  `, 2),
     ['IC_same_claim_untrimmed'],
   );
 });
@@ -2073,7 +2104,7 @@ test('findSupersededCopilotUnavailableSubjects ignores a non-copilot-unavailable
     body: `copilot-unavailable: a ${SHA} ${TS} claim:${CLAIM_A} attempt:1`,
   });
   assert.deepEqual(
-    findSupersededCopilotUnavailableSubjects([unrelated, noNodeId], CLAIM_A),
+    findSupersededCopilotUnavailableSubjects([unrelated, noNodeId], CLAIM_A, 2),
     [],
   );
 });
@@ -2578,6 +2609,80 @@ test('--apply --type copilot-unavailable hides a prior same-claim comment, spare
     assert.deepEqual(readMutatedSubjectIds(mutationLogFile), [
       'IC_same_claim_attempt1',
     ]);
+  } finally {
+    restore();
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('--apply --type copilot-unavailable never hides a same-claim comment carrying a HIGHER attempt than the one just posted (#2754, round 5, chatgpt-codex-connector review)', () => {
+  // Simulates attempt 2 landing FIRST (lower REST id) while a stalled
+  // attempt 1 finally lands second (higher id): the `id <` ordering
+  // restriction alone would treat attempt 2 as "prior" and, without an
+  // attempt-aware filter, this delayed attempt-1 post would hide the more
+  // advanced attempt 2, leaving the regressive attempt 1 as the only
+  // marker expanded.
+  const tempRoot = mkdtempSync(
+    join(tmpdir(), 'idd-hide-at-post-copilot-unavailable-attempt-order-'),
+  );
+  const mutationLogFile = join(tempRoot, 'mutations.jsonl');
+  const restore = withHideAtPostTimeGhStub({
+    priorComments: [
+      {
+        id: 300,
+        node_id: 'IC_higher_attempt_earlier_post',
+        body: `copilot-unavailable: a ${SHA} ${TS} claim:${CLAIM_A} attempt:2`,
+        user: { login: 'kurone-kito' },
+      },
+    ],
+    probeIndex: {
+      IC_higher_attempt_earlier_post: { author: 'kurone-kito' },
+    },
+    mutationLogFile,
+    newCommentId: 9650,
+  });
+  try {
+    const output = execFileSync(
+      process.execPath,
+      [
+        join(REPO_ROOT, 'scripts/post-idd-marker.mjs'),
+        '--type',
+        'copilot-unavailable',
+        '--target',
+        'pr',
+        '1200',
+        '--owner',
+        'o',
+        '--repo',
+        'r',
+        '--agent-id',
+        'a',
+        '--claim-id',
+        CLAIM_A,
+        '--head-sha',
+        SHA,
+        '--attempt',
+        '1',
+        '--timestamp',
+        TS,
+        '--trusted-marker-logins',
+        'kurone-kito',
+        '--apply',
+      ],
+      { cwd: REPO_ROOT, encoding: 'utf8', env: { ...process.env } },
+    );
+    assert.deepEqual(JSON.parse(output), {
+      mode: 'apply',
+      type: 'copilot-unavailable',
+      target: 'pr',
+      number: 1200,
+      commentId: 9650,
+      url: 'https://github.com/o/r/issues/1#issuecomment-9650',
+    });
+    // The higher-attempt candidate was never mutated, even though it has
+    // a lower id (so it passes the ordering filter) and a probeIndex
+    // entry that would otherwise happily minimize it.
+    assert.deepEqual(readMutatedSubjectIds(mutationLogFile), []);
   } finally {
     restore();
     rmSync(tempRoot, { recursive: true, force: true });

--- a/tests/post-idd-marker.test.mts
+++ b/tests/post-idd-marker.test.mts
@@ -2427,6 +2427,74 @@ if (args[0] === 'pr' && args[1] === 'view' && args.includes('headRefOid') && arg
   }
 });
 
+test('--apply --type copilot-unavailable also skips the whole hide pass when the live PR HEAD no longer matches the just-posted marker (#2754, round 4, chatgpt-codex-connector review)', () => {
+  // Same race as the review-ack test above, but for copilot-unavailable:
+  // a delayed, stale-HEAD same-claim poster (e.g. a stalled pre-handoff
+  // session finally completing its retry) must not treat an earlier,
+  // CURRENT-HEAD same-claim comment as "superseded" purely because
+  // findSupersededCopilotUnavailableSubjects matches on claim: equality
+  // alone, with no HEAD comparison of its own. The live-HEAD gate, now
+  // unconditional for both types, closes that gap by never letting a
+  // stale poster run its scan/hide judgment at all.
+  const restore = stubExecutable(
+    'gh',
+    `const fs = require('node:fs');
+const args = process.argv.slice(2);
+function out(s) { fs.writeSync(1, s); process.exit(0); }
+function fail(s) { fs.writeSync(2, s); process.exit(1); }
+if (args[0] === 'pr' && args[1] === 'view' && args.includes('headRefOid') && args.includes('.headRefOid')) {
+  out('${OTHER_SHA}\\n');
+} else if (args[0] === 'api' && args[1] === '--method' && args[2] === 'POST') {
+  fs.readFileSync(0, 'utf8');
+  out(JSON.stringify({ id: 9560, html_url: 'https://github.com/o/r/issues/1#issuecomment-9560' }));
+} else {
+  fail('unexpected gh invocation: ' + args.join(' '));
+}
+`,
+  );
+  try {
+    const output = execFileSync(
+      process.execPath,
+      [
+        join(REPO_ROOT, 'scripts/post-idd-marker.mjs'),
+        '--type',
+        'copilot-unavailable',
+        '--target',
+        'pr',
+        '1200',
+        '--owner',
+        'o',
+        '--repo',
+        'r',
+        '--agent-id',
+        'a',
+        '--claim-id',
+        CLAIM_A,
+        '--head-sha',
+        SHA,
+        '--attempt',
+        '1',
+        '--timestamp',
+        TS,
+        '--trusted-marker-logins',
+        'kurone-kito',
+        '--apply',
+      ],
+      { cwd: REPO_ROOT, encoding: 'utf8', env: { ...process.env } },
+    );
+    assert.deepEqual(JSON.parse(output), {
+      mode: 'apply',
+      type: 'copilot-unavailable',
+      target: 'pr',
+      number: 1200,
+      commentId: 9560,
+      url: 'https://github.com/o/r/issues/1#issuecomment-9560',
+    });
+  } finally {
+    restore();
+  }
+});
+
 test('--apply --type copilot-unavailable hides a prior same-claim comment, spares a foreign-claim one, and is idempotent on an already-minimized candidate (#2754)', () => {
   const tempRoot = mkdtempSync(
     join(tmpdir(), 'idd-hide-at-post-copilot-unavailable-'),
@@ -2735,15 +2803,22 @@ process.exit(1);
 });
 
 test('hideSupersededPostTimeMarkers enforces its remaining budget on the comments listing itself, not just on runMinimize (#2754, round 3)', () => {
-  // The stubbed gh process sleeps a full real second before answering the
-  // --paginate call; a correctly-threaded ~150ms timeoutMs must kill it
-  // long before that, proving the budget bounds this READ, not merely the
-  // later mutation pass (which round 2 already covered).
+  // The stubbed gh process answers the live-HEAD re-check (now unconditional
+  // for both marker types, round 4) instantly with a matching SHA, then
+  // sleeps a full real second before answering the --paginate call; a
+  // correctly-threaded ~150ms remainder must kill the LATTER call long
+  // before that, proving the budget bounds this READ, not merely the later
+  // mutation pass (which round 2 already covered).
   const restore = stubExecutable(
     'gh',
     `const { execSync } = require('node:child_process');
+const fs = require('node:fs');
 const args = process.argv.slice(2);
-function fail(s) { process.stderr.write(s); process.exit(1); }
+function fail(s) { fs.writeSync(2, s); process.exit(1); }
+if (args[0] === 'pr' && args[1] === 'view' && args.includes('headRefOid') && args.includes('.headRefOid')) {
+  fs.writeSync(1, '${SHA}\\n');
+  process.exit(0);
+}
 if (args[0] === 'api' && typeof args[1] === 'string' && args[1].indexOf('/comments') !== -1 && args.indexOf('--paginate') !== -1) {
   execSync('sleep 1');
   process.stdout.write('');
@@ -2757,7 +2832,7 @@ fail('unexpected gh invocation: ' + args.join(' '));
     assert.doesNotThrow(() => {
       hideSupersededPostTimeMarkers(
         'copilot-unavailable',
-        { 'claim-id': CLAIM_A },
+        { 'claim-id': CLAIM_A, 'head-sha': SHA },
         'o',
         'r',
         1200,

--- a/tests/post-idd-marker.test.mts
+++ b/tests/post-idd-marker.test.mts
@@ -13,6 +13,7 @@ import {
   findSupersededCopilotUnavailableSubjects,
   findSupersededReviewAckSubjects,
   HIDE_AT_POST_TIME_MARKER_TYPES,
+  hideSupersededPostTimeMarkers,
   isHideAtPostTimeMarkerType,
   MARKER_TYPES,
   parseArgs,
@@ -2662,6 +2663,116 @@ test('--apply --type review-ack never scans for candidates when the just-posted 
   } finally {
     restore();
     rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+// --- #2754, chatgpt-codex-connector review round 3 on PR #2788: the whole
+// --- step's own HIDE_STEP_DEADLINE_MS budget, not just runMinimize's pass ---
+//
+// Round 2 gave runMinimize an internal deadlineMs, but that clock only
+// started at ITS OWN entry -- every network call BEFORE it (the review-ack
+// live-HEAD re-check, and the comments listing every type makes) stayed
+// outside the budget, bounded only by gh-exec.mts's own defaults (30s for
+// the HEAD re-check, 120s for the paginated comments listing). These tests
+// call the now-exported hideSupersededPostTimeMarkers directly (no CLI
+// subprocess spawn) so a real, enforced execFileSync timeout can be
+// exercised in well under a second instead of needing 45+ real seconds to
+// elapse.
+
+test('hideSupersededPostTimeMarkers makes no gh call at all when deadlineMs is already exhausted at entry (#2754, round 3)', () => {
+  const restore = stubExecutable(
+    'gh',
+    `process.stderr.write('unexpected gh invocation: ' + process.argv.slice(2).join(' '));
+process.exit(1);
+`,
+  );
+  try {
+    assert.doesNotThrow(() => {
+      hideSupersededPostTimeMarkers(
+        'copilot-unavailable',
+        { 'claim-id': CLAIM_A },
+        'o',
+        'r',
+        1200,
+        9999,
+        'kurone-kito',
+        0,
+      );
+    });
+  } finally {
+    restore();
+  }
+});
+
+test('hideSupersededPostTimeMarkers (review-ack) makes no gh call at all when deadlineMs is already exhausted at entry (#2754, round 3)', () => {
+  // Unlike runMinimize's entry check (which always lets the first
+  // candidate's OWN probe through so the pass makes forward progress),
+  // this step's own budget check has no such exemption for its live-HEAD
+  // re-check: an already-exhausted budget must skip everything, review-ack
+  // included.
+  const restore = stubExecutable(
+    'gh',
+    `process.stderr.write('unexpected gh invocation: ' + process.argv.slice(2).join(' '));
+process.exit(1);
+`,
+  );
+  try {
+    assert.doesNotThrow(() => {
+      hideSupersededPostTimeMarkers(
+        'review-ack',
+        { 'head-sha': SHA },
+        'o',
+        'r',
+        1200,
+        9999,
+        'kurone-kito',
+        0,
+      );
+    });
+  } finally {
+    restore();
+  }
+});
+
+test('hideSupersededPostTimeMarkers enforces its remaining budget on the comments listing itself, not just on runMinimize (#2754, round 3)', () => {
+  // The stubbed gh process sleeps a full real second before answering the
+  // --paginate call; a correctly-threaded ~150ms timeoutMs must kill it
+  // long before that, proving the budget bounds this READ, not merely the
+  // later mutation pass (which round 2 already covered).
+  const restore = stubExecutable(
+    'gh',
+    `const { execSync } = require('node:child_process');
+const args = process.argv.slice(2);
+function fail(s) { process.stderr.write(s); process.exit(1); }
+if (args[0] === 'api' && typeof args[1] === 'string' && args[1].indexOf('/comments') !== -1 && args.indexOf('--paginate') !== -1) {
+  execSync('sleep 1');
+  process.stdout.write('');
+  process.exit(0);
+}
+fail('unexpected gh invocation: ' + args.join(' '));
+`,
+  );
+  const start = Date.now();
+  try {
+    assert.doesNotThrow(() => {
+      hideSupersededPostTimeMarkers(
+        'copilot-unavailable',
+        { 'claim-id': CLAIM_A },
+        'o',
+        'r',
+        1200,
+        9999,
+        'kurone-kito',
+        150,
+      );
+    });
+    const elapsed = Date.now() - start;
+    assert.ok(
+      elapsed < 900,
+      `expected the ~150ms timeout to cut off the 1s stub sleep, took ${elapsed}ms`,
+    );
+  } finally {
+    restore();
   }
 });
 

--- a/tests/post-idd-marker.test.mts
+++ b/tests/post-idd-marker.test.mts
@@ -2389,33 +2389,31 @@ test('--apply --type review-ack never hides a differing-HEAD-SHA comment created
   }
 });
 
-test('--apply --type review-ack skips the whole hide pass when the live PR HEAD no longer matches the just-posted marker (#2754, delayed-POST race)', () => {
+test('--apply --type review-ack self-minimizes the just-posted marker when the live PR HEAD no longer matches it (#2754, round 5, chatgpt-codex-connector review)', () => {
   // Simulates the branch advancing between --from-pr's own headRefOid read
   // (embedded in the marker body as SHA) and this call reaching the
   // hide-at-post-time step: a live re-read now reports OTHER_SHA. The
   // `id <` ordering restriction alone cannot tell a stale marker from a
-  // fresh one once both are "prior" by id, so the step must bail out
-  // BEFORE ever listing comments, rather than risk minimizing a
-  // genuinely newer, current-HEAD acknowledgement while leaving this
-  // stale one visible. Any `--paginate` comments-listing or `graphql`
-  // call here falls through to the catch-all "unexpected gh invocation"
-  // failure, proving the scan itself never runs.
-  const restore = stubExecutable(
-    'gh',
-    `const fs = require('node:fs');
-const args = process.argv.slice(2);
-function out(s) { fs.writeSync(1, s); process.exit(0); }
-function fail(s) { fs.writeSync(2, s); process.exit(1); }
-if (args[0] === 'pr' && args[1] === 'view' && args.includes('headRefOid') && args.includes('.headRefOid')) {
-  out('${OTHER_SHA}\\n');
-} else if (args[0] === 'api' && args[1] === '--method' && args[2] === 'POST') {
-  fs.readFileSync(0, 'utf8');
-  out(JSON.stringify({ id: 9550, html_url: 'https://github.com/o/r/issues/1#issuecomment-9550' }));
-} else {
-  fail('unexpected gh invocation: ' + args.join(' '));
-}
-`,
+  // fresh one once both are "prior" by id, so scanning for OTHER
+  // candidates while stale risks minimizing a genuinely newer, current-
+  // HEAD acknowledgement. Round 5 (this test) asserts the step instead
+  // self-minimizes the marker THIS call itself just posted -- mirroring
+  // sibling #2755's self-minimize behavior for
+  // `idd-local-validation-evidence:` -- rather than abandoning it
+  // expanded forever (rounds 3-4's behavior, now superseded).
+  const tempRoot = mkdtempSync(
+    join(tmpdir(), 'idd-hide-at-post-review-ack-stale-'),
   );
+  const mutationLogFile = join(tempRoot, 'mutations.jsonl');
+  const restore = withHideAtPostTimeGhStub({
+    priorComments: [],
+    probeIndex: {
+      IC_posted_self: { author: 'kurone-kito' },
+    },
+    mutationLogFile,
+    newCommentId: 9550,
+    liveHeadSha: OTHER_SHA,
+  });
   try {
     const output = execFileSync(
       process.execPath,
@@ -2443,8 +2441,8 @@ if (args[0] === 'pr' && args[1] === 'view' && args.includes('headRefOid') && arg
       { cwd: REPO_ROOT, encoding: 'utf8', env: { ...process.env } },
     );
     // The marker's own POST result is unaffected: it still succeeds and
-    // reports the newly created comment, even though the hide step bailed
-    // out entirely (best-effort, #2754).
+    // reports the newly created comment, even though that same comment is
+    // then self-minimized as stale (best-effort, #2754).
     assert.deepEqual(JSON.parse(output), {
       mode: 'apply',
       type: 'review-ack',
@@ -2453,36 +2451,38 @@ if (args[0] === 'pr' && args[1] === 'view' && args.includes('headRefOid') && arg
       commentId: 9550,
       url: 'https://github.com/o/r/issues/1#issuecomment-9550',
     });
+    assert.deepEqual(readMutatedSubjectIds(mutationLogFile), [
+      'IC_posted_self',
+    ]);
   } finally {
     restore();
+    rmSync(tempRoot, { recursive: true, force: true });
   }
 });
 
-test('--apply --type copilot-unavailable also skips the whole hide pass when the live PR HEAD no longer matches the just-posted marker (#2754, round 4, chatgpt-codex-connector review)', () => {
-  // Same race as the review-ack test above, but for copilot-unavailable:
-  // a delayed, stale-HEAD same-claim poster (e.g. a stalled pre-handoff
-  // session finally completing its retry) must not treat an earlier,
-  // CURRENT-HEAD same-claim comment as "superseded" purely because
-  // findSupersededCopilotUnavailableSubjects matches on claim: equality
-  // alone, with no HEAD comparison of its own. The live-HEAD gate, now
-  // unconditional for both types, closes that gap by never letting a
-  // stale poster run its scan/hide judgment at all.
-  const restore = stubExecutable(
-    'gh',
-    `const fs = require('node:fs');
-const args = process.argv.slice(2);
-function out(s) { fs.writeSync(1, s); process.exit(0); }
-function fail(s) { fs.writeSync(2, s); process.exit(1); }
-if (args[0] === 'pr' && args[1] === 'view' && args.includes('headRefOid') && args.includes('.headRefOid')) {
-  out('${OTHER_SHA}\\n');
-} else if (args[0] === 'api' && args[1] === '--method' && args[2] === 'POST') {
-  fs.readFileSync(0, 'utf8');
-  out(JSON.stringify({ id: 9560, html_url: 'https://github.com/o/r/issues/1#issuecomment-9560' }));
-} else {
-  fail('unexpected gh invocation: ' + args.join(' '));
-}
-`,
+test('--apply --type copilot-unavailable also self-minimizes the just-posted marker when the live PR HEAD no longer matches it (#2754, round 5, chatgpt-codex-connector review)', () => {
+  // Same stale-HEAD race as the review-ack test above, but for
+  // copilot-unavailable: a delayed, stale-HEAD same-claim poster (e.g. a
+  // stalled pre-handoff session finally completing its retry) must not
+  // treat an earlier, CURRENT-HEAD same-claim comment as "superseded"
+  // purely because findSupersededCopilotUnavailableSubjects matches on
+  // claim: equality alone, with no HEAD comparison of its own. The
+  // live-HEAD gate, unconditional for both types, now self-minimizes
+  // THIS call's own just-posted marker instead of scanning for other
+  // candidates while stale.
+  const tempRoot = mkdtempSync(
+    join(tmpdir(), 'idd-hide-at-post-copilot-unavailable-stale-'),
   );
+  const mutationLogFile = join(tempRoot, 'mutations.jsonl');
+  const restore = withHideAtPostTimeGhStub({
+    priorComments: [],
+    probeIndex: {
+      IC_posted_self: { author: 'kurone-kito' },
+    },
+    mutationLogFile,
+    newCommentId: 9560,
+    liveHeadSha: OTHER_SHA,
+  });
   try {
     const output = execFileSync(
       process.execPath,
@@ -2521,8 +2521,63 @@ if (args[0] === 'pr' && args[1] === 'view' && args.includes('headRefOid') && arg
       commentId: 9560,
       url: 'https://github.com/o/r/issues/1#issuecomment-9560',
     });
+    assert.deepEqual(readMutatedSubjectIds(mutationLogFile), [
+      'IC_posted_self',
+    ]);
   } finally {
     restore();
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('--apply --type review-ack never self-minimizes a stale just-posted marker whose own author is untrusted (#2754, round 5)', () => {
+  // The trust gate on postedComment applies to the self-minimize path
+  // exactly as it already does to the scan-for-others path: an untrusted
+  // poster must not trigger ANY mutation, including of its own comment.
+  const tempRoot = mkdtempSync(
+    join(tmpdir(), 'idd-hide-at-post-review-ack-stale-untrusted-'),
+  );
+  const mutationLogFile = join(tempRoot, 'mutations.jsonl');
+  const restore = withHideAtPostTimeGhStub({
+    priorComments: [],
+    probeIndex: {
+      IC_posted_self: { author: 'some-random-bot' },
+    },
+    mutationLogFile,
+    newCommentId: 9551,
+    liveHeadSha: OTHER_SHA,
+    postedAuthorLogin: 'some-random-bot',
+  });
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        join(REPO_ROOT, 'scripts/post-idd-marker.mjs'),
+        '--type',
+        'review-ack',
+        '--target',
+        'pr',
+        '1200',
+        '--owner',
+        'o',
+        '--repo',
+        'r',
+        '--agent-id',
+        'a',
+        '--head-sha',
+        SHA,
+        '--timestamp',
+        TS,
+        '--trusted-marker-logins',
+        'kurone-kito',
+        '--apply',
+      ],
+      { cwd: REPO_ROOT, encoding: 'utf8', env: { ...process.env } },
+    );
+    assert.deepEqual(readMutatedSubjectIds(mutationLogFile), []);
+  } finally {
+    restore();
+    rmSync(tempRoot, { recursive: true, force: true });
   }
 });
 
@@ -2916,8 +2971,7 @@ test('hideSupersededPostTimeMarkers enforces its remaining budget on the comment
   // mutation pass (which round 2 already covered).
   const restore = stubExecutable(
     'gh',
-    `const { execSync } = require('node:child_process');
-const fs = require('node:fs');
+    `const fs = require('node:fs');
 const args = process.argv.slice(2);
 function fail(s) { fs.writeSync(2, s); process.exit(1); }
 if (args[0] === 'pr' && args[1] === 'view' && args.includes('headRefOid') && args.includes('.headRefOid')) {
@@ -2925,7 +2979,7 @@ if (args[0] === 'pr' && args[1] === 'view' && args.includes('headRefOid') && arg
   process.exit(0);
 }
 if (args[0] === 'api' && typeof args[1] === 'string' && args[1].indexOf('/comments') !== -1 && args.indexOf('--paginate') !== -1) {
-  execSync('sleep 1');
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1000);
   process.stdout.write('');
   process.exit(0);
 }

--- a/tests/post-idd-marker.test.mts
+++ b/tests/post-idd-marker.test.mts
@@ -2240,6 +2240,71 @@ test('--apply --type review-ack hides a stale prior review-ack and spares the cu
   }
 });
 
+test('--apply --type review-ack never hides a differing-HEAD-SHA comment created AFTER the marker just posted (#2754, race condition)', () => {
+  // Simulates a concurrent session's review-ack landing in the window
+  // between this call's own POST and its comments-listing fetch: that
+  // comment's REST id is HIGHER than the id this call's own marker just
+  // received, even though it surfaces in the same --paginate response.
+  // An inequality-only "not this exact comment" filter would wrongly treat
+  // it as a prior, superseded candidate purely because its HEAD SHA
+  // differs; the `id < postedCommentId` restriction must exclude it
+  // regardless.
+  const tempRoot = mkdtempSync(
+    join(tmpdir(), 'idd-hide-at-post-review-ack-race-'),
+  );
+  const mutationLogFile = join(tempRoot, 'mutations.jsonl');
+  const restore = withHideAtPostTimeGhStub({
+    priorComments: [
+      {
+        id: 9999,
+        node_id: 'IC_newer_review_ack',
+        body: `review-ack: a ${OTHER_SHA} ${TS}`,
+        user: { login: 'kurone-kito' },
+      },
+    ],
+    probeIndex: {
+      IC_newer_review_ack: { author: 'kurone-kito' },
+    },
+    mutationLogFile,
+    newCommentId: 9500,
+  });
+  try {
+    const output = execFileSync(
+      process.execPath,
+      [
+        join(REPO_ROOT, 'scripts/post-idd-marker.mjs'),
+        '--type',
+        'review-ack',
+        '--target',
+        'pr',
+        '1200',
+        '--owner',
+        'o',
+        '--repo',
+        'r',
+        '--agent-id',
+        'a',
+        '--head-sha',
+        SHA,
+        '--timestamp',
+        TS,
+        '--trusted-marker-logins',
+        'kurone-kito',
+        '--apply',
+      ],
+      { cwd: REPO_ROOT, encoding: 'utf8', env: { ...process.env } },
+    );
+    assert.equal(JSON.parse(output).commentId, 9500);
+    // The higher-id comment (9999 > 9500) was never mutated, even though
+    // it has a differing HEAD SHA and a probeIndex entry that would
+    // otherwise happily minimize it.
+    assert.deepEqual(readMutatedSubjectIds(mutationLogFile), []);
+  } finally {
+    restore();
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test('--apply --type copilot-unavailable hides a prior same-claim comment, spares a foreign-claim one, and is idempotent on an already-minimized candidate (#2754)', () => {
   const tempRoot = mkdtempSync(
     join(tmpdir(), 'idd-hide-at-post-copilot-unavailable-'),

--- a/tests/post-idd-marker.test.mts
+++ b/tests/post-idd-marker.test.mts
@@ -2121,16 +2121,39 @@ function withHideAtPostTimeGhStub(options: {
    * mismatch short-circuiting them.
    */
   liveHeadSha?: string;
+  /**
+   * `user.login` for the marker comment this call itself just "posted"
+   * (`newCommentId`) once it reappears in the post-POST `--paginate`
+   * listing (#2754, chatgpt-codex-connector review on PR #2788):
+   * `hideSupersededPostTimeMarkers` now re-reads this comment's own author
+   * and requires it to be in `trustedSet` before scanning for anything to
+   * hide. Defaults to `'kurone-kito'` (the sole trusted login every
+   * existing hide-and-spare / race-condition / permission-failure test
+   * already passes via `--trusted-marker-logins`), so those callers keep
+   * passing without this new gate short-circuiting them.
+   */
+  postedAuthorLogin?: string;
 }): () => void {
   const failMutationFor = options.failMutationFor ?? [];
+  const newCommentId = options.newCommentId ?? 9999;
+  const postedAuthorLogin = options.postedAuthorLogin ?? 'kurone-kito';
+  const listedComments = [
+    ...options.priorComments,
+    {
+      id: newCommentId,
+      node_id: 'IC_posted_self',
+      body: '(the marker this call itself just posted)',
+      user: { login: postedAuthorLogin },
+    },
+  ];
   return stubExecutable(
     'gh',
     `const fs = require('node:fs');
 const args = process.argv.slice(2);
-const priorComments = ${JSON.stringify(options.priorComments)};
+const priorComments = ${JSON.stringify(listedComments)};
 const probeIndex = ${JSON.stringify(options.probeIndex)};
 const failMutationFor = ${JSON.stringify(failMutationFor)};
-const newCommentId = ${JSON.stringify(options.newCommentId ?? 9999)};
+const newCommentId = ${JSON.stringify(newCommentId)};
 const mutationLogFile = ${JSON.stringify(options.mutationLogFile)};
 const liveHeadSha = ${JSON.stringify(options.liveHeadSha ?? SHA)};
 function out(s) { fs.writeSync(1, s); process.exit(0); }
@@ -2561,6 +2584,81 @@ test('--apply --type review-ack: a minimize-mutation permission failure never bl
       mutationAttempts.filter((entry) => entry.mutation),
       [{ id: 'IC_permission_denied', mutation: true }],
     );
+  } finally {
+    restore();
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('--apply --type review-ack never scans for candidates when the just-posted marker is itself untrusted (#2754, chatgpt-codex-connector review on PR #2788)', () => {
+  // An untrusted poster's own new marker is already ignored by downstream
+  // trust-filtered consumers -- but without this gate, its mere presence
+  // would still drive this scan, and the OLDER trusted candidate below
+  // (differing HEAD SHA, so it would otherwise qualify) would still get
+  // minimized purely because ITS OWN author is trusted: collapsing the
+  // one copy of the marker consumers actually rely on.
+  const tempRoot = mkdtempSync(
+    join(tmpdir(), 'idd-hide-at-post-untrusted-poster-'),
+  );
+  const mutationLogFile = join(tempRoot, 'mutations.jsonl');
+  const restore = withHideAtPostTimeGhStub({
+    priorComments: [
+      {
+        id: 100,
+        node_id: 'IC_trusted_stale_review_ack',
+        body: `review-ack: a ${OTHER_SHA} ${TS}`,
+        user: { login: 'kurone-kito' },
+      },
+    ],
+    probeIndex: {
+      IC_trusted_stale_review_ack: { author: 'kurone-kito' },
+    },
+    mutationLogFile,
+    newCommentId: 9800,
+    postedAuthorLogin: 'untrusted-stranger',
+  });
+  try {
+    const output = execFileSync(
+      process.execPath,
+      [
+        join(REPO_ROOT, 'scripts/post-idd-marker.mjs'),
+        '--type',
+        'review-ack',
+        '--target',
+        'pr',
+        '1200',
+        '--owner',
+        'o',
+        '--repo',
+        'r',
+        '--agent-id',
+        'a',
+        '--head-sha',
+        SHA,
+        '--timestamp',
+        TS,
+        '--trusted-marker-logins',
+        'kurone-kito',
+        '--apply',
+      ],
+      { cwd: REPO_ROOT, encoding: 'utf8', env: { ...process.env } },
+    );
+    // The marker's own POST result is unaffected: it still succeeds and
+    // reports the newly created comment, even though the hide step bailed
+    // out entirely (best-effort, #2754) because ITS OWN author is
+    // untrusted.
+    assert.deepEqual(JSON.parse(output), {
+      mode: 'apply',
+      type: 'review-ack',
+      target: 'pr',
+      number: 1200,
+      commentId: 9800,
+      url: 'https://github.com/o/r/issues/1#issuecomment-9800',
+    });
+    // No graphql call reached the probe/mutation stage at all: the trusted
+    // stale candidate (which has a valid probeIndex entry and would
+    // otherwise happily minimize) was never touched.
+    assert.deepEqual(readMutatedSubjectIds(mutationLogFile), []);
   } finally {
     restore();
     rmSync(tempRoot, { recursive: true, force: true });

--- a/tests/provider-adapter-parity.test.mts
+++ b/tests/provider-adapter-parity.test.mts
@@ -107,6 +107,7 @@ test('listWorkItemComments: GitHub and fake adapters agree on the normalized sha
       ghApiJson: () => [
         {
           id: 111,
+          node_id: 'IC_kwDOexample000',
           body: '<!-- idd-skill-claimed-by: claude-1 uuid-1 supersedes: none 2026-01-01T00:00:00Z branch: issue/1 -->',
           created_at: '2026-01-01T00:00:00Z',
           updated_at: '2026-01-01T00:05:00Z',
@@ -120,6 +121,7 @@ test('listWorkItemComments: GitHub and fake adapters agree on the normalized sha
       500: [
         {
           id: 111,
+          nodeId: 'IC_kwDOexample000',
           body: '<!-- idd-skill-claimed-by: claude-1 uuid-1 supersedes: none 2026-01-01T00:00:00Z branch: issue/1 -->',
           createdAt: '2026-01-01T00:00:00Z',
           updatedAt: '2026-01-01T00:05:00Z',


### PR DESCRIPTION
# Summary

`review-ack:` and `copilot-unavailable:` had no hide-at-post-time
wiring: only the post-merge F4 cleanup batch ever cleaned up a
superseded instance, unlike the claim chain, `review-watermark`/
`review-baseline`, and `advisory-wait` families, which already hide
their own superseded prior instances right after a fresh one posts.

This PR wires that up for both families, code-automated directly
inside `post-idd-marker.mts` itself rather than as an agent-followed
instruction step (their grouping keys are purely mechanical: embedded
HEAD SHA mismatch for `review-ack:`, the same `claim:` value and a
strictly lower `attempt:` number for `copilot-unavailable:`):

- After a `review-ack` `--apply` POST succeeds, scan the target's other
  comments and minimize (`OUTDATED`) every prior trusted `review-ack:`
  comment whose embedded HEAD SHA differs from the one just posted.
  Never hides a comment matching the current HEAD SHA.
- After a `copilot-unavailable` `--apply` POST succeeds, scan and
  minimize every prior trusted `copilot-unavailable:` comment carrying
  the SAME `claim:` value and a strictly LOWER `attempt:` number than
  the one just posted (a same-or-higher attempt is left alone —
  current-attempt protection). Never hides a comment whose `claim:`
  value differs (foreign-claim protection).
- Reuses `minimize-superseded-markers.mts`'s `runMinimize` /
  `resolveTrustedActors` for the actual mutation — no GraphQL call is
  reimplemented. Best-effort: any failure (permission error, an
  unreadable comment list — preventive; no observed incident yet,
  #2788) is swallowed and never blocks or retries the marker post that
  already succeeded. Idempotent: an already-`isMinimized` candidate is
  skipped (via `runMinimize`'s own live probe).
- `marker-helpers.mts`'s `MARKER_HIDE_POLICY` entries for both
  families flip from `f4-only` to `wired`.

`post-idd-marker.mts` is on the `provider-port` migration list and
must never construct a raw `gh` call itself
(`tests/provider-port-migration-guard.test.mts`), so the prior-comments
scan goes through the existing `listWorkItemComments` port method
rather than a bespoke REST call. That needed one additive, **optional**
field, `ProviderComment.nodeId` (`provider-port.mts` /
`provider-adapter-github.mts`), populated by the real adapter from
REST's `node_id` — outside this issue's own `## Candidate files` list,
but required by that migration-guard boundary; every existing test
fixture that constructs a `ProviderComment` keeps compiling unchanged
since the field is optional.

## Review hardening (chatgpt-codex-connector / copilot-pull-request-reviewer, across several rounds)

Every round below was verified against live code before disposition,
per this repo's "verify before accept" review-triage rule; several
rounds surfaced genuine correctness gaps in the new hide-at-post-time
mechanism itself, not just style points:

- **HEAD-drift / stall protection**: a `review-ack` observed one HEAD
  but POSTed against a later one; the hide step now re-checks the
  live PR HEAD before scanning, and — once a delayed poster is itself
  found to be stale — self-minimizes the marker it just posted instead
  of abandoning it expanded forever (mirroring sibling #2755's
  self-minimize behavior for `idd-local-validation-evidence:`).
- **Trust gating**: an untrusted poster could otherwise trigger hiding
  of an older, trusted candidate; the step now requires its own
  just-posted comment's author to be trusted before scanning at all.
- **Attempt-ordering** (`copilot-unavailable:` only): a delayed
  lower-attempt post could hide a more-advanced higher-attempt post
  purely by id ordering; only a strictly lower attempt is now ever
  superseded.
- **Deadline budget**: `HIDE_STEP_DEADLINE_MS` (45s) now bounds the
  step's THREE network stages (live-HEAD check, comments listing,
  mutation pass) as a genuine wall-clock budget threaded all the way
  down into each underlying `gh` call's own timeout — not just the
  mutation pass, and not just a flat per-call constant regardless of
  how much budget actually remains — closing a series of
  progressively narrower gaps the same review kept finding across
  rounds (including a same-`Date.now()`-read race between a skip
  check and the timeout value it gates).
- Branch-sync merge from `main` reconciled this PR with sibling #2755
  (merged first), which shipped the same self-minimize mechanism for a
  third marker family in the interim; the "wired families" doc count
  and mechanism grouping were updated to describe all three
  code-automated families together.

## Linked issue

Closes #2754

## Follow-up issues (if any)

- [ ] none filed. Known, documented scope boundary (not tracked as a
  separate issue): this hide-at-post-time mechanism lives inside the
  built `.mjs` helper, so it only runs where a helper runtime is
  configured (`vendored-node`, `package-manager`, `ephemeral-npx`).
  Under `instructions-only` (or wherever the helper is otherwise
  unavailable), an agent posts `review-ack:`/`copilot-unavailable:`
  markers by hand with no equivalent manual minimize step yet — they
  accumulate like an `f4-only` family until a future track adds one
  (documented in `idd-comment-minimization.md`'s Timing section).

## Background / rationale (if material)

`idd-skill#2752` (merged, this issue's blocker) added the
`MARKER_HIDE_POLICY` classification table and its completeness guard.
`idd-skill#2755` (a sibling roadmap #2751 Track 3 item, merged during
this PR's review cycle and reconciled via a branch-sync merge above)
flipped `idd-local-validation-evidence:` the same way.

`docs/idd-comment-minimization.md`'s Timing section (edited via its
`idd-template/` canonical source, then `node scripts/sync-docs.mjs
--apply`) now documents six `wired` families across two hide-at-post-time
mechanisms: three pre-existing agent-followed instruction steps, and
three code-automated families (this PR's pair, plus #2755's).

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`npx biome check`, `npx dprint check`,
  `npx markdownlint-cli2`, `npx cspell lint`)
- [x] `pnpm test` (`node --test tests/*.test.mts`, 5559 passed)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (`node scripts/sync-docs.mjs --apply`
  regenerated the mirror; no residual drift)
- [x] `node scripts/idd-doctor.mjs` (passed, pre-existing
  environment-only warnings unrelated to this change)
- [x] `pnpm run build:check`

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdQ5SPdFLaDGus5PNdBUhw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automatically minimizes superseded `review-ack:` and `copilot-unavailable:` comments after successful posting.
  - Supports comment minimization on GitHub Enterprise installations.
- **Improvements**
  - Adds time limits to comment processing to prevent delays and avoid partial updates.
  - Successful marker posting is preserved even if cleanup cannot be completed.
- **Documentation**
  - Clarifies supported marker families, runtime behavior, and best-effort cleanup handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
