### PR TITLE
docs(idd-discover, idd-suitability): align A4.5 selection with A4

### DIFF
--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -30,9 +30,10 @@ drafts and suppresses claims, so skip labeled issues. Unlabeled issues follow
 anchor/set/session `release-complete` gates release/guard; an absent label is
 not proof; release clears it.
 
-For `instructions-only`, use the
-[portable owner resolver](../../docs/idd-autonomy-contract.md#portable-authoring-owner-protocol);
-never infer membership from the label.
+The
+[portable owner resolver](../../docs/idd-autonomy-contract.md#portable-authoring-owner-protocol)
+defines these owner-protocol terms for every helper profile. For
+`instructions-only`, never infer membership from the label.
 
 A0-T, A0-O, and A3 must treat a matching label as not startable. A0-T
 reports `Issue #N is currently being authored` and stops before claim;
@@ -133,11 +134,8 @@ ran and must not be re-entered (no A1 ↔ A0-O or A4 ↔ A0-O loop).
 Search all open issues in the repository. Collect every issue that does
 NOT contain an `idd-skill-roadmap-id` marker (not itself
 a roadmap) or an `idd-skill-blocked-by` marker, AND
-otherwise passes A3's own readiness bullets (no configured
-blocked-by-human/needs-decision label, no configured authoring label,
-no open blocking dependent issue via either visible `Blocked by #NNN`
-or hidden marker form, same fail-safe treatment on an unresolvable
-reference).
+otherwise passes A3's own readiness bullets (the same five criteria A3
+lists; do not re-derive them here).
 
 Apply the configured policy before passing A0-O candidates to A3.5:
 

--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -165,7 +165,9 @@ Can success be verified independently by the agent?
 When an issue fails any suitability check, classify it into one of six
 stable outcomes (table below), and report the failure before continuing.
 A4 discovery paths: drop the candidate from the survivor set and retry
-A4 Step 2 with the next-lowest-numbered candidate. A0-T explicit-target
+A4 Step 2 with the next candidate A4 Step 2 ranks first (highest
+suitability score first, per `idd-discover.instructions.md`). A0-T
+explicit-target
 runs: the candidate set is only the verified target — stop without
 fallback. Stop when the survivor set is empty, or immediately on an
 `invalid` outcome (trust/safety concerns require human review):
@@ -256,10 +258,10 @@ risk, not a blocker on the gate above.
 ## Decision Flow
 
 ```text
-Candidates = A4 survivor set (sorted by ascending issue number)
+Candidates = A4 survivor set in A4 Step 2's ranked order
   (for A0-T: the single verified explicit target; failure = STOP, no fallback)
   (for A0-T: every "remove from Candidates, loop" branch below means: report and STOP)
-Loop: Pick lowest-numbered candidate from Candidates
+Loop: Pick the first remaining candidate in that order
   → Run Check 1 (Repository Fit)
     → PASS → Run Check 2
     → FAIL → Classify as out-of-scope → Report, remove from Candidates, loop

--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -164,10 +164,10 @@ Can success be verified independently by the agent?
 
 When an issue fails any suitability check, classify it into one of six
 stable outcomes (table below), and report the failure before continuing.
-A4 discovery paths: drop the candidate from the survivor set and retry
-A4 Step 2 with the next candidate A4 Step 2 ranks first (highest
-suitability score first, per `idd-discover.instructions.md`). A0-T
-explicit-target
+A4 discovery paths: drop the candidate from the survivor set and rerun
+A4 Step 2 over the remaining survivors to pick the next candidate (see
+`idd-discover.instructions.md`'s A4 Step 2 for the ranking, including
+its `autopilotSuitability.enabled: false` fallback). A0-T explicit-target
 runs: the candidate set is only the verified target — stop without
 fallback. Stop when the survivor set is empty, or immediately on an
 `invalid` outcome (trust/safety concerns require human review):
@@ -258,10 +258,10 @@ risk, not a blocker on the gate above.
 ## Decision Flow
 
 ```text
-Candidates = A4 survivor set in A4 Step 2's ranked order
+Candidates = A4 survivor set
   (for A0-T: the single verified explicit target; failure = STOP, no fallback)
   (for A0-T: every "remove from Candidates, loop" branch below means: report and STOP)
-Loop: Pick the first remaining candidate in that order
+Loop: Rerun A4 Step 2 over Candidates to pick the next candidate
   → Run Check 1 (Repository Fit)
     → PASS → Run Check 2
     → FAIL → Classify as out-of-scope → Report, remove from Candidates, loop

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -25,9 +25,10 @@ drafts and suppresses claims, so skip labeled issues. Unlabeled issues follow
 anchor/set/session `release-complete` gates release/guard; an absent label is
 not proof; release clears it.
 
-For `instructions-only`, use the
-[portable owner resolver](../../docs/idd-autonomy-contract.md#portable-authoring-owner-protocol);
-never infer membership from the label.
+The
+[portable owner resolver](../../docs/idd-autonomy-contract.md#portable-authoring-owner-protocol)
+defines these owner-protocol terms for every helper profile. For
+`instructions-only`, never infer membership from the label.
 
 A0-T, A0-O, and A3 must treat a matching label as not startable. A0-T
 reports `Issue #N is currently being authored` and stops before claim;
@@ -128,11 +129,8 @@ ran and must not be re-entered (no A1 ↔ A0-O or A4 ↔ A0-O loop).
 Search all open issues in the repository. Collect every issue that does
 NOT contain an `{{PROJECT_MARKER_PREFIX}}-roadmap-id` marker (not itself
 a roadmap) or an `{{PROJECT_MARKER_PREFIX}}-blocked-by` marker, AND
-otherwise passes A3's own readiness bullets (no configured
-blocked-by-human/needs-decision label, no configured authoring label,
-no open blocking dependent issue via either visible `Blocked by #NNN`
-or hidden marker form, same fail-safe treatment on an unresolvable
-reference).
+otherwise passes A3's own readiness bullets (the same five criteria A3
+lists; do not re-derive them here).
 
 Apply the configured policy before passing A0-O candidates to A3.5:
 

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -159,10 +159,10 @@ Can success be verified independently by the agent?
 
 When an issue fails any suitability check, classify it into one of six
 stable outcomes (table below), and report the failure before continuing.
