### PR TITLE
fix(discover-roadmap-graph): parse a trailing (#N) task-list child

### DIFF
--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -902,6 +902,22 @@ function checkRoadmapTracksParse(text, shape, isBucketAudit, currentRepo) {
   if (checkboxLineIndexes.length === 0) {
     return pass(id, name, 'no ## Tracks checkbox lines to validate');
   }
+  // Detects a trailing qualified `owner/repo#N` reference -- `(#N)`
+  // optionally wrapped in parens, with an `owner/repo` prefix -- at the
+  // end of a task-list item's text, mirroring
+  // `extractTaskListReferences`'s own trailing-reference shape
+  // (`discover-roadmap-graph.mts`) but without requiring a
+  // `currentRepoRef` match. Used only to distinguish "no reference at
+  // all" from "a qualified reference exists but this run has no repo
+  // context to verify it names the current repository" (idd-skill#2765
+  // review, Codex) -- detection only, never itself trusted as a resolved
+  // child reference. Declared inside the function (not module-level, per
+  // this file's own CLI-entry-order convention -- see
+  // `extractTaskListReferences`'s matching per-call regex construction in
+  // `discover-roadmap-graph.mts`) so it carries no TDZ risk relative to
+  // this file's `if (import.meta.main)` CLI entry block.
+  const qualifiedTrailingReferenceRe =
+    /(?:^|\s)\(?[\w.-]+\/[\w.-]+#\d+\)?[.,;:]*\s*$/u;
   const unparsedLines = [];
   let parsedCount = 0;
   for (const startIndex of checkboxLineIndexes) {
@@ -916,7 +932,20 @@ function checkRoadmapTracksParse(text, shape, isBucketAudit, currentRepo) {
     const itemReferences = extractTaskListReferences(itemText, {
       currentRepoRef: currentRepo,
     });
-    if (itemReferences.length > 0) {
+    if (
+      itemReferences.length > 0 ||
+      // No repo context to verify a qualified `owner/repo#N` reference
+      // against (idd-skill#2765 review, Codex): the documented local
+      // invocation of this linter never passes `--current-repo`, and
+      // `$GITHUB_REPOSITORY` is only set by GitHub Actions, so this is
+      // the common case outside CI. `extractTaskListReferences` then
+      // rejects every qualified reference because it can never equal an
+      // empty current-repository value -- treat a trailing qualified
+      // reference as unverifiable rather than malformed here, so a
+      // well-formed roadmap using that form doesn't hard-fail merely
+      // because this run lacks repo context.
+      (currentRepo === undefined && qualifiedTrailingReferenceRe.test(itemText))
+    ) {
       parsedCount += 1;
     } else {
       unparsedLines.push(sectionLines[startIndex].trim());

--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -10,13 +10,14 @@
 // marker's exactly-one/coherent-value rule, its cross-field agreement with
 // the configured blocked-by-human label, markerPrefix consistency across
 // every authoring marker, the declared shape's required section headings,
-// the roadmap-id/blocked-by dependency-marker rules, visible/hidden line
-// agreement for the suitability and effort footers, and an advisory
-// warning-severity check that flags an issue/PR reference used near
-// coordination language (e.g. "before", "once", "requires") with no
-// corresponding Blocked-by/Depends-on/task-list dependency encoding. The
-// advisory check never fails the report or changes the exit code — see
-// checkProseOnlyDependency.
+// the roadmap shape's `## Tracks` checkbox lines actually resolving to a
+// child issue reference, the roadmap-id/blocked-by dependency-marker
+// rules, visible/hidden line agreement for the suitability and effort
+// footers, and an advisory warning-severity check that flags an issue/PR
+// reference used near coordination language (e.g. "before", "once",
+// "requires") with no corresponding Blocked-by/Depends-on/task-list
+// dependency encoding. The advisory check never fails the report or
+// changes the exit code — see checkProseOnlyDependency.
 //
 // All marker value parsing is delegated to the existing
 // autopilot-suitability.mts / effort.mts / marker-regex.mts /

--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -32,7 +32,12 @@ import {
   extractBlockedByRoadmapMarkers,
   extractDependencyIssueNumbers,
 } from './discover-readiness-check.mjs';
-import { extractRoadmapMarkerId } from './discover-roadmap-graph.mjs';
+import {
+  extractRoadmapMarkerId,
+  extractTaskListReferences,
+  isTaskListBlockBoundary,
+  isTaskListCheckboxLine,
+} from './discover-roadmap-graph.mjs';
 import { parseEffortMarker } from './effort.mjs';
 import {
   isUpstreamEscalationEnabled,
@@ -412,6 +417,12 @@ export function auditAuthoredIssue(body, options) {
       options.upstreamEscalationEnabled === true,
     ),
     checkRequiredHeadings(text, shape, isBucketAudit),
+    checkRoadmapTracksParse(
+      text,
+      shape,
+      isBucketAudit,
+      normalizeCurrentRepo(options.currentRepo),
+    ),
     checkDependencyMarkerRule(text, markerPrefix, shape),
     checkSuitabilityVisibleLineAgreement(text, markerPrefix, suitability),
     checkEffortVisibleLineAgreement(text, markerPrefix),
@@ -822,6 +833,115 @@ function checkRequiredHeadings(text, shape, isBucketAudit) {
     );
   }
   return pass(id, name, 'all required headings are present');
+}
+/**
+ * Slices the `## Tracks` section's own lines out of `text` (already
+ * code-masked by the caller): from the line after the `## Tracks` heading
+ * up to (but excluding) the next `##` heading, or the end of the text
+ * when none follows. Empty when no `## Tracks` heading is present.
+ */
+function extractTracksSectionLines(text) {
+  const lines = text.split(/\r?\n/u);
+  const headingRe = /^ {0,3}##\s+(.+?)\s*$/u;
+  let start = -1;
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = lines[index].match(headingRe);
+    if (match && match[1].trim() === 'Tracks') {
+      start = index + 1;
+      break;
+    }
+  }
+  if (start === -1) {
+    return [];
+  }
+  let end = lines.length;
+  for (let index = start; index < lines.length; index += 1) {
+    if (headingRe.test(lines[index])) {
+      end = index;
+      break;
+    }
+  }
+  return lines.slice(start, end);
+}
+/**
+ * Roadmap-shape only (idd-skill#2765): fails when the `## Tracks` section
+ * has at least one checkbox line but NONE of them resolve to a child
+ * issue reference via `extractTaskListReferences` -- the same parser
+ * `discover-roadmap-graph.mts`'s traversal and
+ * `idd-roadmap-audit-execute.mts`'s childless gate rely on, reused here
+ * rather than a second reference-matching regex. When at least one line
+ * resolves but at least one other does not, this is a `severity:
+ * 'warning'` pass (not a hard fail) naming the unresolved line(s), so a
+ * roadmap with a genuinely mixed Tracks section still publishes with a
+ * visible signal instead of being blocked outright.
+ *
+ * Each checkbox line is evaluated with its own continuation span (the
+ * same stop rule `extractTaskListReferences` uses internally) rather
+ * than diffing the parser's returned `evidence` strings against the raw
+ * checkbox lines, so two textually-identical checkbox lines are scored
+ * independently instead of colliding on a shared evidence string.
+ */
+function checkRoadmapTracksParse(text, shape, isBucketAudit, currentRepo) {
+  const id = 'roadmap-tracks-parse';
+  const name = 'Roadmap Tracks checkbox lines resolve to a child reference';
+  if (isBucketAudit) {
+    return pass(id, name, NOT_APPLICABLE_BUCKET_AUDIT_DETAIL);
+  }
+  if (shape !== 'roadmap') {
+    return pass(
+      id,
+      name,
+      'not applicable: only the roadmap shape has a ## Tracks section',
+    );
+  }
+  const sectionLines = extractTracksSectionLines(text);
+  const checkboxLineIndexes = sectionLines
+    .map((line, index) => (isTaskListCheckboxLine(line) ? index : -1))
+    .filter((index) => index >= 0);
+  if (checkboxLineIndexes.length === 0) {
+    return pass(id, name, 'no ## Tracks checkbox lines to validate');
+  }
+  const unparsedLines = [];
+  let parsedCount = 0;
+  for (const startIndex of checkboxLineIndexes) {
+    let end = startIndex;
+    while (
+      end + 1 < sectionLines.length &&
+      !isTaskListBlockBoundary(sectionLines[end + 1])
+    ) {
+      end += 1;
+    }
+    const itemText = sectionLines.slice(startIndex, end + 1).join('\n');
+    const itemReferences = extractTaskListReferences(itemText, {
+      currentRepoRef: currentRepo,
+    });
+    if (itemReferences.length > 0) {
+      parsedCount += 1;
+    } else {
+      unparsedLines.push(sectionLines[startIndex].trim());
+    }
+  }
+  if (parsedCount === 0) {
+    return fail(
+      id,
+      name,
+      `## Tracks has ${checkboxLineIndexes.length} checkbox line(s) but none resolve to a child issue reference (checked: ${unparsedLines.join(' | ')})`,
+    );
+  }
+  if (unparsedLines.length > 0) {
+    return {
+      id,
+      name,
+      result: 'pass',
+      severity: 'warning',
+      detail: `## Tracks checkbox line(s) did not resolve to a child issue reference: ${unparsedLines.join(' | ')}`,
+    };
+  }
+  return pass(
+    id,
+    name,
+    'every ## Tracks checkbox line resolves to a child issue reference',
+  );
 }
 function checkDependencyMarkerRule(text, markerPrefix, shape) {
   const id = 'dependency-marker-rule';

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -1393,10 +1393,17 @@ export function isTaskListBlockBoundary(line) {
 }
 /**
  * True when `line` opens a task-list checkbox item (`- [ ]` / `- [x]`).
- * Exported for the same reuse reason as {@link isTaskListBlockBoundary}.
+ * Requires whitespace (or end-of-line) immediately after the closing
+ * `]` -- GFM's own task-list syntax requires it, and `- [ ]foo` (no
+ * space) is not a real checkbox item, just list-item text that happens
+ * to start with `[ ]`. Without this bound, the trailing-reference
+ * fallback below (idd-skill#2765 review, Copilot) could misclassify an
+ * ordinary bulleted line as a task-list item merely because it opens
+ * with that exact character sequence. Exported for the same reuse
+ * reason as {@link isTaskListBlockBoundary}.
  */
 export function isTaskListCheckboxLine(line) {
-  return /^\s*-\s*\[(?: |x|X)\]/u.test(line);
+  return /^\s*-\s*\[(?: |x|X)\](?:\s|$)/u.test(line);
 }
 export function extractTaskListReferences(body, options = {}) {
   // Match against a code-masked copy so a checkbox merely quoted inside inline

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -1386,10 +1386,19 @@ export function classifyIssue(
  * (bulleted or ordered), or an ATX heading. Shared between the item-
  * grouping loop below and any external caller that needs to slice the
  * same continuation span (e.g. `audit-authored-issue.mts`'s per-line
- * Tracks-parse check, #2765).
+ * Tracks-parse check, #2765). Each marker alternative also accepts
+ * end-of-line, not only trailing whitespace (idd-skill#2765 review,
+ * Codex): CommonMark allows an EMPTY list item or ATX heading (a bare
+ * `-`, `1.`, or `#` with nothing after it), and without the end-of-line
+ * alternative such a line failed to read as a boundary, letting the
+ * continuation span absorb it (and anything after it, including a
+ * later unrelated `(#N)`) into the preceding checkbox item.
  */
 export function isTaskListBlockBoundary(line) {
-  return line.trim() === '' || /^\s*(?:[-*+]\s|\d+[.)]\s|#{1,6}\s)/u.test(line);
+  return (
+    line.trim() === '' ||
+    /^\s*(?:[-*+](?:\s|$)|\d+[.)](?:\s|$)|#{1,6}(?:\s|$))/u.test(line)
+  );
 }
 /**
  * True when `line` opens a task-list checkbox item (`- [ ]` / `- [x]`).
@@ -1399,11 +1408,20 @@ export function isTaskListBlockBoundary(line) {
  * to start with `[ ]`. Without this bound, the trailing-reference
  * fallback below (idd-skill#2765 review, Copilot) could misclassify an
  * ordinary bulleted line as a task-list item merely because it opens
- * with that exact character sequence. Exported for the same reuse
- * reason as {@link isTaskListBlockBoundary}.
+ * with that exact character sequence. Also requires at least one
+ * whitespace character between the bullet marker and the opening `[`
+ * (idd-skill#2765 review, Codex): CommonMark requires whitespace after
+ * a list marker for it to open a list item at all, so `-[ ] text` (no
+ * space) is not a real checkbox either -- a pre-existing laxness the
+ * two leading-form regexes below also share, but one this new
+ * trailing-reference fallback measurably widens the blast radius of
+ * (from "immediately followed by `#N`" to "an arbitrary trailing
+ * reference anywhere in the item's text"), so it is bounded at this
+ * shared gate rather than left unaddressed. Exported for the same
+ * reuse reason as {@link isTaskListBlockBoundary}.
  */
 export function isTaskListCheckboxLine(line) {
-  return /^\s*-\s*\[(?: |x|X)\](?:\s|$)/u.test(line);
+  return /^\s*-\s+\[(?: |x|X)\](?:\s|$)/u.test(line);
 }
 export function extractTaskListReferences(body, options = {}) {
   // Match against a code-masked copy so a checkbox merely quoted inside inline

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -559,7 +559,7 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
         ? []
         : normalizeSubIssueReferences(await loadSubIssues(issue.number));
     const references = [
-      ...extractTaskListReferences(issue.body),
+      ...extractTaskListReferences(issue.body, { currentRepoRef }),
       ...extractKeywordReferences(issue.body, { currentRepoRef }),
       ...nativeSubIssues,
     ];
@@ -1380,7 +1380,25 @@ export function classifyIssue(
     roadmapMarkerId: '',
   };
 }
-export function extractTaskListReferences(body) {
+/**
+ * True when `line` opens a new Markdown block that must terminate a
+ * task-list item's continuation span: a blank line, a new list item
+ * (bulleted or ordered), or an ATX heading. Shared between the item-
+ * grouping loop below and any external caller that needs to slice the
+ * same continuation span (e.g. `audit-authored-issue.mts`'s per-line
+ * Tracks-parse check, #2765).
+ */
+export function isTaskListBlockBoundary(line) {
+  return line.trim() === '' || /^\s*(?:[-*+]\s|\d+[.)]\s|#{1,6}\s)/u.test(line);
+}
+/**
+ * True when `line` opens a task-list checkbox item (`- [ ]` / `- [x]`).
+ * Exported for the same reuse reason as {@link isTaskListBlockBoundary}.
+ */
+export function isTaskListCheckboxLine(line) {
+  return /^\s*-\s*\[(?: |x|X)\]/u.test(line);
+}
+export function extractTaskListReferences(body, options = {}) {
   // Match against a code-masked copy so a checkbox merely quoted inside inline
   // code or a fenced block is not walked as a real task-list edge — consistent
   // with the #1121 boundary already applied to extractRoadmapMarkerId (#1204).
@@ -1388,40 +1406,104 @@ export function extractTaskListReferences(body) {
   // lines share an index and evidence stays the raw line for any surviving edge
   // (e.g. one that shares a line with unrelated inline code).
   //
-  // Two forms recognized, tried in order (idd-skill#2476): a bare `#123`
-  // or a markdown link whose TEXT is `#123` (e.g. `- [ ] [#123](url)`,
-  // the `[`/`]`/`(...)` around the number all optional); falling back to
-  // a markdown link with arbitrary link text whose URL targets
+  // Three forms recognized (idd-skill#2476, idd-skill#2765), tried in order
+  // per item: a bare `#123` or a markdown link whose TEXT is `#123` (e.g.
+  // `- [ ] [#123](url)`, the `[`/`]`/`(...)` around the number all
+  // optional) directly after the checkbox marker; falling back to a
+  // markdown link with arbitrary link text whose URL targets
   // `.../issues/123` or `.../pull/123` (e.g.
-  // `- [ ] [some text](https://.../issues/123)`) -- inlined per-call
-  // (not hoisted to a module-level const) because this file's CLI entry
-  // point (`if (import.meta.main)`) sits near the top of the file and
-  // can reach this function during synchronous module evaluation, before
-  // a later top-level const would have initialized (TDZ).
+  // `- [ ] [some text](https://.../issues/123)`); falling back further to
+  // a TRAILING local issue reference -- `(#N)`, bare `#N`, or
+  // `owner/repo#N` naming the current repository -- as the last token of
+  // the checkbox item, gathered across the checkbox line and any
+  // continuation lines a soft wrap moved onto the item's own paragraph
+  // (up to the next line that starts a new list item, is blank, or is a
+  // heading -- the exact stop condition idd-skill#2765 specifies; no
+  // additional indentation check, since the stop condition alone already
+  // disambiguates the item's extent). A bare trailing `#N` accepts the
+  // same zero-disambiguation trust the leading bare-`#N` form already
+  // carries -- e.g. "...seen in run #4521" would also match -- a
+  // deliberate tradeoff (see idd-skill#2765's review discussion) rather
+  // than an unreliable keyword denylist. Regex construction is inlined
+  // per-call (not hoisted to a module-level const) because this file's
+  // CLI entry point (`if (import.meta.main)`) sits near the top of the
+  // file and can reach this function during synchronous module
+  // evaluation, before a later top-level const would have initialized
+  // (TDZ).
   const bareOrLinkTextRe =
     /^\s*-\s*\[(?: |x|X)\]\s+\[?#(\d+)\b\]?(?:\([^)\n]*\))?/u;
   const linkUrlRe =
     /^\s*-\s*\[(?: |x|X)\]\s+\[[^\]\n]*\]\([^)\n]*\/(?:issues|pull)\/(\d+)(?:[/?#][^)\n]*)?\)/u;
+  const trailingReferenceRe =
+    /(?:^|\s)\(?(?:([\w.-]+\/[\w.-]+)#(\d+)|#(\d+))\)?[.,;:]*\s*$/u;
+  const currentRepoRef = normalizeRepoRef(
+    options.currentRepoRef
+      ? options.currentRepoRef.split('/')[0]
+      : options.owner,
+    options.currentRepoRef
+      ? options.currentRepoRef.split('/')[1]
+      : options.repo,
+  );
   const rawBody = String(body ?? '');
   const rawLines = rawBody.split(/\r?\n/u);
   const maskedLines = stripMarkdownCodeRegions(rawBody).split(/\r?\n/u);
-  return maskedLines.flatMap((maskedLine, index) => {
-    const match =
-      maskedLine.match(bareOrLinkTextRe) ?? maskedLine.match(linkUrlRe);
-    if (!match) {
-      return [];
+  const references = [];
+  for (let index = 0; index < maskedLines.length; index += 1) {
+    const maskedLine = maskedLines[index];
+    if (!isTaskListCheckboxLine(maskedLine)) {
+      continue;
     }
-    const target = Number.parseInt(match[1], 10);
-    return Number.isInteger(target) && target > 0
-      ? [
-          {
-            target,
-            relationship: 'task-list',
-            evidence: (rawLines[index] ?? maskedLine).trim(),
-          },
-        ]
-      : [];
-  });
+    const leadingMatch =
+      maskedLine.match(bareOrLinkTextRe) ?? maskedLine.match(linkUrlRe);
+    if (leadingMatch) {
+      const target = Number.parseInt(leadingMatch[1], 10);
+      if (Number.isInteger(target) && target > 0) {
+        references.push({
+          target,
+          relationship: 'task-list',
+          evidence: (rawLines[index] ?? maskedLine).trim(),
+        });
+      }
+      continue;
+    }
+    // No leading-form match: gather this item's continuation lines (soft-
+    // wrapped text belonging to the same checkbox item) and retry against
+    // the joined item text, looking for a trailing local issue reference.
+    let end = index;
+    while (
+      end + 1 < maskedLines.length &&
+      !isTaskListBlockBoundary(maskedLines[end + 1])
+    ) {
+      end += 1;
+    }
+    const itemText = maskedLines
+      .slice(index, end + 1)
+      .map((line) => line.trim())
+      .join(' ');
+    const trailingMatch = itemText.match(trailingReferenceRe);
+    if (trailingMatch) {
+      const qualifiedRepoRef = trailingMatch[1]
+        ? normalizeRepoRef(...trailingMatch[1].split('/'))
+        : '';
+      const target = Number.parseInt(
+        trailingMatch[2] ?? trailingMatch[3] ?? '',
+        10,
+      );
+      if (
+        (!qualifiedRepoRef || qualifiedRepoRef === currentRepoRef) &&
+        Number.isInteger(target) &&
+        target > 0
+      ) {
+        references.push({
+          target,
+          relationship: 'task-list',
+          evidence: (rawLines[index] ?? maskedLine).trim(),
+        });
+      }
+    }
+    index = end;
+  }
+  return references;
 }
 export function extractKeywordReferences(body, options = {}) {
   const references = [];

--- a/scripts/idd-roadmap-audit-execute.mjs
+++ b/scripts/idd-roadmap-audit-execute.mjs
@@ -49,6 +49,19 @@ const DEFAULT_CLAIM_STALE_AGE_MS = 24 * 60 * 60 * 1000;
 // detector (`hasTrustedCompletionEvidenceComment`, #1299) so the two never
 // drift out of sync.
 const COMPLETION_AUDIT_HEADING = '**IDD roadmap completion audit**';
+// `RoadmapGraphReference.relationship` kinds that name real child work for
+// the childless-blocker check below (idd-skill#2765): a task-list line, a
+// closing keyword (Closes/Fixes/Resolves), or a native GitHub sub-issue
+// relationship. Every other kind `discover-roadmap-graph.mts` emits --
+// `dependency` (Blocked by / Depends on), `reference` /
+// `non-blocking-reference` (Refs), and `sub-issue-reference` (prose
+// "Sub-issue #N" text) -- is informational or a precondition, never a
+// child, and must not suppress the `childless` blocker on its own.
+const CHILD_RELATIONSHIP_KINDS = new Set([
+  'task-list',
+  'closing-keyword',
+  'sub-issue',
+]);
 // Scope caveat (A1.5): this helper gates only the MECHANICAL completion
 // preconditions. It deliberately does NOT verify the roadmap's free-form
 // success criteria or autonomy-gap items — that is agent judgment "where
@@ -108,8 +121,20 @@ export function evaluateRoadmapAuditGates(report, options = {}) {
     });
   }
   // No explicit child work → childless / malformed. Do not infer completion
-  // from the absence of candidates.
-  if (report.edges.length === 0) {
+  // from the absence of candidates. Only edges that actually name a CHILD
+  // relationship count here (idd-skill#2765): `task-list` (a `- [ ] #N`
+  // line), `closing-keyword` (Closes/Fixes/Resolves), and `sub-issue` (a
+  // native GitHub sub-issue relationship). An edge list containing only
+  // `non-blocking-reference` (a `Refs #N (non-blocking)` breadcrumb),
+  // `dependency` (Blocked by / Depends on -- a precondition, not a
+  // child), `reference` (a plain `Refs #N` mention), or
+  // `sub-issue-reference` (prose "Sub-issue #N" text, distinct from the
+  // native `sub-issue` relationship) is still childless -- none of those
+  // kinds name work this roadmap is tracking as its own.
+  const childRelationshipEdgeCount = report.edges.filter((edge) =>
+    CHILD_RELATIONSHIP_KINDS.has(edge.relationship),
+  ).length;
+  if (childRelationshipEdgeCount === 0) {
     blockers.push({
       kind: 'childless',
       detail: `roadmap #${rootNumber} has no explicit child references (task-list, closing-keyword, or GitHub sub-issue); childless or malformed, not complete`,

--- a/scripts/idd-roadmap-audit-execute.mjs
+++ b/scripts/idd-roadmap-audit-execute.mjs
@@ -49,19 +49,20 @@ const DEFAULT_CLAIM_STALE_AGE_MS = 24 * 60 * 60 * 1000;
 // detector (`hasTrustedCompletionEvidenceComment`, #1299) so the two never
 // drift out of sync.
 const COMPLETION_AUDIT_HEADING = '**IDD roadmap completion audit**';
-// `RoadmapGraphReference.relationship` kinds that name real child work for
-// the childless-blocker check below (idd-skill#2765): a task-list line, a
-// closing keyword (Closes/Fixes/Resolves), or a native GitHub sub-issue
-// relationship. Every other kind `discover-roadmap-graph.mts` emits --
-// `dependency` (Blocked by / Depends on), `reference` /
-// `non-blocking-reference` (Refs), and `sub-issue-reference` (prose
-// "Sub-issue #N" text) -- is informational or a precondition, never a
-// child, and must not suppress the `childless` blocker on its own.
-const CHILD_RELATIONSHIP_KINDS = new Set([
-  'task-list',
-  'closing-keyword',
-  'sub-issue',
-]);
+// `RoadmapGraphReference.relationship` kinds that are PURELY
+// informational and must never, by themselves, satisfy the
+// childless-blocker check below (idd-skill#2765): a `Refs #N
+// (non-blocking)` breadcrumb. Every other kind counts as explicit
+// child work, matching A2's own "Allowed traversal sources"
+// (`idd-discover.instructions.md`) -- which names `Refs #NNN` and
+// "explicit sub-issue lines" (the `reference` / `sub-issue-reference`
+// kinds) alongside task-list entries and GitHub sub-issue
+// relationships as sources A1.5 must fetch descendants through
+// (`idd-roadmap-audit.instructions.md`'s "Use the same outbound
+// traversal sources as A2") -- so only the `(non-blocking)`-annotated
+// form is excluded here, not the plain `reference`/`sub-issue-reference`
+// kinds (idd-skill#2765 review, Codex).
+const NON_CHILD_RELATIONSHIP_KINDS = new Set(['non-blocking-reference']);
 // Scope caveat (A1.5): this helper gates only the MECHANICAL completion
 // preconditions. It deliberately does NOT verify the roadmap's free-form
 // success criteria or autonomy-gap items — that is agent judgment "where
@@ -121,18 +122,18 @@ export function evaluateRoadmapAuditGates(report, options = {}) {
     });
   }
   // No explicit child work → childless / malformed. Do not infer completion
-  // from the absence of candidates. Only edges that actually name a CHILD
-  // relationship count here (idd-skill#2765): `task-list` (a `- [ ] #N`
-  // line), `closing-keyword` (Closes/Fixes/Resolves), and `sub-issue` (a
-  // native GitHub sub-issue relationship). An edge list containing only
-  // `non-blocking-reference` (a `Refs #N (non-blocking)` breadcrumb),
-  // `dependency` (Blocked by / Depends on -- a precondition, not a
-  // child), `reference` (a plain `Refs #N` mention), or
-  // `sub-issue-reference` (prose "Sub-issue #N" text, distinct from the
-  // native `sub-issue` relationship) is still childless -- none of those
-  // kinds name work this roadmap is tracking as its own.
-  const childRelationshipEdgeCount = report.edges.filter((edge) =>
-    CHILD_RELATIONSHIP_KINDS.has(edge.relationship),
+  // from the absence of candidates. An edge counts as child work unless its
+  // relationship is purely informational (idd-skill#2765): only a
+  // `non-blocking-reference` (`Refs #N (non-blocking)`) is excluded here --
+  // `task-list`, `closing-keyword`, `sub-issue`, the plain `reference`
+  // (`Refs #N`, no annotation), and `sub-issue-reference` (prose
+  // "Sub-issue #N" text) all count, matching A2's own allowed traversal
+  // sources. `dependency` (Blocked by / Depends on) is a precondition
+  // pointing away from this roadmap's own descendants, not a child, but is
+  // left counting here unchanged from this check's pre-existing behavior
+  // (`report.edges.length === 0`) since no known repro needs it excluded.
+  const childRelationshipEdgeCount = report.edges.filter(
+    (edge) => !NON_CHILD_RELATIONSHIP_KINDS.has(edge.relationship),
   ).length;
   if (childRelationshipEdgeCount === 0) {
     blockers.push({

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -34,7 +34,12 @@ import {
   extractBlockedByRoadmapMarkers,
   extractDependencyIssueNumbers,
 } from './discover-readiness-check.mts';
-import { extractRoadmapMarkerId } from './discover-roadmap-graph.mts';
+import {
+  extractRoadmapMarkerId,
+  extractTaskListReferences,
+  isTaskListBlockBoundary,
+  isTaskListCheckboxLine,
+} from './discover-roadmap-graph.mts';
 import type { EffortMarkerDetection } from './effort.mts';
 import { parseEffortMarker } from './effort.mts';
 import {
@@ -628,6 +633,12 @@ export function auditAuthoredIssue(
       options.upstreamEscalationEnabled === true,
     ),
     checkRequiredHeadings(text, shape, isBucketAudit),
+    checkRoadmapTracksParse(
+      text,
+      shape,
+      isBucketAudit,
+      normalizeCurrentRepo(options.currentRepo),
+    ),
     checkDependencyMarkerRule(text, markerPrefix, shape),
     checkSuitabilityVisibleLineAgreement(text, markerPrefix, suitability),
     checkEffortVisibleLineAgreement(text, markerPrefix),
@@ -1068,6 +1079,122 @@ function checkRequiredHeadings(
     );
   }
   return pass(id, name, 'all required headings are present');
+}
+
+/**
+ * Slices the `## Tracks` section's own lines out of `text` (already
+ * code-masked by the caller): from the line after the `## Tracks` heading
+ * up to (but excluding) the next `##` heading, or the end of the text
+ * when none follows. Empty when no `## Tracks` heading is present.
+ */
+function extractTracksSectionLines(text: string): string[] {
+  const lines = text.split(/\r?\n/u);
+  const headingRe = /^ {0,3}##\s+(.+?)\s*$/u;
+  let start = -1;
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = lines[index].match(headingRe);
+    if (match && match[1].trim() === 'Tracks') {
+      start = index + 1;
+      break;
+    }
+  }
+  if (start === -1) {
+    return [];
+  }
+  let end = lines.length;
+  for (let index = start; index < lines.length; index += 1) {
+    if (headingRe.test(lines[index])) {
+      end = index;
+      break;
+    }
+  }
+  return lines.slice(start, end);
+}
+
+/**
+ * Roadmap-shape only (idd-skill#2765): fails when the `## Tracks` section
+ * has at least one checkbox line but NONE of them resolve to a child
+ * issue reference via `extractTaskListReferences` -- the same parser
+ * `discover-roadmap-graph.mts`'s traversal and
+ * `idd-roadmap-audit-execute.mts`'s childless gate rely on, reused here
+ * rather than a second reference-matching regex. When at least one line
+ * resolves but at least one other does not, this is a `severity:
+ * 'warning'` pass (not a hard fail) naming the unresolved line(s), so a
+ * roadmap with a genuinely mixed Tracks section still publishes with a
+ * visible signal instead of being blocked outright.
+ *
+ * Each checkbox line is evaluated with its own continuation span (the
+ * same stop rule `extractTaskListReferences` uses internally) rather
+ * than diffing the parser's returned `evidence` strings against the raw
+ * checkbox lines, so two textually-identical checkbox lines are scored
+ * independently instead of colliding on a shared evidence string.
+ */
+function checkRoadmapTracksParse(
+  text: string,
+  shape: IssueShape,
+  isBucketAudit: boolean,
+  currentRepo: string | undefined,
+): AuditFinding {
+  const id = 'roadmap-tracks-parse';
+  const name = 'Roadmap Tracks checkbox lines resolve to a child reference';
+  if (isBucketAudit) {
+    return pass(id, name, NOT_APPLICABLE_BUCKET_AUDIT_DETAIL);
+  }
+  if (shape !== 'roadmap') {
+    return pass(
+      id,
+      name,
+      'not applicable: only the roadmap shape has a ## Tracks section',
+    );
+  }
+  const sectionLines = extractTracksSectionLines(text);
+  const checkboxLineIndexes = sectionLines
+    .map((line, index) => (isTaskListCheckboxLine(line) ? index : -1))
+    .filter((index) => index >= 0);
+  if (checkboxLineIndexes.length === 0) {
+    return pass(id, name, 'no ## Tracks checkbox lines to validate');
+  }
+  const unparsedLines: string[] = [];
+  let parsedCount = 0;
+  for (const startIndex of checkboxLineIndexes) {
+    let end = startIndex;
+    while (
+      end + 1 < sectionLines.length &&
+      !isTaskListBlockBoundary(sectionLines[end + 1])
+    ) {
+      end += 1;
+    }
+    const itemText = sectionLines.slice(startIndex, end + 1).join('\n');
+    const itemReferences = extractTaskListReferences(itemText, {
+      currentRepoRef: currentRepo,
+    });
+    if (itemReferences.length > 0) {
+      parsedCount += 1;
+    } else {
+      unparsedLines.push(sectionLines[startIndex].trim());
+    }
+  }
+  if (parsedCount === 0) {
+    return fail(
+      id,
+      name,
+      `## Tracks has ${checkboxLineIndexes.length} checkbox line(s) but none resolve to a child issue reference (checked: ${unparsedLines.join(' | ')})`,
+    );
+  }
+  if (unparsedLines.length > 0) {
+    return {
+      id,
+      name,
+      result: 'pass',
+      severity: 'warning',
+      detail: `## Tracks checkbox line(s) did not resolve to a child issue reference: ${unparsedLines.join(' | ')}`,
+    };
+  }
+  return pass(
+    id,
+    name,
+    'every ## Tracks checkbox line resolves to a child issue reference',
+  );
 }
 
 function checkDependencyMarkerRule(

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -10,13 +10,14 @@
 // marker's exactly-one/coherent-value rule, its cross-field agreement with
 // the configured blocked-by-human label, markerPrefix consistency across
 // every authoring marker, the declared shape's required section headings,
-// the roadmap-id/blocked-by dependency-marker rules, visible/hidden line
-// agreement for the suitability and effort footers, and an advisory
-// warning-severity check that flags an issue/PR reference used near
-// coordination language (e.g. "before", "once", "requires") with no
-// corresponding Blocked-by/Depends-on/task-list dependency encoding. The
-// advisory check never fails the report or changes the exit code — see
-// checkProseOnlyDependency.
+// the roadmap shape's `## Tracks` checkbox lines actually resolving to a
+// child issue reference, the roadmap-id/blocked-by dependency-marker
+// rules, visible/hidden line agreement for the suitability and effort
+// footers, and an advisory warning-severity check that flags an issue/PR
+// reference used near coordination language (e.g. "before", "once",
+// "requires") with no corresponding Blocked-by/Depends-on/task-list
+// dependency encoding. The advisory check never fails the report or
+// changes the exit code — see checkProseOnlyDependency.
 //
 // All marker value parsing is delegated to the existing
 // autopilot-suitability.mts / effort.mts / marker-regex.mts /

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -1155,6 +1155,22 @@ function checkRoadmapTracksParse(
   if (checkboxLineIndexes.length === 0) {
     return pass(id, name, 'no ## Tracks checkbox lines to validate');
   }
+  // Detects a trailing qualified `owner/repo#N` reference -- `(#N)`
+  // optionally wrapped in parens, with an `owner/repo` prefix -- at the
+  // end of a task-list item's text, mirroring
+  // `extractTaskListReferences`'s own trailing-reference shape
+  // (`discover-roadmap-graph.mts`) but without requiring a
+  // `currentRepoRef` match. Used only to distinguish "no reference at
+  // all" from "a qualified reference exists but this run has no repo
+  // context to verify it names the current repository" (idd-skill#2765
+  // review, Codex) -- detection only, never itself trusted as a resolved
+  // child reference. Declared inside the function (not module-level, per
+  // this file's own CLI-entry-order convention -- see
+  // `extractTaskListReferences`'s matching per-call regex construction in
+  // `discover-roadmap-graph.mts`) so it carries no TDZ risk relative to
+  // this file's `if (import.meta.main)` CLI entry block.
+  const qualifiedTrailingReferenceRe =
+    /(?:^|\s)\(?[\w.-]+\/[\w.-]+#\d+\)?[.,;:]*\s*$/u;
   const unparsedLines: string[] = [];
   let parsedCount = 0;
   for (const startIndex of checkboxLineIndexes) {
@@ -1169,7 +1185,20 @@ function checkRoadmapTracksParse(
     const itemReferences = extractTaskListReferences(itemText, {
       currentRepoRef: currentRepo,
     });
-    if (itemReferences.length > 0) {
+    if (
+      itemReferences.length > 0 ||
+      // No repo context to verify a qualified `owner/repo#N` reference
+      // against (idd-skill#2765 review, Codex): the documented local
+      // invocation of this linter never passes `--current-repo`, and
+      // `$GITHUB_REPOSITORY` is only set by GitHub Actions, so this is
+      // the common case outside CI. `extractTaskListReferences` then
+      // rejects every qualified reference because it can never equal an
+      // empty current-repository value -- treat a trailing qualified
+      // reference as unverifiable rather than malformed here, so a
+      // well-formed roadmap using that form doesn't hard-fail merely
+      // because this run lacks repo context.
+      (currentRepo === undefined && qualifiedTrailingReferenceRe.test(itemText))
+    ) {
       parsedCount += 1;
     } else {
       unparsedLines.push(sectionLines[startIndex].trim());

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -2016,10 +2016,19 @@ export function classifyIssue(
  * (bulleted or ordered), or an ATX heading. Shared between the item-
  * grouping loop below and any external caller that needs to slice the
  * same continuation span (e.g. `audit-authored-issue.mts`'s per-line
- * Tracks-parse check, #2765).
+ * Tracks-parse check, #2765). Each marker alternative also accepts
+ * end-of-line, not only trailing whitespace (idd-skill#2765 review,
+ * Codex): CommonMark allows an EMPTY list item or ATX heading (a bare
+ * `-`, `1.`, or `#` with nothing after it), and without the end-of-line
+ * alternative such a line failed to read as a boundary, letting the
+ * continuation span absorb it (and anything after it, including a
+ * later unrelated `(#N)`) into the preceding checkbox item.
  */
 export function isTaskListBlockBoundary(line: string): boolean {
-  return line.trim() === '' || /^\s*(?:[-*+]\s|\d+[.)]\s|#{1,6}\s)/u.test(line);
+  return (
+    line.trim() === '' ||
+    /^\s*(?:[-*+](?:\s|$)|\d+[.)](?:\s|$)|#{1,6}(?:\s|$))/u.test(line)
+  );
 }
 
 /**
@@ -2030,11 +2039,20 @@ export function isTaskListBlockBoundary(line: string): boolean {
  * to start with `[ ]`. Without this bound, the trailing-reference
  * fallback below (idd-skill#2765 review, Copilot) could misclassify an
  * ordinary bulleted line as a task-list item merely because it opens
- * with that exact character sequence. Exported for the same reuse
- * reason as {@link isTaskListBlockBoundary}.
+ * with that exact character sequence. Also requires at least one
+ * whitespace character between the bullet marker and the opening `[`
+ * (idd-skill#2765 review, Codex): CommonMark requires whitespace after
+ * a list marker for it to open a list item at all, so `-[ ] text` (no
+ * space) is not a real checkbox either -- a pre-existing laxness the
+ * two leading-form regexes below also share, but one this new
+ * trailing-reference fallback measurably widens the blast radius of
+ * (from "immediately followed by `#N`" to "an arbitrary trailing
+ * reference anywhere in the item's text"), so it is bounded at this
+ * shared gate rather than left unaddressed. Exported for the same
+ * reuse reason as {@link isTaskListBlockBoundary}.
  */
 export function isTaskListCheckboxLine(line: string): boolean {
-  return /^\s*-\s*\[(?: |x|X)\](?:\s|$)/u.test(line);
+  return /^\s*-\s+\[(?: |x|X)\](?:\s|$)/u.test(line);
 }
 
 export function extractTaskListReferences(

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -1070,7 +1070,7 @@ export async function enumerateRoadmapGraph(
         ? []
         : normalizeSubIssueReferences(await loadSubIssues(issue.number));
     const references = [
-      ...extractTaskListReferences(issue.body),
+      ...extractTaskListReferences(issue.body, { currentRepoRef }),
       ...extractKeywordReferences(issue.body, { currentRepoRef }),
       ...nativeSubIssues,
     ];
@@ -2010,8 +2010,29 @@ export function classifyIssue(
   };
 }
 
+/**
+ * True when `line` opens a new Markdown block that must terminate a
+ * task-list item's continuation span: a blank line, a new list item
+ * (bulleted or ordered), or an ATX heading. Shared between the item-
+ * grouping loop below and any external caller that needs to slice the
+ * same continuation span (e.g. `audit-authored-issue.mts`'s per-line
+ * Tracks-parse check, #2765).
+ */
+export function isTaskListBlockBoundary(line: string): boolean {
+  return line.trim() === '' || /^\s*(?:[-*+]\s|\d+[.)]\s|#{1,6}\s)/u.test(line);
+}
+
+/**
+ * True when `line` opens a task-list checkbox item (`- [ ]` / `- [x]`).
+ * Exported for the same reuse reason as {@link isTaskListBlockBoundary}.
+ */
+export function isTaskListCheckboxLine(line: string): boolean {
+  return /^\s*-\s*\[(?: |x|X)\]/u.test(line);
+}
+
 export function extractTaskListReferences(
   body: unknown,
+  options: { currentRepoRef?: string; owner?: string; repo?: string } = {},
 ): RoadmapGraphReference[] {
   // Match against a code-masked copy so a checkbox merely quoted inside inline
   // code or a fenced block is not walked as a real task-list edge — consistent
@@ -2020,40 +2041,104 @@ export function extractTaskListReferences(
   // lines share an index and evidence stays the raw line for any surviving edge
   // (e.g. one that shares a line with unrelated inline code).
   //
-  // Two forms recognized, tried in order (idd-skill#2476): a bare `#123`
-  // or a markdown link whose TEXT is `#123` (e.g. `- [ ] [#123](url)`,
-  // the `[`/`]`/`(...)` around the number all optional); falling back to
-  // a markdown link with arbitrary link text whose URL targets
+  // Three forms recognized (idd-skill#2476, idd-skill#2765), tried in order
+  // per item: a bare `#123` or a markdown link whose TEXT is `#123` (e.g.
+  // `- [ ] [#123](url)`, the `[`/`]`/`(...)` around the number all
+  // optional) directly after the checkbox marker; falling back to a
+  // markdown link with arbitrary link text whose URL targets
   // `.../issues/123` or `.../pull/123` (e.g.
-  // `- [ ] [some text](https://.../issues/123)`) -- inlined per-call
-  // (not hoisted to a module-level const) because this file's CLI entry
-  // point (`if (import.meta.main)`) sits near the top of the file and
-  // can reach this function during synchronous module evaluation, before
-  // a later top-level const would have initialized (TDZ).
+  // `- [ ] [some text](https://.../issues/123)`); falling back further to
+  // a TRAILING local issue reference -- `(#N)`, bare `#N`, or
+  // `owner/repo#N` naming the current repository -- as the last token of
+  // the checkbox item, gathered across the checkbox line and any
+  // continuation lines a soft wrap moved onto the item's own paragraph
+  // (up to the next line that starts a new list item, is blank, or is a
+  // heading -- the exact stop condition idd-skill#2765 specifies; no
+  // additional indentation check, since the stop condition alone already
+  // disambiguates the item's extent). A bare trailing `#N` accepts the
+  // same zero-disambiguation trust the leading bare-`#N` form already
+  // carries -- e.g. "...seen in run #4521" would also match -- a
+  // deliberate tradeoff (see idd-skill#2765's review discussion) rather
+  // than an unreliable keyword denylist. Regex construction is inlined
+  // per-call (not hoisted to a module-level const) because this file's
+  // CLI entry point (`if (import.meta.main)`) sits near the top of the
+  // file and can reach this function during synchronous module
+  // evaluation, before a later top-level const would have initialized
+  // (TDZ).
   const bareOrLinkTextRe =
     /^\s*-\s*\[(?: |x|X)\]\s+\[?#(\d+)\b\]?(?:\([^)\n]*\))?/u;
   const linkUrlRe =
     /^\s*-\s*\[(?: |x|X)\]\s+\[[^\]\n]*\]\([^)\n]*\/(?:issues|pull)\/(\d+)(?:[/?#][^)\n]*)?\)/u;
+  const trailingReferenceRe =
+    /(?:^|\s)\(?(?:([\w.-]+\/[\w.-]+)#(\d+)|#(\d+))\)?[.,;:]*\s*$/u;
+  const currentRepoRef = normalizeRepoRef(
+    options.currentRepoRef
+      ? options.currentRepoRef.split('/')[0]
+      : options.owner,
+    options.currentRepoRef
+      ? options.currentRepoRef.split('/')[1]
+      : options.repo,
+  );
   const rawBody = String(body ?? '');
   const rawLines = rawBody.split(/\r?\n/u);
   const maskedLines = stripMarkdownCodeRegions(rawBody).split(/\r?\n/u);
-  return maskedLines.flatMap((maskedLine, index) => {
-    const match =
-      maskedLine.match(bareOrLinkTextRe) ?? maskedLine.match(linkUrlRe);
-    if (!match) {
-      return [];
+  const references: RoadmapGraphReference[] = [];
+  for (let index = 0; index < maskedLines.length; index += 1) {
+    const maskedLine = maskedLines[index];
+    if (!isTaskListCheckboxLine(maskedLine)) {
+      continue;
     }
-    const target = Number.parseInt(match[1], 10);
-    return Number.isInteger(target) && target > 0
-      ? [
-          {
-            target,
-            relationship: 'task-list',
-            evidence: (rawLines[index] ?? maskedLine).trim(),
-          },
-        ]
-      : [];
-  });
+    const leadingMatch =
+      maskedLine.match(bareOrLinkTextRe) ?? maskedLine.match(linkUrlRe);
+    if (leadingMatch) {
+      const target = Number.parseInt(leadingMatch[1], 10);
+      if (Number.isInteger(target) && target > 0) {
+        references.push({
+          target,
+          relationship: 'task-list',
+          evidence: (rawLines[index] ?? maskedLine).trim(),
+        });
+      }
+      continue;
+    }
+    // No leading-form match: gather this item's continuation lines (soft-
+    // wrapped text belonging to the same checkbox item) and retry against
+    // the joined item text, looking for a trailing local issue reference.
+    let end = index;
+    while (
+      end + 1 < maskedLines.length &&
+      !isTaskListBlockBoundary(maskedLines[end + 1])
+    ) {
+      end += 1;
+    }
+    const itemText = maskedLines
+      .slice(index, end + 1)
+      .map((line) => line.trim())
+      .join(' ');
+    const trailingMatch = itemText.match(trailingReferenceRe);
+    if (trailingMatch) {
+      const qualifiedRepoRef = trailingMatch[1]
+        ? normalizeRepoRef(...(trailingMatch[1].split('/') as [string, string]))
+        : '';
+      const target = Number.parseInt(
+        trailingMatch[2] ?? trailingMatch[3] ?? '',
+        10,
+      );
+      if (
+        (!qualifiedRepoRef || qualifiedRepoRef === currentRepoRef) &&
+        Number.isInteger(target) &&
+        target > 0
+      ) {
+        references.push({
+          target,
+          relationship: 'task-list',
+          evidence: (rawLines[index] ?? maskedLine).trim(),
+        });
+      }
+    }
+    index = end;
+  }
+  return references;
 }
 
 export function extractKeywordReferences(

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -2024,10 +2024,17 @@ export function isTaskListBlockBoundary(line: string): boolean {
 
 /**
  * True when `line` opens a task-list checkbox item (`- [ ]` / `- [x]`).
- * Exported for the same reuse reason as {@link isTaskListBlockBoundary}.
+ * Requires whitespace (or end-of-line) immediately after the closing
+ * `]` -- GFM's own task-list syntax requires it, and `- [ ]foo` (no
+ * space) is not a real checkbox item, just list-item text that happens
+ * to start with `[ ]`. Without this bound, the trailing-reference
+ * fallback below (idd-skill#2765 review, Copilot) could misclassify an
+ * ordinary bulleted line as a task-list item merely because it opens
+ * with that exact character sequence. Exported for the same reuse
+ * reason as {@link isTaskListBlockBoundary}.
  */
 export function isTaskListCheckboxLine(line: string): boolean {
-  return /^\s*-\s*\[(?: |x|X)\]/u.test(line);
+  return /^\s*-\s*\[(?: |x|X)\](?:\s|$)/u.test(line);
 }
 
 export function extractTaskListReferences(

--- a/src/scripts/idd-roadmap-audit-execute.mts
+++ b/src/scripts/idd-roadmap-audit-execute.mts
@@ -56,19 +56,20 @@ const DEFAULT_CLAIM_STALE_AGE_MS = 24 * 60 * 60 * 1000;
 // drift out of sync.
 const COMPLETION_AUDIT_HEADING = '**IDD roadmap completion audit**';
 
-// `RoadmapGraphReference.relationship` kinds that name real child work for
-// the childless-blocker check below (idd-skill#2765): a task-list line, a
-// closing keyword (Closes/Fixes/Resolves), or a native GitHub sub-issue
-// relationship. Every other kind `discover-roadmap-graph.mts` emits --
-// `dependency` (Blocked by / Depends on), `reference` /
-// `non-blocking-reference` (Refs), and `sub-issue-reference` (prose
-// "Sub-issue #N" text) -- is informational or a precondition, never a
-// child, and must not suppress the `childless` blocker on its own.
-const CHILD_RELATIONSHIP_KINDS = new Set([
-  'task-list',
-  'closing-keyword',
-  'sub-issue',
-]);
+// `RoadmapGraphReference.relationship` kinds that are PURELY
+// informational and must never, by themselves, satisfy the
+// childless-blocker check below (idd-skill#2765): a `Refs #N
+// (non-blocking)` breadcrumb. Every other kind counts as explicit
+// child work, matching A2's own "Allowed traversal sources"
+// (`idd-discover.instructions.md`) -- which names `Refs #NNN` and
+// "explicit sub-issue lines" (the `reference` / `sub-issue-reference`
+// kinds) alongside task-list entries and GitHub sub-issue
+// relationships as sources A1.5 must fetch descendants through
+// (`idd-roadmap-audit.instructions.md`'s "Use the same outbound
+// traversal sources as A2") -- so only the `(non-blocking)`-annotated
+// form is excluded here, not the plain `reference`/`sub-issue-reference`
+// kinds (idd-skill#2765 review, Codex).
+const NON_CHILD_RELATIONSHIP_KINDS = new Set(['non-blocking-reference']);
 
 // Scope caveat (A1.5): this helper gates only the MECHANICAL completion
 // preconditions. It deliberately does NOT verify the roadmap's free-form
@@ -233,18 +234,18 @@ export function evaluateRoadmapAuditGates(
   }
 
   // No explicit child work → childless / malformed. Do not infer completion
-  // from the absence of candidates. Only edges that actually name a CHILD
-  // relationship count here (idd-skill#2765): `task-list` (a `- [ ] #N`
-  // line), `closing-keyword` (Closes/Fixes/Resolves), and `sub-issue` (a
-  // native GitHub sub-issue relationship). An edge list containing only
-  // `non-blocking-reference` (a `Refs #N (non-blocking)` breadcrumb),
-  // `dependency` (Blocked by / Depends on -- a precondition, not a
-  // child), `reference` (a plain `Refs #N` mention), or
-  // `sub-issue-reference` (prose "Sub-issue #N" text, distinct from the
-  // native `sub-issue` relationship) is still childless -- none of those
-  // kinds name work this roadmap is tracking as its own.
-  const childRelationshipEdgeCount = report.edges.filter((edge) =>
-    CHILD_RELATIONSHIP_KINDS.has(edge.relationship),
+  // from the absence of candidates. An edge counts as child work unless its
+  // relationship is purely informational (idd-skill#2765): only a
+  // `non-blocking-reference` (`Refs #N (non-blocking)`) is excluded here --
+  // `task-list`, `closing-keyword`, `sub-issue`, the plain `reference`
+  // (`Refs #N`, no annotation), and `sub-issue-reference` (prose
+  // "Sub-issue #N" text) all count, matching A2's own allowed traversal
+  // sources. `dependency` (Blocked by / Depends on) is a precondition
+  // pointing away from this roadmap's own descendants, not a child, but is
+  // left counting here unchanged from this check's pre-existing behavior
+  // (`report.edges.length === 0`) since no known repro needs it excluded.
+  const childRelationshipEdgeCount = report.edges.filter(
+    (edge) => !NON_CHILD_RELATIONSHIP_KINDS.has(edge.relationship),
   ).length;
   if (childRelationshipEdgeCount === 0) {
     blockers.push({

--- a/src/scripts/idd-roadmap-audit-execute.mts
+++ b/src/scripts/idd-roadmap-audit-execute.mts
@@ -56,6 +56,20 @@ const DEFAULT_CLAIM_STALE_AGE_MS = 24 * 60 * 60 * 1000;
 // drift out of sync.
 const COMPLETION_AUDIT_HEADING = '**IDD roadmap completion audit**';
 
+// `RoadmapGraphReference.relationship` kinds that name real child work for
+// the childless-blocker check below (idd-skill#2765): a task-list line, a
+// closing keyword (Closes/Fixes/Resolves), or a native GitHub sub-issue
+// relationship. Every other kind `discover-roadmap-graph.mts` emits --
+// `dependency` (Blocked by / Depends on), `reference` /
+// `non-blocking-reference` (Refs), and `sub-issue-reference` (prose
+// "Sub-issue #N" text) -- is informational or a precondition, never a
+// child, and must not suppress the `childless` blocker on its own.
+const CHILD_RELATIONSHIP_KINDS = new Set([
+  'task-list',
+  'closing-keyword',
+  'sub-issue',
+]);
+
 // Scope caveat (A1.5): this helper gates only the MECHANICAL completion
 // preconditions. It deliberately does NOT verify the roadmap's free-form
 // success criteria or autonomy-gap items — that is agent judgment "where
@@ -219,8 +233,20 @@ export function evaluateRoadmapAuditGates(
   }
 
   // No explicit child work → childless / malformed. Do not infer completion
-  // from the absence of candidates.
-  if (report.edges.length === 0) {
+  // from the absence of candidates. Only edges that actually name a CHILD
+  // relationship count here (idd-skill#2765): `task-list` (a `- [ ] #N`
+  // line), `closing-keyword` (Closes/Fixes/Resolves), and `sub-issue` (a
+  // native GitHub sub-issue relationship). An edge list containing only
+  // `non-blocking-reference` (a `Refs #N (non-blocking)` breadcrumb),
+  // `dependency` (Blocked by / Depends on -- a precondition, not a
+  // child), `reference` (a plain `Refs #N` mention), or
+  // `sub-issue-reference` (prose "Sub-issue #N" text, distinct from the
+  // native `sub-issue` relationship) is still childless -- none of those
+  // kinds name work this roadmap is tracking as its own.
+  const childRelationshipEdgeCount = report.edges.filter((edge) =>
+    CHILD_RELATIONSHIP_KINDS.has(edge.relationship),
+  ).length;
+  if (childRelationshipEdgeCount === 0) {
     blockers.push({
       kind: 'childless',
       detail: `roadmap #${rootNumber} has no explicit child references (task-list, closing-keyword, or GitHub sub-issue); childless or malformed, not complete`,

--- a/tests/audit-authored-issue.test.mts
+++ b/tests/audit-authored-issue.test.mts
@@ -605,6 +605,76 @@ test('required-headings does not tolerate 4+ leading spaces on an ATX heading', 
   assert.match(finding?.detail ?? '', /Proposed change/);
 });
 
+// --- roadmap-tracks-parse (#2765) ---
+
+test('roadmap-tracks-parse passes when every Tracks checkbox line resolves to a reference', () => {
+  // roadmapBody()'s default Tracks section is `- [ ] #100`, which already
+  // resolves via the leading-form parser.
+  const report = auditAuthoredIssue(roadmapBody(), { shape: 'roadmap' });
+  assert.equal(findingResult(report, 'roadmap-tracks-parse'), 'pass');
+  const finding = report.findings.find(
+    (entry) => entry.id === 'roadmap-tracks-parse',
+  );
+  assert.equal(finding?.severity, undefined);
+});
+
+test('roadmap-tracks-parse passes on the trailing (#N) shape (#2765)', () => {
+  const body = roadmapBody().replace(
+    '- [ ] #100',
+    '- [ ] Track 1: some description (#100)',
+  );
+  const report = auditAuthoredIssue(body, { shape: 'roadmap' });
+  assert.equal(findingResult(report, 'roadmap-tracks-parse'), 'pass');
+});
+
+test('roadmap-tracks-parse fails when every Tracks checkbox line carries no issue reference at all (#2765)', () => {
+  const body = roadmapBody().replace(
+    '- [ ] #100',
+    '- [ ] Track 1: no reference here at all',
+  );
+  const report = auditAuthoredIssue(body, { shape: 'roadmap' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'roadmap-tracks-parse',
+  );
+  assert.equal(finding?.result, 'fail');
+  assert.match(finding?.detail ?? '', /no reference here at all/);
+});
+
+test('roadmap-tracks-parse warns (does not fail) when only some Tracks checkbox lines resolve (#2765)', () => {
+  const body = roadmapBody().replace(
+    '- [ ] #100',
+    ['- [ ] #100', '- [ ] Track 2: no reference here at all'].join('\n'),
+  );
+  const report = auditAuthoredIssue(body, { shape: 'roadmap' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'roadmap-tracks-parse',
+  );
+  assert.equal(finding?.result, 'pass');
+  assert.equal(finding?.severity, 'warning');
+  assert.match(finding?.detail ?? '', /no reference here at all/);
+  // A warning-severity finding must never flip the overall report to failed.
+  assert.equal(report.passed, true);
+});
+
+test('roadmap-tracks-parse is not applicable outside the roadmap shape', () => {
+  const report = auditAuthoredIssue(orphanBody(), { shape: 'orphan' });
+  assert.equal(findingResult(report, 'roadmap-tracks-parse'), 'pass');
+});
+
+test('roadmap-tracks-parse is not applicable during a bucket audit', () => {
+  const body = [
+    '<!-- idd-skill-authoring-bucket: needs-decision -->',
+    '## Background',
+    '',
+    'Some background text needing a maintainer decision.',
+  ].join('\n');
+  const report = auditAuthoredIssue(body, {
+    shape: 'roadmap',
+    expectedAuthoringBucket: 'needs-decision',
+  });
+  assert.equal(findingResult(report, 'roadmap-tracks-parse'), 'pass');
+});
+
 // --- dependency-marker-rule ---
 
 test('dependency-marker-rule fails when a child issue carries a roadmap-id marker', () => {

--- a/tests/audit-authored-issue.test.mts
+++ b/tests/audit-authored-issue.test.mts
@@ -627,6 +627,45 @@ test('roadmap-tracks-parse passes on the trailing (#N) shape (#2765)', () => {
   assert.equal(findingResult(report, 'roadmap-tracks-parse'), 'pass');
 });
 
+test('roadmap-tracks-parse passes on an empty Tracks section (no checkbox lines yet, #2765)', () => {
+  // The issue-authoring contract explicitly allows a roadmap shell to
+  // publish with an empty `## Tracks` section until child issue numbers
+  // exist (skills/issue-authoring/references/workflow-boundary.md); this
+  // must never fail as if it were an unresolved checkbox line.
+  const body = roadmapBody().replace(
+    '- [ ] #100',
+    '_No tracks published yet._',
+  );
+  const report = auditAuthoredIssue(body, { shape: 'roadmap' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'roadmap-tracks-parse',
+  );
+  assert.equal(finding?.result, 'pass');
+  assert.equal(finding?.severity, undefined);
+});
+
+test('roadmap-tracks-parse still slices the Tracks section when it is the last content in the body, no trailing heading (#2765)', () => {
+  const body = [
+    '## Goal',
+    '',
+    'Ship the initiative.',
+    '',
+    '## Background',
+    '',
+    'Why this exists.',
+    '',
+    '## Tracks',
+    '',
+    '- [ ] Track 1: no reference here at all',
+  ].join('\n');
+  const report = auditAuthoredIssue(body, { shape: 'roadmap' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'roadmap-tracks-parse',
+  );
+  assert.equal(finding?.result, 'fail');
+  assert.match(finding?.detail ?? '', /no reference here at all/);
+});
+
 test('roadmap-tracks-parse fails when every Tracks checkbox line carries no issue reference at all (#2765)', () => {
   const body = roadmapBody().replace(
     '- [ ] #100',

--- a/tests/audit-authored-issue.test.mts
+++ b/tests/audit-authored-issue.test.mts
@@ -695,6 +695,50 @@ test('roadmap-tracks-parse warns (does not fail) when only some Tracks checkbox 
   assert.equal(report.passed, true);
 });
 
+test('roadmap-tracks-parse treats a qualified owner/repo#N reference as unverifiable, not malformed, when no --current-repo context is passed (#2765 review, Codex)', () => {
+  // The documented local CLI invocation never passes --current-repo, and
+  // $GITHUB_REPOSITORY is only set by GitHub Actions, so `currentRepo` is
+  // commonly undefined outside CI. A well-formed roadmap using the
+  // qualified trailing form must not hard-fail just because this run
+  // lacks repo context to verify the reference.
+  const body = roadmapBody().replace(
+    '- [ ] #100',
+    '- [ ] Track 1: some description (kurone-kito/idd-skill#100)',
+  );
+  const report = auditAuthoredIssue(body, { shape: 'roadmap' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'roadmap-tracks-parse',
+  );
+  assert.equal(finding?.result, 'pass');
+  assert.equal(finding?.severity, undefined);
+});
+
+test('roadmap-tracks-parse still resolves a qualified owner/repo#N reference normally when --current-repo IS passed (#2765)', () => {
+  const body = roadmapBody().replace(
+    '- [ ] #100',
+    '- [ ] Track 1: some description (kurone-kito/idd-skill#100)',
+  );
+  const report = auditAuthoredIssue(body, {
+    shape: 'roadmap',
+    currentRepo: 'kurone-kito/idd-skill',
+  });
+  assert.equal(findingResult(report, 'roadmap-tracks-parse'), 'pass');
+  // A cross-repo qualified reference is still correctly rejected (not
+  // "unverifiable") once repo context IS available.
+  const crossRepoBody = roadmapBody().replace(
+    '- [ ] #100',
+    '- [ ] Track 1: some description (other/repo#100)',
+  );
+  const crossRepoReport = auditAuthoredIssue(crossRepoBody, {
+    shape: 'roadmap',
+    currentRepo: 'kurone-kito/idd-skill',
+  });
+  const crossRepoFinding = crossRepoReport.findings.find(
+    (entry) => entry.id === 'roadmap-tracks-parse',
+  );
+  assert.equal(crossRepoFinding?.result, 'fail');
+});
+
 test('roadmap-tracks-parse is not applicable outside the roadmap shape', () => {
   const report = auditAuthoredIssue(orphanBody(), { shape: 'orphan' });
   assert.equal(findingResult(report, 'roadmap-tracks-parse'), 'pass');

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -724,6 +724,49 @@ test('extractTaskListReferences requires whitespace (or end-of-line) after the c
   assert.deepEqual(extractTaskListReferences('- [ ]'), []);
 });
 
+test('extractTaskListReferences requires whitespace between the bullet and the checkbox, not just "-[ ]" (#2765 review, Codex)', () => {
+  // "-[ ] text (#2752)" (no space between "-" and "[") is not a real
+  // CommonMark list item at all -- a list marker requires at least one
+  // following space to open a list item. Without this bound, the
+  // trailing-reference fallback could attach an unrelated "(#N)" to a
+  // mistyped bullet line.
+  const line = '-[ ] Track 1: text (#2752)';
+  assert.deepEqual(extractTaskListReferences(line), []);
+  // The equivalent, correctly-spaced line still resolves normally.
+  const validLine = '- [ ] Track 1: text (#2752)';
+  assert.deepEqual(extractTaskListReferences(validLine), [
+    { target: 2752, relationship: 'task-list', evidence: validLine },
+  ]);
+});
+
+test('extractTaskListReferences trailing-reference form stops the continuation span at an EMPTY list item or heading marker too (#2765 review, Codex)', () => {
+  // A bare "-" (or "1.", or "#") with no trailing whitespace is still a
+  // valid CommonMark empty list item / heading and must still terminate
+  // the continuation span -- otherwise the scan absorbs it and any
+  // following text, including an unrelated trailing "(#N)", into the
+  // preceding checkbox item.
+  const emptyBullet = [
+    '- [ ] Track 1: no reference here',
+    '-',
+    'Unrelated prose mentioning (#2752)',
+  ].join('\n');
+  assert.deepEqual(extractTaskListReferences(emptyBullet), []);
+
+  const emptyOrdered = [
+    '- [ ] Track 1: no reference here',
+    '1.',
+    'Unrelated prose mentioning (#2752)',
+  ].join('\n');
+  assert.deepEqual(extractTaskListReferences(emptyOrdered), []);
+
+  const emptyHeading = [
+    '- [ ] Track 1: no reference here',
+    '#',
+    'Unrelated prose mentioning (#2752)',
+  ].join('\n');
+  assert.deepEqual(extractTaskListReferences(emptyHeading), []);
+});
+
 test('extractTaskListReferences trailing-reference form respects the current-repo scope for owner/repo#N (#2765)', () => {
   const line = '- [ ] Track 1: text kurone-kito/idd-skill#2752';
   assert.deepEqual(

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -672,6 +672,87 @@ test('extractTaskListReferences ignores a checkbox quoted inside a fence (#1204)
   ]);
 });
 
+test('extractTaskListReferences accepts a trailing (#N) reference on the checkbox line itself (#2765)', () => {
+  const line = '- [ ] Track 1: text (#2752)';
+  assert.deepEqual(extractTaskListReferences(line), [
+    { target: 2752, relationship: 'task-list', evidence: line },
+  ]);
+});
+
+test('extractTaskListReferences accepts a trailing (#N) reference soft-wrapped onto an indented continuation line (#2765)', () => {
+  const body = [
+    '- [ ] Track 1: operational-marker hide-policy enumeration guard +',
+    '      minimization timing doc fix (#2752)',
+  ].join('\n');
+  assert.deepEqual(extractTaskListReferences(body), [
+    {
+      target: 2752,
+      relationship: 'task-list',
+      evidence:
+        '- [ ] Track 1: operational-marker hide-policy enumeration guard +',
+    },
+  ]);
+});
+
+test('extractTaskListReferences accepts a bare trailing #N reference with no parens (#2765)', () => {
+  const line = '- [ ] text #2752';
+  assert.deepEqual(extractTaskListReferences(line), [
+    { target: 2752, relationship: 'task-list', evidence: line },
+  ]);
+});
+
+test('extractTaskListReferences ignores a trailing-reference checkbox item quoted inside a fence (#2765)', () => {
+  const fenced = ['```md', '- [ ] Track 1: text (#2752)', '```'].join('\n');
+  assert.deepEqual(extractTaskListReferences(fenced), []);
+});
+
+test('extractTaskListReferences trailing-reference form respects the current-repo scope for owner/repo#N (#2765)', () => {
+  const line = '- [ ] Track 1: text kurone-kito/idd-skill#2752';
+  assert.deepEqual(
+    extractTaskListReferences(line, {
+      currentRepoRef: 'kurone-kito/idd-skill',
+    }),
+    [{ target: 2752, relationship: 'task-list', evidence: line }],
+  );
+  // A cross-repo trailing reference is never counted as a local edge.
+  assert.deepEqual(
+    extractTaskListReferences(line, { currentRepoRef: 'other/repo' }),
+    [],
+  );
+});
+
+test('extractTaskListReferences trailing-reference form stops the continuation span at the next list item, blank line, or heading (#2765)', () => {
+  // The next checkbox item is a separate list item and must not be
+  // absorbed into the first item's continuation span, nor treated as a
+  // reference source for the first (unresolved) item.
+  const twoItems = [
+    '- [ ] Track 1: no reference here',
+    '- [ ] Track 2 (#2752)',
+  ].join('\n');
+  assert.deepEqual(extractTaskListReferences(twoItems), [
+    {
+      target: 2752,
+      relationship: 'task-list',
+      evidence: '- [ ] Track 2 (#2752)',
+    },
+  ]);
+
+  // A blank line also stops the continuation span.
+  const blankSeparated = [
+    '- [ ] Track 1: no reference here',
+    '',
+    'Track 1 continues in prose (#2752), unrelated to the checkbox item.',
+  ].join('\n');
+  assert.deepEqual(extractTaskListReferences(blankSeparated), []);
+
+  // A heading also stops the continuation span.
+  const headingSeparated = [
+    '- [ ] Track 1: no reference here',
+    '## Next section (#2752)',
+  ].join('\n');
+  assert.deepEqual(extractTaskListReferences(headingSeparated), []);
+});
+
 test('graph traversal creates no phantom edges from code-quoted refs in a child body (#1204)', async () => {
   // Reproduces the #1142/#1143 audit false-positive at the graph level: a
   // completed child that documents the dependency parser quotes example

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -706,6 +706,24 @@ test('extractTaskListReferences ignores a trailing-reference checkbox item quote
   assert.deepEqual(extractTaskListReferences(fenced), []);
 });
 
+test('extractTaskListReferences requires whitespace (or end-of-line) after the checkbox marker, not just "- [ ]" (#2765 review, Copilot)', () => {
+  // "- [ ]foo" (no space after "]") is not valid GFM task-list syntax --
+  // GitHub renders it as plain list-item text, not a checkbox. Before the
+  // whitespace requirement, the trailing-reference fallback could still
+  // misclassify a line shaped this way as a real task-list item merely
+  // because it starts with the exact "- [ ]" character sequence.
+  const line = '- [ ]foo bar (#2752)';
+  assert.deepEqual(extractTaskListReferences(line), []);
+  // The equivalent line WITH the required space still resolves normally.
+  const validLine = '- [ ] foo bar (#2752)';
+  assert.deepEqual(extractTaskListReferences(validLine), [
+    { target: 2752, relationship: 'task-list', evidence: validLine },
+  ]);
+  // A checkbox marker at the very end of the line (empty item text) is
+  // still a valid checkbox line under this bound (end-of-line counts).
+  assert.deepEqual(extractTaskListReferences('- [ ]'), []);
+});
+
 test('extractTaskListReferences trailing-reference form respects the current-repo scope for owner/repo#N (#2765)', () => {
   const line = '- [ ] Track 1: text kurone-kito/idd-skill#2752';
   assert.deepEqual(

--- a/tests/idd-roadmap-audit-execute.test.mts
+++ b/tests/idd-roadmap-audit-execute.test.mts
@@ -796,6 +796,37 @@ test('a roadmap whose only edges are non-blocking-reference is childless, not re
   );
 });
 
+test('a roadmap whose only edge is a plain reference (no non-blocking annotation) is NOT childless (#2765 review, Codex)', () => {
+  // A2's own "Allowed traversal sources" name `Refs #NNN` and explicit
+  // sub-issue lines alongside task-list entries as valid child-work
+  // signals; only the `(non-blocking)`-annotated form is purely
+  // informational. A plain `reference` edge (and, by the same logic, a
+  // `sub-issue-reference` edge) must count as explicit child work here.
+  const report = readyReport();
+  report.nodes = [
+    node({ number: ROADMAP, classification: 'roadmap', state: 'CLOSED' }),
+    node({ number: 9999, classification: 'execution', state: 'CLOSED' }),
+  ];
+  report.edges = [
+    {
+      source: ROADMAP,
+      target: 9999,
+      relationship: 'reference',
+      evidence: 'Refs #9999',
+    },
+  ];
+  report.executionCandidates = [];
+  report.provenancePaths = [
+    { target: ROADMAP, path: [ROADMAP] },
+    { target: 9999, path: [ROADMAP, 9999] },
+  ];
+  const blockers = evaluateRoadmapAuditGates(report);
+  assert.deepEqual(
+    blockers.map((blocker) => blocker.kind),
+    [],
+  );
+});
+
 test('a human-gate label on the roadmap root blocks the close', () => {
   const report = readyReport();
   report.nodes = report.nodes.map((entry) =>

--- a/tests/idd-roadmap-audit-execute.test.mts
+++ b/tests/idd-roadmap-audit-execute.test.mts
@@ -771,6 +771,31 @@ test('a childless roadmap (no edges) is reported, never closed', () => {
   );
 });
 
+test('a roadmap whose only edges are non-blocking-reference is childless, not ready (#2765)', () => {
+  // A `Refs #N (non-blocking)` breadcrumb is informational, never a child —
+  // an edge list containing only that relationship kind must still report
+  // `childless`, the same as an empty edge list.
+  const report = readyReport();
+  report.nodes = [
+    node({ number: ROADMAP, classification: 'roadmap', state: 'OPEN' }),
+  ];
+  report.edges = [
+    {
+      source: ROADMAP,
+      target: 9999,
+      relationship: 'non-blocking-reference',
+      evidence: 'Refs #9999 (non-blocking)',
+    },
+  ];
+  report.executionCandidates = [];
+  report.provenancePaths = [{ target: ROADMAP, path: [ROADMAP] }];
+  const blockers = evaluateRoadmapAuditGates(report);
+  assert.deepEqual(
+    blockers.map((blocker) => blocker.kind),
+    ['childless'],
+  );
+});
+
 test('a human-gate label on the roadmap root blocks the close', () => {
   const report = readyReport();
   report.nodes = report.nodes.map((entry) =>


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Closes three related gaps that let a roadmap task-list child referenced
only by a trailing `(#N)` (including when a soft wrap moves that
reference onto an indented continuation line) slip past every
mechanical check:

- `extractTaskListReferences` (`discover-roadmap-graph.mts`) now groups
  a checkbox line with its continuation lines and recognizes a trailing
  `(#N)`, bare `#N`, or `owner/repo#N` reference, in addition to the
  two existing leading-form shapes it already handled.
- `idd-roadmap-audit-execute.mts`'s A1.5 childless-blocker check now
  excludes purely-informational `non-blocking-reference` edges from
  counting as explicit child work — an edge list containing only
  `Refs #N (non-blocking)` breadcrumbs no longer reads as "has
  children," while every other relationship kind (`task-list`,
  `closing-keyword`, `sub-issue`, plain `reference`,
  `sub-issue-reference`, `dependency`) still counts, unchanged from
  this check's pre-existing behavior.
- `audit-authored-issue.mts`'s pre-publish linter gained a
  `roadmap-tracks-parse` check that reuses the same parser to flag a
  `## Tracks` checkbox line that doesn't resolve to a child reference,
  so a malformed roadmap draft is caught before publication rather than
  discovered later by a concurrent A1.5 audit.

See the issue for the full reproduction (roadmap `#2751`, closed
2026-09-09, reproduced this exact failure with all three of its
children still open).

## Linked issue

Closes #2765

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

- **Bare trailing `#N` is intentionally unbounded.** A checkbox item
  ending in `... #4521` with no other issue reference nearby resolves
  as a task-list edge, the same zero-disambiguation trust the
  pre-existing *leading* bare-`#N` form already carries. An ad hoc
  keyword denylist (to exclude "run #4521", "priority #1", etc.) was
  considered and rejected as unreliable, open-ended scope creep beyond
  what the issue's acceptance criteria ask for.
- **The childless-gate excludes only `non-blocking-reference`.** An
  earlier commit on this branch also excluded the plain `reference`
  and `sub-issue-reference` relationship kinds; Codex's review
  correctly flagged this as narrower than A2's own "Allowed traversal
  sources" (`Refs #NNN` and explicit sub-issue lines both count
  there), so a follow-up commit widened the exclusion back down to
  just `non-blocking-reference` — the one kind the issue actually
  names as purely informational.
- Confirmed against `skills/issue-authoring/references/draft-patterns.md`'s
  roadmap examples, which all use the already-working leading
  `- [ ] #NNN` form — no shell-publish regression from either change.

No other production caller of the widened `extractTaskListReferences`
exists (`discover-readiness-check.mts`'s own task-list dependency
detector uses an independent regex), so this change is scoped to the
roadmap traversal and the new linter check only.

**Review disposition**: across four review rounds, Copilot and Codex
raised six review-thread findings; five were genuinely real and
tractable (checkbox-continuation misclassification risk, the
childless-gate exclusion set, checkbox-bullet whitespace, the
block-boundary empty-marker case, and `roadmap-tracks-parse` failing
closed with no repo context) and were each fixed in a follow-up commit
and dispositioned `**Accepted**` on their thread; the sixth (round 4's
hypothetical HTML-comment-hidden-checkbox scenario) was dispositioned
`**Rejected**` with evidence that it isn't reachable via this repo's
actual masking path. Codex's plain-comment summary walkthrough on the
final commit was acknowledged (`**Accepted**`, no actionable content).
CodeRabbit did not review any HEAD of this PR (`**Rejected**` — no
review evidence to disposition).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CK2SHn8Bir6VHrXrMVMdn3

