### PR TITLE
docs(issue-authoring): exempt the releasing set's own rechecks

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -1396,11 +1396,13 @@ only approval boundary.
   markers and the anchor's `mode=release-guard` as the expected state
   rather than as a competing generation; the acquisition-time rule that
   a target carrying a release marker cannot be re-acquired until that
-  release's `release-complete` is found applies to a later acquisition
-  or resume, not to the releasing set's own rechecks, and the current
-  winner is unchanged by them until the anchor's reconciled
-  `release-complete` closes the generation. Only after a fresh re-read
-  verifies every target's release
+  release's `release-complete` is found applies to a later session's
+  fresh acquisition of the child, not to the releasing set's own
+  rechecks or to a resume of the exact interrupted set, which stays
+  the established recovery path when `release-complete` is missing;
+  the current winner is unchanged by any of them until the anchor's
+  reconciled `release-complete` closes the generation. Only after a
+  fresh re-read verifies every target's release
   marker and label removal and the anchor's `release-complete` marker does
   the set-level release close all target generations, after which a later
   `acquire` starts a new generation. The

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -1390,7 +1390,17 @@ only approval boundary.
   and matching prior owner token. A `release` marker must match the current
   owner and set, but remains provisional while its set release is in
   progress; an individual label removal never closes that target's
-  generation. Only after a fresh re-read verifies every target's release
+  generation. During the owning set's own Stage 2 (observed 2026-09-09,
+  kurone-kito/idd-skill#2791), the heartbeat renewal and the pre-removal
+  ownership recheck must treat that set's provisional `mode=release`
+  markers and the anchor's `mode=release-guard` as the expected state
+  rather than as a competing generation; the acquisition-time rule that
+  a target carrying a release marker cannot be re-acquired until that
+  release's `release-complete` is found applies to a later acquisition
+  or resume, not to the releasing set's own rechecks, and the current
+  winner is unchanged by them until the anchor's reconciled
+  `release-complete` closes the generation. Only after a fresh re-read
+  verifies every target's release
   marker and label removal and the anchor's `release-complete` marker does
   the set-level release close all target generations, after which a later
   `acquire` starts a new generation. The

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -1400,9 +1400,9 @@ only approval boundary.
   fresh acquisition of the child, not to the releasing set's own
   rechecks or to a resume of the exact interrupted set, which stays
   the established recovery path when `release-complete` is missing;
-  the current winner is unchanged by any of them until the anchor's
-  reconciled `release-complete` closes the generation. Only after a
-  fresh re-read verifies every target's release
+  the releasing set's own rechecks never change the current winner,
+  unlike a valid resume marker for that exact set, which does. Only
+  after a fresh re-read verifies every target's release
   marker and label removal and the anchor's `release-complete` marker does
   the set-level release close all target generations, after which a later
   `acquire` starts a new generation. The

--- a/.claude/skills/issue-authoring/references/workflow-boundary.md
+++ b/.claude/skills/issue-authoring/references/workflow-boundary.md
@@ -202,11 +202,13 @@ approval boundary that hands off to IDD execution.
   markers and the anchor's `mode=release-guard` as the expected state
   rather than as a competing generation; the acquisition-time rule that
   a target carrying a release marker cannot be re-acquired until that
-  release's `release-complete` is found applies to a later acquisition
-  or resume, not to the releasing set's own rechecks, and the current
-  winner is unchanged by them until the anchor's reconciled
-  `release-complete` closes the generation. Only after a fresh re-read
-  verifies every target's release
+  release's `release-complete` is found applies to a later session's
+  fresh acquisition of the child, not to the releasing set's own
+  rechecks or to a resume of the exact interrupted set, which stays
+  the established recovery path when `release-complete` is missing;
+  the current winner is unchanged by any of them until the anchor's
+  reconciled `release-complete` closes the generation. Only after a
+  fresh re-read verifies every target's release
   marker and label removal and the anchor's `release-complete` marker does
   the set-level release close all target generations, after which a later
   `acquire` starts a new generation. The

--- a/.claude/skills/issue-authoring/references/workflow-boundary.md
+++ b/.claude/skills/issue-authoring/references/workflow-boundary.md
@@ -206,9 +206,9 @@ approval boundary that hands off to IDD execution.
   fresh acquisition of the child, not to the releasing set's own
   rechecks or to a resume of the exact interrupted set, which stays
   the established recovery path when `release-complete` is missing;
