### PR TITLE
docs(idd-advisory-wait, idd-ci): no custom wait for non-primary bots

### DIFF
--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -27,6 +27,15 @@ delta** (`idd-review-snapshot.instructions.md`), re-checked by the
 F2/F3 merge-readiness gate (`idd-pre-merge.instructions.md`), which
 forbids a bare CI-green merge without a fresh covering snapshot.
 
+**Do not build a substitute wait for a non-primary bot.** A polling
+loop, scheduled wakeup, or background monitor that blocks on a
+specific non-primary bot's review reaching current HEAD (Codex, or
+any bot other than the configured `advisoryWait.primaryBotLogin`) is
+not this protocol — it has none of this protocol's caps, timeouts, or
+hold routes, and the bot may never review the PR at all, so the wait
+has no bounded exit. Rely on the E1/review-watermark/F2/F3 safety net
+above instead.
+
 ## Fast path — common case
 
 The advisory bot usually reviews current HEAD within minutes, reducing

--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -29,12 +29,13 @@ forbids a bare CI-green merge without a fresh covering snapshot.
 
 **Do not build a substitute wait for a non-primary bot.** A polling
 loop, scheduled wakeup, or background monitor that blocks on a
-specific non-primary bot's review reaching current HEAD (Codex, or
-any bot other than the configured `advisoryWait.primaryBotLogin`) is
-not this protocol — it has none of this protocol's caps, timeouts, or
-hold routes, and the bot may never review the PR at all, so the wait
-has no bounded exit. Rely on the E1/review-watermark/F2/F3 safety net
-above instead.
+specific non-primary bot's review reaching current HEAD (any bot
+other than the configured `advisoryWait.primaryBotLogin` — for
+example, Codex, on a repository where it is not that configured bot)
+is not this protocol — it has none of this protocol's caps, timeouts,
+or hold routes, and the bot may never review the PR at all, so the
+wait has no bounded exit. Rely on the E1/review-watermark/F2/F3
+safety net above instead.
 
 ## Fast path — common case
 

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -377,8 +377,9 @@ condition below accounts for this.
   await/reap it or reuse its eventual result rather than starting a
   second concurrent instance. No watch form above watches Copilot
   review state either — see
-  `idd-advisory-wait.instructions.md`. A bare `sleep` may
-  be sandboxed or blocked in some runtimes (preventive; no observed
+  `idd-advisory-wait.instructions.md`, whose Scope section also covers
+  why a non-primary bot's review must not gate a custom wait either. A
+  bare `sleep` may be sandboxed or blocked in some runtimes (preventive; no observed
   incident yet); a `run_in_background` Bash task or other
   detached/backgrounded mechanism must not be used for this wait
   unless the topology-safety condition above is confirmed. Never

--- a/.github/instructions/lite/idd-advisory-wait-lite.instructions.md
+++ b/.github/instructions/lite/idd-advisory-wait-lite.instructions.md
@@ -48,6 +48,12 @@ excluded) never reaches those call sites. If it somehow does anyway,
 stop and ask for a stronger session or a human to run the full-size
 advisory-wait instructions directly.
 
+**Do not build a substitute wait for a non-primary bot.** Same
+prohibition as the full-size file's Scope section — rely on the
+standard E1/review-watermark/F2/F3 safety net there instead of a
+custom poll on any bot other than the configured
+`advisoryWait.primaryBotLogin`.
+
 ## Stop-and-ask conditions
 
 - A required helper field is missing, the helper exits non-zero,

--- a/.github/instructions/lite/idd-ci-lite.instructions.md
+++ b/.github/instructions/lite/idd-ci-lite.instructions.md
@@ -164,4 +164,6 @@ to this turn; otherwise wait synchronously. Batch every post-wait
 action (disposition, replies, marker, next gate) into one turn. Do not
 insert "is it done yet?" turns. Never end a turn on a future-tense wait
 promise ("I will wait...") with no wait mechanism actually armed — arm
-one of the mechanisms above first.
+one of the mechanisms above first. No wait mechanism here may poll a
+non-primary bot's review state either — see
+`idd-advisory-wait-lite.instructions.md`'s Scope boundary section.

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -22,6 +22,15 @@ delta** (`idd-review-snapshot.instructions.md`), re-checked by the
 F2/F3 merge-readiness gate (`idd-pre-merge.instructions.md`), which
 forbids a bare CI-green merge without a fresh covering snapshot.
 
+**Do not build a substitute wait for a non-primary bot.** A polling
+loop, scheduled wakeup, or background monitor that blocks on a
+specific non-primary bot's review reaching current HEAD (Codex, or
+any bot other than the configured `advisoryWait.primaryBotLogin`) is
+not this protocol — it has none of this protocol's caps, timeouts, or
+hold routes, and the bot may never review the PR at all, so the wait
+has no bounded exit. Rely on the E1/review-watermark/F2/F3 safety net
+above instead.
+
 ## Fast path — common case
 
 The advisory bot usually reviews current HEAD within minutes, reducing

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -24,12 +24,13 @@ forbids a bare CI-green merge without a fresh covering snapshot.
 
 **Do not build a substitute wait for a non-primary bot.** A polling
 loop, scheduled wakeup, or background monitor that blocks on a
