### PR TITLE
docs(idd-pr-submit): name the live-operator-directed side-fix path in D3

### DIFF
--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -214,6 +214,9 @@ and the side-fix branch's commit messages must not contain a closing
 keyword referencing it — still run D3.5 step 6's exact-set comparison
 and step 7's commit-message scan to confirm both, treating the
 originating issue as outside the side-fix PR's deliberate closing set.
+On a non-default `{development-branch}`, D3.5's own skip rule applies
+unchanged instead: skip all seven steps, since `closingIssuesReferences`
+never populates there regardless of this carve-out.
 
 While a side-fix PR that the claimed issue's PR depends on is in
 flight, periodically re-check the claimed issue's own PR review and CI

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -185,23 +185,40 @@ an immediate fix for a blocking bug unrelated to the claimed work, the
 session may proceed with that fix under the operator's live authority
 instead of routing it through the `issue-authoring` skill first.
 Minimum provenance: the side-fix PR body must cross-reference the
-originating claimed issue using a **non-closing** keyword (for
-example, `Refs #<claimed-issue-number>` — never
-`Closes`/`Fixes`/`Resolves`, which would auto-close the originating
+originating claimed issue using a **non-closing cross-reference** (for
+example, `Refs #<claimed-issue-number>` — never a closing keyword such
+as `Closes`/`Fixes`/`Resolves`, which would auto-close the originating
 issue on the side-fix's own merge). Formal `issue-authoring` tracking
 is still preferred when time allows, but it is not a start blocker for
 this carve-out.
+
+The side-fix has no claimed issue of its own to route through A5/B1,
+so create it on a fresh sibling worktree on a branch that does **not**
+match the `issue/<number>-*` pattern (cut from
+`origin/{development-branch}`, named for example
+`side-fix/<short-slug>`) — never on the originating claim's own
+worktree/branch, and never through the normal A5 claim flow. Because
+the branch does not match `issue/*`, it falls outside both the shared
+claim revalidation gate's cwd-vs-claim check
+(`idd-overview-core.instructions.md`) and A5 pre-check (e)'s
+orphaned-branch hold, so no second claim is needed or possible for it;
+the shared claim revalidation gate and D2 step 1 above keep applying,
+unchanged, to mutations for the originating claim from its own
+worktree. If the side-fix instead deserves its own tracked issue, file
+it through the `issue-authoring` skill and follow the normal A5/B1
+claim and worktree flow for that issue instead of this carve-out.
 
 D3's closing-keyword requirement and D3.5's presence-detection and
 auto-injection (steps 1-5, including step 4) apply only to the
 side-fix PR's own deliberate closing set — its own linked issue, if
 any, or none otherwise — never to the originating claimed issue named
 above; do not let them treat the non-closing cross-reference above as
-missing, or rewrite it into a closing keyword. Still run D3.5 step 6's
-exact-set comparison and step 7's commit-message scan against the
-originating claimed issue's number too, treating it as outside the
-side-fix PR's deliberate closing set — the same stray-keyword safety
-nets D3.5 already applies to every issue outside that set.
+missing, or rewrite it into a closing keyword. The originating claimed
+issue must not appear in the side-fix PR's `closingIssuesReferences`,
+and the side-fix branch's commit messages must not contain a closing
+keyword referencing it — still run D3.5 step 6's exact-set comparison
+and step 7's commit-message scan to confirm both, treating the
+originating issue as outside the side-fix PR's deliberate closing set.
 
 While a side-fix PR that the claimed issue's PR depends on is in
 flight, periodically re-check the claimed issue's own PR review and CI

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -176,6 +176,38 @@ follow-up is important enough to file in-repo now, invoke the
 `issue-authoring` skill (its Stage 1 hold) instead of improvising a
 body. Do not add a parallel "worker-lite authoring" contract.
 
+### Live-operator-directed immediate-fix carve-out
+
+The "never call `gh issue create`" rule immediately above assumes
+unattended execution with no live operator present. When a live
+operator is present during a claimed issue's own execution and directs
+an immediate fix for a blocking bug unrelated to the claimed work, the
+session may proceed with that fix under the operator's live authority
+instead of routing it through the `issue-authoring` skill first.
+Minimum provenance: the side-fix PR body must cross-reference the
+originating claimed issue using a **non-closing** keyword (for
+example, `Refs #<claimed-issue-number>` — never
+`Closes`/`Fixes`/`Resolves`, which would auto-close the originating
+issue on the side-fix's own merge). Formal `issue-authoring` tracking
+is still preferred when time allows, but it is not a start blocker for
+this carve-out.
+
+D3's closing-keyword requirement and D3.5's presence-detection and
+auto-injection (steps 1-5, including step 4) apply only to the
+side-fix PR's own deliberate closing set — its own linked issue, if
+any, or none otherwise — never to the originating claimed issue named
+above; do not let them treat the non-closing cross-reference above as
+missing, or rewrite it into a closing keyword. Still run D3.5 step 6's
+exact-set comparison and step 7's commit-message scan against the
+originating claimed issue's number too, treating it as outside the
+side-fix PR's deliberate closing set — the same stray-keyword safety
+nets D3.5 already applies to every issue outside that set.
+
+While a side-fix PR that the claimed issue's PR depends on is in
+flight, periodically re-check the claimed issue's own PR review and CI
+state — unresolved review threads and failing checks — rather than
+discovering that backlog only after the side-fix merges.
+
 ### D3.6 — Derive the IDD impact checklist
 
 Skip this sub-step and D3.7 below entirely when

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -192,21 +192,16 @@ issue on the side-fix's own merge). Formal `issue-authoring` tracking
 is still preferred when time allows, but it is not a start blocker for
 this carve-out.
 
-The side-fix has no claimed issue of its own to route through A5/B1,
-so create it on a fresh sibling worktree on a branch that does **not**
-match the `issue/<number>-*` pattern (cut from
-`origin/{development-branch}`, named for example
-`side-fix/<short-slug>`) — never on the originating claim's own
-worktree/branch, and never through the normal A5 claim flow. Because
-the branch does not match `issue/*`, it falls outside both the shared
-claim revalidation gate's cwd-vs-claim check
-(`idd-overview-core.instructions.md`) and A5 pre-check (e)'s
-orphaned-branch hold, so no second claim is needed or possible for it;
-the shared claim revalidation gate and D2 step 1 above keep applying,
-unchanged, to mutations for the originating claim from its own
-worktree. If the side-fix instead deserves its own tracked issue, file
-it through the `issue-authoring` skill and follow the normal A5/B1
-claim and worktree flow for that issue instead of this carve-out.
+How the executing session obtains a branch, worktree, and claim for
+the side-fix while the originating claim stays active — and how the
+side-fix's own merge and cleanup avoid releasing that originating
+claim — is not yet defined. The shared claim revalidation gate
+(`idd-overview-core.instructions.md`) scopes its cwd-vs-claim check off
+the active claim's recorded `branch:` field, not the mutation's target
+branch, so no branch-naming convention alone exempts a same-session
+side-fix from it. Treat this as an open gap: this carve-out authorizes
+the _decision_ to proceed under live authority; the operator directing
+it owns the mechanics until a follow-up defines them.
 
 D3's closing-keyword requirement and D3.5's presence-detection and
 auto-injection (steps 1-5, including step 4) apply only to the

--- a/.github/instructions/lite/idd-pr-submit-lite.instructions.md
+++ b/.github/instructions/lite/idd-pr-submit-lite.instructions.md
@@ -242,6 +242,17 @@ loop instead of returning to this D1 rebase path.
    create` (or the REST issues API) yourself. Recommended follow-ups
    stay in the PR body prose above; if one is important enough to file
    now, invoke the `issue-authoring` skill instead.
+9. **Live-operator-directed immediate-fix carve-out**: a live operator
+   may direct an immediate fix for a blocking bug unrelated to the
+   claimed work instead of routing it through `issue-authoring` first.
+   Cross-reference the originating claimed issue in the side-fix PR
+   body with a non-closing reference (`Refs #N`, never
+   `Closes`/`Fixes`/`Resolves`) — D3.5 below applies only to the
+   side-fix's own linked issue, if any, never to the originating one.
+   How the session obtains a branch/worktree/claim for the side-fix,
+   and how its own completion avoids releasing the originating claim,
+   is not yet defined (see `idd-pr-submit.instructions.md`'s matching
+   carve-out).
 
 ### D3.5 — Verify closing keyword detection
 

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -171,6 +171,38 @@ follow-up is important enough to file in-repo now, invoke the
 `issue-authoring` skill (its Stage 1 hold) instead of improvising a
 body. Do not add a parallel "worker-lite authoring" contract.
 
+### Live-operator-directed immediate-fix carve-out
+
+The "never call `gh issue create`" rule immediately above assumes
+unattended execution with no live operator present. When a live
+operator is present during a claimed issue's own execution and directs
+an immediate fix for a blocking bug unrelated to the claimed work, the
+session may proceed with that fix under the operator's live authority
+instead of routing it through the `issue-authoring` skill first.
+Minimum provenance: the side-fix PR body must cross-reference the
+originating claimed issue using a **non-closing** keyword (for
+example, `Refs #<claimed-issue-number>` — never
+`Closes`/`Fixes`/`Resolves`, which would auto-close the originating
+issue on the side-fix's own merge). Formal `issue-authoring` tracking
+is still preferred when time allows, but it is not a start blocker for
+this carve-out.
+
+D3's closing-keyword requirement and D3.5's presence-detection and
+auto-injection (steps 1-5, including step 4) apply only to the
+side-fix PR's own deliberate closing set — its own linked issue, if
+any, or none otherwise — never to the originating claimed issue named
+above; do not let them treat the non-closing cross-reference above as
+missing, or rewrite it into a closing keyword. Still run D3.5 step 6's
+exact-set comparison and step 7's commit-message scan against the
+originating claimed issue's number too, treating it as outside the
+side-fix PR's deliberate closing set — the same stray-keyword safety
+nets D3.5 already applies to every issue outside that set.
+
+While a side-fix PR that the claimed issue's PR depends on is in
+flight, periodically re-check the claimed issue's own PR review and CI
+state — unresolved review threads and failing checks — rather than
+discovering that backlog only after the side-fix merges.
+
 ### D3.6 — Derive the IDD impact checklist
 
 Skip this sub-step and D3.7 below entirely when

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -187,21 +187,16 @@ issue on the side-fix's own merge). Formal `issue-authoring` tracking
 is still preferred when time allows, but it is not a start blocker for
 this carve-out.
 
-The side-fix has no claimed issue of its own to route through A5/B1,
-so create it on a fresh sibling worktree on a branch that does **not**
-match the `issue/<number>-*` pattern (cut from
-`origin/{development-branch}`, named for example
-`side-fix/<short-slug>`) — never on the originating claim's own
-worktree/branch, and never through the normal A5 claim flow. Because
-the branch does not match `issue/*`, it falls outside both the shared
-claim revalidation gate's cwd-vs-claim check
-(`idd-overview-core.instructions.md`) and A5 pre-check (e)'s
-orphaned-branch hold, so no second claim is needed or possible for it;
-the shared claim revalidation gate and D2 step 1 above keep applying,
-unchanged, to mutations for the originating claim from its own
-worktree. If the side-fix instead deserves its own tracked issue, file
-it through the `issue-authoring` skill and follow the normal A5/B1
-claim and worktree flow for that issue instead of this carve-out.
+How the executing session obtains a branch, worktree, and claim for
+the side-fix while the originating claim stays active — and how the
+side-fix's own merge and cleanup avoid releasing that originating
+claim — is not yet defined. The shared claim revalidation gate
+(`idd-overview-core.instructions.md`) scopes its cwd-vs-claim check off
+the active claim's recorded `branch:` field, not the mutation's target
+branch, so no branch-naming convention alone exempts a same-session
+side-fix from it. Treat this as an open gap: this carve-out authorizes
+the _decision_ to proceed under live authority; the operator directing
+it owns the mechanics until a follow-up defines them.
 
 D3's closing-keyword requirement and D3.5's presence-detection and
 auto-injection (steps 1-5, including step 4) apply only to the

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -209,6 +209,9 @@ and the side-fix branch's commit messages must not contain a closing
 keyword referencing it — still run D3.5 step 6's exact-set comparison
 and step 7's commit-message scan to confirm both, treating the
 originating issue as outside the side-fix PR's deliberate closing set.
+On a non-default `{development-branch}`, D3.5's own skip rule applies
+unchanged instead: skip all seven steps, since `closingIssuesReferences`
+never populates there regardless of this carve-out.
 
 While a side-fix PR that the claimed issue's PR depends on is in
 flight, periodically re-check the claimed issue's own PR review and CI

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -180,23 +180,40 @@ an immediate fix for a blocking bug unrelated to the claimed work, the
 session may proceed with that fix under the operator's live authority
 instead of routing it through the `issue-authoring` skill first.
 Minimum provenance: the side-fix PR body must cross-reference the
-originating claimed issue using a **non-closing** keyword (for
-example, `Refs #<claimed-issue-number>` — never
-`Closes`/`Fixes`/`Resolves`, which would auto-close the originating
+originating claimed issue using a **non-closing cross-reference** (for
+example, `Refs #<claimed-issue-number>` — never a closing keyword such
+as `Closes`/`Fixes`/`Resolves`, which would auto-close the originating
 issue on the side-fix's own merge). Formal `issue-authoring` tracking
 is still preferred when time allows, but it is not a start blocker for
 this carve-out.
+
+The side-fix has no claimed issue of its own to route through A5/B1,
+so create it on a fresh sibling worktree on a branch that does **not**
+match the `issue/<number>-*` pattern (cut from
+`origin/{development-branch}`, named for example
+`side-fix/<short-slug>`) — never on the originating claim's own
+worktree/branch, and never through the normal A5 claim flow. Because
+the branch does not match `issue/*`, it falls outside both the shared
+claim revalidation gate's cwd-vs-claim check
+(`idd-overview-core.instructions.md`) and A5 pre-check (e)'s
+orphaned-branch hold, so no second claim is needed or possible for it;
+the shared claim revalidation gate and D2 step 1 above keep applying,
+unchanged, to mutations for the originating claim from its own
+worktree. If the side-fix instead deserves its own tracked issue, file
+it through the `issue-authoring` skill and follow the normal A5/B1
+claim and worktree flow for that issue instead of this carve-out.
 
 D3's closing-keyword requirement and D3.5's presence-detection and
 auto-injection (steps 1-5, including step 4) apply only to the
 side-fix PR's own deliberate closing set — its own linked issue, if
 any, or none otherwise — never to the originating claimed issue named
 above; do not let them treat the non-closing cross-reference above as
-missing, or rewrite it into a closing keyword. Still run D3.5 step 6's
-exact-set comparison and step 7's commit-message scan against the
-originating claimed issue's number too, treating it as outside the
-side-fix PR's deliberate closing set — the same stray-keyword safety
-nets D3.5 already applies to every issue outside that set.
+missing, or rewrite it into a closing keyword. The originating claimed
+issue must not appear in the side-fix PR's `closingIssuesReferences`,
+and the side-fix branch's commit messages must not contain a closing
+keyword referencing it — still run D3.5 step 6's exact-set comparison
+and step 7's commit-message scan to confirm both, treating the
+originating issue as outside the side-fix PR's deliberate closing set.
 
 While a side-fix PR that the claimed issue's PR depends on is in
 flight, periodically re-check the claimed issue's own PR review and CI

--- a/idd-template/.github/instructions/lite/idd-pr-submit-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-pr-submit-lite.instructions.md
@@ -237,6 +237,17 @@ loop instead of returning to this D1 rebase path.
    create` (or the REST issues API) yourself. Recommended follow-ups
    stay in the PR body prose above; if one is important enough to file
    now, invoke the `issue-authoring` skill instead.
+9. **Live-operator-directed immediate-fix carve-out**: a live operator
+   may direct an immediate fix for a blocking bug unrelated to the
+   claimed work instead of routing it through `issue-authoring` first.
+   Cross-reference the originating claimed issue in the side-fix PR
+   body with a non-closing reference (`Refs #N`, never
+   `Closes`/`Fixes`/`Resolves`) — D3.5 below applies only to the
+   side-fix's own linked issue, if any, never to the originating one.
+   How the session obtains a branch/worktree/claim for the side-fix,
+   and how its own completion avoids releasing the originating claim,
+   is not yet defined (see `idd-pr-submit.instructions.md`'s matching
+   carve-out).
 
 ### D3.5 — Verify closing keyword detection
 


### PR DESCRIPTION
# Summary

D3's "never call `gh issue create`" rule assumed unattended execution
with no live operator present, leaving no documented path for the
case where a live operator directs an immediate fix of a blocking bug
unrelated to the claimed work mid-session. Add a "Live-operator-
directed immediate-fix carve-out" subsection to D3 in the canonical
`idd-template/.github/instructions/idd-pr-submit.instructions.md`
source (regenerated into the `.github/instructions/` mirror via
`sync-docs.mjs`), and mirror the carve-out into the lite profile's
`idd-pr-submit-lite.instructions.md`. It permits the live-authority
side-fix path with a non-closing PR-body cross-reference to the
originating claimed issue as minimum provenance, explicitly scopes
D3.5's closing-keyword checks so the side-fix PR's own body/commit
safety nets still guard against accidentally auto-closing the
originating issue (including on a non-default `{development-branch}`,
where D3.5 is skipped entirely per its own existing rule), and adds
guidance to periodically re-check the parked original PR's review
threads and CI state while the side-fix is in flight.

## Linked issue

Closes #2717

## Follow-up issues (if any)

- [ ] Define how the executing session obtains a branch/worktree/claim
      for the side-fix while the originating claim stays active, and
      how the side-fix's own merge/cleanup avoid releasing that
      originating claim. Review on this PR (Copilot, Codex) showed an
      earlier attempt at this carve-out — naming the side-fix branch
      outside `issue/*` — does not actually exempt it from the shared
      claim revalidation gate: the gate's cwd-vs-claim check scopes
      off the *active claim's* own recorded `branch:` field, not the
      mutation's target branch, so a same-session side-fix still fails
      that comparison regardless of branch naming. A correct fix
      needs changes to `idd-overview-core.instructions.md`'s shared
      claim revalidation gate itself (and to F4's release-on-cleanup
      step), which is out of proportion for this docs-only issue. Not
      yet filed as a tracked issue; recorded here for a maintainer or
      a future session to pick up.
- [ ] Lite-profile D3.5 structural parity: `idd-pr-submit-lite.instructions.md`'s
      condensed closing-keyword check ends after its step 5 equivalent
      — it has no step 6/7 equivalent (commit-message scan) and no
      non-default-`{development-branch}` skip rule, for *any* lite PR,
      not only a side-fix. This is a pre-existing lite/standard parity
      gap (`docs/weak-model-lite-profile-design.md`'s no-semantic-
      drift non-goal) that this carve-out's mirror inherits rather than
      introduces; restructuring lite D3.5 generally is out of
      proportion for this docs-only issue. Not yet filed as a tracked
      issue; recorded here for a maintainer or a future session to
      pick up.

## Background / rationale (if material)

Field cost cited in the issue: while a roughly 2-hour side-fix PR was
in flight (10+ live review rounds from 3 advisory bots), the original
claimed issue's own PR kept accumulating separate review activity (4
distinct unresolved threads) unnoticed until returning to it
afterward.

`docs/idd-workflow.md`, `docs/issue-authoring-skill.md`, and
`skills/issue-authoring/references/contract.md` were checked and left
unchanged: none of them currently mention D3's "never call `gh issue
create`" rule by name, so the issue's own conditional pointer
instruction does not apply, and the parked-original-PR re-check
guidance fits naturally inside D3 itself.

Three rounds of automated review (Copilot, Codex) found real issues
across the first three drafts: (1) the carve-out called `Refs #<N>` a
"non-closing keyword", but D3.5 elsewhere in the file reserves
"keyword" for GitHub's closing keywords specifically — fixed to
"non-closing cross-reference" with an explicit statement of the
intended `closingIssuesReferences`/commit-message checks. (2) An
attempted fix for how the side-fix obtains its own branch/worktree
turned out to be incorrect on closer verification (see the Follow-up
issues item above) and was retracted rather than iterated on further,
per this repository's own PATH B disposition-closes-the-loop review
policy. (3) The carve-out was missing from the lite profile entirely,
and the standard file lacked an explicit non-default-branch D3.5 skip
statement for the carve-out — both fixed by mirroring the carve-out
into `idd-pr-submit-lite.instructions.md` and adding the skip
sentence to the standard file.

A fourth review round raised three further findings on that same
mirror/skip fix. Two (lite lacks a commit-message-scan equivalent;
lite lacks a non-default-branch skip equivalent) were accepted as
real but deferred to the new lite-profile-parity follow-up item above
— they are a pre-existing structural gap in lite D3.5 that applies to
every lite PR, not something this carve-out introduces, so fixing it
generally is out of proportion here. The third (D3.5 steps 1-5 have
no defined `<N>` when the side-fix has no linked issue at all) was
dispositioned without a text change: the existing paragraph already
scopes steps 1-5 to "the side-fix PR's own deliberate closing set...
or none otherwise" and separately forbids treating the non-closing
cross-reference as missing or rewriting it — when that set is empty,
steps 1-5 have nothing to act on and correctly do not fire, while
steps 6-7 remain the safety net the paragraph already mandates.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed (documentation
      only — no code, config, or automation changed; flagged because
      the new text scopes when D3.5's closing-keyword/auto-close
      checks apply)

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CK2SHn8Bir6VHrXrMVMdn3
