### PR TITLE
fix(idd-work): document WorkTrunk approval-prompt hang in B1

### DIFF
--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -133,6 +133,22 @@ Non-interactive/automation: append `-x <noop>` (e.g. `-x true`) so
 WorkTrunk creates, runs the pre-start hook, and exits without
 changing the caller's directory.
 
+**Pre-start hook approval hang** (confirmed live 2026-09-09, issue
+`#2797`): even with `-x <noop>`, `wt switch --create` still hangs
+non-interactively when the `[pre-start]` hook's own install command has
+not already been approved — WorkTrunk's own `approvals.toml` mechanism
+prompts for command approval on first run and fails outright outside a
+TTY, with `Cannot prompt for approval in non-interactive environment. To
+skip prompts in CI/CD, add --yes`. Before the first `wt switch --create`
+in such an environment, run `wt config approvals add --yes` once from
+the primary worktree to pre-approve the project's hook and alias
+commands (stored in `~/.config/worktrunk/approvals.toml`, scoped to the
+git project so the approval carries over to every sibling worktree).
+This one-time pre-approval step is narrower than adding the global
+`-y`/`--yes` flag to every `wt switch` call, which would also silently
+skip approval for any other command WorkTrunk runs on that invocation —
+prefer the pre-approval step for that reason.
+
 If WorkTrunk is unavailable, choose the correct case:
 
 <!-- dprint-ignore-start -->

--- a/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/.github/instructions/lite/idd-work-lite.instructions.md
@@ -90,38 +90,47 @@ worktree removal) behind the
     (`<base-branch>` is normally `main`).
 16. On Windows, use `git-wt switch --create -b <base-branch> <branch-name> -x true`,
     or the same `wt switch` form if `git-wt` is unavailable.
-17. Do not use `wt new`.
-18. If WorkTrunk uses a pre-start install hook, its first command must acquire
+17. If the `[pre-start]` hook's install command has not already been
+    approved, `wt switch --create` hangs non-interactively even with
+    `-x <noop>` (`Cannot prompt for approval in non-interactive
+    environment`). Before the first `wt switch --create` in such an
+    environment, run `wt config approvals add --yes` once from the
+    primary worktree to pre-approve it (issue `#2797`); this is scoped
+    to the git project, so sibling worktrees inherit it, and is
+    narrower than the global `-y`/`--yes` flag, which would also skip
+    approval for any other command WorkTrunk runs on that call.
+18. Do not use `wt new`.
+19. If WorkTrunk uses a pre-start install hook, its first command must acquire
     the worktree lock before it installs anything.
-19. If the hook cannot acquire the lock, create the worktree without the hook.
-20. If WorkTrunk is unavailable, use
+20. If the hook cannot acquire the lock, create the worktree without the hook.
+21. If WorkTrunk is unavailable, use
     `git worktree add <path> -b <branch-name> origin/main` for a fresh claim.
-21. If WorkTrunk is unavailable and this is a takeover, use
+22. If WorkTrunk is unavailable and this is a takeover, use
     `git worktree add <path> <branch-name>` with the local branch.
-22. If WorkTrunk is unavailable and only the remote branch exists, run
+23. If WorkTrunk is unavailable and only the remote branch exists, run
     `git fetch origin <branch-name>`.
-23. If WorkTrunk is unavailable and only the remote branch exists, use
+24. If WorkTrunk is unavailable and only the remote branch exists, use
     `git worktree add <path> -b <branch-name> origin/<branch-name>`.
-24. If WorkTrunk is unavailable and neither a local nor a remote branch
+25. If WorkTrunk is unavailable and neither a local nor a remote branch
     exists (rare), treat it as a fresh claim while preserving the inherited
     branch name.
-25. For manual `git worktree add` or WorkTrunk without a hook, acquire the
+26. For manual `git worktree add` or WorkTrunk without a hook, acquire the
     worktree lock with the profile-selected `claim-lock` helper immediately
     after creation and before any install or other mutation.
