### PR TITLE
docs(idd-work): caveat b1 for launch-workspace-bound file tools

### DIFF
--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -213,7 +213,9 @@ Before continuing to B2, verify all of the following:
   `main`.
 - `git worktree list` includes the new sibling worktree path.
 - The agent's current working directory is the new sibling worktree
-  path, not the primary worktree.
+  path, not the primary worktree; a launch-workspace-bound file-tool
+  harness (Grok Build observed) needs this absolute path, not
+  `cd`/`pwd`.
 
 If any check fails, the B1 worktree-creation contract has been
 violated: stop, post a hold note describing which check failed, and do
@@ -225,10 +227,9 @@ The optional local `_idd-worktree-guard.sh` hook (enabled via
 `worktreeGuard.enabled: true`) automates part of this self-check by
 refusing a commit/push from the primary worktree while HEAD matches an
 implementation-branch pattern (default `issue/*`, `roadmap-audit/*`).
-By itself it does **not** catch a session that skips B1 entirely and
-commits directly on the base branch — set the separate
-`worktreeGuard.refuseBaseBranchCommits: true` opt-in (#2801) to also
-refuse that case.
+It does **not** catch skipping B1 and committing on the base
+branch — set `worktreeGuard.refuseBaseBranchCommits: true` (#2801) to
+also refuse that case.
 
 If WorkTrunk reports its `Cannot change directory — shell integration
 installed but not active` diagnostic, re-verify the current working

--- a/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/.github/instructions/lite/idd-work-lite.instructions.md
@@ -23,6 +23,9 @@ repository is `instructions-only`, use the standard work instructions instead.
 
 - The active claim is ambiguous, disputed, or lost.
 - The current directory is not the sibling worktree for the claimed branch.
+  For a harness whose file-read/edit tools stay bound to the launch
+  workspace (Grok Build observed), check those tools' own absolute-path
+  access, not a shell `cd`/`pwd`.
 - The claimed branch is not the current branch.
 - A required helper or validation command is unavailable, invalid, or disagrees
   with live state.
@@ -41,6 +44,9 @@ request, or other GitHub side effect, confirm all of the following:
    confirm it still wins (no later trusted marker for this claim id
    won the tie-break instead).
 3. The current directory is the sibling worktree for the claimed branch.
+   For a harness whose file-read/edit tools stay bound to the launch
+   workspace (Grok Build observed), use the sibling's absolute path for
+   those tools rather than a shell `cd`/`pwd`.
 4. `git branch --show-current` equals the claimed branch.
 5. Acquire the worktree-local claim lock with the profile-selected
    `claim-lock` helper (`node scripts/claim-lock.mjs --acquire
@@ -120,7 +126,10 @@ worktree removal) behind the
 27. Run `install-deps` on the manual/no-hook path.
 28. Verify the primary worktree's HEAD is still on `main`.
 29. Verify `git worktree list` shows the new path.
-30. Verify the current directory is the new sibling worktree.
+30. Verify the current directory is the new sibling worktree. For a
+    harness whose file-read/edit tools stay bound to the launch
+    workspace (Grok Build observed), use the sibling's absolute path
+    for those tools rather than a shell `cd`/`pwd`.
 31. If any of steps 28-30 fails, the worktree-creation contract is violated:
     stop, post a hold note naming the failed check, and do not continue to
     B2 from the primary worktree.

--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -346,6 +346,34 @@ as unverified for every later command in the session — confirm it (e.g.
 `pwd`) before trusting a command that depends on the current directory,
 rather than assuming it still matches the last-known worktree.
 
+### B1 self-check — Grok Build file tools bound to launch workspace
+
+A Grok Build session's file-read and file-edit tools resolve relative
+paths against the session's launch workspace — the primary clone,
+whose HEAD B1 keeps on `main` — not the shell's current directory, so
+a `cd` into the sibling worktree does not rebind them. Reproduced by
+creating a sibling worktree, writing a unique marker only into that
+worktree's uncommitted `README.md`, then running Grok's
+workspace-default grep for the marker: it found nothing, while the
+same grep given the sibling's absolute path found it immediately. A
+shell `cd` into the sibling and a `pwd` reporting the sibling path
+both looked like a passing B1 self-check throughout (#2819,
+2026-09-10).
+
+This is a different failure class from #2114's off-convention
+worktree-creation primitives (`grok --worktree`, `isolation:
+worktree`, `x.ai/git/worktree/*`): there, B1 creates the wrong
+worktree altogether; here the worktree is correct and only the file
+tools' workspace binding stays stale. It sits alongside #2332's
+WorkTrunk cwd-tracking caveat above as another way a harness's own
+working-directory signal can drift from what B1's self-check actually
+verifies.
+
+**What to do**: for a harness whose file-read/edit tools stay bound to
+the launch workspace, pass every such tool call the sibling worktree's
+absolute path instead of relying on a shell `cd`; a shell `pwd`
+reporting the sibling path is not evidence those tools moved with it.
+
 ### B2.1 — Premise verification (decision-transcription issues)
 
 Field evidence showed a worker asked to transcribe a maintainer's

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -208,7 +208,9 @@ Before continuing to B2, verify all of the following:
   `main`.
 - `git worktree list` includes the new sibling worktree path.
 - The agent's current working directory is the new sibling worktree
-  path, not the primary worktree.
+  path, not the primary worktree; a launch-workspace-bound file-tool
+  harness (Grok Build observed) needs this absolute path, not
+  `cd`/`pwd`.
 
 If any check fails, the B1 worktree-creation contract has been
 violated: stop, post a hold note describing which check failed, and do
@@ -220,10 +222,9 @@ The optional local `_idd-worktree-guard.sh` hook (enabled via
 `worktreeGuard.enabled: true`) automates part of this self-check by
 refusing a commit/push from the primary worktree while HEAD matches an
 implementation-branch pattern (default `issue/*`, `roadmap-audit/*`).
-By itself it does **not** catch a session that skips B1 entirely and
-commits directly on the base branch — set the separate
-`worktreeGuard.refuseBaseBranchCommits: true` opt-in (#2801) to also
-refuse that case.
+It does **not** catch skipping B1 and committing on the base
+branch — set `worktreeGuard.refuseBaseBranchCommits: true` (#2801) to
+also refuse that case.
 
 If WorkTrunk reports its `Cannot change directory — shell integration
 installed but not active` diagnostic, re-verify the current working

--- a/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
@@ -18,6 +18,9 @@ repository is `instructions-only`, use the standard work instructions instead.
 
 - The active claim is ambiguous, disputed, or lost.
 - The current directory is not the sibling worktree for the claimed branch.
+  For a harness whose file-read/edit tools stay bound to the launch
+  workspace (Grok Build observed), check those tools' own absolute-path
+  access, not a shell `cd`/`pwd`.
 - The claimed branch is not the current branch.
 - A required helper or validation command is unavailable, invalid, or disagrees
   with live state.
@@ -36,6 +39,9 @@ request, or other GitHub side effect, confirm all of the following:
    confirm it still wins (no later trusted marker for this claim id
    won the tie-break instead).
 3. The current directory is the sibling worktree for the claimed branch.
+   For a harness whose file-read/edit tools stay bound to the launch
+   workspace (Grok Build observed), use the sibling's absolute path for
+   those tools rather than a shell `cd`/`pwd`.
 4. `git branch --show-current` equals the claimed branch.
 5. Acquire the worktree-local claim lock with the profile-selected
    `claim-lock` helper (`node scripts/claim-lock.mjs --acquire
@@ -115,7 +121,10 @@ worktree removal) behind the
 27. Run `install-deps` on the manual/no-hook path.
 28. Verify the primary worktree's HEAD is still on `main`.
 29. Verify `git worktree list` shows the new path.
-30. Verify the current directory is the new sibling worktree.
+30. Verify the current directory is the new sibling worktree. For a
+    harness whose file-read/edit tools stay bound to the launch
+    workspace (Grok Build observed), use the sibling's absolute path
+    for those tools rather than a shell `cd`/`pwd`.
 31. If any of steps 28-30 fails, the worktree-creation contract is violated:
     stop, post a hold note naming the failed check, and do not continue to
     B2 from the primary worktree.

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -348,6 +348,35 @@ as unverified for every later command in the session — confirm it (e.g.
 `pwd`) before trusting a command that depends on the current directory,
 rather than assuming it still matches the last-known worktree.
 
+### B1 self-check — Grok Build file tools bound to launch workspace
+
+A Grok Build session's file-read and file-edit tools resolve relative
+paths against the session's launch workspace — the primary clone,
+whose HEAD B1 keeps on `main` — not the shell's current directory, so
+a `cd` into the sibling worktree does not rebind them. Reproduced by
+creating a sibling worktree, writing a unique marker only into that
+worktree's uncommitted `README.md`, then running Grok's
+workspace-default grep for the marker: it found nothing, while the
+same grep given the sibling's absolute path found it immediately. A
+shell `cd` into the sibling and a `pwd` reporting the sibling path
+both looked like a passing B1 self-check throughout
+(kurone-kito/idd-skill#2819, 2026-09-10).
+
+This is a different failure class from
+kurone-kito/idd-skill#2114's off-convention worktree-creation
+primitives (`grok --worktree`, `isolation: worktree`,
+`x.ai/git/worktree/*`): there, B1 creates the wrong worktree
+altogether; here the worktree is correct and only the file tools'
+workspace binding stays stale. It sits alongside
+kurone-kito/idd-skill#2332's WorkTrunk cwd-tracking caveat above as
+another way a harness's own working-directory signal can drift from
+what B1's self-check actually verifies.
+
+**What to do**: for a harness whose file-read/edit tools stay bound to
+the launch workspace, pass every such tool call the sibling worktree's
+absolute path instead of relying on a shell `cd`; a shell `pwd`
+reporting the sibling path is not evidence those tools moved with it.
+
 ### B2.1 — Premise verification (decision-transcription issues)
 
 Field evidence showed a worker asked to transcribe a maintainer's


### PR DESCRIPTION
# Summary

A Grok Build session's file-read/edit tools resolve relative paths
against the session's launch workspace (the primary clone), not the
shell's current directory, so a `cd` into the sibling worktree never
rebinds them — a shell `cd`/`pwd` can look like a passing B1
self-check the whole time while those tools still read/write stale
`main`. This is a different failure class from the already-documented
Grok worktree-creation primitives (`grok --worktree`,
`isolation: worktree`, `x.ai/git/worktree/*`): here the worktree
itself is correct, only the file tools' workspace binding stays
stale.

- Fold one sentence into B1's existing "current working directory"
  self-check bullet in `idd-work.instructions.md`, stating that such a
  harness (Grok Build observed) must use the sibling worktree's
  absolute path for file-read/edit tools, since a shell `cd`/`pwd` is
  not passing evidence.
- Carry the same one-sentence rule into
  `idd-work-lite.instructions.md` at all three sibling-directory
  checks (Stop-and-ask conditions, Pre-mutation guard item 3, B1 step
  30), extending each existing list item in place rather than
  inserting a new numbered entry, since a later step cross-references
  "steps 28-30" by number.
- Record the full incident (2026-09-10 token-grep repro) and the
  distinction from issue #2114's off-convention worktree-creation
  primitives in a new rationale section in
  `idd-template/docs/idd-design-rationale.md`. This is a
  `structure`-mode sync pair with no auto-generation, so
  `docs/idd-design-rationale.md` gets the identical section by hand,
  matching this repo's existing split of bare `#NNNN` issue
  references in the dogfood copy versus fully-qualified
  `kurone-kito/idd-skill#NNNN` in the portable template.
- Run `sync-docs.mjs --apply` for the two auto-generated instruction
  mirrors.

## Linked issue

Closes #2819

## Follow-up issues (if any)

- [ ] Codex's review (P1, rejected below with reasoning) observed that
      this caveat only lives in `idd-work.instructions.md` /
      `idd-work-lite.instructions.md`, so a session that resumes
      directly into a later phase (D/E) via the overview/resume
      routing never sees it — an independent check confirmed the gap
      also extends to `idd-resume-lite`, `idd-pr-submit-lite`,
      `idd-review-snapshot-lite`, and `idd-review-fix-lite`. Genuine
      and wider than the review comment stated, but propagating the
      caveat repo-wide is out of scope for this issue's minimal,
      byte-budget-constrained fix and spans several separately
      near-ceiling bundles (including the always-loaded, 20,000-byte
      `idd-overview-core.instructions.md`). Recommend a separate
      follow-up issue to scope and budget that propagation.

## Background / rationale (if material)

`audit-docs.mjs --check`'s `context-ceiling-200k` guard caps
`bundle-work` (the three-file `idd-overview-appendix` +
`idd-overview-core` + `idd-work` instruction bundle) at 98% of its
52,000-byte budget — 50,960 bytes — not just under the raw limit.
Current `main` already sat at 50,894 bytes (97.87%) before this
change, leaving only 66 bytes of real headroom, not the ~470 bytes
the issue estimated against the raw 52,000-byte limit at its
authoring commit. To fit the new sentence, this PR also tightens the
adjacent `worktreeGuard` paragraph's wording in `idd-work.instructions.md`
(both the `idd-template/` source and its generated mirror) with no
meaning change, landing `bundle-work` at 97.97% utilization. The
optional `docs/idd-workflow.md` Grok-Build-row pointer mentioned as
optional in the issue's proposed change is left out of scope — it
isn't required by any acceptance criterion.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SfqRji5K2g9EhgXLcRBaiC

