### PR TITLE
feat(worktree-guard): add opt-in base-branch refusal

### DIFF
--- a/.githooks/_idd-worktree-guard.sh
+++ b/.githooks/_idd-worktree-guard.sh
@@ -114,7 +114,7 @@ _IDD_WTG_EOF_
         printf 'IDD worktree guard: refusing to %s directly on "%s" from the primary worktree (%s).\n' \
           "$action" "$branch" "$repo_root" >&2
         printf 'worktreeGuard.refuseBaseBranchCommits is enabled: implementation work must go\n' >&2
-        printf 'through B1 (create a sibling worktree on an implementation branch) before any commit.\n' >&2
+        printf 'through B1 (create a sibling worktree on an implementation branch) first.\n' >&2
         printf 'See B1 in .github/instructions/idd-work.instructions.md.\n' >&2
         printf '(To bypass intentionally, re-run the git command with --no-verify.)\n' >&2
         return 1

--- a/.githooks/_idd-worktree-guard.sh
+++ b/.githooks/_idd-worktree-guard.sh
@@ -9,6 +9,18 @@
 # branch (issue/* or roadmap-audit/*), because B1 requires that work to
 # live in a sibling worktree. Run git with --no-verify to bypass it
 # intentionally.
+#
+# By default the guard does NOT refuse a commit/push made from the
+# primary worktree while HEAD is on the repository's own base branch
+# (e.g. a session that skips B1 entirely and commits directly on
+# `developmentBranch`) -- only the implementation-branch patterns above
+# are covered. Set the separate opt-in
+# `worktreeGuard.refuseBaseBranchCommits: true` to also refuse that
+# case (#2801). It compares HEAD against the configured
+# `developmentBranch` only -- this pure-POSIX-sh hook has no network
+# access to resolve the live GitHub default branch the way
+# `idd-work.instructions.md`'s B1 does, so an absent `developmentBranch`
+# leaves this stricter check a no-op even when the opt-in is set.
 
 idd_worktree_guard_check() {
   # $1: human-readable action word ("commit" or "push").
@@ -84,6 +96,31 @@ _IDD_WTG_EOF_
   # roadmap-audit/* when the key is absent. (A detached HEAD, or an
   # unborn HEAD, reports "HEAD" here and never matches.)
   [ -n "$branch" ] && [ "$branch" != "HEAD" ] || return 0
+
+  # Opt-in stricter mode (#2801): also refuse a commit/push while HEAD
+  # is on the configured base branch itself. `developmentBranch` is a
+  # top-level config key, not nested under worktreeGuard, so it is
+  # read from the full compact document, not guard_body.
+  case "$guard_body" in
+    *'"refuseBaseBranchCommits":true'*)
+      development_branch=''
+      case "$compact" in
+        *'"developmentBranch":"'*)
+          dev_raw=${compact#*'"developmentBranch":"'}
+          development_branch=${dev_raw%%\"*}
+          ;;
+      esac
+      if [ -n "$development_branch" ] && [ "$branch" = "$development_branch" ]; then
+        printf 'IDD worktree guard: refusing to %s directly on "%s" from the primary worktree (%s).\n' \
+          "$action" "$branch" "$repo_root" >&2
+        printf 'worktreeGuard.refuseBaseBranchCommits is enabled: implementation work must go\n' >&2
+        printf 'through B1 (create a sibling worktree on an implementation branch) before any commit.\n' >&2
+        printf 'See B1 in .github/instructions/idd-work.instructions.md.\n' >&2
+        printf '(To bypass intentionally, re-run the git command with --no-verify.)\n' >&2
+        return 1
+      fi
+      ;;
+  esac
 
   patterns='issue/* roadmap-audit/*'
   case "$guard_body" in

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -205,6 +205,14 @@ not continue to B2 from the primary worktree. Repair by removing the
 misplaced branch (after confirming no work is lost) and recreating the
 sibling worktree through the Worktree creation steps above.
 
+The optional local `_idd-worktree-guard.sh` hook (`worktreeGuard.enabled:
+true`) automates part of this self-check by refusing a commit/push from
+the primary worktree while HEAD matches an implementation-branch pattern
+(default `issue/*`, `roadmap-audit/*`). By itself it does **not** catch a
+session that skips B1 entirely and commits directly on the base branch —
+set the separate `worktreeGuard.refuseBaseBranchCommits: true` opt-in
+(#2801) to also refuse that case.
+
 If WorkTrunk reports its `Cannot change directory — shell integration
 installed but not active` diagnostic, re-verify the current working
 directory on every later command — see

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -205,13 +205,14 @@ not continue to B2 from the primary worktree. Repair by removing the
 misplaced branch (after confirming no work is lost) and recreating the
 sibling worktree through the Worktree creation steps above.
 
-The optional local `_idd-worktree-guard.sh` hook (`worktreeGuard.enabled:
-true`) automates part of this self-check by refusing a commit/push from
-the primary worktree while HEAD matches an implementation-branch pattern
-(default `issue/*`, `roadmap-audit/*`). By itself it does **not** catch a
-session that skips B1 entirely and commits directly on the base branch —
-set the separate `worktreeGuard.refuseBaseBranchCommits: true` opt-in
-(#2801) to also refuse that case.
+The optional local `_idd-worktree-guard.sh` hook (enabled via
+`worktreeGuard.enabled: true`) automates part of this self-check by
+refusing a commit/push from the primary worktree while HEAD matches an
+implementation-branch pattern (default `issue/*`, `roadmap-audit/*`).
+By itself it does **not** catch a session that skips B1 entirely and
+commits directly on the base branch — set the separate
+`worktreeGuard.refuseBaseBranchCommits: true` opt-in (#2801) to also
+refuse that case.
 
 If WorkTrunk reports its `Cannot change directory — shell integration
 installed but not active` diagnostic, re-verify the current working

--- a/idd-template/.githooks/_idd-worktree-guard.sh
+++ b/idd-template/.githooks/_idd-worktree-guard.sh
@@ -114,7 +114,7 @@ _IDD_WTG_EOF_
         printf 'IDD worktree guard: refusing to %s directly on "%s" from the primary worktree (%s).\n' \
           "$action" "$branch" "$repo_root" >&2
         printf 'worktreeGuard.refuseBaseBranchCommits is enabled: implementation work must go\n' >&2
-        printf 'through B1 (create a sibling worktree on an implementation branch) before any commit.\n' >&2
+        printf 'through B1 (create a sibling worktree on an implementation branch) first.\n' >&2
         printf 'See B1 in .github/instructions/idd-work.instructions.md.\n' >&2
         printf '(To bypass intentionally, re-run the git command with --no-verify.)\n' >&2
         return 1

--- a/idd-template/.githooks/_idd-worktree-guard.sh
+++ b/idd-template/.githooks/_idd-worktree-guard.sh
@@ -9,6 +9,18 @@
 # branch (issue/* or roadmap-audit/*), because B1 requires that work to
 # live in a sibling worktree. Run git with --no-verify to bypass it
 # intentionally.
+#
+# By default the guard does NOT refuse a commit/push made from the
+# primary worktree while HEAD is on the repository's own base branch
+# (e.g. a session that skips B1 entirely and commits directly on
+# `developmentBranch`) -- only the implementation-branch patterns above
+# are covered. Set the separate opt-in
+# `worktreeGuard.refuseBaseBranchCommits: true` to also refuse that
+# case (#2801). It compares HEAD against the configured
+# `developmentBranch` only -- this pure-POSIX-sh hook has no network
+# access to resolve the live GitHub default branch the way
+# `idd-work.instructions.md`'s B1 does, so an absent `developmentBranch`
+# leaves this stricter check a no-op even when the opt-in is set.
 
 idd_worktree_guard_check() {
   # $1: human-readable action word ("commit" or "push").
@@ -84,6 +96,31 @@ _IDD_WTG_EOF_
   # roadmap-audit/* when the key is absent. (A detached HEAD, or an
   # unborn HEAD, reports "HEAD" here and never matches.)
   [ -n "$branch" ] && [ "$branch" != "HEAD" ] || return 0
+
+  # Opt-in stricter mode (#2801): also refuse a commit/push while HEAD
+  # is on the configured base branch itself. `developmentBranch` is a
+  # top-level config key, not nested under worktreeGuard, so it is
+  # read from the full compact document, not guard_body.
+  case "$guard_body" in
+    *'"refuseBaseBranchCommits":true'*)
+      development_branch=''
+      case "$compact" in
+        *'"developmentBranch":"'*)
+          dev_raw=${compact#*'"developmentBranch":"'}
+          development_branch=${dev_raw%%\"*}
+          ;;
+      esac
+      if [ -n "$development_branch" ] && [ "$branch" = "$development_branch" ]; then
+        printf 'IDD worktree guard: refusing to %s directly on "%s" from the primary worktree (%s).\n' \
+          "$action" "$branch" "$repo_root" >&2
+        printf 'worktreeGuard.refuseBaseBranchCommits is enabled: implementation work must go\n' >&2
+        printf 'through B1 (create a sibling worktree on an implementation branch) before any commit.\n' >&2
+        printf 'See B1 in .github/instructions/idd-work.instructions.md.\n' >&2
+        printf '(To bypass intentionally, re-run the git command with --no-verify.)\n' >&2
+        return 1
+      fi
+      ;;
+  esac
 
   patterns='issue/* roadmap-audit/*'
   case "$guard_body" in

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -200,13 +200,14 @@ not continue to B2 from the primary worktree. Repair by removing the
 misplaced branch (after confirming no work is lost) and recreating the
 sibling worktree through the Worktree creation steps above.
 
-The optional local `_idd-worktree-guard.sh` hook (`worktreeGuard.enabled:
-true`) automates part of this self-check by refusing a commit/push from
-the primary worktree while HEAD matches an implementation-branch pattern
-(default `issue/*`, `roadmap-audit/*`). By itself it does **not** catch a
-session that skips B1 entirely and commits directly on the base branch —
-set the separate `worktreeGuard.refuseBaseBranchCommits: true` opt-in
-(#2801) to also refuse that case.
+The optional local `_idd-worktree-guard.sh` hook (enabled via
+`worktreeGuard.enabled: true`) automates part of this self-check by
+refusing a commit/push from the primary worktree while HEAD matches an
+implementation-branch pattern (default `issue/*`, `roadmap-audit/*`).
+By itself it does **not** catch a session that skips B1 entirely and
+commits directly on the base branch — set the separate
+`worktreeGuard.refuseBaseBranchCommits: true` opt-in (#2801) to also
+refuse that case.
 
 If WorkTrunk reports its `Cannot change directory — shell integration
 installed but not active` diagnostic, re-verify the current working

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -200,6 +200,14 @@ not continue to B2 from the primary worktree. Repair by removing the
 misplaced branch (after confirming no work is lost) and recreating the
 sibling worktree through the Worktree creation steps above.
 
+The optional local `_idd-worktree-guard.sh` hook (`worktreeGuard.enabled:
+true`) automates part of this self-check by refusing a commit/push from
+the primary worktree while HEAD matches an implementation-branch pattern
+(default `issue/*`, `roadmap-audit/*`). By itself it does **not** catch a
+session that skips B1 entirely and commits directly on the base branch —
+set the separate `worktreeGuard.refuseBaseBranchCommits: true` opt-in
+(#2801) to also refuse that case.
+
 If WorkTrunk reports its `Cannot change directory — shell integration
 installed but not active` diagnostic, re-verify the current working
 directory on every later command — see

--- a/schemas/policy.schema.json
+++ b/schemas/policy.schema.json
@@ -754,6 +754,10 @@
             "description": "Each entry must contain a non-whitespace character. This mirrors the runtime, which trims each glob and ignores blank entries (falling back to the defaults), so a whitespace-only pattern is rejected at validation time instead of silently never matching."
           },
           "description": "Branch globs the guard treats as implementation branches that must not live in the primary worktree (default [\"issue/*\", \"roadmap-audit/*\"] when absent)."
+        },
+        "refuseBaseBranchCommits": {
+          "type": "boolean",
+          "description": "Opt-in stricter mode (default false; absent means false; #2801): also refuses a commit/push made from the primary worktree while HEAD is on the configured `developmentBranch` itself, catching a session that skips B1 entirely and commits directly on the base branch -- a gap the `branchPatterns` check above does not cover, since the base branch never matches an implementation-branch glob. Compares against `developmentBranch` only; the pure-POSIX-sh hook has no network access to resolve the live GitHub default branch, so an absent `developmentBranch` leaves this check a no-op even when enabled. A direct base-branch commit from the primary worktree is also legitimate routine action for a human maintainer working outside an IDD session, so this stays opt-in rather than becoming the default."
         }
       },
       "description": "Container for the disposable-worktree guard's enablement and protected branch-name patterns. Optional; omitting it keeps the guard's historical advisory-only behavior."

--- a/tests/worktree-guard-hook.test.mts
+++ b/tests/worktree-guard-hook.test.mts
@@ -182,6 +182,60 @@ test('hook honors a custom worktreeGuard.branchPatterns override', () => {
   }
 });
 
+test('hook blocks a base-branch commit in the primary worktree when refuseBaseBranchCommits is enabled (#2801)', () => {
+  const repo = setupRepo({
+    worktreeGuard: { enabled: true, refuseBaseBranchCommits: true },
+    developmentBranch: 'main',
+  });
+  try {
+    // setupRepo's init commit already leaves HEAD on "main".
+    assert.equal(runHook(repo, 'pre-commit'), 1);
+    assert.equal(runHook(repo, 'pre-push'), 1);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test('hook leaves base-branch commits allowed when refuseBaseBranchCommits is absent (default off)', () => {
+  const repo = setupRepo({
+    worktreeGuard: { enabled: true },
+    developmentBranch: 'main',
+  });
+  try {
+    assert.equal(runHook(repo, 'pre-commit'), 0);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test('hook leaves base-branch commits allowed when refuseBaseBranchCommits is true but developmentBranch is unset', () => {
+  // developmentBranch absent: the hook has no network access to resolve
+  // the live GitHub default branch the way idd-work.instructions.md's
+  // B1 does, so this stricter check is documented to no-op rather than
+  // guessing.
+  const repo = setupRepo({
+    worktreeGuard: { enabled: true, refuseBaseBranchCommits: true },
+  });
+  try {
+    assert.equal(runHook(repo, 'pre-commit'), 0);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test('hook still allows a non-base, non-pattern-matched branch when refuseBaseBranchCommits is enabled', () => {
+  const repo = setupRepo({
+    worktreeGuard: { enabled: true, refuseBaseBranchCommits: true },
+    developmentBranch: 'main',
+  });
+  try {
+    git(repo, ['checkout', '-q', '-b', 'feature-not-guarded']);
+    assert.equal(runHook(repo, 'pre-commit'), 0);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
 test('hook allows a detached HEAD in the primary worktree when enabled', () => {
   const repo = setupRepo({ worktreeGuard: { enabled: true } });
   try {


### PR DESCRIPTION
## Summary

The shipped `worktreeGuard` hook refuses a commit/push made from the
primary worktree only when HEAD matches a `branchPatterns` glob
(default `issue/*`, `roadmap-audit/*`). It has no special case for
the repository's own base branch, so a session that skips B1 entirely
and commits directly on the base branch in the primary worktree is
never refused — field evidence: a delegated worker skipped both the
claim step and B1, editing implementation source directly in the
primary worktree while HEAD stayed on the base branch throughout.

Adds an opt-in `worktreeGuard.refuseBaseBranchCommits` key, defaulting
to `false` so existing adopters see no behavior change. When enabled,
compares HEAD against the configured `developmentBranch`; the hook is
pure POSIX sh with no node/jq/gh/network dependency, so an absent
`developmentBranch` leaves this stricter check a documented no-op
rather than attempting to resolve the live GitHub default branch the
way `idd-work.instructions.md`'s B1 phase can. Documents the guard's
actual default scope next to its existing description, both in the
hook's own header comment and in B1's self-check section.

## Verification

- All 5 acceptance criteria from the issue satisfied
- `node scripts/audit-docs.mjs --check` (pass; `audit/sync-manifest.json`
  untouched, no `bundleBudgets` limit raised)
- `shellcheck .githooks/_idd-worktree-guard.sh` clean (POSIX `sh` mode)
- `pnpm run typecheck`, `pnpm test` (5566/5566 pass, 16/16 in the
  hook's own test file including 4 new tests), markdownlint, dprint,
  cspell, `audit-code-span-wrap.mjs`, biome all clean
- Report-only critique fork traced the shell control flow by hand for
  every scenario (absent/false, missing `developmentBranch`, primary
  vs. sibling worktree, `issue/*` still refused for the original
  reason), verified the `developmentBranch` extraction is safe against
  the schema's own value pattern, validated the schema JSON, and ran
  additional manual edge-case tests beyond the 4 shipped ones — found
  no defects

Closes #2801

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDJpTELrY2SnjHW9m5Aw7i