### PR TITLE
fix(supersession-detection): recognize renamed and body-edit events

### DIFF
--- a/scripts/claim-approval-gate.mjs
+++ b/scripts/claim-approval-gate.mjs
@@ -45,6 +45,9 @@ export function evaluateClaimApprovalGate(input, options = {}) {
   const issue = normalizeIssue(input.issue);
   const comments = normalizeComments(input.comments);
   const timelineState = normalizeTimeline(input.timeline);
+  const userContentEditsState = normalizeUserContentEdits(
+    input.userContentEdits,
+  );
   const policyState = normalizePolicy(input.policy);
   const generatedPlanState = detectGeneratedPlanUpdateAt({
     comments,
@@ -116,6 +119,7 @@ export function evaluateClaimApprovalGate(input, options = {}) {
   const latestSubstantiveEditAt = resolveLatestSubstantiveEditAt(
     issue,
     timelineState,
+    userContentEditsState,
   );
   const freshnessAnchor = maxTimestamp(
     latestSubstantiveEditAt,
@@ -170,6 +174,9 @@ export function evaluateClaimApprovalGate(input, options = {}) {
   const timelineKnown = timelineState.known;
   if (!timelineKnown) {
     ambiguity.push('issue-timeline-unavailable');
+  }
+  if (!userContentEditsState.known) {
+    ambiguity.push('issue-user-content-edits-unavailable');
   }
   if (!generatedPlanState.known) {
     ambiguity.push('generated-plan-freshness-unavailable');
@@ -260,6 +267,16 @@ function runCli() {
     created_at: c.createdAt,
   }));
   const timelineState = fetchIssueTimeline(port, args.issue ?? 0);
+  // #2762: the raw fetch result (string[] on success, or the `null`
+  // failure sentinel) is passed straight through as `userContentEdits`
+  // below -- never flattened to a bare array the way `timeline:
+  // timelineState.events` above discards its own `known` flag. Flattening
+  // this one the same way would silently collapse a failed GraphQL read
+  // back to "known-empty" and reintroduce the bug this issue fixes.
+  const userContentEditsState = fetchIssueUserContentEdits(
+    port,
+    args.issue ?? 0,
+  );
   const policy = loadPolicy(args.policy);
   const permissionCache = new Map();
   const resolvePermission = (login) =>
@@ -274,6 +291,9 @@ function runCli() {
       issue,
       comments,
       timeline: timelineState.events,
+      userContentEdits: userContentEditsState.known
+        ? userContentEditsState.timestamps
+        : null,
       policy: policy.config,
       generatedPlanUpdatedAt: args.generatedPlanUpdatedAt,
     },
@@ -301,6 +321,7 @@ function runCli() {
         })),
     timelineAvailable: timelineState.known,
     timelineParseError: timelineState.parseError,
+    userContentEditsAvailable: userContentEditsState.known,
   };
   process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
 }
@@ -395,8 +416,11 @@ Output schema:
   "gateEnabled": true,
   "policy": {"skipIssueAuthorApprovalGate": false, "maintainerApprovalActorPolicy": "owners-and-maintainers-only", "approvalSignals": {"readyLabelName": "idd:ready", "labelFreshnessMode": "presence-only"}, "source": ".github/idd/config.json"},
   "checks": [{"id":"gate_enabled","name":"Issue-author gate enabled","result":"pass|fail","evidence":"..."}],
-  "timelineAvailable": true
+  "timelineAvailable": true,
+  "userContentEditsAvailable": true
 }
