### PR TITLE
docs(idd-advisory-wait): retire the PR #2054 fixes it caveat

### DIFF
--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -384,7 +384,8 @@ hold.
 
 **`suppressedCount` unvalidated**: `#1511` is `itemCount`-only; reroll
 never zeroed it in `kurone-kito/lints-config` PRs `#243`/`#245`
-(2026-08-10/11). PR #2054 fixes it.
+(2026-08-10/11). The review-ack escape hatch below (PR `#2054`, issue
+`#2050`) covers it; the reroll itself still does not zero the count.
 
 **Already-handled escape hatch**: when the blocking suppressed
 finding(s) have already been read and handled, a reroll is
@@ -450,8 +451,10 @@ still needs a valid waiver), and F2/F3's `advisoryWait.copilotUnavailable`/
 > merging.
 
 **Waived**: rerun the existing `idd-advisory-convergence` run (never
-`workflow_dispatch` — see Rerun mechanics below); both fields recompute
-every call, so an expired/invalid marker reverts automatically.
+`workflow_dispatch` — see
+[rerun mechanics](idd-ci.instructions.md#rerun-mechanics)); both fields
+recompute every call, so an expired/invalid marker reverts
+automatically.
 
 **Sustained outage (`#2320`)**: when `providerOutage.declarationTarget`
 is configured and holds an active declaration for `idd-advisory-convergence`,

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -379,7 +379,8 @@ hold.
 
 **`suppressedCount` unvalidated**: `#1511` is `itemCount`-only; reroll
 never zeroed it in `kurone-kito/lints-config` PRs `#243`/`#245`
-(2026-08-10/11). PR #2054 fixes it.
+(2026-08-10/11). The review-ack escape hatch below (PR `#2054`, issue
+`#2050`) covers it; the reroll itself still does not zero the count.
 
 **Already-handled escape hatch**: when the blocking suppressed
 finding(s) have already been read and handled, a reroll is
@@ -445,8 +446,10 @@ still needs a valid waiver), and F2/F3's `advisoryWait.copilotUnavailable`/
 > merging.
 
 **Waived**: rerun the existing `idd-advisory-convergence` run (never
-`workflow_dispatch` — see Rerun mechanics below); both fields recompute
-every call, so an expired/invalid marker reverts automatically.
+`workflow_dispatch` — see
+[rerun mechanics](idd-ci.instructions.md#rerun-mechanics)); both fields
+recompute every call, so an expired/invalid marker reverts
+automatically.
 
 **Sustained outage (`#2320`)**: when `providerOutage.declarationTarget`
 is configured and holds an active declaration for `idd-advisory-convergence`,


### PR DESCRIPTION
## Summary

- Retires the AW6 note's inaccurate "PR #2054 fixes it" caveat: #2054
  only added the review-ack escape hatch, and the reroll itself still
  never zeroes `suppressedCount`. Reworded to point at the escape
  hatch instead of implying the underlying gap is fixed.
- Replaces the dangling "Rerun mechanics below" self-reference with a
  proper cross-reference link to `idd-ci.instructions.md`, matching
  the link form `idd-review-triage.instructions.md` already uses for
  the same anchor.

## Verification

- Confirmed `src/scripts/advisory-convergence.mts` still has no code
  path that zeroes `suppressedCount` on reroll (read directly from
  review data, unrelated to reroll markers).
- Confirmed `## Rerun mechanics` anchor exists in
  `idd-ci.instructions.md`.
- `node scripts/sync-docs.mjs --apply` (mirror in sync)
- `node scripts/audit-docs.mjs --check` (pass; only pre-existing
  unrelated bundle notices)
- All 4 acceptance-criteria greps from the issue body match exactly
- `audit/sync-manifest.json` untouched (bundle limits not raised)
- `pnpm run typecheck`, `pnpm test` (5521/5521 pass), markdownlint,
  dprint, cspell, `audit-code-span-wrap.mjs` all clean

Closes #2776

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDJpTELrY2SnjHW9m5Aw7i