-specific non-primary bot's review reaching current HEAD (Codex, or
-any bot other than the configured `advisoryWait.primaryBotLogin`) is
-not this protocol — it has none of this protocol's caps, timeouts, or
-hold routes, and the bot may never review the PR at all, so the wait
-has no bounded exit. Rely on the E1/review-watermark/F2/F3 safety net
-above instead.
+specific non-primary bot's review reaching current HEAD (any bot
+other than the configured `advisoryWait.primaryBotLogin` — for
+example, Codex, on a repository where it is not that configured bot)
+is not this protocol — it has none of this protocol's caps, timeouts,
+or hold routes, and the bot may never review the PR at all, so the
+wait has no bounded exit. Rely on the E1/review-watermark/F2/F3
+safety net above instead.
 
 ## Fast path — common case
 

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -372,8 +372,9 @@ condition below accounts for this.
   await/reap it or reuse its eventual result rather than starting a
   second concurrent instance. No watch form above watches Copilot
   review state either — see
-  `idd-advisory-wait.instructions.md`. A bare `sleep` may
-  be sandboxed or blocked in some runtimes (preventive; no observed
+  `idd-advisory-wait.instructions.md`, whose Scope section also covers
+  why a non-primary bot's review must not gate a custom wait either. A
+  bare `sleep` may be sandboxed or blocked in some runtimes (preventive; no observed
   incident yet); a `run_in_background` Bash task or other
   detached/backgrounded mechanism must not be used for this wait
   unless the topology-safety condition above is confirmed. Never

--- a/idd-template/.github/instructions/lite/idd-advisory-wait-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-advisory-wait-lite.instructions.md
@@ -43,6 +43,12 @@ excluded) never reaches those call sites. If it somehow does anyway,
 stop and ask for a stronger session or a human to run the full-size
 advisory-wait instructions directly.
 
+**Do not build a substitute wait for a non-primary bot.** Same
+prohibition as the full-size file's Scope section — rely on the
+standard E1/review-watermark/F2/F3 safety net there instead of a
+custom poll on any bot other than the configured
+`advisoryWait.primaryBotLogin`.
+
 ## Stop-and-ask conditions
 
 - A required helper field is missing, the helper exits non-zero,

--- a/idd-template/.github/instructions/lite/idd-ci-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-ci-lite.instructions.md
@@ -159,4 +159,6 @@ to this turn; otherwise wait synchronously. Batch every post-wait
 action (disposition, replies, marker, next gate) into one turn. Do not
 insert "is it done yet?" turns. Never end a turn on a future-tense wait
 promise ("I will wait...") with no wait mechanism actually armed — arm
-one of the mechanisms above first.
+one of the mechanisms above first. No wait mechanism here may poll a
+non-primary bot's review state either — see
+`idd-advisory-wait-lite.instructions.md`'s Scope boundary section.


### PR DESCRIPTION
# Summary

Makes the advisory-wait protocol's "Copilot-only" settle/wait scope
explicit about non-primary bots too. A session's own background
CI-wait loop treated Codex (a non-primary advisory bot) as a
co-primary reviewer across three PRs, polling its review commit SHA
and blocking settlement until it matched HEAD -- even though the
Scope section already says the wait window covers Copilot only. The
only in-context signal was descriptive framing ("no wait window
here"), which reads as "no *built-in* wait, so add your own" rather
than "do not add one".

`idd-advisory-wait.instructions.md`'s Scope section gets a new
paragraph stating a custom polling loop, scheduled wakeup, or
background monitor for a non-primary bot is not this protocol and has
no bounded exit, and `idd-ci.instructions.md`'s Wake-up discipline
section cross-references it. Both edits land in the canonical
`idd-template/` sources; `node scripts/sync-docs.mjs --apply`
regenerated the two `mode: "exact"` `.github/instructions/` mirrors.

## Linked issue

Closes #2813

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Observed directly in session
<https://claude.ai/code/session_01EycqtGKuWjJMpw2tUav3Tn> (2026-09-09)
across three consecutive PRs (Refs #2757, #2760, #2784). The wording
fix for `idd-ci.instructions.md` differs slightly from the issue's
literal quote: the live sentence there ends with an em dash + period
(`...either — see \`idd-advisory-wait.instructions.md\`.`), not the
issue's `--`, so the new clause continues the sentence with a comma
rather than being appended after the period. The proposed paragraph's
`F2-F3` was also normalized to `F2/F3` to match this repo's existing
16/16 usage of the slash form elsewhere in these two files.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`biome check`, `dprint check`, `markdownlint-cli2`)
- [x] `pnpm test` (`node --test tests/*.test.mts`, 5585 passed)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (`node scripts/sync-docs.mjs --apply`
      produced no further drift)
- [x] `node scripts/idd-doctor.mjs` (passed; 4 pre-existing warnings
      unrelated to this change)

Also verified the issue's own acceptance-criteria greps:

```sh
grep -n "Do not build a substitute wait" .github/instructions/idd-advisory-wait.instructions.md
grep -n "must not gate a custom wait" .github/instructions/idd-ci.instructions.md
```

`bundle-merge` utilization moved from 96.75% to 97.20% (still under
the 98% `maxUtilizationPct` error line); no `limitBytes` value was
raised.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CK2SHn8Bir6VHrXrMVMdn3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that non-primary advisory reviews must not create separate waits, polling loops, scheduled wakeups, or background monitors.
  - Directed late findings to existing review safety mechanisms.
  - Clarified that only the configured primary advisory wait may gate progress.
  - Added cross-references defining advisory-wait scope and noted that basic sleep commands may be sandboxed or blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->