-  the current winner is unchanged by any of them until the anchor's
-  reconciled `release-complete` closes the generation. Only after a
-  fresh re-read verifies every target's release
+  the releasing set's own rechecks never change the current winner,
+  unlike a valid resume marker for that exact set, which does. Only
+  after a fresh re-read verifies every target's release
   marker and label removal and the anchor's `release-complete` marker does
   the set-level release close all target generations, after which a later
   `acquire` starts a new generation. The

--- a/.claude/skills/issue-authoring/references/workflow-boundary.md
+++ b/.claude/skills/issue-authoring/references/workflow-boundary.md
@@ -196,7 +196,17 @@ approval boundary that hands off to IDD execution.
   and matching prior owner token. A `release` marker must match the current
   owner and set, but remains provisional while its set release is in
   progress; an individual label removal never closes that target's
-  generation. Only after a fresh re-read verifies every target's release
+  generation. During the owning set's own Stage 2 (observed 2026-09-09,
+  kurone-kito/idd-skill#2791), the heartbeat renewal and the pre-removal
+  ownership recheck must treat that set's provisional `mode=release`
+  markers and the anchor's `mode=release-guard` as the expected state
+  rather than as a competing generation; the acquisition-time rule that
+  a target carrying a release marker cannot be re-acquired until that
+  release's `release-complete` is found applies to a later acquisition
+  or resume, not to the releasing set's own rechecks, and the current
+  winner is unchanged by them until the anchor's reconciled
+  `release-complete` closes the generation. Only after a fresh re-read
+  verifies every target's release
   marker and label removal and the anchor's `release-complete` marker does
   the set-level release close all target generations, after which a later
   `acquire` starts a new generation. The

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -963,10 +963,12 @@ ownership recheck must treat that set's provisional `mode=release`
 markers and the anchor's `mode=release-guard` as the expected state
 rather than as a competing generation; the acquisition-time rule that
 a target carrying a release marker cannot be re-acquired until that
-release's `release-complete` is found applies to a later acquisition
-or resume, not to the releasing set's own rechecks, and the current
-winner is unchanged by them until the anchor's reconciled
-`release-complete` closes the generation. Only after a fresh re-read
+release's `release-complete` is found applies to a later session's
+fresh acquisition of the child, not to the releasing set's own
+rechecks or to a resume of the exact interrupted set, which stays the
+established recovery path when `release-complete` is missing; the
+current winner is unchanged by any of them until the anchor's
+reconciled `release-complete` closes the generation. Only after a fresh re-read
 verifies every target's release marker
 and label removal and the anchor's `release-complete` marker does the set-level
 release close all target generations, after which a later `acquire` starts a

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -967,8 +967,9 @@ release's `release-complete` is found applies to a later session's
 fresh acquisition of the child, not to the releasing set's own
 rechecks or to a resume of the exact interrupted set, which stays the
 established recovery path when `release-complete` is missing; the
-current winner is unchanged by any of them until the anchor's
-reconciled `release-complete` closes the generation. Only after a fresh re-read
+releasing set's own rechecks never change the current winner, unlike
+a valid resume marker for that exact set, which does. Only after a
+fresh re-read
 verifies every target's release marker
 and label removal and the anchor's `release-complete` marker does the set-level
 release close all target generations, after which a later `acquire` starts a

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -957,7 +957,17 @@ resume marker by GitHub comment order wins. A
 and matching prior owner token. A `release` marker must match the current
 owner and set, but remains provisional while its set release is in
 progress; an individual label removal never closes that target's
-generation. Only after a fresh re-read verifies every target's release marker
+generation. During the owning set's own Stage 2 (observed 2026-09-09,
+kurone-kito/idd-skill#2791), the heartbeat renewal and the pre-removal
+ownership recheck must treat that set's provisional `mode=release`
+markers and the anchor's `mode=release-guard` as the expected state
+rather than as a competing generation; the acquisition-time rule that
+a target carrying a release marker cannot be re-acquired until that
+release's `release-complete` is found applies to a later acquisition
+or resume, not to the releasing set's own rechecks, and the current
+winner is unchanged by them until the anchor's reconciled
+`release-complete` closes the generation. Only after a fresh re-read
+verifies every target's release marker
 and label removal and the anchor's `release-complete` marker does the set-level
 release close all target generations, after which a later `acquire` starts a
 new generation. The

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -1396,11 +1396,13 @@ only approval boundary.
   markers and the anchor's `mode=release-guard` as the expected state
   rather than as a competing generation; the acquisition-time rule that
   a target carrying a release marker cannot be re-acquired until that
