### PR TITLE
docs(idd-workflow): document Discover re-run cadence for fan-out

### DIFF
--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -807,37 +807,48 @@ Running this variant safely requires:
 
 ### Discover re-run cadence
 
-The full `discover-roadmap-graph.mjs --all-roadmaps --with-readiness
---with-claim-state` traversal paired with
-`discover-orphan-filter.mjs --autopilot --with-claim-state` is too
-expensive to re-run after every delegated-worker completion; a
+The full Discover enumeration this session's own A0/A0-O routing
+selects — `discover-roadmap-graph.mjs --all-roadmaps --with-readiness
+--with-claim-state`, and `discover-orphan-filter.mjs --autopilot
+--with-claim-state` only when `issue-scope`/`orphan-first-policy`
+actually routes to A0-O (`idd-discover.instructions.md`'s A0/A0-O) —
+is too expensive to re-run after every delegated-worker completion; a
 2026-09-09 hearing decided to document a re-run cadence for it
 (kurone-kito/idd-skill#2706).
 
-- **Do not re-run** the full all-roadmaps + orphan-filter pair after
-  every delegated-worker completion. Dispatch the next worker from
-  the previously enumerated graph instead.
-- **Do re-run** when either condition holds: a worker reports
-  exhaustion or no startable candidate remains in the graph already
-  in hand, or that graph is stale enough that the orchestrator no
-  longer trusts it for the next dispatch — for example when a
-  completed issue may have unblocked a dependent still listed as
-  not-ready. A worker merely finishing the issue it was dispatched
-  for is not by itself a reason to re-run: that happens on every
-  successful dispatch, so treating it as a trigger would collapse
-  straight back into the every-completion cadence the first bullet
-  rules out. Wait for the helper's own process exit before parsing
-  its output — never a mid-run stdout read — per
+- **Do not re-run** the full enumeration this session's A0/A0-O
+  routing already selected, after every delegated-worker completion.
+  Dispatch the next worker from the previously enumerated graph
+  instead, after a fresh target-local A3 readiness check for that
+  specific candidate (the configured authoring label, and any
+  newly-added open dependency) — the per-delegation A4/A4.5/A5 gates
+  above do not repeat A3's own exclusions, so a candidate that became
+  blocked only after the graph was built would otherwise slip through
+  uncaught.
+- **Do re-run** on any of the following: a worker reports exhaustion
+  or no startable candidate remains in the graph already in hand, or
+  that graph is stale enough that the orchestrator no longer trusts it
+  for the next dispatch — for example when a completed issue may have
+  unblocked a dependent still listed as not-ready. A worker merely
+  finishing the issue it was dispatched for is not by itself a reason
+  to re-run: that happens on every successful dispatch, so treating it
+  as a trigger would collapse straight back into the every-completion
+  cadence the first bullet rules out. Wait for the helper's own
+  process exit before parsing its output — never a mid-run stdout
+  read — per
   [A2's helper read timing note](../.github/instructions/idd-discover.instructions.md#a2--enumerate-sub-issues).
 - **On a caller-side tool timeout** during the Discover invocation —
   the orchestrator's own tool-invocation wrapper (for example a
   bounded Bash-tool or subprocess timeout) elapsing while the helper
   process may still be running to completion, not the helper itself
-  erroring or exiting non-zero — retry that same invocation once with
-  a longer time budget before concluding anything failed. Only a
-  second timeout on the retried invocation counts as an A2 enumeration
-  failure; a helper that actually errors or exits non-zero is already
-  an A2 enumeration failure on the first occurrence, unchanged.
+  erroring or exiting non-zero — give that same invocation one more
+  attempt with a longer time budget (re-attach to the still-running
+  process when the tool only stopped waiting rather than killing it;
+  otherwise reissue the command) before concluding anything failed.
+  Only a second timeout under the longer budget counts as an A2
+  enumeration failure, unchanged from today's A2 rule; a helper that
+  actually errors or exits non-zero is already an A2 enumeration
+  failure on the first occurrence.
 - **No caching layer or change-detection pre-check**: this section
   documents a cadence, not a cache.
 

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -805,6 +805,32 @@ Running this variant safely requires:
   claim before dispatching further workers, rather than assuming success
   or failure either way.
 
+### Discover re-run cadence
+
+The full `discover-roadmap-graph.mjs --all-roadmaps --with-readiness
+--with-claim-state` traversal paired with
+`discover-orphan-filter.mjs --autopilot --with-claim-state` is too
+expensive to re-run after every delegated-worker completion; a
+2026-09-09 hearing decided to document a re-run cadence for it
+(kurone-kito/idd-skill#2706).
+
+- **Do not re-run** the full all-roadmaps + orphan-filter pair after
+  every delegated-worker completion. Dispatch the next worker from
+  the previously enumerated graph instead.
+- **Do re-run** when either condition holds: a worker reports
+  exhaustion or no startable candidate, or the previously enumerated
+  graph predates a merge or issue closure one of this session's own
+  workers has landed since that graph was built. Wait for the
+  helper's own process exit before parsing its output — never a
+  mid-run stdout read — per
+  [A2's helper read timing note](../.github/instructions/idd-discover.instructions.md#a2--enumerate-sub-issues).
+- **On a caller-side tool timeout** during the Discover invocation,
+  retry that same invocation once with a longer time budget before
+  concluding anything failed. Only a second timeout on the retried
+  invocation counts as an A2 enumeration failure.
+- **No caching layer or change-detection pre-check**: this section
+  documents a cadence, not a cache.
+
 ## Live Status Digests
 
 Use the live status digest contract in

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -818,11 +818,16 @@ expensive to re-run after every delegated-worker completion; a
   every delegated-worker completion. Dispatch the next worker from
   the previously enumerated graph instead.
 - **Do re-run** when either condition holds: a worker reports
-  exhaustion or no startable candidate, or the previously enumerated
-  graph predates a merge or issue closure one of this session's own
-  workers has landed since that graph was built. Wait for the
-  helper's own process exit before parsing its output — never a
-  mid-run stdout read — per
+  exhaustion or no startable candidate remains in the graph already
+  in hand, or that graph is stale enough that the orchestrator no
+  longer trusts it for the next dispatch — for example when a
+  completed issue may have unblocked a dependent still listed as
+  not-ready. A worker merely finishing the issue it was dispatched
+  for is not by itself a reason to re-run: that happens on every
+  successful dispatch, so treating it as a trigger would collapse
+  straight back into the every-completion cadence the first bullet
+  rules out. Wait for the helper's own process exit before parsing
+  its output — never a mid-run stdout read — per
   [A2's helper read timing note](../.github/instructions/idd-discover.instructions.md#a2--enumerate-sub-issues).
 - **On a caller-side tool timeout** during the Discover invocation,
   retry that same invocation once with a longer time budget before

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -807,17 +807,17 @@ Running this variant safely requires:
 
 ### Discover re-run cadence
 
-The full Discover enumeration this session's own A0/A0-O routing
-selects — `discover-roadmap-graph.mjs --all-roadmaps --with-readiness
---with-claim-state`, and `discover-orphan-filter.mjs --autopilot
---with-claim-state` only when `issue-scope`/`orphan-first-policy`
-actually routes to A0-O (`idd-discover.instructions.md`'s A0/A0-O) —
-is too expensive to re-run after every delegated-worker completion; a
-2026-09-09 hearing decided to document a re-run cadence for it
-(kurone-kito/idd-skill#2706).
+Re-running the full Discover enumeration this session established
+(`discover-roadmap-graph`, and `discover-orphan-filter` when A0/A0-O
+routes there) after every delegated-worker completion is too
+expensive; a 2026-09-09 hearing decided to document a re-run cadence
+instead (kurone-kito/idd-skill#2706). A re-run always repeats the mode
+and routing already in force for this session — A1's single-root or
+cross-roadmap choice, and A0/A0-O's own `issue-scope`/
+`orphan-first-policy` routing — refreshing the same search, never
+widening it to a broader mode this session never selected.
 
-- **Do not re-run** the full enumeration this session's A0/A0-O
-  routing already selected, after every delegated-worker completion.
+- **Do not re-run** Discover after every delegated-worker completion.
   Dispatch the next worker from the previously enumerated graph
   instead, after a fresh target-local A3 readiness check for that
   specific candidate (the configured authoring label, and any

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -829,10 +829,15 @@ expensive to re-run after every delegated-worker completion; a
   rules out. Wait for the helper's own process exit before parsing
   its output — never a mid-run stdout read — per
   [A2's helper read timing note](../.github/instructions/idd-discover.instructions.md#a2--enumerate-sub-issues).
-- **On a caller-side tool timeout** during the Discover invocation,
-  retry that same invocation once with a longer time budget before
-  concluding anything failed. Only a second timeout on the retried
-  invocation counts as an A2 enumeration failure.
+- **On a caller-side tool timeout** during the Discover invocation —
+  the orchestrator's own tool-invocation wrapper (for example a
+  bounded Bash-tool or subprocess timeout) elapsing while the helper
+  process may still be running to completion, not the helper itself
+  erroring or exiting non-zero — retry that same invocation once with
+  a longer time budget before concluding anything failed. Only a
+  second timeout on the retried invocation counts as an A2 enumeration
+  failure; a helper that actually errors or exits non-zero is already
+  an A2 enumeration failure on the first occurrence, unchanged.
 - **No caching layer or change-detection pre-check**: this section
   documents a cadence, not a cache.
 

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -813,7 +813,7 @@ routes there) after every delegated-worker completion is too
 expensive; a 2026-09-09 hearing decided to document a re-run cadence
 instead (kurone-kito/idd-skill#2706). A re-run always repeats the mode
 and routing already in force for this session — A1's single-root or
-cross-roadmap choice, and A0/A0-O's own `issue-scope`/
+cross-roadmap choice, and A0/A0-O's own `issue-scope` and
 `orphan-first-policy` routing — refreshing the same search, never
 widening it to a broader mode this session never selected.
 

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -783,6 +783,32 @@ Running this variant safely requires:
   claim before dispatching further workers, rather than assuming success
   or failure either way.
 
+### Discover re-run cadence
+
+The full `discover-roadmap-graph.mjs --all-roadmaps --with-readiness
+--with-claim-state` traversal paired with
+`discover-orphan-filter.mjs --autopilot --with-claim-state` is too
+expensive to re-run after every delegated-worker completion; a
+2026-09-09 hearing decided to document a re-run cadence for it
+(kurone-kito/idd-skill#2706).
+
+- **Do not re-run** the full all-roadmaps + orphan-filter pair after
+  every delegated-worker completion. Dispatch the next worker from
+  the previously enumerated graph instead.
+- **Do re-run** when either condition holds: a worker reports
+  exhaustion or no startable candidate, or the previously enumerated
+  graph predates a merge or issue closure one of this session's own
+  workers has landed since that graph was built. Wait for the
+  helper's own process exit before parsing its output — never a
+  mid-run stdout read — per
+  [A2's helper read timing note](../.github/instructions/idd-discover.instructions.md#a2--enumerate-sub-issues).
+- **On a caller-side tool timeout** during the Discover invocation,
+  retry that same invocation once with a longer time budget before
+  concluding anything failed. Only a second timeout on the retried
+  invocation counts as an A2 enumeration failure.
+- **No caching layer or change-detection pre-check**: this section
+  documents a cadence, not a cache.
+
 ## Live Status Digests
 
 Use the live status digest contract in

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -807,10 +807,15 @@ expensive to re-run after every delegated-worker completion; a
   rules out. Wait for the helper's own process exit before parsing
   its output — never a mid-run stdout read — per
   [A2's helper read timing note](../.github/instructions/idd-discover.instructions.md#a2--enumerate-sub-issues).
-- **On a caller-side tool timeout** during the Discover invocation,
-  retry that same invocation once with a longer time budget before
-  concluding anything failed. Only a second timeout on the retried
-  invocation counts as an A2 enumeration failure.
+- **On a caller-side tool timeout** during the Discover invocation —
+  the orchestrator's own tool-invocation wrapper (for example a
+  bounded Bash-tool or subprocess timeout) elapsing while the helper
+  process may still be running to completion, not the helper itself
+  erroring or exiting non-zero — retry that same invocation once with
+  a longer time budget before concluding anything failed. Only a
+  second timeout on the retried invocation counts as an A2 enumeration
+  failure; a helper that actually errors or exits non-zero is already
+  an A2 enumeration failure on the first occurrence, unchanged.
 - **No caching layer or change-detection pre-check**: this section
   documents a cadence, not a cache.
 

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -791,7 +791,7 @@ routes there) after every delegated-worker completion is too
 expensive; a 2026-09-09 hearing decided to document a re-run cadence
 instead (kurone-kito/idd-skill#2706). A re-run always repeats the mode
 and routing already in force for this session — A1's single-root or
-cross-roadmap choice, and A0/A0-O's own `issue-scope`/
+cross-roadmap choice, and A0/A0-O's own `issue-scope` and
 `orphan-first-policy` routing — refreshing the same search, never
 widening it to a broader mode this session never selected.
 

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -785,37 +785,48 @@ Running this variant safely requires:
 
 ### Discover re-run cadence
 
-The full `discover-roadmap-graph.mjs --all-roadmaps --with-readiness
---with-claim-state` traversal paired with
-`discover-orphan-filter.mjs --autopilot --with-claim-state` is too
-expensive to re-run after every delegated-worker completion; a
+The full Discover enumeration this session's own A0/A0-O routing
+selects — `discover-roadmap-graph.mjs --all-roadmaps --with-readiness
+--with-claim-state`, and `discover-orphan-filter.mjs --autopilot
+--with-claim-state` only when `issue-scope`/`orphan-first-policy`
+actually routes to A0-O (`idd-discover.instructions.md`'s A0/A0-O) —
+is too expensive to re-run after every delegated-worker completion; a
 2026-09-09 hearing decided to document a re-run cadence for it
 (kurone-kito/idd-skill#2706).
 
-- **Do not re-run** the full all-roadmaps + orphan-filter pair after
-  every delegated-worker completion. Dispatch the next worker from
-  the previously enumerated graph instead.
-- **Do re-run** when either condition holds: a worker reports
-  exhaustion or no startable candidate remains in the graph already
-  in hand, or that graph is stale enough that the orchestrator no
-  longer trusts it for the next dispatch — for example when a
-  completed issue may have unblocked a dependent still listed as
-  not-ready. A worker merely finishing the issue it was dispatched
-  for is not by itself a reason to re-run: that happens on every
-  successful dispatch, so treating it as a trigger would collapse
-  straight back into the every-completion cadence the first bullet
-  rules out. Wait for the helper's own process exit before parsing
-  its output — never a mid-run stdout read — per
+- **Do not re-run** the full enumeration this session's A0/A0-O
+  routing already selected, after every delegated-worker completion.
+  Dispatch the next worker from the previously enumerated graph
+  instead, after a fresh target-local A3 readiness check for that
+  specific candidate (the configured authoring label, and any
+  newly-added open dependency) — the per-delegation A4/A4.5/A5 gates
+  above do not repeat A3's own exclusions, so a candidate that became
+  blocked only after the graph was built would otherwise slip through
+  uncaught.
+- **Do re-run** on any of the following: a worker reports exhaustion
+  or no startable candidate remains in the graph already in hand, or
+  that graph is stale enough that the orchestrator no longer trusts it
+  for the next dispatch — for example when a completed issue may have
+  unblocked a dependent still listed as not-ready. A worker merely
+  finishing the issue it was dispatched for is not by itself a reason
+  to re-run: that happens on every successful dispatch, so treating it
+  as a trigger would collapse straight back into the every-completion
+  cadence the first bullet rules out. Wait for the helper's own
+  process exit before parsing its output — never a mid-run stdout
+  read — per
   [A2's helper read timing note](../.github/instructions/idd-discover.instructions.md#a2--enumerate-sub-issues).
 - **On a caller-side tool timeout** during the Discover invocation —
   the orchestrator's own tool-invocation wrapper (for example a
   bounded Bash-tool or subprocess timeout) elapsing while the helper
   process may still be running to completion, not the helper itself
-  erroring or exiting non-zero — retry that same invocation once with
-  a longer time budget before concluding anything failed. Only a
-  second timeout on the retried invocation counts as an A2 enumeration
-  failure; a helper that actually errors or exits non-zero is already
-  an A2 enumeration failure on the first occurrence, unchanged.
+  erroring or exiting non-zero — give that same invocation one more
+  attempt with a longer time budget (re-attach to the still-running
+  process when the tool only stopped waiting rather than killing it;
+  otherwise reissue the command) before concluding anything failed.
+  Only a second timeout under the longer budget counts as an A2
+  enumeration failure, unchanged from today's A2 rule; a helper that
+  actually errors or exits non-zero is already an A2 enumeration
+  failure on the first occurrence.
 - **No caching layer or change-detection pre-check**: this section
   documents a cadence, not a cache.
 

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -796,11 +796,16 @@ expensive to re-run after every delegated-worker completion; a
   every delegated-worker completion. Dispatch the next worker from
   the previously enumerated graph instead.
 - **Do re-run** when either condition holds: a worker reports
-  exhaustion or no startable candidate, or the previously enumerated
-  graph predates a merge or issue closure one of this session's own
-  workers has landed since that graph was built. Wait for the
-  helper's own process exit before parsing its output — never a
-  mid-run stdout read — per
+  exhaustion or no startable candidate remains in the graph already
+  in hand, or that graph is stale enough that the orchestrator no
+  longer trusts it for the next dispatch — for example when a
+  completed issue may have unblocked a dependent still listed as
+  not-ready. A worker merely finishing the issue it was dispatched
+  for is not by itself a reason to re-run: that happens on every
+  successful dispatch, so treating it as a trigger would collapse
+  straight back into the every-completion cadence the first bullet
+  rules out. Wait for the helper's own process exit before parsing
+  its output — never a mid-run stdout read — per
   [A2's helper read timing note](../.github/instructions/idd-discover.instructions.md#a2--enumerate-sub-issues).
 - **On a caller-side tool timeout** during the Discover invocation,
   retry that same invocation once with a longer time budget before

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -785,17 +785,17 @@ Running this variant safely requires:
 
 ### Discover re-run cadence
 
-The full Discover enumeration this session's own A0/A0-O routing
-selects — `discover-roadmap-graph.mjs --all-roadmaps --with-readiness
---with-claim-state`, and `discover-orphan-filter.mjs --autopilot
---with-claim-state` only when `issue-scope`/`orphan-first-policy`
-actually routes to A0-O (`idd-discover.instructions.md`'s A0/A0-O) —
-is too expensive to re-run after every delegated-worker completion; a
-2026-09-09 hearing decided to document a re-run cadence for it
-(kurone-kito/idd-skill#2706).
+Re-running the full Discover enumeration this session established
+(`discover-roadmap-graph`, and `discover-orphan-filter` when A0/A0-O
+routes there) after every delegated-worker completion is too
+expensive; a 2026-09-09 hearing decided to document a re-run cadence
+instead (kurone-kito/idd-skill#2706). A re-run always repeats the mode
+and routing already in force for this session — A1's single-root or
+cross-roadmap choice, and A0/A0-O's own `issue-scope`/
+`orphan-first-policy` routing — refreshing the same search, never
+widening it to a broader mode this session never selected.
 
-- **Do not re-run** the full enumeration this session's A0/A0-O
-  routing already selected, after every delegated-worker completion.
+- **Do not re-run** Discover after every delegated-worker completion.
   Dispatch the next worker from the previously enumerated graph
   instead, after a fresh target-local A3 readiness check for that
   specific candidate (the configured authoring label, and any


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

`docs/idd-workflow.md`'s Orchestrator fan-out variant section had no
guidance on how often a long-lived orchestrating session should
re-run the full Discover enumeration (`discover-roadmap-graph`, and
`discover-orphan-filter` when this session's own A0/A0-O routing
calls for it) between delegated-worker completions. A 2026-09-09
hearing (kurone-kito/idd-skill#2706) decided to document a cadence
instead of adding a caching layer or a change-detection pre-check.

Add a "Discover re-run cadence" subsection to the Orchestrator
fan-out variant section, in both `docs/idd-workflow.md` and its
`idd-template/docs/idd-workflow.md` canonical-structure counterpart
(the `idd-workflow-doc` sync pair in `audit/sync-manifest.json` is
`structure` mode, so `sync-docs.mjs --apply` cannot regenerate it —
both copies are hand-edited here):

- Do not re-run Discover after every delegated-worker completion.
  Dispatch the next worker from the graph already in hand instead,
  after a fresh target-local A3 readiness check for that candidate
  (the configured authoring label, and any newly-added open
  dependency) — the per-delegation A4/A4.5/A5 gates never repeat A3's
  own exclusions.
- Do re-run on exhaustion / no startable candidate, or when the
  in-hand graph is stale enough to no longer be trusted for the next
  dispatch. A re-run always repeats the mode and routing this session
  already established (A1's single-root or cross-roadmap choice, and
  A0/A0-O's own `issue-scope`/`orphan-first-policy` routing) — it
  refreshes the same search, never widens it to a broader mode the
  session never selected.
- On a caller-side tool timeout during the Discover invocation, give
  that same invocation one more attempt with a longer time budget
  before treating it as an A2 enumeration failure; a helper that
  actually errors or exits non-zero is already an A2 enumeration
  failure on the first occurrence, unchanged.
- Explicitly out of scope: a caching layer or a "did anything change"
  pre-check helper.

The bullets above reflect several rounds of live PR review (Copilot,
Codex, CodeRabbit) on top of this PR's own C1/E2 self-review passes —
see the commit history and the review thread dispositions for the
specific findings each commit addressed (a circular staleness
trigger, an A0/A0-O issue-scope gap, an A1 single-root/cross-roadmap
gap, a missing A3 readiness re-check on cached dispatch, and a
code-span line-wrap rendering glitch).

## Linked issue

Closes #2718

## Follow-up issues (if any)

- [ ] none

Noted but not filed: live review also surfaced that A2 owns
graph-membership/execution-leaf classification (has this candidate
been removed from its roadmap, or reclassified, since the graph was
enumerated?) and that A3/A4.5/A5 never repeat that check either — the
same class of gap as the A3-readiness fix above, one level up the
stack. This PR's candidate files (per issue #2718) are docs/
idd-workflow.md and idd-template/docs/idd-workflow.md only; closing
every axis of "is a cached dispatch still valid" is a larger,
separate piece of work than documenting a re-run cadence, so it is
deliberately deferred rather than folded in here.

## Background / rationale (if material)

The new subsection is placed as a `###` sibling immediately after the
existing "Orchestrator fan-out variant" bullet list (before "## Live
Status Digests"), matching this file's existing convention of
same-level subsections for topically adjacent content (the file has
no `####` headings anywhere). It cites
`kurone-kito/idd-skill#2706` (the 2026-09-09 hearing) per this
repository's "cite the observed incident" convention
(`docs/idd-design-rationale.md#cite-the-observed-incident`), and links
to `.github/instructions/idd-discover.instructions.md`'s A2 section
for the existing helper-read-timing ("wait for process exit, never a
mid-run stdout read") guidance the issue asked this section to reuse
rather than restate.

Earlier drafts named the specific helper invocation flags
(`--all-roadmaps`, `--autopilot`, etc.) inline, matching the
originating issue's own wording, but each specific flag turned out to
invite a review finding about exactly the config axis it hard-coded
(A0/A0-O's `issue-scope`/`orphan-first-policy` routing, A1's
single-root default). The final wording states the general rule once
— a re-run always repeats this session's already-established mode and
routing — rather than re-deriving it per flag.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SfqRji5K2g9EhgXLcRBaiC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for rerunning discovery workflows.
  - Clarified when existing discovery results can be reused and when a full rerun is required.
  - Documented requirements for waiting on helper processes, handling timeouts, and avoiding caching or change-detection checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
