### PR TITLE
docs(idd-suitability): continue Discover past a re-reported invalid

### DIFF
--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -180,7 +180,7 @@ outcome (trust/safety concerns require human review):
 | `blocked-by-human` | Requires human coordination | Report, try next candidate |
 | `duplicate` | Duplicate or superseded work | Report, try next candidate |
 | `out-of-scope` | Outside repository scope | Report, try next candidate |
-| `invalid` | Trust/safety concern or defect | Fresh: report, stop. Already reported (`existingRejection`: `outcome: invalid`), confirmed today: exclude, post nothing, loop |
+| `invalid` | Trust/safety concern or defect | Fresh: report, stop (do not retry). Reconfirmed (`existingRejection`: `outcome: invalid`): exclude, post nothing, loop |
 <!-- dprint-ignore-end -->
 
 ## Mutation Policy and Coordination Rule

--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -180,7 +180,7 @@ outcome (trust/safety concerns require human review):
 | `blocked-by-human` | Requires human coordination | Report, try next candidate |
 | `duplicate` | Duplicate or superseded work | Report, try next candidate |
 | `out-of-scope` | Outside repository scope | Report, try next candidate |
-| `invalid` | Trust/safety concern or defect | Fresh: report and stop (do not retry). Already reported (`existingRejection`: `outcome: invalid`), confirmed today: exclude, post nothing, loop |
+| `invalid` | Trust/safety concern or defect | Fresh: report, stop. Already reported (`existingRejection`: `outcome: invalid`), confirmed today: exclude, post nothing, loop |
 <!-- dprint-ignore-end -->
 
 ## Mutation Policy and Coordination Rule
@@ -272,8 +272,9 @@ Loop: Rerun A4 Step 2 over Candidates to pick the next candidate
     → FAIL → Classify as unclear → Report, remove from Candidates, loop
   → Run Check 3 (Trust/Safety)
     → PASS → Run Check 4
-    → FAIL → Classify as invalid → existingRejection.outcome is invalid:
-      remove from Candidates, loop; else Report and STOP
+    → FAIL → Classify as invalid → existingRejection.outcome is
+      invalid, reconfirmed: remove from Candidates, loop; else Report
+      and STOP
   → Run Check 4 (Duplicates)
     → PASS → Run Check 5
     → FAIL → Classify as duplicate → Report, remove from Candidates, loop

--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -169,17 +169,19 @@ A4 Step 2 over the remaining survivors to pick the next candidate (see
 `idd-discover.instructions.md`'s A4 Step 2 for the ranking, including
 its `autopilotSuitability.enabled: false` fallback). A0-T explicit-target
 runs: the candidate set is only the verified target — stop without
-fallback. Stop when the survivor set is empty, or immediately on an
-`invalid` outcome (trust/safety concerns require human review):
+fallback. Stop when the survivor set is empty, or on a fresh `invalid`
+outcome (trust/safety concerns require human review):
 
-| Outcome            | Meaning                        | Next Steps (A4: try next; A0-T: stop) |
-| ------------------ | ------------------------------ | ------------------------------------- |
-| `unclear`          | Issue needs clarification      | Report, try next candidate            |
-| `needs-decision`   | Requires maintainer decision   | Report, try next candidate            |
-| `blocked-by-human` | Requires human coordination    | Report, try next candidate            |
-| `duplicate`        | Duplicate or superseded work   | Report, try next candidate            |
-| `out-of-scope`     | Outside repository scope       | Report, try next candidate            |
-| `invalid`          | Trust/safety concern or defect | Report and stop (do not retry)        |
+<!-- dprint-ignore-start -->
+| Outcome | Meaning | Next Steps (A4: try next; A0-T: stop) |
+| --- | --- | --- |
+| `unclear` | Issue needs clarification | Report, try next candidate |
+| `needs-decision` | Requires maintainer decision | Report, try next candidate |
+| `blocked-by-human` | Requires human coordination | Report, try next candidate |
+| `duplicate` | Duplicate or superseded work | Report, try next candidate |
+| `out-of-scope` | Outside repository scope | Report, try next candidate |
+| `invalid` | Trust/safety concern or defect | Fresh: report and stop (do not retry). Already reported (`existingRejection`: `outcome: invalid`), confirmed today: exclude, post nothing, loop |
+<!-- dprint-ignore-end -->
 
 ## Mutation Policy and Coordination Rule
 
@@ -270,7 +272,8 @@ Loop: Rerun A4 Step 2 over Candidates to pick the next candidate
     → FAIL → Classify as unclear → Report, remove from Candidates, loop
   → Run Check 3 (Trust/Safety)
     → PASS → Run Check 4