-  release's `release-complete` is found applies to a later acquisition
-  or resume, not to the releasing set's own rechecks, and the current
-  winner is unchanged by them until the anchor's reconciled
-  `release-complete` closes the generation. Only after a fresh re-read
-  verifies every target's release
+  release's `release-complete` is found applies to a later session's
+  fresh acquisition of the child, not to the releasing set's own
+  rechecks or to a resume of the exact interrupted set, which stays
+  the established recovery path when `release-complete` is missing;
+  the current winner is unchanged by any of them until the anchor's
+  reconciled `release-complete` closes the generation. Only after a
+  fresh re-read verifies every target's release
   marker and label removal and the anchor's `release-complete` marker does
   the set-level release close all target generations, after which a later
   `acquire` starts a new generation. The

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -1390,7 +1390,17 @@ only approval boundary.
   and matching prior owner token. A `release` marker must match the current
   owner and set, but remains provisional while its set release is in
   progress; an individual label removal never closes that target's
-  generation. Only after a fresh re-read verifies every target's release
+  generation. During the owning set's own Stage 2 (observed 2026-09-09,
+  kurone-kito/idd-skill#2791), the heartbeat renewal and the pre-removal
+  ownership recheck must treat that set's provisional `mode=release`
+  markers and the anchor's `mode=release-guard` as the expected state
+  rather than as a competing generation; the acquisition-time rule that
+  a target carrying a release marker cannot be re-acquired until that
+  release's `release-complete` is found applies to a later acquisition
+  or resume, not to the releasing set's own rechecks, and the current
+  winner is unchanged by them until the anchor's reconciled
+  `release-complete` closes the generation. Only after a fresh re-read
+  verifies every target's release
   marker and label removal and the anchor's `release-complete` marker does
   the set-level release close all target generations, after which a later
   `acquire` starts a new generation. The

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -1400,9 +1400,9 @@ only approval boundary.
   fresh acquisition of the child, not to the releasing set's own
   rechecks or to a resume of the exact interrupted set, which stays
   the established recovery path when `release-complete` is missing;
-  the current winner is unchanged by any of them until the anchor's
-  reconciled `release-complete` closes the generation. Only after a
-  fresh re-read verifies every target's release
+  the releasing set's own rechecks never change the current winner,
+  unlike a valid resume marker for that exact set, which does. Only
+  after a fresh re-read verifies every target's release
   marker and label removal and the anchor's `release-complete` marker does
   the set-level release close all target generations, after which a later
   `acquire` starts a new generation. The

--- a/skills/issue-authoring/references/workflow-boundary.md
+++ b/skills/issue-authoring/references/workflow-boundary.md
@@ -202,11 +202,13 @@ approval boundary that hands off to IDD execution.
   markers and the anchor's `mode=release-guard` as the expected state
   rather than as a competing generation; the acquisition-time rule that
   a target carrying a release marker cannot be re-acquired until that
-  release's `release-complete` is found applies to a later acquisition
-  or resume, not to the releasing set's own rechecks, and the current
-  winner is unchanged by them until the anchor's reconciled
-  `release-complete` closes the generation. Only after a fresh re-read
-  verifies every target's release
+  release's `release-complete` is found applies to a later session's
+  fresh acquisition of the child, not to the releasing set's own
+  rechecks or to a resume of the exact interrupted set, which stays
+  the established recovery path when `release-complete` is missing;
+  the current winner is unchanged by any of them until the anchor's
+  reconciled `release-complete` closes the generation. Only after a
+  fresh re-read verifies every target's release
   marker and label removal and the anchor's `release-complete` marker does
   the set-level release close all target generations, after which a later
   `acquire` starts a new generation. The

