### PR TITLE
feat(issue-authoring): hide superseded owner/publication markers

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -1429,6 +1429,61 @@ only approval boundary.
   winner by deterministic comment order; an immediate local read never
   authorizes edits. Apply the same settle delay and full paginated replay after
   every heartbeat before it authorizes an edit or label removal.
+- **Hide superseded owner/publication-intent markers.** Once a fresh
+  `authoring-owner` marker (any `mode`, including the first,
+  generation-opening `acquire`/`bootstrap`) or `authoring-publication-intent`
+  record (any `state`) has been posted and its own POST and re-fetch/verify
+  above have both succeeded -- never before, and never interleaved with
+  posting -- scan that same target's prior comments (the target issue for
+  `authoring-owner`; the journal issue named in the record's own `journal`
+  field for `authoring-publication-intent`, which naturally also hides other
+  authoring sets' already superseded journal records on that shared journal
+  -- intentional, since the journal read path is the same paginated scan and
+  is unaffected either way) and minimize (classifier `OUTDATED`) every prior
+  comment from a trusted marker actor whose body is a byte-exact match of the
+  canonical rendered template for the same marker family.
+  `matchCanonicalAuthoringMarkerFamily` (`marker-helpers.mts`, re-exported by
+  `protocol-helpers.mts`) implements that check: it parses the candidate,
+  re-renders the parsed fields with `renderAuthoringOwnerMarker` /
+  `renderAuthoringPublicationIntentMarker`, and requires the result to equal
+  the candidate's body exactly. A candidate that deviates from the template
+  in any way -- reordered or extra fields, altered spacing, trailing
+  content, a different visible note -- is never minimized; leave it visible
+  rather than guessing. Skip the just-posted comment itself and any
+  candidate whose `isMinimized` is already `true` (idempotent; the minimize
+  helper's own probe already enforces this).
+
+  Convert each eligible candidate's REST comment id to its GraphQL node id
+  and call the existing minimize helper -- reuse it rather than
+  reimplementing the mutation:
+
+  ```sh
+  node scripts/minimize-superseded-markers.mjs --subject-ids <id1,id2,...> \
+    --classifier OUTDATED --trusted-marker-logins <trusted-login-1,...> \
+    --apply
+  ```
+
+  Or, for npx/package-manager profiles, the equivalent
+  `idd-minimize-superseded-markers` command.
+
+  **Best-effort, never blocking.** A permission error, an unreadable
+  comment list, or an unavailable helper runtime (`instructions-only`
+  profile, or Node.js absent) skips this step silently and continues the
+  normal marker-posting flow unmodified -- this must never retry-loop or
+  fail the authoring flow. Mirrors `docs/idd-comment-minimization.md`'s
+  framing: this is UI cleanup only and never replaces the append-only
+  audit trail.
+
+  **Scope.** In scope: `authoring-owner` and `authoring-publication-intent`
+  only. Out of scope: `authoring-publication` -- a body-line token embedded
+  in the newly created issue's own body at creation time, not a comment, so
+  there is nothing to minimize -- and every marker family already covered
+  by the post-merge F4 cleanup driver (for example `claimed-by`,
+  `review-watermark`, `advisory-wait`; see `docs/idd-comment-minimization.md`).
+  Do not add `authoring-owner`, `authoring-publication-intent`, or
+  `authoring-publication` to `OPERATIONAL_MARKERS`, and do not fold this
+  step into the F4 driver: it is a separate, earlier-lifecycle,
+  hide-at-post-time behavior.
 - **Conflict check before every edit.** Immediately before each body or
   roadmap relationship update, re-fetch both the target and the set anchor
   (the same fresh snapshot serves both roles when the target is the anchor).

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -1212,6 +1212,20 @@ only approval boundary.
   <!-- <marker-prefix>-authoring-publication-intent: target=<opaque-target-id>; anchor=<opaque-anchor-id>; set=<opaque-set-id>; session=<opaque-session-id>; token=<opaque-publication-token>; journal=<owner>/<repo>#<number>; issue=<owner>/<repo>#<number>|none; actor=<trusted-marker-actor>; state=<pending|member|cleanup|abandoned> -->
   ```
 
+  Append the visible note below immediately after this HTML comment, joined
+  by a single newline (no blank line between them, matching the
+  `authoring-owner` marker's own posted shape) — this exact pairing is the
+  canonical rendered template `matchCanonicalAuthoringMarkerFamily`
+  (`marker-helpers.mts`) matches for the hide-on-supersede step below.
+  Historical comments predating this canonical pin may use a different
+  separator, note text, or no note at all (#2750); those never
+  byte-exact-match the canonical template and are correctly left visible —
+  expected fail-closed behavior, not retroactive cleanup:
+
+  ```text
+  _Issue-authoring publication-intent record. Do not edit or delete._
+  ```
+
   `issue` is the returned canonical issue identity or `none`. Append
   `state=pending; issue=none` before creation, then append the returned
   identity while it remains `pending`, append `member` only after the owner
@@ -1295,6 +1309,15 @@ only approval boundary.
   ```
 
   _Issue-authoring ownership marker. Do not edit or delete._
+
+  Join the HTML comment and the visible note above by a single newline (no
+  blank line between them) -- this exact pairing, for any `mode`, is the
+  canonical rendered template `matchCanonicalAuthoringMarkerFamily`
+  (`marker-helpers.mts`) matches for the hide-on-supersede step below.
+  Historical comments predating this canonical pin may use a blank-line
+  separator instead (#2750); those never byte-exact-match the canonical
+  template and are correctly left visible -- expected fail-closed behavior,
+  not retroactive cleanup.
 
   The companion uses the same `body-sha256` and `snapshot-sha256` fields as the
   portable owner protocol. Target markers hash the exact UTF-8 body from the
@@ -1454,8 +1477,9 @@ only approval boundary.
   helper's own probe already enforces this).
 
   Convert each eligible candidate's REST comment id to its GraphQL node id
-  and call the existing minimize helper -- reuse it rather than
-  reimplementing the mutation:
+  (the paginated comment list already carries it as `node_id` -- no extra
+  fetch needed) and call the existing minimize helper -- reuse it rather
+  than reimplementing the mutation:
 
   ```sh
   node scripts/minimize-superseded-markers.mjs --subject-ids <id1,id2,...> \

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -998,6 +998,61 @@ winner by deterministic comment order; an immediate local read never
 authorizes edits. Apply the same settle delay and full paginated replay after
 every heartbeat before it authorizes an edit or label removal.
 
+**Hide superseded owner/publication-intent markers.** Once a fresh
+`authoring-owner` marker (any `mode`, including the first, generation-opening
+`acquire`/`bootstrap`) or `authoring-publication-intent` record (any `state`)
+has been posted and its own POST and re-fetch/verify above have both
+succeeded -- never before, and never interleaved with posting -- scan that
+same target's prior comments (the target issue for `authoring-owner`; the
+journal issue named in the record's own `journal` field for
+`authoring-publication-intent`, which naturally also hides other authoring
+sets' already superseded journal records on that shared journal --
+intentional, since the journal read path is the same paginated scan and is
+unaffected either way) and minimize (classifier `OUTDATED`) every prior
+comment from a trusted marker actor whose body is a byte-exact match of the
+canonical rendered template for the same marker family.
+`matchCanonicalAuthoringMarkerFamily` (`marker-helpers.mts`, re-exported by
+`protocol-helpers.mts`) implements that check: it parses the candidate,
+re-renders the parsed fields with `renderAuthoringOwnerMarker` /
+`renderAuthoringPublicationIntentMarker`, and requires the result to equal
+the candidate's body exactly. A candidate that deviates from the template in
+any way -- reordered or extra fields, altered spacing, trailing content, a
+different visible note -- is never minimized; leave it visible rather than
+guessing. Skip the just-posted comment itself and any candidate whose
+`isMinimized` is already `true` (idempotent; the minimize helper's own probe
+already enforces this).
+
+Convert each eligible candidate's REST comment id to its GraphQL node id and
+call the existing minimize helper -- reuse it rather than reimplementing the
+mutation:
+
+```sh
+node scripts/minimize-superseded-markers.mjs --subject-ids <id1,id2,...> \
+  --classifier OUTDATED --trusted-marker-logins <trusted-login-1,...> \
+  --apply
+```
+
+Or, for npx/package-manager profiles, the equivalent
+`idd-minimize-superseded-markers` command.
+
+This step is best-effort and never blocking: a permission error, an
+unreadable comment list, or an unavailable helper runtime
+(`instructions-only` profile, or Node.js absent) skips it silently and
+continues the normal marker-posting flow unmodified -- it must never
+retry-loop or fail the authoring flow. Mirrors
+`docs/idd-comment-minimization.md`'s framing: this is UI cleanup only and
+never replaces the append-only audit trail.
+
+In scope: `authoring-owner` and `authoring-publication-intent` only. Out of
+scope: `authoring-publication` -- a body-line token embedded in the newly
+created issue's own body at creation time, not a comment, so there is
+nothing to minimize -- and every marker family already covered by the
+post-merge F4 cleanup driver (for example `claimed-by`, `review-watermark`,
+`advisory-wait`; see `docs/idd-comment-minimization.md`). Do not add
+`authoring-owner`, `authoring-publication-intent`, or `authoring-publication`
+to `OPERATIONAL_MARKERS`, and do not fold this step into the F4 driver: it
+is a separate, earlier-lifecycle, hide-at-post-time behavior.
+
 Immediately before every body or roadmap relationship update, re-fetch both
 the target and the set anchor (the same fresh snapshot serves both roles when
 the target is the anchor). Require each target's expected owner token

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -787,6 +787,20 @@ The originating Stage 1 hold uses this append-only publication-intent record:
 <!-- <marker-prefix>-authoring-publication-intent: target=<opaque-target-id>; anchor=<opaque-anchor-id>; set=<opaque-set-id>; session=<opaque-session-id>; token=<opaque-publication-token>; journal=<owner>/<repo>#<number>; issue=<owner>/<repo>#<number>|none; actor=<trusted-marker-actor>; state=<pending|member|cleanup|abandoned> -->
 ```
 
+Append the visible note below immediately after this HTML comment, joined by
+a single newline (no blank line between them, matching the `authoring-owner`
+marker's own posted shape) -- this exact pairing is the canonical rendered
+template `matchCanonicalAuthoringMarkerFamily` (`marker-helpers.mts`)
+matches for the hide-on-supersede step below. Historical comments predating
+this canonical pin may use a different separator, note text, or no note at
+all (#2750); those never byte-exact-match the canonical template and are
+correctly left visible -- expected fail-closed behavior, not retroactive
+cleanup:
+
+```text
+_Issue-authoring publication-intent record. Do not edit or delete._
+```
+
 `issue` is the returned canonical issue identity or `none`. Append
 `state=pending; issue=none` before creation, then append the returned identity
 while it remains `pending`, append `member` only after the owner marker is
@@ -862,6 +876,15 @@ comment using the resolved marker prefix:
 ```
 
 _Issue-authoring ownership marker. Do not edit or delete._
+
+Join the HTML comment and the visible note above by a single newline (no
+blank line between them) -- this exact pairing, for any `mode`, is the
+canonical rendered template `matchCanonicalAuthoringMarkerFamily`
+(`marker-helpers.mts`) matches for the hide-on-supersede step below.
+Historical comments predating this canonical pin may use a blank-line
+separator instead (#2750); those never byte-exact-match the canonical
+template and are correctly left visible -- expected fail-closed behavior,
+not retroactive cleanup.
 
 The companion uses the same `body-sha256` and `snapshot-sha256` semantics as
 the portable owner protocol. Target markers hash the exact UTF-8 body from the
@@ -1022,9 +1045,10 @@ guessing. Skip the just-posted comment itself and any candidate whose
 `isMinimized` is already `true` (idempotent; the minimize helper's own probe
 already enforces this).
 
-Convert each eligible candidate's REST comment id to its GraphQL node id and
-call the existing minimize helper -- reuse it rather than reimplementing the
-mutation:
+Convert each eligible candidate's REST comment id to its GraphQL node id
+(the paginated comment list already carries it as `node_id` -- no extra
+fetch needed) and call the existing minimize helper -- reuse it rather than
+reimplementing the mutation:
 
 ```sh
 node scripts/minimize-superseded-markers.mjs --subject-ids <id1,id2,...> \

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -1285,12 +1285,18 @@ export function parseAuthoringPublicationIntentComment(body, markerPrefix) {
 }
 /**
  * Render the canonical `authoring-owner` marker body (#2750): HTML-comment
- * token + the fixed visible note, joined by a single newline -- confirmed
- * against live posted instances, this pair carries **no** blank line between
- * them, unlike the `claimed-by`-family renderers below. `markerPrefix` is
- * the same value `parseAuthoringOwnerComment` takes as its second argument;
- * every other field mirrors {@link ParsedAuthoringOwnerMarker}. Throws on an
- * invalid payload, matching every other renderer in this module.
+ * token + the fixed visible note, joined by a single newline -- this pair
+ * carries **no** blank line between them, unlike the `claimed-by`-family
+ * renderers below. This is the format the issue-authoring contract
+ * (`skills/issue-authoring/references/contract.md`) now pins as canonical,
+ * matching the most recently posted live instances; a real historical
+ * comment from before that pin can instead use a blank-line separator
+ * (confirmed live, e.g. kurone-kito/idd-skill#2706) and will correctly fail
+ * to byte-exact-match -- fail-closed, not a defect (independent critique
+ * pass, PR #2821). `markerPrefix` is the same value
+ * `parseAuthoringOwnerComment` takes as its second argument; every other
+ * field mirrors {@link ParsedAuthoringOwnerMarker}. Throws on an invalid
+ * payload, matching every other renderer in this module.
  */
 export function renderAuthoringOwnerMarker(payload) {
   const markerPrefix = normalizeNonWhitespaceToken(payload?.markerPrefix);
@@ -1356,8 +1362,15 @@ export function renderAuthoringOwnerMarker(payload) {
  * Render the canonical `authoring-publication-intent` marker body (#2750),
  * mirroring {@link renderAuthoringOwnerMarker}'s contract (single-newline
  * join, `markerPrefix` as the resolved target prefix, one field per
- * {@link ParsedAuthoringPublicationIntentMarker}). Throws on an invalid
- * payload.
+ * {@link ParsedAuthoringPublicationIntentMarker}). Before this issue, the
+ * contract documented no visible note at all for this marker family, and
+ * live comments on the authoring journal (kurone-kito/idd-skill#2674)
+ * drifted across three shapes in practice: no note, a blank-line-separated
+ * note, and a single-newline-separated note with different wording
+ * (confirmed live; independent critique pass, PR #2821). This renderer's
+ * shape is the one the contract now pins as canonical going forward; none
+ * of the pre-pin variants will byte-exact-match it, by design (fail-closed,
+ * not retroactive cleanup). Throws on an invalid payload.
  */
 export function renderAuthoringPublicationIntentMarker(payload) {
   const markerPrefix = normalizeNonWhitespaceToken(payload?.markerPrefix);

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -1283,6 +1283,177 @@ export function parseAuthoringPublicationIntentComment(body, markerPrefix) {
     state: state,
   };
 }
+/**
+ * Render the canonical `authoring-owner` marker body (#2750): HTML-comment
+ * token + the fixed visible note, joined by a single newline -- confirmed
+ * against live posted instances, this pair carries **no** blank line between
+ * them, unlike the `claimed-by`-family renderers below. `markerPrefix` is
+ * the same value `parseAuthoringOwnerComment` takes as its second argument;
+ * every other field mirrors {@link ParsedAuthoringOwnerMarker}. Throws on an
+ * invalid payload, matching every other renderer in this module.
+ */
+export function renderAuthoringOwnerMarker(payload) {
+  const markerPrefix = normalizeNonWhitespaceToken(payload?.markerPrefix);
+  const target = normalizeNonWhitespaceToken(payload?.target);
+  const anchor = normalizeNonWhitespaceToken(payload?.anchor);
+  const mode = normalizeNonWhitespaceToken(payload?.mode);
+  const modeValid = AUTHORING_OWNER_MODES.has(mode);
+  const owner = normalizeNonWhitespaceToken(payload?.owner);
+  const set = normalizeNonWhitespaceToken(payload?.set);
+  const session = normalizeNonWhitespaceToken(payload?.session);
+  const bodySha256 = normalizeNonWhitespaceToken(payload?.bodySha256);
+  const bodySha256Valid = AUTHORING_OWNER_DIGEST_PATTERN.test(bodySha256);
+  const snapshotSha256 = normalizeNonWhitespaceToken(payload?.snapshotSha256);
+  const snapshotSha256Valid =
+    AUTHORING_OWNER_DIGEST_PATTERN.test(snapshotSha256);
+  const supersedes = normalizeNonWhitespaceToken(payload?.supersedes);
+  if (
+    !markerPrefix ||
+    !target ||
+    !anchor ||
+    !modeValid ||
+    !owner ||
+    !set ||
+    !session ||
+    !bodySha256Valid ||
+    !snapshotSha256Valid ||
+    !supersedes
+  ) {
+    throw new Error(
+      'invalid authoring-owner marker payload' +
+        describeInvalidMarkerFields([
+          {
+            name: 'markerPrefix',
+            raw: payload?.markerPrefix,
+            failed: !markerPrefix,
+          },
+          { name: 'target', raw: payload?.target, failed: !target },
+          { name: 'anchor', raw: payload?.anchor, failed: !anchor },
+          { name: 'mode', raw: payload?.mode, failed: !modeValid },
+          { name: 'owner', raw: payload?.owner, failed: !owner },
+          { name: 'set', raw: payload?.set, failed: !set },
+          { name: 'session', raw: payload?.session, failed: !session },
+          {
+            name: 'bodySha256',
+            raw: payload?.bodySha256,
+            failed: !bodySha256Valid,
+          },
+          {
+            name: 'snapshotSha256',
+            raw: payload?.snapshotSha256,
+            failed: !snapshotSha256Valid,
+          },
+          { name: 'supersedes', raw: payload?.supersedes, failed: !supersedes },
+        ]),
+    );
+  }
+  return [
+    `<!-- ${markerPrefix}-authoring-owner: target=${target}; anchor=${anchor}; mode=${mode}; owner=${owner}; set=${set}; session=${session}; body-sha256=${bodySha256}; snapshot-sha256=${snapshotSha256}; supersedes=${supersedes} -->`,
+    '_Issue-authoring ownership marker. Do not edit or delete._',
+  ].join('\n');
+}
+/**
+ * Render the canonical `authoring-publication-intent` marker body (#2750),
+ * mirroring {@link renderAuthoringOwnerMarker}'s contract (single-newline
+ * join, `markerPrefix` as the resolved target prefix, one field per
+ * {@link ParsedAuthoringPublicationIntentMarker}). Throws on an invalid
+ * payload.
+ */
+export function renderAuthoringPublicationIntentMarker(payload) {
+  const markerPrefix = normalizeNonWhitespaceToken(payload?.markerPrefix);
+  const target = normalizeNonWhitespaceToken(payload?.target);
+  const anchor = normalizeNonWhitespaceToken(payload?.anchor);
+  const set = normalizeNonWhitespaceToken(payload?.set);
+  const session = normalizeNonWhitespaceToken(payload?.session);
+  const token = normalizeNonWhitespaceToken(payload?.token);
+  const journal = normalizeNonWhitespaceToken(payload?.journal);
+  const issue = normalizeNonWhitespaceToken(payload?.issue);
+  const actor = normalizeNonWhitespaceToken(payload?.actor);
+  const state = normalizeNonWhitespaceToken(payload?.state);
+  const stateValid = AUTHORING_PUBLICATION_INTENT_STATES.has(state);
+  if (
+    !markerPrefix ||
+    !target ||
+    !anchor ||
+    !set ||
+    !session ||
+    !token ||
+    !journal ||
+    !issue ||
+    !actor ||
+    !stateValid
+  ) {
+    throw new Error(
+      'invalid authoring-publication-intent marker payload' +
+        describeInvalidMarkerFields([
+          {
+            name: 'markerPrefix',
+            raw: payload?.markerPrefix,
+            failed: !markerPrefix,
+          },
+          { name: 'target', raw: payload?.target, failed: !target },
+          { name: 'anchor', raw: payload?.anchor, failed: !anchor },
+          { name: 'set', raw: payload?.set, failed: !set },
+          { name: 'session', raw: payload?.session, failed: !session },
+          { name: 'token', raw: payload?.token, failed: !token },
+          { name: 'journal', raw: payload?.journal, failed: !journal },
+          { name: 'issue', raw: payload?.issue, failed: !issue },
+          { name: 'actor', raw: payload?.actor, failed: !actor },
+          { name: 'state', raw: payload?.state, failed: !stateValid },
+        ]),
+    );
+  }
+  return [
+    `<!-- ${markerPrefix}-authoring-publication-intent: target=${target}; anchor=${anchor}; set=${set}; session=${session}; token=${token}; journal=${journal}; issue=${issue}; actor=${actor}; state=${state} -->`,
+    '_Issue-authoring publication-intent record. Do not edit or delete._',
+  ].join('\n');
+}
+/**
+ * Determine whether `body` is a byte-exact canonical rendering of an
+ * `authoring-owner` or `authoring-publication-intent` marker for the given
+ * `markerPrefix` (#2750): parse it with {@link parseAuthoringOwnerComment} /
+ * {@link parseAuthoringPublicationIntentComment}, re-render the parsed
+ * fields with the matching renderer above, and require the result to equal
+ * `body` exactly. A body that fails to parse, or that parses but whose
+ * canonical re-rendering differs in any way -- reordered or extra fields,
+ * altered spacing, trailing content, a different visible note -- is a
+ * **non-match**: this function never guesses, matching the "exact-template
+ * match only, fail closed" rule the hide-on-supersede step relies on. Tried
+ * in `authoring-owner` then `authoring-publication-intent` order; a body
+ * cannot validly match both, since each requires a different fixed marker
+ * label.
+ *
+ * Returns the matched family name, or `null` when neither matches.
+ */
+export function matchCanonicalAuthoringMarkerFamily(body, markerPrefix) {
+  const owner = parseAuthoringOwnerComment(body, markerPrefix);
+  if (owner) {
+    try {
+      if (renderAuthoringOwnerMarker({ markerPrefix, ...owner }) === body) {
+        return 'authoring-owner';
+      }
+    } catch {
+      // A parsed field failed the renderer's own stricter validation (for
+      // example internal whitespace the parser's plain trim() does not
+      // reject) -- a body that cannot be reconstructed is never a safe
+      // match.
+    }
+  }
+  const intent = parseAuthoringPublicationIntentComment(body, markerPrefix);
+  if (intent) {
+    try {
+      if (
+        renderAuthoringPublicationIntentMarker({ markerPrefix, ...intent }) ===
+        body
+      ) {
+        return 'authoring-publication-intent';
+      }
+    } catch {
+      // Same rationale as the authoring-owner branch above.
+    }
+  }
+  return null;
+}
 // --- Per-cycle marker body renderers (#900) ---
 //
 // Pure, network-free renderers for the three operational markers an agent

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -1429,6 +1429,61 @@ only approval boundary.
   winner by deterministic comment order; an immediate local read never
   authorizes edits. Apply the same settle delay and full paginated replay after
   every heartbeat before it authorizes an edit or label removal.
+- **Hide superseded owner/publication-intent markers.** Once a fresh
+  `authoring-owner` marker (any `mode`, including the first,
+  generation-opening `acquire`/`bootstrap`) or `authoring-publication-intent`
+  record (any `state`) has been posted and its own POST and re-fetch/verify
+  above have both succeeded -- never before, and never interleaved with
+  posting -- scan that same target's prior comments (the target issue for
+  `authoring-owner`; the journal issue named in the record's own `journal`
+  field for `authoring-publication-intent`, which naturally also hides other
+  authoring sets' already superseded journal records on that shared journal
+  -- intentional, since the journal read path is the same paginated scan and
+  is unaffected either way) and minimize (classifier `OUTDATED`) every prior
+  comment from a trusted marker actor whose body is a byte-exact match of the
+  canonical rendered template for the same marker family.
+  `matchCanonicalAuthoringMarkerFamily` (`marker-helpers.mts`, re-exported by
+  `protocol-helpers.mts`) implements that check: it parses the candidate,
+  re-renders the parsed fields with `renderAuthoringOwnerMarker` /
+  `renderAuthoringPublicationIntentMarker`, and requires the result to equal
+  the candidate's body exactly. A candidate that deviates from the template
+  in any way -- reordered or extra fields, altered spacing, trailing
+  content, a different visible note -- is never minimized; leave it visible
+  rather than guessing. Skip the just-posted comment itself and any
+  candidate whose `isMinimized` is already `true` (idempotent; the minimize
+  helper's own probe already enforces this).
+
+  Convert each eligible candidate's REST comment id to its GraphQL node id
+  and call the existing minimize helper -- reuse it rather than
+  reimplementing the mutation:
+
+  ```sh
+  node scripts/minimize-superseded-markers.mjs --subject-ids <id1,id2,...> \
+    --classifier OUTDATED --trusted-marker-logins <trusted-login-1,...> \
+    --apply
+  ```
+
+  Or, for npx/package-manager profiles, the equivalent
+  `idd-minimize-superseded-markers` command.
+
+  **Best-effort, never blocking.** A permission error, an unreadable
+  comment list, or an unavailable helper runtime (`instructions-only`
+  profile, or Node.js absent) skips this step silently and continues the
+  normal marker-posting flow unmodified -- this must never retry-loop or
+  fail the authoring flow. Mirrors `docs/idd-comment-minimization.md`'s
+  framing: this is UI cleanup only and never replaces the append-only
+  audit trail.
+
+  **Scope.** In scope: `authoring-owner` and `authoring-publication-intent`
+  only. Out of scope: `authoring-publication` -- a body-line token embedded
+  in the newly created issue's own body at creation time, not a comment, so
+  there is nothing to minimize -- and every marker family already covered
+  by the post-merge F4 cleanup driver (for example `claimed-by`,
+  `review-watermark`, `advisory-wait`; see `docs/idd-comment-minimization.md`).
+  Do not add `authoring-owner`, `authoring-publication-intent`, or
+  `authoring-publication` to `OPERATIONAL_MARKERS`, and do not fold this
+  step into the F4 driver: it is a separate, earlier-lifecycle,
+  hide-at-post-time behavior.
 - **Conflict check before every edit.** Immediately before each body or
   roadmap relationship update, re-fetch both the target and the set anchor
   (the same fresh snapshot serves both roles when the target is the anchor).

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -1212,6 +1212,20 @@ only approval boundary.
   <!-- <marker-prefix>-authoring-publication-intent: target=<opaque-target-id>; anchor=<opaque-anchor-id>; set=<opaque-set-id>; session=<opaque-session-id>; token=<opaque-publication-token>; journal=<owner>/<repo>#<number>; issue=<owner>/<repo>#<number>|none; actor=<trusted-marker-actor>; state=<pending|member|cleanup|abandoned> -->
   ```
 
+  Append the visible note below immediately after this HTML comment, joined
+  by a single newline (no blank line between them, matching the
+  `authoring-owner` marker's own posted shape) — this exact pairing is the
+  canonical rendered template `matchCanonicalAuthoringMarkerFamily`
+  (`marker-helpers.mts`) matches for the hide-on-supersede step below.
+  Historical comments predating this canonical pin may use a different
+  separator, note text, or no note at all (#2750); those never
+  byte-exact-match the canonical template and are correctly left visible —
+  expected fail-closed behavior, not retroactive cleanup:
+
+  ```text
+  _Issue-authoring publication-intent record. Do not edit or delete._
+  ```
+
   `issue` is the returned canonical issue identity or `none`. Append
   `state=pending; issue=none` before creation, then append the returned
   identity while it remains `pending`, append `member` only after the owner
@@ -1295,6 +1309,15 @@ only approval boundary.
   ```
 
   _Issue-authoring ownership marker. Do not edit or delete._
+
+  Join the HTML comment and the visible note above by a single newline (no
+  blank line between them) -- this exact pairing, for any `mode`, is the
+  canonical rendered template `matchCanonicalAuthoringMarkerFamily`
+  (`marker-helpers.mts`) matches for the hide-on-supersede step below.
+  Historical comments predating this canonical pin may use a blank-line
+  separator instead (#2750); those never byte-exact-match the canonical
+  template and are correctly left visible -- expected fail-closed behavior,
+  not retroactive cleanup.
 
   The companion uses the same `body-sha256` and `snapshot-sha256` fields as the
   portable owner protocol. Target markers hash the exact UTF-8 body from the
@@ -1454,8 +1477,9 @@ only approval boundary.
   helper's own probe already enforces this).
 
   Convert each eligible candidate's REST comment id to its GraphQL node id
-  and call the existing minimize helper -- reuse it rather than
-  reimplementing the mutation:
+  (the paginated comment list already carries it as `node_id` -- no extra
+  fetch needed) and call the existing minimize helper -- reuse it rather
+  than reimplementing the mutation:
 
   ```sh
   node scripts/minimize-superseded-markers.mjs --subject-ids <id1,id2,...> \

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -1798,12 +1798,18 @@ export function parseAuthoringPublicationIntentComment(
 
 /**
  * Render the canonical `authoring-owner` marker body (#2750): HTML-comment
- * token + the fixed visible note, joined by a single newline -- confirmed
- * against live posted instances, this pair carries **no** blank line between
- * them, unlike the `claimed-by`-family renderers below. `markerPrefix` is
- * the same value `parseAuthoringOwnerComment` takes as its second argument;
- * every other field mirrors {@link ParsedAuthoringOwnerMarker}. Throws on an
- * invalid payload, matching every other renderer in this module.
+ * token + the fixed visible note, joined by a single newline -- this pair
+ * carries **no** blank line between them, unlike the `claimed-by`-family
+ * renderers below. This is the format the issue-authoring contract
+ * (`skills/issue-authoring/references/contract.md`) now pins as canonical,
+ * matching the most recently posted live instances; a real historical
+ * comment from before that pin can instead use a blank-line separator
+ * (confirmed live, e.g. kurone-kito/idd-skill#2706) and will correctly fail
+ * to byte-exact-match -- fail-closed, not a defect (independent critique
+ * pass, PR #2821). `markerPrefix` is the same value
+ * `parseAuthoringOwnerComment` takes as its second argument; every other
+ * field mirrors {@link ParsedAuthoringOwnerMarker}. Throws on an invalid
+ * payload, matching every other renderer in this module.
  */
 export function renderAuthoringOwnerMarker(payload: {
   markerPrefix?: unknown;
@@ -1881,8 +1887,15 @@ export function renderAuthoringOwnerMarker(payload: {
  * Render the canonical `authoring-publication-intent` marker body (#2750),
  * mirroring {@link renderAuthoringOwnerMarker}'s contract (single-newline
  * join, `markerPrefix` as the resolved target prefix, one field per
- * {@link ParsedAuthoringPublicationIntentMarker}). Throws on an invalid
- * payload.
+ * {@link ParsedAuthoringPublicationIntentMarker}). Before this issue, the
+ * contract documented no visible note at all for this marker family, and
+ * live comments on the authoring journal (kurone-kito/idd-skill#2674)
+ * drifted across three shapes in practice: no note, a blank-line-separated
+ * note, and a single-newline-separated note with different wording
+ * (confirmed live; independent critique pass, PR #2821). This renderer's
+ * shape is the one the contract now pins as canonical going forward; none
+ * of the pre-pin variants will byte-exact-match it, by design (fail-closed,
+ * not retroactive cleanup). Throws on an invalid payload.
  */
 export function renderAuthoringPublicationIntentMarker(payload: {
   markerPrefix?: unknown;

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -1564,9 +1564,15 @@ export function parseLocalValidationEvidenceComment(
 // Three markers from the issue-authoring skill's "Authoring label lifecycle"
 // protocol (docs/issue-authoring-skill.md), each using a semicolon-separated
 // `key=value; key2=value2` grammar distinct from every marker above (which
-// use fixed positional tokens). Parsing only -- nothing in this codebase
-// renders these; the issue-authoring skill posts them directly via its own
-// documented HTTP path, not through a shared renderer here.
+// use fixed positional tokens). The issue-authoring skill still posts every
+// one of these directly via its own documented HTTP path, not through a
+// shared renderer here -- `authoring-publication` stays parse-only for that
+// reason. `authoring-owner` and `authoring-publication-intent` additionally
+// get a renderer below (#2750): not for posting, but so a byte-exact
+// canonical-template match can be detected by parsing a candidate comment
+// then re-rendering it from the parsed fields and comparing the result
+// against the original body -- see `matchCanonicalAuthoringMarkerFamily`
+// below.
 
 /** Parsed `<!-- {prefix}-authoring-owner: ... -->` marker. */
 export interface ParsedAuthoringOwnerMarker {
@@ -1788,6 +1794,205 @@ export function parseAuthoringPublicationIntentComment(
     actor: fields.actor,
     state: state as ParsedAuthoringPublicationIntentMarker['state'],
   };
+}
+
+/**
+ * Render the canonical `authoring-owner` marker body (#2750): HTML-comment
+ * token + the fixed visible note, joined by a single newline -- confirmed
+ * against live posted instances, this pair carries **no** blank line between
+ * them, unlike the `claimed-by`-family renderers below. `markerPrefix` is
+ * the same value `parseAuthoringOwnerComment` takes as its second argument;
+ * every other field mirrors {@link ParsedAuthoringOwnerMarker}. Throws on an
+ * invalid payload, matching every other renderer in this module.
+ */
+export function renderAuthoringOwnerMarker(payload: {
+  markerPrefix?: unknown;
+  target?: unknown;
+  anchor?: unknown;
+  mode?: unknown;
+  owner?: unknown;
+  set?: unknown;
+  session?: unknown;
+  bodySha256?: unknown;
+  snapshotSha256?: unknown;
+  supersedes?: unknown;
+}): string {
+  const markerPrefix = normalizeNonWhitespaceToken(payload?.markerPrefix);
+  const target = normalizeNonWhitespaceToken(payload?.target);
+  const anchor = normalizeNonWhitespaceToken(payload?.anchor);
+  const mode = normalizeNonWhitespaceToken(payload?.mode);
+  const modeValid = AUTHORING_OWNER_MODES.has(mode);
+  const owner = normalizeNonWhitespaceToken(payload?.owner);
+  const set = normalizeNonWhitespaceToken(payload?.set);
+  const session = normalizeNonWhitespaceToken(payload?.session);
+  const bodySha256 = normalizeNonWhitespaceToken(payload?.bodySha256);
+  const bodySha256Valid = AUTHORING_OWNER_DIGEST_PATTERN.test(bodySha256);
+  const snapshotSha256 = normalizeNonWhitespaceToken(payload?.snapshotSha256);
+  const snapshotSha256Valid =
+    AUTHORING_OWNER_DIGEST_PATTERN.test(snapshotSha256);
+  const supersedes = normalizeNonWhitespaceToken(payload?.supersedes);
+  if (
+    !markerPrefix ||
+    !target ||
+    !anchor ||
+    !modeValid ||
+    !owner ||
+    !set ||
+    !session ||
+    !bodySha256Valid ||
+    !snapshotSha256Valid ||
+    !supersedes
+  ) {
+    throw new Error(
+      'invalid authoring-owner marker payload' +
+        describeInvalidMarkerFields([
+          {
+            name: 'markerPrefix',
+            raw: payload?.markerPrefix,
+            failed: !markerPrefix,
+          },
+          { name: 'target', raw: payload?.target, failed: !target },
+          { name: 'anchor', raw: payload?.anchor, failed: !anchor },
+          { name: 'mode', raw: payload?.mode, failed: !modeValid },
+          { name: 'owner', raw: payload?.owner, failed: !owner },
+          { name: 'set', raw: payload?.set, failed: !set },
+          { name: 'session', raw: payload?.session, failed: !session },
+          {
+            name: 'bodySha256',
+            raw: payload?.bodySha256,
+            failed: !bodySha256Valid,
+          },
+          {
+            name: 'snapshotSha256',
+            raw: payload?.snapshotSha256,
+            failed: !snapshotSha256Valid,
+          },
+          { name: 'supersedes', raw: payload?.supersedes, failed: !supersedes },
+        ]),
+    );
+  }
+  return [
+    `<!-- ${markerPrefix}-authoring-owner: target=${target}; anchor=${anchor}; mode=${mode}; owner=${owner}; set=${set}; session=${session}; body-sha256=${bodySha256}; snapshot-sha256=${snapshotSha256}; supersedes=${supersedes} -->`,
+    '_Issue-authoring ownership marker. Do not edit or delete._',
+  ].join('\n');
+}
+
+/**
+ * Render the canonical `authoring-publication-intent` marker body (#2750),
+ * mirroring {@link renderAuthoringOwnerMarker}'s contract (single-newline
+ * join, `markerPrefix` as the resolved target prefix, one field per
+ * {@link ParsedAuthoringPublicationIntentMarker}). Throws on an invalid
+ * payload.
+ */
+export function renderAuthoringPublicationIntentMarker(payload: {
+  markerPrefix?: unknown;
+  target?: unknown;
+  anchor?: unknown;
+  set?: unknown;
+  session?: unknown;
+  token?: unknown;
+  journal?: unknown;
+  issue?: unknown;
+  actor?: unknown;
+  state?: unknown;
+}): string {
+  const markerPrefix = normalizeNonWhitespaceToken(payload?.markerPrefix);
+  const target = normalizeNonWhitespaceToken(payload?.target);
+  const anchor = normalizeNonWhitespaceToken(payload?.anchor);
+  const set = normalizeNonWhitespaceToken(payload?.set);
+  const session = normalizeNonWhitespaceToken(payload?.session);
+  const token = normalizeNonWhitespaceToken(payload?.token);
+  const journal = normalizeNonWhitespaceToken(payload?.journal);
+  const issue = normalizeNonWhitespaceToken(payload?.issue);
+  const actor = normalizeNonWhitespaceToken(payload?.actor);
+  const state = normalizeNonWhitespaceToken(payload?.state);
+  const stateValid = AUTHORING_PUBLICATION_INTENT_STATES.has(state);
+  if (
+    !markerPrefix ||
+    !target ||
+    !anchor ||
+    !set ||
+    !session ||
+    !token ||
+    !journal ||
+    !issue ||
+    !actor ||
+    !stateValid
+  ) {
+    throw new Error(
+      'invalid authoring-publication-intent marker payload' +
+        describeInvalidMarkerFields([
+          {
+            name: 'markerPrefix',
+            raw: payload?.markerPrefix,
+            failed: !markerPrefix,
+          },
+          { name: 'target', raw: payload?.target, failed: !target },
+          { name: 'anchor', raw: payload?.anchor, failed: !anchor },
+          { name: 'set', raw: payload?.set, failed: !set },
+          { name: 'session', raw: payload?.session, failed: !session },
+          { name: 'token', raw: payload?.token, failed: !token },
+          { name: 'journal', raw: payload?.journal, failed: !journal },
+          { name: 'issue', raw: payload?.issue, failed: !issue },
+          { name: 'actor', raw: payload?.actor, failed: !actor },
+          { name: 'state', raw: payload?.state, failed: !stateValid },
+        ]),
+    );
+  }
+  return [
+    `<!-- ${markerPrefix}-authoring-publication-intent: target=${target}; anchor=${anchor}; set=${set}; session=${session}; token=${token}; journal=${journal}; issue=${issue}; actor=${actor}; state=${state} -->`,
+    '_Issue-authoring publication-intent record. Do not edit or delete._',
+  ].join('\n');
+}
+
+/**
+ * Determine whether `body` is a byte-exact canonical rendering of an
+ * `authoring-owner` or `authoring-publication-intent` marker for the given
+ * `markerPrefix` (#2750): parse it with {@link parseAuthoringOwnerComment} /
+ * {@link parseAuthoringPublicationIntentComment}, re-render the parsed
+ * fields with the matching renderer above, and require the result to equal
+ * `body` exactly. A body that fails to parse, or that parses but whose
+ * canonical re-rendering differs in any way -- reordered or extra fields,
+ * altered spacing, trailing content, a different visible note -- is a
+ * **non-match**: this function never guesses, matching the "exact-template
+ * match only, fail closed" rule the hide-on-supersede step relies on. Tried
+ * in `authoring-owner` then `authoring-publication-intent` order; a body
+ * cannot validly match both, since each requires a different fixed marker
+ * label.
+ *
+ * Returns the matched family name, or `null` when neither matches.
+ */
+export function matchCanonicalAuthoringMarkerFamily(
+  body: string,
+  markerPrefix: string,
+): 'authoring-owner' | 'authoring-publication-intent' | null {
+  const owner = parseAuthoringOwnerComment(body, markerPrefix);
+  if (owner) {
+    try {
+      if (renderAuthoringOwnerMarker({ markerPrefix, ...owner }) === body) {
+        return 'authoring-owner';
+      }
+    } catch {
+      // A parsed field failed the renderer's own stricter validation (for
+      // example internal whitespace the parser's plain trim() does not
+      // reject) -- a body that cannot be reconstructed is never a safe
+      // match.
+    }
+  }
+  const intent = parseAuthoringPublicationIntentComment(body, markerPrefix);
+  if (intent) {
+    try {
+      if (
+        renderAuthoringPublicationIntentMarker({ markerPrefix, ...intent }) ===
+        body
+      ) {
+        return 'authoring-publication-intent';
+      }
+    } catch {
+      // Same rationale as the authoring-owner branch above.
+    }
+  }
+  return null;
 }
 
 // --- Per-cycle marker body renderers (#900) ---

--- a/tests/marker-helpers-facade.test.mts
+++ b/tests/marker-helpers-facade.test.mts
@@ -409,6 +409,33 @@ test('matchCanonicalAuthoringMarkerFamily: an altered field value is a negative 
   );
 });
 
+// #2750 (independent critique pass, PR #2821): the separator/note-text
+// pairing genuinely drifted across past posting sessions before this issue
+// pinned a canonical shape -- a live blank-line-separated authoring-owner
+// comment (kurone-kito/idd-skill#2706, comment id 5580125588, fetched
+// verbatim) predates the pin and never byte-exact-matches the newly-pinned
+// single-newline template. This is the fail-closed behavior the contract
+// documents (skills/issue-authoring/references/contract.md), not a defect:
+// a historical comment in the old shape is correctly left visible rather
+// than guessed at.
+test('matchCanonicalAuthoringMarkerFamily: a real pre-pin blank-line-separated comment is a negative match (fail-closed, not retroactive cleanup)', () => {
+  const legacyBlankLineBody =
+    '<!-- idd-skill-authoring-owner: target=kurone-kito/idd-skill#2706; anchor=kurone-kito/idd-skill#2706; mode=acquire; owner=owner-7f0bdd05cfcb6f75; set=set-5f974e50cf506b08; session=claude-idd1-35ad1f618a3a; body-sha256=2633e24463dbbabf260232d64f267cfd35b452d59c57df0955f24d5c6d60af69; snapshot-sha256=none; supersedes=none -->\n' +
+    '\n' +
+    '_Issue-authoring ownership marker. Do not edit or delete._';
+  assert.ok(
+    direct.parseAuthoringOwnerComment(legacyBlankLineBody, 'idd-skill'),
+    'the legacy body must still parse (sanity check for this test itself)',
+  );
+  assert.strictEqual(
+    direct.matchCanonicalAuthoringMarkerFamily(
+      legacyBlankLineBody,
+      'idd-skill',
+    ),
+    null,
+  );
+});
+
 test('matchCanonicalAuthoringMarkerFamily: a different marker prefix is a negative match', () => {
   const ownerBody = direct.renderAuthoringOwnerMarker(AUTHORING_OWNER_PAYLOAD);
   assert.strictEqual(

--- a/tests/marker-helpers-facade.test.mts
+++ b/tests/marker-helpers-facade.test.mts
@@ -49,6 +49,9 @@ const SAMPLE_NAMES = [
   'hasReviewReplyStamp',
   'appendReviewReplyStamp',
   'isIddOriginatedReply',
+  'renderAuthoringOwnerMarker',
+  'renderAuthoringPublicationIntentMarker',
+  'matchCanonicalAuthoringMarkerFamily',
 ] as const;
 
 test('protocol-helpers re-exports every sampled marker-helpers name by identity', () => {
@@ -247,5 +250,201 @@ test('MARKER_HIDE_POLICY does not leak the underlying map through inherited Obje
     typeof direct.MARKER_HIDE_POLICY.toString(),
     'string',
     'toString() must stay a harmless primitive, not expose the underlying map',
+  );
+});
+
+// #2750: renderAuthoringOwnerMarker / renderAuthoringPublicationIntentMarker
+// exist so a candidate comment's canonical rendering can be compared
+// byte-for-byte against its live body (matchCanonicalAuthoringMarkerFamily,
+// tested further below) -- these renderers themselves round-trip through
+// the existing parseAuthoringOwnerComment / parseAuthoringPublicationIntentComment
+// functions, and reject a payload missing/invalid fields the same way every
+// other renderer in this module does.
+
+const AUTHORING_OWNER_PAYLOAD = {
+  markerPrefix: 'idd-skill',
+  target: 'kurone-kito/idd-skill#2750',
+  anchor: 'kurone-kito/idd-skill#2750',
+  mode: 'acquire',
+  owner: 'owner-9ffa338d8a416b86',
+  set: 'set-1e23beadb3e60e42',
+  session: 'claude-idd3-5201e45ac16c',
+  bodySha256:
+    'f370d4b220dd04d2d896a6c1d7841ecb261a7825bed8e68f07452073972fe389',
+  snapshotSha256: 'none',
+  supersedes: 'none',
+} as const;
+
+const AUTHORING_PUBLICATION_INTENT_PAYLOAD = {
+  markerPrefix: 'idd-skill',
+  target: 'target-720705e9015f0dda',
+  anchor: 'target-720705e9015f0dda',
+  set: 'set-74bec4d0d29e21ae',
+  session: 'claude-idd1-9f3a2b7c1e4d',
+  token: 'pub-7e1361eb1b96bc36',
+  journal: 'kurone-kito/idd-skill#2674',
+  issue: 'none',
+  actor: 'kurone-kito',
+  state: 'pending',
+} as const;
+
+test('renderAuthoringOwnerMarker matches the live-posted canonical shape and round-trips through the parser', () => {
+  const body = direct.renderAuthoringOwnerMarker(AUTHORING_OWNER_PAYLOAD);
+  assert.strictEqual(
+    body,
+    '<!-- idd-skill-authoring-owner: target=kurone-kito/idd-skill#2750; anchor=kurone-kito/idd-skill#2750; mode=acquire; owner=owner-9ffa338d8a416b86; set=set-1e23beadb3e60e42; session=claude-idd3-5201e45ac16c; body-sha256=f370d4b220dd04d2d896a6c1d7841ecb261a7825bed8e68f07452073972fe389; snapshot-sha256=none; supersedes=none -->\n' +
+      '_Issue-authoring ownership marker. Do not edit or delete._',
+  );
+  const parsed = direct.parseAuthoringOwnerComment(body, 'idd-skill');
+  assert.deepStrictEqual(parsed, {
+    target: AUTHORING_OWNER_PAYLOAD.target,
+    anchor: AUTHORING_OWNER_PAYLOAD.anchor,
+    mode: AUTHORING_OWNER_PAYLOAD.mode,
+    owner: AUTHORING_OWNER_PAYLOAD.owner,
+    set: AUTHORING_OWNER_PAYLOAD.set,
+    session: AUTHORING_OWNER_PAYLOAD.session,
+    bodySha256: AUTHORING_OWNER_PAYLOAD.bodySha256,
+    snapshotSha256: AUTHORING_OWNER_PAYLOAD.snapshotSha256,
+    supersedes: AUTHORING_OWNER_PAYLOAD.supersedes,
+  });
+});
+
+test('renderAuthoringOwnerMarker throws on a missing/invalid field', () => {
+  assert.throws(
+    () =>
+      direct.renderAuthoringOwnerMarker({
+        ...AUTHORING_OWNER_PAYLOAD,
+        mode: 'not-a-real-mode',
+      }),
+    /invalid authoring-owner marker payload.*invalid "mode"/s,
+  );
+  assert.throws(
+    () =>
+      direct.renderAuthoringOwnerMarker({
+        ...AUTHORING_OWNER_PAYLOAD,
+        target: undefined,
+      }),
+    /invalid authoring-owner marker payload.*missing "target"/s,
+  );
+});
+
+test('renderAuthoringPublicationIntentMarker matches the live-posted canonical shape and round-trips through the parser', () => {
+  const body = direct.renderAuthoringPublicationIntentMarker(
+    AUTHORING_PUBLICATION_INTENT_PAYLOAD,
+  );
+  assert.strictEqual(
+    body,
+    '<!-- idd-skill-authoring-publication-intent: target=target-720705e9015f0dda; anchor=target-720705e9015f0dda; set=set-74bec4d0d29e21ae; session=claude-idd1-9f3a2b7c1e4d; token=pub-7e1361eb1b96bc36; journal=kurone-kito/idd-skill#2674; issue=none; actor=kurone-kito; state=pending -->\n' +
+      '_Issue-authoring publication-intent record. Do not edit or delete._',
+  );
+  const parsed = direct.parseAuthoringPublicationIntentComment(
+    body,
+    'idd-skill',
+  );
+  assert.deepStrictEqual(parsed, {
+    target: AUTHORING_PUBLICATION_INTENT_PAYLOAD.target,
+    anchor: AUTHORING_PUBLICATION_INTENT_PAYLOAD.anchor,
+    set: AUTHORING_PUBLICATION_INTENT_PAYLOAD.set,
+    session: AUTHORING_PUBLICATION_INTENT_PAYLOAD.session,
+    token: AUTHORING_PUBLICATION_INTENT_PAYLOAD.token,
+    journal: AUTHORING_PUBLICATION_INTENT_PAYLOAD.journal,
+    issue: AUTHORING_PUBLICATION_INTENT_PAYLOAD.issue,
+    actor: AUTHORING_PUBLICATION_INTENT_PAYLOAD.actor,
+    state: AUTHORING_PUBLICATION_INTENT_PAYLOAD.state,
+  });
+});
+
+test('renderAuthoringPublicationIntentMarker throws on a missing/invalid field', () => {
+  assert.throws(
+    () =>
+      direct.renderAuthoringPublicationIntentMarker({
+        ...AUTHORING_PUBLICATION_INTENT_PAYLOAD,
+        state: 'not-a-real-state',
+      }),
+    /invalid authoring-publication-intent marker payload.*invalid "state"/s,
+  );
+});
+
+// #2750: matchCanonicalAuthoringMarkerFamily is the exact-template-match
+// primitive the issue-authoring contract's hide-on-supersede step relies
+// on -- a byte-exact canonical marker body is a positive match; the same
+// body with one appended or altered character is a negative match (never
+// minimized).
+test('matchCanonicalAuthoringMarkerFamily: byte-exact canonical bodies match their own family', () => {
+  const ownerBody = direct.renderAuthoringOwnerMarker(AUTHORING_OWNER_PAYLOAD);
+  assert.strictEqual(
+    direct.matchCanonicalAuthoringMarkerFamily(ownerBody, 'idd-skill'),
+    'authoring-owner',
+  );
+
+  const intentBody = direct.renderAuthoringPublicationIntentMarker(
+    AUTHORING_PUBLICATION_INTENT_PAYLOAD,
+  );
+  assert.strictEqual(
+    direct.matchCanonicalAuthoringMarkerFamily(intentBody, 'idd-skill'),
+    'authoring-publication-intent',
+  );
+});
+
+test('matchCanonicalAuthoringMarkerFamily: an appended character is a negative match', () => {
+  const ownerBody = direct.renderAuthoringOwnerMarker(AUTHORING_OWNER_PAYLOAD);
+  assert.strictEqual(
+    direct.matchCanonicalAuthoringMarkerFamily(`${ownerBody}x`, 'idd-skill'),
+    null,
+  );
+  assert.strictEqual(
+    direct.matchCanonicalAuthoringMarkerFamily(`${ownerBody}\n`, 'idd-skill'),
+    null,
+    'a trailing newline is still an appended character, not a match',
+  );
+});
+
+test('matchCanonicalAuthoringMarkerFamily: an altered field value is a negative match', () => {
+  const ownerBody = direct.renderAuthoringOwnerMarker(AUTHORING_OWNER_PAYLOAD);
+  const altered = ownerBody.replace('mode=acquire', 'mode=acquire ');
+  assert.notStrictEqual(altered, ownerBody);
+  assert.strictEqual(
+    direct.matchCanonicalAuthoringMarkerFamily(altered, 'idd-skill'),
+    null,
+  );
+});
+
+test('matchCanonicalAuthoringMarkerFamily: a different marker prefix is a negative match', () => {
+  const ownerBody = direct.renderAuthoringOwnerMarker(AUTHORING_OWNER_PAYLOAD);
+  assert.strictEqual(
+    direct.matchCanonicalAuthoringMarkerFamily(ownerBody, 'other-prefix'),
+    null,
+  );
+});
+
+test('matchCanonicalAuthoringMarkerFamily: non-marker prose is a negative match', () => {
+  assert.strictEqual(
+    direct.matchCanonicalAuthoringMarkerFamily(
+      'Just a regular comment.',
+      'idd-skill',
+    ),
+    null,
+  );
+});
+
+// A field value carrying an embedded space parses successfully (the
+// semicolon/equals splitter only trims leading/trailing whitespace) but
+// fails renderAuthoringOwnerMarker's own stricter no-internal-whitespace
+// validation -- matchCanonicalAuthoringMarkerFamily must treat that thrown
+// render error as a non-match (fail closed) rather than propagating it.
+test('matchCanonicalAuthoringMarkerFamily: a parsed field that cannot be re-rendered is a negative match, not a thrown error', () => {
+  const body =
+    '<!-- idd-skill-authoring-owner: target=kurone-kito/idd-skill#2750 extra; anchor=kurone-kito/idd-skill#2750; mode=acquire; owner=owner-9ffa338d8a416b86; set=set-1e23beadb3e60e42; session=claude-idd3-5201e45ac16c; body-sha256=f370d4b220dd04d2d896a6c1d7841ecb261a7825bed8e68f07452073972fe389; snapshot-sha256=none; supersedes=none -->\n' +
+    '_Issue-authoring ownership marker. Do not edit or delete._';
+  assert.ok(
+    direct.parseAuthoringOwnerComment(body, 'idd-skill'),
+    'the malformed target value must still parse (sanity check for this test itself)',
+  );
+  assert.doesNotThrow(() =>
+    direct.matchCanonicalAuthoringMarkerFamily(body, 'idd-skill'),
+  );
+  assert.strictEqual(
+    direct.matchCanonicalAuthoringMarkerFamily(body, 'idd-skill'),
+    null,
   );
 });


### PR DESCRIPTION
# Summary

Editing an already-published issue under the issue-authoring ownership
protocol appends a new append-only `authoring-owner` marker comment
before every body edit, plus `authoring-publication-intent` records on
the repository's authoring journal issue during Stage 1 publication.
These comments are fully templated and never edited or deleted, so
they accumulate for the lifetime of an issue or a long-lived journal
with zero substantive discussion (issue #2706 currently carries 76
such comments; the journal issue #2674 carries 54) -- pure noise for a
human skimming either thread.

This is safe to hide: the contract already requires every owner-marker
read to use paginated REST retrieval, which has no `is_minimized`
field and always returns the full body regardless of minimize state,
so minimizing via the GraphQL `minimizeComment` mutation cannot break
the existing audit trail -- it only collapses the comment in GitHub's
web UI. This repository's existing precedent (issue #731, #733)
already applies the same "hide superseded markers" pattern to the
main execution loop's operational markers; this PR extends the same
idea to issue-authoring's own comment markers, explicitly excluded
from that existing scope until now.

Adds `renderAuthoringOwnerMarker` / `renderAuthoringPublicationIntentMarker`
to `marker-helpers.mts` alongside the existing `parse*` functions for
these two marker families, plus `matchCanonicalAuthoringMarkerFamily`,
which determines a byte-exact canonical-template match by parsing a
candidate comment and re-rendering it from the parsed fields -- fail
closed on any deviation (reordered/extra fields, altered spacing,
trailing content, or a body that parses but cannot be reconstructed).
Documents the resulting hide-on-supersede step in the issue-authoring
contract (`skills/issue-authoring/references/contract.md`, mirrored to
`.claude/skills/issue-authoring/references/contract.md` via
`sync-docs.mjs`, and to `docs/issue-authoring-skill.md` by hand): scan
the same target's prior comments once the new marker's own post and
verify have succeeded, and reuse the existing
`minimize-superseded-markers` helper for the mutation rather than
reimplementing it.

## Linked issue

Closes #2750

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

`authoring-publication` stays out of scope (a body-line token embedded
at issue creation, not a comment, so there is nothing to minimize),
and neither `authoring-owner` nor `authoring-publication-intent` is
added to `OPERATIONAL_MARKERS` or folded into the post-merge F4
cleanup driver -- this is a separate, earlier-lifecycle, best-effort,
never-blocking behavior, matching `docs/idd-comment-minimization.md`'s
framing for the existing operational-marker families.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CK2SHn8Bir6VHrXrMVMdn3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Superseded authoring owner and publication-intent markers are now automatically minimized after a new marker is successfully published.
  * Cleanup only applies to unchanged, canonical markers; altered or malformed comments remain visible.
  * Cleanup is repeatable and does not block publication if permissions or runtime issues prevent minimization.

* **Documentation**
  * Updated authoring guidance to describe marker cleanup behavior and excluded marker types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->