-    → FAIL → Classify as invalid → Report and STOP (do not retry)
+    → FAIL → Classify as invalid → existingRejection.outcome is invalid:
+      remove from Candidates, loop; else Report and STOP
   → Run Check 4 (Duplicates)
     → PASS → Run Check 5
     → FAIL → Classify as duplicate → Report, remove from Candidates, loop

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1433,7 +1433,11 @@ stops the pass instead, though an already-reported `invalid` (a trusted
 `existingRejection` on this exact candidate, confirmed by a fresh Check 3
 failure) narrows that halt to excluding just that one candidate — see
 [`idd-suitability.instructions.md`](../.github/instructions/idd-suitability.instructions.md#failure-outcomes)'s
-Failure Outcomes table for both cases.
+Failure Outcomes table for both cases. This carve-out responds to a
+concrete incident: a 2026-09-08 false-positive `invalid` verdict
+(kurone-kito/idd-skill#2738) that the unconditional halt would have
+forced every later concurrent session to re-report, resolved by a
+2026-09-09 maintainer hearing (kurone-kito/idd-skill#2747).
 
 The configured ready label from `approvalSignals.readyLabelName`
 (default: `idd:ready`) is an approval signal, not an operational

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1407,7 +1407,7 @@ non-ready work as explicit outcomes, not to silently drop it.
 | `blocked-by-human` | `status:blocked-by-human` (if available)           | Keep the issue open with a hold comment, remove it from the current candidate set, and continue scanning autonomous candidates. Applying the recommended label requires the same A4.5 mutation-policy customization as the rows below; the default is the diagnostic comment alone (optionally the transient `triage:blocked-by-human` label).         |
 | `duplicate`        | `duplicate`, optional `triage:duplicate`           | Default is read-only triage (comment/link and continue). Only allow close/extra labels after the repository customizes A4.5 mutation policy.                                                                                                                                                                                                           |
 | `out-of-scope`     | optional `triage:out-of-scope`                     | Default is read-only triage (comment-and-stop for that issue). Close/label mutations require explicit A4.5 mutation-policy customization.                                                                                                                                                                                                              |
-| `invalid`          | optional `triage:invalid`                          | Default is read-only triage and immediate stop for `invalid` outcomes. Close/label mutations require explicit A4.5 mutation-policy updates.                                                                                                                                                                                                            |
+| `invalid`          | optional `triage:invalid`                          | Default is read-only triage and immediate stop for a fresh `invalid` outcome; an already-reported `invalid` (see below) excludes the candidate and continues instead. Close/label mutations require explicit A4.5 mutation-policy updates.                                                                                                             |
 
 Every non-`ready` row shares one default: the diagnostic comment plus
 an optional transient `triage:{outcome}` label is the ceiling; any
@@ -1428,7 +1428,12 @@ default.
 
 When confidence is low, keep the issue open and route via a concise
 comment. "Uncertain means open" is the safe default, and selection
-continues with the next candidate unless the outcome is `invalid`.
+continues with the next candidate; a genuinely fresh `invalid` outcome
+stops the pass instead, though an already-reported `invalid` (a trusted
+`existingRejection` on this exact candidate, confirmed by a fresh Check 3
+failure) narrows that halt to excluding just that one candidate — see
+[`idd-suitability.instructions.md`](../.github/instructions/idd-suitability.instructions.md#failure-outcomes)'s
+Failure Outcomes table for both cases.
 
 The configured ready label from `approvalSignals.readyLabelName`
 (default: `idd:ready`) is an approval signal, not an operational

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -175,7 +175,7 @@ outcome (trust/safety concerns require human review):
 | `blocked-by-human` | Requires human coordination | Report, try next candidate |
 | `duplicate` | Duplicate or superseded work | Report, try next candidate |
 | `out-of-scope` | Outside repository scope | Report, try next candidate |
-| `invalid` | Trust/safety concern or defect | Fresh: report, stop. Already reported (`existingRejection`: `outcome: invalid`), confirmed today: exclude, post nothing, loop |
+| `invalid` | Trust/safety concern or defect | Fresh: report, stop (do not retry). Reconfirmed (`existingRejection`: `outcome: invalid`): exclude, post nothing, loop |
 <!-- dprint-ignore-end -->
 
 ## Mutation Policy and Coordination Rule

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -164,17 +164,19 @@ A4 Step 2 over the remaining survivors to pick the next candidate (see
 `idd-discover.instructions.md`'s A4 Step 2 for the ranking, including
 its `autopilotSuitability.enabled: false` fallback). A0-T explicit-target
 runs: the candidate set is only the verified target — stop without
-fallback. Stop when the survivor set is empty, or immediately on an
-`invalid` outcome (trust/safety concerns require human review):
+fallback. Stop when the survivor set is empty, or on a fresh `invalid`
+outcome (trust/safety concerns require human review):
 
-| Outcome            | Meaning                        | Next Steps (A4: try next; A0-T: stop) |
-| ------------------ | ------------------------------ | ------------------------------------- |
-| `unclear`          | Issue needs clarification      | Report, try next candidate            |
-| `needs-decision`   | Requires maintainer decision   | Report, try next candidate            |
-| `blocked-by-human` | Requires human coordination    | Report, try next candidate            |
-| `duplicate`        | Duplicate or superseded work   | Report, try next candidate            |
-| `out-of-scope`     | Outside repository scope       | Report, try next candidate            |
-| `invalid`          | Trust/safety concern or defect | Report and stop (do not retry)        |
+<!-- dprint-ignore-start -->
+| Outcome | Meaning | Next Steps (A4: try next; A0-T: stop) |
+| --- | --- | --- |
+| `unclear` | Issue needs clarification | Report, try next candidate |
+| `needs-decision` | Requires maintainer decision | Report, try next candidate |
+| `blocked-by-human` | Requires human coordination | Report, try next candidate |
+| `duplicate` | Duplicate or superseded work | Report, try next candidate |
+| `out-of-scope` | Outside repository scope | Report, try next candidate |
+| `invalid` | Trust/safety concern or defect | Fresh: report and stop (do not retry). Already reported (`existingRejection`: `outcome: invalid`), confirmed today: exclude, post nothing, loop |
+<!-- dprint-ignore-end -->
 
 ## Mutation Policy and Coordination Rule
 
@@ -265,7 +267,8 @@ Loop: Rerun A4 Step 2 over Candidates to pick the next candidate
     → FAIL → Classify as unclear → Report, remove from Candidates, loop
   → Run Check 3 (Trust/Safety)
     → PASS → Run Check 4
-    → FAIL → Classify as invalid → Report and STOP (do not retry)
+    → FAIL → Classify as invalid → existingRejection.outcome is invalid:
+      remove from Candidates, loop; else Report and STOP
   → Run Check 4 (Duplicates)
     → PASS → Run Check 5
     → FAIL → Classify as duplicate → Report, remove from Candidates, loop

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -175,7 +175,7 @@ outcome (trust/safety concerns require human review):
 | `blocked-by-human` | Requires human coordination | Report, try next candidate |
 | `duplicate` | Duplicate or superseded work | Report, try next candidate |
 | `out-of-scope` | Outside repository scope | Report, try next candidate |
-| `invalid` | Trust/safety concern or defect | Fresh: report and stop (do not retry). Already reported (`existingRejection`: `outcome: invalid`), confirmed today: exclude, post nothing, loop |
+| `invalid` | Trust/safety concern or defect | Fresh: report, stop. Already reported (`existingRejection`: `outcome: invalid`), confirmed today: exclude, post nothing, loop |
 <!-- dprint-ignore-end -->
 
 ## Mutation Policy and Coordination Rule
@@ -267,8 +267,9 @@ Loop: Rerun A4 Step 2 over Candidates to pick the next candidate
     → FAIL → Classify as unclear → Report, remove from Candidates, loop
   → Run Check 3 (Trust/Safety)
     → PASS → Run Check 4
-    → FAIL → Classify as invalid → existingRejection.outcome is invalid:
-      remove from Candidates, loop; else Report and STOP
+    → FAIL → Classify as invalid → existingRejection.outcome is
+      invalid, reconfirmed: remove from Candidates, loop; else Report
+      and STOP
   → Run Check 4 (Duplicates)
     → PASS → Run Check 5
     → FAIL → Classify as duplicate → Report, remove from Candidates, loop

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -1433,7 +1433,11 @@ stops the pass instead, though an already-reported `invalid` (a trusted
 `existingRejection` on this exact candidate, confirmed by a fresh Check 3
 failure) narrows that halt to excluding just that one candidate — see
 [`idd-suitability.instructions.md`](../.github/instructions/idd-suitability.instructions.md#failure-outcomes)'s
-Failure Outcomes table for both cases.
+Failure Outcomes table for both cases. This carve-out responds to a
+concrete incident: a 2026-09-08 false-positive `invalid` verdict
+(kurone-kito/idd-skill#2738) that the unconditional halt would have
+forced every later concurrent session to re-report, resolved by a
+2026-09-09 maintainer hearing (kurone-kito/idd-skill#2747).
 
 The configured ready label from `approvalSignals.readyLabelName`
 (default: `idd:ready`) is an approval signal, not an operational

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -1407,7 +1407,7 @@ non-ready work as explicit outcomes, not to silently drop it.
 | `blocked-by-human` | `status:blocked-by-human` (if available)           | Keep the issue open with a hold comment, remove it from the current candidate set, and continue scanning autonomous candidates. Applying the recommended label requires the same A4.5 mutation-policy customization as the rows below; the default is the diagnostic comment alone (optionally the transient `triage:blocked-by-human` label).         |
 | `duplicate`        | `duplicate`, optional `triage:duplicate`           | Default is read-only triage (comment/link and continue). Only allow close/extra labels after the repository customizes A4.5 mutation policy.                                                                                                                                                                                                           |
 | `out-of-scope`     | optional `triage:out-of-scope`                     | Default is read-only triage (comment-and-stop for that issue). Close/label mutations require explicit A4.5 mutation-policy customization.                                                                                                                                                                                                              |
-| `invalid`          | optional `triage:invalid`                          | Default is read-only triage and immediate stop for `invalid` outcomes. Close/label mutations require explicit A4.5 mutation-policy updates.                                                                                                                                                                                                            |
+| `invalid`          | optional `triage:invalid`                          | Default is read-only triage and immediate stop for a fresh `invalid` outcome; an already-reported `invalid` (see below) excludes the candidate and continues instead. Close/label mutations require explicit A4.5 mutation-policy updates.                                                                                                             |
 
 Every non-`ready` row shares one default: the diagnostic comment plus
 an optional transient `triage:{outcome}` label is the ceiling; any
@@ -1428,7 +1428,12 @@ default.
 
 When confidence is low, keep the issue open and route via a concise
 comment. "Uncertain means open" is the safe default, and selection
-continues with the next candidate unless the outcome is `invalid`.
+continues with the next candidate; a genuinely fresh `invalid` outcome
+stops the pass instead, though an already-reported `invalid` (a trusted
+`existingRejection` on this exact candidate, confirmed by a fresh Check 3
+failure) narrows that halt to excluding just that one candidate — see
+[`idd-suitability.instructions.md`](../.github/instructions/idd-suitability.instructions.md#failure-outcomes)'s
+Failure Outcomes table for both cases.
 
 The configured ready label from `approvalSignals.readyLabelName`
 (default: `idd:ready`) is an approval signal, not an operational


### PR DESCRIPTION
# Summary

Narrows the Check-3 (Trust/Safety) `invalid` halt in
`idd-suitability.instructions.md` so a Discover pass doesn't stop
entirely when an `invalid` candidate has already been reported once. A
2026-09-09 maintainer hearing decided: when a trusted `existingRejection`
(the field `suitability-triage.mjs` already surfaces) shows
`outcome: invalid` for the exact same candidate, and today's own fresh
Check 3 evaluation independently agrees, the session excludes just that
candidate and continues instead of halting the whole pass and posting
nothing new. A genuinely fresh `invalid` (no matching prior rejection)
keeps today's report-and-stop; an A0-T explicit-target run keeps
stopping either way, unchanged.

Changes (canonical `idd-template/` sources; repo-root mirrors
regenerated via `sync-docs.mjs`):

- `idd-suitability.instructions.md`'s Failure Outcomes table `invalid`
  row and Decision Flow Check-3-FAIL branch now state both cases,
  naming `existingRejection` as the recognition evidence.
- `docs/customization.md`'s outcome-mapping table and the "unless the
  outcome is `invalid`" sentence now reflect the same carve-out, with a
  link to the Failure Outcomes section.

## Linked issue

Closes #2747

## Follow-up issues (if any)

- [ ] Recommended (not filed): `existingRejection` carries no
  staleness check against the issue's own latest substantive edit (the
  `outcome`-based lookup this PR relies on, unlike the separate
  `markerOutcome` path Discover's own candidate-selection filter
  already staleness-checks). Narrow edge case: an issue edited after a
  prior `invalid` rejection, whose edit fixes the original problem but
  leaves (or introduces) a *different* Check-3 failure, could have that
  new finding silently folded into the stale rejection's carve-out
  instead of freshly reported. Flagged by review (Codex, P1) on this
  PR; out of scope here since the 2026-09-09 hearing this PR implements
  didn't address issue-edit interactions, and a real fix needs either a
  `findTrustedSuitabilityRejection` code change or bundle-budget room
  this PR doesn't have.
- [ ] Recommended (not filed): `idd-suitability.instructions.md`'s two
  general "report the failure" sentences (the Failure Outcomes intro
  paragraph and the Mutation Policy section) don't carry an explicit
  carve-out for this PR's new post-nothing branch, even though the
  specific table row and Decision Flow branch govern this exact case.
  Flagged by review (Codex, P2); not fixed here since bundle-discovery
  has only a few bytes of headroom left after this round's fixes.

## Background / rationale (if material)

**Byte-budget constraint (disclosed deviation from the issue's
"Proposed change" wishlist — the issue's actual Acceptance Criteria are
fully met).** `idd-suitability.instructions.md` and
`idd-discover.instructions.md` share the `bundle-discovery` bundle in
`audit/sync-manifest.json` (`limitBytes: 109700`), gated at 98% max
utilization by `node scripts/audit-docs.mjs --check`'s
`context-ceiling-200k` rule. Before this change the bundle already sat
at 97.99% utilization (a documented near-ceiling band in
`docs/policy-constants.md`, which recommends trimming the net addition
over raising a limit once utilization is this high — and the issue's
own Acceptance Criteria explicitly requires no `bundleBudgets` limit be
raised). The full change requested in the issue's "Proposed change"
section (table + decision flow + a one-line pointer in
`idd-discover.instructions.md`'s A4.5 hand-off + a second
`existingRejection` mention in the "Machine-readable outcome marker"
paragraph) measured well over budget. Two items were dropped to fit,
both absent from the issue's actual Acceptance Criteria:
`idd-discover.instructions.md` is unchanged (no pointer added), and the
second `existingRejection` mention was dropped since the table row and
Decision Flow already name it once each, satisfying the requirement.
The Failure Outcomes table was also converted to a `dprint-ignore`
block (matching the convention already used for two tables in
`idd-overview-core.instructions.md`) so the longer `invalid` cell
doesn't force every other row's column to pad to its width — this
alone nets a byte saving. Final `bundle-discovery` usage is
107497/109700 bytes (97.99%, ~9 bytes of headroom) — re-verified after
each review-driven correctness/clarity fix (see below), a CI-breaking
byte-funding mistake caught and fixed in the same review round, and
after rebasing onto `main`.

**Self-review found and fixed a real bug before this PR was opened.** A
C1 critique round caught that an earlier draft of the Decision Flow
branch tested only whether `existingRejection` was *present*, not
whether its `outcome` was specifically `invalid` — since
`findTrustedSuitabilityRejection` returns the issue's latest trusted
rejection regardless of outcome (`duplicate`, `unclear`, etc. all
qualify), that draft could have wrongly suppressed a genuinely fresh
`invalid` verdict whenever *any* unrelated prior rejection existed on
the issue. Fixed to `existingRejection.outcome is invalid:` before this
diff was pushed, and re-reviewed in a second round.

**Review response.** A Codex finding on this PR (citing AGENTS.md's
"cite the observed incident" convention) pointed out that the new
`docs/customization.md` carve-out sentence named a failure mode without
citing the concrete incident behind it. Fixed by adding the 2026-09-08
false-positive rejection (#2738) and the 2026-09-09 hearing that
resolved it, directly in `docs/customization.md` prose — that file
carries no `bundleBudgets` constraint, so the citation didn't need to
compete with the near-ceiling instruction files for space. A second
Codex finding (P1) on the re-review pointed out that the Decision
Flow's carve-out branch didn't distinguish an affirmatively
re-confirmed defect from the separate Edge Cases fail-closed default
(an agent unable to reliably evaluate Check 3 also classifies as
`invalid` and must stop, since failing open on a safety check is a
concrete security risk) — an unrelated evaluation-uncertainty case
could otherwise silently take the loop branch whenever any prior
rejection happened to exist. Fixed by requiring the branch read
`existingRejection.outcome is invalid, reconfirmed`. A follow-up commit
was needed: an initial version funded this by trimming "(do not
retry)" from the table's fresh-invalid cell, which broke
`tests/consistency.test.mts`'s check that the cell documents that
phrase — restored it and instead shortened the same cell's
already-reported half to "Reconfirmed (...)" (matching the Decision
Flow's own wording), which both restores the required text and nets a
small additional byte saving — still no `bundleBudgets` limit raised.
Other review findings (Copilot and Codex both raised the
same underlying A0-T clarity question from different angles) were
dispositioned as non-blocking on the PR threads: the table's existing
"A4: try next; A0-T: stop" header and the Decision Flow's unchanged
A0-T override both already force a stop on this new branch regardless
of the "post
nothing" phrasing, satisfying the hearing's "A0-T keeps stopping either
way" requirement even though the exact wording reads densely.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SfqRji5K2g9EhgXLcRBaiC




