### PR TITLE
docs(idd-design-rationale): move claim-release CAS record from #2000

### DIFF
--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -309,6 +309,106 @@ Either way, preserve that branch's real history and move only the
 misplaced commit. `scripts/idd-doctor.mjs` warns on the same
 primary-worktree-HEAD symptom this gate catches at mutation time.
 
+### Claim release has no compare-and-swap: deferred (2026-08-13)
+
+While resolving kurone-kito/idd-skill#1985 (PR kurone-kito/idd-skill#1993's
+"Operator-present release" recovery path), round 6 review found that the
+claim-marker protocol has no atomic compare-and-swap for releasing a
+claim: `idd-claim.instructions.md`'s Claim-state parsing rule 5 releases
+a claim via `unclaimed-by` on an exact `{agent-id}`/`{claim-id}` match
+alone, with no check on whether the releasing session's belief ("no
+later claimant activity") is still true at write time. The maintainer
+accepted this as a documented, bounded residual risk for
+kurone-kito/idd-skill#1985 specifically — blast radius already limited
+by the pre-existing claim revalidation gate, since a session that loses
+its claim mid-window detects it on its own next required pre-mutation
+check and stops, making this a detectable lost-claim event rather than
+silent double-ownership. kurone-kito/idd-skill#2000 recorded the broader
+protocol-level question that decision deliberately left open: should the
+claim-marker protocol close this gap generally, beyond that one path?
+
+**What "true CAS" would actually require.** Two GitHub-native mechanisms
+give genuine atomic compare-and-swap, and both were considered and
+rejected rather than being unavailable:
+
+- **Non-force git ref updates** (e.g. `refs/idd/claims/issue-N`) — a ref
+  update only succeeds as a fast-forward of its current value, which is
+  real CAS with zero external infrastructure. Rejected because it
+  abandons the append-only, human-readable, trusted-actor comment ledger
+  the entire IDD claim/audit/trust model is built on.
+- **GitHub Actions concurrency groups** — routing claim mutations through
+  a per-issue-serialized dispatched workflow gives real mutual exclusion.
+  Rejected on added latency, a hard dependency on Actions, and
+  incompatibility with the `instructions-only` helper profile, which by
+  design requires no workflow at all.
+
+Neither is impossible — both trade away a load-bearing IDD design
+property (portability, comment-ledger auditability, or
+infrastructure-free operation) that this repository has consistently
+protected elsewhere.
+
+**What's actually achievable without new infrastructure.** The claim
+protocol already has a self-healing, re-derivable consistency check for
+the _take_ side: Claim-state parsing rule 4 re-evaluates whether a
+superseded claim was genuinely stale **at the new comment's own
+`created_at`**, from the live comment timeline — not from whatever the
+superseding session believed when it decided to act. If a heartbeat
+lands between a session's stale-check read and its takeover post,
+replaying the timeline correctly invalidates the takeover. This is
+optimistic concurrency with post-hoc detection, not true atomicity, but
+it is genuinely self-healing. The _release_ side (rule 5) has no
+equivalent: it is a bare identity match with no timeline-derived
+liveness predicate. The parser-level fix would mirror rule 4's pattern
+for releases — e.g. an `unclaimed-by` variant that embeds the timestamp
+of the pause-evidence comment it is anchored to, honored only if no
+trusted claimant activity has a `created_at` between that anchor and the
+release event itself, re-derivable by any future parser exactly like
+rule 4's staleness check already is. This would need a **new sibling
+marker type** alongside the existing `unclaimed-by`, not a field added
+to that same token: the existing token is parsed by a strict whole-body
+anchor regex requiring exactly its current fields and nothing else, so
+every existing (and every not-yet-upgraded) parser would read an
+extended token as malformed and silently lose the release event. A new
+sibling type keeps old parsers on today's accepted-risk behavior while
+letting new parsers apply the stronger check.
+
+**Coverage is inherently partial either way.** Even with the parser
+extension, only comment-visible activity (heartbeats, comments, reviews)
+is re-derivable from the timeline. The Operator-present release path's
+own prose predicate also considers branch/PR movement, which a
+comment-timeline parser cannot see. Rule 4's existing stale-clock has the
+identical limitation today (only heartbeats refresh it, not pushes), so
+this would be consistent with the existing design rather than a new gap
+— but it means even the "real" fix would not fully close the class of
+race the round-6 finding raised.
+
+**Revisit triggers.** Reconsider this only if either becomes true:
+
+- An **actually-observed** instance of this race class occurs (not a
+  theoretical review finding) — i.e., a session genuinely loses work or
+  produces confusing state because of a stale-read release, takeover, or
+  forced-handoff decision.
+- This repository's operating model shifts toward materially higher
+  concurrent-session, multi-writer load on the same issues (today's
+  desync/contention tooling — `discover.selectionDesync`,
+  `discover-shared-file-overlap` — targets _different_-issue
+  parallelism, not concurrent claim decisions on the _same_ issue).
+
+**Candidate files (if ever pursued)**:
+
+- `idd-template/.github/instructions/idd-claim.instructions.md` (Claim-state
+  parsing rules, marker format)
+- `idd-template/.github/instructions/idd-overview-core.instructions.md`
+  (Claim format / Unclaim format sections)
+- `src/scripts/marker-helpers.mts` (marker regex/parsing)
+- `src/scripts/protocol-helpers.mts` (marker classification)
+
+Deliberately deferred, not `needs-decision`: there is no currently
+blocking choice, since kurone-kito/idd-skill#1985 already resolved its
+own narrower question. This record moved here from
+kurone-kito/idd-skill#2000, which stayed open only as a findable record
+until one of the revisit triggers above fires.
+
 ## Work and self-review
 
 ### B1 Step 3 — install-deps silent under-install detection

