### PR TITLE
feat(idd): hide superseded local-validation-evidence markers at post time

### DIFF
--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -147,8 +147,10 @@ active E or F gate. Four families ship this today: the claim chain
 `advisory-reroll:`, grouped by embedded HEAD SHA mismatch, AW3-H,
 `idd-advisory-wait.instructions.md`), and
 `<!-- idd-local-validation-evidence:` (grouped by embedded HEAD SHA
-mismatch, mirroring AW3-H, `local-validation-evidence.mts`'s own
-`--record --apply` path). A family classified `f4-only` has
+mismatch, mirroring AW3-H, wired into `idd-local-validation-evidence`'s
+own `--record --apply` path -- see
+[this helper's doc](idd-helper-scripts.md#local-validation-evidence-helper)).
+A family classified `f4-only` has
 no such wiring yet and follows the default F4-only timing above until a
 future track adds it -- concretely, the post-merge F4 batch means
 `audit-pr-cleanup.mts`'s generic marker-prefix match

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -134,18 +134,21 @@ after one of these is true:
 - a maintainer explicitly starts a merged-PR audit
 
 **Exception -- hide-at-post-time for `wired` families** (issue #731,
-issue #733, issue #2751). A `wired` family may be minimized immediately
-after its own new instance's POST+verify succeeds, pre-merge, using
-that family's documented supersession/grouping key -- never for any
-other reason during an active E or F gate. Three families ship this
-today: the claim chain
+issue #733, issue #2751, issue #2755). A `wired` family may be
+minimized immediately after its own new instance's POST+verify
+succeeds, pre-merge, using that family's documented
+supersession/grouping key -- never for any other reason during an
+active E or F gate. Four families ship this today: the claim chain
 (`claimed-by:`/`unclaimed-by:`, grouped by
 `supersedes:` lineage, `idd-claim.instructions.md`), `review-watermark:`/
 `review-baseline:` (grouped by same claim-id,
-`idd-review-snapshot.instructions.md`), and the `advisory-wait` family
+`idd-review-snapshot.instructions.md`), the `advisory-wait` family
 (`advisory-wait:`/`advisory-wait-recovery:`/`<!-- advisory-wait:`/
 `advisory-reroll:`, grouped by embedded HEAD SHA mismatch, AW3-H,
-`idd-advisory-wait.instructions.md`). A family classified `f4-only` has
+`idd-advisory-wait.instructions.md`), and
+`<!-- idd-local-validation-evidence:` (grouped by embedded HEAD SHA
+mismatch, mirroring AW3-H, `local-validation-evidence.mts`'s own
+`--record --apply` path). A family classified `f4-only` has
 no such wiring yet and follows the default F4-only timing above until a
 future track adds it -- concretely, the post-merge F4 batch means
 `audit-pr-cleanup.mts`'s generic marker-prefix match

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1474,6 +1474,17 @@ Interpretation rules:
     (default `PT4H`), never an embedded timestamp.
   - `--record --covers <names> --outcome <pass|fail>`: renders and (with
     `--apply`) posts the evidence marker to the pull request.
