### PR TITLE
fix(discover-orphan-filter): exclude provider-outage target

### DIFF
--- a/scripts/discover-orphan-filter.mjs
+++ b/scripts/discover-orphan-filter.mjs
@@ -385,6 +385,15 @@ export function getOrphanFirstPolicy(config) {
   return 'none';
 }
 export function classifyIssue(issue, options) {
+  // #2800: checked first, ahead of every marker/label check below — the
+  // declaration target is deliberately marker-less and label-less, so
+  // none of those checks would ever catch it on their own.
+  if (
+    options.providerOutageDeclarationTarget != null &&
+    Number(issue.number) === options.providerOutageDeclarationTarget
+  ) {
+    return { orphan: false, reason: 'provider_outage_target' };
+  }
   const labels = new Set(normalizeLabels(issue.labels));
   const body = String(issue.body ?? '');
   const markerPrefix = normalizeMarkerPrefix(options.markerPrefix);
@@ -524,6 +533,7 @@ export async function filterOrphanIssues(issues, options = {}) {
       ? options.fetchIssueStateByNumber
       : () => 'UNRESOLVABLE';
   const filtered = {
+    provider_outage_target: [],
     roadmap_marker: [],
     blocked_by_marker: [],
     blocked_label: [],
@@ -564,6 +574,7 @@ export async function filterOrphanIssues(issues, options = {}) {
       blockedByHumanLabelName: options.blockedByHumanLabelName,
       needsDecisionLabelName: options.needsDecisionLabelName,
       roadmapLabelName: options.roadmapLabelName,
+      providerOutageDeclarationTarget: options.providerOutageDeclarationTarget,
       openIssueDetailsByNumber,
     });
     if (result.reason === 'unresolvable_reference') {
@@ -812,6 +823,7 @@ async function runCli() {
     blockedByHumanLabelName: policy.blockedByHumanLabelName,
     needsDecisionLabelName: policy.needsDecisionLabelName,
     roadmapLabelName: policy.roadmapLabelName,
+    providerOutageDeclarationTarget: policy.providerOutageDeclarationTarget,
     autopilotSuitabilityFloor: policy.autopilotSuitabilityFloor,
     autopilotSuitabilityEnabled: policy.autopilotSuitabilityEnabled,
     autopilot: args.autopilot,
@@ -931,6 +943,7 @@ Output schema:
   "orphans": [{"number": 1, "title": "...", "state": "OPEN", "reason": "orphan|blocked_references_closed", "url": "...", "autopilotSuitability": 4, "effort": "S|M|L|null", "milestone": "v0.8.0|null"}],
   "routed_to_human": [{"number": 2, "title": "...", "state": "OPEN", "reason": "orphan", "url": "...", "autopilotSuitability": 1, "effort": "S|M|L|null", "milestone": "v0.8.0|null"}],
   "filtered": {
+    "provider_outage_target": [...],
     "roadmap_marker": [...],
     "blocked_by_marker": [...],
     "blocked_label": [...],
@@ -945,6 +958,14 @@ Output schema:
   "warnings": [{"issueNumber": 1, "message": "Warning: ..."}],
   "counts": {"scanned": 0, "orphans": 0, "routed_to_human": 0, "filtered": {...}, "unresolvable": 0}
 }
+
+"filtered.provider_outage_target" (#2800) excludes the exact issue named by
+the configured "providerOutage.declarationTarget" -- a permanent,
+adopter-authored coordination issue documented to stay open indefinitely,
+never claimed, never closed, and carrying no roadmap/blocked marker or
+blocking label of its own. Checked by issue number alone, ahead of every
+marker/label check above, since none of them would otherwise catch it.
+Absent config leaves this filter a no-op.
 
 "filtered.runtime_observation_precondition" (#2467) excludes an issue whose
 body names a runtime/production-observation precondition in prose --
@@ -1021,7 +1042,8 @@ function loadPolicy(policyPath) {
   const { path: source, config: rawConfig } = loadPolicyConfig(policyPath);
   const config = rawConfig ?? {};
   const authoringPolicy = resolveAuthoringGuardPolicy(config);
-  const labelsPolicy = normalizePolicyConfig(config).labels;
+  const normalizedPolicy = normalizePolicyConfig(config);
+  const labelsPolicy = normalizedPolicy.labels;
   return {
     source,
     orphanFirstPolicy: getOrphanFirstPolicy(config),
@@ -1032,6 +1054,12 @@ function loadPolicy(policyPath) {
     blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
     needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
     roadmapLabelName: labelsPolicy.roadmapLabelName,
+    // #2800: own-property-omitted when unconfigured or invalid, matching
+    // normalizePolicyConfig's own absence semantics -- resolved to
+    // `null` below so downstream callers get a stable, always-present
+    // field instead of testing for key presence.
+    providerOutageDeclarationTarget:
+      normalizedPolicy.providerOutage.declarationTarget ?? null,
     autopilotSuitabilityFloor: resolveAutopilotSuitabilityFloor(config),
     autopilotSuitabilityEnabled: resolveAutopilotSuitabilityEnabled(config),
     // Passed through verbatim (raw, un-normalized) for

--- a/src/scripts/discover-orphan-filter.mts
+++ b/src/scripts/discover-orphan-filter.mts
@@ -160,6 +160,7 @@ const WORD_CHAR_PATTERN = /[A-Za-z0-9]/;
 
 /** Reasons that keep an issue out of the orphan candidate list. */
 export type OrphanFilteredReason =
+  | 'provider_outage_target'
   | 'roadmap_marker'
   | 'blocked_by_marker'
   | 'blocked_label'
@@ -180,6 +181,7 @@ export type OrphanClassification =
   | {
       orphan: false;
       reason:
+        | 'provider_outage_target'
         | 'roadmap_marker'
         | 'blocked_by_marker'
         | 'runtime_observation_precondition';
@@ -218,6 +220,15 @@ interface ClassifyIssueOptions {
   needsDecisionLabelName?: unknown;
   roadmapLabelName?: unknown;
   /**
+   * The configured `providerOutage.declarationTarget` issue number
+   * (#2800), or `null`/absent when unconfigured. That issue is a
+   * permanent, adopter-authored coordination issue meant to stay open
+   * indefinitely, carrying no roadmap/blocked markers or blocking
+   * labels of its own — so it is excluded by number, ahead of every
+   * marker/label check below, rather than relying on any of them.
+   */
+  providerOutageDeclarationTarget?: number | null;
+  /**
    * Lookup used **only** to resolve an open `Depends on #NNN` / task-list
    * dependency reference's title/labels for the parent-epic exemption
    * (#1536) — never for `Blocked by` references, which have no exemption,
@@ -237,6 +248,8 @@ interface FilterOrphanIssuesOptions {
   blockedByHumanLabelName?: unknown;
   needsDecisionLabelName?: unknown;
   roadmapLabelName?: unknown;
+  /** See {@link ClassifyIssueOptions.providerOutageDeclarationTarget}. */
+  providerOutageDeclarationTarget?: number | null;
   authoringStaleAgeMs?: number;
   autopilotSuitabilityFloor?: number;
   autopilotSuitabilityEnabled?: boolean;
@@ -593,6 +606,16 @@ export function classifyIssue(
   issue: OrphanIssueInput,
   options: ClassifyIssueOptions,
 ): OrphanClassification {
+  // #2800: checked first, ahead of every marker/label check below — the
+  // declaration target is deliberately marker-less and label-less, so
+  // none of those checks would ever catch it on their own.
+  if (
+    options.providerOutageDeclarationTarget != null &&
+    Number(issue.number) === options.providerOutageDeclarationTarget
+  ) {
+    return { orphan: false, reason: 'provider_outage_target' };
+  }
+
   const labels = new Set(normalizeLabels(issue.labels));
   const body = String(issue.body ?? '');
   const markerPrefix = normalizeMarkerPrefix(options.markerPrefix);
@@ -751,6 +774,7 @@ export async function filterOrphanIssues(
       ? options.fetchIssueStateByNumber
       : () => 'UNRESOLVABLE';
   const filtered: Record<OrphanFilteredReason, FilteredIssueEntry[]> = {
+    provider_outage_target: [],
     roadmap_marker: [],
     blocked_by_marker: [],
     blocked_label: [],
@@ -800,6 +824,7 @@ export async function filterOrphanIssues(
       blockedByHumanLabelName: options.blockedByHumanLabelName,
       needsDecisionLabelName: options.needsDecisionLabelName,
       roadmapLabelName: options.roadmapLabelName,
+      providerOutageDeclarationTarget: options.providerOutageDeclarationTarget,
       openIssueDetailsByNumber,
     });
 
@@ -1064,6 +1089,7 @@ async function runCli() {
     blockedByHumanLabelName: policy.blockedByHumanLabelName,
     needsDecisionLabelName: policy.needsDecisionLabelName,
     roadmapLabelName: policy.roadmapLabelName,
+    providerOutageDeclarationTarget: policy.providerOutageDeclarationTarget,
     autopilotSuitabilityFloor: policy.autopilotSuitabilityFloor,
     autopilotSuitabilityEnabled: policy.autopilotSuitabilityEnabled,
     autopilot: args.autopilot,
@@ -1188,6 +1214,7 @@ Output schema:
   "orphans": [{"number": 1, "title": "...", "state": "OPEN", "reason": "orphan|blocked_references_closed", "url": "...", "autopilotSuitability": 4, "effort": "S|M|L|null", "milestone": "v0.8.0|null"}],
   "routed_to_human": [{"number": 2, "title": "...", "state": "OPEN", "reason": "orphan", "url": "...", "autopilotSuitability": 1, "effort": "S|M|L|null", "milestone": "v0.8.0|null"}],
   "filtered": {
+    "provider_outage_target": [...],
     "roadmap_marker": [...],
     "blocked_by_marker": [...],
     "blocked_label": [...],
@@ -1202,6 +1229,14 @@ Output schema:
   "warnings": [{"issueNumber": 1, "message": "Warning: ..."}],
   "counts": {"scanned": 0, "orphans": 0, "routed_to_human": 0, "filtered": {...}, "unresolvable": 0}
 }
+
+"filtered.provider_outage_target" (#2800) excludes the exact issue named by
+the configured "providerOutage.declarationTarget" -- a permanent,
+adopter-authored coordination issue documented to stay open indefinitely,
+never claimed, never closed, and carrying no roadmap/blocked marker or
+blocking label of its own. Checked by issue number alone, ahead of every
+marker/label check above, since none of them would otherwise catch it.
+Absent config leaves this filter a no-op.
 
 "filtered.runtime_observation_precondition" (#2467) excludes an issue whose
 body names a runtime/production-observation precondition in prose --
@@ -1283,7 +1318,8 @@ function loadPolicy(policyPath: string) {
     trustedMarkerActors?: unknown;
   };
   const authoringPolicy = resolveAuthoringGuardPolicy(config);
-  const labelsPolicy = normalizePolicyConfig(config).labels;
+  const normalizedPolicy = normalizePolicyConfig(config);
+  const labelsPolicy = normalizedPolicy.labels;
   return {
     source,
     orphanFirstPolicy: getOrphanFirstPolicy(config),
@@ -1294,6 +1330,12 @@ function loadPolicy(policyPath: string) {
     blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
     needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
     roadmapLabelName: labelsPolicy.roadmapLabelName,
+    // #2800: own-property-omitted when unconfigured or invalid, matching
+    // normalizePolicyConfig's own absence semantics -- resolved to
+    // `null` below so downstream callers get a stable, always-present
+    // field instead of testing for key presence.
+    providerOutageDeclarationTarget:
+      normalizedPolicy.providerOutage.declarationTarget ?? null,
     autopilotSuitabilityFloor: resolveAutopilotSuitabilityFloor(config),
     autopilotSuitabilityEnabled: resolveAutopilotSuitabilityEnabled(config),
     // Passed through verbatim (raw, un-normalized) for

--- a/tests/discover-orphan-filter.test.mts
+++ b/tests/discover-orphan-filter.test.mts
@@ -101,6 +101,49 @@ test('classifyIssue rejects roadmap and blocked marker issues', () => {
   assert.equal(blocked.reason, 'blocked_by_marker');
 });
 
+test('classifyIssue excludes the configured providerOutage.declarationTarget by number (#2800)', () => {
+  const declarationIssue = {
+    number: 42,
+    title: 'Provider outage coordination',
+    state: 'OPEN',
+    labels: [],
+    body: 'No markers, no labels -- a permanent coordination issue.',
+  };
+  const excluded = classifyIssue(declarationIssue, {
+    issueStateByNumber: new Map(),
+    fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    providerOutageDeclarationTarget: 42,
+  });
+  assert.equal(excluded.orphan, false);
+  assert.equal(excluded.reason, 'provider_outage_target');
+
+  // A different issue number is unaffected by the same configured target.
+  const other = classifyIssue(
+    { ...declarationIssue, number: 43 },
+    {
+      issueStateByNumber: new Map(),
+      fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+      providerOutageDeclarationTarget: 42,
+    },
+  );
+  assert.equal(other.reason, 'orphan');
+});
+
+test('classifyIssue leaves the target issue as a normal orphan when providerOutageDeclarationTarget is absent', () => {
+  const declarationIssue = {
+    number: 42,
+    title: 'Provider outage coordination',
+    state: 'OPEN',
+    labels: [],
+    body: 'No markers, no labels -- a permanent coordination issue.',
+  };
+  const result = classifyIssue(declarationIssue, {
+    issueStateByNumber: new Map(),
+    fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+  });
+  assert.equal(result.reason, 'orphan');
+});
+
 test('classifyIssue accepts marker forms without colon', () => {
   const roadmap = classifyIssue(
     {
@@ -204,6 +247,45 @@ test('filterOrphanIssues excludes blocked labels and open blockers', async () =>
   assert.equal(result.orphans[0].number, 12);
   assert.equal(result.filtered.blocked_by_open_reference.length, 1);
   assert.equal(result.filtered.blocked_label.length, 1);
+});
+
+test('filterOrphanIssues excludes providerOutage.declarationTarget end-to-end (#2800)', async () => {
+  const issues = [
+    {
+      number: 50,
+      title: 'Provider outage coordination',
+      state: 'OPEN',
+      labels: [],
+      body: 'No markers, no labels -- a permanent coordination issue.',
+      url: 'https://example.com/50',
+    },
+    {
+      number: 51,
+      title: 'ordinary orphan',
+      state: 'OPEN',
+      labels: [],
+      body: '',
+      url: 'https://example.com/51',
+    },
+  ];
+
+  const configured = await filterOrphanIssues(issues, {
+    issueStateByNumber: new Map(),
+    fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    providerOutageDeclarationTarget: 50,
+  });
+  assert.equal(configured.orphans.length, 1);
+  assert.equal(configured.orphans[0].number, 51);
+  assert.equal(configured.filtered.provider_outage_target.length, 1);
+  assert.equal(configured.filtered.provider_outage_target[0].number, 50);
+
+  // Absent config: behavior is unchanged from today -- both are orphans.
+  const unconfigured = await filterOrphanIssues(issues, {
+    issueStateByNumber: new Map(),
+    fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+  });
+  assert.equal(unconfigured.orphans.length, 2);
+  assert.equal(unconfigured.filtered.provider_outage_target.length, 0);
 });
 
 test('filterOrphanIssues resolves configured blocked-label names (#1273)', async () => {


### PR DESCRIPTION
## Summary

`providerOutage.declarationTarget` names a permanent, adopter-authored
coordination issue that stays open indefinitely, is never claimed or
closed, and deliberately carries no roadmap-id/blocked-by marker or
blocking label of its own. `discover-orphan-filter.mts`'s
`classifyIssue` had no awareness of this config field, so such an
issue appeared in every `--autopilot` orphan scan, unscored, costing
a wasted A4.5 evaluation pass every Discover run for any adopter who
configures the feature.

Reads `providerOutage.declarationTarget` (via the already-normalized
`policy-helpers.mts` config) and excludes that exact issue number
from the orphan candidate set outright, checked first in
`classifyIssue` ahead of every marker/label check.

## Verification

- All 4 acceptance criteria from the issue satisfied (configured
  exclusion, absent-config unchanged behavior, unit test coverage,
  test-runner pass)
- `pnpm run typecheck`, `pnpm test` (5524/5524 pass), biome all clean
- Report-only critique fork found no functional/type-safety defects;
  applied its one accepted suggestion (reorder the new reason to the
  front of 4 parallel lists, matching its actual first-checked
  position in `classifyIssue`)

Closes #2800

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDJpTELrY2SnjHW9m5Aw7i