--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -401,6 +401,10 @@ race the round-6 finding raised.
   parsing rules, marker format)
 - `idd-template/.github/instructions/idd-overview-core.instructions.md`
   (Claim format / Unclaim format sections)
+- `idd-template/.github/instructions/idd-resume.instructions.md`
+  (Operator-present release Step 2 — the actual writer of today's bare
+  `unclaimed-by`; a guarded release marker needs this call site too, or
+  the race it targets would remain unguarded here)
 - `src/scripts/marker-helpers.mts` (marker regex/parsing)
 - `src/scripts/protocol-helpers.mts` (marker classification)
 

--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -317,9 +317,10 @@ claim-marker protocol has no atomic compare-and-swap for releasing a
 claim: `idd-claim.instructions.md`'s Claim-state parsing rule 5 releases
 a claim via `unclaimed-by` on an exact `{agent-id}`/`{claim-id}` match
 alone, with no check on whether the releasing session's belief ("no
-later claimant activity") is still true at write time. The maintainer
-accepted this as a documented, bounded residual risk for
-kurone-kito/idd-skill#1985 specifically — blast radius already limited
+later claimant activity") is still true at write time (preventive; no
+observed incident yet). The maintainer accepted this as a documented,
+bounded residual risk for kurone-kito/idd-skill#1985 specifically —
+blast radius already limited
 by the pre-existing claim revalidation gate, since a session that loses
 its claim mid-window detects it on its own next required pre-mutation
 check and stops, making this a detectable lost-claim event rather than

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -396,14 +396,22 @@ race the round-6 finding raised.
   `discover-shared-file-overlap` — targets _different_-issue
   parallelism, not concurrent claim decisions on the _same_ issue).
 
-**Candidate files (if ever pursued)**:
+**Candidate files (if ever pursued)**, named as they land once imported
+(the `idd-template/` prefix drops from this document's own path, and
+`src/scripts/*.mts` never ships — an adopter's `vendored-node` profile
+gets the generated `.mjs` copy instead; other profiles resolve the
+same logic through the installed package rather than a local file; the
+repository-local `docs/idd-design-rationale.md` mirror keeps the
+source-tree paths, since those genuinely exist there):
 
-- `idd-template/.github/instructions/idd-claim.instructions.md` (Claim-state
+- `.github/instructions/idd-claim.instructions.md` (Claim-state
   parsing rules, marker format)
-- `idd-template/.github/instructions/idd-overview-core.instructions.md`
+- `.github/instructions/idd-overview-core.instructions.md`
   (Claim format / Unclaim format sections)
-- `src/scripts/marker-helpers.mts` (marker regex/parsing)
-- `src/scripts/protocol-helpers.mts` (marker classification)
+- `scripts/marker-helpers.mjs` (marker regex/parsing; `vendored-node`
+  only)
+- `scripts/protocol-helpers.mjs` (marker classification;
+  `vendored-node` only)
 
 Deliberately deferred, not `needs-decision`: there is no currently
 blocking choice, since kurone-kito/idd-skill#1985 already resolved its

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -318,9 +318,10 @@ claim-marker protocol has no atomic compare-and-swap for releasing a
 claim: `idd-claim.instructions.md`'s Claim-state parsing rule 5 releases
 a claim via `unclaimed-by` on an exact `{agent-id}`/`{claim-id}` match
 alone, with no check on whether the releasing session's belief ("no
-later claimant activity") is still true at write time. The maintainer
-accepted this as a documented, bounded residual risk for
-kurone-kito/idd-skill#1985 specifically — blast radius already limited
+later claimant activity") is still true at write time (preventive; no
+observed incident yet). The maintainer accepted this as a documented,
+bounded residual risk for kurone-kito/idd-skill#1985 specifically —
+blast radius already limited
 by the pre-existing claim revalidation gate, since a session that loses
 its claim mid-window detects it on its own next required pre-mutation
 check and stops, making this a detectable lost-claim event rather than

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -310,6 +310,106 @@ Either way, preserve that branch's real history and move only the
 misplaced commit. `scripts/idd-doctor.mjs` warns on the same
 primary-worktree-HEAD symptom this gate catches at mutation time.
 