+
+#2762: the freshness anchor behind "ready_label_present" / "ready_comment_fresh" now also recognizes a timeline "renamed" event (a title edit) and GraphQL "userContentEdits.editedAt" (a body edit) -- the only place GitHub records either kind of real edit. "userContentEditsAvailable" reports whether that second GraphQL read succeeded; a failed read degrades the anchor to unknown ("freshness-undetermined") rather than falling back to the issue's own created_at.
 `);
 }
 function normalizeIssue(issue) {
@@ -541,16 +565,56 @@ function detectGeneratedPlanUpdateAt({ comments, override }) {
     .filter(Boolean);
   return { known: true, updatedAt: maxTimestamp(...generatedPlanComments) };
 }
-function resolveLatestSubstantiveEditAt(issue, timelineState) {
-  if (!timelineState.known) {
+/**
+ * Duplicates `supersession-detection.mts`'s
+ * `resolveLatestSubstantiveIssueEditAt` by design (see this file's module
+ * header note near that function's #2243 usage) rather than importing it,
+ * so this file's dependency surface stays unchanged. #2762 extends both in
+ * lockstep: a `renamed` timeline event counts as a title edit with no
+ * `changes` payload required (the real shape GitHub emits for a rename),
+ * and `userContentEditsState.timestamps` (GraphQL body-edit timestamps)
+ * feed the same anchor. Returns `null` when either source is unknown --
+ * see {@link UserContentEditsState}'s doc comment for why an *omitted*
+ * `userContentEdits` input does not count as "unknown" here.
+ */
+function resolveLatestSubstantiveEditAt(
+  issue,
+  timelineState,
+  userContentEditsState,
+) {
+  if (!timelineState.known || !userContentEditsState.known) {
     return null;
   }
   const editedAt = timelineState.events
-    .filter((event) => String(event?.event ?? '') === 'edited')
-    .filter((event) => event?.changes?.title || event?.changes?.body)
+    .filter((event) => {
+      const eventType = String(event?.event ?? '');
+      return (
+        eventType === 'renamed' ||
+        (eventType === 'edited' &&
+          Boolean(event?.changes?.title || event?.changes?.body))
+      );
+    })
     .map((event) => normalizeIso(event?.created_at))
     .filter(Boolean);
-  return maxTimestamp(issue.createdAt, ...editedAt);
+  return maxTimestamp(
+    issue.createdAt,
+    ...editedAt,
+    ...userContentEditsState.timestamps,
+  );
+}
+function normalizeUserContentEdits(edits) {
+  if (edits === undefined) {
+    return { known: true, timestamps: [] };
+  }
+  if (!Array.isArray(edits)) {
+    return { known: false, timestamps: [] };
+  }
+  return {
+    known: true,
+    timestamps: edits
+      .map((value) => normalizeIso(value))
+      .filter((value) => value !== null),
+  };
 }
 function findLatestReadyLabelEvent(events, readyLabelName) {
   if (!Array.isArray(events)) {
@@ -746,6 +810,22 @@ function fetchIssueTimeline(port, issueNumber) {
     // being indistinguishable from "no timeline data".
     const parseError = error instanceof SyntaxError ? error.message : '';
     return { known: false, events: [], parseError };
+  }
+}
+/** #2762: mirrors {@link fetchIssueTimeline}'s try/catch shape. The CLI
+ * call site below reads `known` before forwarding `timestamps` to
+ * `evaluateClaimApprovalGate` -- unlike `timeline: timelineState.events`
+ * above, which forwards `events` unconditionally and silently loses its
+ * own `known: false` on failure -- so a genuine fetch failure here reaches
+ * the evaluator as the `null` sentinel, never a flattened empty array. */
+function fetchIssueUserContentEdits(port, issueNumber) {
+  try {
+    return {
+      known: true,
+      timestamps: port.getWorkItemUserContentEditTimestamps(issueNumber),
+    };
+  } catch {
+    return { known: false, timestamps: [] };
   }
 }
 function resolveCollaboratorPermission({ owner, repo, login, cache }) {

--- a/scripts/discover-orphan-filter.mjs
+++ b/scripts/discover-orphan-filter.mjs
@@ -655,6 +655,10 @@ export async function filterOrphanIssues(issues, options = {}) {
       typeof options.fetchTimelineByIssueNumber === 'function'
         ? options.fetchTimelineByIssueNumber
         : () => [];
+    const fetchUserContentEdits =
+      typeof options.fetchUserContentEditsByIssueNumber === 'function'
+        ? options.fetchUserContentEditsByIssueNumber
+        : () => [];
     const trustedMarkerLogins = options.trustedMarkerLogins;
     const markerPrefix =
       typeof options.markerPrefix === 'string'
@@ -679,10 +683,17 @@ export async function filterOrphanIssues(issues, options = {}) {
       }
       let editedAt = null;
       if (record?.markerOutcome) {
+        // Both fetches evaluate inside this one try block (#2762): a
+        // failure from EITHER the timeline or the userContentEdits read
+        // degrades the whole anchor to null ("unknown") rather than
+        // computing a partial result from whichever fetch happened to
+        // succeed -- a partial result could still collapse to the bare
+        // `created_at` anchor this issue fixes.
         try {
           editedAt = resolveLatestSubstantiveIssueEditAt(
             issueCreatedAtByNumber.get(orphan.number),
             fetchTimeline(orphan.number),
+            fetchUserContentEdits(orphan.number),
           );
         } catch {
           editedAt = null;
@@ -816,6 +827,8 @@ async function runCli() {
       fetchIssueCommentsForTriageVerdict(port, issueNumber),
     fetchTimelineByIssueNumber: (issueNumber) =>
       port.getWorkItemTimeline(issueNumber),
+    fetchUserContentEditsByIssueNumber: (issueNumber) =>
+      port.getWorkItemUserContentEditTimestamps(issueNumber),
     trustedMarkerLogins,
     markerPrefix: policy.markerPrefix,
     authoringLabelName: policy.authoringLabelName,
@@ -1007,7 +1020,10 @@ configured, this check is a no-op and makes no extra GitHub API call.
 Staleness-checked (fail-closed toward NOT excluding): the marker only
 excludes when the rejection comment is at or after the issue's latest
 substantive (title/body) edit, so an issue legitimately improved after
-being rejected stays selectable.
+being rejected stays selectable -- a title edit is a timeline "renamed"
+event, and a body edit is a GraphQL "userContentEdits.editedAt" value
+(#2762); a failed GraphQL read degrades the anchor to unknown rather than
+falling back to created_at.
 
 --with-claim-state (opt-in) annotates each candidate in "orphans" and
 "routed_to_human" with active-claim eligibility, exactly mirroring

--- a/scripts/discover-readiness-check.mjs
+++ b/scripts/discover-readiness-check.mjs
@@ -110,6 +110,10 @@ if (import.meta.main) {
     loadIssue: buildIssueLoader(owner, repo),
     fetchCommentsByIssueNumber: buildIssueCommentsLoader(owner, repo),
     fetchTimelineByIssueNumber: buildIssueTimelineLoader(owner, repo),
+    fetchUserContentEditsByIssueNumber: buildIssueUserContentEditsLoader(
+      owner,
+      repo,
+    ),
     trustedMarkerLogins,
     // `--swarm-floor` output never surfaces the stale-authoring warning, so
     // skip the per-issue timeline fetch this loader runs — over a whole-repo
@@ -159,6 +163,7 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
     now = new Date(),
     fetchCommentsByIssueNumber,
     fetchTimelineByIssueNumber,
+    fetchUserContentEditsByIssueNumber,
     trustedMarkerLogins,
   } = options ?? {};
   const triageVerdictCheckEnabled =
@@ -371,11 +376,20 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
       }
       let editedAt = null;
       if (record?.markerOutcome) {
+        // Both fetches evaluate inside this one try block (#2762): a
+        // failure from EITHER the timeline or the userContentEdits read
+        // degrades the whole anchor to null ("unknown") rather than
+        // computing a partial result from whichever fetch happened to
+        // succeed -- a partial result could still collapse to the bare
+        // `created_at` anchor this issue fixes.
         try {
           editedAt = resolveLatestSubstantiveIssueEditAt(
             issue.createdAt,
             typeof fetchTimelineByIssueNumber === 'function'
               ? fetchTimelineByIssueNumber(issue.number)
+              : [],
+            typeof fetchUserContentEditsByIssueNumber === 'function'
+              ? fetchUserContentEditsByIssueNumber(issue.number)
               : [],
           );
         } catch {
@@ -674,7 +688,10 @@ function printHelp() {
   configured (env/flag/repo config); with none configured, this check is a
   no-op and makes no extra GitHub API call. Staleness-checked (fail-closed
   toward NOT excluding): the marker only excludes when the rejection
-  comment is at or after the issue's latest substantive (title/body) edit.
+  comment is at or after the issue's latest substantive (title/body) edit
+  -- a title edit is a timeline "renamed" event, and a body edit is a
+  GraphQL "userContentEdits.editedAt" value (#2762); a failed GraphQL read
+  degrades the anchor to unknown rather than falling back to created_at.
 
 Output schema (JSON mode):
   {
@@ -872,6 +889,13 @@ function fetchIssueLabelEvents(port, issueNumber) {
 function buildIssueTimelineLoader(owner, repo) {
   const port = createGithubProviderAdapter(owner, repo);
   return (issueNumber) => port.getWorkItemTimeline(issueNumber);
+}
+/** #2762: GraphQL `userContentEdits.editedAt` values, for
+ * {@link resolveLatestSubstantiveIssueEditAt}'s body-edit source. */
+function buildIssueUserContentEditsLoader(owner, repo) {
+  const port = createGithubProviderAdapter(owner, repo);
+  return (issueNumber) =>
+    port.getWorkItemUserContentEditTimestamps(issueNumber);
 }
 /**
  * #2243: adapts {@link ProviderPort.listWorkItemComments}'s camelCase

--- a/scripts/provider-adapter-fake.mjs
+++ b/scripts/provider-adapter-fake.mjs
@@ -76,6 +76,9 @@ export function createFakeProviderAdapter(fixture) {
     getWorkItemTimeline(number) {
       return fixture.timelines?.[number] ?? [];
     },
+    getWorkItemUserContentEditTimestamps(number) {
+      return fixture.userContentEditTimestamps?.[number] ?? [];
+    },
     getWorkItemState(number) {
       return fixture.issueStates?.[number] ?? null;
     },

--- a/scripts/provider-adapter-github.mjs
+++ b/scripts/provider-adapter-github.mjs
@@ -605,8 +605,23 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
       ];
       const parsed = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
       assertNoGraphqlErrors(parsed, 'userContentEdits lookup');
-      const nodes = parsed.data?.repository?.issue?.userContentEdits?.nodes;
-      return (nodes ?? [])
+      // Codex review, PR #2836: reject an absent connection/nodes array
+      // instead of defaulting to `[]` -- a null `issue` (deleted/
+      // inaccessible between the earlier REST fetch and this call), a
+      // null `userContentEdits`, or a payload missing `nodes` entirely
+      // are all genuine read failures, indistinguishable from "zero
+      // edits" if silently coerced to an empty array. Every caller of
+      // this method already treats a throw as "anchor unknown" and
+      // degrades accordingly (never falling back to a bare `created_at`
+      // anchor) -- swallowing this case here would silently reintroduce
+      // that exact failure mode one layer down.
+      const connection = parsed.data?.repository?.issue?.userContentEdits;
+      if (!connection || !Array.isArray(connection.nodes)) {
+        throw new Error(
+          'userContentEdits: issue, connection, or nodes is null/absent',
+        );
+      }
+      return connection.nodes
         .map((node) => node?.editedAt)
         .filter((value) => typeof value === 'string');
     },

--- a/scripts/provider-adapter-github.mjs
+++ b/scripts/provider-adapter-github.mjs
@@ -580,6 +580,36 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
         extraArgs: ['-H', 'Accept: application/vnd.github+json'],
       });
     },
+    getWorkItemUserContentEditTimestamps(number) {
+      const query = `query($owner:String!,$repo:String!,$number:Int!){
+  repository(owner:$owner,name:$repo){
+    issue(number:$number){
+      userContentEdits(last:100){
+        nodes { editedAt }
+      }
+    }
+  }
+}`;
+      const apiArgs = [
+        'api',
+        'graphql',
+        ...graphqlHostnameArgs(),
+        '-f',
+        `query=${query}`,
+        '-f',
+        `owner=${owner}`,
+        '-f',
+        `repo=${repo}`,
+        '-F',
+        `number=${number}`,
+      ];
+      const parsed = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
+      assertNoGraphqlErrors(parsed, 'userContentEdits lookup');
+      const nodes = parsed.data?.repository?.issue?.userContentEdits?.nodes;
+      return (nodes ?? [])
+        .map((node) => node?.editedAt)
+        .filter((value) => typeof value === 'string');
+    },
     getWorkItemState(number) {
       try {
         const state = deps.ghText(

--- a/scripts/supersession-detection.mjs
+++ b/scripts/supersession-detection.mjs
@@ -333,18 +333,26 @@ export function parseSuitabilityTriageVerdictMarker(
 }
 /**
  * Staleness anchor for a suitability-rejection marker (#2243): the latest
- * GitHub `created_at` among the issue's own creation and every timeline
- * `edited` event that changed the title or body. Mirrors
- * `claim-approval-gate.mts`'s private `resolveLatestSubstantiveEditAt` --
- * duplicated rather than imported to keep this module's dependency-light,
- * I/O-free kernel contract intact (see the file header). Returns `null`
- * only when neither `issueCreatedAt` nor any qualifying event yields a
- * parseable timestamp -- callers must treat that as "unknown", never as
- * "always stale" or "never stale".
+ * GitHub `created_at` among the issue's own creation, every timeline
+ * `renamed` event (a title edit -- GitHub emits this event shape for a
+ * title change, never an `edited` event with a `changes.title` payload,
+ * #2762), every timeline `edited` event that changed the title or body
+ * (kept for defensive/forward compatibility; not an observed live shape
+ * as of #2762's investigation, see the worked evidence in that issue), and
+ * every timestamp in `bodyEditTimestamps` (GraphQL `Issue.userContentEdits
+ * { editedAt }` values -- the only place GitHub records a body edit,
+ * #2762). Mirrors `claim-approval-gate.mts`'s private
+ * `resolveLatestSubstantiveEditAt` -- duplicated rather than imported to
+ * keep this module's dependency-light, I/O-free kernel contract intact
+ * (see the file header). Returns `null` only when neither
+ * `issueCreatedAt` nor any qualifying event/timestamp yields a parseable
+ * value -- callers must treat that as "unknown", never as "always stale"
+ * or "never stale".
  */
 export function resolveLatestSubstantiveIssueEditAt(
   issueCreatedAt,
   timelineEvents,
+  bodyEditTimestamps,
 ) {
   const candidates = [];
   if (typeof issueCreatedAt === 'string' && issueCreatedAt) {
@@ -353,14 +361,23 @@ export function resolveLatestSubstantiveIssueEditAt(
   if (Array.isArray(timelineEvents)) {
     for (const raw of timelineEvents) {
       const event = raw ?? {};
-      if (String(event.event ?? '') !== 'edited') {
-        continue;
-      }
-      if (!event.changes?.title && !event.changes?.body) {
+      const eventType = String(event.event ?? '');
+      const isRenamed = eventType === 'renamed';
+      const isEditedTitleOrBody =
+        eventType === 'edited' &&
+        Boolean(event.changes?.title || event.changes?.body);
+      if (!isRenamed && !isEditedTitleOrBody) {
         continue;
       }
       if (typeof event.created_at === 'string' && event.created_at) {
         candidates.push(event.created_at);
+      }
+    }
+  }
+  if (Array.isArray(bodyEditTimestamps)) {
+    for (const raw of bodyEditTimestamps) {
+      if (typeof raw === 'string' && raw) {
+        candidates.push(raw);
       }
     }
   }

--- a/src/scripts/claim-approval-gate.mts
+++ b/src/scripts/claim-approval-gate.mts
@@ -54,6 +54,21 @@ interface TimelineState {
   events: TimelineEvent[];
 }
 
+/** #2762: GraphQL `userContentEdits.editedAt` values -- the only place
+ * GitHub records a body edit (a REST timeline `edited` event with a
+ * `changes.body` payload is never emitted for a real edit). Deliberately
+ * asymmetric with {@link TimelineState}: an omitted `userContentEdits`
+ * input normalizes to `known: true, timestamps: []` ("this caller doesn't
+ * supply the new signal"), not `known: false`, so every existing 2-field
+ * caller keeps its current freshness behavior unchanged. Only an explicit
+ * non-array value (the CLI's failure sentinel on a failed GraphQL read)
+ * normalizes to `known: false`, matching this gate's documented
+ * fail-closed posture for a genuine read failure. */
+interface UserContentEditsState {
+  known: boolean;
+  timestamps: string[];
+}
+
 interface PolicyState {
   skipIssueAuthorApprovalGate: boolean;
   maintainerApprovalActorPolicy: string;
@@ -85,6 +100,10 @@ interface EvaluateInput {
   issue?: unknown;
   comments?: unknown;
   timeline?: unknown;
+  /** #2762: GraphQL `userContentEdits.editedAt` values (see
+   * {@link UserContentEditsState}'s doc comment for the normalization
+   * contract). */
+  userContentEdits?: unknown;
   policy?: unknown;
   generatedPlanUpdatedAt?: unknown;
 }
@@ -122,6 +141,9 @@ export function evaluateClaimApprovalGate(
   const issue = normalizeIssue(input.issue);
   const comments = normalizeComments(input.comments);
   const timelineState = normalizeTimeline(input.timeline);
+  const userContentEditsState = normalizeUserContentEdits(
+    input.userContentEdits,
+  );
   const policyState = normalizePolicy(input.policy);
   const generatedPlanState = detectGeneratedPlanUpdateAt({
     comments,
@@ -197,6 +219,7 @@ export function evaluateClaimApprovalGate(
   const latestSubstantiveEditAt = resolveLatestSubstantiveEditAt(
     issue,
     timelineState,
+    userContentEditsState,
   );
   const freshnessAnchor = maxTimestamp(
     latestSubstantiveEditAt,
@@ -254,6 +277,9 @@ export function evaluateClaimApprovalGate(
   const timelineKnown = timelineState.known;
   if (!timelineKnown) {
     ambiguity.push('issue-timeline-unavailable');
+  }
+  if (!userContentEditsState.known) {
+    ambiguity.push('issue-user-content-edits-unavailable');
   }
   if (!generatedPlanState.known) {
     ambiguity.push('generated-plan-freshness-unavailable');
@@ -348,6 +374,16 @@ function runCli(): void {
     created_at: c.createdAt,
   }));
   const timelineState = fetchIssueTimeline(port, args.issue ?? 0);
+  // #2762: the raw fetch result (string[] on success, or the `null`
+  // failure sentinel) is passed straight through as `userContentEdits`
+  // below -- never flattened to a bare array the way `timeline:
+  // timelineState.events` above discards its own `known` flag. Flattening
+  // this one the same way would silently collapse a failed GraphQL read
+  // back to "known-empty" and reintroduce the bug this issue fixes.
+  const userContentEditsState = fetchIssueUserContentEdits(
+    port,
+    args.issue ?? 0,
+  );
   const policy = loadPolicy(args.policy);
   const permissionCache = new Map<string, PermissionResult>();
   const resolvePermission: ResolvePermission = (login) =>
