### PR TITLE
fix(idd-ci): document --watch --required non-block case

### DIFF
--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -351,11 +351,13 @@ condition below accounts for this.
   instead. That bare form still returns once every visible check
   reaches a terminal GitHub state, which is not the same as "safe to
   proceed" — a lone `CANCELLED` check with no same-producer successor
-  is one such terminal-but-`pending` case (#2714). All three watch
-  forms above only block, never decide: required-only scoping,
-  duplicate-name collapse, the no-required-checks route, and the
-  `ciWait.runningTimeout`/`generationTimeout` bound all stay with the
-  algorithm above — track elapsed time and apply its rerun-or-hold
+  is one such terminal-but-`pending` case (#2714). None of the three
+  watch forms above decides anything by itself — required-only
+  scoping, duplicate-name collapse, the no-required-checks route, and
+  the `ciWait.runningTimeout`/`generationTimeout` bound are all
+  interpretation-time concerns that stay with the algorithm above
+  regardless of which form blocked the wait — track elapsed time and
+  apply its rerun-or-hold
   decision if a watch outlasts it. Issue that blocking call with an
   execution-timeout override set at or near the calling tool's own
   execution-timeout ceiling, not the tool's default, which can
@@ -363,8 +365,8 @@ condition below accounts for this.
   tool-timeout kill of the watch call is not a CI verdict — re-issue
   the same blocking watch, keep accumulating elapsed time against the
   bound above, and do not fall back to `run_in_background` or another
-  detached/backgrounded mechanism just because of the kill. None of the
-  three watch forms above watches Copilot review state — see
+  detached/backgrounded mechanism just because of the kill. No watch
+  form above watches Copilot review state either — see
   `idd-advisory-wait.instructions.md`. A bare `sleep` may
   be sandboxed or blocked in some runtimes (preventive; no observed
   incident yet); a `run_in_background` Bash task or other

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -340,9 +340,16 @@ condition below accounts for this.
   completion, or background only if the topology is confirmed to route
   completion back to this turn; otherwise wait synchronously — block
   with `gh pr checks <pr-number> --watch --required` (works on a
-  fine-grained PAT; `gh run watch <run-id> --exit-status` does not).
-  Both only block, never decide: required-only scoping, duplicate-name
-  collapse, the no-required-checks route, and the
+  fine-grained PAT; `gh run watch <run-id> --exit-status` does not) —
+  **but only once** [Required-check discovery](#required-check-discovery)
+  has resolved `noRequiredChecksConfigured: false`. When it resolved
+  `true`, `--watch --required` returns immediately, non-blocking,
+  printing a "no required checks reported" message even while real CI
+  is still running — block with the bare
+  `gh pr checks <pr-number> --watch` (no `--required`) instead. Both
+  `--watch --required` and `gh run watch` only block, never decide:
+  required-only scoping, duplicate-name collapse, the no-required-checks
+  route, and the
   `ciWait.runningTimeout`/`generationTimeout` bound all stay with the
   algorithm above — track elapsed time and apply its rerun-or-hold
   decision if a watch outlasts it. Issue that blocking call with an
@@ -353,7 +360,8 @@ condition below accounts for this.
   the same blocking watch, keep accumulating elapsed time against the
   bound above, and do not fall back to `run_in_background` or another
   detached/backgrounded mechanism just because of the kill. Neither
-  watches Copilot review state — see
+  `--watch --required` nor `gh run watch` watches Copilot review state —
+  see
   `idd-advisory-wait.instructions.md`. A bare `sleep` may
   be sandboxed or blocked in some runtimes (preventive; no observed
   incident yet); a `run_in_background` Bash task or other

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -342,11 +342,12 @@ condition below accounts for this.
   with `gh pr checks <pr-number> --watch --required` (works on a
   fine-grained PAT; `gh run watch <run-id> --exit-status` does not) —
   **but only once** [Required-check discovery](#required-check-discovery)
-  has resolved `noRequiredChecksConfigured: false`. When it resolved
-  `true`, `--watch --required` returns immediately, non-blocking,
-  printing a "no required checks reported" message even while real CI
-  is still running — block with the bare
-  `gh pr checks <pr-number> --watch` (no `--required`) instead. Both
+  has resolved `noRequiredChecksConfigured: false`. When
+  `noRequiredChecksConfigured` resolved `true`, `--watch --required`
+  returns immediately, non-blocking, printing a "no required checks
+  reported" message even while real CI is still running — block with
+  the bare `gh pr checks <pr-number> --watch` (no `--required`)
+  instead. Both
   `--watch --required` and `gh run watch` only block, never decide:
   required-only scoping, duplicate-name collapse, the no-required-checks
   route, and the

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -342,15 +342,17 @@ condition below accounts for this.
   with `gh pr checks <pr-number> --watch --required` (works on a
   fine-grained PAT; `gh run watch <run-id> --exit-status` does not) —
   **but only once** [Required-check discovery](#required-check-discovery)
-  has resolved `noRequiredChecksConfigured: false`. When
-  `noRequiredChecksConfigured` resolved `true`, `--watch --required`
+  has resolved `noRequiredChecksConfigured: false`. When it has
+  resolved `noRequiredChecksConfigured: true`, `--watch --required`
   returns immediately, non-blocking, printing a "no required checks
   reported" message even while real CI is still running — block with
   the bare `gh pr checks <pr-number> --watch` (no `--required`)
-  instead. Both
-  `--watch --required` and `gh run watch` only block, never decide:
-  required-only scoping, duplicate-name collapse, the no-required-checks
-  route, and the
+  instead. That bare form still returns once every visible check
+  reaches a terminal GitHub state, which is not the same as "safe to
+  proceed" — a lone `CANCELLED` check with no same-producer successor
+  is one such terminal-but-`pending` case (#2714). All three watch
+  forms above only block, never decide: required-only scoping,
+  duplicate-name collapse, the no-required-checks route, and the
   `ciWait.runningTimeout`/`generationTimeout` bound all stay with the
   algorithm above — track elapsed time and apply its rerun-or-hold
   decision if a watch outlasts it. Issue that blocking call with an
@@ -360,9 +362,8 @@ condition below accounts for this.
   tool-timeout kill of the watch call is not a CI verdict — re-issue
   the same blocking watch, keep accumulating elapsed time against the
   bound above, and do not fall back to `run_in_background` or another
-  detached/backgrounded mechanism just because of the kill. Neither
-  `--watch --required` nor `gh run watch` watches Copilot review state —
-  see
+  detached/backgrounded mechanism just because of the kill. None of the
+  three watch forms above watches Copilot review state — see
   `idd-advisory-wait.instructions.md`. A bare `sleep` may
   be sandboxed or blocked in some runtimes (preventive; no observed
   incident yet); a `run_in_background` Bash task or other

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -342,9 +342,10 @@ condition below accounts for this.
   with `gh pr checks <pr-number> --watch --required` (works on a
   fine-grained PAT; `gh run watch <run-id> --exit-status` does not) —
   **but only once** [Required-check discovery](#required-check-discovery)
-  has resolved `noRequiredChecksConfigured: false`. When it has
-  resolved `noRequiredChecksConfigured: true`, `--watch --required`
-  returns immediately, non-blocking, printing a "no required checks
+  has resolved `noRequiredChecksConfigured: false`. When Required-check
+  discovery has instead resolved `noRequiredChecksConfigured: true`,
+  `--watch --required` returns immediately, non-blocking, printing a
+  "no required checks
   reported" message even while real CI is still running — block with
   the bare `gh pr checks <pr-number> --watch` (no `--required`)
   instead. That bare form still returns once every visible check

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -346,11 +346,13 @@ condition below accounts for this.
   instead. That bare form still returns once every visible check
   reaches a terminal GitHub state, which is not the same as "safe to
   proceed" — a lone `CANCELLED` check with no same-producer successor
-  is one such terminal-but-`pending` case (#2714). All three watch
-  forms above only block, never decide: required-only scoping,
-  duplicate-name collapse, the no-required-checks route, and the
-  `ciWait.runningTimeout`/`generationTimeout` bound all stay with the
-  algorithm above — track elapsed time and apply its rerun-or-hold
+  is one such terminal-but-`pending` case (#2714). None of the three
+  watch forms above decides anything by itself — required-only
+  scoping, duplicate-name collapse, the no-required-checks route, and
+  the `ciWait.runningTimeout`/`generationTimeout` bound are all
+  interpretation-time concerns that stay with the algorithm above
+  regardless of which form blocked the wait — track elapsed time and
+  apply its rerun-or-hold
   decision if a watch outlasts it. Issue that blocking call with an
   execution-timeout override set at or near the calling tool's own
   execution-timeout ceiling, not the tool's default, which can
@@ -358,8 +360,8 @@ condition below accounts for this.
   tool-timeout kill of the watch call is not a CI verdict — re-issue
   the same blocking watch, keep accumulating elapsed time against the
   bound above, and do not fall back to `run_in_background` or another
-  detached/backgrounded mechanism just because of the kill. None of the
-  three watch forms above watches Copilot review state — see
+  detached/backgrounded mechanism just because of the kill. No watch
+  form above watches Copilot review state either — see
   `idd-advisory-wait.instructions.md`. A bare `sleep` may
   be sandboxed or blocked in some runtimes (preventive; no observed
   incident yet); a `run_in_background` Bash task or other

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -337,9 +337,10 @@ condition below accounts for this.
   with `gh pr checks <pr-number> --watch --required` (works on a
   fine-grained PAT; `gh run watch <run-id> --exit-status` does not) —
   **but only once** [Required-check discovery](#required-check-discovery)
-  has resolved `noRequiredChecksConfigured: false`. When it has
-  resolved `noRequiredChecksConfigured: true`, `--watch --required`
-  returns immediately, non-blocking, printing a "no required checks
+  has resolved `noRequiredChecksConfigured: false`. When Required-check
+  discovery has instead resolved `noRequiredChecksConfigured: true`,
+  `--watch --required` returns immediately, non-blocking, printing a
+  "no required checks
   reported" message even while real CI is still running — block with
   the bare `gh pr checks <pr-number> --watch` (no `--required`)
   instead. That bare form still returns once every visible check

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -337,11 +337,12 @@ condition below accounts for this.
   with `gh pr checks <pr-number> --watch --required` (works on a
   fine-grained PAT; `gh run watch <run-id> --exit-status` does not) —
   **but only once** [Required-check discovery](#required-check-discovery)
-  has resolved `noRequiredChecksConfigured: false`. When it resolved
-  `true`, `--watch --required` returns immediately, non-blocking,
-  printing a "no required checks reported" message even while real CI
-  is still running — block with the bare
-  `gh pr checks <pr-number> --watch` (no `--required`) instead. Both
+  has resolved `noRequiredChecksConfigured: false`. When
+  `noRequiredChecksConfigured` resolved `true`, `--watch --required`
+  returns immediately, non-blocking, printing a "no required checks
+  reported" message even while real CI is still running — block with
+  the bare `gh pr checks <pr-number> --watch` (no `--required`)
+  instead. Both
   `--watch --required` and `gh run watch` only block, never decide:
   required-only scoping, duplicate-name collapse, the no-required-checks
   route, and the

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -335,9 +335,16 @@ condition below accounts for this.
   completion, or background only if the topology is confirmed to route
   completion back to this turn; otherwise wait synchronously — block
   with `gh pr checks <pr-number> --watch --required` (works on a
-  fine-grained PAT; `gh run watch <run-id> --exit-status` does not).
-  Both only block, never decide: required-only scoping, duplicate-name
-  collapse, the no-required-checks route, and the
+  fine-grained PAT; `gh run watch <run-id> --exit-status` does not) —
+  **but only once** [Required-check discovery](#required-check-discovery)
+  has resolved `noRequiredChecksConfigured: false`. When it resolved
+  `true`, `--watch --required` returns immediately, non-blocking,
+  printing a "no required checks reported" message even while real CI
+  is still running — block with the bare
+  `gh pr checks <pr-number> --watch` (no `--required`) instead. Both
+  `--watch --required` and `gh run watch` only block, never decide:
+  required-only scoping, duplicate-name collapse, the no-required-checks
+  route, and the
   `ciWait.runningTimeout`/`generationTimeout` bound all stay with the
   algorithm above — track elapsed time and apply its rerun-or-hold
   decision if a watch outlasts it. Issue that blocking call with an
@@ -348,7 +355,8 @@ condition below accounts for this.
   the same blocking watch, keep accumulating elapsed time against the
   bound above, and do not fall back to `run_in_background` or another
   detached/backgrounded mechanism just because of the kill. Neither
-  watches Copilot review state — see
+  `--watch --required` nor `gh run watch` watches Copilot review state —
+  see
   `idd-advisory-wait.instructions.md`. A bare `sleep` may
   be sandboxed or blocked in some runtimes (preventive; no observed
   incident yet); a `run_in_background` Bash task or other

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -337,15 +337,17 @@ condition below accounts for this.
   with `gh pr checks <pr-number> --watch --required` (works on a
   fine-grained PAT; `gh run watch <run-id> --exit-status` does not) —
   **but only once** [Required-check discovery](#required-check-discovery)
-  has resolved `noRequiredChecksConfigured: false`. When
-  `noRequiredChecksConfigured` resolved `true`, `--watch --required`
+  has resolved `noRequiredChecksConfigured: false`. When it has
+  resolved `noRequiredChecksConfigured: true`, `--watch --required`
   returns immediately, non-blocking, printing a "no required checks
   reported" message even while real CI is still running — block with
   the bare `gh pr checks <pr-number> --watch` (no `--required`)
-  instead. Both
-  `--watch --required` and `gh run watch` only block, never decide:
-  required-only scoping, duplicate-name collapse, the no-required-checks
-  route, and the
+  instead. That bare form still returns once every visible check
+  reaches a terminal GitHub state, which is not the same as "safe to
+  proceed" — a lone `CANCELLED` check with no same-producer successor
+  is one such terminal-but-`pending` case (#2714). All three watch
+  forms above only block, never decide: required-only scoping,
+  duplicate-name collapse, the no-required-checks route, and the
   `ciWait.runningTimeout`/`generationTimeout` bound all stay with the
   algorithm above — track elapsed time and apply its rerun-or-hold
   decision if a watch outlasts it. Issue that blocking call with an
@@ -355,9 +357,8 @@ condition below accounts for this.
   tool-timeout kill of the watch call is not a CI verdict — re-issue
   the same blocking watch, keep accumulating elapsed time against the
   bound above, and do not fall back to `run_in_background` or another
-  detached/backgrounded mechanism just because of the kill. Neither
-  `--watch --required` nor `gh run watch` watches Copilot review state —
-  see
+  detached/backgrounded mechanism just because of the kill. None of the
+  three watch forms above watches Copilot review state — see
   `idd-advisory-wait.instructions.md`. A bare `sleep` may
   be sandboxed or blocked in some runtimes (preventive; no observed
   incident yet); a `run_in_background` Bash task or other


### PR DESCRIPTION
## Summary

Wake-up discipline presented `gh pr checks --watch --required` as
the canonical blocking wait for CI with no caveat, but the same
file's Required-check discovery section already treats
`noRequiredChecksConfigured` as a real, intentional state. Confirmed
live: `--watch --required` returns immediately, non-blocking,
printing "no required checks reported" even while real CI is still
running, on a repository with no required checks configured for the
PR's base branch. A session following Wake-up discipline literally,
without cross-referencing Required-check discovery first, could read
the instant return as "nothing to wait for" and move past unfinished
CI.

Adds the caveat, names the fallback (bare `--watch`, no
`--required`), and cross-references Required-check discovery so
resolving `noRequiredChecksConfigured` before choosing a wait command
is the documented path.

## Verification

- All 3 acceptance criteria from the issue satisfied
- `node scripts/sync-docs.mjs --apply` (mirror in sync)
- `node scripts/audit-docs.mjs --check` (pass; `audit/sync-manifest.json`
  untouched)
- `pnpm run typecheck`, `pnpm test` (5524/5524 pass), markdownlint,
  dprint, cspell, `audit-code-span-wrap.mjs` all clean
- Report-only critique fork found no blocking issues; applied all 3
  of its clarity/precision/style suggestions (disambiguate "Both"/
  "Neither" now that a third wait command is named, match the exact
  "no required checks reported" CLI message text, un-bold the caveat
  body to match the file's existing convention)

Closes #2796

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDJpTELrY2SnjHW9m5Aw7i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated CI monitoring guidance to use required-check monitoring when required checks are configured.
  - When no required checks are configured, guidance now uses general CI monitoring so running checks remain visible.
  - Clarified that CI watch commands do not monitor Copilot review status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->