### PR TITLE
fix(idd-pre-merge): wire D3.5/D3.7 re-verify into F2/F3

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -179,9 +179,12 @@ Before any mutating action in F3, apply the
      carries. On a mismatch, fix it per D3.5/D3.7's own documented
      handling. Any fix here — whether or not it changes HEAD, since a
      PR-body edit alone (D3.7's remediation, or D3.5 step 6's) still
-     counts — invalidates this step's own claim re-validation and
-     advisory state revalidation above; re-run both before merging. If
-     the fix additionally amended or rebased a commit (changing HEAD),
+     counts — invalidates step 3's own **Re-validate claim** ("confirm
+     the active claim still uses your current `{claim-id}`") and
+     **Advisory state revalidation** (re-run AW1, escalating through
+     AW2/AW3 as needed) checks above; re-run both of those before
+     merging. If the fix additionally amended or rebased a commit
+     (changing HEAD),
      return to E1 instead of just re-validating in place — F2's own
      snapshot is invalidated by a new HEAD. Otherwise repeat this field
      once; if it still fails, stop and do not merge.

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -165,7 +165,17 @@ Before any mutating action in F3, apply the
      sub-condition on it
      ([Terminal routing](idd-advisory-wait.instructions.md#terminal-routing-1570));
    - all required CI checks pass for the current head;
-   - claim ownership still uses your `{claim-id}`.
+   - claim ownership still uses your `{claim-id}`;
+   - D3.5 steps 6-7 and D3.7 (`idd-pr-submit.instructions.md`) have
+     been re-run against `${PR_HEAD_SHA_F3}` (#2749) — covers commits
+     that landed between F2 and this final gate, for example a
+     required `{development-branch}` sync. Skip D3.5 steps 6-7 under
+     the same non-default-`{development-branch}` exemption D3.5 itself
+     carries. On a mismatch, fix it per D3.5/D3.7's own documented
+     handling. If step 7's fix amended or rebased a commit (changing
+     HEAD), return to E1 instead of continuing this gate — F2's own
+     snapshot is invalidated by a new HEAD. Otherwise repeat this
+     field once; if it still fails, stop and do not merge.
 
    For the head-SHA field, use this **copy-paste-safe, fail-closed**
    check — both operands fully quoted, no glob, abort on mismatch —

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -169,13 +169,22 @@ Before any mutating action in F3, apply the
    - D3.5 steps 6-7 and D3.7 (`idd-pr-submit.instructions.md`) have
      been re-run against `${PR_HEAD_SHA_F3}` (#2749) — covers commits
      that landed between F2 and this final gate, for example a
-     required `{development-branch}` sync. Skip D3.5 steps 6-7 under
-     the same non-default-`{development-branch}` exemption D3.5 itself
+     required `{development-branch}` sync. Before running them,
+     confirm the local worktree is checked out at `${PR_HEAD_SHA_F3}`
+     exactly (`git fetch` plus `git checkout`/`git reset --hard` if a
+     resumed or external-push session left it stale) — D3.5 step 7's
+     `git log` and D3.7's inherited `git diff` both read local git
+     state, not the remote PR directly. Skip D3.5 steps 6-7 under the
+     same non-default-`{development-branch}` exemption D3.5 itself
      carries. On a mismatch, fix it per D3.5/D3.7's own documented
-     handling. If step 7's fix amended or rebased a commit (changing
-     HEAD), return to E1 instead of continuing this gate — F2's own
-     snapshot is invalidated by a new HEAD. Otherwise repeat this
-     field once; if it still fails, stop and do not merge.
+     handling. Any fix here — whether or not it changes HEAD, since a
+     PR-body edit alone (D3.7's remediation, or D3.5 step 6's) still
+     counts — invalidates this step's own claim re-validation and
+     advisory state revalidation above; re-run both before merging. If
+     the fix additionally amended or rebased a commit (changing HEAD),
+     return to E1 instead of just re-validating in place — F2's own
+     snapshot is invalidated by a new HEAD. Otherwise repeat this field
+     once; if it still fails, stop and do not merge.
 
    For the head-SHA field, use this **copy-paste-safe, fail-closed**
    check — both operands fully quoted, no glob, abort on mismatch —

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -447,8 +447,10 @@ completion.
    (`idd-review-fix.instructions.md` E9-E12) or a `{development-branch}`
    merge — are not automatically covered; `idd-pre-merge.instructions.md`
    F2's "Closing-set and impact-checklist re-verification" condition
-   and `idd-merge.instructions.md` F3's Gate checklist both name this
-   step explicitly and re-run it against the final HEAD before merge.
+   names this step explicitly and re-runs it against the then-current
+   HEAD, and `idd-merge.instructions.md` F3's Gate checklist re-runs it
+   again immediately before merging — F2 can run before further HEAD
+   changes land, which is exactly why the F3 re-run also exists.
 
 ### D3.7 — Re-verify the IDD impact checklist before merge
 
@@ -477,10 +479,12 @@ never populates and the check would be meaningless) — edited prose can
 otherwise introduce a stray keyword-adjacent reference.
 
 **Wired to F2/F3**: `idd-pre-merge.instructions.md` F2's "Closing-set
-and impact-checklist re-verification" condition and
-`idd-merge.instructions.md` F3's Gate checklist both name this step
-explicitly and re-run it against the final HEAD before merge (#2749)
-— no longer an implicit, name-only cross-reference.
+and impact-checklist re-verification" condition names this step
+explicitly and re-runs it against the then-current HEAD, and
+`idd-merge.instructions.md` F3's Gate checklist re-runs it again
+immediately before merging (#2749) — F2 can run before further HEAD
+changes land, which is exactly why the F3 re-run also exists; no
+longer an implicit, name-only cross-reference.
 
 ## D4 — Wait for CI
 

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -445,8 +445,10 @@ completion.
    **Re-run before merge**: this scan only covers commits present at
    D3.5 time. Later branch commits — accepted review fixes
    (`idd-review-fix.instructions.md` E9-E12) or a `{development-branch}`
-   merge — are not automatically covered; re-run this step against the final HEAD
-   before F3 merges.
+   merge — are not automatically covered; `idd-pre-merge.instructions.md`
+   F2's "Closing-set and impact-checklist re-verification" condition
+   and `idd-merge.instructions.md` F3's Gate checklist both name this
+   step explicitly and re-run it against the final HEAD before merge.
 
 ### D3.7 — Re-verify the IDD impact checklist before merge
 
@@ -474,11 +476,11 @@ condition D3.5 itself skips under, where `closingIssuesReferences`
 never populates and the check would be meaningless) — edited prose can
 otherwise introduce a stray keyword-adjacent reference.
 
-**Known gap**: no phase file currently re-invokes D3.5 or this step by
-name from F1-F3, so this re-check depends on the same implicit trigger
-D3.5 step 7 already relies on rather than an explicit F-phase call —
-out of this step's own scope to close; recommend a follow-up issue to
-wire an explicit F2/F3 trigger if this gap is not already tracked.
+**Wired to F2/F3**: `idd-pre-merge.instructions.md` F2's "Closing-set
+and impact-checklist re-verification" condition and
+`idd-merge.instructions.md` F3's Gate checklist both name this step
+explicitly and re-run it against the final HEAD before merge (#2749)
+— no longer an implicit, name-only cross-reference.
 
 ## D4 — Wait for CI
 

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -401,20 +401,26 @@ turns an operator-visible failure into a silent stall.
   cause makes it `false`, and the gate still routes to E1/E4. Fails
   closed: an unusable check makes this condition unmet.
 - **Closing-set and impact-checklist re-verification** (D3.5/D3.7
-  re-run against current HEAD, #2749): re-run
-  `idd-pr-submit.instructions.md`'s D3.5 steps 6-7 (the
-  `closingIssuesReferences` set comparison and the commit-message
-  closing-keyword scan) and D3.7 (the IDD-impact-checklist
-  re-derivation) against the PR's current HEAD. Skip D3.5 steps 6-7
-  under the same non-default-`{development-branch}` exemption D3.5
-  itself carries. On a mismatch, apply the fix each sub-step already
-  documents (D3.5 steps 4-7 for a closing-set drift, D3.7's own
-  mismatch handling for a checklist drift). If step 7's fix amended or
-  rebased a commit (changing HEAD), return to this list's first
-  condition instead of only repeating this one — the new HEAD
-  invalidates the conditions already checked above. Otherwise, repeat
-  this condition once. If it still fails, post a hold note and stop —
-  do not proceed to F3.
+  re-run against current HEAD, #2749): confirm the local worktree is
+  checked out at the PR's current HEAD exactly (`git fetch` plus
+  `git checkout`/`git reset --hard` if a resumed or external-push
+  session left it stale) — D3.5 step 7's `git log` and D3.7's
+  inherited `git diff` both read local git state, not the remote PR
+  directly. Then re-run `idd-pr-submit.instructions.md`'s D3.5 steps
+  6-7 (the `closingIssuesReferences` set comparison and the
+  commit-message closing-keyword scan) and D3.7 (the
+  IDD-impact-checklist re-derivation) against that HEAD. Skip D3.5
+  steps 6-7 under the same non-default-`{development-branch}`
+  exemption D3.5 itself carries. On a mismatch: for a closing-set
+  drift, apply D3.5 step 6's own remediation (reusing step 4's
+  edit-and-recheck mechanism for a missing entry); for a stray
+  commit-message match, apply D3.5 step 7's own remediation (amend or
+  rebase); for a checklist drift, apply D3.7's own mismatch handling.
+  If the fix amended or rebased a commit (changing HEAD), return to
+  this list's first condition instead of only repeating this one — the
+  new HEAD invalidates the conditions already checked above. Otherwise,
+  repeat this condition once. If it still fails, post a hold note and
+  stop — do not proceed to F3.
 
 When any F2 condition routes to a hold/stop or back to E1/E14, update
 the digest after recording the blocking evidence and before

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -400,6 +400,21 @@ turns an operator-visible failure into a silent stall.
   rollup. The signal never changes `route` itself; any other blocking
   cause makes it `false`, and the gate still routes to E1/E4. Fails
   closed: an unusable check makes this condition unmet.