@@ -363,6 +399,9 @@ function runCli(): void {
       issue,
       comments,
       timeline: timelineState.events,
+      userContentEdits: userContentEditsState.known
+        ? userContentEditsState.timestamps
+        : null,
       policy: policy.config,
       generatedPlanUpdatedAt: args.generatedPlanUpdatedAt,
     },
@@ -390,6 +429,7 @@ function runCli(): void {
         })),
     timelineAvailable: timelineState.known,
     timelineParseError: timelineState.parseError,
+    userContentEditsAvailable: userContentEditsState.known,
   };
 
   process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
@@ -505,8 +545,11 @@ Output schema:
   "gateEnabled": true,
   "policy": {"skipIssueAuthorApprovalGate": false, "maintainerApprovalActorPolicy": "owners-and-maintainers-only", "approvalSignals": {"readyLabelName": "idd:ready", "labelFreshnessMode": "presence-only"}, "source": ".github/idd/config.json"},
   "checks": [{"id":"gate_enabled","name":"Issue-author gate enabled","result":"pass|fail","evidence":"..."}],
-  "timelineAvailable": true
+  "timelineAvailable": true,
+  "userContentEditsAvailable": true
 }
+
+#2762: the freshness anchor behind "ready_label_present" / "ready_comment_fresh" now also recognizes a timeline "renamed" event (a title edit) and GraphQL "userContentEdits.editedAt" (a body edit) -- the only place GitHub records either kind of real edit. "userContentEditsAvailable" reports whether that second GraphQL read succeeded; a failed read degrades the anchor to unknown ("freshness-undetermined") rather than falling back to the issue's own created_at.
 `);
 }
 
@@ -697,19 +740,57 @@ function detectGeneratedPlanUpdateAt({
   return { known: true, updatedAt: maxTimestamp(...generatedPlanComments) };
 }
 
+/**
+ * Duplicates `supersession-detection.mts`'s
+ * `resolveLatestSubstantiveIssueEditAt` by design (see this file's module
+ * header note near that function's #2243 usage) rather than importing it,
+ * so this file's dependency surface stays unchanged. #2762 extends both in
+ * lockstep: a `renamed` timeline event counts as a title edit with no
+ * `changes` payload required (the real shape GitHub emits for a rename),
+ * and `userContentEditsState.timestamps` (GraphQL body-edit timestamps)
+ * feed the same anchor. Returns `null` when either source is unknown --
+ * see {@link UserContentEditsState}'s doc comment for why an *omitted*
+ * `userContentEdits` input does not count as "unknown" here.
+ */
 function resolveLatestSubstantiveEditAt(
   issue: NormalizedIssue,
   timelineState: TimelineState,
+  userContentEditsState: UserContentEditsState,
 ): string | null {
-  if (!timelineState.known) {
+  if (!timelineState.known || !userContentEditsState.known) {
     return null;
   }
   const editedAt = timelineState.events
-    .filter((event) => String(event?.event ?? '') === 'edited')
-    .filter((event) => event?.changes?.title || event?.changes?.body)
+    .filter((event) => {
+      const eventType = String(event?.event ?? '');
+      return (
+        eventType === 'renamed' ||
+        (eventType === 'edited' &&
+          Boolean(event?.changes?.title || event?.changes?.body))
+      );
+    })
     .map((event) => normalizeIso(event?.created_at))
     .filter(Boolean);
-  return maxTimestamp(issue.createdAt, ...editedAt);
+  return maxTimestamp(
+    issue.createdAt,
+    ...editedAt,
+    ...userContentEditsState.timestamps,
+  );
+}
+
+function normalizeUserContentEdits(edits: unknown): UserContentEditsState {
+  if (edits === undefined) {
+    return { known: true, timestamps: [] };
+  }
+  if (!Array.isArray(edits)) {
+    return { known: false, timestamps: [] };
+  }
+  return {
+    known: true,
+    timestamps: edits
+      .map((value) => normalizeIso(value))
+      .filter((value): value is string => value !== null),
+  };
 }
 
 interface NormalizedLabelEvent {
@@ -953,6 +1034,26 @@ function fetchIssueTimeline(
     // being indistinguishable from "no timeline data".
     const parseError = error instanceof SyntaxError ? error.message : '';
     return { known: false, events: [], parseError };
+  }
+}
+
+/** #2762: mirrors {@link fetchIssueTimeline}'s try/catch shape. The CLI
+ * call site below reads `known` before forwarding `timestamps` to
+ * `evaluateClaimApprovalGate` -- unlike `timeline: timelineState.events`
+ * above, which forwards `events` unconditionally and silently loses its
+ * own `known: false` on failure -- so a genuine fetch failure here reaches
+ * the evaluator as the `null` sentinel, never a flattened empty array. */
+function fetchIssueUserContentEdits(
+  port: ProviderPort,
+  issueNumber: number,
+): { known: boolean; timestamps: string[] } {
+  try {
+    return {
+      known: true,
+      timestamps: port.getWorkItemUserContentEditTimestamps(issueNumber),
+    };
+  } catch {
+    return { known: false, timestamps: [] };
   }
 }
 

--- a/src/scripts/discover-orphan-filter.mts
+++ b/src/scripts/discover-orphan-filter.mts
@@ -282,6 +282,17 @@ interface FilterOrphanIssuesOptions {
    * when omitted, which only widens the staleness window (never narrows
    * it), so an absent fetcher cannot itself cause a wrongful skip. */
   fetchTimelineByIssueNumber?: (issueNumber: number) => unknown[];
+  /** #2762: per-candidate GraphQL `userContentEdits.editedAt` fetch for the
+   * same staleness anchor -- the only place GitHub records a body edit (a
+   * REST timeline `edited` event with a `changes.body` payload is never
+   * emitted for a real edit). Defaults to "no timestamps" when omitted,
+   * which only widens the staleness window like
+   * {@link fetchTimelineByIssueNumber} above, never narrows it. Called
+   * inside the same try/catch as the timeline fetch below, so a failure
+   * here degrades the whole anchor to `null` ("unknown") rather than
+   * silently falling back to a partial computation -- never the bare
+   * `created_at` anchor #2762 fixes. */
+  fetchUserContentEditsByIssueNumber?: (issueNumber: number) => unknown[];
   /** #2243: trust-actor allowlist for the triage-verdict marker scan, same
    * semantics as `idd-claim.instructions.md`'s trusted marker actors. */
   trustedMarkerLogins?: string[];
@@ -909,6 +920,10 @@ export async function filterOrphanIssues(
       typeof options.fetchTimelineByIssueNumber === 'function'
         ? options.fetchTimelineByIssueNumber
         : () => [];
+    const fetchUserContentEdits =
+      typeof options.fetchUserContentEditsByIssueNumber === 'function'
+        ? options.fetchUserContentEditsByIssueNumber
+        : () => [];
     const trustedMarkerLogins = options.trustedMarkerLogins;
     const markerPrefix =
       typeof options.markerPrefix === 'string'
@@ -933,10 +948,17 @@ export async function filterOrphanIssues(
       }
       let editedAt: string | null = null;
       if (record?.markerOutcome) {
+        // Both fetches evaluate inside this one try block (#2762): a
+        // failure from EITHER the timeline or the userContentEdits read
+        // degrades the whole anchor to null ("unknown") rather than
+        // computing a partial result from whichever fetch happened to
+        // succeed -- a partial result could still collapse to the bare
+        // `created_at` anchor this issue fixes.
         try {
           editedAt = resolveLatestSubstantiveIssueEditAt(
             issueCreatedAtByNumber.get(orphan.number),
             fetchTimeline(orphan.number),
+            fetchUserContentEdits(orphan.number),
           );
         } catch {
           editedAt = null;
@@ -1082,6 +1104,8 @@ async function runCli() {
       fetchIssueCommentsForTriageVerdict(port, issueNumber),
     fetchTimelineByIssueNumber: (issueNumber) =>
       port.getWorkItemTimeline(issueNumber),
+    fetchUserContentEditsByIssueNumber: (issueNumber) =>
+      port.getWorkItemUserContentEditTimestamps(issueNumber),
     trustedMarkerLogins,
     markerPrefix: policy.markerPrefix,
     authoringLabelName: policy.authoringLabelName,
@@ -1278,7 +1302,10 @@ configured, this check is a no-op and makes no extra GitHub API call.
 Staleness-checked (fail-closed toward NOT excluding): the marker only
 excludes when the rejection comment is at or after the issue's latest
 substantive (title/body) edit, so an issue legitimately improved after
-being rejected stays selectable.
+being rejected stays selectable -- a title edit is a timeline "renamed"
+event, and a body edit is a GraphQL "userContentEdits.editedAt" value
+(#2762); a failed GraphQL read degrades the anchor to unknown rather than
+falling back to created_at.
 
 --with-claim-state (opt-in) annotates each candidate in "orphans" and
 "routed_to_human" with active-claim eligibility, exactly mirroring

--- a/src/scripts/discover-readiness-check.mts
+++ b/src/scripts/discover-readiness-check.mts
@@ -174,6 +174,17 @@ interface EvaluateDiscoverReadinessOptions {
    * when omitted, which only widens the staleness window (never narrows
    * it), so an absent fetcher cannot itself cause a wrongful skip. */
   fetchTimelineByIssueNumber?: (issueNumber: number) => unknown[];
+  /** #2762: per-candidate GraphQL `userContentEdits.editedAt` fetch for the
+   * same staleness anchor -- the only place GitHub records a body edit (a
+   * REST timeline `edited` event with a `changes.body` payload is never
+   * emitted for a real edit). Defaults to "no timestamps" when omitted,
+   * which only widens the staleness window like
+   * {@link fetchTimelineByIssueNumber} above, never narrows it. Called
+   * inside the same try/catch as the timeline fetch below, so a failure
+   * here degrades the whole anchor to `null` ("unknown") rather than
+   * silently falling back to a partial computation -- never the bare
+   * `created_at` anchor #2762 fixes. */
+  fetchUserContentEditsByIssueNumber?: (issueNumber: number) => unknown[];
   /** #2243: trust-actor allowlist for the triage-verdict marker scan, same
    * semantics as `idd-claim.instructions.md`'s trusted marker actors. */
   trustedMarkerLogins?: string[];
@@ -264,6 +275,10 @@ if (import.meta.main) {
     loadIssue: buildIssueLoader(owner, repo),
     fetchCommentsByIssueNumber: buildIssueCommentsLoader(owner, repo),
     fetchTimelineByIssueNumber: buildIssueTimelineLoader(owner, repo),
+    fetchUserContentEditsByIssueNumber: buildIssueUserContentEditsLoader(
+      owner,
+      repo,
+    ),
     trustedMarkerLogins,
     // `--swarm-floor` output never surfaces the stale-authoring warning, so
     // skip the per-issue timeline fetch this loader runs — over a whole-repo
@@ -318,6 +333,7 @@ export async function evaluateDiscoverReadiness(
     now = new Date(),
     fetchCommentsByIssueNumber,
     fetchTimelineByIssueNumber,
+    fetchUserContentEditsByIssueNumber,
     trustedMarkerLogins,
   } = options ?? {};
   const triageVerdictCheckEnabled =
@@ -539,11 +555,20 @@ export async function evaluateDiscoverReadiness(
       }
       let editedAt: string | null = null;
       if (record?.markerOutcome) {
+        // Both fetches evaluate inside this one try block (#2762): a
+        // failure from EITHER the timeline or the userContentEdits read
+        // degrades the whole anchor to null ("unknown") rather than
+        // computing a partial result from whichever fetch happened to
+        // succeed -- a partial result could still collapse to the bare
+        // `created_at` anchor this issue fixes.
         try {
           editedAt = resolveLatestSubstantiveIssueEditAt(
             issue.createdAt,
             typeof fetchTimelineByIssueNumber === 'function'
               ? fetchTimelineByIssueNumber(issue.number)
+              : [],
+            typeof fetchUserContentEditsByIssueNumber === 'function'
+              ? fetchUserContentEditsByIssueNumber(issue.number)
               : [],
           );
         } catch {
@@ -873,7 +898,10 @@ function printHelp() {
   configured (env/flag/repo config); with none configured, this check is a
   no-op and makes no extra GitHub API call. Staleness-checked (fail-closed
   toward NOT excluding): the marker only excludes when the rejection
-  comment is at or after the issue's latest substantive (title/body) edit.
+  comment is at or after the issue's latest substantive (title/body) edit
+  -- a title edit is a timeline "renamed" event, and a body edit is a
+  GraphQL "userContentEdits.editedAt" value (#2762); a failed GraphQL read
+  degrades the anchor to unknown rather than falling back to created_at.
 
 Output schema (JSON mode):
   {
@@ -1112,6 +1140,14 @@ function fetchIssueLabelEvents(port: ProviderPort, issueNumber: number) {
 function buildIssueTimelineLoader(owner: string, repo: string) {
   const port = createGithubProviderAdapter(owner, repo);
   return (issueNumber: number) => port.getWorkItemTimeline(issueNumber);
+}
+
+/** #2762: GraphQL `userContentEdits.editedAt` values, for
+ * {@link resolveLatestSubstantiveIssueEditAt}'s body-edit source. */
+function buildIssueUserContentEditsLoader(owner: string, repo: string) {
+  const port = createGithubProviderAdapter(owner, repo);
+  return (issueNumber: number) =>
+    port.getWorkItemUserContentEditTimestamps(issueNumber);
 }
 
 /**

--- a/src/scripts/provider-adapter-fake.mts
+++ b/src/scripts/provider-adapter-fake.mts
@@ -71,6 +71,9 @@ export interface FakeProviderFixture {
     }
   >;
   timelines?: Record<number, ProviderTimelineEvent[]>;
+  /** Backs {@link ProviderPort.getWorkItemUserContentEditTimestamps}
+   * (#2762): GraphQL `userContentEdits.editedAt` values per issue number. */
+  userContentEditTimestamps?: Record<number, string[]>;
   comments?: Record<number, ProviderComment[]>;
   closingPullRequestPages?: Record<number, ProviderClosingPullRequestsPage[]>;
   connectedPrEventsSingle?: Record<number, ProviderConnectedPrEvent[]>;
@@ -332,6 +335,10 @@ export function createFakeProviderAdapter(
 
     getWorkItemTimeline(number: number): ProviderTimelineEvent[] {
       return fixture.timelines?.[number] ?? [];
+    },
+
+    getWorkItemUserContentEditTimestamps(number: number): string[] {
+      return fixture.userContentEditTimestamps?.[number] ?? [];
     },
 
     getWorkItemState(number: number): string | null {

--- a/src/scripts/provider-adapter-github.mts
+++ b/src/scripts/provider-adapter-github.mts
@@ -776,6 +776,46 @@ export function createGithubProviderAdapter(
       }) as ProviderTimelineEvent[];
     },
 
+    getWorkItemUserContentEditTimestamps(number: number): string[] {
+      const query = `query($owner:String!,$repo:String!,$number:Int!){
+  repository(owner:$owner,name:$repo){
+    issue(number:$number){
+      userContentEdits(last:100){
+        nodes { editedAt }
+      }
+    }
+  }
+}`;
+      const apiArgs = [
+        'api',
+        'graphql',
+        ...graphqlHostnameArgs(),
+        '-f',
+        `query=${query}`,
+        '-f',
+        `owner=${owner}`,
+        '-f',
+        `repo=${repo}`,
+        '-F',
+        `number=${number}`,
+      ];
+      const parsed = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS)) as {
+        data?: {
+          repository?: {
+            issue?: {
+              userContentEdits?: { nodes?: { editedAt?: unknown }[] } | null;
+            } | null;
+          } | null;
+        };
+        errors?: { message?: unknown }[];
+      };
+      assertNoGraphqlErrors(parsed, 'userContentEdits lookup');
+      const nodes = parsed.data?.repository?.issue?.userContentEdits?.nodes;
+      return (nodes ?? [])
+        .map((node) => node?.editedAt)
+        .filter((value): value is string => typeof value === 'string');
+    },
+
     getWorkItemState(number: number): string | null {
       try {
         const state = deps.ghText(

--- a/src/scripts/provider-adapter-github.mts
+++ b/src/scripts/provider-adapter-github.mts
@@ -810,8 +810,23 @@ export function createGithubProviderAdapter(
         errors?: { message?: unknown }[];
       };
       assertNoGraphqlErrors(parsed, 'userContentEdits lookup');
-      const nodes = parsed.data?.repository?.issue?.userContentEdits?.nodes;
-      return (nodes ?? [])
+      // Codex review, PR #2836: reject an absent connection/nodes array
+      // instead of defaulting to `[]` -- a null `issue` (deleted/
+      // inaccessible between the earlier REST fetch and this call), a
+      // null `userContentEdits`, or a payload missing `nodes` entirely
+      // are all genuine read failures, indistinguishable from "zero
+      // edits" if silently coerced to an empty array. Every caller of
+      // this method already treats a throw as "anchor unknown" and
+      // degrades accordingly (never falling back to a bare `created_at`
+      // anchor) -- swallowing this case here would silently reintroduce
+      // that exact failure mode one layer down.
+      const connection = parsed.data?.repository?.issue?.userContentEdits;
+      if (!connection || !Array.isArray(connection.nodes)) {
+        throw new Error(
+          'userContentEdits: issue, connection, or nodes is null/absent',
+        );
+      }
+      return connection.nodes
         .map((node) => node?.editedAt)
         .filter((value): value is string => typeof value === 'string');
     },

--- a/src/scripts/provider-port.mts
+++ b/src/scripts/provider-port.mts
@@ -436,6 +436,19 @@ export interface ProviderPort {
   getWorkItemTimeline(number: number): ProviderTimelineEvent[];
 
   /**
+   * work-items. The GraphQL `Issue.userContentEdits { editedAt }`
+   * read (#2762) -- the only place GitHub records a body edit; a REST
+   * timeline `edited` event with a `changes.body` payload is never emitted
+   * for a real edit. Bounded to the most recent 100 edits (`last: 100`,
+   * not `first`, so a long edit history keeps the newest edits rather than
+   * the oldest -- callers only ever need the latest one). Returns the
+   * `editedAt` values in ascending order as GitHub itself returns them;
+   * throws on any `gh` failure, matching {@link getWorkItemTimeline}'s
+   * throw-on-failure contract rather than swallowing it.
+   */
+  getWorkItemUserContentEditTimestamps(number: number): string[];
+
+  /**
    * work-items. The distinct `gh issue view --json state --jq .state` call
    * shape -- GraphQL-resolved, NOT the REST `issues/{number}` shape
    * {@link getWorkItem} uses. Not interchangeable: empirically, `gh issue