-26. Run `install-deps` on the manual/no-hook path.
-27. Verify the primary worktree's HEAD is still on `main`.
-28. Verify `git worktree list` shows the new path.
-29. Verify the current directory is the new sibling worktree.
-30. If any of steps 27-29 fails, the worktree-creation contract is violated:
+27. Run `install-deps` on the manual/no-hook path.
+28. Verify the primary worktree's HEAD is still on `main`.
+29. Verify `git worktree list` shows the new path.
+30. Verify the current directory is the new sibling worktree.
+31. If any of steps 28-30 fails, the worktree-creation contract is violated:
     stop, post a hold note naming the failed check, and do not continue to
     B2 from the primary worktree.
-31. Repair a contract violation by removing the misplaced branch from the
+32. Repair a contract violation by removing the misplaced branch from the
     primary worktree, after confirming no work is lost, then recreate the
     sibling worktree from step 12.
-32. If WorkTrunk reported `Cannot change directory — shell integration
+33. If WorkTrunk reported `Cannot change directory — shell integration
     installed but not active`, treat every later command's working
     directory as unverified until confirmed (e.g. `pwd`), not only at
-    steps 27-29.
+    steps 28-30.
 
 ## B2 — Create and refine plan
 

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -128,6 +128,22 @@ Non-interactive/automation: append `-x <noop>` (e.g. `-x true`) so
 WorkTrunk creates, runs the pre-start hook, and exits without
 changing the caller's directory.
 
+**Pre-start hook approval hang** (confirmed live 2026-09-09, issue
+`#2797`): even with `-x <noop>`, `wt switch --create` still hangs
+non-interactively when the `[pre-start]` hook's own install command has
+not already been approved — WorkTrunk's own `approvals.toml` mechanism
+prompts for command approval on first run and fails outright outside a
+TTY, with `Cannot prompt for approval in non-interactive environment. To
+skip prompts in CI/CD, add --yes`. Before the first `wt switch --create`
+in such an environment, run `wt config approvals add --yes` once from
+the primary worktree to pre-approve the project's hook and alias
+commands (stored in `~/.config/worktrunk/approvals.toml`, scoped to the
+git project so the approval carries over to every sibling worktree).
+This one-time pre-approval step is narrower than adding the global
+`-y`/`--yes` flag to every `wt switch` call, which would also silently
+skip approval for any other command WorkTrunk runs on that invocation —
+prefer the pre-approval step for that reason.
+
 If WorkTrunk is unavailable, choose the correct case:
 
 <!-- dprint-ignore-start -->

--- a/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
@@ -85,38 +85,47 @@ worktree removal) behind the
     (`<base-branch>` is normally `main`).
 16. On Windows, use `git-wt switch --create -b <base-branch> <branch-name> -x true`,
     or the same `wt switch` form if `git-wt` is unavailable.
-17. Do not use `wt new`.
-18. If WorkTrunk uses a pre-start install hook, its first command must acquire
+17. If the `[pre-start]` hook's install command has not already been
+    approved, `wt switch --create` hangs non-interactively even with
+    `-x <noop>` (`Cannot prompt for approval in non-interactive
+    environment`). Before the first `wt switch --create` in such an
+    environment, run `wt config approvals add --yes` once from the
+    primary worktree to pre-approve it (issue `#2797`); this is scoped
+    to the git project, so sibling worktrees inherit it, and is
+    narrower than the global `-y`/`--yes` flag, which would also skip
+    approval for any other command WorkTrunk runs on that call.
+18. Do not use `wt new`.
+19. If WorkTrunk uses a pre-start install hook, its first command must acquire
     the worktree lock before it installs anything.
-19. If the hook cannot acquire the lock, create the worktree without the hook.
-20. If WorkTrunk is unavailable, use
+20. If the hook cannot acquire the lock, create the worktree without the hook.
+21. If WorkTrunk is unavailable, use
     `git worktree add <path> -b <branch-name> origin/main` for a fresh claim.
-21. If WorkTrunk is unavailable and this is a takeover, use
+22. If WorkTrunk is unavailable and this is a takeover, use
     `git worktree add <path> <branch-name>` with the local branch.
-22. If WorkTrunk is unavailable and only the remote branch exists, run
+23. If WorkTrunk is unavailable and only the remote branch exists, run
     `git fetch origin <branch-name>`.
-23. If WorkTrunk is unavailable and only the remote branch exists, use
+24. If WorkTrunk is unavailable and only the remote branch exists, use
     `git worktree add <path> -b <branch-name> origin/<branch-name>`.