+- **Closing-set and impact-checklist re-verification** (D3.5/D3.7
+  re-run against current HEAD, #2749): re-run
+  `idd-pr-submit.instructions.md`'s D3.5 steps 6-7 (the
+  `closingIssuesReferences` set comparison and the commit-message
+  closing-keyword scan) and D3.7 (the IDD-impact-checklist
+  re-derivation) against the PR's current HEAD. Skip D3.5 steps 6-7
+  under the same non-default-`{development-branch}` exemption D3.5
+  itself carries. On a mismatch, apply the fix each sub-step already
+  documents (D3.5 steps 4-7 for a closing-set drift, D3.7's own
+  mismatch handling for a checklist drift). If step 7's fix amended or
+  rebased a commit (changing HEAD), return to this list's first
+  condition instead of only repeating this one — the new HEAD
+  invalidates the conditions already checked above. Otherwise, repeat
+  this condition once. If it still fails, post a hold note and stop —
+  do not proceed to F3.
 
 When any F2 condition routes to a hold/stop or back to E1/E14, update
 the digest after recording the blocking evidence and before

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -164,13 +164,22 @@ Before any mutating action in F3, apply the
    - D3.5 steps 6-7 and D3.7 (`idd-pr-submit.instructions.md`) have
      been re-run against `${PR_HEAD_SHA_F3}` (#2749) — covers commits
      that landed between F2 and this final gate, for example a
-     required `{development-branch}` sync. Skip D3.5 steps 6-7 under
-     the same non-default-`{development-branch}` exemption D3.5 itself
+     required `{development-branch}` sync. Before running them,
+     confirm the local worktree is checked out at `${PR_HEAD_SHA_F3}`
+     exactly (`git fetch` plus `git checkout`/`git reset --hard` if a
+     resumed or external-push session left it stale) — D3.5 step 7's
+     `git log` and D3.7's inherited `git diff` both read local git
+     state, not the remote PR directly. Skip D3.5 steps 6-7 under the
+     same non-default-`{development-branch}` exemption D3.5 itself
      carries. On a mismatch, fix it per D3.5/D3.7's own documented
-     handling. If step 7's fix amended or rebased a commit (changing
-     HEAD), return to E1 instead of continuing this gate — F2's own
-     snapshot is invalidated by a new HEAD. Otherwise repeat this
-     field once; if it still fails, stop and do not merge.
+     handling. Any fix here — whether or not it changes HEAD, since a
+     PR-body edit alone (D3.7's remediation, or D3.5 step 6's) still
+     counts — invalidates this step's own claim re-validation and
+     advisory state revalidation above; re-run both before merging. If
+     the fix additionally amended or rebased a commit (changing HEAD),
+     return to E1 instead of just re-validating in place — F2's own
+     snapshot is invalidated by a new HEAD. Otherwise repeat this field
+     once; if it still fails, stop and do not merge.
 
    For the head-SHA field, use this **copy-paste-safe, fail-closed**
    check — both operands fully quoted, no glob, abort on mismatch —

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -174,9 +174,12 @@ Before any mutating action in F3, apply the
      carries. On a mismatch, fix it per D3.5/D3.7's own documented
      handling. Any fix here — whether or not it changes HEAD, since a
      PR-body edit alone (D3.7's remediation, or D3.5 step 6's) still