+- **Hide-at-post-time (#2755).** After a successful `--record --apply`
+  POST, this helper also hides (classifier `OUTDATED`) prior
+  `idd-local-validation-evidence:` comments whose embedded HEAD SHA
+  differs from the one just recorded, grouped by embedded HEAD SHA
+  mismatch mirroring the `advisory-wait` AW3-H rule -- see
+  [Comment minimization](idd-comment-minimization.md#timing). Best-effort:
+  any failure there never blocks or retries the marker post that already
+  succeeded. `--trusted-marker-logins a,b` gates that step's trusted-author
+  check (falls back to `IDD_TRUSTED_MARKER_ACTORS` /
+  `.github/idd/config.json`'s `trustedMarkerActors`, the same ladder as
+  every other `minimize-superseded-markers.mjs` caller).
 - **Never a merge gate.** `pre-merge-readiness.mts` reports this
   helper's resolution as its own additive `localValidationEvidence`
   field; `computePreMergeReadinessBlockers` (protocol-helpers.mts) has

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -147,8 +147,10 @@ active E or F gate. Four families ship this today: the claim chain
 `advisory-reroll:`, grouped by embedded HEAD SHA mismatch, AW3-H,
 `idd-advisory-wait.instructions.md`), and
 `<!-- idd-local-validation-evidence:` (grouped by embedded HEAD SHA
-mismatch, mirroring AW3-H, `local-validation-evidence.mts`'s own
-`--record --apply` path). A family classified `f4-only` has
+mismatch, mirroring AW3-H, wired into `idd-local-validation-evidence`'s
+own `--record --apply` path -- see
+[this helper's doc](idd-helper-scripts.md#local-validation-evidence-helper)).
+A family classified `f4-only` has
 no such wiring yet and follows the default F4-only timing above until a
 future track adds it -- concretely, the post-merge F4 batch means
 `audit-pr-cleanup.mts`'s generic marker-prefix match

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -134,18 +134,21 @@ after one of these is true:
 - a maintainer explicitly starts a merged-PR audit
 
 **Exception -- hide-at-post-time for `wired` families** (issue #731,
-issue #733, issue #2751). A `wired` family may be minimized immediately
-after its own new instance's POST+verify succeeds, pre-merge, using
-that family's documented supersession/grouping key -- never for any
-other reason during an active E or F gate. Three families ship this
-today: the claim chain
+issue #733, issue #2751, issue #2755). A `wired` family may be
+minimized immediately after its own new instance's POST+verify
+succeeds, pre-merge, using that family's documented
+supersession/grouping key -- never for any other reason during an
+active E or F gate. Four families ship this today: the claim chain
 (`claimed-by:`/`unclaimed-by:`, grouped by
 `supersedes:` lineage, `idd-claim.instructions.md`), `review-watermark:`/
 `review-baseline:` (grouped by same claim-id,
-`idd-review-snapshot.instructions.md`), and the `advisory-wait` family
+`idd-review-snapshot.instructions.md`), the `advisory-wait` family
 (`advisory-wait:`/`advisory-wait-recovery:`/`<!-- advisory-wait:`/
 `advisory-reroll:`, grouped by embedded HEAD SHA mismatch, AW3-H,
-`idd-advisory-wait.instructions.md`). A family classified `f4-only` has
+`idd-advisory-wait.instructions.md`), and
+`<!-- idd-local-validation-evidence:` (grouped by embedded HEAD SHA
+mismatch, mirroring AW3-H, `local-validation-evidence.mts`'s own
+`--record --apply` path). A family classified `f4-only` has
 no such wiring yet and follows the default F4-only timing above until a
 future track adds it -- concretely, the post-merge F4 batch means
 `audit-pr-cleanup.mts`'s generic marker-prefix match

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1474,6 +1474,17 @@ Interpretation rules:
     (default `PT4H`), never an embedded timestamp.
   - `--record --covers <names> --outcome <pass|fail>`: renders and (with
     `--apply`) posts the evidence marker to the pull request.
+- **Hide-at-post-time (#2755).** After a successful `--record --apply`
+  POST, this helper also hides (classifier `OUTDATED`) prior
+  `idd-local-validation-evidence:` comments whose embedded HEAD SHA
+  differs from the one just recorded, grouped by embedded HEAD SHA
+  mismatch mirroring the `advisory-wait` AW3-H rule -- see
+  [Comment minimization](idd-comment-minimization.md#timing). Best-effort:
+  any failure there never blocks or retries the marker post that already
+  succeeded. `--trusted-marker-logins a,b` gates that step's trusted-author
+  check (falls back to `IDD_TRUSTED_MARKER_ACTORS` /
+  `.github/idd/config.json`'s `trustedMarkerActors`, the same ladder as
+  every other `minimize-superseded-markers.mjs` caller).
 - **Never a merge gate.** `pre-merge-readiness.mts` reports this
   helper's resolution as its own additive `localValidationEvidence`
   field; `computePreMergeReadinessBlockers` (protocol-helpers.mts) has

--- a/scripts/local-validation-evidence.mjs
+++ b/scripts/local-validation-evidence.mjs
@@ -378,6 +378,25 @@ function postComment({ owner, repo, prNumber, body }) {
   }
 }
 /**
+ * Read the PR's LIVE current HEAD SHA (#2755, Codex review on PR #2792) --
+ * used by {@link hideSupersededLocalValidationEvidenceMarkers} to refuse to
+ * hide anything when the just-recorded `newHeadSha` no longer matches the
+ * PR's actual current HEAD, mirroring `post-idd-marker.mts`'s identical
+ * `review-ack` live-HEAD check (#2754).
+ */
+function fetchPrHeadSha({ owner, repo, prNumber }) {
+  return String(
+    ghText([
+      'api',
+      `repos/${owner}/${repo}/pulls/${prNumber}`,
+      '--jq',
+      '.head.sha',
+    ]),
+  )
+    .trim()
+    .toLowerCase();
+}
+/**
  * Find prior `idd-local-validation-evidence:` comments (among `comments`)
  * whose embedded HEAD SHA differs from `newHeadSha` -- the candidates a
  * fresh `--record --apply` post should hide as `OUTDATED` (#2755),
@@ -412,32 +431,68 @@ export function findSupersededLocalValidationEvidenceSubjects(
 /**
  * Best-effort hide-at-post-time step (#2755) for a freshly recorded
  * `idd-local-validation-evidence:` marker. Runs only after `poster(...)`'s
- * own POST already succeeded, reuses `priorComments` (the same PR comment
- * listing already fetched earlier in {@link runLocalValidationEvidence},
- * necessarily gathered *before* this post -- unlike `post-idd-marker.mts`'s
- * equivalent step, which re-lists comments *after* its own POST and must
- * therefore exclude a same-window concurrent marker by `id`, a pre-post
- * snapshot can by construction never contain this post or anything newer,
- * so no id-ordering filter is needed here), and reuses
- * `minimize-superseded-markers.mts`'s `runMinimize` for the actual
- * mutation -- the same trusted-author gate, already-`isMinimized` skip, and
- * `viewerCanMinimize` check that helper already implements. Every failure
- * (an unreadable comment list, a `gh` permission error, a malformed
- * GraphQL response, anything else) is swallowed here: this step must never
- * retry-loop or throw back into the caller, since the marker it is hiding
- * *for* has already posted successfully by the time this runs.
+ * own POST already succeeded, and reuses `minimize-superseded-markers.mts`'s
+ * `runMinimize` for the actual mutation -- the same trusted-author gate,
+ * already-`isMinimized` skip, and `viewerCanMinimize` check that helper
+ * already implements. Every failure (an unreadable comment list, a `gh`
+ * permission error, a malformed GraphQL response, anything else) is
+ * swallowed here: this step must never retry-loop or throw back into the
+ * caller, since the marker it is hiding *for* has already posted
+ * successfully by the time this runs.
+ *
+ * Two safety checks, both added after Codex review on PR #2792 caught the
+ * first version's reliance on a pre-POST comment snapshot as insufficient:
+ *
+ * - **Live-HEAD verification.** Re-reads the PR's actual current HEAD SHA
+ *   and bails out (no scan, no mutation) unless it still matches
+ *   `newHeadSha` -- mirroring `post-idd-marker.mts`'s identical
+ *   `review-ack` check (#2754). Without this, a `--record --apply`
+ *   invocation for an older HEAD that finishes late (after another,
+ *   already-more-current invocation has posted evidence for a newer HEAD)
+ *   would see that newer marker as merely "a different HEAD" and hide the
+ *   more-current evidence while leaving its own, now-stale one visible --
+ *   exactly backwards.
+ * - **Post-POST re-fetch with an `id <` filter.** Re-lists the PR's
+ *   comments AFTER this call's own POST (never reusing an earlier, pre-POST
+ *   snapshot) and restricts candidates to `comment.id < postedCommentId`.
+ *   A pre-POST snapshot can only ever miss a genuinely concurrent
+ *   `--record --apply` invocation's own marker (posted in the gap between
+ *   this call's own comment fetch and its POST), leaving that marker
+ *   un-hidden forever since no later invocation would necessarily rescan
+ *   it. The `id <` restriction, not a bare exclude-this-one-id check,
+ *   guards the re-fetch itself: a concurrent session's marker created
+ *   during THIS scan can already appear with a HIGHER id than
+ *   `postedCommentId`, and treating that genuinely newer marker as "prior"
+ *   would hide it -- exactly backwards, since it is this call's own marker
+ *   that is older by comparison.
  */
 export function hideSupersededLocalValidationEvidenceMarkers({
-  priorComments,
+  owner,
+  repo,
+  prNumber,
   newHeadSha,
+  postedCommentId,
   trustedMarkerLoginsFlag,
   rawConfig,
+  fetchLiveHeadSha = fetchPrHeadSha,
+  fetchPriorComments = fetchPrComments,
   resolveTrustedActorsFn = resolveTrustedActors,
   runMinimizeFn = runMinimize,
 }) {
   try {
+    const target = newHeadSha.trim().toLowerCase();
+    const liveHeadSha = fetchLiveHeadSha({ owner, repo, prNumber });
+    if (liveHeadSha !== target) {
+      return;
+    }
+    const comments = fetchPriorComments({ owner, repo, prNumber }).filter(
+      (comment) => {
+        const id = Number(comment.id);
+        return Number.isFinite(id) && id < postedCommentId;
+      },
+    );
     const subjectIds = findSupersededLocalValidationEvidenceSubjects(
-      priorComments,
+      comments,
       newHeadSha,
     );
     if (subjectIds.length === 0) {
@@ -448,6 +503,13 @@ export function hideSupersededLocalValidationEvidenceMarkers({
       envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
       config: rawConfig,
     });
+    // #2755, Copilot review on PR #2792: an empty trusted set can never
+    // minimize anything under allowUntrusted:false -- runMinimize would
+    // still probe every subject over GraphQL for nothing. Skip the call
+    // entirely rather than pay that cost for a guaranteed no-op.
+    if (actors.length === 0) {
+      return;
+    }
     runMinimizeFn({
       subjectIds,
       classifier: 'OUTDATED',
@@ -457,9 +519,7 @@ export function hideSupersededLocalValidationEvidenceMarkers({
     });
   } catch {
     // Best-effort only (#2755) -- never block or retry-loop the marker
-    // post that already succeeded above. Covers both a thrown failure from
-    // runMinimizeFn itself (e.g. a gh permission error) and one from
-    // resolveTrustedActorsFn.
+    // post that already succeeded above.
   }
 }
 export async function runLocalValidationEvidence(options = {}) {
@@ -559,12 +619,18 @@ export async function runLocalValidationEvidence(options = {}) {
   }
   const poster = options.postComment ?? postComment;
   const posted = poster({ owner, repo: name, prNumber: args.prNumber, body });
-  hideSupersededLocalValidationEvidenceMarkers({
-    priorComments: comments,
-    newHeadSha: args.headSha,
-    trustedMarkerLoginsFlag: args.trustedMarkerLogins,
-    rawConfig,
-  });
+  const postedCommentId = Number(posted.id);
+  if (Number.isFinite(postedCommentId)) {
+    hideSupersededLocalValidationEvidenceMarkers({
+      owner,
+      repo: name,
+      prNumber: args.prNumber,
+      newHeadSha: args.headSha,
+      postedCommentId,
+      trustedMarkerLoginsFlag: args.trustedMarkerLogins,
+      rawConfig,
+    });
+  }
   const result = {
     mode: args.mode,
     apply: true,

--- a/scripts/local-validation-evidence.mjs
+++ b/scripts/local-validation-evidence.mjs
@@ -33,6 +33,10 @@ import {
   safeGhText,
 } from './gh-exec.mjs';
 import {
+  resolveTrustedActors,
+  runMinimize,
+} from './minimize-superseded-markers.mjs';
+import {
   normalizePolicyConfig,
   parseIsoDurationToMs,
 } from './policy-helpers.mjs';
@@ -248,6 +252,7 @@ const LOCAL_VALIDATION_EVIDENCE_FLAG_SPEC = {
   '--owner': { type: 'string', default: '' },
   '--apply': { type: 'boolean', default: false },
   '--format': { type: 'string', default: 'json' },
+  '--trusted-marker-logins': { type: 'string', default: '' },
   '--help': { type: 'boolean', short: 'h' },
 };
 function parsePositiveIntegerFlag(value, flag) {
@@ -298,6 +303,7 @@ export function parseArgs(argv) {
     owner: values.owner.trim(),
     apply: values.apply,
     format,
+    trustedMarkerLogins: values['trusted-marker-logins'].trim(),
     help,
   };
   if (!parsed.help) {
@@ -369,6 +375,91 @@ function postComment({ owner, repo, prNumber, body }) {
     return JSON.parse(payload || '{}');
   } catch {
     return {};
+  }
+}
+/**
+ * Find prior `idd-local-validation-evidence:` comments (among `comments`)
+ * whose embedded HEAD SHA differs from `newHeadSha` -- the candidates a
+ * fresh `--record --apply` post should hide as `OUTDATED` (#2755),
+ * mirroring the shipped `advisory-wait` AW3-H rule and `post-idd-marker.mts`'s
+ * `review-ack` hide-at-post-time step (#2754). Never returns a candidate
+ * matching `newHeadSha` (current-HEAD protection, since
+ * `resolveLocalValidationEvidence` resolves current evidence by HEAD match)
+ * or an unparseable / non-`idd-local-validation-evidence:` comment.
+ */
+export function findSupersededLocalValidationEvidenceSubjects(
+  comments,
+  newHeadSha,
+) {
+  const target = newHeadSha.trim().toLowerCase();
+  const subjects = [];
+  for (const comment of comments) {
+    const nodeId = String(comment.node_id ?? '').trim();
+    if (!nodeId) {
+      continue;
+    }
+    const parsed = parseLocalValidationEvidenceComment(
+      String(comment.body ?? ''),
+      String(comment.created_at ?? ''),
+    );
+    if (!parsed || parsed.headSha === target) {
+      continue;
+    }
+    subjects.push(nodeId);
+  }
+  return subjects;
+}
+/**
+ * Best-effort hide-at-post-time step (#2755) for a freshly recorded
+ * `idd-local-validation-evidence:` marker. Runs only after `poster(...)`'s
+ * own POST already succeeded, reuses `priorComments` (the same PR comment
+ * listing already fetched earlier in {@link runLocalValidationEvidence},
+ * necessarily gathered *before* this post -- unlike `post-idd-marker.mts`'s
+ * equivalent step, which re-lists comments *after* its own POST and must
+ * therefore exclude a same-window concurrent marker by `id`, a pre-post
+ * snapshot can by construction never contain this post or anything newer,
+ * so no id-ordering filter is needed here), and reuses
+ * `minimize-superseded-markers.mts`'s `runMinimize` for the actual
+ * mutation -- the same trusted-author gate, already-`isMinimized` skip, and
+ * `viewerCanMinimize` check that helper already implements. Every failure
+ * (an unreadable comment list, a `gh` permission error, a malformed
+ * GraphQL response, anything else) is swallowed here: this step must never
+ * retry-loop or throw back into the caller, since the marker it is hiding
+ * *for* has already posted successfully by the time this runs.
+ */
+export function hideSupersededLocalValidationEvidenceMarkers({
+  priorComments,
+  newHeadSha,
+  trustedMarkerLoginsFlag,
+  rawConfig,
+  resolveTrustedActorsFn = resolveTrustedActors,
+  runMinimizeFn = runMinimize,
+}) {
+  try {
+    const subjectIds = findSupersededLocalValidationEvidenceSubjects(
+      priorComments,
+      newHeadSha,
+    );
+    if (subjectIds.length === 0) {
+      return;
+    }
+    const { actors } = resolveTrustedActorsFn({
+      flagValue: trustedMarkerLoginsFlag,
+      envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
+      config: rawConfig,
+    });
+    runMinimizeFn({
+      subjectIds,
+      classifier: 'OUTDATED',
+      trustedSet: new Set(actors),
+      apply: true,
+      allowUntrusted: false,
+    });
+  } catch {
+    // Best-effort only (#2755) -- never block or retry-loop the marker
+    // post that already succeeded above. Covers both a thrown failure from
+    // runMinimizeFn itself (e.g. a gh permission error) and one from
+    // resolveTrustedActorsFn.
   }
 }
 export async function runLocalValidationEvidence(options = {}) {
@@ -468,6 +559,12 @@ export async function runLocalValidationEvidence(options = {}) {
   }
   const poster = options.postComment ?? postComment;
   const posted = poster({ owner, repo: name, prNumber: args.prNumber, body });
+  hideSupersededLocalValidationEvidenceMarkers({
+    priorComments: comments,
+    newHeadSha: args.headSha,
+    trustedMarkerLoginsFlag: args.trustedMarkerLogins,
+    rawConfig,
+  });
   const result = {
     mode: args.mode,
     apply: true,
@@ -520,6 +617,9 @@ Options:
                                      repository name -- not both --owner
                                      and a combined --repo together)
   --apply                           post the canonical marker comment after validation (--record)
+  --trusted-marker-logins a,b        gate --record --apply's hide-at-post-time
+                                      step (falls back to
+                                      IDD_TRUSTED_MARKER_ACTORS / config)
   --format <json|text>              output format (default: json)
   --help                            show this message
 `);

--- a/scripts/local-validation-evidence.mjs
+++ b/scripts/local-validation-evidence.mjs
@@ -440,18 +440,23 @@ export function findSupersededLocalValidationEvidenceSubjects(
  * caller, since the marker it is hiding *for* has already posted
  * successfully by the time this runs.
  *
- * Two safety checks, both added after Codex review on PR #2792 caught the
- * first version's reliance on a pre-POST comment snapshot as insufficient:
+ * Three safety checks, all added after Codex/Copilot review on PR #2792
+ * caught the first version's reliance on a pre-POST comment snapshot as
+ * insufficient:
  *
  * - **Live-HEAD verification.** Re-reads the PR's actual current HEAD SHA
- *   and bails out (no scan, no mutation) unless it still matches
- *   `newHeadSha` -- mirroring `post-idd-marker.mts`'s identical
- *   `review-ack` check (#2754). Without this, a `--record --apply`
- *   invocation for an older HEAD that finishes late (after another,
- *   already-more-current invocation has posted evidence for a newer HEAD)
- *   would see that newer marker as merely "a different HEAD" and hide the
- *   more-current evidence while leaving its own, now-stale one visible --
- *   exactly backwards.
+ *   and, when it no longer matches `newHeadSha`, self-minimizes the
+ *   just-posted marker (`postedCommentNodeId`) instead of scanning prior
+ *   comments -- mirroring `post-idd-marker.mts`'s identical `review-ack`
+ *   check (#2754), extended per a second Codex finding on this same PR:
+ *   a delayed `--record --apply` invocation for an older HEAD can finish
+ *   *after* another, already-more-current invocation has already posted
+ *   and hidden nothing (since this invocation's marker did not exist
+ *   yet), leaving this invocation's own now-stale marker un-hidden with
+ *   no later invocation guaranteed to sweep it. Self-minimizing here
+ *   closes that gap instead of relying on F4 cleanup for it. The
+ *   still-current branch below (`liveHeadSha === target`) is unaffected:
+ *   it never touches the just-posted marker, only genuinely prior ones.
  * - **Post-POST re-fetch with an `id <` filter.** Re-lists the PR's
  *   comments AFTER this call's own POST (never reusing an earlier, pre-POST
  *   snapshot) and restricts candidates to `comment.id < postedCommentId`.
@@ -465,6 +470,10 @@ export function findSupersededLocalValidationEvidenceSubjects(
  *   `postedCommentId`, and treating that genuinely newer marker as "prior"
  *   would hide it -- exactly backwards, since it is this call's own marker
  *   that is older by comparison.
+ * - **Skip an empty trusted set.** An empty trusted set can never minimize
+ *   anything under `allowUntrusted:false`, but `runMinimize` would still
+ *   probe every subject over GraphQL for a guaranteed no-op -- resolved
+ *   once, after computing subjects for either branch above.
  */
 export function hideSupersededLocalValidationEvidenceMarkers({
   owner,
@@ -472,6 +481,7 @@ export function hideSupersededLocalValidationEvidenceMarkers({
   prNumber,
   newHeadSha,
   postedCommentId,
+  postedCommentNodeId,
   trustedMarkerLoginsFlag,
   rawConfig,
   fetchLiveHeadSha = fetchPrHeadSha,
@@ -482,19 +492,22 @@ export function hideSupersededLocalValidationEvidenceMarkers({
   try {
     const target = newHeadSha.trim().toLowerCase();
     const liveHeadSha = fetchLiveHeadSha({ owner, repo, prNumber });
+    let subjectIds;
     if (liveHeadSha !== target) {
-      return;
+      const nodeId = postedCommentNodeId.trim();
+      subjectIds = nodeId ? [nodeId] : [];
+    } else {
+      const comments = fetchPriorComments({ owner, repo, prNumber }).filter(
+        (comment) => {
+          const id = Number(comment.id);
+          return Number.isFinite(id) && id < postedCommentId;
+        },
+      );
+      subjectIds = findSupersededLocalValidationEvidenceSubjects(
+        comments,
+        newHeadSha,
+      );
     }
-    const comments = fetchPriorComments({ owner, repo, prNumber }).filter(
-      (comment) => {
-        const id = Number(comment.id);
-        return Number.isFinite(id) && id < postedCommentId;
-      },
-    );
-    const subjectIds = findSupersededLocalValidationEvidenceSubjects(
-      comments,
-      newHeadSha,
-    );
     if (subjectIds.length === 0) {
       return;
     }
@@ -627,6 +640,7 @@ export async function runLocalValidationEvidence(options = {}) {
       prNumber: args.prNumber,
       newHeadSha: args.headSha,
       postedCommentId,
+      postedCommentNodeId: String(posted.node_id ?? ''),
       trustedMarkerLoginsFlag: args.trustedMarkerLogins,
       rawConfig,
     });

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -315,9 +315,9 @@ const MARKER_HIDE_POLICY_ENTRIES = [
   },
   {
     label: '<!-- idd-local-validation-evidence:',
-    policy: 'f4-only',
+    policy: 'wired',
     reason:
-      'No hide-at-post-time wiring yet; only the post-merge F4 cleanup batch cleans it up today. Flipped to wired by roadmap #2751 Track 3 (#2755).',
+      'idd-local-validation-evidence family, grouped by embedded HEAD SHA mismatch (mirroring the shipped advisory-wait AW3-H rule). Hidden at post time by local-validation-evidence.mts itself (code-automated, right after its own --record --apply POST succeeds) -- roadmap #2751 Track 3 (#2755).',
   },
 ];
 /**

--- a/src/scripts/local-validation-evidence.mts
+++ b/src/scripts/local-validation-evidence.mts
@@ -485,7 +485,7 @@ function postComment({
   repo: string;
   prNumber: number;
   body: string;
-}): { html_url?: string; url?: string } {
+}): { id?: number; html_url?: string; url?: string } {
   const payload = ghText([
     'api',
     `repos/${owner}/${repo}/issues/${prNumber}/comments`,
@@ -499,6 +499,34 @@ function postComment({
   } catch {
     return {};
   }
+}
+
+/**
+ * Read the PR's LIVE current HEAD SHA (#2755, Codex review on PR #2792) --
+ * used by {@link hideSupersededLocalValidationEvidenceMarkers} to refuse to
+ * hide anything when the just-recorded `newHeadSha` no longer matches the
+ * PR's actual current HEAD, mirroring `post-idd-marker.mts`'s identical
+ * `review-ack` live-HEAD check (#2754).
+ */
+function fetchPrHeadSha({
+  owner,
+  repo,
+  prNumber,
+}: {
+  owner: string;
+  repo: string;
+  prNumber: number;
+}): string {
+  return String(
+    ghText([
+      'api',
+      `repos/${owner}/${repo}/pulls/${prNumber}`,
+      '--jq',
+      '.head.sha',
+    ]),
+  )
+    .trim()
+    .toLowerCase();
 }
 
 /**
@@ -537,39 +565,80 @@ export function findSupersededLocalValidationEvidenceSubjects(
 /**
  * Best-effort hide-at-post-time step (#2755) for a freshly recorded
  * `idd-local-validation-evidence:` marker. Runs only after `poster(...)`'s
- * own POST already succeeded, reuses `priorComments` (the same PR comment
- * listing already fetched earlier in {@link runLocalValidationEvidence},
- * necessarily gathered *before* this post -- unlike `post-idd-marker.mts`'s
- * equivalent step, which re-lists comments *after* its own POST and must
- * therefore exclude a same-window concurrent marker by `id`, a pre-post
- * snapshot can by construction never contain this post or anything newer,
- * so no id-ordering filter is needed here), and reuses
- * `minimize-superseded-markers.mts`'s `runMinimize` for the actual
- * mutation -- the same trusted-author gate, already-`isMinimized` skip, and
- * `viewerCanMinimize` check that helper already implements. Every failure
- * (an unreadable comment list, a `gh` permission error, a malformed
- * GraphQL response, anything else) is swallowed here: this step must never
- * retry-loop or throw back into the caller, since the marker it is hiding
- * *for* has already posted successfully by the time this runs.
+ * own POST already succeeded, and reuses `minimize-superseded-markers.mts`'s
+ * `runMinimize` for the actual mutation -- the same trusted-author gate,
+ * already-`isMinimized` skip, and `viewerCanMinimize` check that helper
+ * already implements. Every failure (an unreadable comment list, a `gh`
+ * permission error, a malformed GraphQL response, anything else) is
+ * swallowed here: this step must never retry-loop or throw back into the
+ * caller, since the marker it is hiding *for* has already posted
+ * successfully by the time this runs.
+ *
+ * Two safety checks, both added after Codex review on PR #2792 caught the
+ * first version's reliance on a pre-POST comment snapshot as insufficient:
+ *
+ * - **Live-HEAD verification.** Re-reads the PR's actual current HEAD SHA
+ *   and bails out (no scan, no mutation) unless it still matches
+ *   `newHeadSha` -- mirroring `post-idd-marker.mts`'s identical
+ *   `review-ack` check (#2754). Without this, a `--record --apply`
+ *   invocation for an older HEAD that finishes late (after another,
+ *   already-more-current invocation has posted evidence for a newer HEAD)
+ *   would see that newer marker as merely "a different HEAD" and hide the
+ *   more-current evidence while leaving its own, now-stale one visible --
+ *   exactly backwards.
+ * - **Post-POST re-fetch with an `id <` filter.** Re-lists the PR's
+ *   comments AFTER this call's own POST (never reusing an earlier, pre-POST
+ *   snapshot) and restricts candidates to `comment.id < postedCommentId`.
+ *   A pre-POST snapshot can only ever miss a genuinely concurrent
+ *   `--record --apply` invocation's own marker (posted in the gap between
+ *   this call's own comment fetch and its POST), leaving that marker
+ *   un-hidden forever since no later invocation would necessarily rescan
+ *   it. The `id <` restriction, not a bare exclude-this-one-id check,
+ *   guards the re-fetch itself: a concurrent session's marker created
+ *   during THIS scan can already appear with a HIGHER id than
+ *   `postedCommentId`, and treating that genuinely newer marker as "prior"
+ *   would hide it -- exactly backwards, since it is this call's own marker
+ *   that is older by comparison.
  */
 export function hideSupersededLocalValidationEvidenceMarkers({
-  priorComments,
+  owner,
+  repo,
+  prNumber,
   newHeadSha,
+  postedCommentId,
   trustedMarkerLoginsFlag,
   rawConfig,
+  fetchLiveHeadSha = fetchPrHeadSha,
+  fetchPriorComments = fetchPrComments,
   resolveTrustedActorsFn = resolveTrustedActors,
   runMinimizeFn = runMinimize,
 }: {
-  priorComments: CommentLike[];
+  owner: string;
+  repo: string;
+  prNumber: number;
   newHeadSha: string;
+  postedCommentId: number;
   trustedMarkerLoginsFlag: string;
   rawConfig: unknown;
+  fetchLiveHeadSha?: typeof fetchPrHeadSha;
+  fetchPriorComments?: typeof fetchPrComments;
   resolveTrustedActorsFn?: typeof resolveTrustedActors;
   runMinimizeFn?: typeof runMinimize;
 }): void {
   try {
+    const target = newHeadSha.trim().toLowerCase();
+    const liveHeadSha = fetchLiveHeadSha({ owner, repo, prNumber });
+    if (liveHeadSha !== target) {
+      return;
+    }
+    const comments = fetchPriorComments({ owner, repo, prNumber }).filter(
+      (comment) => {
+        const id = Number(comment.id);
+        return Number.isFinite(id) && id < postedCommentId;
+      },
+    );
     const subjectIds = findSupersededLocalValidationEvidenceSubjects(
-      priorComments,
+      comments,
       newHeadSha,
     );
     if (subjectIds.length === 0) {
@@ -580,6 +649,13 @@ export function hideSupersededLocalValidationEvidenceMarkers({
       envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
       config: rawConfig,
     });
+    // #2755, Copilot review on PR #2792: an empty trusted set can never
+    // minimize anything under allowUntrusted:false -- runMinimize would
+    // still probe every subject over GraphQL for nothing. Skip the call
+    // entirely rather than pay that cost for a guaranteed no-op.
+    if (actors.length === 0) {
+      return;
+    }
     runMinimizeFn({
       subjectIds,
       classifier: 'OUTDATED',
@@ -589,9 +665,7 @@ export function hideSupersededLocalValidationEvidenceMarkers({
     });
   } catch {
     // Best-effort only (#2755) -- never block or retry-loop the marker
-    // post that already succeeded above. Covers both a thrown failure from
-    // runMinimizeFn itself (e.g. a gh permission error) and one from
-    // resolveTrustedActorsFn.
+    // post that already succeeded above.
   }
 }
 
@@ -707,12 +781,18 @@ export async function runLocalValidationEvidence(
 
   const poster = options.postComment ?? postComment;
   const posted = poster({ owner, repo: name, prNumber: args.prNumber, body });
-  hideSupersededLocalValidationEvidenceMarkers({
-    priorComments: comments,
-    newHeadSha: args.headSha,
-    trustedMarkerLoginsFlag: args.trustedMarkerLogins,
-    rawConfig,
-  });
+  const postedCommentId = Number(posted.id);
+  if (Number.isFinite(postedCommentId)) {
+    hideSupersededLocalValidationEvidenceMarkers({
+      owner,
+      repo: name,
+      prNumber: args.prNumber,
+      newHeadSha: args.headSha,
+      postedCommentId,
+      trustedMarkerLoginsFlag: args.trustedMarkerLogins,
+      rawConfig,
+    });
+  }
   const result = {
     mode: args.mode,
     apply: true,

--- a/src/scripts/local-validation-evidence.mts
+++ b/src/scripts/local-validation-evidence.mts
@@ -485,7 +485,7 @@ function postComment({
   repo: string;
   prNumber: number;
   body: string;
-}): { id?: number; html_url?: string; url?: string } {
+}): { id?: number; node_id?: string; html_url?: string; url?: string } {
   const payload = ghText([
     'api',
     `repos/${owner}/${repo}/issues/${prNumber}/comments`,
@@ -574,18 +574,23 @@ export function findSupersededLocalValidationEvidenceSubjects(
  * caller, since the marker it is hiding *for* has already posted
  * successfully by the time this runs.
  *
- * Two safety checks, both added after Codex review on PR #2792 caught the
- * first version's reliance on a pre-POST comment snapshot as insufficient:
+ * Three safety checks, all added after Codex/Copilot review on PR #2792
+ * caught the first version's reliance on a pre-POST comment snapshot as
+ * insufficient:
  *
  * - **Live-HEAD verification.** Re-reads the PR's actual current HEAD SHA
- *   and bails out (no scan, no mutation) unless it still matches
- *   `newHeadSha` -- mirroring `post-idd-marker.mts`'s identical
- *   `review-ack` check (#2754). Without this, a `--record --apply`
- *   invocation for an older HEAD that finishes late (after another,
- *   already-more-current invocation has posted evidence for a newer HEAD)
- *   would see that newer marker as merely "a different HEAD" and hide the
- *   more-current evidence while leaving its own, now-stale one visible --
- *   exactly backwards.
+ *   and, when it no longer matches `newHeadSha`, self-minimizes the
+ *   just-posted marker (`postedCommentNodeId`) instead of scanning prior
+ *   comments -- mirroring `post-idd-marker.mts`'s identical `review-ack`
+ *   check (#2754), extended per a second Codex finding on this same PR:
+ *   a delayed `--record --apply` invocation for an older HEAD can finish
+ *   *after* another, already-more-current invocation has already posted
+ *   and hidden nothing (since this invocation's marker did not exist
+ *   yet), leaving this invocation's own now-stale marker un-hidden with
+ *   no later invocation guaranteed to sweep it. Self-minimizing here
+ *   closes that gap instead of relying on F4 cleanup for it. The
+ *   still-current branch below (`liveHeadSha === target`) is unaffected:
+ *   it never touches the just-posted marker, only genuinely prior ones.
  * - **Post-POST re-fetch with an `id <` filter.** Re-lists the PR's
  *   comments AFTER this call's own POST (never reusing an earlier, pre-POST
  *   snapshot) and restricts candidates to `comment.id < postedCommentId`.
@@ -599,6 +604,10 @@ export function findSupersededLocalValidationEvidenceSubjects(
  *   `postedCommentId`, and treating that genuinely newer marker as "prior"
  *   would hide it -- exactly backwards, since it is this call's own marker
  *   that is older by comparison.
+ * - **Skip an empty trusted set.** An empty trusted set can never minimize
+ *   anything under `allowUntrusted:false`, but `runMinimize` would still
+ *   probe every subject over GraphQL for a guaranteed no-op -- resolved
+ *   once, after computing subjects for either branch above.
  */
 export function hideSupersededLocalValidationEvidenceMarkers({
   owner,
@@ -606,6 +615,7 @@ export function hideSupersededLocalValidationEvidenceMarkers({
   prNumber,
   newHeadSha,
   postedCommentId,
+  postedCommentNodeId,
   trustedMarkerLoginsFlag,
   rawConfig,
   fetchLiveHeadSha = fetchPrHeadSha,
@@ -618,6 +628,7 @@ export function hideSupersededLocalValidationEvidenceMarkers({
   prNumber: number;
   newHeadSha: string;
   postedCommentId: number;
+  postedCommentNodeId: string;
   trustedMarkerLoginsFlag: string;
   rawConfig: unknown;
   fetchLiveHeadSha?: typeof fetchPrHeadSha;
@@ -628,19 +639,22 @@ export function hideSupersededLocalValidationEvidenceMarkers({
   try {
     const target = newHeadSha.trim().toLowerCase();
     const liveHeadSha = fetchLiveHeadSha({ owner, repo, prNumber });
+    let subjectIds: string[];
     if (liveHeadSha !== target) {
-      return;
+      const nodeId = postedCommentNodeId.trim();
+      subjectIds = nodeId ? [nodeId] : [];
+    } else {
+      const comments = fetchPriorComments({ owner, repo, prNumber }).filter(
+        (comment) => {
+          const id = Number(comment.id);
+          return Number.isFinite(id) && id < postedCommentId;
+        },
+      );
+      subjectIds = findSupersededLocalValidationEvidenceSubjects(
+        comments,
+        newHeadSha,
+      );
     }
-    const comments = fetchPriorComments({ owner, repo, prNumber }).filter(
-      (comment) => {
-        const id = Number(comment.id);
-        return Number.isFinite(id) && id < postedCommentId;
-      },
-    );
-    const subjectIds = findSupersededLocalValidationEvidenceSubjects(
-      comments,
-      newHeadSha,
-    );
     if (subjectIds.length === 0) {
       return;
     }
@@ -789,6 +803,7 @@ export async function runLocalValidationEvidence(
       prNumber: args.prNumber,
       newHeadSha: args.headSha,
       postedCommentId,
+      postedCommentNodeId: String(posted.node_id ?? ''),
       trustedMarkerLoginsFlag: args.trustedMarkerLogins,
       rawConfig,
     });

--- a/src/scripts/local-validation-evidence.mts
+++ b/src/scripts/local-validation-evidence.mts
@@ -35,6 +35,10 @@ import {
   safeGhText,
 } from './gh-exec.mts';
 import {
+  resolveTrustedActors,
+  runMinimize,
+} from './minimize-superseded-markers.mts';
+import {
   normalizePolicyConfig,
   parseIsoDurationToMs,
 } from './policy-helpers.mts';
@@ -52,6 +56,7 @@ type NormalizedPolicy = ReturnType<typeof normalizePolicyConfig>;
 /** One issue/PR comment, in the shape the GitHub REST list endpoint returns. */
 export interface CommentLike {
   id?: string | number | null;
+  node_id?: string | null;
   html_url?: string | null;
   url?: string | null;
   body?: string | null;
@@ -318,6 +323,7 @@ interface LocalValidationEvidenceArgs {
   owner: string;
   apply: boolean;
   format: string;
+  trustedMarkerLogins: string;
   help: boolean;
 }
 
@@ -336,6 +342,7 @@ const LOCAL_VALIDATION_EVIDENCE_FLAG_SPEC = {
   '--owner': { type: 'string', default: '' },
   '--apply': { type: 'boolean', default: false },
   '--format': { type: 'string', default: 'json' },
+  '--trusted-marker-logins': { type: 'string', default: '' },
   '--help': { type: 'boolean', short: 'h' },
 } as const;
 
@@ -395,6 +402,7 @@ export function parseArgs(argv: string[]): LocalValidationEvidenceArgs {
     owner: (values.owner as string).trim(),
     apply: values.apply as boolean,
     format,
+    trustedMarkerLogins: (values['trusted-marker-logins'] as string).trim(),
     help,
   };
 
@@ -490,6 +498,100 @@ function postComment({
     return JSON.parse(payload || '{}');
   } catch {
     return {};
+  }
+}
+
+/**
+ * Find prior `idd-local-validation-evidence:` comments (among `comments`)
+ * whose embedded HEAD SHA differs from `newHeadSha` -- the candidates a
+ * fresh `--record --apply` post should hide as `OUTDATED` (#2755),
+ * mirroring the shipped `advisory-wait` AW3-H rule and `post-idd-marker.mts`'s
+ * `review-ack` hide-at-post-time step (#2754). Never returns a candidate
+ * matching `newHeadSha` (current-HEAD protection, since
+ * `resolveLocalValidationEvidence` resolves current evidence by HEAD match)
+ * or an unparseable / non-`idd-local-validation-evidence:` comment.
+ */
+export function findSupersededLocalValidationEvidenceSubjects(
+  comments: readonly CommentLike[],
+  newHeadSha: string,
+): string[] {
+  const target = newHeadSha.trim().toLowerCase();
+  const subjects: string[] = [];
+  for (const comment of comments) {
+    const nodeId = String(comment.node_id ?? '').trim();
+    if (!nodeId) {
+      continue;
+    }
+    const parsed = parseLocalValidationEvidenceComment(
+      String(comment.body ?? ''),
+      String(comment.created_at ?? ''),
+    );
+    if (!parsed || parsed.headSha === target) {
+      continue;
+    }
+    subjects.push(nodeId);
+  }
+  return subjects;
+}
+
+/**
+ * Best-effort hide-at-post-time step (#2755) for a freshly recorded
+ * `idd-local-validation-evidence:` marker. Runs only after `poster(...)`'s
+ * own POST already succeeded, reuses `priorComments` (the same PR comment
+ * listing already fetched earlier in {@link runLocalValidationEvidence},
+ * necessarily gathered *before* this post -- unlike `post-idd-marker.mts`'s
+ * equivalent step, which re-lists comments *after* its own POST and must
+ * therefore exclude a same-window concurrent marker by `id`, a pre-post
+ * snapshot can by construction never contain this post or anything newer,
+ * so no id-ordering filter is needed here), and reuses
+ * `minimize-superseded-markers.mts`'s `runMinimize` for the actual
+ * mutation -- the same trusted-author gate, already-`isMinimized` skip, and
+ * `viewerCanMinimize` check that helper already implements. Every failure
+ * (an unreadable comment list, a `gh` permission error, a malformed
+ * GraphQL response, anything else) is swallowed here: this step must never
+ * retry-loop or throw back into the caller, since the marker it is hiding
+ * *for* has already posted successfully by the time this runs.
+ */
+export function hideSupersededLocalValidationEvidenceMarkers({
+  priorComments,
+  newHeadSha,
+  trustedMarkerLoginsFlag,
+  rawConfig,
+  resolveTrustedActorsFn = resolveTrustedActors,
+  runMinimizeFn = runMinimize,
+}: {
+  priorComments: CommentLike[];
+  newHeadSha: string;
+  trustedMarkerLoginsFlag: string;
+  rawConfig: unknown;
+  resolveTrustedActorsFn?: typeof resolveTrustedActors;
+  runMinimizeFn?: typeof runMinimize;
+}): void {
+  try {
+    const subjectIds = findSupersededLocalValidationEvidenceSubjects(
+      priorComments,
+      newHeadSha,
+    );
+    if (subjectIds.length === 0) {
+      return;
+    }
+    const { actors } = resolveTrustedActorsFn({
+      flagValue: trustedMarkerLoginsFlag,
+      envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
+      config: rawConfig,
+    });
+    runMinimizeFn({
+      subjectIds,
+      classifier: 'OUTDATED',
+      trustedSet: new Set(actors),
+      apply: true,
+      allowUntrusted: false,
+    });
+  } catch {
+    // Best-effort only (#2755) -- never block or retry-loop the marker
+    // post that already succeeded above. Covers both a thrown failure from
+    // runMinimizeFn itself (e.g. a gh permission error) and one from
+    // resolveTrustedActorsFn.
   }
 }
 
@@ -605,6 +707,12 @@ export async function runLocalValidationEvidence(
 
   const poster = options.postComment ?? postComment;
   const posted = poster({ owner, repo: name, prNumber: args.prNumber, body });
+  hideSupersededLocalValidationEvidenceMarkers({
+    priorComments: comments,
+    newHeadSha: args.headSha,
+    trustedMarkerLoginsFlag: args.trustedMarkerLogins,
+    rawConfig,
+  });
   const result = {
     mode: args.mode,
     apply: true,
@@ -660,6 +768,9 @@ Options:
                                      repository name -- not both --owner
                                      and a combined --repo together)
   --apply                           post the canonical marker comment after validation (--record)
+  --trusted-marker-logins a,b        gate --record --apply's hide-at-post-time
+                                      step (falls back to
+                                      IDD_TRUSTED_MARKER_ACTORS / config)
   --format <json|text>              output format (default: json)
   --help                            show this message
 `);

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -596,9 +596,9 @@ const MARKER_HIDE_POLICY_ENTRIES: readonly MarkerHidePolicyEntry[] = [
   },
   {
     label: '<!-- idd-local-validation-evidence:',
-    policy: 'f4-only',
+    policy: 'wired',
     reason:
-      'No hide-at-post-time wiring yet; only the post-merge F4 cleanup batch cleans it up today. Flipped to wired by roadmap #2751 Track 3 (#2755).',
+      'idd-local-validation-evidence family, grouped by embedded HEAD SHA mismatch (mirroring the shipped advisory-wait AW3-H rule). Hidden at post time by local-validation-evidence.mts itself (code-automated, right after its own --record --apply POST succeeds) -- roadmap #2751 Track 3 (#2755).',
   },
 ];
 

--- a/tests/local-validation-evidence.test.mts
+++ b/tests/local-validation-evidence.test.mts
@@ -449,6 +449,7 @@ function baseHideOptions(
     ...HIDE_TARGET,
     newHeadSha: HEAD,
     postedCommentId: POSTED_ID,
+    postedCommentNodeId: 'IC_posted',
     trustedMarkerLoginsFlag: 'kurone-kito',
     rawConfig: {},
     fetchLiveHeadSha: () => HEAD,
@@ -573,9 +574,9 @@ test('hideSupersededLocalValidationEvidenceMarkers swallows a resolveTrustedActo
   });
 });
 
-test('hideSupersededLocalValidationEvidenceMarkers bails out (no fetch, no mutation) when the live HEAD no longer matches the just-recorded HEAD (#2755, Codex review on PR #2792)', () => {
+test('hideSupersededLocalValidationEvidenceMarkers self-minimizes the just-posted marker (never scanning prior comments) when the live HEAD no longer matches the just-recorded HEAD (#2755, Codex review on PR #2792)', () => {
   let fetchedComments = false;
-  let minimized = false;
+  const calls: unknown[] = [];
   hideSupersededLocalValidationEvidenceMarkers(
     baseHideOptions({
       fetchLiveHeadSha: () => OTHER_HEAD,
@@ -583,14 +584,45 @@ test('hideSupersededLocalValidationEvidenceMarkers bails out (no fetch, no mutat
         fetchedComments = true;
         return [];
       },
-      runMinimizeFn: () => {
-        minimized = true;
-        throw new Error('should never be called');
+      runMinimizeFn: (input) => {
+        calls.push(input);
+        return {
+          mode: 'apply',
+          classifier: 'OUTDATED',
+          counts: {
+            eligible: 1,
+            alreadyMinimized: 0,
+            cannotMinimize: 0,
+            untrusted: 0,
+            unsupportedType: 0,
+            applied: 1,
+            failed: 0,
+          },
+          items: [],
+        };
       },
     }),
   );
   assert.equal(fetchedComments, false);
-  assert.equal(minimized, false);
+  assert.equal(calls.length, 1);
+  assert.deepEqual((calls[0] as { subjectIds: string[] }).subjectIds, [
+    'IC_posted',
+  ]);
+});
+
+test('hideSupersededLocalValidationEvidenceMarkers never calls runMinimizeFn on a live-HEAD mismatch when postedCommentNodeId is empty', () => {
+  let called = false;
+  hideSupersededLocalValidationEvidenceMarkers(
+    baseHideOptions({
+      postedCommentNodeId: '',
+      fetchLiveHeadSha: () => OTHER_HEAD,
+      runMinimizeFn: () => {
+        called = true;
+        throw new Error('should never be called');
+      },
+    }),
+  );
+  assert.equal(called, false);
 });
 
 test('hideSupersededLocalValidationEvidenceMarkers excludes a re-fetched comment whose id is not strictly older than postedCommentId (#2755, Codex review on PR #2792)', () => {

--- a/tests/local-validation-evidence.test.mts
+++ b/tests/local-validation-evidence.test.mts
@@ -437,34 +437,62 @@ test('findSupersededLocalValidationEvidenceSubjects ignores a non-marker comment
   );
 });
 
-test('hideSupersededLocalValidationEvidenceMarkers calls runMinimizeFn with every superseded subject id', () => {
-  const stale = evidenceComment({ headSha: OTHER_HEAD, nodeId: 'IC_stale' });
-  const current = evidenceComment({ headSha: HEAD, nodeId: 'IC_current' });
-  const calls: unknown[] = [];
-  hideSupersededLocalValidationEvidenceMarkers({
-    priorComments: [stale, current],
+const HIDE_TARGET = { owner: 'kurone-kito', repo: 'idd-skill', prNumber: 123 };
+const POSTED_ID = 1000;
+
+function baseHideOptions(
+  overrides: Partial<
+    Parameters<typeof hideSupersededLocalValidationEvidenceMarkers>[0]
+  > = {},
+) {
+  return {
+    ...HIDE_TARGET,
     newHeadSha: HEAD,
+    postedCommentId: POSTED_ID,
     trustedMarkerLoginsFlag: 'kurone-kito',
     rawConfig: {},
-    resolveTrustedActorsFn: () => ({ actors: TRUSTED, source: 'flag' }),
-    runMinimizeFn: (input) => {
-      calls.push(input);
-      return {
-        mode: 'apply',
-        classifier: 'OUTDATED',
-        counts: {
-          eligible: 1,
-          alreadyMinimized: 0,
-          cannotMinimize: 0,
-          untrusted: 0,
-          unsupportedType: 0,
-          applied: 1,
-          failed: 0,
-        },
-        items: [],
-      };
-    },
+    fetchLiveHeadSha: () => HEAD,
+    fetchPriorComments: () => [],
+    resolveTrustedActorsFn: () => ({
+      actors: TRUSTED,
+      source: 'flag' as const,
+    }),
+    ...overrides,
+  };
+}
+
+test('hideSupersededLocalValidationEvidenceMarkers calls runMinimizeFn with every superseded subject id', () => {
+  const stale = evidenceComment({
+    headSha: OTHER_HEAD,
+    nodeId: 'IC_stale',
   });
+  const current = evidenceComment({ headSha: HEAD, nodeId: 'IC_current' });
+  const calls: unknown[] = [];
+  hideSupersededLocalValidationEvidenceMarkers(
+    baseHideOptions({
+      fetchPriorComments: () => [
+        { ...stale, id: 1 },
+        { ...current, id: 2 },
+      ],
+      runMinimizeFn: (input) => {
+        calls.push(input);
+        return {
+          mode: 'apply',
+          classifier: 'OUTDATED',
+          counts: {
+            eligible: 1,
+            alreadyMinimized: 0,
+            cannotMinimize: 0,
+            untrusted: 0,
+            unsupportedType: 0,
+            applied: 1,
+            failed: 0,
+          },
+          items: [],
+        };
+      },
+    }),
+  );
   assert.equal(calls.length, 1);
   assert.deepEqual((calls[0] as { subjectIds: string[] }).subjectIds, [
     'IC_stale',
@@ -474,79 +502,150 @@ test('hideSupersededLocalValidationEvidenceMarkers calls runMinimizeFn with ever
 test('hideSupersededLocalValidationEvidenceMarkers never calls runMinimizeFn when nothing is superseded', () => {
   const current = evidenceComment({ headSha: HEAD, nodeId: 'IC_current' });
   let called = false;
-  hideSupersededLocalValidationEvidenceMarkers({
-    priorComments: [current],
-    newHeadSha: HEAD,
-    trustedMarkerLoginsFlag: 'kurone-kito',
-    rawConfig: {},
-    runMinimizeFn: () => {
-      called = true;
-      throw new Error('should never be called');
-    },
-  });
+  hideSupersededLocalValidationEvidenceMarkers(
+    baseHideOptions({
+      fetchPriorComments: () => [{ ...current, id: 1 }],
+      runMinimizeFn: () => {
+        called = true;
+        throw new Error('should never be called');
+      },
+    }),
+  );
   assert.equal(called, false);
 });
 
 test("hideSupersededLocalValidationEvidenceMarkers passes an already-minimized-reporting runMinimizeFn call through unmodified (the skip itself is runMinimize's own pre-existing, unmodified logic; this wrapper never inspects the report)", () => {
   const stale = evidenceComment({ headSha: OTHER_HEAD, nodeId: 'IC_stale' });
   assert.doesNotThrow(() => {
-    hideSupersededLocalValidationEvidenceMarkers({
-      priorComments: [stale],
-      newHeadSha: HEAD,
-      trustedMarkerLoginsFlag: 'kurone-kito',
-      rawConfig: {},
-      resolveTrustedActorsFn: () => ({ actors: TRUSTED, source: 'flag' }),
-      runMinimizeFn: () => ({
-        mode: 'apply',
-        classifier: 'OUTDATED',
-        counts: {
-          eligible: 1,
-          alreadyMinimized: 1,
-          cannotMinimize: 0,
-          untrusted: 0,
-          unsupportedType: 0,
-          applied: 0,
-          failed: 0,
-        },
-        items: [
-          {
-            subjectId: 'IC_stale',
-            status: 'skipped',
-            reason: 'already-minimized',
+    hideSupersededLocalValidationEvidenceMarkers(
+      baseHideOptions({
+        fetchPriorComments: () => [{ ...stale, id: 1 }],
+        runMinimizeFn: () => ({
+          mode: 'apply',
+          classifier: 'OUTDATED',
+          counts: {
+            eligible: 1,
+            alreadyMinimized: 1,
+            cannotMinimize: 0,
+            untrusted: 0,
+            unsupportedType: 0,
+            applied: 0,
+            failed: 0,
           },
-        ],
+          items: [
+            {
+              subjectId: 'IC_stale',
+              status: 'skipped',
+              reason: 'already-minimized',
+            },
+          ],
+        }),
       }),
-    });
+    );
   });
 });
 
 test('hideSupersededLocalValidationEvidenceMarkers swallows a runMinimizeFn failure (permission error) without throwing or blocking', () => {
   const stale = evidenceComment({ headSha: OTHER_HEAD, nodeId: 'IC_stale' });
   assert.doesNotThrow(() => {
-    hideSupersededLocalValidationEvidenceMarkers({
-      priorComments: [stale],
-      newHeadSha: HEAD,
-      trustedMarkerLoginsFlag: 'kurone-kito',
-      rawConfig: {},
-      resolveTrustedActorsFn: () => ({ actors: TRUSTED, source: 'flag' }),
-      runMinimizeFn: () => {
-        throw new Error('gh: permission denied');
-      },
-    });
+    hideSupersededLocalValidationEvidenceMarkers(
+      baseHideOptions({
+        fetchPriorComments: () => [{ ...stale, id: 1 }],
+        runMinimizeFn: () => {
+          throw new Error('gh: permission denied');
+        },
+      }),
+    );
   });
 });
 
 test('hideSupersededLocalValidationEvidenceMarkers swallows a resolveTrustedActorsFn failure without throwing', () => {
   const stale = evidenceComment({ headSha: OTHER_HEAD, nodeId: 'IC_stale' });
   assert.doesNotThrow(() => {
-    hideSupersededLocalValidationEvidenceMarkers({
-      priorComments: [stale],
-      newHeadSha: HEAD,
-      trustedMarkerLoginsFlag: 'kurone-kito',
-      rawConfig: {},
-      resolveTrustedActorsFn: () => {
-        throw new Error('config read failed');
-      },
-    });
+    hideSupersededLocalValidationEvidenceMarkers(
+      baseHideOptions({
+        fetchPriorComments: () => [{ ...stale, id: 1 }],
+        resolveTrustedActorsFn: () => {
+          throw new Error('config read failed');
+        },
+      }),
+    );
   });
+});
+
+test('hideSupersededLocalValidationEvidenceMarkers bails out (no fetch, no mutation) when the live HEAD no longer matches the just-recorded HEAD (#2755, Codex review on PR #2792)', () => {
+  let fetchedComments = false;
+  let minimized = false;
+  hideSupersededLocalValidationEvidenceMarkers(
+    baseHideOptions({
+      fetchLiveHeadSha: () => OTHER_HEAD,
+      fetchPriorComments: () => {
+        fetchedComments = true;
+        return [];
+      },
+      runMinimizeFn: () => {
+        minimized = true;
+        throw new Error('should never be called');
+      },
+    }),
+  );
+  assert.equal(fetchedComments, false);
+  assert.equal(minimized, false);
+});
+
+test('hideSupersededLocalValidationEvidenceMarkers excludes a re-fetched comment whose id is not strictly older than postedCommentId (#2755, Codex review on PR #2792)', () => {
+  const staleOlder = evidenceComment({
+    headSha: OTHER_HEAD,
+    nodeId: 'IC_older',
+  });
+  const staleConcurrentNewer = evidenceComment({
+    headSha: OTHER_HEAD,
+    nodeId: 'IC_newer_concurrent',
+  });
+  const calls: unknown[] = [];
+  hideSupersededLocalValidationEvidenceMarkers(
+    baseHideOptions({
+      fetchPriorComments: () => [
+        { ...staleOlder, id: POSTED_ID - 1 },
+        { ...staleConcurrentNewer, id: POSTED_ID + 1 },
+      ],
+      runMinimizeFn: (input) => {
+        calls.push(input);
+        return {
+          mode: 'apply',
+          classifier: 'OUTDATED',
+          counts: {
+            eligible: 1,
+            alreadyMinimized: 0,
+            cannotMinimize: 0,
+            untrusted: 0,
+            unsupportedType: 0,
+            applied: 1,
+            failed: 0,
+          },
+          items: [],
+        };
+      },
+    }),
+  );
+  assert.equal(calls.length, 1);
+  assert.deepEqual((calls[0] as { subjectIds: string[] }).subjectIds, [
+    'IC_older',
+  ]);
+});
+
+test('hideSupersededLocalValidationEvidenceMarkers never calls runMinimizeFn when no trusted actor resolves (#2755, Copilot review on PR #2792)', () => {
+  const stale = evidenceComment({ headSha: OTHER_HEAD, nodeId: 'IC_stale' });
+  let called = false;
+  hideSupersededLocalValidationEvidenceMarkers(
+    baseHideOptions({
+      fetchPriorComments: () => [{ ...stale, id: 1 }],
+      resolveTrustedActorsFn: () => ({ actors: [], source: 'none' as const }),
+      runMinimizeFn: () => {
+        called = true;
+        throw new Error('should never be called');
+      },
+    }),
+  );
+  assert.equal(called, false);
 });

--- a/tests/local-validation-evidence.test.mts
+++ b/tests/local-validation-evidence.test.mts
@@ -3,6 +3,8 @@ import { test } from 'node:test';
 import {
   type CommentLike,
   evaluateLocalValidationEvidenceRecovery,
+  findSupersededLocalValidationEvidenceSubjects,
+  hideSupersededLocalValidationEvidenceMarkers,
   parseArgs,
   renderText,
   resolveLocalValidationEvidence,
@@ -25,6 +27,7 @@ function evidenceComment(overrides: {
   outcome?: string;
   createdAt?: string;
   authorLogin?: string;
+  nodeId?: string;
 }): CommentLike {
   const body = renderLocalValidationEvidenceComment({
     actor: overrides.actor ?? 'kurone-kito',
@@ -39,6 +42,7 @@ function evidenceComment(overrides: {
     author: {
       login: overrides.authorLogin ?? overrides.actor ?? 'kurone-kito',
     },
+    node_id: overrides.nodeId ?? 'IC_default',
   };
 }
 
@@ -400,4 +404,149 @@ test('parseArgs: default mode is resolve', () => {
   const parsed = parseArgs(['--pr', '123', '--head-sha', HEAD]);
   assert.equal(parsed.mode, 'resolve');
   assert.equal(parsed.service, 'ci-actions');
+});
+
+// --- #2755: hide-at-post-time for idd-local-validation-evidence ----------
+
+test('findSupersededLocalValidationEvidenceSubjects hides a prior marker whose HEAD SHA differs from the new one', () => {
+  const stale = evidenceComment({ headSha: OTHER_HEAD, nodeId: 'IC_stale' });
+  assert.deepEqual(
+    findSupersededLocalValidationEvidenceSubjects([stale], HEAD),
+    ['IC_stale'],
+  );
+});
+
+test('findSupersededLocalValidationEvidenceSubjects never hides a marker matching the new HEAD SHA (current-HEAD protection)', () => {
+  const current = evidenceComment({ headSha: HEAD, nodeId: 'IC_current' });
+  assert.deepEqual(
+    findSupersededLocalValidationEvidenceSubjects([current], HEAD),
+    [],
+  );
+});
+
+test('findSupersededLocalValidationEvidenceSubjects ignores a non-marker comment and one with no node id', () => {
+  const unrelated: CommentLike = {
+    body: 'just a regular comment',
+    created_at: '2026-09-01T05:00:00Z',
+    node_id: 'IC_unrelated',
+  };
+  const noNodeId = evidenceComment({ headSha: OTHER_HEAD, nodeId: '' });
+  assert.deepEqual(
+    findSupersededLocalValidationEvidenceSubjects([unrelated, noNodeId], HEAD),
+    [],
+  );
+});
+
+test('hideSupersededLocalValidationEvidenceMarkers calls runMinimizeFn with every superseded subject id', () => {
+  const stale = evidenceComment({ headSha: OTHER_HEAD, nodeId: 'IC_stale' });
+  const current = evidenceComment({ headSha: HEAD, nodeId: 'IC_current' });
+  const calls: unknown[] = [];
+  hideSupersededLocalValidationEvidenceMarkers({
+    priorComments: [stale, current],
+    newHeadSha: HEAD,
+    trustedMarkerLoginsFlag: 'kurone-kito',
+    rawConfig: {},
+    resolveTrustedActorsFn: () => ({ actors: TRUSTED, source: 'flag' }),
+    runMinimizeFn: (input) => {
+      calls.push(input);
+      return {
+        mode: 'apply',
+        classifier: 'OUTDATED',
+        counts: {
+          eligible: 1,
+          alreadyMinimized: 0,
+          cannotMinimize: 0,
+          untrusted: 0,
+          unsupportedType: 0,
+          applied: 1,
+          failed: 0,
+        },
+        items: [],
+      };
+    },
+  });
+  assert.equal(calls.length, 1);
+  assert.deepEqual((calls[0] as { subjectIds: string[] }).subjectIds, [
+    'IC_stale',
+  ]);
+});
+
+test('hideSupersededLocalValidationEvidenceMarkers never calls runMinimizeFn when nothing is superseded', () => {
+  const current = evidenceComment({ headSha: HEAD, nodeId: 'IC_current' });
+  let called = false;
+  hideSupersededLocalValidationEvidenceMarkers({
+    priorComments: [current],
+    newHeadSha: HEAD,
+    trustedMarkerLoginsFlag: 'kurone-kito',
+    rawConfig: {},
+    runMinimizeFn: () => {
+      called = true;
+      throw new Error('should never be called');
+    },
+  });
+  assert.equal(called, false);
+});
+
+test("hideSupersededLocalValidationEvidenceMarkers passes an already-minimized-reporting runMinimizeFn call through unmodified (the skip itself is runMinimize's own pre-existing, unmodified logic; this wrapper never inspects the report)", () => {
+  const stale = evidenceComment({ headSha: OTHER_HEAD, nodeId: 'IC_stale' });
+  assert.doesNotThrow(() => {
+    hideSupersededLocalValidationEvidenceMarkers({
+      priorComments: [stale],
+      newHeadSha: HEAD,
+      trustedMarkerLoginsFlag: 'kurone-kito',
+      rawConfig: {},
+      resolveTrustedActorsFn: () => ({ actors: TRUSTED, source: 'flag' }),
+      runMinimizeFn: () => ({
+        mode: 'apply',
+        classifier: 'OUTDATED',
+        counts: {
+          eligible: 1,
+          alreadyMinimized: 1,
+          cannotMinimize: 0,
+          untrusted: 0,
+          unsupportedType: 0,
+          applied: 0,
+          failed: 0,
+        },
+        items: [
+          {
+            subjectId: 'IC_stale',
+            status: 'skipped',
+            reason: 'already-minimized',
+          },
+        ],
+      }),
+    });
+  });
+});
+
+test('hideSupersededLocalValidationEvidenceMarkers swallows a runMinimizeFn failure (permission error) without throwing or blocking', () => {
+  const stale = evidenceComment({ headSha: OTHER_HEAD, nodeId: 'IC_stale' });
+  assert.doesNotThrow(() => {
+    hideSupersededLocalValidationEvidenceMarkers({
+      priorComments: [stale],
+      newHeadSha: HEAD,
+      trustedMarkerLoginsFlag: 'kurone-kito',
+      rawConfig: {},
+      resolveTrustedActorsFn: () => ({ actors: TRUSTED, source: 'flag' }),
+      runMinimizeFn: () => {
+        throw new Error('gh: permission denied');
+      },
+    });
+  });
+});
+
+test('hideSupersededLocalValidationEvidenceMarkers swallows a resolveTrustedActorsFn failure without throwing', () => {
+  const stale = evidenceComment({ headSha: OTHER_HEAD, nodeId: 'IC_stale' });
+  assert.doesNotThrow(() => {
+    hideSupersededLocalValidationEvidenceMarkers({
+      priorComments: [stale],
+      newHeadSha: HEAD,
+      trustedMarkerLoginsFlag: 'kurone-kito',
+      rawConfig: {},
+      resolveTrustedActorsFn: () => {
+        throw new Error('config read failed');
+      },
+    });
+  });
 });


### PR DESCRIPTION
## Summary

`idd-local-validation-evidence:` markers (#2323) recorded HEAD-pinned, expiring local-validation evidence but had zero hide-at-post-time wiring — a superseded instance (a prior HEAD's evidence) stayed visible until the post-merge F4 cleanup batch, unlike the already-shipped `advisory-wait` AW3-H family this one's own purpose text mirrors.

- Add `findSupersededLocalValidationEvidenceSubjects()` to `local-validation-evidence.mts`: finds prior `idd-local-validation-evidence:` comments whose embedded HEAD SHA differs from a freshly recorded one (never the current-HEAD match, mirroring how `resolveLocalValidationEvidence` resolves current evidence).
- Wire `hideSupersededLocalValidationEvidenceMarkers()` into `--record --apply`, immediately after the new marker's own POST succeeds, reusing `minimize-superseded-markers.mts`'s existing `runMinimize`/`resolveTrustedActors` — best-effort, never blocks or retries the marker post that already succeeded on failure. Unlike `post-idd-marker.mts`'s `review-ack`/`copilot-unavailable` hide step (#2754), no post-POST id-ordering filter is needed: the prior-comments list this reuses was fetched earlier in the same call, strictly before the post.
- Add a `--trusted-marker-logins` flag (previously absent), following the same flag > env (`IDD_TRUSTED_MARKER_ACTORS`) > config ladder every other `minimize-superseded-markers.mts` caller uses.
- Flip `idd-local-validation-evidence:`'s classification-table entry from `f4-only` to `wired` in `marker-helpers.mts`, completing roadmap #2751's Track 3.

## Test plan

- [x] Unit tests cover: a differing-HEAD-SHA prior marker is hidden; a current-HEAD-SHA marker is left visible; a non-marker/no-node-id comment is ignored; the wrapper calls `runMinimizeFn` with the right subject ids; never calls it when nothing is superseded; completes without throwing when the injected `runMinimizeFn` reports an already-minimized skip; swallows a thrown `runMinimizeFn` failure; swallows a thrown `resolveTrustedActorsFn` failure
- [x] `node --test tests/*.test.mts` — 5517/5517 passing
- [x] `pnpm run typecheck` clean
- [x] `pnpm run build` regenerated the `.mjs` mirrors; `pnpm run build:check`'s `git diff HEAD` is clean post-commit
- [x] `dprint check`, `markdownlint-cli2`, `cspell lint` clean
- [x] No change to `pre-merge-readiness.mts`'s evidence resolution logic or any other marker family's posting/hide behavior
- [x] Independent report-only critique pass found no functional defects

Closes #2755

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDJpTELrY2SnjHW9m5Aw7i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Local validation evidence now automatically minimizes eligible comments from older commit versions after new evidence is posted.
  - Added configuration for trusted accounts allowed to perform this cleanup.
  - Added a `--trusted-marker-logins` command-line option.

- **Bug Fixes**
  - Cleanup safely handles missing comment data, already-minimized comments, commit changes, and temporary errors without preventing new evidence from being posted.

- **Documentation**
  - Updated guidance to reflect the expanded local validation evidence comment policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->