### PR TITLE
docs(idd-claim): name hold subjects in verification copy

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -361,9 +361,11 @@ race-safe checks below:
    forced-handoff, where steps 1–4 see nothing to disagree about (both
    `{claim-id}`s genuinely match). No marker posted: treat as passed.
 
-6. Re-fetch labels/paginated owner log; a hold contests this claim. If active and
-   step 5 passed, release/verify `unclaimed-by`, then use `(A0-T)`, not A5(c).
-   If step 5 failed, retain it; never release on nonce mismatch.
+6. Re-fetch labels and the paginated owner-marker log. If an authoring
+   hold is active on this issue, it contests this claim: when step 5
+   passed, post and verify `unclaimed-by`, then take the
+   already-claimed/Discover fallback (A0-T stops) — never A5(c); when
+   step 5 failed, keep the claim and never release on a nonce mismatch.
 
 If any check fails, treat the claim as contested.
 
@@ -407,21 +409,20 @@ rule 7). Adopt **both fields verbatim** as your own `{agent-id}` /
 fresh claim-id or keeping your own native agent-id; no separate
 `claimed-by supersedes: none` post is required for the transfer itself.
 
-**Adopt-verbatim is still an activation**: immediately before every activation
-nonce, including this nonce-only handoff, repeat the label/authoring-state
-guard above.
-Post your own
+**Adopt-verbatim is still an activation**: immediately before this nonce,
+repeat the label/authoring-state guard above. Post your own
 [activation-nonce marker](#activation-nonce-format) for `new-claim-id`
 too (see the
-[rationale](../../docs/idd-design-rationale.md#activation-nonce-why-a-separate-marker-and-what-stays-deferred)
-for why this path needs its own nonce). Verify it the same way step 5
-above does: wait `claim.verifySettleDelay`, recompute the nonce winner
-for `new-claim-id`, and confirm it is yours — the only nonce check
-that fires here, since posting no `claimed-by` means this path never
-enters _Claim verification_ above. After nonce verification, repeat that
-guard; on mismatch or either hold, re-resolve pair/nonce before fallback. If
-the pair still owns claim and nonce (or none competes), post/verify
-`unclaimed-by`; else leave successor claim.
+[rationale](../../docs/idd-design-rationale.md#activation-nonce-why-a-separate-marker-and-what-stays-deferred)).
+Verify it the same way step 5 above does: wait `claim.verifySettleDelay`,
+recompute the nonce winner for `new-claim-id`, and confirm it is yours —
+the only nonce check here (this path posts no `claimed-by`). After nonce
+verification, repeat that guard. On nonce mismatch or an incomplete or
+current authoring hold, re-resolve the adopted pair and nonce; if that
+pair still owns claim and nonce (or none competes), post/verify
+`unclaimed-by` for the adopted pair (this session cannot keep that
+activation); else leave the successor claim; then take the
+already-claimed/Discover fallback (A0-T stops).
 
 Always use the assigned pair verbatim: never invent `claimed-by` or reuse the
 displaced `{claim-id}`. A native agent-id that is not the assigned value fails

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -356,9 +356,11 @@ race-safe checks below:
    forced-handoff, where steps 1–4 see nothing to disagree about (both
    `{claim-id}`s genuinely match). No marker posted: treat as passed.
 
-6. Re-fetch labels/paginated owner log; a hold contests this claim. If active and
-   step 5 passed, release/verify `unclaimed-by`, then use `(A0-T)`, not A5(c).
-   If step 5 failed, retain it; never release on nonce mismatch.
+6. Re-fetch labels and the paginated owner-marker log. If an authoring
+   hold is active on this issue, it contests this claim: when step 5
+   passed, post and verify `unclaimed-by`, then take the
+   already-claimed/Discover fallback (A0-T stops) — never A5(c); when
+   step 5 failed, keep the claim and never release on a nonce mismatch.
 
 If any check fails, treat the claim as contested.
 
@@ -402,21 +404,20 @@ rule 7). Adopt **both fields verbatim** as your own `{agent-id}` /
 fresh claim-id or keeping your own native agent-id; no separate
 `claimed-by supersedes: none` post is required for the transfer itself.
 
-**Adopt-verbatim is still an activation**: immediately before every activation
-nonce, including this nonce-only handoff, repeat the label/authoring-state
-guard above.
-Post your own
+**Adopt-verbatim is still an activation**: immediately before this nonce,
+repeat the label/authoring-state guard above. Post your own
 [activation-nonce marker](#activation-nonce-format) for `new-claim-id`
 too (see the
-[rationale](../../docs/idd-design-rationale.md#activation-nonce-why-a-separate-marker-and-what-stays-deferred)
-for why this path needs its own nonce). Verify it the same way step 5
-above does: wait `claim.verifySettleDelay`, recompute the nonce winner
-for `new-claim-id`, and confirm it is yours — the only nonce check
-that fires here, since posting no `claimed-by` means this path never
-enters _Claim verification_ above. After nonce verification, repeat that
-guard; on mismatch or either hold, re-resolve pair/nonce before fallback. If
-the pair still owns claim and nonce (or none competes), post/verify
-`unclaimed-by`; else leave successor claim.
+[rationale](../../docs/idd-design-rationale.md#activation-nonce-why-a-separate-marker-and-what-stays-deferred)).
+Verify it the same way step 5 above does: wait `claim.verifySettleDelay`,
+recompute the nonce winner for `new-claim-id`, and confirm it is yours —
+the only nonce check here (this path posts no `claimed-by`). After nonce
+verification, repeat that guard. On nonce mismatch or an incomplete or
+current authoring hold, re-resolve the adopted pair and nonce; if that
+pair still owns claim and nonce (or none competes), post/verify
+`unclaimed-by` for the adopted pair (this session cannot keep that
+activation); else leave the successor claim; then take the
+already-claimed/Discover fallback (A0-T stops).
 
 Always use the assigned pair verbatim: never invent `claimed-by` or reuse the
 displaced `{claim-id}`. A native agent-id that is not the assigned value fails


### PR DESCRIPTION
# Summary

Rewrite two half-named clauses in Claim verification so a cold read
names the authoring hold, the already-claimed/Discover fallback
(A0-T stops), and which pair `unclaimed-by` releases.

Canonical source: `idd-template/.github/instructions/idd-claim.instructions.md`.
Generated mirror: `.github/instructions/idd-claim.instructions.md`.
Net growth +131 bytes; `bundle-discovery` `limitBytes` unchanged.

## Linked issue

Closes #2774

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Step 6 said "If active" and "use `(A0-T)`", which treated Discover's
explicit-target shortcut as an action. The adopt-verbatim walk-away
said "either hold" and "before fallback" without naming incomplete vs
current holds or the adopted pair. Sibling tracks of the same roadmap
edit the same bundle, so the rewrite stays under a 150-byte cap.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

Changed files:

- `.github/instructions/idd-claim.instructions.md`
- `idd-template/.github/instructions/idd-claim.instructions.md`

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

Also: `grep -c "If active"`, `use \`(A0-T)\``, `"either hold"`, and
`"before fallback"` are 0; step 6 contains `stop`.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved claim verification by refreshing claim labels and ownership activity before completing verification.
  - Claims are now preserved when verification detects a nonce mismatch.
  - Improved handling of active authoring holds during claim release, discovery, and handoff workflows.
  - Forced handoffs now re-check claim state during activation and verification, resolving or releasing claims when conditions change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->