-     counts — invalidates this step's own claim re-validation and
-     advisory state revalidation above; re-run both before merging. If
-     the fix additionally amended or rebased a commit (changing HEAD),
+     counts — invalidates step 3's own **Re-validate claim** ("confirm
+     the active claim still uses your current `{claim-id}`") and
+     **Advisory state revalidation** (re-run AW1, escalating through
+     AW2/AW3 as needed) checks above; re-run both of those before
+     merging. If the fix additionally amended or rebased a commit
+     (changing HEAD),
      return to E1 instead of just re-validating in place — F2's own
      snapshot is invalidated by a new HEAD. Otherwise repeat this field
      once; if it still fails, stop and do not merge.

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -160,7 +160,17 @@ Before any mutating action in F3, apply the
      sub-condition on it
      ([Terminal routing](idd-advisory-wait.instructions.md#terminal-routing-1570));
    - all required CI checks pass for the current head;
-   - claim ownership still uses your `{claim-id}`.
+   - claim ownership still uses your `{claim-id}`;
+   - D3.5 steps 6-7 and D3.7 (`idd-pr-submit.instructions.md`) have
+     been re-run against `${PR_HEAD_SHA_F3}` (#2749) — covers commits
+     that landed between F2 and this final gate, for example a
+     required `{development-branch}` sync. Skip D3.5 steps 6-7 under
+     the same non-default-`{development-branch}` exemption D3.5 itself
+     carries. On a mismatch, fix it per D3.5/D3.7's own documented
+     handling. If step 7's fix amended or rebased a commit (changing
+     HEAD), return to E1 instead of continuing this gate — F2's own
+     snapshot is invalidated by a new HEAD. Otherwise repeat this
+     field once; if it still fails, stop and do not merge.
 
    For the head-SHA field, use this **copy-paste-safe, fail-closed**
    check — both operands fully quoted, no glob, abort on mismatch —

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -440,8 +440,10 @@ completion.
    **Re-run before merge**: this scan only covers commits present at
    D3.5 time. Later branch commits — accepted review fixes
    (`idd-review-fix.instructions.md` E9-E12) or a `{development-branch}`
-   merge — are not automatically covered; re-run this step against the final HEAD
-   before F3 merges.
+   merge — are not automatically covered; `idd-pre-merge.instructions.md`
+   F2's "Closing-set and impact-checklist re-verification" condition
+   and `idd-merge.instructions.md` F3's Gate checklist both name this
+   step explicitly and re-run it against the final HEAD before merge.
 
 ### D3.7 — Re-verify the IDD impact checklist before merge
 
@@ -469,11 +471,11 @@ condition D3.5 itself skips under, where `closingIssuesReferences`
 never populates and the check would be meaningless) — edited prose can
 otherwise introduce a stray keyword-adjacent reference.
 
-**Known gap**: no phase file currently re-invokes D3.5 or this step by
-name from F1-F3, so this re-check depends on the same implicit trigger
-D3.5 step 7 already relies on rather than an explicit F-phase call —
-out of this step's own scope to close; recommend a follow-up issue to
-wire an explicit F2/F3 trigger if this gap is not already tracked.
+**Wired to F2/F3**: `idd-pre-merge.instructions.md` F2's "Closing-set
+and impact-checklist re-verification" condition and
+`idd-merge.instructions.md` F3's Gate checklist both name this step
+explicitly and re-run it against the final HEAD before merge (#2749)
+— no longer an implicit, name-only cross-reference.
 
 ## D4 — Wait for CI
 

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -442,8 +442,10 @@ completion.
    (`idd-review-fix.instructions.md` E9-E12) or a `{development-branch}`
    merge — are not automatically covered; `idd-pre-merge.instructions.md`
    F2's "Closing-set and impact-checklist re-verification" condition
-   and `idd-merge.instructions.md` F3's Gate checklist both name this
-   step explicitly and re-run it against the final HEAD before merge.
+   names this step explicitly and re-runs it against the then-current
+   HEAD, and `idd-merge.instructions.md` F3's Gate checklist re-runs it
+   again immediately before merging — F2 can run before further HEAD
+   changes land, which is exactly why the F3 re-run also exists.
 
 ### D3.7 — Re-verify the IDD impact checklist before merge
 
@@ -472,10 +474,12 @@ never populates and the check would be meaningless) — edited prose can
 otherwise introduce a stray keyword-adjacent reference.
 
 **Wired to F2/F3**: `idd-pre-merge.instructions.md` F2's "Closing-set
-and impact-checklist re-verification" condition and
-`idd-merge.instructions.md` F3's Gate checklist both name this step
-explicitly and re-run it against the final HEAD before merge (#2749)
-— no longer an implicit, name-only cross-reference.
+and impact-checklist re-verification" condition names this step
+explicitly and re-runs it against the then-current HEAD, and
+`idd-merge.instructions.md` F3's Gate checklist re-runs it again
+immediately before merging (#2749) — F2 can run before further HEAD
+changes land, which is exactly why the F3 re-run also exists; no
+longer an implicit, name-only cross-reference.
 
 ## D4 — Wait for CI
 

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -396,20 +396,26 @@ turns an operator-visible failure into a silent stall.
   cause makes it `false`, and the gate still routes to E1/E4. Fails
   closed: an unusable check makes this condition unmet.
 - **Closing-set and impact-checklist re-verification** (D3.5/D3.7
-  re-run against current HEAD, #2749): re-run
-  `idd-pr-submit.instructions.md`'s D3.5 steps 6-7 (the
-  `closingIssuesReferences` set comparison and the commit-message
-  closing-keyword scan) and D3.7 (the IDD-impact-checklist
-  re-derivation) against the PR's current HEAD. Skip D3.5 steps 6-7
-  under the same non-default-`{development-branch}` exemption D3.5
-  itself carries. On a mismatch, apply the fix each sub-step already
-  documents (D3.5 steps 4-7 for a closing-set drift, D3.7's own
-  mismatch handling for a checklist drift). If step 7's fix amended or
-  rebased a commit (changing HEAD), return to this list's first
-  condition instead of only repeating this one — the new HEAD
-  invalidates the conditions already checked above. Otherwise, repeat
-  this condition once. If it still fails, post a hold note and stop —
-  do not proceed to F3.
+  re-run against current HEAD, #2749): confirm the local worktree is
+  checked out at the PR's current HEAD exactly (`git fetch` plus
+  `git checkout`/`git reset --hard` if a resumed or external-push
+  session left it stale) — D3.5 step 7's `git log` and D3.7's
+  inherited `git diff` both read local git state, not the remote PR
+  directly. Then re-run `idd-pr-submit.instructions.md`'s D3.5 steps
+  6-7 (the `closingIssuesReferences` set comparison and the
+  commit-message closing-keyword scan) and D3.7 (the
+  IDD-impact-checklist re-derivation) against that HEAD. Skip D3.5
+  steps 6-7 under the same non-default-`{development-branch}`
+  exemption D3.5 itself carries. On a mismatch: for a closing-set
+  drift, apply D3.5 step 6's own remediation (reusing step 4's
+  edit-and-recheck mechanism for a missing entry); for a stray
+  commit-message match, apply D3.5 step 7's own remediation (amend or
+  rebase); for a checklist drift, apply D3.7's own mismatch handling.
+  If the fix amended or rebased a commit (changing HEAD), return to
+  this list's first condition instead of only repeating this one — the
+  new HEAD invalidates the conditions already checked above. Otherwise,
+  repeat this condition once. If it still fails, post a hold note and
+  stop — do not proceed to F3.
 
 When any F2 condition routes to a hold/stop or back to E1/E14, update
 the digest after recording the blocking evidence and before

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -395,6 +395,21 @@ turns an operator-visible failure into a silent stall.
   rollup. The signal never changes `route` itself; any other blocking
   cause makes it `false`, and the gate still routes to E1/E4. Fails
   closed: an unusable check makes this condition unmet.
