### PR TITLE
fix(idd-ci): scope reissue-on-timeout guidance to remote polling

### DIFF
--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -352,7 +352,15 @@ condition below accounts for this.
   tool-timeout kill of the watch call is not a CI verdict — re-issue
   the same blocking watch, keep accumulating elapsed time against the
   bound above, and do not fall back to `run_in_background` or another
-  detached/backgrounded mechanism just because of the kill. Neither
+  detached/backgrounded mechanism just because of the kill. This
+  reissue-on-timeout guidance is scoped to an idempotent, read-only
+  remote poll like the watch call above. Never blindly re-issue a
+  heavy, non-idempotent local command (a full build, test, or lint run)
+  that auto-backgrounds past the tool's default timeout — check whether
+  the prior invocation is still running first (e.g. via the calling
+  tool's own background-task listing or equivalent), then await/reap it
+  or reuse its eventual result rather than starting a second concurrent
+  instance. Neither
   watches Copilot review state — see
   `idd-advisory-wait.instructions.md`. A bare `sleep` may
   be sandboxed or blocked in some runtimes (preventive; no observed

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -355,12 +355,14 @@ condition below accounts for this.
   detached/backgrounded mechanism just because of the kill. This
   reissue-on-timeout guidance is scoped to an idempotent, read-only
   remote poll like the watch call above. Never blindly re-issue a
-  heavy, non-idempotent local command (a full build, test, or lint run)
-  that auto-backgrounds past the tool's default timeout — check whether
-  the prior invocation is still running first (e.g. via the calling
-  tool's own background-task listing or equivalent), then await/reap it
-  or reuse its eventual result rather than starting a second concurrent
-  instance. Neither
+  heavy local command (a full build, test, or lint run) that
+  auto-backgrounds past the tool's default timeout — being idempotent
+  does not make it safe to run twice at once; two concurrent instances
+  can still collide on shared output (e.g. a `coverage/` directory).
+  Check whether the prior invocation is still running first (e.g. via
+  the calling tool's own background-task listing or equivalent), then
+  await/reap it or reuse its eventual result rather than starting a
+  second concurrent instance. Neither blocking-watch command
   watches Copilot review state — see
   `idd-advisory-wait.instructions.md`. A bare `sleep` may
   be sandboxed or blocked in some runtimes (preventive; no observed

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -350,12 +350,14 @@ condition below accounts for this.
   detached/backgrounded mechanism just because of the kill. This
   reissue-on-timeout guidance is scoped to an idempotent, read-only
   remote poll like the watch call above. Never blindly re-issue a
-  heavy, non-idempotent local command (a full build, test, or lint run)
-  that auto-backgrounds past the tool's default timeout — check whether
-  the prior invocation is still running first (e.g. via the calling
-  tool's own background-task listing or equivalent), then await/reap it
-  or reuse its eventual result rather than starting a second concurrent
-  instance. Neither
+  heavy local command (a full build, test, or lint run) that
+  auto-backgrounds past the tool's default timeout — being idempotent
+  does not make it safe to run twice at once; two concurrent instances
+  can still collide on shared output (e.g. a `coverage/` directory).
+  Check whether the prior invocation is still running first (e.g. via
+  the calling tool's own background-task listing or equivalent), then
+  await/reap it or reuse its eventual result rather than starting a
+  second concurrent instance. Neither blocking-watch command
   watches Copilot review state — see
   `idd-advisory-wait.instructions.md`. A bare `sleep` may
   be sandboxed or blocked in some runtimes (preventive; no observed

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -347,7 +347,15 @@ condition below accounts for this.
   tool-timeout kill of the watch call is not a CI verdict — re-issue
   the same blocking watch, keep accumulating elapsed time against the
   bound above, and do not fall back to `run_in_background` or another
-  detached/backgrounded mechanism just because of the kill. Neither
+  detached/backgrounded mechanism just because of the kill. This
+  reissue-on-timeout guidance is scoped to an idempotent, read-only
+  remote poll like the watch call above. Never blindly re-issue a
+  heavy, non-idempotent local command (a full build, test, or lint run)
+  that auto-backgrounds past the tool's default timeout — check whether
+  the prior invocation is still running first (e.g. via the calling
+  tool's own background-task listing or equivalent), then await/reap it
+  or reuse its eventual result rather than starting a second concurrent
+  instance. Neither
   watches Copilot review state — see
   `idd-advisory-wait.instructions.md`. A bare `sleep` may
   be sandboxed or blocked in some runtimes (preventive; no observed


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

`idd-ci.instructions.md`'s Wake-up discipline section told a worker to
"re-issue the same blocking watch" after a tool-timeout kill, without
scoping that guidance to its actual worked example -- an idempotent,
read-only remote poll (`gh pr checks --watch`). A worker applied the
same reflexive-reissue pattern to a heavy, non-idempotent local command
(a backgrounded `pnpm run test` run) instead, colliding two concurrent
instances on the same shared `coverage/` output and producing a test
failure unrelated to any real code defect.

This PR narrows the reissue-on-timeout sentence to state explicitly
that it applies only to an idempotent, read-only remote poll, and adds
an adjacent rule: before re-issuing a heavy local build/test/lint
command that auto-backgrounds past a tool's default timeout, check
whether the prior invocation is still running, and either await/reap
it or reuse its eventual result instead of starting a second
concurrent instance.

Only the canonical `idd-template/.github/instructions/idd-ci.instructions.md`
source was edited; the `.github/instructions/idd-ci.instructions.md`
mirror was regenerated with `node scripts/sync-docs.mjs --apply --force`
(this pair syncs in exact mode).

## Linked issue

Closes #2798

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`idd-ci-lite.instructions.md`'s own condensed Wake-up discipline section
has no reissue-on-timeout text at all, so it needs no matching edit.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdQ5SPdFLaDGus5PNdBUhw