-A4 discovery paths: drop the candidate from the survivor set and retry
-A4 Step 2 with the next candidate A4 Step 2 ranks first (highest
-suitability score first, per `idd-discover.instructions.md`). A0-T
-explicit-target
+A4 discovery paths: drop the candidate from the survivor set and rerun
+A4 Step 2 over the remaining survivors to pick the next candidate (see
+`idd-discover.instructions.md`'s A4 Step 2 for the ranking, including
+its `autopilotSuitability.enabled: false` fallback). A0-T explicit-target
 runs: the candidate set is only the verified target — stop without
 fallback. Stop when the survivor set is empty, or immediately on an
 `invalid` outcome (trust/safety concerns require human review):
@@ -253,10 +253,10 @@ risk, not a blocker on the gate above.
 ## Decision Flow
 
 ```text
-Candidates = A4 survivor set in A4 Step 2's ranked order
+Candidates = A4 survivor set
   (for A0-T: the single verified explicit target; failure = STOP, no fallback)
   (for A0-T: every "remove from Candidates, loop" branch below means: report and STOP)
-Loop: Pick the first remaining candidate in that order
+Loop: Rerun A4 Step 2 over Candidates to pick the next candidate
   → Run Check 1 (Repository Fit)
     → PASS → Run Check 2
     → FAIL → Classify as out-of-scope → Report, remove from Candidates, loop

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -160,7 +160,9 @@ Can success be verified independently by the agent?
 When an issue fails any suitability check, classify it into one of six
 stable outcomes (table below), and report the failure before continuing.
 A4 discovery paths: drop the candidate from the survivor set and retry
-A4 Step 2 with the next-lowest-numbered candidate. A0-T explicit-target
+A4 Step 2 with the next candidate A4 Step 2 ranks first (highest
+suitability score first, per `idd-discover.instructions.md`). A0-T
+explicit-target
 runs: the candidate set is only the verified target — stop without
 fallback. Stop when the survivor set is empty, or immediately on an
 `invalid` outcome (trust/safety concerns require human review):
@@ -251,10 +253,10 @@ risk, not a blocker on the gate above.
 ## Decision Flow
 
 ```text
-Candidates = A4 survivor set (sorted by ascending issue number)
+Candidates = A4 survivor set in A4 Step 2's ranked order
   (for A0-T: the single verified explicit target; failure = STOP, no fallback)
   (for A0-T: every "remove from Candidates, loop" branch below means: report and STOP)
-Loop: Pick lowest-numbered candidate from Candidates
+Loop: Pick the first remaining candidate in that order
   → Run Check 1 (Repository Fit)
     → PASS → Run Check 2
     → FAIL → Classify as out-of-scope → Report, remove from Candidates, loop


### PR DESCRIPTION
## Summary

- `idd-suitability.instructions.md`'s Failure Outcomes and Decision Flow described plain ascending-issue-number candidate selection in three places, silently contradicting A4 Step 2's actual ranking (highest authored autopilot-suitability score first, issue number only as a last-resort tie-break). Replaced all three with pointers to A4 Step 2's real ranked order.
- `idd-discover.instructions.md`'s A0-O section re-enumerated A3's five readiness bullets in a parenthetical but only listed four, silently dropping the "no external human coordination or prose-only runtime/production-observation precondition" bullet (#2467). Replaced the re-enumeration with a pointer to A3's own list.
- The Authoring label guard's portable-owner-resolver link was incorrectly scoped to `instructions-only` even though the owner-protocol terms it defines are used by every helper profile in the file. Split into a general definitional sentence and a separate `instructions-only`-specific instruction.

`bundle-discovery` sits at ~97.8% of its `limitBytes` with the #2697 near-ceiling ratchet guard blocking any raise, so this issue explicitly required a byte-neutral edit; the net change is actually byte-negative (utilization went from 97.87% to 97.83%). `audit/sync-manifest.json` is untouched.

## Test plan

- [x] `grep -n -i -E "lowest-numbered|ascending issue number" .github/instructions/idd-suitability.instructions.md` — empty
- [x] `grep -n "no configured blocked-by-human/needs-decision label" .github/instructions/idd-discover.instructions.md` — empty
- [x] Authoring label guard's `portable-authoring-owner-protocol` line no longer starts with "For `instructions-only`"
- [x] `node scripts/audit-docs.mjs --check` passes (bundle-discovery limit not raised)
- [x] `npx markdownlint-cli2 "**/*.md"` clean
- [x] `npx dprint check` clean
- [x] `node scripts/audit-code-span-wrap.mjs` clean
- [x] `pnpm test` — 5509/5509 passing
- [x] Independent report-only critique pass found no defects

Closes #2777

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDJpTELrY2SnjHW9m5Aw7i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified owner-protocol terminology across helper profiles and prohibited inferring membership from labels for `instructions-only`.
  - Updated readiness guidance to use the complete set of established readiness criteria.
  - Corrected candidate fallback and decision-flow ordering to follow ranked suitability rather than issue numbers.
  - Applied these guidance updates consistently across the main instructions and the template instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->