+- **Closing-set and impact-checklist re-verification** (D3.5/D3.7
+  re-run against current HEAD, #2749): re-run
+  `idd-pr-submit.instructions.md`'s D3.5 steps 6-7 (the
+  `closingIssuesReferences` set comparison and the commit-message
+  closing-keyword scan) and D3.7 (the IDD-impact-checklist
+  re-derivation) against the PR's current HEAD. Skip D3.5 steps 6-7
+  under the same non-default-`{development-branch}` exemption D3.5
+  itself carries. On a mismatch, apply the fix each sub-step already
+  documents (D3.5 steps 4-7 for a closing-set drift, D3.7's own
+  mismatch handling for a checklist drift). If step 7's fix amended or
+  rebased a commit (changing HEAD), return to this list's first
+  condition instead of only repeating this one — the new HEAD
+  invalidates the conditions already checked above. Otherwise, repeat
+  this condition once. If it still fails, post a hold note and stop —
+  do not proceed to F3.
 
 When any F2 condition routes to a hold/stop or back to E1/E14, update
 the digest after recording the blocking evidence and before


### PR DESCRIPTION
## Summary

`idd-pr-submit.instructions.md`'s D3.5 step 6+7 and D3.7 both document
that they must be re-run against the PR's final HEAD immediately
before F3 merge, but no phase file actually named or invoked this
re-check — D3.7 ended with its own self-flagged "Known gap" admitting
it. Field evidence: two real PRs in this repo's history merged without
the re-check because nothing forced it.