+### Claim release has no compare-and-swap: deferred (2026-08-13)
+
+While resolving kurone-kito/idd-skill#1985 (PR kurone-kito/idd-skill#1993's
+"Operator-present release" recovery path), round 6 review found that the
+claim-marker protocol has no atomic compare-and-swap for releasing a
+claim: `idd-claim.instructions.md`'s Claim-state parsing rule 5 releases
+a claim via `unclaimed-by` on an exact `{agent-id}`/`{claim-id}` match
+alone, with no check on whether the releasing session's belief ("no
+later claimant activity") is still true at write time. The maintainer
+accepted this as a documented, bounded residual risk for
+kurone-kito/idd-skill#1985 specifically — blast radius already limited
+by the pre-existing claim revalidation gate, since a session that loses
+its claim mid-window detects it on its own next required pre-mutation
+check and stops, making this a detectable lost-claim event rather than
+silent double-ownership. kurone-kito/idd-skill#2000 recorded the broader
+protocol-level question that decision deliberately left open: should the
+claim-marker protocol close this gap generally, beyond that one path?
+
+**What "true CAS" would actually require.** Two GitHub-native mechanisms
+give genuine atomic compare-and-swap, and both were considered and
+rejected rather than being unavailable:
+
+- **Non-force git ref updates** (e.g. `refs/idd/claims/issue-N`) — a ref
+  update only succeeds as a fast-forward of its current value, which is
+  real CAS with zero external infrastructure. Rejected because it
+  abandons the append-only, human-readable, trusted-actor comment ledger
+  the entire IDD claim/audit/trust model is built on.
+- **GitHub Actions concurrency groups** — routing claim mutations through
+  a per-issue-serialized dispatched workflow gives real mutual exclusion.
+  Rejected on added latency, a hard dependency on Actions, and
+  incompatibility with the `instructions-only` helper profile, which by
+  design requires no workflow at all.
+
+Neither is impossible — both trade away a load-bearing IDD design
+property (portability, comment-ledger auditability, or
+infrastructure-free operation) that this repository has consistently
+protected elsewhere.
+
+**What's actually achievable without new infrastructure.** The claim
+protocol already has a self-healing, re-derivable consistency check for
+the _take_ side: Claim-state parsing rule 4 re-evaluates whether a
+superseded claim was genuinely stale **at the new comment's own
+`created_at`**, from the live comment timeline — not from whatever the
+superseding session believed when it decided to act. If a heartbeat
+lands between a session's stale-check read and its takeover post,
+replaying the timeline correctly invalidates the takeover. This is
+optimistic concurrency with post-hoc detection, not true atomicity, but
+it is genuinely self-healing. The _release_ side (rule 5) has no
+equivalent: it is a bare identity match with no timeline-derived
+liveness predicate. The parser-level fix would mirror rule 4's pattern
+for releases — e.g. an `unclaimed-by` variant that embeds the timestamp
+of the pause-evidence comment it is anchored to, honored only if no
+trusted claimant activity has a `created_at` between that anchor and the
+release event itself, re-derivable by any future parser exactly like
+rule 4's staleness check already is. This would need a **new sibling
+marker type** alongside the existing `unclaimed-by`, not a field added
+to that same token: the existing token is parsed by a strict whole-body
+anchor regex requiring exactly its current fields and nothing else, so
+every existing (and every not-yet-upgraded) parser would read an
+extended token as malformed and silently lose the release event. A new
+sibling type keeps old parsers on today's accepted-risk behavior while
+letting new parsers apply the stronger check.
+
+**Coverage is inherently partial either way.** Even with the parser
+extension, only comment-visible activity (heartbeats, comments, reviews)
+is re-derivable from the timeline. The Operator-present release path's
+own prose predicate also considers branch/PR movement, which a
+comment-timeline parser cannot see. Rule 4's existing stale-clock has the
+identical limitation today (only heartbeats refresh it, not pushes), so
+this would be consistent with the existing design rather than a new gap
+— but it means even the "real" fix would not fully close the class of
+race the round-6 finding raised.
+
+**Revisit triggers.** Reconsider this only if either becomes true:
+
+- An **actually-observed** instance of this race class occurs (not a
+  theoretical review finding) — i.e., a session genuinely loses work or
+  produces confusing state because of a stale-read release, takeover, or
+  forced-handoff decision.
+- This repository's operating model shifts toward materially higher
+  concurrent-session, multi-writer load on the same issues (today's
+  desync/contention tooling — `discover.selectionDesync`,
+  `discover-shared-file-overlap` — targets _different_-issue
+  parallelism, not concurrent claim decisions on the _same_ issue).
+
+**Candidate files (if ever pursued)**:
+
+- `idd-template/.github/instructions/idd-claim.instructions.md` (Claim-state
+  parsing rules, marker format)
+- `idd-template/.github/instructions/idd-overview-core.instructions.md`
+  (Claim format / Unclaim format sections)
+- `src/scripts/marker-helpers.mts` (marker regex/parsing)
+- `src/scripts/protocol-helpers.mts` (marker classification)
+
+Deliberately deferred, not `needs-decision`: there is no currently
+blocking choice, since kurone-kito/idd-skill#1985 already resolved its
+own narrower question. This record moved here from
+kurone-kito/idd-skill#2000, which stayed open only as a findable record
+until one of the revisit triggers above fires.
+
 ## Work and self-review
 
 ### B1 Step 3 — install-deps silent under-install detection

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -411,6 +411,10 @@ since those genuinely exist there):
   parsing rules, marker format)
 - `.github/instructions/idd-overview-core.instructions.md`
   (Claim format / Unclaim format sections)