--- a/src/scripts/provider-port.mts
+++ b/src/scripts/provider-port.mts
@@ -436,7 +436,12 @@ export interface ProviderPort {
   getWorkItemTimeline(number: number): ProviderTimelineEvent[];
 
   /**
-   * work-items. The GraphQL `Issue.userContentEdits { editedAt }`
+   * work-items (issues only -- see the file header's `getWorkItem*` vs
+   * `*ChangeRequest*` split; a pull request's own body-edit history is a
+   * separate, unimplemented surface, even though GraphQL's
+   * `userContentEdits` field is not itself issue-exclusive -- both
+   * `Issue` and `PullRequest` implement the underlying `UpdatableComment`
+   * interface). The GraphQL `Issue.userContentEdits { editedAt }`
    * read (#2762) -- the only place GitHub records a body edit; a REST
    * timeline `edited` event with a `changes.body` payload is never emitted
    * for a real edit. Bounded to the most recent 100 edits (`last: 100`,

--- a/src/scripts/supersession-detection.mts
+++ b/src/scripts/supersession-detection.mts
@@ -464,18 +464,26 @@ export function parseSuitabilityTriageVerdictMarker(
 
 /**
  * Staleness anchor for a suitability-rejection marker (#2243): the latest
- * GitHub `created_at` among the issue's own creation and every timeline
- * `edited` event that changed the title or body. Mirrors
- * `claim-approval-gate.mts`'s private `resolveLatestSubstantiveEditAt` --
- * duplicated rather than imported to keep this module's dependency-light,
- * I/O-free kernel contract intact (see the file header). Returns `null`
- * only when neither `issueCreatedAt` nor any qualifying event yields a
- * parseable timestamp -- callers must treat that as "unknown", never as
- * "always stale" or "never stale".
+ * GitHub `created_at` among the issue's own creation, every timeline
+ * `renamed` event (a title edit -- GitHub emits this event shape for a
+ * title change, never an `edited` event with a `changes.title` payload,
+ * #2762), every timeline `edited` event that changed the title or body
+ * (kept for defensive/forward compatibility; not an observed live shape
+ * as of #2762's investigation, see the worked evidence in that issue), and
+ * every timestamp in `bodyEditTimestamps` (GraphQL `Issue.userContentEdits
+ * { editedAt }` values -- the only place GitHub records a body edit,
+ * #2762). Mirrors `claim-approval-gate.mts`'s private
+ * `resolveLatestSubstantiveEditAt` -- duplicated rather than imported to
+ * keep this module's dependency-light, I/O-free kernel contract intact
+ * (see the file header). Returns `null` only when neither
+ * `issueCreatedAt` nor any qualifying event/timestamp yields a parseable
+ * value -- callers must treat that as "unknown", never as "always stale"
+ * or "never stale".
  */
 export function resolveLatestSubstantiveIssueEditAt(
   issueCreatedAt: unknown,
   timelineEvents: unknown,
+  bodyEditTimestamps?: unknown,
 ): string | null {
   const candidates: string[] = [];
   if (typeof issueCreatedAt === 'string' && issueCreatedAt) {
@@ -488,14 +496,23 @@ export function resolveLatestSubstantiveIssueEditAt(
         created_at?: unknown;
         changes?: { title?: unknown; body?: unknown } | null;
       };
-      if (String(event.event ?? '') !== 'edited') {
-        continue;
-      }
-      if (!event.changes?.title && !event.changes?.body) {
+      const eventType = String(event.event ?? '');
+      const isRenamed = eventType === 'renamed';
+      const isEditedTitleOrBody =
+        eventType === 'edited' &&
+        Boolean(event.changes?.title || event.changes?.body);
+      if (!isRenamed && !isEditedTitleOrBody) {
         continue;
       }
       if (typeof event.created_at === 'string' && event.created_at) {
         candidates.push(event.created_at);
+      }
+    }
+  }
+  if (Array.isArray(bodyEditTimestamps)) {
+    for (const raw of bodyEditTimestamps) {
+      if (typeof raw === 'string' && raw) {
+        candidates.push(raw);
       }
     }
   }

--- a/tests/claim-approval-gate.test.mts
+++ b/tests/claim-approval-gate.test.mts
@@ -354,6 +354,138 @@ test('event-freshness label approval fails closed when label events are unavaila
   assert.equal(findCheck(result, 'ambiguity_guard')?.result, 'fail');
 });
 
+// #2762: the same freshness anchor also needs to see a `renamed` timeline
+// event and a GraphQL `userContentEdits` timestamp -- the real shapes
+// GitHub emits for a title/body edit, neither of which the pre-#2762
+// anchor recognized.
+
+test('event-freshness label approval becomes stale after a renamed (title) event (#2762)', () => {
+  const result = evaluateClaimApprovalGate(
+    {
+      issue: { ...BASE_ISSUE, labels: [{ name: 'custom:ready' }] },
+      policy: {
+        approvalSignals: {
+          readyLabelName: 'custom:ready',
+          labelFreshnessMode: 'event-freshness',
+        },
+      },
+      timeline: [
+        {
+          event: 'labeled',
+          created_at: '2026-05-10T09:00:00Z',
+          label: { name: 'custom:ready' },
+        },
+        // The real shape GitHub emits for a title edit: no `changes`
+        // payload at all.
+        { event: 'renamed', created_at: '2026-05-10T10:00:00Z' },
+      ],
+      comments: [],
+    },
+    {
+      resolvePermission: permissionResolver({
+        author: { known: true, permission: 'none' },
+      }),
+    },
+  );
+  assert.equal(result.approved, false);
+  assert.equal(result.reason, 'approval-missing');
+  assert.match(
+    findCheck(result, 'ready_label_present')?.evidence ?? '',
+    /last applied at 2026-05-10T09:00:00Z; freshness anchor is 2026-05-10T10:00:00Z/,
+  );
+});
+
+test('event-freshness label approval becomes stale via a GraphQL userContentEdits timestamp when the REST timeline has no edited event (#2762)', () => {
+  const result = evaluateClaimApprovalGate(
+    {
+      issue: { ...BASE_ISSUE, labels: [{ name: 'custom:ready' }] },
+      policy: {
+        approvalSignals: {
+          readyLabelName: 'custom:ready',
+          labelFreshnessMode: 'event-freshness',
+        },
+      },
+      timeline: [
+        {
+          event: 'labeled',
+          created_at: '2026-05-10T09:00:00Z',
+          label: { name: 'custom:ready' },
+        },
+      ],
+      userContentEdits: ['2026-05-10T10:00:00Z'],
+      comments: [],
+    },
+    {
+      resolvePermission: permissionResolver({
+        author: { known: true, permission: 'none' },
+      }),
+    },
+  );
+  assert.equal(result.approved, false);
+  assert.equal(result.reason, 'approval-missing');
+  assert.match(
+    findCheck(result, 'ready_label_present')?.evidence ?? '',
+    /last applied at 2026-05-10T09:00:00Z; freshness anchor is 2026-05-10T10:00:00Z/,
+  );
+});
+
+test('a failed userContentEdits read makes freshness undetermined, never falling back to created_at (#2762)', () => {
+  const result = evaluateClaimApprovalGate(
+    {
+      issue: { ...BASE_ISSUE, labels: [{ name: 'custom:ready' }] },
+      policy: {
+        approvalSignals: {
+          readyLabelName: 'custom:ready',
+          labelFreshnessMode: 'event-freshness',
+        },
+      },
+      timeline: BASE_TIMELINE,
+      // The CLI's explicit failure sentinel for a failed GraphQL read --
+      // not an omitted field, which normalizes to known-empty instead.
+      userContentEdits: null,
+      comments: [],
+    },
+    {
+      resolvePermission: permissionResolver({
+        author: { known: true, permission: 'none' },
+      }),
+    },
+  );
+  assert.equal(result.approved, false);
+  assert.equal(result.reason, 'freshness-undetermined');
+  assert.equal(findCheck(result, 'ambiguity_guard')?.result, 'fail');
+});
+
+test('an omitted userContentEdits input is backward-compatible: known-empty, not unknown (#2762)', () => {
+  const result = evaluateClaimApprovalGate(
+    {
+      issue: { ...BASE_ISSUE, labels: [{ name: 'custom:ready' }] },
+      policy: {
+        approvalSignals: {
+          readyLabelName: 'custom:ready',
+          labelFreshnessMode: 'event-freshness',
+        },
+      },
+      timeline: [
+        ...BASE_TIMELINE,
+        {
+          event: 'labeled',
+          created_at: '2026-05-10T12:00:00Z',
+          label: { name: 'custom:ready' },
+        },
+      ],
+      comments: [],
+    },
+    {
+      resolvePermission: permissionResolver({
+        author: { known: true, permission: 'none' },
+      }),
+    },
+  );
+  assert.equal(result.approved, true);
+  assert.equal(result.reason, 'ready-label-present');
+});
+
 test('ready comment must be exact or standalone line and fresh', () => {
   const result = evaluateClaimApprovalGate(
     {

--- a/tests/discover-orphan-filter.test.mts
+++ b/tests/discover-orphan-filter.test.mts
@@ -1916,3 +1916,44 @@ test('a throwing timeline fetcher fails open: the candidate stays selectable (Co
   assert.equal(result.orphans.length, 1);
   assert.equal(result.filtered.triage_verdict_rejected.length, 0);
 });
+
+// #2762: parity coverage for the same anchor extension already tested in
+// discover-readiness-check.test.mts -- this file's triage-verdict call
+// site takes the identical two-fetcher shape.
+
+test('a stale marker becomes ready again via userContentEdits when the REST timeline has no edited event (#2738 fixture, #2762)', async () => {
+  const issues = [triageVerdictIssue()];
+  const result = await filterOrphanIssues(issues, {
+    issueStateByNumber: new Map(),
+    fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    fetchCommentsByIssueNumber: () => [
+      triageVerdictRejectionComment('duplicate', '2026-08-05T00:00:00Z'),
+    ],
+    fetchTimelineByIssueNumber: () => [
+      { event: 'commented', created_at: '2026-08-06T00:00:00Z' },
+      { event: 'labeled', created_at: '2026-08-07T00:00:00Z' },
+    ],
+    fetchUserContentEditsByIssueNumber: () => ['2026-08-12T00:00:00Z'],
+    trustedMarkerLogins: ['kurone-kito'],
+  });
+  assert.equal(result.orphans.length, 1);
+  assert.equal(result.filtered.triage_verdict_rejected.length, 0);
+});
+
+test('a throwing userContentEdits fetcher fails open: the candidate stays selectable, never falling back to createdAt (#2762)', async () => {
+  const issues = [triageVerdictIssue()];
+  const result = await filterOrphanIssues(issues, {
+    issueStateByNumber: new Map(),
+    fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    fetchCommentsByIssueNumber: () => [
+      triageVerdictRejectionComment('duplicate', '2026-08-10T00:00:00Z'),
+    ],
+    fetchTimelineByIssueNumber: () => [],
+    fetchUserContentEditsByIssueNumber: () => {
+      throw new Error('transient GitHub GraphQL failure');
+    },
+    trustedMarkerLogins: ['kurone-kito'],
+  });
+  assert.equal(result.orphans.length, 1);
+  assert.equal(result.filtered.triage_verdict_rejected.length, 0);
+});

--- a/tests/discover-orphan-filter.test.mts
+++ b/tests/discover-orphan-filter.test.mts
@@ -1940,6 +1940,32 @@ test('a stale marker becomes ready again via userContentEdits when the REST time
   assert.equal(result.filtered.triage_verdict_rejected.length, 0);
 });
 
+// E2 critique (PR #2836): the positive case above only proves a LATER
+// userContentEdits signal clears staleness -- also prove the negative:
+// an EARLIER one must not, end to end through this file's own pipeline.
+
+test('a userContentEdits timestamp before the rejection leaves the marker current (negative case, #2762)', async () => {
+  const issues = [triageVerdictIssue()];
+  const result = await filterOrphanIssues(issues, {
+    issueStateByNumber: new Map(),
+    fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    fetchCommentsByIssueNumber: () => [
+      triageVerdictRejectionComment('duplicate', '2026-08-10T00:00:00Z'),
+    ],
+    fetchTimelineByIssueNumber: () => [],
+    // The body edit landed BEFORE the rejection -- the marker is still
+    // current.
+    fetchUserContentEditsByIssueNumber: () => ['2026-08-05T00:00:00Z'],
+    trustedMarkerLogins: ['kurone-kito'],
+  });
+  assert.equal(result.orphans.length, 0);
+  assert.equal(result.filtered.triage_verdict_rejected.length, 1);
+  assert.equal(
+    result.filtered.triage_verdict_rejected[0]?.details,
+    'duplicate',
+  );
+});
+
 test('a throwing userContentEdits fetcher fails open: the candidate stays selectable, never falling back to createdAt (#2762)', async () => {
   const issues = [triageVerdictIssue()];
   const result = await filterOrphanIssues(issues, {

--- a/tests/discover-readiness-check.test.mts
+++ b/tests/discover-readiness-check.test.mts
@@ -1559,3 +1559,79 @@ test('a throwing timeline fetcher fails open: the candidate stays ready (CodeRab
   assert.equal(summary.ready.length, 1);
   assert.equal(summary.filteredOut.length, 0);
 });
+
+// #2762: the anchor also needs to see a `renamed` timeline event and a
+// GraphQL `userContentEdits` body-edit timestamp -- neither of which the
+// pre-#2762 anchor recognized, so a rejection comment predating either
+// stayed wrongly "current" forever.
+
+test('a stale marker (issue renamed after the rejection) leaves the candidate ready (#2762)', async () => {
+  const issue = triageVerdictReadinessIssue();
+  const summary = await evaluateDiscoverReadiness([1901], {
+    loadIssue: async () => issue,
+    findRoadmapsByMarker: async () => [],
+    fetchCommentsByIssueNumber: () => [
+      triageVerdictReadinessRejectionComment(
+        'duplicate',
+        '2026-08-05T00:00:00Z',
+      ),
+    ],
+    // A title rename landed AFTER the rejection comment, with no
+    // `changes` payload -- the real shape GitHub emits for a rename.
+    fetchTimelineByIssueNumber: () => [
+      { event: 'renamed', created_at: '2026-08-12T00:00:00Z' },
+    ],
+    trustedMarkerLogins: ['kurone-kito'],
+  });
+  assert.equal(summary.ready.length, 1);
+  assert.equal(summary.filteredOut.length, 0);
+});
+
+// #2738 fixture reproduction: a REST timeline carrying zero qualifying
+// `edited` events (only `commented`/`cross-referenced`/`labeled`/
+// `referenced`/`unlabeled`, matching #2738's live shape) alongside a
+// GraphQL `userContentEdits` read that reports a later body edit. Before
+// #2762, this anchor collapsed to the issue's own createdAt and the
+// candidate stayed wrongly excluded forever.
+test('a stale marker becomes ready again via userContentEdits when the REST timeline has no edited event (#2738 fixture, #2762)', async () => {
+  const issue = triageVerdictReadinessIssue();
+  const summary = await evaluateDiscoverReadiness([1901], {
+    loadIssue: async () => issue,
+    findRoadmapsByMarker: async () => [],
+    fetchCommentsByIssueNumber: () => [
+      triageVerdictReadinessRejectionComment(
+        'duplicate',
+        '2026-08-05T00:00:00Z',
+      ),
+    ],
+    fetchTimelineByIssueNumber: () => [
+      { event: 'commented', created_at: '2026-08-06T00:00:00Z' },
+      { event: 'labeled', created_at: '2026-08-07T00:00:00Z' },
+    ],
+    fetchUserContentEditsByIssueNumber: () => ['2026-08-12T00:00:00Z'],
+    trustedMarkerLogins: ['kurone-kito'],
+  });
+  assert.equal(summary.ready.length, 1);
+  assert.equal(summary.filteredOut.length, 0);
+});
+
+test('a throwing userContentEdits fetcher fails open: the candidate stays ready, never falling back to createdAt (#2762)', async () => {
+  const issue = triageVerdictReadinessIssue();
+  const summary = await evaluateDiscoverReadiness([1901], {
+    loadIssue: async () => issue,
+    findRoadmapsByMarker: async () => [],
+    fetchCommentsByIssueNumber: () => [
+      triageVerdictReadinessRejectionComment(
+        'duplicate',
+        '2026-08-10T00:00:00Z',
+      ),
+    ],
+    fetchTimelineByIssueNumber: () => [],
+    fetchUserContentEditsByIssueNumber: () => {
+      throw new Error('transient GitHub GraphQL failure');
+    },
+    trustedMarkerLogins: ['kurone-kito'],
+  });
+  assert.equal(summary.ready.length, 1);
+  assert.equal(summary.filteredOut.length, 0);
+});

--- a/tests/discover-readiness-check.test.mts
+++ b/tests/discover-readiness-check.test.mts
@@ -1615,6 +1615,58 @@ test('a stale marker becomes ready again via userContentEdits when the REST time
   assert.equal(summary.filteredOut.length, 0);
 });
 
+// E2 critique (PR #2836): the positive cases above only prove a LATER
+// renamed/userContentEdits signal clears staleness -- also prove the
+// negative: an EARLIER one must not, end to end through the same
+// pipeline, not just at the pure resolveLatestSubstantiveIssueEditAt
+// level (already covered in supersession-detection.test.mts).
+
+test('a renamed event before the rejection leaves the marker current (negative case, #2762)', async () => {
+  const issue = triageVerdictReadinessIssue();
+  const summary = await evaluateDiscoverReadiness([1901], {
+    loadIssue: async () => issue,
+    findRoadmapsByMarker: async () => [],
+    fetchCommentsByIssueNumber: () => [
+      triageVerdictReadinessRejectionComment(
+        'duplicate',
+        '2026-08-10T00:00:00Z',
+      ),
+    ],
+    // The rename landed BEFORE the rejection -- the marker is still current.
+    fetchTimelineByIssueNumber: () => [
+      { event: 'renamed', created_at: '2026-08-05T00:00:00Z' },
+    ],
+    trustedMarkerLogins: ['kurone-kito'],
+  });
+  assert.equal(summary.ready.length, 0);
+  assert.deepEqual(summary.filteredOut[0]?.reasons, [
+    'triage_verdict:duplicate',
+  ]);
+});
+
+test('a userContentEdits timestamp before the rejection leaves the marker current (negative case, #2762)', async () => {
+  const issue = triageVerdictReadinessIssue();
+  const summary = await evaluateDiscoverReadiness([1901], {
+    loadIssue: async () => issue,
+    findRoadmapsByMarker: async () => [],
+    fetchCommentsByIssueNumber: () => [
+      triageVerdictReadinessRejectionComment(
+        'duplicate',
+        '2026-08-10T00:00:00Z',
+      ),
+    ],
+    fetchTimelineByIssueNumber: () => [],
+    // The body edit landed BEFORE the rejection -- the marker is still
+    // current.
+    fetchUserContentEditsByIssueNumber: () => ['2026-08-05T00:00:00Z'],
+    trustedMarkerLogins: ['kurone-kito'],
+  });
+  assert.equal(summary.ready.length, 0);
+  assert.deepEqual(summary.filteredOut[0]?.reasons, [
+    'triage_verdict:duplicate',
+  ]);
+});
+
 test('a throwing userContentEdits fetcher fails open: the candidate stays ready, never falling back to createdAt (#2762)', async () => {
   const issue = triageVerdictReadinessIssue();
   const summary = await evaluateDiscoverReadiness([1901], {

--- a/tests/provider-adapter-github.test.mts
+++ b/tests/provider-adapter-github.test.mts
@@ -391,6 +391,108 @@ test('getWorkItemClosingPullRequestsPage throws when the connection itself is nu
   );
 });
 
+// ---------------------------------------------------------------------------
+// getWorkItemUserContentEditTimestamps (#2762). Codex review, PR #2836: the
+// pre-fix implementation defaulted a null/absent `issue`, `userContentEdits`
+// connection, or missing `nodes` to an empty array -- indistinguishable from
+// a genuinely edit-free issue. Every caller of this method treats a throw as
+// "anchor unknown" and degrades accordingly (never falling back to the bare
+// `created_at` anchor #2762 fixes), so silently coercing a real read failure
+// to `[]` here would reintroduce that exact bug one layer down. Mirrors
+// getWorkItemClosingPullRequestsPage's own null-node/null-connection tests
+// above.
+// ---------------------------------------------------------------------------
+
+test('getWorkItemUserContentEditTimestamps returns editedAt values in order', () => {
+  const port = createGithubProviderAdapter(
+    'kurone-kito',
+    'idd-skill',
+    fakeDeps({
+      ghText: () =>
+        JSON.stringify({
+          data: {
+            repository: {
+              issue: {
+                userContentEdits: {
+                  nodes: [
+                    { editedAt: '2026-09-08T15:16:28Z' },
+                    { editedAt: '2026-09-09T01:08:31Z' },
+                  ],
+                },
+              },
+            },
+          },
+        }),
+    }),
+  );
+  assert.deepEqual(port.getWorkItemUserContentEditTimestamps(2738), [
+    '2026-09-08T15:16:28Z',
+    '2026-09-09T01:08:31Z',
+  ]);
+});
+
+test('getWorkItemUserContentEditTimestamps returns an empty array for a genuinely empty connection', () => {
+  const port = createGithubProviderAdapter(
+    'kurone-kito',
+    'idd-skill',
+    fakeDeps({
+      ghText: () =>
+        JSON.stringify({
+          data: { repository: { issue: { userContentEdits: { nodes: [] } } } },
+        }),
+    }),
+  );
+  assert.deepEqual(port.getWorkItemUserContentEditTimestamps(2738), []);
+});
+
+test('getWorkItemUserContentEditTimestamps throws when the issue node is null/absent', () => {
+  const port = createGithubProviderAdapter(
+    'kurone-kito',
+    'idd-skill',
+    fakeDeps({
+      ghText: () => JSON.stringify({ data: { repository: { issue: null } } }),
+    }),
+  );
+  assert.throws(
+    () => port.getWorkItemUserContentEditTimestamps(2738),
+    /connection, or nodes is null\/absent/,
+  );
+});
+
+test('getWorkItemUserContentEditTimestamps throws when the userContentEdits connection itself is null/absent', () => {
+  const port = createGithubProviderAdapter(
+    'kurone-kito',
+    'idd-skill',
+    fakeDeps({
+      ghText: () =>
+        JSON.stringify({
+          data: { repository: { issue: { userContentEdits: null } } },
+        }),
+    }),
+  );
+  assert.throws(
+    () => port.getWorkItemUserContentEditTimestamps(2738),
+    /connection, or nodes is null\/absent/,
+  );
+});
+
+test('getWorkItemUserContentEditTimestamps throws when nodes is missing from an otherwise-present connection', () => {
+  const port = createGithubProviderAdapter(
+    'kurone-kito',
+    'idd-skill',
+    fakeDeps({
+      ghText: () =>
+        JSON.stringify({
+          data: { repository: { issue: { userContentEdits: {} } } },
+        }),
+    }),
+  );
+  assert.throws(
+    () => port.getWorkItemUserContentEditTimestamps(2738),
+    /connection, or nodes is null\/absent/,
+  );
+});
+
 test('getConnectedPullRequestEventsPage returns a normal page', () => {
   const port = createGithubProviderAdapter(
     'kurone-kito',

--- a/tests/supersession-detection.test.mts
+++ b/tests/supersession-detection.test.mts
@@ -1271,6 +1271,9 @@ test('resolveLatestSubstantiveIssueEditAt: a later body edit wins over createdAt
   assert.equal(result, '2026-08-10T00:00:00Z');
 });
 
+// This `edited`+`changes.title` shape is defensive/forward-compatible
+// coverage only -- #2762's live investigation found GitHub never actually
+// emits it; a real title edit arrives as the `renamed` event below.
 test('resolveLatestSubstantiveIssueEditAt: a title edit counts too', () => {
   const result = resolveLatestSubstantiveIssueEditAt('2026-08-01T00:00:00Z', [
     {
@@ -1280,6 +1283,49 @@ test('resolveLatestSubstantiveIssueEditAt: a title edit counts too', () => {
     },
   ]);
   assert.equal(result, '2026-08-10T00:00:00Z');
+});
+
+test('resolveLatestSubstantiveIssueEditAt: a renamed event counts as a title edit, no `changes` payload needed (#2762)', () => {
+  const result = resolveLatestSubstantiveIssueEditAt('2026-08-01T00:00:00Z', [
+    { event: 'renamed', created_at: '2026-08-10T00:00:00Z' },
+  ]);
+  assert.equal(result, '2026-08-10T00:00:00Z');
+});
+
+test('resolveLatestSubstantiveIssueEditAt: a later GraphQL userContentEdits timestamp wins over createdAt (#2762)', () => {
+  const result = resolveLatestSubstantiveIssueEditAt(
+    '2026-08-01T00:00:00Z',
+    [],
+    ['2026-09-09T01:08:31Z'],
+  );
+  assert.equal(result, '2026-09-09T01:08:31Z');
+});
+
+test('resolveLatestSubstantiveIssueEditAt: the later of a renamed event and a userContentEdits timestamp wins (#2762)', () => {
+  const result = resolveLatestSubstantiveIssueEditAt(
+    '2026-08-01T00:00:00Z',
+    [{ event: 'renamed', created_at: '2026-08-05T00:00:00Z' }],
+    ['2026-08-12T00:00:00Z'],
+  );
+  assert.equal(result, '2026-08-12T00:00:00Z');
+});
+
+test('resolveLatestSubstantiveIssueEditAt: a malformed (non-array) bodyEditTimestamps argument is ignored, not thrown (#2762)', () => {
+  const result = resolveLatestSubstantiveIssueEditAt(
+    '2026-08-01T00:00:00Z',
+    [],
+    'not-an-array',
+  );
+  assert.equal(result, '2026-08-01T00:00:00Z');
+});
+
+test('resolveLatestSubstantiveIssueEditAt: non-string entries in bodyEditTimestamps are ignored (#2762)', () => {
+  const result = resolveLatestSubstantiveIssueEditAt(
+    '2026-08-01T00:00:00Z',
+    [],
+    [null, 42, {}, '2026-08-15T00:00:00Z'],
+  );
+  assert.equal(result, '2026-08-15T00:00:00Z');
 });
 
 test('resolveLatestSubstantiveIssueEditAt: a non-body/title event (e.g. labeled) is ignored', () => {


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

The `#2243` staleness anchor that decides whether a trusted A4.5
suitability-rejection marker is still current only scanned REST timeline
`edited` events with a `changes.title`/`changes.body` payload. GitHub
never emits that shape for a real edit: a title change arrives as a
`renamed` event with no `changes` payload, and a body change is recorded
only via GraphQL `Issue.userContentEdits`. So the anchor silently
collapsed to the issue's own `created_at` forever, and a Groom-rewritten
candidate stayed excluded from Discover no matter how thoroughly its
body was rewritten -- this was worked around once, by hand, on issue
`#2738`.

This PR:

- Extends `resolveLatestSubstantiveIssueEditAt`
  (`src/scripts/supersession-detection.mts`) to also recognize a
  `renamed` timeline event and an optional list of GraphQL
  `userContentEdits.editedAt` timestamps.
- Adds a `getWorkItemUserContentEditTimestamps` read to `ProviderPort`
  and its GitHub/fake adapters (bounded to the most recent 100 edits via
  `last: 100`, verified against live GitHub state against issue `#2738`
  itself during implementation).
- Threads the new signal through `discover-readiness-check.mts` and
  `discover-orphan-filter.mts`'s triage-verdict staleness checks, and
  `claim-approval-gate.mts`'s duplicate staleness anchor for A3.5
  approval-signal freshness. Both Discover call sites fetch the new
  GraphQL signal inside the same `try`/`catch` as the existing timeline
  fetch, so a failed read degrades the whole anchor to "unknown" rather
  than computing a partial result that could still collapse back to the
  bare `created_at` this PR fixes.
- Adds unit tests covering the `renamed` event, the GraphQL timestamp, a
  malformed/failed-read fallback, and a fixture reproducing issue
  `#2738`'s exact live shape (REST timeline with zero qualifying `edited`
  events, GraphQL `userContentEdits` reporting a later edit) against
  `discover-readiness-check`.

## Linked issue

Closes #2762

## Follow-up issues (if any)

- [ ] none

`claim-approval-gate.mts`'s CLI wiring already had a pre-existing,
unrelated defect independent of this PR: `timeline:
timelineState.events` forwards only the fetched events array, not the
fetch's own `known` flag, so a live REST timeline-fetch failure
silently reads as "known, zero events" today rather than "unknown" --
the exact flattening hazard this PR's own `userContentEdits` wiring
deliberately avoids (it forwards the raw fetch result, `string[]` or
the `null` failure sentinel, unflattened). Not fixed here: it is not
named in the issue's Candidate files, and folding it in would make this
commit non-atomic. Recommending it as a follow-up rather than filing it
now, since it needs its own analysis of the CLI-to-evaluator boundary
contract.

## Background / rationale (if material)

An independent critique pass (Agent tool, `general-purpose`) reviewed
the implementation plan before coding started; its findings (a
sentinel-flattening risk in the CLI wiring, the `last`-vs-`first`
pagination direction, and a few doc/comment polish items) are folded
into the diff -- see the plan-refinement comment on the issue for the
full critique.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (only pre-existing, unrelated warnings)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdQ5SPdFLaDGus5PNdBUhw