Adds an explicit F2 condition (`idd-pre-merge.instructions.md`) and F3
Gate checklist item (`idd-merge.instructions.md`) naming D3.5 steps
6-7 and D3.7 by name and requiring their re-run against current HEAD
before merge proceeds. Updates D3.5 step 7's "Re-run before merge"
note and D3.7's "Known gap" paragraph to point at the new named steps
instead of describing an unwired implicit trigger. Routes a
HEAD-changing fix (D3.5 step 7's amend/rebase remedy) back to F2's
first condition / E1 rather than only repeating the one check, since a
new HEAD invalidates conditions already verified above it.

**Scope note**: `idd-pr-submit.instructions.md` was edited despite not
being in the issue's own Candidate files list: the issue's acceptance
criteria explicitly requires updating D3.5 step 7's and D3.7's
paragraphs, which exist only in that file — a genuine inconsistency in
the issue's own authoring, resolved in the AC's favor.

## Verification

- All 5 acceptance criteria satisfied
- `node scripts/sync-docs.mjs --apply` (mirrors in sync)
- `node scripts/audit-docs.mjs --check` (pass; `bundle-merge` now at
  95.84%, a first-time crossing of the 95% notice threshold still well
  under the 98% hard ceiling; `audit/sync-manifest.json` untouched, no
  `bundleBudgets` limit raised)
- `pnpm run typecheck`, `pnpm test` (5568/5568 pass), markdownlint,
  dprint, cspell, `audit-code-span-wrap.mjs` all clean
- Report-only critique fork found one substantive gap (the first draft
  only wired D3.5 step 6, not step 7, despite the issue's own Proposed
  Change explicitly requiring "step 6+7") plus a secondary robustness
  gap (a HEAD-changing fix wasn't routed back through already-checked
  conditions) — both fixed in this PR's current state; also confirmed
  the third-file scope decision was correct

Closes #2749

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDJpTELrY2SnjHW9m5Aw7i