### PR TITLE
docs(customization): link the source-repo strip-untrusted-labels recipe

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -892,7 +892,9 @@ may apply — do not rely on that as a mitigation.
 
 The idd-skill source repository (`kurone-kito/idd-skill`, distinct from
 your own repository below) guards against this with
-`.github/workflows/strip-untrusted-labels.yml`: a same-event
+`.github/workflows/strip-untrusted-labels.yml`
+(<https://github.com/kurone-kito/idd-skill/blob/main/.github/workflows/strip-untrusted-labels.yml>):
+a same-event
 `issues: labeled` / `pull_request_target: labeled` handler that removes
 a reserved label the instant a configured untrusted actor applies it.
 Two paths produce this file for your own repository, below.

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -892,7 +892,9 @@ may apply — do not rely on that as a mitigation.
 
 The idd-skill source repository (`kurone-kito/idd-skill`, distinct from
 your own repository below) guards against this with
-`.github/workflows/strip-untrusted-labels.yml`: a same-event
+`.github/workflows/strip-untrusted-labels.yml`
+(<https://github.com/kurone-kito/idd-skill/blob/main/.github/workflows/strip-untrusted-labels.yml>):
+a same-event
 `issues: labeled` / `pull_request_target: labeled` handler that removes
 a reserved label the instant a configured untrusted actor applies it.
 Two paths produce this file for your own repository, below.


### PR DESCRIPTION
# Summary

Add a blob URL next to the first mention of
`.github/workflows/strip-untrusted-labels.yml` in the reserved-label
guard recipe, matching the section's existing policy-decisions link.
Regenerate the exact `docs/customization.md` mirror.

## Linked issue

Closes #2807

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

The mention already disclosed that the workflow is source-repo-only
but was not navigable. The file must not be copied into
`idd-template/`; this change is the missing link only.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

Changed paths: `idd-template/docs/customization.md` (canonical) and
`docs/customization.md` (exact mirror).

## Verification

- [ ] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

Also ran the repository `pre-push-validate` chain.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
