### PR TITLE
fix(discover-viability-gate): honor Groom-pass resolved-decision lines

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -79,6 +79,7 @@ scripts/provider-port.mjs linguist-generated=true
 scripts/readline-prompt.mjs linguist-generated=true
 scripts/rerun-advisory-convergence.mjs linguist-generated=true
 scripts/resolve-review-thread.mjs linguist-generated=true
+scripts/resolved-decision.mjs linguist-generated=true
 scripts/resume-claim-routing.mjs linguist-generated=true
 scripts/resume-route-selection.mjs linguist-generated=true
 scripts/review-activity-snapshot.mjs linguist-generated=true

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -599,9 +599,11 @@ inline prose in the issue body: `Maintainer decision (<provenance>,
 Groom hearing, <date>): <resolution text>` -- the shape
 `suitability-triage.mjs`'s Check 7 recognizes as a resolved
 decision (`#2661`); a comment may additionally note the decision, but the body
-itself is what re-triage reads. The next ordinary Discover pass then
-picks the issue up normally -- grooming itself never claims or works
-the issue (see
+itself is what re-triage reads. This exact line is also exempt from A4's
+own `autonomous_completion` gate (`discover-viability-gate.mjs`, `#2763`),
+so a re-groomed issue is not discarded before Check 7 ever sees it. The
+next ordinary Discover pass then picks the issue up normally -- grooming
+itself never claims or works the issue (see
 [Mutation Policy and Coordination Rule](../.github/instructions/idd-suitability.instructions.md#mutation-policy-and-coordination-rule)).
 
 **Worked example.** An issue was rejected `needs-decision` at score

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -583,7 +583,12 @@ Groom hearing, <date>): <resolution text>` -- the shape
 decision
 ([kurone-kito/idd-skill#2661](https://github.com/kurone-kito/idd-skill/issues/2661)
 in the source repository); a comment may additionally note the
-decision, but the body itself is what re-triage reads. The next
+decision, but the body itself is what re-triage reads. This exact line
+is also exempt from A4's own `autonomous_completion` gate
+(`discover-viability-gate.mjs`,
+[kurone-kito/idd-skill#2763](https://github.com/kurone-kito/idd-skill/issues/2763)
+in the source repository), so a re-groomed issue is not discarded
+before Check 7 ever sees it. The next
 ordinary Discover pass then
 picks the issue up normally -- grooming itself never claims or works
 the issue (see

--- a/scripts/discover-viability-gate.mjs
+++ b/scripts/discover-viability-gate.mjs
@@ -9,6 +9,7 @@ import {
   createGithubProviderAdapter,
   resolveCurrentGithubRepository,
 } from './provider-adapter-github.mjs';
+import { findInlineResolvedDecisionSpans } from './resolved-decision.mjs';
 
 const CRITERIA = [
   {
@@ -651,14 +652,32 @@ function isFollowedByGenericMentionNoun(corpus, matchIndex, matchEnd) {
   );
 }
 /**
+ * True when `index` (an EXTERNAL_COORDINATION_PATTERN match start) falls
+ * inside a genuine resolved-decision line -- #2763: `docs/idd-workflow.md`'s
+ * Groom-pass workflow tells an operator to record a resolved hearing
+ * outcome as `Maintainer decision (<provenance>, <date>): <resolution>`,
+ * the exact shape `resolved-decision.mts`'s `findInlineResolvedDecisionSpans`
+ * recognizes (single-sourced with suitability-triage.mts's Check 7, #2661)
+ * so this file's own gate does not fail an issue groomed exactly as
+ * documented, before Check 7 ever gets to honor it. `spans` is precomputed
+ * once per `corpus` by the caller, not per match, since it always scans the
+ * whole corpus regardless of which EXTERNAL_COORDINATION_PATTERN match is
+ * currently being checked.
+ */
+function isWithinResolvedDecisionSpan(spans, index) {
+  return spans.some((span) => index >= span.start && index < span.end);
+}
+/**
  * Finds the first EXTERNAL_COORDINATION_PATTERN occurrence that survives
  * every exclusion check (#2738): a match inside a code span, governed by a
  * negation cue, inside a quoted/cited example, described as an
- * already-completed investigation, or naming a generic pattern rather than
- * an asserted requirement does not describe this issue's own remaining
- * completion blocker and is skipped.
+ * already-completed investigation, naming a generic pattern rather than an
+ * asserted requirement, or opening a genuine resolved-decision line (#2763)
+ * does not describe this issue's own remaining completion blocker and is
+ * skipped.
  */
 function findUnexcludedExternalCoordinationMatch(corpus) {
+  const resolvedDecisionSpans = findInlineResolvedDecisionSpans(corpus);
   for (const match of corpus.matchAll(EXTERNAL_COORDINATION_PATTERN)) {
     const index = match.index;
     const end = index + match[0].length;
@@ -667,7 +686,8 @@ function findUnexcludedExternalCoordinationMatch(corpus) {
       isInsideQuotedExample(corpus, index, end) ||
       isGovernedByNegation(corpus, index) ||
       isDescribedByPastInvestigation(corpus, index, end) ||
-      isFollowedByGenericMentionNoun(corpus, index, end)
+      isFollowedByGenericMentionNoun(corpus, index, end) ||
+      isWithinResolvedDecisionSpan(resolvedDecisionSpans, index)
     ) {
       continue;
     }
@@ -683,8 +703,13 @@ export function evaluateAutonomousCompletion(issue) {
   // like "No credential changes" must not suppress a genuine body blocker
   // -- Codex review round 2, PR #2757). An ordinary soft-wrapped line
   // inside the body is still a single "\n" and remains ungoverned by this
-  // rule, per #2711's own wrapped-quotation requirement.
-  const corpus = `${issue.title}\n\n${issue.body}`;
+  // rule, per #2711's own wrapped-quotation requirement. `\r\n` is
+  // normalized to `\n` (#2763) so this corpus's offsets share the same
+  // 1-char line separator `findInlineResolvedDecisionSpans` normalizes to
+  // internally -- without it, a CRLF issue body would drift the two
+  // functions' coordinate spaces apart by one byte per CRLF line, the same
+  // #2531-class risk `resolved-decision.mts` itself defends against.
+  const corpus = `${issue.title}\n\n${issue.body}`.replace(/\r\n/g, '\n');
   const match = findUnexcludedExternalCoordinationMatch(corpus);
   if (match !== null) {
     return {

--- a/scripts/resolved-decision.mjs
+++ b/scripts/resolved-decision.mjs
@@ -1,0 +1,434 @@
+// idd-generated-from: src/scripts/resolved-decision.mts
+//
+// The scripts/resolved-decision.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+/**
+ * Single-sourced detector for a "resolved maintainer decision" signal in an
+ * issue body -- the shape `docs/idd-workflow.md`'s Groom-pass workflow
+ * (#2494) records, either as a `## Decision (... resolved ...)` heading or
+ * as inline prose: `Maintainer decision (<provenance>, <date>): <resolution
+ * text>`.
+ *
+ * `suitability-triage.mts`'s Check 7 (Verifiability) originated this
+ * detection for #2661/#2711 across many independent review rounds (cited
+ * inline below); `discover-viability-gate.mts`'s `autonomous_completion`
+ * criterion (#2763) reuses it verbatim to exclude the SAME resolved-decision
+ * line from its own `EXTERNAL_COORDINATION_PATTERN` scan, rather than
+ * maintaining a second, independently-drifting regex for the same shape --
+ * `docs/idd-workflow.md`'s Groom section tells an operator to write exactly
+ * this line, so an issue groomed as documented must not then fail the A4
+ * gate that runs before Check 7 ever sees it.
+ */
+import {
+  findMarkdownCodeRanges,
+  maskMarkdownCodeRegionsPreservingPositions,
+} from './markdown-code.mjs';
+// #2661 PR #2662 review: the reporting-verb vocabulary a quoting/citing
+// sentence uses to introduce someone else's decision as an example, rather
+// than asserting it as this issue's own. Exported: also used by
+// suitability-triage.mts's `isFramedAsDescriptive` (`hasSubjectiveApproval`,
+// #2512), an unrelated feature that happens to reuse the same vocabulary.
+export const FRAMING_VERB_PATTERN =
+  /\b(documents?|describes?|says?|states?|explains?|reports?)\b/i;
+/**
+ * Blank-line-delimited paragraph offsets within `body`. Exported: also used
+ * by suitability-triage.mts's `hasSubjectiveApproval` framing check, an
+ * unrelated feature that happens to need the same paragraph boundaries.
+ */
+export function getParagraphSpans(body) {
+  const spans = [];
+  let cursor = 0;
+  for (const boundary of body.matchAll(/\r?\n[ \t]*(?:\r?\n)+/g)) {
+    spans.push({ start: cursor, end: boundary.index });
+    cursor = boundary.index + boundary[0].length;
+  }
+  spans.push({ start: cursor, end: body.length });
+  return spans;
+}
+// #2661 PR #2662 review round 6 (Codex): an issue-template author commonly
+// leaves hidden instructional scaffolding as an HTML comment -- e.g.
+// `<!-- Maintainer decision (Groom hearing, YYYY-MM-DD): <resolution text>
+// -->` -- invisible in the rendered issue but still present in a
+// code-masked body (Markdown code masking does not touch HTML comments).
+// Masked the same way as inline/fenced code, before the inline-decision
+// pattern scan. An unterminated `<!--` (no matching `-->`) extends to
+// end-of-body: CommonMark renders such an HTML block through EOF, so the
+// entire remaining body -- a genuine marker and Acceptance Criteria
+// included -- can be invisible in the rendered issue while still matching
+// this scan if left unmasked (round 7, PR #2662).
+//
+// #2711: an issue that documents this convention's own syntax inside a
+// fenced code example -- e.g. a fence containing a literal, deliberately
+// unterminated `<!--` to illustrate the shape -- must not have that
+// example's opener treated as a REAL unterminated comment: doing so masks
+// through EOF and swallows a genuine later "Maintainer decision (...)"
+// that follows the fence. The same applies to an INLINE code span
+// demonstrating the same syntax (PR #2735 Codex review round 2) -- e.g.
+// `` `<!--` `` followed by a later bullet naming the real artifact.
+// `ignoredOpenerRanges` (optional, defaults to none so existing callers
+// with no code content to worry about are unaffected) lets a caller
+// exclude any `<!--` whose own opening `<` falls inside one of these
+// ranges from consideration entirely; pass fenced + indented + inline
+// ranges (e.g. `findMarkdownCodeRanges`'s result) to cover every code
+// shape, not just fenced blocks.
+//
+// #2711 PR #2735 review round 5 (Codex): a backslash-escaped opener
+// (`\<!--`) renders as a literal string in CommonMark, not a real HTML
+// comment start -- an issue documenting the literal marker syntax (e.g.
+// `Document the literal \<!-- marker`) must not have everything after it
+// masked through EOF. A single preceding backslash is enough to treat it
+// as escaped (soft heuristic, matching this file's existing style; does
+// not attempt full backslash-run parity for a doubly-escaped `\\<!--`).
+//
+// Exported: also used by suitability-triage.mts's Check 6 (Autonomy) and
+// Check 7 (Verifiability, Acceptance Criteria masking) for the same
+// generic "mask an HTML comment" need, unrelated to resolved-decision
+// detection specifically.
+export function findHtmlCommentRanges(text, ignoredOpenerRanges = []) {
+  const ranges = [];
+  const openPattern = /<!--/g;
+  let openMatch = openPattern.exec(text);
+  while (openMatch) {
+    const openIndex = openMatch.index;
+    const isEscaped = text[openIndex - 1] === '\\';
+    const isIgnored =
+      isEscaped ||
+      ignoredOpenerRanges.some(
+        (range) => openIndex >= range.start && openIndex < range.end,
+      );
+    if (isIgnored) {
+      openPattern.lastIndex = openIndex + 4;
+      openMatch = openPattern.exec(text);
+      continue;
+    }
+    const closeIndex = text.indexOf('-->', openIndex + 4);
+    const end = closeIndex === -1 ? text.length : closeIndex + 3;
+    ranges.push({ start: openIndex, end });
+    openPattern.lastIndex = end;
+    openMatch = openPattern.exec(text);
+  }
+  return ranges;
+}
+// A heading line such as "## Decision (resolved 2026-06-27)" records that a
+// human has already ruled on the issue's open question (see Check 7). The
+// negative lookahead rejects only a still-open *phrase* that directly negates
+// "resolved" ("not [yet] [been] resolved", "to be resolved", "never [been]
+// resolved"), so an unrelated negator elsewhere on the line -- e.g. "Decision
+// (not user-facing; resolved 2026-06-27)" -- still counts as resolved. A
+// lookahead (not a variable-length lookbehind) keeps the assertion portable
+// across JavaScript regex engines.
+export const RESOLVED_DECISION_PATTERN =
+  /^#{1,6}\s+Decision\b(?![^\n]*\b(?:not(?:\s+yet)?(?:\s+been)?\s+resolved|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+resolved|never(?:\s+been)?\s+resolved)\b)[^\n]*\bresolved\b/im;
+// #2661: the grooming-pass workflow (docs/idd-workflow.md, from #2494)
+// records a resolved decision as inline prose -- "Maintainer decision
+// (<provenance>, <date>): <resolution text>" -- not a "## Decision" heading,
+// so RESOLVED_DECISION_PATTERN above never matches it. The parenthetical's own
+// provenance (an issue reference and/or "Groom hearing" and/or a date) is
+// this shape's resolved signal, so -- unlike the heading form -- the literal
+// word "resolved" is not required. `[^)]` (not `[^)\n]`) lets the parenthetical
+// span a hard-wrapped line break -- GitHub issue bodies wrap at ~80 chars, so
+// "(kurone-kito/idd-skill#2637, Groom hearing,\n2026-09-05):" routinely splits
+// the provenance across two physical lines (the same line-wrap-is-not-a-
+// boundary shape as the proximity check above, #2512). A "still open" guard
+// applies immediately after the colon, so a placeholder resolution is not
+// mistaken for a real one -- both the heading form's own negated-"resolved"
+// phrasing ("not yet decided") and this inline form's own still-pending
+// vocabulary (TBD, pending, undecided, deferred, "still open"), since the
+// inline form has no positive `\bresolved\b` requirement to fall back on
+// (#2661 C1 review). The leading `[\s*_\`>-]*` skips past Markdown emphasis
+// (`**pending**`, `_TBD_`, `` `still open` ``) and list/blockquote markers
+// ("- TBD ...", "> pending ...") that would otherwise land between the colon
+// and the denylist word (Codex + Copilot review, PR #2662); the trailing
+// `(?![a-zA-Z])` replaces a plain `\b`, which fails to end the match after
+// "TBD_" (both `D` and `_` are `\w`, so `\b` finds no boundary there) even
+// though the underscore is just a closing emphasis marker, not part of the
+// word. The negated-decision-noun class (`no\s+(?:decision|consensus|
+// agreement|resolution|verdict|ruling|conclusion)(?:\s+yet)?`) and the
+// still-open-state class (`(?:still|remains?)\s+(?:open|undecided|
+// unresolved|pending|unsettled)`) replace the earlier single-phrase
+// entries ("no decision yet", "still open") with their semantic families,
+// covering "no consensus yet" and similar noun-first phrasings the
+// verb-first "not (yet) decided" denylist entries don't match (Codex
+// rounds 2-3, PR #2662) without enumerating every synonym as its own
+// literal. Deliberately NOT a bare `no\s+\w+`: "no changes to the API;
+// keep as-is" is a genuinely resolved decision, not a pending one.
+// **Convergence boundary**: this denylist is already stricter than
+// precedent -- `RESOLVED_DECISION_PATTERN` above has carried no
+// resolution-text denylist at all since #1135, and its own docstring
+// accepts exactly this soft-heuristic trade-off. A denylist can never
+// enumerate every future synonym; widen a *class* here only for a
+// concrete reported case, not for a hypothetical one. Resolution text must
+// start on the SAME LINE as the colon (`[ \t]*`, no newline tolerance): an
+// earlier revision allowed a single hard-wrapped line break here, which
+// fixed the immediate "colon immediately followed by a blank line" case
+// (Codex round 2, PR #2662) but still let an empty marker consume the very
+// next line's first character even with no blank line at all -- e.g. a
+// heading's "#" right after "Maintainer decision (...):\n" (Copilot round
+// 6, PR #2662). Dropping the newline tolerance entirely closes both cases
+// at once; neither of this fix's two real-world citations (#2644, #2641)
+// ever needed it, since GitHub's hard-wrap only splits the provenance
+// parenthetical, never the colon-to-resolution boundary itself. The
+// lookahead right after the opening "("
+// requires the parenthetical to actually contain one of the three
+// provenance signals this shape is documented to carry -- an issue/PR
+// reference, "Groom hearing", or an ISO-style date -- rather than accepting
+// any (or empty) parenthetical content as if provenance were merely
+// decorative (Copilot review round 2, PR #2662): without this, "Maintainer
+// decision (): ..." or "Maintainer decision (just kidding): ..." could
+// bypass the subjective-approval gate with no real grooming-pass record
+// behind it. `pending`/`undecided`/`deferred` additionally require a clause
+// boundary (through optional "yet"/"still"/"for now" and Markdown
+// decoration) immediately after the word -- these three, unlike TBD/TBA/TBC,
+// are ordinary English adjectives that can open a genuinely settled
+// resolution's own sentence ("deferred to follow-up issue #100 so this
+// patch remains scoped", "pending requests will be rejected with HTTP
+// 409"); only a bare, sentence-ending use of the word signals a real
+// placeholder (Codex round 4, PR #2662). This is the same soft
+// co-occurrence heuristic as the heading form: it does not verify the
+// resolution text actually settles the exact approval wording elsewhere in
+// the body.
+export const INLINE_MAINTAINER_DECISION_PATTERN =
+  /(?<![\w-])Maintainer decision(?![\w-])\s*\((?=[^)]{0,200}(?:#\d+|Groom hearing|\d{4}-\d{2}-\d{2}))[^)]{0,200}\)\s*:[ \t]*(?![\s*_`>-]*(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|no\s+(?:decision|consensus|agreement|resolution|verdict|ruling|conclusion)(?:\s+yet)?|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided)|TBD|TBA|TBC|(?:pending|undecided|deferred)(?:\s+(?:yet|still|for\s+now))?[\s*_`]*(?=[.,;:\n]|$)|awaiting\s+(?:a\s+)?(?:decision|consensus|sign-?off|approval)|(?:still|remains?)\s+(?:open|undecided|unresolved|pending|unsettled))(?![a-zA-Z]))\S/i;
+// #2661 PR #2662 review round 2 (Codex): unlike a whole-paragraph framing
+// scan, this scans only the paragraph text BEFORE `offset`, not the whole
+// paragraph. Used solely for the inline-decision scan, where the match's own
+// resolution text (after the colon) can legitimately contain an ordinary
+// reporting verb -- "Maintainer decision (...): the helper reports an
+// actionable error" -- without that making the marker itself a quoted
+// example of someone else's decision. A genuine quoting/reporting frame
+// always precedes the quoted marker in natural prose ("issue #2641 states
+// \"Maintainer decision (...)\"..."), so only text before the match need be
+// checked here. Bounded to the current SENTENCE, not the whole paragraph
+// prefix (round 6, PR #2662): an unrelated reporting verb in an earlier,
+// already-terminated sentence of the same paragraph -- "The current helper
+// reports status. Maintainer decision (...): choose A" -- must not suppress
+// a genuine decision merely for sharing a paragraph with an unrelated use of
+// the same vocabulary.
+// #2711: the terminal punctuation of a sentence may be immediately
+// followed by a closing Markdown emphasis marker or quote character before
+// the whitespace that ends it -- e.g. a sentence ending `"done."` or
+// `*settled*.`. A plain literal ". "/"! "/"? " scan finds no boundary at
+// such a position (the quote/emphasis character sits between the
+// punctuation and the space) and falls back to an EARLIER, unrelated
+// sentence boundary instead, widening the scan window enough to catch that
+// earlier sentence's own framing verb.
+const SENTENCE_TERMINATOR_PATTERN = /[.!?][)"'*_`\]]*(?=\s|$)/;
+function findLastSentenceBoundaryEnd(scanText) {
+  const pattern = new RegExp(SENTENCE_TERMINATOR_PATTERN.source, 'g');
+  let end = -1;
+  let match = pattern.exec(scanText);
+  while (match !== null) {
+    end = match.index + match[0].length;
+    match = pattern.exec(scanText);
+  }
+  return end;
+}
+function findFirstSentenceBoundaryEnd(scanText) {
+  const match = SENTENCE_TERMINATOR_PATTERN.exec(scanText);
+  return match === null ? scanText.length : match.index + match[0].length;
+}
+function isPrecededByFramingVerb(normalizedBody, paragraphSpans, offset) {
+  const span =
+    paragraphSpans.find(
+      (candidate) => offset >= candidate.start && offset <= candidate.end,
+    ) ?? paragraphSpans[paragraphSpans.length - 1];
+  const scanText = normalizedBody.slice(span?.start ?? 0, offset);
+  const sentenceStart = findLastSentenceBoundaryEnd(scanText);
+  return FRAMING_VERB_PATTERN.test(
+    scanText.slice(sentenceStart === -1 ? 0 : sentenceStart),
+  );
+}
+// #2711: an inverted-attribution quotation states the marker FIRST and its
+// reporting verb after it -- "'Maintainer decision (...): choose A,'
+// reports the referenced tracking issue" -- which `isPrecededByFramingVerb`
+// above never sees, since it only scans text BEFORE the match. Mirrors that
+// function's own single-sentence bound, forward instead of backward, so an
+// unrelated LATER sentence's own framing verb doesn't wrongly suppress a
+// genuine decision two sentences later.
+const QUOTE_CHARS = ['"', "'"];
+function isFollowedByFramingVerb(
+  normalizedBody,
+  paragraphSpans,
+  matchStart,
+  matchEnd,
+) {
+  const span =
+    paragraphSpans.find(
+      (candidate) =>
+        matchStart >= candidate.start && matchStart <= candidate.end,
+    ) ?? paragraphSpans[paragraphSpans.length - 1];
+  const paragraphStart = span?.start ?? 0;
+  const paragraphEnd = span?.end ?? normalizedBody.length;
+  // Deliberately narrower than "any framing verb somewhere later in the
+  // sentence": the marker must be immediately preceded by an opening quote
+  // character, closed by that SAME character before the framing verb.
+  // Without this, an ordinary reporting verb inside the marker's OWN
+  // resolution text -- "Maintainer decision (...): the helper reports an
+  // actionable error..." -- would be wrongly read as external framing (PR
+  // #2662 Codex review's own regression coverage for the backward-scan
+  // case; the forward scan needs the identical guard).
+  const precedingChar = normalizedBody[matchStart - 1];
+  if (
+    matchStart <= paragraphStart ||
+    !QUOTE_CHARS.includes(precedingChar ?? '')
+  ) {
+    return false;
+  }
+  const followingText = normalizedBody.slice(matchEnd, paragraphEnd);
+  const closingQuoteIndex = followingText.indexOf(precedingChar);
+  if (closingQuoteIndex === -1) {
+    return false;
+  }
+  const afterQuote = followingText.slice(closingQuoteIndex + 1);
+  const sentenceEnd = findFirstSentenceBoundaryEnd(afterQuote);
+  return FRAMING_VERB_PATTERN.test(afterQuote.slice(0, sentenceEnd));
+}
+// #2661 PR #2662 review round 2 (Codex): a Markdown blockquote ("> Maintainer
+// decision (...): ...") is itself a quoting signal, independent of
+// `isPrecededByFramingVerb` -- pasting another issue's decision as a
+// blockquote carries no reporting verb of its own, so the framing-verb check
+// alone lets a quoted decision through. Checks BOTH the matched line's own
+// ">" prefix (the direct case -- also covers a quote that starts partway
+// through a paragraph, e.g. "For reference:" followed immediately by
+// "> Maintainer decision (...)": CommonMark starts a new blockquote block at
+// that "> " line regardless of the preceding unquoted line, Codex round 5,
+// PR #2662) AND the containing PARAGRAPH's first line (CommonMark's
+// blockquote "lazy continuation" rule -- this repo's own coverage:
+// tests/markdown-code.test.mts's "permits lazy continuation" case -- renders
+// a line with no ">" of its own as still inside the quote when it continues
+// a paragraph that started with "> ", Codex round 4, PR #2662). An earlier
+// round-4 revision checked only the paragraph's first line and dropped the
+// original round-2 direct-line check, reintroducing exactly the round-5 gap.
+function isInBlockquotedParagraph(normalizedBody, paragraphSpans, offset) {
+  const lineStart = normalizedBody.lastIndexOf('\n', offset - 1) + 1;
+  if (/^[ \t]*>/.test(normalizedBody.slice(lineStart, offset))) {
+    return true;
+  }
+  const span =
+    paragraphSpans.find(
+      (candidate) => offset >= candidate.start && offset <= candidate.end,
+    ) ?? paragraphSpans[paragraphSpans.length - 1];
+  const paragraphStart = span?.start ?? 0;
+  const firstLineEnd = normalizedBody.indexOf('\n', paragraphStart);
+  const firstLine = normalizedBody.slice(
+    paragraphStart,
+    firstLineEnd === -1 ? normalizedBody.length : firstLineEnd,
+  );
+  return /^[ \t]*>/.test(firstLine);
+}
+// #2711: a GFM strikethrough span ("~~Maintainer decision (...): choose
+// A~~") marks its content as struck through -- rendered convention for
+// "retracted" or "superseded" -- so a decision inside one must not count
+// as this issue's current live resolution, independent of any framing verb
+// or blockquote. Pairs consecutive "~~" delimiters left-to-right within the
+// containing paragraph (a soft heuristic, not full CommonMark strikethrough
+// parsing, matching this file's existing style for inline-span detection)
+// and reports whether `offset` falls strictly inside any pair's content.
+//
+// #2711 PR #2735 review round 3 (Codex): scans a code-masked body, not the
+// raw `normalizedBody`, so a literal "~~" inside an inline/fenced code
+// example demonstrating the syntax -- masked to spaces there -- is never
+// mistaken for a real delimiter. `codeMaskedBody` must be the SAME length
+// and position-preserving relative to `normalizedBody` (as
+// `maskMarkdownCodeRegionsPreservingPositions` guarantees) so `paragraphSpans`
+// and `offset`, both computed against `normalizedBody`, stay valid against
+// it.
+//
+// #2711 PR #2735 review round 5 (Codex): a backslash-escaped delimiter
+// (`\~~`) renders as a literal string in CommonMark, not a real
+// strikethrough boundary -- two literal `\~~` examples surrounding a
+// genuine, unstruck "Maintainer decision (...)" must not be paired as if
+// they were real delimiters. A single preceding backslash is enough to
+// treat a `~~` as escaped (soft heuristic, matching this file's existing
+// style; does not attempt full backslash-run parity for `\\~~`).
+function isInStrikethroughSpan(codeMaskedBody, paragraphSpans, offset) {
+  const span =
+    paragraphSpans.find(
+      (candidate) => offset >= candidate.start && offset <= candidate.end,
+    ) ?? paragraphSpans[paragraphSpans.length - 1];
+  const paragraphStart = span?.start ?? 0;
+  const paragraphEnd = span?.end ?? codeMaskedBody.length;
+  const paragraphText = codeMaskedBody.slice(paragraphStart, paragraphEnd);
+  const relativeOffset = offset - paragraphStart;
+  const delimiterPattern = /~~/g;
+  const delimiterStarts = [];
+  let delimiterMatch = delimiterPattern.exec(paragraphText);
+  while (delimiterMatch !== null) {
+    if (paragraphText[delimiterMatch.index - 1] !== '\\') {
+      delimiterStarts.push(delimiterMatch.index);
+    }
+    delimiterPattern.lastIndex = delimiterMatch.index + 2;
+    delimiterMatch = delimiterPattern.exec(paragraphText);
+  }
+  for (let index = 0; index + 1 < delimiterStarts.length; index += 2) {
+    const contentStart = (delimiterStarts[index] ?? 0) + 2;
+    const contentEnd = delimiterStarts[index + 1] ?? 0;
+    if (relativeOffset >= contentStart && relativeOffset < contentEnd) {
+      return true;
+    }
+  }
+  return false;
+}
+/**
+ * Finds every inline "Maintainer decision (<provenance>): <resolution>"
+ * occurrence in `body` that survives the framing-verb / blockquote /
+ * strikethrough exclusion checks above -- a genuine resolved decision, not a
+ * quoted or struck-through example of someone else's. Self-contained: `body`
+ * is normalized and code/HTML-comment-masked internally, so a caller passes
+ * the raw issue body with no precomputation of its own. Returned spans are
+ * offsets into `body` AFTER `\r\n` normalization (`\r\n` -> `\n`); a caller
+ * comparing indices from a separately-scanned corpus must normalize that
+ * corpus the same way first, or the two coordinate spaces can drift by one
+ * byte per CRLF line -- an edge case with no realistic GitHub-fetched issue
+ * body, whose API responses are already `\n`-only.
+ */
+export function findInlineResolvedDecisionSpans(body) {
+  const normalizedBody = body.replace(/\r\n/g, '\n');
+  const paragraphSpans = getParagraphSpans(normalizedBody);
+  const codeRanges = findMarkdownCodeRanges(normalizedBody);
+  const codeMaskedBody = maskMarkdownCodeRegionsPreservingPositions(
+    normalizedBody,
+    [...codeRanges, ...findHtmlCommentRanges(normalizedBody, codeRanges)],
+  );
+  const spans = [];
+  const inlinePattern = new RegExp(
+    INLINE_MAINTAINER_DECISION_PATTERN.source,
+    'gi',
+  );
+  let inlineMatch = inlinePattern.exec(codeMaskedBody);
+  while (inlineMatch) {
+    const matchStart = inlineMatch.index;
+    const matchEnd = matchStart + inlineMatch[0].length;
+    if (
+      !isPrecededByFramingVerb(normalizedBody, paragraphSpans, matchStart) &&
+      !isFollowedByFramingVerb(
+        normalizedBody,
+        paragraphSpans,
+        matchStart,
+        matchEnd,
+      ) &&
+      !isInBlockquotedParagraph(normalizedBody, paragraphSpans, matchStart) &&
+      !isInStrikethroughSpan(codeMaskedBody, paragraphSpans, matchStart)
+    ) {
+      spans.push({ start: matchStart, end: matchEnd });
+    }
+    inlineMatch = inlinePattern.exec(codeMaskedBody);
+  }
+  return spans;
+}
+/**
+ * True when `body` records a resolved maintainer decision, either the
+ * heading form (`## Decision (... resolved ...)`) or the inline
+ * grooming-pass form. Replaces `suitability-triage.mts`'s own former
+ * `hasResolvedDecision` computation; `discover-viability-gate.mts` uses
+ * `findInlineResolvedDecisionSpans` directly instead, since its
+ * `autonomous_completion` criterion needs per-occurrence match offsets, not
+ * just a whole-body boolean.
+ */
+export function hasResolvedDecision(body) {
+  return (
+    RESOLVED_DECISION_PATTERN.test(body) ||
+    findInlineResolvedDecisionSpans(body).length > 0
+  );
+}

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -31,6 +31,12 @@ import { escapeRegex } from './marker-regex.mjs';
 import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mjs';
 import { resolveTrustedMarkerActors } from './protocol-helpers.mjs';
 import {
+  hasResolvedDecision as computeHasResolvedDecision,
+  FRAMING_VERB_PATTERN,
+  findHtmlCommentRanges,
+  getParagraphSpans,
+} from './resolved-decision.mjs';
+import {
   buildClosedByMergedPrArgs,
   buildMergedPrByBranchArgs,
   buildMergedPrListArgs,
@@ -208,19 +214,10 @@ const SUBJECTIVE_PROXIMITY_PATTERN = new RegExp(
 // false negative (an unrelated reporting verb elsewhere in a long
 // paragraph) is accepted in exchange for not re-deriving sentence
 // boundaries.
-const FRAMING_VERB_PATTERN =
-  /\b(documents?|describes?|says?|states?|explains?|reports?)\b/i;
-/** Blank-line-delimited paragraph offsets within `body`. */
-function getParagraphSpans(body) {
-  const spans = [];
-  let cursor = 0;
-  for (const boundary of body.matchAll(/\r?\n[ \t]*(?:\r?\n)+/g)) {
-    spans.push({ start: cursor, end: boundary.index });
-    cursor = boundary.index + boundary[0].length;
-  }
-  spans.push({ start: cursor, end: body.length });
-  return spans;
-}
+// FRAMING_VERB_PATTERN and getParagraphSpans now live in
+// resolved-decision.mts (imported above), shared with that module's own
+// resolved-decision detection -- this file's isFramedAsDescriptive below
+// still uses both, just via the import instead of a local definition.
 // #2661 C1 review: shared between `hasSubjectiveApproval` (#2512's original
 // use) and `hasResolvedDecision`'s inline-form scan. A match landing in a
 // paragraph that reports on another decision/approval as an example --
@@ -240,245 +237,14 @@ function isFramedAsDescriptive(normalizedBody, paragraphSpans, offset) {
     normalizedBody.slice(span?.start ?? 0, span?.end ?? normalizedBody.length),
   );
 }
-// #2661 PR #2662 review (Codex): unlike `isFramedAsDescriptive` above, this
-// scans only the paragraph text BEFORE `offset`, not the whole paragraph.
-// Used solely for the inline-decision scan, where the match's own resolution
-// text (after the colon) can legitimately contain an ordinary reporting verb
-// -- "Maintainer decision (...): the helper reports an actionable error" --
-// without that making the marker itself a quoted example of someone else's
-// decision. A genuine quoting/reporting frame always precedes the quoted
-// marker in natural prose ("issue #2641 states \"Maintainer decision
-// (...)\"..."), so only text before the match need be checked here. Bounded
-// to the current SENTENCE, not the whole paragraph prefix (round 6, PR
-// #2662): an unrelated reporting verb in an earlier, already-terminated
-// sentence of the same paragraph -- "The current helper reports status.
-// Maintainer decision (...): choose A" -- must not suppress a genuine
-// decision merely for sharing a paragraph with an unrelated use of the same
-// vocabulary.
-// #2711: the terminal punctuation of a sentence may be immediately
-// followed by a closing Markdown emphasis marker or quote character before
-// the whitespace that ends it -- e.g. a sentence ending `"done."` or
-// `*settled*.`. The previous literal ". "/"! "/"? " scan below found no
-// boundary at such a position (the quote/emphasis character sits between
-// the punctuation and the space) and fell back to an EARLIER, unrelated
-// sentence boundary instead, widening the scan window enough to catch that
-// earlier sentence's own framing verb.
-const SENTENCE_TERMINATOR_PATTERN = /[.!?][)"'*_`\]]*(?=\s|$)/;
-function findLastSentenceBoundaryEnd(scanText) {
-  const pattern = new RegExp(SENTENCE_TERMINATOR_PATTERN.source, 'g');
-  let end = -1;
-  let match = pattern.exec(scanText);
-  while (match !== null) {
-    end = match.index + match[0].length;
-    match = pattern.exec(scanText);
-  }
-  return end;
-}
-function findFirstSentenceBoundaryEnd(scanText) {
-  const match = SENTENCE_TERMINATOR_PATTERN.exec(scanText);
-  return match === null ? scanText.length : match.index + match[0].length;
-}
-function isPrecededByFramingVerb(normalizedBody, paragraphSpans, offset) {
-  const span =
-    paragraphSpans.find(
-      (candidate) => offset >= candidate.start && offset <= candidate.end,
-    ) ?? paragraphSpans[paragraphSpans.length - 1];
-  const scanText = normalizedBody.slice(span?.start ?? 0, offset);
-  const sentenceStart = findLastSentenceBoundaryEnd(scanText);
-  return FRAMING_VERB_PATTERN.test(
-    scanText.slice(sentenceStart === -1 ? 0 : sentenceStart),
-  );
-}
-// #2711: an inverted-attribution quotation states the marker FIRST and its
-// reporting verb after it -- "'Maintainer decision (...): choose A,'
-// reports the referenced tracking issue" -- which `isPrecededByFramingVerb`
-// above never sees, since it only scans text BEFORE the match. Mirrors that
-// function's own single-sentence bound, forward instead of backward, so an
-// unrelated LATER sentence's own framing verb doesn't wrongly suppress a
-// genuine decision two sentences later.
-const QUOTE_CHARS = ['"', "'"];
-function isFollowedByFramingVerb(
-  normalizedBody,
-  paragraphSpans,
-  matchStart,
-  matchEnd,
-) {
-  const span =
-    paragraphSpans.find(
-      (candidate) =>
-        matchStart >= candidate.start && matchStart <= candidate.end,
-    ) ?? paragraphSpans[paragraphSpans.length - 1];
-  const paragraphStart = span?.start ?? 0;
-  const paragraphEnd = span?.end ?? normalizedBody.length;
-  // Deliberately narrower than "any framing verb somewhere later in the
-  // sentence": the marker must be immediately preceded by an opening quote
-  // character, closed by that SAME character before the framing verb.
-  // Without this, an ordinary reporting verb inside the marker's OWN
-  // resolution text -- "Maintainer decision (...): the helper reports an
-  // actionable error..." -- would be wrongly read as external framing (PR
-  // #2662 Codex review's own regression coverage for the backward-scan
-  // case; the forward scan needs the identical guard).
-  const precedingChar = normalizedBody[matchStart - 1];
-  if (
-    matchStart <= paragraphStart ||
-    !QUOTE_CHARS.includes(precedingChar ?? '')
-  ) {
-    return false;
-  }
-  const followingText = normalizedBody.slice(matchEnd, paragraphEnd);
-  const closingQuoteIndex = followingText.indexOf(precedingChar);
-  if (closingQuoteIndex === -1) {
-    return false;
-  }
-  const afterQuote = followingText.slice(closingQuoteIndex + 1);
-  const sentenceEnd = findFirstSentenceBoundaryEnd(afterQuote);
-  return FRAMING_VERB_PATTERN.test(afterQuote.slice(0, sentenceEnd));
-}
-// #2661 PR #2662 review round 2 (Codex): a Markdown blockquote ("> Maintainer
-// decision (...): ...") is itself a quoting signal, independent of
-// `isPrecededByFramingVerb` -- pasting another issue's decision as a
-// blockquote carries no reporting verb of its own, so the framing-verb check
-// alone lets a quoted decision through. Checks BOTH the matched line's own
-// ">" prefix (the direct case -- also covers a quote that starts partway
-// through a paragraph, e.g. "For reference:" followed immediately by
-// "> Maintainer decision (...)": CommonMark starts a new blockquote block at
-// that "> " line regardless of the preceding unquoted line, Codex round 5,
-// PR #2662) AND the containing PARAGRAPH's first line (CommonMark's
-// blockquote "lazy continuation" rule -- this repo's own coverage:
-// tests/markdown-code.test.mts's "permits lazy continuation" case -- renders
-// a line with no ">" of its own as still inside the quote when it continues
-// a paragraph that started with "> ", Codex round 4, PR #2662). An earlier
-// round-4 revision checked only the paragraph's first line and dropped the
-// original round-2 direct-line check, reintroducing exactly the round-5 gap.
-function isInBlockquotedParagraph(normalizedBody, paragraphSpans, offset) {
-  const lineStart = normalizedBody.lastIndexOf('\n', offset - 1) + 1;
-  if (/^[ \t]*>/.test(normalizedBody.slice(lineStart, offset))) {
-    return true;
-  }
-  const span =
-    paragraphSpans.find(
-      (candidate) => offset >= candidate.start && offset <= candidate.end,
-    ) ?? paragraphSpans[paragraphSpans.length - 1];
-  const paragraphStart = span?.start ?? 0;
-  const firstLineEnd = normalizedBody.indexOf('\n', paragraphStart);
-  const firstLine = normalizedBody.slice(
-    paragraphStart,
-    firstLineEnd === -1 ? normalizedBody.length : firstLineEnd,
-  );
-  return /^[ \t]*>/.test(firstLine);
-}
-// #2711: a GFM strikethrough span ("~~Maintainer decision (...): choose
-// A~~") marks its content as struck through -- rendered convention for
-// "retracted" or "superseded" -- so a decision inside one must not count
-// as this issue's current live resolution, independent of any framing verb
-// or blockquote. Pairs consecutive "~~" delimiters left-to-right within the
-// containing paragraph (a soft heuristic, not full CommonMark strikethrough
-// parsing, matching this file's existing style for inline-span detection)
-// and reports whether `offset` falls strictly inside any pair's content.
-//
-// #2711 PR #2735 review round 3 (Codex): scans `codeMaskedBody` (e.g.
-// `normalizedCodeMaskedBody`), not the raw `normalizedBody`, so a literal
-// "~~" inside an inline/fenced code example demonstrating the syntax --
-// masked to spaces there -- is never mistaken for a real delimiter.
-// `codeMaskedBody` must be the SAME length and position-preserving
-// relative to `normalizedBody` (as `maskMarkdownCodeRegionsPreservingPositions`
-// guarantees) so `paragraphSpans` and `offset`, both computed against
-// `normalizedBody`, stay valid against it.
-//
-// #2711 PR #2735 review round 5 (Codex): a backslash-escaped delimiter
-// (`\~~`) renders as a literal string in CommonMark, not a real
-// strikethrough boundary -- two literal `\~~` examples surrounding a
-// genuine, unstruck "Maintainer decision (...)" must not be paired as if
-// they were real delimiters. A single preceding backslash is enough to
-// treat a `~~` as escaped (soft heuristic, matching this file's existing
-// style; does not attempt full backslash-run parity for `\\~~`).
-function isInStrikethroughSpan(codeMaskedBody, paragraphSpans, offset) {
-  const span =
-    paragraphSpans.find(
-      (candidate) => offset >= candidate.start && offset <= candidate.end,
-    ) ?? paragraphSpans[paragraphSpans.length - 1];
-  const paragraphStart = span?.start ?? 0;
-  const paragraphEnd = span?.end ?? codeMaskedBody.length;
-  const paragraphText = codeMaskedBody.slice(paragraphStart, paragraphEnd);
-  const relativeOffset = offset - paragraphStart;
-  const delimiterPattern = /~~/g;
-  const delimiterStarts = [];
-  let delimiterMatch = delimiterPattern.exec(paragraphText);
-  while (delimiterMatch !== null) {
-    if (paragraphText[delimiterMatch.index - 1] !== '\\') {
-      delimiterStarts.push(delimiterMatch.index);
-    }
-    delimiterPattern.lastIndex = delimiterMatch.index + 2;
-    delimiterMatch = delimiterPattern.exec(paragraphText);
-  }
-  for (let index = 0; index + 1 < delimiterStarts.length; index += 2) {
-    const contentStart = (delimiterStarts[index] ?? 0) + 2;
-    const contentEnd = delimiterStarts[index + 1] ?? 0;
-    if (relativeOffset >= contentStart && relativeOffset < contentEnd) {
-      return true;
-    }
-  }
-  return false;
-}
-// #2661 PR #2662 review round 6 (Codex): an issue-template author commonly
-// leaves hidden instructional scaffolding as an HTML comment -- e.g.
-// `<!-- Maintainer decision (Groom hearing, YYYY-MM-DD): <resolution text>
-// -->` -- invisible in the rendered issue but still present in
-// `normalizedCodeMaskedBody` (Markdown code masking does not touch HTML
-// comments). Masked the same way as inline/fenced code, before the
-// inline-decision pattern scan. An unterminated `<!--` (no matching `-->`)
-// extends to end-of-body: CommonMark renders such an HTML block through
-// EOF, so the entire remaining body -- a genuine marker and Acceptance
-// Criteria included -- can be invisible in the rendered issue while still
-// matching this scan if left unmasked (round 7, PR #2662).
-//
-// #2711: an issue that documents this convention's own syntax inside a
-// fenced code example -- e.g. a fence containing a literal, deliberately
-// unterminated `<!--` to illustrate the shape -- must not have that
-// example's opener treated as a REAL unterminated comment: doing so masks
-// through EOF and swallows a genuine later "Maintainer decision (...)"
-// that follows the fence. The same applies to an INLINE code span
-// demonstrating the same syntax (PR #2735 Codex review round 2) -- e.g.
-// `` `<!--` `` followed by a later bullet naming the real artifact.
-// `ignoredOpenerRanges` (optional, defaults to none so existing callers
-// with no code content to worry about are unaffected) lets a caller
-// exclude any `<!--` whose own opening `<` falls inside one of these
-// ranges from consideration entirely; pass fenced + indented + inline
-// ranges (e.g. `findMarkdownCodeRanges`'s result) to cover every code
-// shape, not just fenced blocks.
-//
-// #2711 PR #2735 review round 5 (Codex): a backslash-escaped opener
-// (`\<!--`) renders as a literal string in CommonMark, not a real HTML
-// comment start -- an issue documenting the literal marker syntax (e.g.
-// `Document the literal \<!-- marker`) must not have everything after it
-// masked through EOF. A single preceding backslash is enough to treat it
-// as escaped (soft heuristic, matching this file's existing style; does
-// not attempt full backslash-run parity for a doubly-escaped `\\<!--`).
-function findHtmlCommentRanges(text, ignoredOpenerRanges = []) {
-  const ranges = [];
-  const openPattern = /<!--/g;
-  let openMatch = openPattern.exec(text);
-  while (openMatch) {
-    const openIndex = openMatch.index;
-    const isEscaped = text[openIndex - 1] === '\\';
-    const isIgnored =
-      isEscaped ||
-      ignoredOpenerRanges.some(
-        (range) => openIndex >= range.start && openIndex < range.end,
-      );
-    if (isIgnored) {
-      openPattern.lastIndex = openIndex + 4;
-      openMatch = openPattern.exec(text);
-      continue;
-    }
-    const closeIndex = text.indexOf('-->', openIndex + 4);
-    const end = closeIndex === -1 ? text.length : closeIndex + 3;
-    ranges.push({ start: openIndex, end });
-    openPattern.lastIndex = end;
-    openMatch = openPattern.exec(text);
-  }
-  return ranges;
-}
+// The sentence-boundary helpers, the inline "Maintainer decision (...): ..."
+// pattern's framing-verb / blockquote / strikethrough exclusion checks, and
+// findHtmlCommentRanges all now live in resolved-decision.mts (#2763),
+// single-sourced with discover-viability-gate.mts's own
+// autonomous_completion criterion. findHtmlCommentRanges is imported above
+// for this file's other two call sites (Check 6 Autonomy, Check 7's
+// Acceptance-Criteria masking); the resolved-decision scan itself is
+// replaced below by a single call to the imported `hasResolvedDecision`.
 // Check 3 precision: an unsafe execution directive tells the agent to act on
 // *supplied / untrusted* content, not any command verb that merely lands near
 // the ordinary determiner "this". Match the strong untrusted-origin signals, or
@@ -1015,86 +781,12 @@ function hasBareDottedFilename(text) {
   }
   return false;
 }
-// A heading line such as "## Decision (resolved 2026-06-27)" records that a
-// human has already ruled on the issue's open question (see Check 7). The
-// negative lookahead rejects only a still-open *phrase* that directly negates
-// "resolved" ("not [yet] [been] resolved", "to be resolved", "never [been]
-// resolved"), so an unrelated negator elsewhere on the line — e.g. "Decision
-// (not user-facing; resolved 2026-06-27)" — still counts as resolved. A
-// lookahead (not a variable-length lookbehind) keeps the assertion portable
-// across JavaScript regex engines.
-const RESOLVED_DECISION_PATTERN =
-  /^#{1,6}\s+Decision\b(?![^\n]*\b(?:not(?:\s+yet)?(?:\s+been)?\s+resolved|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+resolved|never(?:\s+been)?\s+resolved)\b)[^\n]*\bresolved\b/im;
-// #2661: the grooming-pass workflow (docs/idd-workflow.md, from #2494)
-// records a resolved decision as inline prose -- "Maintainer decision
-// (<provenance>, <date>): <resolution text>" -- not a "## Decision" heading,
-// so RESOLVED_DECISION_PATTERN above never matches it. The parenthetical's own
-// provenance (an issue reference and/or "Groom hearing" and/or a date) is
-// this shape's resolved signal, so -- unlike the heading form -- the literal
-// word "resolved" is not required. `[^)]` (not `[^)\n]`) lets the parenthetical
-// span a hard-wrapped line break -- GitHub issue bodies wrap at ~80 chars, so
-// "(kurone-kito/idd-skill#2637, Groom hearing,\n2026-09-05):" routinely splits
-// the provenance across two physical lines (the same line-wrap-is-not-a-
-// boundary shape as the proximity check above, #2512). A "still open" guard
-// applies immediately after the colon, so a placeholder resolution is not
-// mistaken for a real one -- both the heading form's own negated-"resolved"
-// phrasing ("not yet decided") and this inline form's own still-pending
-// vocabulary (TBD, pending, undecided, deferred, "still open"), since the
-// inline form has no positive `\bresolved\b` requirement to fall back on
-// (#2661 C1 review). The leading `[\s*_\`>-]*` skips past Markdown emphasis
-// (`**pending**`, `_TBD_`, `` `still open` ``) and list/blockquote markers
-// ("- TBD ...", "> pending ...") that would otherwise land between the colon
-// and the denylist word (Codex + Copilot review, PR #2662); the trailing
-// `(?![a-zA-Z])` replaces a plain `\b`, which fails to end the match after
-// "TBD_" (both `D` and `_` are `\w`, so `\b` finds no boundary there) even
-// though the underscore is just a closing emphasis marker, not part of the
-// word. The negated-decision-noun class (`no\s+(?:decision|consensus|
-// agreement|resolution|verdict|ruling|conclusion)(?:\s+yet)?`) and the
-// still-open-state class (`(?:still|remains?)\s+(?:open|undecided|
-// unresolved|pending|unsettled)`) replace the earlier single-phrase
-// entries ("no decision yet", "still open") with their semantic families,
-// covering "no consensus yet" and similar noun-first phrasings the
-// verb-first "not (yet) decided" denylist entries don't match (Codex
-// rounds 2-3, PR #2662) without enumerating every synonym as its own
-// literal. Deliberately NOT a bare `no\s+\w+`: "no changes to the API;
-// keep as-is" is a genuinely resolved decision, not a pending one.
-// **Convergence boundary**: this denylist is already stricter than
-// precedent -- `RESOLVED_DECISION_PATTERN` above has carried no
-// resolution-text denylist at all since #1135, and its own docstring
-// accepts exactly this soft-heuristic trade-off. A denylist can never
-// enumerate every future synonym; widen a *class* here only for a
-// concrete reported case, not for a hypothetical one. Resolution text must
-// start on the SAME LINE as the colon (`[ \t]*`, no newline tolerance): an
-// earlier revision allowed a single hard-wrapped line break here, which
-// fixed the immediate "colon immediately followed by a blank line" case
-// (Codex round 2, PR #2662) but still let an empty marker consume the very
-// next line's first character even with no blank line at all -- e.g. a
-// heading's "#" right after "Maintainer decision (...):\n" (Copilot round
-// 6, PR #2662). Dropping the newline tolerance entirely closes both cases
-// at once; neither of this fix's two real-world citations (#2644, #2641)
-// ever needed it, since GitHub's hard-wrap only splits the provenance
-// parenthetical, never the colon-to-resolution boundary itself. The
-// lookahead right after the opening "("
-// requires the parenthetical to actually contain one of the three
-// provenance signals this shape is documented to carry -- an issue/PR
-// reference, "Groom hearing", or an ISO-style date -- rather than accepting
-// any (or empty) parenthetical content as if provenance were merely
-// decorative (Copilot review round 2, PR #2662): without this, "Maintainer
-// decision (): ..." or "Maintainer decision (just kidding): ..." could
-// bypass the subjective-approval gate with no real grooming-pass record
-// behind it. `pending`/`undecided`/`deferred` additionally require a clause
-// boundary (through optional "yet"/"still"/"for now" and Markdown
-// decoration) immediately after the word -- these three, unlike TBD/TBA/TBC,
-// are ordinary English adjectives that can open a genuinely settled
-// resolution's own sentence ("deferred to follow-up issue #100 so this
-// patch remains scoped", "pending requests will be rejected with HTTP
-// 409"); only a bare, sentence-ending use of the word signals a real
-// placeholder (Codex round 4, PR #2662). This is the same soft
-// co-occurrence heuristic as the heading form: it does not verify the
-// resolution text actually settles the exact approval wording elsewhere in
-// the body.
-const INLINE_MAINTAINER_DECISION_PATTERN =
-  /(?<![\w-])Maintainer decision(?![\w-])\s*\((?=[^)]{0,200}(?:#\d+|Groom hearing|\d{4}-\d{2}-\d{2}))[^)]{0,200}\)\s*:[ \t]*(?![\s*_`>-]*(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|no\s+(?:decision|consensus|agreement|resolution|verdict|ruling|conclusion)(?:\s+yet)?|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided)|TBD|TBA|TBC|(?:pending|undecided|deferred)(?:\s+(?:yet|still|for\s+now))?[\s*_`]*(?=[.,;:\n]|$)|awaiting\s+(?:a\s+)?(?:decision|consensus|sign-?off|approval)|(?:still|remains?)\s+(?:open|undecided|unresolved|pending|unsettled))(?![a-zA-Z]))\S/i;
+// RESOLVED_DECISION_PATTERN (the "## Decision (resolved ...)" heading form)
+// and INLINE_MAINTAINER_DECISION_PATTERN (the grooming-pass inline
+// "Maintainer decision (<provenance>): <resolution text>" form, #2661) now
+// live in resolved-decision.mts, single-sourced with
+// discover-viability-gate.mts's own autonomous_completion criterion
+// (#2763) -- see that module for the full pattern history and rationale.
 // #2024: a negation word immediately before the trigger verb, allowing at
 // most one intervening word (e.g. "does not *ever* skip") between the
 // negation word and the trailing whitespace that reaches the verb. The
@@ -2844,68 +2536,13 @@ export function checkVerifiability(context) {
   // accepted trade-off for maintainer-authored issues. An approval-gated
   // body with no resolved decision still routes to needs-decision.
   //
-  // The inline form additionally requires no framing verb PRECEDE it in its
-  // own paragraph (#2661 C1/PR review): a body that merely *quotes* another
-  // issue's already-resolved decision as an example -- "issue #2641 states
-  // \"Maintainer decision (...)\" as an example of the convention" -- must
-  // not borrow that resolution for THIS issue's own subjective gate. Scoped
-  // to text before the match (`isPrecededByFramingVerb`, not the
-  // whole-paragraph `isFramedAsDescriptive`) so a genuine resolution whose
-  // OWN text happens to use a reporting verb -- "Maintainer decision (...):
-  // the helper reports an actionable error" -- is not wrongly excluded
-  // (Codex review, PR #2662). `isFollowedByFramingVerb` (#2711) catches the
-  // inverted-attribution shape of the same quoting problem, where the
-  // reporting verb follows the marker instead of preceding it -- "'Maintainer
-  // decision (...): choose A,' reports the referenced tracking issue". A
-  // Markdown blockquote is a third, independent quoting signal with no
-  // reporting verb of its own -- "> Maintainer decision (...): ..." -- so
-  // `isInBlockquotedParagraph` also excludes a match (Codex review rounds 2
-  // and 4, PR #2662). A GFM strikethrough span (#2711) is a fourth,
-  // independent signal: a struck-through decision reads as retracted/
-  // superseded, not this issue's current live resolution, regardless of
-  // whether any framing verb or blockquote is also present. The heading
-  // form has no equivalent gap: a "## Decision (resolved …)" section is, by
-  // construction, this issue's own decision record, never a quoted example
-  // of someone else's.
-  const hasInlineResolvedDecision = (() => {
-    const inlinePattern = new RegExp(
-      INLINE_MAINTAINER_DECISION_PATTERN.source,
-      'gi',
-    );
-    let inlineMatch = inlinePattern.exec(normalizedCodeMaskedBody);
-    while (inlineMatch) {
-      const matchEnd = inlineMatch.index + inlineMatch[0].length;
-      if (
-        !isPrecededByFramingVerb(
-          normalizedBody,
-          paragraphSpans,
-          inlineMatch.index,
-        ) &&
-        !isFollowedByFramingVerb(
-          normalizedBody,
-          paragraphSpans,
-          inlineMatch.index,
-          matchEnd,
-        ) &&
-        !isInBlockquotedParagraph(
-          normalizedBody,
-          paragraphSpans,
-          inlineMatch.index,
-        ) &&
-        !isInStrikethroughSpan(
-          normalizedCodeMaskedBody,
-          paragraphSpans,
-          inlineMatch.index,
-        )
-      ) {
-        return true;
-      }
-      inlineMatch = inlinePattern.exec(normalizedCodeMaskedBody);
-    }
-    return false;
-  })();
-  const hasResolvedDecision =
-    RESOLVED_DECISION_PATTERN.test(body) || hasInlineResolvedDecision;
+  // Both the heading and inline forms, and the inline form's own
+  // framing-verb / blockquote / strikethrough exclusion checks (#2661,
+  // #2711), now live in resolved-decision.mts's `hasResolvedDecision`
+  // (imported above as `computeHasResolvedDecision`), single-sourced with
+  // discover-viability-gate.mts's `autonomous_completion` criterion (#2763)
+  // rather than re-derived here.
+  const hasResolvedDecision = computeHasResolvedDecision(body);
   if (hasSubjectiveApproval && !(hasResolvedDecision && hasObjectiveCriteria)) {
     return {
       pass: false,
@@ -2968,8 +2605,9 @@ export function checkVerifiability(context) {
   //
   // The verb+topic check just above is matched against
   // normalizedCodeMaskedBody (not normalizedBody), the same
-  // position-preserving code-masked body the resolved-decision scan above
-  // already uses (Codex review, PR #2725 round 4): an AC bullet that quotes
+  // position-preserving code-masked body `hasResolvedDecision` (now
+  // resolved-decision.mts) computes its own equivalent of internally
+  // (Codex review, PR #2725 round 4): an AC bullet that quotes
   // this exact escape-hatch phrasing as a literal example inside inline or
   // fenced code -- e.g. "Add a lint rule rejecting `Either add validation,
   // or document why validation is not needed`" -- must not have its quoted

--- a/src/scripts/discover-viability-gate.mts
+++ b/src/scripts/discover-viability-gate.mts
@@ -10,6 +10,7 @@ import {
   createGithubProviderAdapter,
   resolveCurrentGithubRepository,
 } from './provider-adapter-github.mts';
+import { findInlineResolvedDecisionSpans } from './resolved-decision.mts';
 
 interface NormalizedIssue {
   number: number;
@@ -774,16 +775,38 @@ function isFollowedByGenericMentionNoun(
 }
 
 /**
+ * True when `index` (an EXTERNAL_COORDINATION_PATTERN match start) falls
+ * inside a genuine resolved-decision line -- #2763: `docs/idd-workflow.md`'s
+ * Groom-pass workflow tells an operator to record a resolved hearing
+ * outcome as `Maintainer decision (<provenance>, <date>): <resolution>`,
+ * the exact shape `resolved-decision.mts`'s `findInlineResolvedDecisionSpans`
+ * recognizes (single-sourced with suitability-triage.mts's Check 7, #2661)
+ * so this file's own gate does not fail an issue groomed exactly as
+ * documented, before Check 7 ever gets to honor it. `spans` is precomputed
+ * once per `corpus` by the caller, not per match, since it always scans the
+ * whole corpus regardless of which EXTERNAL_COORDINATION_PATTERN match is
+ * currently being checked.
+ */
+function isWithinResolvedDecisionSpan(
+  spans: { start: number; end: number }[],
+  index: number,
+): boolean {
+  return spans.some((span) => index >= span.start && index < span.end);
+}
+
+/**
  * Finds the first EXTERNAL_COORDINATION_PATTERN occurrence that survives
  * every exclusion check (#2738): a match inside a code span, governed by a
  * negation cue, inside a quoted/cited example, described as an
- * already-completed investigation, or naming a generic pattern rather than
- * an asserted requirement does not describe this issue's own remaining
- * completion blocker and is skipped.
+ * already-completed investigation, naming a generic pattern rather than an
+ * asserted requirement, or opening a genuine resolved-decision line (#2763)
+ * does not describe this issue's own remaining completion blocker and is
+ * skipped.
  */
 function findUnexcludedExternalCoordinationMatch(
   corpus: string,
 ): string | null {
+  const resolvedDecisionSpans = findInlineResolvedDecisionSpans(corpus);
   for (const match of corpus.matchAll(EXTERNAL_COORDINATION_PATTERN)) {
     const index = match.index;
     const end = index + match[0].length;
@@ -792,7 +815,8 @@ function findUnexcludedExternalCoordinationMatch(
       isInsideQuotedExample(corpus, index, end) ||
       isGovernedByNegation(corpus, index) ||
       isDescribedByPastInvestigation(corpus, index, end) ||
-      isFollowedByGenericMentionNoun(corpus, index, end)
+      isFollowedByGenericMentionNoun(corpus, index, end) ||
+      isWithinResolvedDecisionSpan(resolvedDecisionSpans, index)
     ) {
       continue;
     }
@@ -811,8 +835,13 @@ export function evaluateAutonomousCompletion(
   // like "No credential changes" must not suppress a genuine body blocker
   // -- Codex review round 2, PR #2757). An ordinary soft-wrapped line
   // inside the body is still a single "\n" and remains ungoverned by this
-  // rule, per #2711's own wrapped-quotation requirement.
-  const corpus = `${issue.title}\n\n${issue.body}`;
+  // rule, per #2711's own wrapped-quotation requirement. `\r\n` is
+  // normalized to `\n` (#2763) so this corpus's offsets share the same
+  // 1-char line separator `findInlineResolvedDecisionSpans` normalizes to
+  // internally -- without it, a CRLF issue body would drift the two
+  // functions' coordinate spaces apart by one byte per CRLF line, the same
+  // #2531-class risk `resolved-decision.mts` itself defends against.
+  const corpus = `${issue.title}\n\n${issue.body}`.replace(/\r\n/g, '\n');
   const match = findUnexcludedExternalCoordinationMatch(corpus);
   if (match !== null) {
     return {

--- a/src/scripts/resolved-decision.mts
+++ b/src/scripts/resolved-decision.mts
@@ -1,0 +1,473 @@
+// idd-generated-from: src/scripts/resolved-decision.mts
+//
+// The scripts/resolved-decision.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+
+/**
+ * Single-sourced detector for a "resolved maintainer decision" signal in an
+ * issue body -- the shape `docs/idd-workflow.md`'s Groom-pass workflow
+ * (#2494) records, either as a `## Decision (... resolved ...)` heading or
+ * as inline prose: `Maintainer decision (<provenance>, <date>): <resolution
+ * text>`.
+ *
+ * `suitability-triage.mts`'s Check 7 (Verifiability) originated this
+ * detection for #2661/#2711 across many independent review rounds (cited
+ * inline below); `discover-viability-gate.mts`'s `autonomous_completion`
+ * criterion (#2763) reuses it verbatim to exclude the SAME resolved-decision
+ * line from its own `EXTERNAL_COORDINATION_PATTERN` scan, rather than
+ * maintaining a second, independently-drifting regex for the same shape --
+ * `docs/idd-workflow.md`'s Groom section tells an operator to write exactly
+ * this line, so an issue groomed as documented must not then fail the A4
+ * gate that runs before Check 7 ever sees it.
+ */
+
+import {
+  findMarkdownCodeRanges,
+  type MarkdownCodeRange,
+  maskMarkdownCodeRegionsPreservingPositions,
+} from './markdown-code.mts';
+
+// #2661 PR #2662 review: the reporting-verb vocabulary a quoting/citing
+// sentence uses to introduce someone else's decision as an example, rather
+// than asserting it as this issue's own. Exported: also used by
+// suitability-triage.mts's `isFramedAsDescriptive` (`hasSubjectiveApproval`,
+// #2512), an unrelated feature that happens to reuse the same vocabulary.
+export const FRAMING_VERB_PATTERN =
+  /\b(documents?|describes?|says?|states?|explains?|reports?)\b/i;
+
+/**
+ * Blank-line-delimited paragraph offsets within `body`. Exported: also used
+ * by suitability-triage.mts's `hasSubjectiveApproval` framing check, an
+ * unrelated feature that happens to need the same paragraph boundaries.
+ */
+export function getParagraphSpans(
+  body: string,
+): { start: number; end: number }[] {
+  const spans: { start: number; end: number }[] = [];
+  let cursor = 0;
+  for (const boundary of body.matchAll(/\r?\n[ \t]*(?:\r?\n)+/g)) {
+    spans.push({ start: cursor, end: boundary.index });
+    cursor = boundary.index + boundary[0].length;
+  }
+  spans.push({ start: cursor, end: body.length });
+  return spans;
+}
+
+// #2661 PR #2662 review round 6 (Codex): an issue-template author commonly
+// leaves hidden instructional scaffolding as an HTML comment -- e.g.
+// `<!-- Maintainer decision (Groom hearing, YYYY-MM-DD): <resolution text>
+// -->` -- invisible in the rendered issue but still present in a
+// code-masked body (Markdown code masking does not touch HTML comments).
+// Masked the same way as inline/fenced code, before the inline-decision
+// pattern scan. An unterminated `<!--` (no matching `-->`) extends to
+// end-of-body: CommonMark renders such an HTML block through EOF, so the
+// entire remaining body -- a genuine marker and Acceptance Criteria
+// included -- can be invisible in the rendered issue while still matching
+// this scan if left unmasked (round 7, PR #2662).
+//
+// #2711: an issue that documents this convention's own syntax inside a
+// fenced code example -- e.g. a fence containing a literal, deliberately
+// unterminated `<!--` to illustrate the shape -- must not have that
+// example's opener treated as a REAL unterminated comment: doing so masks
+// through EOF and swallows a genuine later "Maintainer decision (...)"
+// that follows the fence. The same applies to an INLINE code span
+// demonstrating the same syntax (PR #2735 Codex review round 2) -- e.g.
+// `` `<!--` `` followed by a later bullet naming the real artifact.
+// `ignoredOpenerRanges` (optional, defaults to none so existing callers
+// with no code content to worry about are unaffected) lets a caller
+// exclude any `<!--` whose own opening `<` falls inside one of these
+// ranges from consideration entirely; pass fenced + indented + inline
+// ranges (e.g. `findMarkdownCodeRanges`'s result) to cover every code
+// shape, not just fenced blocks.
+//
+// #2711 PR #2735 review round 5 (Codex): a backslash-escaped opener
+// (`\<!--`) renders as a literal string in CommonMark, not a real HTML
+// comment start -- an issue documenting the literal marker syntax (e.g.
+// `Document the literal \<!-- marker`) must not have everything after it
+// masked through EOF. A single preceding backslash is enough to treat it
+// as escaped (soft heuristic, matching this file's existing style; does
+// not attempt full backslash-run parity for a doubly-escaped `\\<!--`).
+//
+// Exported: also used by suitability-triage.mts's Check 6 (Autonomy) and
+// Check 7 (Verifiability, Acceptance Criteria masking) for the same
+// generic "mask an HTML comment" need, unrelated to resolved-decision
+// detection specifically.
+export function findHtmlCommentRanges(
+  text: string,
+  ignoredOpenerRanges: MarkdownCodeRange[] = [],
+): MarkdownCodeRange[] {
+  const ranges: MarkdownCodeRange[] = [];
+  const openPattern = /<!--/g;
+  let openMatch = openPattern.exec(text);
+  while (openMatch) {
+    const openIndex = openMatch.index;
+    const isEscaped = text[openIndex - 1] === '\\';
+    const isIgnored =
+      isEscaped ||
+      ignoredOpenerRanges.some(
+        (range) => openIndex >= range.start && openIndex < range.end,
+      );
+    if (isIgnored) {
+      openPattern.lastIndex = openIndex + 4;
+      openMatch = openPattern.exec(text);
+      continue;
+    }
+    const closeIndex = text.indexOf('-->', openIndex + 4);
+    const end = closeIndex === -1 ? text.length : closeIndex + 3;
+    ranges.push({ start: openIndex, end });
+    openPattern.lastIndex = end;
+    openMatch = openPattern.exec(text);
+  }
+  return ranges;
+}
+
+// A heading line such as "## Decision (resolved 2026-06-27)" records that a
+// human has already ruled on the issue's open question (see Check 7). The
+// negative lookahead rejects only a still-open *phrase* that directly negates
+// "resolved" ("not [yet] [been] resolved", "to be resolved", "never [been]
+// resolved"), so an unrelated negator elsewhere on the line -- e.g. "Decision
+// (not user-facing; resolved 2026-06-27)" -- still counts as resolved. A
+// lookahead (not a variable-length lookbehind) keeps the assertion portable
+// across JavaScript regex engines.
+export const RESOLVED_DECISION_PATTERN =
+  /^#{1,6}\s+Decision\b(?![^\n]*\b(?:not(?:\s+yet)?(?:\s+been)?\s+resolved|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+resolved|never(?:\s+been)?\s+resolved)\b)[^\n]*\bresolved\b/im;
+
+// #2661: the grooming-pass workflow (docs/idd-workflow.md, from #2494)
+// records a resolved decision as inline prose -- "Maintainer decision
+// (<provenance>, <date>): <resolution text>" -- not a "## Decision" heading,
+// so RESOLVED_DECISION_PATTERN above never matches it. The parenthetical's own
+// provenance (an issue reference and/or "Groom hearing" and/or a date) is
+// this shape's resolved signal, so -- unlike the heading form -- the literal
+// word "resolved" is not required. `[^)]` (not `[^)\n]`) lets the parenthetical
+// span a hard-wrapped line break -- GitHub issue bodies wrap at ~80 chars, so
+// "(kurone-kito/idd-skill#2637, Groom hearing,\n2026-09-05):" routinely splits
+// the provenance across two physical lines (the same line-wrap-is-not-a-
+// boundary shape as the proximity check above, #2512). A "still open" guard
+// applies immediately after the colon, so a placeholder resolution is not
+// mistaken for a real one -- both the heading form's own negated-"resolved"
+// phrasing ("not yet decided") and this inline form's own still-pending
+// vocabulary (TBD, pending, undecided, deferred, "still open"), since the
+// inline form has no positive `\bresolved\b` requirement to fall back on
+// (#2661 C1 review). The leading `[\s*_\`>-]*` skips past Markdown emphasis
+// (`**pending**`, `_TBD_`, `` `still open` ``) and list/blockquote markers
+// ("- TBD ...", "> pending ...") that would otherwise land between the colon
+// and the denylist word (Codex + Copilot review, PR #2662); the trailing
+// `(?![a-zA-Z])` replaces a plain `\b`, which fails to end the match after
+// "TBD_" (both `D` and `_` are `\w`, so `\b` finds no boundary there) even
+// though the underscore is just a closing emphasis marker, not part of the
+// word. The negated-decision-noun class (`no\s+(?:decision|consensus|
+// agreement|resolution|verdict|ruling|conclusion)(?:\s+yet)?`) and the
+// still-open-state class (`(?:still|remains?)\s+(?:open|undecided|
+// unresolved|pending|unsettled)`) replace the earlier single-phrase
+// entries ("no decision yet", "still open") with their semantic families,
+// covering "no consensus yet" and similar noun-first phrasings the
+// verb-first "not (yet) decided" denylist entries don't match (Codex
+// rounds 2-3, PR #2662) without enumerating every synonym as its own
+// literal. Deliberately NOT a bare `no\s+\w+`: "no changes to the API;
+// keep as-is" is a genuinely resolved decision, not a pending one.
+// **Convergence boundary**: this denylist is already stricter than
+// precedent -- `RESOLVED_DECISION_PATTERN` above has carried no
+// resolution-text denylist at all since #1135, and its own docstring
+// accepts exactly this soft-heuristic trade-off. A denylist can never
+// enumerate every future synonym; widen a *class* here only for a
+// concrete reported case, not for a hypothetical one. Resolution text must
+// start on the SAME LINE as the colon (`[ \t]*`, no newline tolerance): an
+// earlier revision allowed a single hard-wrapped line break here, which
+// fixed the immediate "colon immediately followed by a blank line" case
+// (Codex round 2, PR #2662) but still let an empty marker consume the very
+// next line's first character even with no blank line at all -- e.g. a
+// heading's "#" right after "Maintainer decision (...):\n" (Copilot round
+// 6, PR #2662). Dropping the newline tolerance entirely closes both cases
+// at once; neither of this fix's two real-world citations (#2644, #2641)
+// ever needed it, since GitHub's hard-wrap only splits the provenance
+// parenthetical, never the colon-to-resolution boundary itself. The
+// lookahead right after the opening "("
+// requires the parenthetical to actually contain one of the three
+// provenance signals this shape is documented to carry -- an issue/PR
+// reference, "Groom hearing", or an ISO-style date -- rather than accepting
+// any (or empty) parenthetical content as if provenance were merely
+// decorative (Copilot review round 2, PR #2662): without this, "Maintainer
+// decision (): ..." or "Maintainer decision (just kidding): ..." could
+// bypass the subjective-approval gate with no real grooming-pass record
+// behind it. `pending`/`undecided`/`deferred` additionally require a clause
+// boundary (through optional "yet"/"still"/"for now" and Markdown
+// decoration) immediately after the word -- these three, unlike TBD/TBA/TBC,
+// are ordinary English adjectives that can open a genuinely settled
+// resolution's own sentence ("deferred to follow-up issue #100 so this
+// patch remains scoped", "pending requests will be rejected with HTTP
+// 409"); only a bare, sentence-ending use of the word signals a real
+// placeholder (Codex round 4, PR #2662). This is the same soft
+// co-occurrence heuristic as the heading form: it does not verify the
+// resolution text actually settles the exact approval wording elsewhere in
+// the body.
+export const INLINE_MAINTAINER_DECISION_PATTERN =
+  /(?<![\w-])Maintainer decision(?![\w-])\s*\((?=[^)]{0,200}(?:#\d+|Groom hearing|\d{4}-\d{2}-\d{2}))[^)]{0,200}\)\s*:[ \t]*(?![\s*_`>-]*(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|no\s+(?:decision|consensus|agreement|resolution|verdict|ruling|conclusion)(?:\s+yet)?|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided)|TBD|TBA|TBC|(?:pending|undecided|deferred)(?:\s+(?:yet|still|for\s+now))?[\s*_`]*(?=[.,;:\n]|$)|awaiting\s+(?:a\s+)?(?:decision|consensus|sign-?off|approval)|(?:still|remains?)\s+(?:open|undecided|unresolved|pending|unsettled))(?![a-zA-Z]))\S/i;
+
+// #2661 PR #2662 review round 2 (Codex): unlike a whole-paragraph framing
+// scan, this scans only the paragraph text BEFORE `offset`, not the whole
+// paragraph. Used solely for the inline-decision scan, where the match's own
+// resolution text (after the colon) can legitimately contain an ordinary
+// reporting verb -- "Maintainer decision (...): the helper reports an
+// actionable error" -- without that making the marker itself a quoted
+// example of someone else's decision. A genuine quoting/reporting frame
+// always precedes the quoted marker in natural prose ("issue #2641 states
+// \"Maintainer decision (...)\"..."), so only text before the match need be
+// checked here. Bounded to the current SENTENCE, not the whole paragraph
+// prefix (round 6, PR #2662): an unrelated reporting verb in an earlier,
+// already-terminated sentence of the same paragraph -- "The current helper
+// reports status. Maintainer decision (...): choose A" -- must not suppress
+// a genuine decision merely for sharing a paragraph with an unrelated use of
+// the same vocabulary.
+// #2711: the terminal punctuation of a sentence may be immediately
+// followed by a closing Markdown emphasis marker or quote character before
+// the whitespace that ends it -- e.g. a sentence ending `"done."` or
+// `*settled*.`. A plain literal ". "/"! "/"? " scan finds no boundary at
+// such a position (the quote/emphasis character sits between the
+// punctuation and the space) and falls back to an EARLIER, unrelated
+// sentence boundary instead, widening the scan window enough to catch that
+// earlier sentence's own framing verb.
+const SENTENCE_TERMINATOR_PATTERN = /[.!?][)"'*_`\]]*(?=\s|$)/;
+
+function findLastSentenceBoundaryEnd(scanText: string): number {
+  const pattern = new RegExp(SENTENCE_TERMINATOR_PATTERN.source, 'g');
+  let end = -1;
+  let match = pattern.exec(scanText);
+  while (match !== null) {
+    end = match.index + match[0].length;
+    match = pattern.exec(scanText);
+  }
+  return end;
+}
+
+function findFirstSentenceBoundaryEnd(scanText: string): number {
+  const match = SENTENCE_TERMINATOR_PATTERN.exec(scanText);
+  return match === null ? scanText.length : match.index + match[0].length;
+}
+
+function isPrecededByFramingVerb(
+  normalizedBody: string,
+  paragraphSpans: { start: number; end: number }[],
+  offset: number,
+): boolean {
+  const span =
+    paragraphSpans.find(
+      (candidate) => offset >= candidate.start && offset <= candidate.end,
+    ) ?? paragraphSpans[paragraphSpans.length - 1];
+  const scanText = normalizedBody.slice(span?.start ?? 0, offset);
+  const sentenceStart = findLastSentenceBoundaryEnd(scanText);
+  return FRAMING_VERB_PATTERN.test(
+    scanText.slice(sentenceStart === -1 ? 0 : sentenceStart),
+  );
+}
+
+// #2711: an inverted-attribution quotation states the marker FIRST and its
+// reporting verb after it -- "'Maintainer decision (...): choose A,'
+// reports the referenced tracking issue" -- which `isPrecededByFramingVerb`
+// above never sees, since it only scans text BEFORE the match. Mirrors that
+// function's own single-sentence bound, forward instead of backward, so an
+// unrelated LATER sentence's own framing verb doesn't wrongly suppress a
+// genuine decision two sentences later.
+const QUOTE_CHARS = ['"', "'"];
+
+function isFollowedByFramingVerb(
+  normalizedBody: string,
+  paragraphSpans: { start: number; end: number }[],
+  matchStart: number,
+  matchEnd: number,
+): boolean {
+  const span =
+    paragraphSpans.find(
+      (candidate) =>
+        matchStart >= candidate.start && matchStart <= candidate.end,
+    ) ?? paragraphSpans[paragraphSpans.length - 1];
+  const paragraphStart = span?.start ?? 0;
+  const paragraphEnd = span?.end ?? normalizedBody.length;
+
+  // Deliberately narrower than "any framing verb somewhere later in the
+  // sentence": the marker must be immediately preceded by an opening quote
+  // character, closed by that SAME character before the framing verb.
+  // Without this, an ordinary reporting verb inside the marker's OWN
+  // resolution text -- "Maintainer decision (...): the helper reports an
+  // actionable error..." -- would be wrongly read as external framing (PR
+  // #2662 Codex review's own regression coverage for the backward-scan
+  // case; the forward scan needs the identical guard).
+  const precedingChar = normalizedBody[matchStart - 1];
+  if (
+    matchStart <= paragraphStart ||
+    !QUOTE_CHARS.includes(precedingChar ?? '')
+  ) {
+    return false;
+  }
+  const followingText = normalizedBody.slice(matchEnd, paragraphEnd);
+  const closingQuoteIndex = followingText.indexOf(precedingChar as string);
+  if (closingQuoteIndex === -1) {
+    return false;
+  }
+  const afterQuote = followingText.slice(closingQuoteIndex + 1);
+  const sentenceEnd = findFirstSentenceBoundaryEnd(afterQuote);
+  return FRAMING_VERB_PATTERN.test(afterQuote.slice(0, sentenceEnd));
+}
+
+// #2661 PR #2662 review round 2 (Codex): a Markdown blockquote ("> Maintainer
+// decision (...): ...") is itself a quoting signal, independent of
+// `isPrecededByFramingVerb` -- pasting another issue's decision as a
+// blockquote carries no reporting verb of its own, so the framing-verb check
+// alone lets a quoted decision through. Checks BOTH the matched line's own
+// ">" prefix (the direct case -- also covers a quote that starts partway
+// through a paragraph, e.g. "For reference:" followed immediately by
+// "> Maintainer decision (...)": CommonMark starts a new blockquote block at
+// that "> " line regardless of the preceding unquoted line, Codex round 5,
+// PR #2662) AND the containing PARAGRAPH's first line (CommonMark's
+// blockquote "lazy continuation" rule -- this repo's own coverage:
+// tests/markdown-code.test.mts's "permits lazy continuation" case -- renders
+// a line with no ">" of its own as still inside the quote when it continues
+// a paragraph that started with "> ", Codex round 4, PR #2662). An earlier
+// round-4 revision checked only the paragraph's first line and dropped the
+// original round-2 direct-line check, reintroducing exactly the round-5 gap.
+function isInBlockquotedParagraph(
+  normalizedBody: string,
+  paragraphSpans: { start: number; end: number }[],
+  offset: number,
+): boolean {
+  const lineStart = normalizedBody.lastIndexOf('\n', offset - 1) + 1;
+  if (/^[ \t]*>/.test(normalizedBody.slice(lineStart, offset))) {
+    return true;
+  }
+  const span =
+    paragraphSpans.find(
+      (candidate) => offset >= candidate.start && offset <= candidate.end,
+    ) ?? paragraphSpans[paragraphSpans.length - 1];
+  const paragraphStart = span?.start ?? 0;
+  const firstLineEnd = normalizedBody.indexOf('\n', paragraphStart);
+  const firstLine = normalizedBody.slice(
+    paragraphStart,
+    firstLineEnd === -1 ? normalizedBody.length : firstLineEnd,
+  );
+  return /^[ \t]*>/.test(firstLine);
+}
+
+// #2711: a GFM strikethrough span ("~~Maintainer decision (...): choose
+// A~~") marks its content as struck through -- rendered convention for
+// "retracted" or "superseded" -- so a decision inside one must not count
+// as this issue's current live resolution, independent of any framing verb
+// or blockquote. Pairs consecutive "~~" delimiters left-to-right within the
+// containing paragraph (a soft heuristic, not full CommonMark strikethrough
+// parsing, matching this file's existing style for inline-span detection)
+// and reports whether `offset` falls strictly inside any pair's content.
+//
+// #2711 PR #2735 review round 3 (Codex): scans a code-masked body, not the
+// raw `normalizedBody`, so a literal "~~" inside an inline/fenced code
+// example demonstrating the syntax -- masked to spaces there -- is never
+// mistaken for a real delimiter. `codeMaskedBody` must be the SAME length
+// and position-preserving relative to `normalizedBody` (as
+// `maskMarkdownCodeRegionsPreservingPositions` guarantees) so `paragraphSpans`
+// and `offset`, both computed against `normalizedBody`, stay valid against
+// it.
+//
+// #2711 PR #2735 review round 5 (Codex): a backslash-escaped delimiter
+// (`\~~`) renders as a literal string in CommonMark, not a real
+// strikethrough boundary -- two literal `\~~` examples surrounding a
+// genuine, unstruck "Maintainer decision (...)" must not be paired as if
+// they were real delimiters. A single preceding backslash is enough to
+// treat a `~~` as escaped (soft heuristic, matching this file's existing
+// style; does not attempt full backslash-run parity for `\\~~`).
+function isInStrikethroughSpan(
+  codeMaskedBody: string,
+  paragraphSpans: { start: number; end: number }[],
+  offset: number,
+): boolean {
+  const span =
+    paragraphSpans.find(
+      (candidate) => offset >= candidate.start && offset <= candidate.end,
+    ) ?? paragraphSpans[paragraphSpans.length - 1];
+  const paragraphStart = span?.start ?? 0;
+  const paragraphEnd = span?.end ?? codeMaskedBody.length;
+  const paragraphText = codeMaskedBody.slice(paragraphStart, paragraphEnd);
+  const relativeOffset = offset - paragraphStart;
+  const delimiterPattern = /~~/g;
+  const delimiterStarts: number[] = [];
+  let delimiterMatch = delimiterPattern.exec(paragraphText);
+  while (delimiterMatch !== null) {
+    if (paragraphText[delimiterMatch.index - 1] !== '\\') {
+      delimiterStarts.push(delimiterMatch.index);
+    }
+    delimiterPattern.lastIndex = delimiterMatch.index + 2;
+    delimiterMatch = delimiterPattern.exec(paragraphText);
+  }
+  for (let index = 0; index + 1 < delimiterStarts.length; index += 2) {
+    const contentStart = (delimiterStarts[index] ?? 0) + 2;
+    const contentEnd = delimiterStarts[index + 1] ?? 0;
+    if (relativeOffset >= contentStart && relativeOffset < contentEnd) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Finds every inline "Maintainer decision (<provenance>): <resolution>"
+ * occurrence in `body` that survives the framing-verb / blockquote /
+ * strikethrough exclusion checks above -- a genuine resolved decision, not a
+ * quoted or struck-through example of someone else's. Self-contained: `body`
+ * is normalized and code/HTML-comment-masked internally, so a caller passes
+ * the raw issue body with no precomputation of its own. Returned spans are
+ * offsets into `body` AFTER `\r\n` normalization (`\r\n` -> `\n`); a caller
+ * comparing indices from a separately-scanned corpus must normalize that
+ * corpus the same way first, or the two coordinate spaces can drift by one
+ * byte per CRLF line -- an edge case with no realistic GitHub-fetched issue
+ * body, whose API responses are already `\n`-only.
+ */
+export function findInlineResolvedDecisionSpans(
+  body: string,
+): MarkdownCodeRange[] {
+  const normalizedBody = body.replace(/\r\n/g, '\n');
+  const paragraphSpans = getParagraphSpans(normalizedBody);
+  const codeRanges = findMarkdownCodeRanges(normalizedBody);
+  const codeMaskedBody = maskMarkdownCodeRegionsPreservingPositions(
+    normalizedBody,
+    [...codeRanges, ...findHtmlCommentRanges(normalizedBody, codeRanges)],
+  );
+
+  const spans: MarkdownCodeRange[] = [];
+  const inlinePattern = new RegExp(
+    INLINE_MAINTAINER_DECISION_PATTERN.source,
+    'gi',
+  );
+  let inlineMatch = inlinePattern.exec(codeMaskedBody);
+  while (inlineMatch) {
+    const matchStart = inlineMatch.index;
+    const matchEnd = matchStart + inlineMatch[0].length;
+    if (
+      !isPrecededByFramingVerb(normalizedBody, paragraphSpans, matchStart) &&
+      !isFollowedByFramingVerb(
+        normalizedBody,
+        paragraphSpans,
+        matchStart,
+        matchEnd,
+      ) &&
+      !isInBlockquotedParagraph(normalizedBody, paragraphSpans, matchStart) &&
+      !isInStrikethroughSpan(codeMaskedBody, paragraphSpans, matchStart)
+    ) {
+      spans.push({ start: matchStart, end: matchEnd });
+    }
+    inlineMatch = inlinePattern.exec(codeMaskedBody);
+  }
+  return spans;
+}
+
+/**
+ * True when `body` records a resolved maintainer decision, either the
+ * heading form (`## Decision (... resolved ...)`) or the inline
+ * grooming-pass form. Replaces `suitability-triage.mts`'s own former
+ * `hasResolvedDecision` computation; `discover-viability-gate.mts` uses
+ * `findInlineResolvedDecisionSpans` directly instead, since its
+ * `autonomous_completion` criterion needs per-occurrence match offsets, not
+ * just a whole-body boolean.
+ */
+export function hasResolvedDecision(body: string): boolean {
+  return (
+    RESOLVED_DECISION_PATTERN.test(body) ||
+    findInlineResolvedDecisionSpans(body).length > 0
+  );
+}

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -34,6 +34,12 @@ import { escapeRegex } from './marker-regex.mts';
 import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mts';
 import { resolveTrustedMarkerActors } from './protocol-helpers.mts';
 import {
+  hasResolvedDecision as computeHasResolvedDecision,
+  FRAMING_VERB_PATTERN,
+  findHtmlCommentRanges,
+  getParagraphSpans,
+} from './resolved-decision.mts';
+import {
   buildClosedByMergedPrArgs,
   buildMergedPrByBranchArgs,
   buildMergedPrListArgs,
@@ -337,20 +343,10 @@ const SUBJECTIVE_PROXIMITY_PATTERN = new RegExp(
 // false negative (an unrelated reporting verb elsewhere in a long
 // paragraph) is accepted in exchange for not re-deriving sentence
 // boundaries.
-const FRAMING_VERB_PATTERN =
-  /\b(documents?|describes?|says?|states?|explains?|reports?)\b/i;
-
-/** Blank-line-delimited paragraph offsets within `body`. */
-function getParagraphSpans(body: string): { start: number; end: number }[] {
-  const spans: { start: number; end: number }[] = [];
-  let cursor = 0;
-  for (const boundary of body.matchAll(/\r?\n[ \t]*(?:\r?\n)+/g)) {
-    spans.push({ start: cursor, end: boundary.index });
-    cursor = boundary.index + boundary[0].length;
-  }
-  spans.push({ start: cursor, end: body.length });
-  return spans;
-}
+// FRAMING_VERB_PATTERN and getParagraphSpans now live in
+// resolved-decision.mts (imported above), shared with that module's own
+// resolved-decision detection -- this file's isFramedAsDescriptive below
+// still uses both, just via the import instead of a local definition.
 
 // #2661 C1 review: shared between `hasSubjectiveApproval` (#2512's original
 // use) and `hasResolvedDecision`'s inline-form scan. A match landing in a
@@ -376,269 +372,14 @@ function isFramedAsDescriptive(
   );
 }
 
-// #2661 PR #2662 review (Codex): unlike `isFramedAsDescriptive` above, this
-// scans only the paragraph text BEFORE `offset`, not the whole paragraph.
-// Used solely for the inline-decision scan, where the match's own resolution
-// text (after the colon) can legitimately contain an ordinary reporting verb
-// -- "Maintainer decision (...): the helper reports an actionable error" --
-// without that making the marker itself a quoted example of someone else's
-// decision. A genuine quoting/reporting frame always precedes the quoted
-// marker in natural prose ("issue #2641 states \"Maintainer decision
-// (...)\"..."), so only text before the match need be checked here. Bounded
-// to the current SENTENCE, not the whole paragraph prefix (round 6, PR
-// #2662): an unrelated reporting verb in an earlier, already-terminated
-// sentence of the same paragraph -- "The current helper reports status.
-// Maintainer decision (...): choose A" -- must not suppress a genuine
-// decision merely for sharing a paragraph with an unrelated use of the same
-// vocabulary.
-// #2711: the terminal punctuation of a sentence may be immediately
-// followed by a closing Markdown emphasis marker or quote character before
-// the whitespace that ends it -- e.g. a sentence ending `"done."` or
-// `*settled*.`. The previous literal ". "/"! "/"? " scan below found no
-// boundary at such a position (the quote/emphasis character sits between
-// the punctuation and the space) and fell back to an EARLIER, unrelated
-// sentence boundary instead, widening the scan window enough to catch that
-// earlier sentence's own framing verb.
-const SENTENCE_TERMINATOR_PATTERN = /[.!?][)"'*_`\]]*(?=\s|$)/;
-
-function findLastSentenceBoundaryEnd(scanText: string): number {
-  const pattern = new RegExp(SENTENCE_TERMINATOR_PATTERN.source, 'g');
-  let end = -1;
-  let match = pattern.exec(scanText);
-  while (match !== null) {
-    end = match.index + match[0].length;
-    match = pattern.exec(scanText);
-  }
-  return end;
-}
-
-function findFirstSentenceBoundaryEnd(scanText: string): number {
-  const match = SENTENCE_TERMINATOR_PATTERN.exec(scanText);
-  return match === null ? scanText.length : match.index + match[0].length;
-}
-
-function isPrecededByFramingVerb(
-  normalizedBody: string,
-  paragraphSpans: { start: number; end: number }[],
-  offset: number,
-): boolean {
-  const span =
-    paragraphSpans.find(
-      (candidate) => offset >= candidate.start && offset <= candidate.end,
-    ) ?? paragraphSpans[paragraphSpans.length - 1];
-  const scanText = normalizedBody.slice(span?.start ?? 0, offset);
-  const sentenceStart = findLastSentenceBoundaryEnd(scanText);
-  return FRAMING_VERB_PATTERN.test(
-    scanText.slice(sentenceStart === -1 ? 0 : sentenceStart),
-  );
-}
-
-// #2711: an inverted-attribution quotation states the marker FIRST and its
-// reporting verb after it -- "'Maintainer decision (...): choose A,'
-// reports the referenced tracking issue" -- which `isPrecededByFramingVerb`
-// above never sees, since it only scans text BEFORE the match. Mirrors that
-// function's own single-sentence bound, forward instead of backward, so an
-// unrelated LATER sentence's own framing verb doesn't wrongly suppress a
-// genuine decision two sentences later.
-const QUOTE_CHARS = ['"', "'"];
-
-function isFollowedByFramingVerb(
-  normalizedBody: string,
-  paragraphSpans: { start: number; end: number }[],
-  matchStart: number,
-  matchEnd: number,
-): boolean {
-  const span =
-    paragraphSpans.find(
-      (candidate) =>
-        matchStart >= candidate.start && matchStart <= candidate.end,
-    ) ?? paragraphSpans[paragraphSpans.length - 1];
-  const paragraphStart = span?.start ?? 0;
-  const paragraphEnd = span?.end ?? normalizedBody.length;
-
-  // Deliberately narrower than "any framing verb somewhere later in the
-  // sentence": the marker must be immediately preceded by an opening quote
-  // character, closed by that SAME character before the framing verb.
-  // Without this, an ordinary reporting verb inside the marker's OWN
-  // resolution text -- "Maintainer decision (...): the helper reports an
-  // actionable error..." -- would be wrongly read as external framing (PR
-  // #2662 Codex review's own regression coverage for the backward-scan
-  // case; the forward scan needs the identical guard).
-  const precedingChar = normalizedBody[matchStart - 1];
-  if (
-    matchStart <= paragraphStart ||
-    !QUOTE_CHARS.includes(precedingChar ?? '')
-  ) {
-    return false;
-  }
-  const followingText = normalizedBody.slice(matchEnd, paragraphEnd);
-  const closingQuoteIndex = followingText.indexOf(precedingChar as string);
-  if (closingQuoteIndex === -1) {
-    return false;
-  }
-  const afterQuote = followingText.slice(closingQuoteIndex + 1);
-  const sentenceEnd = findFirstSentenceBoundaryEnd(afterQuote);
-  return FRAMING_VERB_PATTERN.test(afterQuote.slice(0, sentenceEnd));
-}
-
-// #2661 PR #2662 review round 2 (Codex): a Markdown blockquote ("> Maintainer
-// decision (...): ...") is itself a quoting signal, independent of
-// `isPrecededByFramingVerb` -- pasting another issue's decision as a
-// blockquote carries no reporting verb of its own, so the framing-verb check
-// alone lets a quoted decision through. Checks BOTH the matched line's own
-// ">" prefix (the direct case -- also covers a quote that starts partway
-// through a paragraph, e.g. "For reference:" followed immediately by
-// "> Maintainer decision (...)": CommonMark starts a new blockquote block at
-// that "> " line regardless of the preceding unquoted line, Codex round 5,
-// PR #2662) AND the containing PARAGRAPH's first line (CommonMark's
-// blockquote "lazy continuation" rule -- this repo's own coverage:
-// tests/markdown-code.test.mts's "permits lazy continuation" case -- renders
-// a line with no ">" of its own as still inside the quote when it continues
-// a paragraph that started with "> ", Codex round 4, PR #2662). An earlier
-// round-4 revision checked only the paragraph's first line and dropped the
-// original round-2 direct-line check, reintroducing exactly the round-5 gap.
-function isInBlockquotedParagraph(
-  normalizedBody: string,
-  paragraphSpans: { start: number; end: number }[],
-  offset: number,
-): boolean {
-  const lineStart = normalizedBody.lastIndexOf('\n', offset - 1) + 1;
-  if (/^[ \t]*>/.test(normalizedBody.slice(lineStart, offset))) {
-    return true;
-  }
-  const span =
-    paragraphSpans.find(
-      (candidate) => offset >= candidate.start && offset <= candidate.end,
-    ) ?? paragraphSpans[paragraphSpans.length - 1];
-  const paragraphStart = span?.start ?? 0;
-  const firstLineEnd = normalizedBody.indexOf('\n', paragraphStart);
-  const firstLine = normalizedBody.slice(
-    paragraphStart,
-    firstLineEnd === -1 ? normalizedBody.length : firstLineEnd,
-  );
-  return /^[ \t]*>/.test(firstLine);
-}
-
-// #2711: a GFM strikethrough span ("~~Maintainer decision (...): choose
-// A~~") marks its content as struck through -- rendered convention for
-// "retracted" or "superseded" -- so a decision inside one must not count
-// as this issue's current live resolution, independent of any framing verb
-// or blockquote. Pairs consecutive "~~" delimiters left-to-right within the
-// containing paragraph (a soft heuristic, not full CommonMark strikethrough
-// parsing, matching this file's existing style for inline-span detection)
-// and reports whether `offset` falls strictly inside any pair's content.
-//
-// #2711 PR #2735 review round 3 (Codex): scans `codeMaskedBody` (e.g.
-// `normalizedCodeMaskedBody`), not the raw `normalizedBody`, so a literal
-// "~~" inside an inline/fenced code example demonstrating the syntax --
-// masked to spaces there -- is never mistaken for a real delimiter.
-// `codeMaskedBody` must be the SAME length and position-preserving
-// relative to `normalizedBody` (as `maskMarkdownCodeRegionsPreservingPositions`
-// guarantees) so `paragraphSpans` and `offset`, both computed against
-// `normalizedBody`, stay valid against it.
-//
-// #2711 PR #2735 review round 5 (Codex): a backslash-escaped delimiter
-// (`\~~`) renders as a literal string in CommonMark, not a real
-// strikethrough boundary -- two literal `\~~` examples surrounding a
-// genuine, unstruck "Maintainer decision (...)" must not be paired as if
-// they were real delimiters. A single preceding backslash is enough to
-// treat a `~~` as escaped (soft heuristic, matching this file's existing
-// style; does not attempt full backslash-run parity for `\\~~`).
-function isInStrikethroughSpan(
-  codeMaskedBody: string,
-  paragraphSpans: { start: number; end: number }[],
-  offset: number,
-): boolean {
-  const span =
-    paragraphSpans.find(
-      (candidate) => offset >= candidate.start && offset <= candidate.end,
-    ) ?? paragraphSpans[paragraphSpans.length - 1];
-  const paragraphStart = span?.start ?? 0;
-  const paragraphEnd = span?.end ?? codeMaskedBody.length;
-  const paragraphText = codeMaskedBody.slice(paragraphStart, paragraphEnd);
-  const relativeOffset = offset - paragraphStart;
-  const delimiterPattern = /~~/g;
-  const delimiterStarts: number[] = [];
-  let delimiterMatch = delimiterPattern.exec(paragraphText);
-  while (delimiterMatch !== null) {
-    if (paragraphText[delimiterMatch.index - 1] !== '\\') {
-      delimiterStarts.push(delimiterMatch.index);
-    }
-    delimiterPattern.lastIndex = delimiterMatch.index + 2;
-    delimiterMatch = delimiterPattern.exec(paragraphText);
-  }
-  for (let index = 0; index + 1 < delimiterStarts.length; index += 2) {
-    const contentStart = (delimiterStarts[index] ?? 0) + 2;
-    const contentEnd = delimiterStarts[index + 1] ?? 0;
-    if (relativeOffset >= contentStart && relativeOffset < contentEnd) {
-      return true;
-    }
-  }
-  return false;
-}
-
-// #2661 PR #2662 review round 6 (Codex): an issue-template author commonly
-// leaves hidden instructional scaffolding as an HTML comment -- e.g.
-// `<!-- Maintainer decision (Groom hearing, YYYY-MM-DD): <resolution text>
-// -->` -- invisible in the rendered issue but still present in
-// `normalizedCodeMaskedBody` (Markdown code masking does not touch HTML
-// comments). Masked the same way as inline/fenced code, before the
-// inline-decision pattern scan. An unterminated `<!--` (no matching `-->`)
-// extends to end-of-body: CommonMark renders such an HTML block through
-// EOF, so the entire remaining body -- a genuine marker and Acceptance
-// Criteria included -- can be invisible in the rendered issue while still
-// matching this scan if left unmasked (round 7, PR #2662).
-//
-// #2711: an issue that documents this convention's own syntax inside a
-// fenced code example -- e.g. a fence containing a literal, deliberately
-// unterminated `<!--` to illustrate the shape -- must not have that
-// example's opener treated as a REAL unterminated comment: doing so masks
-// through EOF and swallows a genuine later "Maintainer decision (...)"
-// that follows the fence. The same applies to an INLINE code span
-// demonstrating the same syntax (PR #2735 Codex review round 2) -- e.g.
-// `` `<!--` `` followed by a later bullet naming the real artifact.
-// `ignoredOpenerRanges` (optional, defaults to none so existing callers
-// with no code content to worry about are unaffected) lets a caller
-// exclude any `<!--` whose own opening `<` falls inside one of these
-// ranges from consideration entirely; pass fenced + indented + inline
-// ranges (e.g. `findMarkdownCodeRanges`'s result) to cover every code
-// shape, not just fenced blocks.
-//
-// #2711 PR #2735 review round 5 (Codex): a backslash-escaped opener
-// (`\<!--`) renders as a literal string in CommonMark, not a real HTML
-// comment start -- an issue documenting the literal marker syntax (e.g.
-// `Document the literal \<!-- marker`) must not have everything after it
-// masked through EOF. A single preceding backslash is enough to treat it
-// as escaped (soft heuristic, matching this file's existing style; does
-// not attempt full backslash-run parity for a doubly-escaped `\\<!--`).
-function findHtmlCommentRanges(
-  text: string,
-  ignoredOpenerRanges: MarkdownCodeRange[] = [],
-): MarkdownCodeRange[] {
-  const ranges: MarkdownCodeRange[] = [];
-  const openPattern = /<!--/g;
-  let openMatch = openPattern.exec(text);
-  while (openMatch) {
-    const openIndex = openMatch.index;
-    const isEscaped = text[openIndex - 1] === '\\';
-    const isIgnored =
-      isEscaped ||
-      ignoredOpenerRanges.some(
-        (range) => openIndex >= range.start && openIndex < range.end,
-      );
-    if (isIgnored) {
-      openPattern.lastIndex = openIndex + 4;
-      openMatch = openPattern.exec(text);
-      continue;
-    }
-    const closeIndex = text.indexOf('-->', openIndex + 4);
-    const end = closeIndex === -1 ? text.length : closeIndex + 3;
-    ranges.push({ start: openIndex, end });
-    openPattern.lastIndex = end;
-    openMatch = openPattern.exec(text);
-  }
-  return ranges;
-}
+// The sentence-boundary helpers, the inline "Maintainer decision (...): ..."
+// pattern's framing-verb / blockquote / strikethrough exclusion checks, and
+// findHtmlCommentRanges all now live in resolved-decision.mts (#2763),
+// single-sourced with discover-viability-gate.mts's own
+// autonomous_completion criterion. findHtmlCommentRanges is imported above
+// for this file's other two call sites (Check 6 Autonomy, Check 7's
+// Acceptance-Criteria masking); the resolved-decision scan itself is
+// replaced below by a single call to the imported `hasResolvedDecision`.
 
 // Check 3 precision: an unsafe execution directive tells the agent to act on
 // *supplied / untrusted* content, not any command verb that merely lands near
@@ -1197,87 +938,12 @@ function hasBareDottedFilename(text: string): boolean {
   }
   return false;
 }
-// A heading line such as "## Decision (resolved 2026-06-27)" records that a
-// human has already ruled on the issue's open question (see Check 7). The
-// negative lookahead rejects only a still-open *phrase* that directly negates
-// "resolved" ("not [yet] [been] resolved", "to be resolved", "never [been]
-// resolved"), so an unrelated negator elsewhere on the line — e.g. "Decision
-// (not user-facing; resolved 2026-06-27)" — still counts as resolved. A
-// lookahead (not a variable-length lookbehind) keeps the assertion portable
-// across JavaScript regex engines.
-const RESOLVED_DECISION_PATTERN =
-  /^#{1,6}\s+Decision\b(?![^\n]*\b(?:not(?:\s+yet)?(?:\s+been)?\s+resolved|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+resolved|never(?:\s+been)?\s+resolved)\b)[^\n]*\bresolved\b/im;
-
-// #2661: the grooming-pass workflow (docs/idd-workflow.md, from #2494)
-// records a resolved decision as inline prose -- "Maintainer decision
-// (<provenance>, <date>): <resolution text>" -- not a "## Decision" heading,
-// so RESOLVED_DECISION_PATTERN above never matches it. The parenthetical's own
-// provenance (an issue reference and/or "Groom hearing" and/or a date) is
-// this shape's resolved signal, so -- unlike the heading form -- the literal
-// word "resolved" is not required. `[^)]` (not `[^)\n]`) lets the parenthetical
-// span a hard-wrapped line break -- GitHub issue bodies wrap at ~80 chars, so
-// "(kurone-kito/idd-skill#2637, Groom hearing,\n2026-09-05):" routinely splits
-// the provenance across two physical lines (the same line-wrap-is-not-a-
-// boundary shape as the proximity check above, #2512). A "still open" guard
-// applies immediately after the colon, so a placeholder resolution is not
-// mistaken for a real one -- both the heading form's own negated-"resolved"
-// phrasing ("not yet decided") and this inline form's own still-pending
-// vocabulary (TBD, pending, undecided, deferred, "still open"), since the
-// inline form has no positive `\bresolved\b` requirement to fall back on
-// (#2661 C1 review). The leading `[\s*_\`>-]*` skips past Markdown emphasis
-// (`**pending**`, `_TBD_`, `` `still open` ``) and list/blockquote markers
-// ("- TBD ...", "> pending ...") that would otherwise land between the colon
-// and the denylist word (Codex + Copilot review, PR #2662); the trailing
-// `(?![a-zA-Z])` replaces a plain `\b`, which fails to end the match after
-// "TBD_" (both `D` and `_` are `\w`, so `\b` finds no boundary there) even
-// though the underscore is just a closing emphasis marker, not part of the
-// word. The negated-decision-noun class (`no\s+(?:decision|consensus|
-// agreement|resolution|verdict|ruling|conclusion)(?:\s+yet)?`) and the
-// still-open-state class (`(?:still|remains?)\s+(?:open|undecided|
-// unresolved|pending|unsettled)`) replace the earlier single-phrase
-// entries ("no decision yet", "still open") with their semantic families,
-// covering "no consensus yet" and similar noun-first phrasings the
-// verb-first "not (yet) decided" denylist entries don't match (Codex
-// rounds 2-3, PR #2662) without enumerating every synonym as its own
-// literal. Deliberately NOT a bare `no\s+\w+`: "no changes to the API;
-// keep as-is" is a genuinely resolved decision, not a pending one.
-// **Convergence boundary**: this denylist is already stricter than
-// precedent -- `RESOLVED_DECISION_PATTERN` above has carried no
-// resolution-text denylist at all since #1135, and its own docstring
-// accepts exactly this soft-heuristic trade-off. A denylist can never
-// enumerate every future synonym; widen a *class* here only for a
-// concrete reported case, not for a hypothetical one. Resolution text must
-// start on the SAME LINE as the colon (`[ \t]*`, no newline tolerance): an
-// earlier revision allowed a single hard-wrapped line break here, which
-// fixed the immediate "colon immediately followed by a blank line" case
-// (Codex round 2, PR #2662) but still let an empty marker consume the very
-// next line's first character even with no blank line at all -- e.g. a
-// heading's "#" right after "Maintainer decision (...):\n" (Copilot round
-// 6, PR #2662). Dropping the newline tolerance entirely closes both cases
-// at once; neither of this fix's two real-world citations (#2644, #2641)
-// ever needed it, since GitHub's hard-wrap only splits the provenance
-// parenthetical, never the colon-to-resolution boundary itself. The
-// lookahead right after the opening "("
-// requires the parenthetical to actually contain one of the three
-// provenance signals this shape is documented to carry -- an issue/PR
-// reference, "Groom hearing", or an ISO-style date -- rather than accepting
-// any (or empty) parenthetical content as if provenance were merely
-// decorative (Copilot review round 2, PR #2662): without this, "Maintainer
-// decision (): ..." or "Maintainer decision (just kidding): ..." could
-// bypass the subjective-approval gate with no real grooming-pass record
-// behind it. `pending`/`undecided`/`deferred` additionally require a clause
-// boundary (through optional "yet"/"still"/"for now" and Markdown
-// decoration) immediately after the word -- these three, unlike TBD/TBA/TBC,
-// are ordinary English adjectives that can open a genuinely settled
-// resolution's own sentence ("deferred to follow-up issue #100 so this
-// patch remains scoped", "pending requests will be rejected with HTTP
-// 409"); only a bare, sentence-ending use of the word signals a real
-// placeholder (Codex round 4, PR #2662). This is the same soft
-// co-occurrence heuristic as the heading form: it does not verify the
-// resolution text actually settles the exact approval wording elsewhere in
-// the body.
-const INLINE_MAINTAINER_DECISION_PATTERN =
-  /(?<![\w-])Maintainer decision(?![\w-])\s*\((?=[^)]{0,200}(?:#\d+|Groom hearing|\d{4}-\d{2}-\d{2}))[^)]{0,200}\)\s*:[ \t]*(?![\s*_`>-]*(?:not(?:\s+yet)?(?:\s+been)?\s+(?:resolved|decided)|no\s+(?:decision|consensus|agreement|resolution|verdict|ruling|conclusion)(?:\s+yet)?|(?:to\s+be|yet\s+to\s+be|remains?\s+to\s+be)\s+(?:resolved|decided)|never(?:\s+been)?\s+(?:resolved|decided)|TBD|TBA|TBC|(?:pending|undecided|deferred)(?:\s+(?:yet|still|for\s+now))?[\s*_`]*(?=[.,;:\n]|$)|awaiting\s+(?:a\s+)?(?:decision|consensus|sign-?off|approval)|(?:still|remains?)\s+(?:open|undecided|unresolved|pending|unsettled))(?![a-zA-Z]))\S/i;
+// RESOLVED_DECISION_PATTERN (the "## Decision (resolved ...)" heading form)
+// and INLINE_MAINTAINER_DECISION_PATTERN (the grooming-pass inline
+// "Maintainer decision (<provenance>): <resolution text>" form, #2661) now
+// live in resolved-decision.mts, single-sourced with
+// discover-viability-gate.mts's own autonomous_completion criterion
+// (#2763) -- see that module for the full pattern history and rationale.
 
 // #2024: a negation word immediately before the trigger verb, allowing at
 // most one intervening word (e.g. "does not *ever* skip") between the
@@ -3114,68 +2780,13 @@ export function checkVerifiability(context: Context): CheckOutcome {
   // accepted trade-off for maintainer-authored issues. An approval-gated
   // body with no resolved decision still routes to needs-decision.
   //
-  // The inline form additionally requires no framing verb PRECEDE it in its
-  // own paragraph (#2661 C1/PR review): a body that merely *quotes* another
-  // issue's already-resolved decision as an example -- "issue #2641 states
-  // \"Maintainer decision (...)\" as an example of the convention" -- must
-  // not borrow that resolution for THIS issue's own subjective gate. Scoped
-  // to text before the match (`isPrecededByFramingVerb`, not the
-  // whole-paragraph `isFramedAsDescriptive`) so a genuine resolution whose
-  // OWN text happens to use a reporting verb -- "Maintainer decision (...):
-  // the helper reports an actionable error" -- is not wrongly excluded
-  // (Codex review, PR #2662). `isFollowedByFramingVerb` (#2711) catches the
-  // inverted-attribution shape of the same quoting problem, where the
-  // reporting verb follows the marker instead of preceding it -- "'Maintainer
-  // decision (...): choose A,' reports the referenced tracking issue". A
-  // Markdown blockquote is a third, independent quoting signal with no
-  // reporting verb of its own -- "> Maintainer decision (...): ..." -- so
-  // `isInBlockquotedParagraph` also excludes a match (Codex review rounds 2
-  // and 4, PR #2662). A GFM strikethrough span (#2711) is a fourth,
-  // independent signal: a struck-through decision reads as retracted/
-  // superseded, not this issue's current live resolution, regardless of
-  // whether any framing verb or blockquote is also present. The heading
-  // form has no equivalent gap: a "## Decision (resolved …)" section is, by
-  // construction, this issue's own decision record, never a quoted example
-  // of someone else's.
-  const hasInlineResolvedDecision = ((): boolean => {
-    const inlinePattern = new RegExp(
-      INLINE_MAINTAINER_DECISION_PATTERN.source,
-      'gi',
-    );
-    let inlineMatch = inlinePattern.exec(normalizedCodeMaskedBody);
-    while (inlineMatch) {
-      const matchEnd = inlineMatch.index + inlineMatch[0].length;
-      if (
-        !isPrecededByFramingVerb(
-          normalizedBody,
-          paragraphSpans,
-          inlineMatch.index,
-        ) &&
-        !isFollowedByFramingVerb(
-          normalizedBody,
-          paragraphSpans,
-          inlineMatch.index,
-          matchEnd,
-        ) &&
-        !isInBlockquotedParagraph(
-          normalizedBody,
-          paragraphSpans,
-          inlineMatch.index,
-        ) &&
-        !isInStrikethroughSpan(
-          normalizedCodeMaskedBody,
-          paragraphSpans,
-          inlineMatch.index,
-        )
-      ) {
-        return true;
-      }
-      inlineMatch = inlinePattern.exec(normalizedCodeMaskedBody);
-    }
-    return false;
-  })();
-  const hasResolvedDecision =
-    RESOLVED_DECISION_PATTERN.test(body) || hasInlineResolvedDecision;
+  // Both the heading and inline forms, and the inline form's own
+  // framing-verb / blockquote / strikethrough exclusion checks (#2661,
+  // #2711), now live in resolved-decision.mts's `hasResolvedDecision`
+  // (imported above as `computeHasResolvedDecision`), single-sourced with
+  // discover-viability-gate.mts's `autonomous_completion` criterion (#2763)
+  // rather than re-derived here.
+  const hasResolvedDecision = computeHasResolvedDecision(body);
   if (hasSubjectiveApproval && !(hasResolvedDecision && hasObjectiveCriteria)) {
     return {
       pass: false,
@@ -3239,8 +2850,9 @@ export function checkVerifiability(context: Context): CheckOutcome {
   //
   // The verb+topic check just above is matched against
   // normalizedCodeMaskedBody (not normalizedBody), the same
-  // position-preserving code-masked body the resolved-decision scan above
-  // already uses (Codex review, PR #2725 round 4): an AC bullet that quotes
+  // position-preserving code-masked body `hasResolvedDecision` (now
+  // resolved-decision.mts) computes its own equivalent of internally
+  // (Codex review, PR #2725 round 4): an AC bullet that quotes
   // this exact escape-hatch phrasing as a literal example inside inline or
   // fenced code -- e.g. "Add a lint rule rejecting `Either add validation,
   // or document why validation is not needed`" -- must not have its quoted

--- a/tests/discover-viability-gate.test.mts
+++ b/tests/discover-viability-gate.test.mts
@@ -863,6 +863,78 @@ test('still fails autonomous completion when a past-investigation cue is unrelat
   assert.ok(result.failedCriteria.includes('autonomous_completion'));
 });
 
+// --- #2763: a Groom-pass-recorded resolved decision must not fail
+// autonomous_completion -- discover-viability-gate.mts's EXTERNAL_
+// COORDINATION_PATTERN previously had no exemption for the exact
+// "Maintainer decision (<provenance>): <resolution>" line
+// docs/idd-workflow.md's Groom section tells an operator to write, and
+// suitability-triage.mts's Check 7 already recognizes -----------------
+
+test('passes autonomous completion on the exact Groom-pass resolved-decision reproduction (#2763)', () => {
+  const result = evaluateA4Viability({
+    number: 62,
+    title: 'apply Groom hearing outcome',
+    body:
+      'Maintainer decision (Groom hearing, 2026-09-09): proceed.\n\n' +
+      '## Acceptance criteria\n\n' +
+      '- [ ] Add the change and a regression test.\n\n' +
+      'Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, true);
+  assert.deepEqual(result.failedCriteria, []);
+});
+
+test('still fails autonomous completion on a bare "maintainer decision" mention with no resolved-decision shape (#2763)', () => {
+  const result = evaluateA4Viability({
+    number: 63,
+    title: 'wire external approval gate',
+    body:
+      'This issue needs a maintainer decision before implementation. ' +
+      'Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.failedCriteria.includes('autonomous_completion'));
+});
+
+test('a quoted example of the resolved-decision line keeps its current (passing) result (#2763)', () => {
+  // Already passed before #2763 via the existing quoted-example exclusion
+  // (isInsideQuotedExample); this pins that the new resolved-decision
+  // exclusion does not change the outcome for a genuinely cited example.
+  const result = evaluateA4Viability({
+    number: 64,
+    title: 'fix quotation masking in checkVerifiability framing-verb scan',
+    body:
+      'For reference: "Maintainer decision (Groom hearing, 2026-09-05): ' +
+      'choose A" is quoted from another issue. ' +
+      'Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, true);
+  assert.deepEqual(result.failedCriteria, []);
+});
+
+test('still fails autonomous completion when a distinct genuine blocker follows a resolved decision (#2763)', () => {
+  // Adversarial case: excluding the resolved-decision occurrence must not
+  // also swallow a SEPARATE, still-live blocker elsewhere in the body.
+  const result = evaluateA4Viability({
+    number: 65,
+    title: 'wire external approval gate',
+    body:
+      'Maintainer decision (Groom hearing, 2026-09-09): proceed with the ' +
+      'first half. Waiting for maintainer sign-off on the second half is ' +
+      'still required before this can ship. Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.failedCriteria.includes('autonomous_completion'));
+});
+
 test('evaluateDiscoverViability fails closed when a lookup aborts', async () => {
   // A non-404 gh failure (auth / rate-limit / network) propagates out of
   // loadIssue instead of being swallowed into a silent issue_not_found.


### PR DESCRIPTION
# Summary

The A4 `autonomous_completion` viability gate
(`discover-viability-gate.mts`) discarded an issue exactly after it was
groomed per `docs/idd-workflow.md`'s own Groom-pass instructions:
recording `Maintainer decision (<provenance>, <date>): <resolution
text>` in the body. `EXTERNAL_COORDINATION_PATTERN`'s `maintainer
decision` bigram had no exemption for this shape, even though
`suitability-triage.mts`'s Check 7 already recognizes it as a resolved
decision (#2661/#2711) through a hardened, multi-round-reviewed regex
and framing-verb/blockquote/strikethrough exclusion scan.

Rather than add a second, independently-drifting regex to
`discover-viability-gate.mts`, this PR extracts Check 7's
resolved-decision detector into a new shared module,
`src/scripts/resolved-decision.mts`, and points both files at it:

- `suitability-triage.mts`'s Check 7 now calls the imported
  `hasResolvedDecision` instead of a local copy (behavior-preserving —
  the full test suite, including `tests/suitability-triage.test.mts`,
  passes unchanged).
- `discover-viability-gate.mts`'s `autonomous_completion` criterion now
  excludes an `EXTERNAL_COORDINATION_PATTERN` match that falls inside a
  genuine resolved-decision span, using the same per-occurrence
  exclusion structure its other exclusions already use.
- `docs/idd-workflow.md` and `idd-template/docs/idd-workflow.md`'s
  Groom section each name the new A4 exemption in one sentence.

## Linked issue

Closes #2763

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Verified with the exact reproduction from the issue: a body whose only
prose line is `Maintainer decision (Groom hearing, 2026-09-09):
proceed.` plus a checklist acceptance criterion now passes
`autonomous_completion` (previously failed). A bare
`needs a maintainer decision before implementation` sentence with no
resolved-decision shape still fails it, and a quoted example of the
decision line keeps its existing (already-passing) result.

`resolved-decision.mts` is self-contained (recomputes its own
normalized/code-masked body internally) rather than threading
`suitability-triage.mts`'s already-computed `normalizedBody` /
`paragraphSpans` / `normalizedCodeMaskedBody` through as parameters,
since those variables are also reused later in `checkVerifiability` for
unrelated purposes (AC-section extraction, escape-hatch branch checks)
and stay computed there unchanged.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (via `npx biome check`, `npx dprint check`,
      `npx markdownlint-cli2`, `npx cspell lint`)
- [x] `pnpm test` (`node --test tests/*.test.mts` — 5583 tests pass)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (covered by `audit-docs.mjs --check`
      above, which validates the structure-mode sync pair)
- [x] `node scripts/idd-doctor.mjs` (passed, 4 pre-existing/environmental
      warnings unrelated to this change)
- [x] `pnpm run typecheck`
- [x] `pnpm run build:check`
- [x] `node scripts/token-cost-report.mjs --check`

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CK2SHn8Bir6VHrXrMVMdn3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recognized maintainer decision entries can now be recorded directly in issue descriptions.
  * Documented decisions are handled consistently during issue grooming and viability checks.
  * Markdown examples, quoted text, code, comments, and strikethrough content are excluded from decision detection.

* **Documentation**
  * Updated workflow guidance and templates to describe the recognized maintainer decision format and re-triage behavior.

* **Bug Fixes**
  * Improved handling of line endings to ensure reliable decision detection across issue content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->