--- a/skills/issue-authoring/references/workflow-boundary.md
+++ b/skills/issue-authoring/references/workflow-boundary.md
@@ -206,9 +206,9 @@ approval boundary that hands off to IDD execution.
   fresh acquisition of the child, not to the releasing set's own
   rechecks or to a resume of the exact interrupted set, which stays
   the established recovery path when `release-complete` is missing;
-  the current winner is unchanged by any of them until the anchor's
-  reconciled `release-complete` closes the generation. Only after a
-  fresh re-read verifies every target's release
+  the releasing set's own rechecks never change the current winner,
+  unlike a valid resume marker for that exact set, which does. Only
+  after a fresh re-read verifies every target's release
   marker and label removal and the anchor's `release-complete` marker does
   the set-level release close all target generations, after which a later
   `acquire` starts a new generation. The

--- a/skills/issue-authoring/references/workflow-boundary.md
+++ b/skills/issue-authoring/references/workflow-boundary.md
@@ -196,7 +196,17 @@ approval boundary that hands off to IDD execution.
   and matching prior owner token. A `release` marker must match the current
   owner and set, but remains provisional while its set release is in
   progress; an individual label removal never closes that target's
-  generation. Only after a fresh re-read verifies every target's release
+  generation. During the owning set's own Stage 2 (observed 2026-09-09,
+  kurone-kito/idd-skill#2791), the heartbeat renewal and the pre-removal
+  ownership recheck must treat that set's provisional `mode=release`
+  markers and the anchor's `mode=release-guard` as the expected state
+  rather than as a competing generation; the acquisition-time rule that
+  a target carrying a release marker cannot be re-acquired until that
+  release's `release-complete` is found applies to a later acquisition
+  or resume, not to the releasing set's own rechecks, and the current
+  winner is unchanged by them until the anchor's reconciled
+  `release-complete` closes the generation. Only after a fresh re-read
+  verifies every target's release
   marker and label removal and the anchor's `release-complete` marker does
   the set-level release close all target generations, after which a later
   `acquire` starts a new generation. The


### PR DESCRIPTION
## Summary

During the owning set's own Stage 2, the pre-removal heartbeat renewal
re-reads each target's owner markers via the same fail-closed
ownership-recheck rule that acquisition-time uses. At that moment
every target already carries the set's own provisional
`mode=release` marker and the anchor carries `release-guard`, with no
`release-complete` yet posted by construction — so a verifier that
reuses the acquisition-time rule unmodified can mistake its own
pending release for a competing generation and stop.

Observed 2026-09-09 during the Stage 2 release of the sets anchored at
issue #2762 and issue #2770: the first anchor heartbeat's ownership
recheck rejected the set's own release marker and the run stopped
before any label was removed. The retry reused the recorded markers
(no duplicates appended) and completed. The contract's fail-closed
defaults made the stop safe, but the two existing sentences did not
say this recheck should tolerate the releasing set's own pending
markers.

## Changes

Insert one clarifying sentence directly after "an individual label
removal never closes that target's generation." in the three
hand-maintained copies of the release-marker paragraph, then
regenerate the `.claude/` mirrors:

- `docs/issue-authoring-skill.md`
- `skills/issue-authoring/references/contract.md`
- `skills/issue-authoring/references/workflow-boundary.md`
- `.claude/skills/issue-authoring/references/contract.md` (regenerated)
- `.claude/skills/issue-authoring/references/workflow-boundary.md`
  (regenerated)

`skills/issue-authoring/SKILL.md` step 7 is untouched — it does not
restate the fail-closed rule, so it needs no citation.

## Test plan

- [x] `grep -c "kurone-kito/idd-skill#2791" docs/issue-authoring-skill.md skills/issue-authoring/references/contract.md skills/issue-authoring/references/workflow-boundary.md` prints `1` for each file
- [x] the same grep against `skills/issue-authoring/SKILL.md` prints `0`
- [x] `grep -n -A8 "remains provisional" <file>` shows the citation within 8 following lines, for all three copies
- [x] `diff skills/issue-authoring/references/{contract,workflow-boundary}.md .claude/skills/issue-authoring/references/{contract,workflow-boundary}.md` print nothing
- [x] `node scripts/audit-docs.mjs --check` passes
- [x] `node scripts/audit-code-span-wrap.mjs` passes
- [x] `npx markdownlint-cli2 "**/*.md"` passes

Closes #2791

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDJpTELrY2SnjHW9m5Aw7i