-24. If WorkTrunk is unavailable and neither a local nor a remote branch
+25. If WorkTrunk is unavailable and neither a local nor a remote branch
     exists (rare), treat it as a fresh claim while preserving the inherited
     branch name.
-25. For manual `git worktree add` or WorkTrunk without a hook, acquire the
+26. For manual `git worktree add` or WorkTrunk without a hook, acquire the
     worktree lock with the profile-selected `claim-lock` helper immediately
     after creation and before any install or other mutation.
-26. Run `install-deps` on the manual/no-hook path.
-27. Verify the primary worktree's HEAD is still on `main`.
-28. Verify `git worktree list` shows the new path.
-29. Verify the current directory is the new sibling worktree.
-30. If any of steps 27-29 fails, the worktree-creation contract is violated:
+27. Run `install-deps` on the manual/no-hook path.
+28. Verify the primary worktree's HEAD is still on `main`.
+29. Verify `git worktree list` shows the new path.
+30. Verify the current directory is the new sibling worktree.
+31. If any of steps 28-30 fails, the worktree-creation contract is violated:
     stop, post a hold note naming the failed check, and do not continue to
     B2 from the primary worktree.
-31. Repair a contract violation by removing the misplaced branch from the
+32. Repair a contract violation by removing the misplaced branch from the
     primary worktree, after confirming no work is lost, then recreate the
     sibling worktree from step 12.
-32. If WorkTrunk reported `Cannot change directory — shell integration
+33. If WorkTrunk reported `Cannot change directory — shell integration
     installed but not active`, treat every later command's working
     directory as unverified until confirmed (e.g. `pwd`), not only at
-    steps 27-29.
+    steps 28-30.
 
 ## B2 — Create and refine plan
 


### PR DESCRIPTION
# Summary

B1's documented non-interactive WorkTrunk invocation (`wt switch
--create ... -x true`) still hangs when the project's `[pre-start]` hook
install command has not already been approved -- confirmed live in this
environment: `Cannot prompt for approval in non-interactive
environment. To skip prompts in CI/CD, add --yes`. This is a second,
distinct hang from the one `-x <noop>` already fixes (the interactive
`cd`-restart), and B1 had no guidance for it.

Adds a "Pre-start hook approval hang" paragraph to B1's Worktree
creation steps documenting the confirmed fix: run `wt config approvals
add --yes` once from the primary worktree, before the first `wt switch
--create`, to pre-approve the project's hook/alias commands. This
narrower one-time pre-approval (over a blanket `-y`/`--yes` on every
`wt switch` call) was verified end-to-end in a scratch repository with a
`[pre-start]` hook: the approval persists to
`~/.config/worktrunk/approvals.toml`, is scoped to the git project (not
the individual worktree path), and carries over to every sibling
worktree created afterward.

Also extends the lite work profile
(`idd-work-lite.instructions.md`), whose own text states any mismatch
with the standard work phase is a bug in that file -- not in the
issue's own Candidate files list, but required by that file's explicit
consistency contract.

Both `idd-template/.github/instructions/idd-work.instructions.md` and
`idd-template/.github/instructions/lite/idd-work-lite.instructions.md`
are the canonical sources edited here; the two
`.github/instructions/**` mirrors are regenerated via `node
scripts/sync-docs.mjs --apply`, never hand-edited.

## Linked issue

Closes #2797

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

A C1 self-review delegate pass (CodeRabbit CLI) suggested the new
`wt config approvals add --yes` guidance should first verify the
`[pre-start]` hook's command template against a trusted baseline before
approving it. Considered and rejected for this issue: the hook config
lives on `{development-branch}` (`main`), which already passed this
repository's own IDD review/merge gates before B1 ever fetches it -- the
same trust boundary the adjacent `install-deps` step already relies on
when it runs `pnpm install` (arbitrary `postinstall` lifecycle scripts)
with no extra per-command verification. No tooling exists in this
repository to diff/verify a hook template against a trusted baseline;
adding one is separate design work with its own acceptance criteria,
not a same-issue fix for a narrowly-scoped documentation hang. Full
reasoning is on the issue thread.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CK2SHn8Bir6VHrXrMVMdn3
