### PR TITLE
fix(discover-roadmap-graph): collapse same-body duplicate mentions

### DIFF
--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -436,8 +436,12 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
     visitedIssuePaths.add(visitKey);
     recordNode(issue, path);
     const references = await getReferences(issue);
-    const seenSourceTargets = new Set();
-    const seenSourceEdgeKeys = new Set();
+    // Per visit, not graph-global: the same issue can be visited again on
+    // another provenance path. A later same-triple mention in this body
+    // (prose + standalone `Blocked by #N`, or two identical task-list
+    // lines) collapses to the first edge (#2799). A remaining
+    // same-source different-relationship pair is still a duplicate.
+    const seenSourceTriples = new Set();
     const firstReferenceBySourceTarget = new Map();
     for (const reference of references) {
       const edge = {
@@ -446,23 +450,16 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
         relationship: reference.relationship,
         evidence: reference.evidence,
       };
-      const edgeKey = buildEdgeKey(edge);
-      if (seenSourceEdgeKeys.has(edgeKey)) {
-        recordDuplicateReference(edge, edge);
+      const tripleKey = `${edge.source}:${edge.target}:${edge.relationship}`;
+      if (seenSourceTriples.has(tripleKey)) {
         continue;
       }
-      seenSourceEdgeKeys.add(edgeKey);
+      seenSourceTriples.add(tripleKey);
+      const edgeKey = buildEdgeKey(edge);
       if (!edgeKeys.has(edgeKey)) {
         edgeKeys.add(edgeKey);
         edges.push(edge);
         const sourceTargetKey = `${edge.source}:${edge.target}`;
-        if (seenSourceTargets.has(sourceTargetKey)) {
-          recordDuplicateReference(
-            edge,
-            firstReferenceBySourceTarget.get(sourceTargetKey) ?? edge,
-          );
-        }
-        seenSourceTargets.add(sourceTargetKey);
         const firstReference =
           firstReferenceBySourceTarget.get(sourceTargetKey);
         if (firstReference) {

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -938,8 +938,12 @@ export async function enumerateRoadmapGraph(
 
     recordNode(issue, path);
     const references = await getReferences(issue);
-    const seenSourceTargets = new Set<string>();
-    const seenSourceEdgeKeys = new Set<string>();
+    // Per visit, not graph-global: the same issue can be visited again on
+    // another provenance path. A later same-triple mention in this body
+    // (prose + standalone `Blocked by #N`, or two identical task-list
+    // lines) collapses to the first edge (#2799). A remaining
+    // same-source different-relationship pair is still a duplicate.
+    const seenSourceTriples = new Set<string>();
     const firstReferenceBySourceTarget = new Map<string, RoadmapGraphEdge>();
 
     for (const reference of references) {
@@ -949,25 +953,17 @@ export async function enumerateRoadmapGraph(
         relationship: reference.relationship,
         evidence: reference.evidence,
       };
-      const edgeKey = buildEdgeKey(edge);
-      if (seenSourceEdgeKeys.has(edgeKey)) {
-        recordDuplicateReference(edge, edge);
+      const tripleKey = `${edge.source}:${edge.target}:${edge.relationship}`;
+      if (seenSourceTriples.has(tripleKey)) {
         continue;
       }
-      seenSourceEdgeKeys.add(edgeKey);
+      seenSourceTriples.add(tripleKey);
+      const edgeKey = buildEdgeKey(edge);
       if (!edgeKeys.has(edgeKey)) {
         edgeKeys.add(edgeKey);
         edges.push(edge);
 
         const sourceTargetKey = `${edge.source}:${edge.target}`;
-        if (seenSourceTargets.has(sourceTargetKey)) {
-          recordDuplicateReference(
-            edge,
-            firstReferenceBySourceTarget.get(sourceTargetKey) ?? edge,
-          );
-        }
-        seenSourceTargets.add(sourceTargetKey);
-
         const firstReference =
           firstReferenceBySourceTarget.get(sourceTargetKey);
         if (firstReference) {

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -1041,7 +1041,7 @@ test('keeps a back-edge from a closed ROADMAP node as a blocking cycle', async (
   ]);
 });
 
-test('counts exact duplicate references from the same issue body', async () => {
+test('collapses exact same-triple mentions from the same issue body', async () => {
   const issues = new Map([
     [320, roadmapIssue(320, '- [ ] #321\n- [ ] #321', 'root-roadmap')],
     [321, executionIssue(321, 'leaf execution')],
@@ -1059,15 +1059,65 @@ test('counts exact duplicate references from the same issue body', async () => {
       evidence: '- [ ] #321',
     },
   ]);
-  assert.deepEqual(graph.diagnostics.duplicateReferences, [
+  assert.deepEqual(graph.diagnostics.duplicateReferences, []);
+});
+
+test('collapses same-body Blocked-by prose and standalone line to one dependency', async () => {
+  // #2799: issue-authoring routinely narrates why a dependency exists and
+  // restates it as a standalone `Blocked by #N` line. Both are `dependency`
+  // with different evidence; that must not emit duplicateReferences.
+  const issues = new Map([
+    [330, roadmapIssue(330, '- [ ] #331', 'blocked-by-double-mention-roadmap')],
+    [
+      331,
+      executionIssue(
+        331,
+        'sessions follow when they hit the condition (Blocked by #332)\n\nBlocked by #332',
+      ),
+    ],
+    [332, executionIssue(332, 'closed dependency', 'closed')],
+  ]);
+
+  const graph = await enumerateRoadmapGraph(330, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+
+  const dependencyEdges = graph.edges.filter(
+    (edge) =>
+      edge.source === 331 &&
+      edge.target === 332 &&
+      edge.relationship === 'dependency',
+  );
+  assert.deepEqual(dependencyEdges, [
     {
-      source: 320,
-      target: 321,
-      relationship: 'task-list',
-      evidence: '- [ ] #321',
-      firstSeenFrom: 320,
+      source: 331,
+      target: 332,
+      relationship: 'dependency',
+      evidence: 'sessions follow when they hit the condition (Blocked by #332)',
     },
   ]);
+  assert.deepEqual(graph.diagnostics.duplicateReferences, []);
+});
+
+test('does not flag two sources that share a Blocked-by target as a duplicate', async () => {
+  const issues = new Map([
+    [340, roadmapIssue(340, '- [ ] #341\n- [ ] #342', 'blocked-by-diamond')],
+    [341, executionIssue(341, 'Blocked by #343')],
+    [342, executionIssue(342, 'Blocked by #343')],
+    [343, executionIssue(343, 'shared dependency', 'closed')],
+  ]);
+
+  const graph = await enumerateRoadmapGraph(340, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+
+  assert.equal(
+    graph.edges.filter(
+      (edge) => edge.target === 343 && edge.relationship === 'dependency',
+    ).length,
+    2,
+  );
+  assert.deepEqual(graph.diagnostics.duplicateReferences, []);
 });
 
 test('keeps traversing descendants when a shared node is reached through multiple paths', async () => {


### PR DESCRIPTION
# Summary

Collapse same-body `(source, target, relationship)` mentions in
`discover-roadmap-graph` so a child issue that narrates a dependency
and restates it as a standalone `Blocked by` line no longer emits a
`duplicateReferences` diagnostic. Same-source mixed-relationship pairs
(task-list plus `Refs`) stay flagged; two distinct sources that share
a target stay a diamond, not a duplicate.

## Linked issue

Closes #2799

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Issue AC2 says a shared target from two distinct sources should still
emit `duplicateReferences`. Live `visitIssue` bookkeeping is
per-source, so that case is a diamond (already covered by the
multi-path test) and must stay non-duplicate. This PR maps AC2 to
the genuine same-source mixed-relationship case (task-list + `Refs`),
which still flags, and collapses only same-triple same-body repeats.

Issue-authoring routinely writes a narrative `Blocked by` mention plus
a standalone dependency line. `visitIssue` keyed those as
`source:target` regardless of evidence, so the second mention looked
like a duplicate. This change collapses the same relationship triple
onto the first edge and leaves A1.5 audit-execute policy untouched.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

Changed paths: `src/scripts/discover-roadmap-graph.mts`,
`scripts/discover-roadmap-graph.mjs` (generated),
`tests/discover-roadmap-graph.test.mts`.

## Verification

- [ ] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

Also ran the repository `pre-push-validate` chain (biome, dprint,
markdownlint, cspell, audit-code-span-wrap, tests, `build:check`,
token-cost-report).

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