+- `.github/instructions/idd-resume.instructions.md` (Operator-present
+  release Step 2 — the actual writer of today's bare `unclaimed-by`; a
+  guarded release marker needs this call site too, or the race it
+  targets would remain unguarded here)
 - `scripts/marker-helpers.mjs` (marker regex/parsing; `vendored-node`
   only)
 - `scripts/protocol-helpers.mjs` (marker classification;

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -399,10 +399,13 @@ race the round-6 finding raised.
 **Candidate files (if ever pursued)**, named as they land once imported
 (the `idd-template/` prefix drops from this document's own path, and
 `src/scripts/*.mts` never ships — an adopter's `vendored-node` profile
-gets the generated `.mjs` copy instead; other profiles resolve the
-same logic through the installed package rather than a local file; the
-repository-local `docs/idd-design-rationale.md` mirror keeps the
-source-tree paths, since those genuinely exist there):
+gets the generated `.mjs` copy instead; `package-manager`/`ephemeral-npx`
+resolve the same logic through the installed package rather than a
+local file; `instructions-only` has no helper runtime at all, so this
+deferred work would need direct instruction-level parsing rules there
+instead of a helper file. The repository-local
+`docs/idd-design-rationale.md` mirror keeps the source-tree paths,
+since those genuinely exist there):
 
 - `.github/instructions/idd-claim.instructions.md` (Claim-state
   parsing rules, marker format)


### PR DESCRIPTION
# Summary

Relocates the deferred design-record analysis from issue #2000 ("no
compare-and-swap for claim release") into `docs/idd-design-rationale.md`'s
existing "Claim resolution" section (and its `idd-template/` canonical
source), so the record stays findable without the ongoing Discover-routing
cost of an open, low-suitability issue. Adds a single new subsection,
"Claim release has no compare-and-swap: deferred (2026-08-13)",
transcribing issue #2000's body faithfully: the accepted residual risk
from #1985/#1993, the two rejected CAS mechanisms with their stated
reasons, the achievable parser-level mirror framed as a new sibling
marker type, the partial-coverage note, and both revisit triggers
verbatim. No instruction file or protocol/parsing code is touched — this
is a documentation move only.

The subsection's prose body is identical in both files. Its trailing
"Candidate files" list intentionally diverges: `idd-template/`'s copy is
adopter-facing, so it names the paths as they land once imported
(`.github/instructions/...` without the `idd-template/` prefix, and the
generated `.mjs` helper copies qualified by runtime profile), while
`docs/idd-design-rationale.md`'s copy keeps the genuine source-tree paths
(`idd-template/.github/instructions/...`, `src/scripts/*.mts`) that
resolve in this repository. This divergence was itself a review finding
on this PR (Codex) and is deliberate, not drift.

## Linked issue

Closes #2766

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Issue #2000 scored 2/5 on autopilot suitability and was routed to the
`routed_to_human` bucket on every autopilot Discover pass, per the
issue's own background section. The maintainer decided on 2026-09-09 to
relocate the record rather than keep paying that recurring Discover cost.
Once this PR merges, issue #2000 will be closed with a comment linking
the new subsection (a post-merge step performed by the merging session,
per the issue's own acceptance criteria — not via a PR closing keyword,
to keep this PR's own closing set exact).

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`biome check`, `dprint check "**/*.md"`, `markdownlint-cli2`)
- [x] `pnpm test` (`node --test tests/*.test.mts` — 5597 tests pass)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdQ5SPdFLaDGus5PNdBUhw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added design rationale documenting how claim-release race conditions are handled.
  * Recorded current safeguards, known coverage limitations, rejected alternatives, and potential future improvements.
  * Documented conditions for revisiting the deferred decision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
