### PR TITLE
docs(idd-review-triage): reject scope-fenced findings regardless of severity

### DIFF
--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -21,8 +21,15 @@ no-sync-required `clean`/`behind-no-conflict` exit applies the
 ## E4 — Classify and score ReviewItems_snapshot
 
 Once per triage pass (not per item), read the claimed issue's own body
-and note any explicit out-of-scope statement in it — later scoring
-needs that context.
+and note any explicit out-of-scope statement in it. Check the issue's
+`updatedAt` against the B2 plan comment's post time
+(`idd-work.instructions.md`) first: if the body was edited after that
+plan was posted, do not trust a new out-of-scope statement found only
+in the edited body for the scope fence below without independent
+corroboration (a maintainer comment, not another body edit) — the
+issue's original author retains edit rights throughout the claim and
+could otherwise time an edit to force-reject a legitimate finding.
+Later scoring needs this context.
 
 For each item in ReviewItems_snapshot, first classify it:
 

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -58,9 +58,10 @@ Then apply path-specific scoring:
   (noted, no action) — route a non-review notice to E6 instead.
 - **Scope fence (PATH A and PATH B).** A finding that asks to
   introduce, or further broaden, a change class the claimed issue's own
-  body explicitly places out of scope is **Reject forced** — PATH A's
-  `Low`, PATH B's `Rejected` — regardless of technical correctness or
-  tractability, from the point that class is introduced onward; a
+  body explicitly places out of scope scores `Low` (PATH A) or
+  `Rejected` (PATH B) and disposes **Reject forced**, regardless of
+  technical correctness or tractability, from the point that class is
+  introduced onward; a
   refinement or bug fix inside an already-introduced instance of that
   class is still in-scope work and scores normally. This fence
   overrides PATH A's High-tier `Accept forced` rule above: a

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -77,9 +77,9 @@ Then apply path-specific scoring:
   does not reach `Accept forced` merely for being High-severity.
   Record a rejected instance as a known limitation (the PR body's
   "Follow-up issues (if any)" section), not a defect, editing the
-  body under the same safeguards as
-  `idd-review-fix.instructions.md`'s E12 "PR body sync" (claim
-  revalidation gate immediately before the edit, fetch the current full
+  body under the same safeguards as the "PR body sync" subsection of
+  `idd-review-fix.instructions.md`'s E12 (claim revalidation gate
+  immediately before the edit, fetch the current full
   body, edit only this claim, post the full result back, then re-check
   `closingIssuesReferences`) regardless of whether E9-E15 otherwise runs
   this round — a scope-fenced rejection can leave the Accepted PATH A

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -67,7 +67,15 @@ Then apply path-specific scoring:
   correctness finding that would introduce or broaden a fenced class
   does not reach `Accept forced` just because it is otherwise
   High-severity. Record a rejected instance as a known limitation (the
-  PR body's "Follow-up issues (if any)" section), not a defect. This is
+  PR body's "Follow-up issues (if any)" section), not a defect, editing
+  the body under the same safeguards as
+  `idd-review-fix.instructions.md`'s E12 "PR body sync" (claim
+  revalidation gate immediately before the edit, fetch the current full
+  body, edit only this claim, post the full result back, then re-check
+  `closingIssuesReferences`) regardless of whether E9-E15 otherwise runs
+  this round — a scope-fenced rejection can leave the Accepted PATH A
+  count at zero, which skips E9-E15 (E8) and E12 along with it, so this
+  edit cannot rely on being reached through that path. This is
   a sibling of `idd-review-fix.instructions.md`'s E10 "Round-count
   heuristic for genuinely-new findings": that heuristic covers a shared
   root cause once PATH A work is already underway, while this fence

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -21,16 +21,19 @@ no-sync-required `clean`/`behind-no-conflict` exit applies the
 ## E4 — Classify and score ReviewItems_snapshot
 
 Once per triage pass (not per item), read the claimed issue's own body
-and note any explicit out-of-scope statement in it. Check the issue's
-`userContentEdits` (GraphQL) for an entry whose `editedAt` postdates the
-B2 plan comment's post time (`idd-work.instructions.md`) — `updatedAt`
-is not this signal, since it also advances on comments, labels, and
-other activity unrelated to the body. A body edit after the plan was
-posted does not get trusted for a new out-of-scope statement used in
-the scope fence below without independent corroboration (a maintainer
-comment, not another body edit) — the issue's original author retains
-edit rights throughout the claim and could otherwise time an edit to
-force-reject a legitimate finding. Later scoring needs this context.
+and note any explicit out-of-scope statement in it, trusted for the
+scope fence below only if it predates the B2 plan
+(`idd-work.instructions.md`) — an author keeps edit rights throughout
+the claim and could otherwise time an edit to force-reject a legitimate
+finding. Fetch `userContentEdits` (GraphQL; `updatedAt` also moves on
+unrelated activity, so it will not do) and find the entry with the
+latest `editedAt` at or before the plan's post time; that entry's
+`diff` (or the original creation content, if none predates the plan)
+is the trusted snapshot. A statement absent from it — added later, or
+present now but not there — needs independent corroboration (a
+maintainer comment, not another edit). Treat an unavailable or failed
+`userContentEdits` read the same way: fail closed, never assume no
+post-plan edit occurred.
 
 For each item in ReviewItems_snapshot, first classify it:
 
@@ -75,20 +78,17 @@ Then apply path-specific scoring:
   overrides PATH A's High-tier `Accept forced` rule: even a
   correctness finding that would introduce or broaden a fenced class
   does not reach `Accept forced` merely for being High-severity.
-  Record a rejected instance as a known limitation (the PR body's
-  "Follow-up issues (if any)" section), not a defect, editing the
-  body under the same safeguards as the "PR body sync" subsection of
-  `idd-review-fix.instructions.md`'s E12 (claim revalidation gate
-  immediately before the edit, fetch the current full
-  body, edit only this claim, post the full result back, then re-check
-  `closingIssuesReferences`) regardless of whether E9-E15 otherwise runs
-  this round — a scope-fenced rejection can leave the Accepted PATH A
-  count at zero, which skips E9-E15 (E8) and E12 along with it, so this
-  edit cannot rely on being reached through that path. This rule
-  parallels `idd-review-fix.instructions.md`'s E10 "Round-count
-  heuristic for genuinely-new findings": that heuristic covers a shared
-  root cause once PATH A work is already underway, while this fence
-  applies at PATH A/B scoring, before that work starts.
+  Record a rejected instance as a known limitation in the PR body's
+  follow-up-issues content (`idd-pr-submit.instructions.md` — mapped
+  onto the template's "Follow-up issues" section when one exists), not
+  a defect. Edit it under E12's "PR body sync" safeguards
+  (`idd-review-fix.instructions.md`: claim revalidation first, fetch
+  the full body, edit only this claim, post the full result back,
+  re-check `closingIssuesReferences`) even when E8's zero-Accepted-
+  PATH-A skip bypasses E9-E15, and E12 with it. This rule parallels
+  E10's "Round-count heuristic for genuinely-new findings" (same file):
+  that heuristic covers a shared root cause once PATH A work is
+  underway; this fence applies earlier, at PATH A/B scoring.
 
 ## E5 — Record Accept / Reject decisions
 

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -20,6 +20,10 @@ no-sync-required `clean`/`behind-no-conflict` exit applies the
 
 ## E4 — Classify and score ReviewItems_snapshot
 
+Once per triage pass (not per item), read the claimed issue's own body
+and note any explicit out-of-scope statement in it — later scoring
+needs that context.
+
 For each item in ReviewItems_snapshot, first classify it:
 
 - **PATH A — actionable feedback**: human reviewer threads and regular
@@ -52,6 +56,22 @@ Then apply path-specific scoring:
 - **PATH B**: no High/Medium/Low. Score only a _completed_ review of
   current HEAD as `Accepted` (confirmed/useful) or `Rejected`
   (noted, no action) — route a non-review notice to E6 instead.
+- **Scope fence (PATH A and PATH B).** A finding that asks to
+  introduce, or further broaden, a change class the claimed issue's own
+  body explicitly places out of scope is **Reject forced** — PATH A's
+  `Low`, PATH B's `Rejected` — regardless of technical correctness or
+  tractability, from the point that class is introduced onward; a
+  refinement or bug fix inside an already-introduced instance of that
+  class is still in-scope work and scores normally. This fence
+  overrides PATH A's High-tier `Accept forced` rule above: a
+  correctness finding that would introduce or broaden a fenced class
+  does not reach `Accept forced` just because it is otherwise
+  High-severity. Record a rejected instance as a known limitation (the
+  PR body's "Follow-up issues (if any)" section), not a defect. This is
+  a sibling of `idd-review-fix.instructions.md`'s E10 "Round-count
+  heuristic for genuinely-new findings": that heuristic covers a shared
+  root cause once PATH A work is already underway, while this fence
+  applies at PATH A/B scoring, before that work starts.
 
 ## E5 — Record Accept / Reject decisions
 
@@ -60,7 +80,8 @@ Record a path-specific disposition for every item:
 - **PATH A**: High-severity items reach Accepted only via "Verify
   before accept" below, or — when the actor-permission cap applies —
   an explicit maintainer confirmation reply; Medium/Low require an
-  explicit Accept or Reject decision.
+  explicit Accept or Reject decision, except a scope-fenced finding
+  (E4), which is Reject forced regardless of severity.
 - **PATH B** (a _completed_ review of the current HEAD): `Accepted`
   means the advisory confirms the implementation or captures useful
   context; `Rejected` means noted, no action required. An advisory

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -22,14 +22,15 @@ no-sync-required `clean`/`behind-no-conflict` exit applies the
 
 Once per triage pass (not per item), read the claimed issue's own body
 and note any explicit out-of-scope statement in it. Check the issue's
-`updatedAt` against the B2 plan comment's post time
-(`idd-work.instructions.md`) first: if the body was edited after that
-plan was posted, do not trust a new out-of-scope statement found only
-in the edited body for the scope fence below without independent
-corroboration (a maintainer comment, not another body edit) — the
-issue's original author retains edit rights throughout the claim and
-could otherwise time an edit to force-reject a legitimate finding.
-Later scoring needs this context.
+`userContentEdits` (GraphQL) for an entry whose `editedAt` postdates the
+B2 plan comment's post time (`idd-work.instructions.md`) — `updatedAt`
+is not this signal, since it also advances on comments, labels, and
+other activity unrelated to the body. A body edit after the plan was
+posted does not get trusted for a new out-of-scope statement used in
+the scope fence below without independent corroboration (a maintainer
+comment, not another body edit) — the issue's original author retains
+edit rights throughout the claim and could otherwise time an edit to
+force-reject a legitimate finding. Later scoring needs this context.
 
 For each item in ReviewItems_snapshot, first classify it:
 

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -68,23 +68,23 @@ Then apply path-specific scoring:
   body explicitly places out of scope scores `Low` (PATH A) or
   `Rejected` (PATH B) and disposes **Reject forced**, regardless of
   technical correctness or tractability, from the point that class is
-  introduced onward; a
-  refinement or bug fix inside an already-introduced instance of that
-  class is still in-scope work and scores normally. This fence
-  overrides PATH A's High-tier `Accept forced` rule above: a
+  introduced onward. A refinement or bug fix inside an
+  already-introduced instance of that class is still in-scope work and
+  scores normally. This fence
+  overrides PATH A's High-tier `Accept forced` rule: even a
   correctness finding that would introduce or broaden a fenced class
-  does not reach `Accept forced` just because it is otherwise
-  High-severity. Record a rejected instance as a known limitation (the
-  PR body's "Follow-up issues (if any)" section), not a defect, editing
-  the body under the same safeguards as
+  does not reach `Accept forced` merely for being High-severity.
+  Record a rejected instance as a known limitation (the PR body's
+  "Follow-up issues (if any)" section), not a defect, editing the
+  body under the same safeguards as
   `idd-review-fix.instructions.md`'s E12 "PR body sync" (claim
   revalidation gate immediately before the edit, fetch the current full
   body, edit only this claim, post the full result back, then re-check
   `closingIssuesReferences`) regardless of whether E9-E15 otherwise runs
   this round — a scope-fenced rejection can leave the Accepted PATH A
   count at zero, which skips E9-E15 (E8) and E12 along with it, so this
-  edit cannot rely on being reached through that path. This is
-  a sibling of `idd-review-fix.instructions.md`'s E10 "Round-count
+  edit cannot rely on being reached through that path. This rule
+  parallels `idd-review-fix.instructions.md`'s E10 "Round-count
   heuristic for genuinely-new findings": that heuristic covers a shared
   root cause once PATH A work is already underway, while this fence
   applies at PATH A/B scoring, before that work starts.

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -72,9 +72,9 @@ Then apply path-specific scoring:
   does not reach `Accept forced` merely for being High-severity.
   Record a rejected instance as a known limitation (the PR body's
   "Follow-up issues (if any)" section), not a defect, editing the
-  body under the same safeguards as
-  `idd-review-fix.instructions.md`'s E12 "PR body sync" (claim
-  revalidation gate immediately before the edit, fetch the current full
+  body under the same safeguards as the "PR body sync" subsection of
+  `idd-review-fix.instructions.md`'s E12 (claim revalidation gate
+  immediately before the edit, fetch the current full
   body, edit only this claim, post the full result back, then re-check
   `closingIssuesReferences`) regardless of whether E9-E15 otherwise runs
   this round — a scope-fenced rejection can leave the Accepted PATH A

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -15,6 +15,10 @@ no-sync-required `clean`/`behind-no-conflict` exit applies the
 
 ## E4 — Classify and score ReviewItems_snapshot
 
+Once per triage pass (not per item), read the claimed issue's own body
+and note any explicit out-of-scope statement in it — later scoring
+needs that context.
+
 For each item in ReviewItems_snapshot, first classify it:
 
 - **PATH A — actionable feedback**: human reviewer threads and regular
@@ -47,6 +51,22 @@ Then apply path-specific scoring:
 - **PATH B**: no High/Medium/Low. Score only a _completed_ review of
   current HEAD as `Accepted` (confirmed/useful) or `Rejected`
   (noted, no action) — route a non-review notice to E6 instead.
+- **Scope fence (PATH A and PATH B).** A finding that asks to
+  introduce, or further broaden, a change class the claimed issue's own
+  body explicitly places out of scope is **Reject forced** — PATH A's
+  `Low`, PATH B's `Rejected` — regardless of technical correctness or
+  tractability, from the point that class is introduced onward; a
+  refinement or bug fix inside an already-introduced instance of that
+  class is still in-scope work and scores normally. This fence
+  overrides PATH A's High-tier `Accept forced` rule above: a
+  correctness finding that would introduce or broaden a fenced class
+  does not reach `Accept forced` just because it is otherwise
+  High-severity. Record a rejected instance as a known limitation (the
+  PR body's "Follow-up issues (if any)" section), not a defect. This is
+  a sibling of `idd-review-fix.instructions.md`'s E10 "Round-count
+  heuristic for genuinely-new findings": that heuristic covers a shared
+  root cause once PATH A work is already underway, while this fence
+  applies at PATH A/B scoring, before that work starts.
 
 ## E5 — Record Accept / Reject decisions
 
@@ -55,7 +75,8 @@ Record a path-specific disposition for every item:
 - **PATH A**: High-severity items reach Accepted only via "Verify
   before accept" below, or — when the actor-permission cap applies —
   an explicit maintainer confirmation reply; Medium/Low require an
-  explicit Accept or Reject decision.
+  explicit Accept or Reject decision, except a scope-fenced finding
+  (E4), which is Reject forced regardless of severity.
 - **PATH B** (a _completed_ review of the current HEAD): `Accepted`
   means the advisory confirms the implementation or captures useful
   context; `Rejected` means noted, no action required. An advisory

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -16,8 +16,15 @@ no-sync-required `clean`/`behind-no-conflict` exit applies the
 ## E4 — Classify and score ReviewItems_snapshot
 
 Once per triage pass (not per item), read the claimed issue's own body
-and note any explicit out-of-scope statement in it — later scoring
-needs that context.
+and note any explicit out-of-scope statement in it. Check the issue's
+`updatedAt` against the B2 plan comment's post time
+(`idd-work.instructions.md`) first: if the body was edited after that
+plan was posted, do not trust a new out-of-scope statement found only
+in the edited body for the scope fence below without independent
+corroboration (a maintainer comment, not another body edit) — the
+issue's original author retains edit rights throughout the claim and
+could otherwise time an edit to force-reject a legitimate finding.
+Later scoring needs this context.
 
 For each item in ReviewItems_snapshot, first classify it:
 

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -53,9 +53,10 @@ Then apply path-specific scoring:
   (noted, no action) — route a non-review notice to E6 instead.
 - **Scope fence (PATH A and PATH B).** A finding that asks to
   introduce, or further broaden, a change class the claimed issue's own
-  body explicitly places out of scope is **Reject forced** — PATH A's
-  `Low`, PATH B's `Rejected` — regardless of technical correctness or
-  tractability, from the point that class is introduced onward; a
+  body explicitly places out of scope scores `Low` (PATH A) or
+  `Rejected` (PATH B) and disposes **Reject forced**, regardless of
+  technical correctness or tractability, from the point that class is
+  introduced onward; a
   refinement or bug fix inside an already-introduced instance of that
   class is still in-scope work and scores normally. This fence
   overrides PATH A's High-tier `Accept forced` rule above: a

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -63,23 +63,23 @@ Then apply path-specific scoring:
   body explicitly places out of scope scores `Low` (PATH A) or
   `Rejected` (PATH B) and disposes **Reject forced**, regardless of
   technical correctness or tractability, from the point that class is
-  introduced onward; a
-  refinement or bug fix inside an already-introduced instance of that
-  class is still in-scope work and scores normally. This fence
-  overrides PATH A's High-tier `Accept forced` rule above: a
+  introduced onward. A refinement or bug fix inside an
+  already-introduced instance of that class is still in-scope work and
+  scores normally. This fence
+  overrides PATH A's High-tier `Accept forced` rule: even a
   correctness finding that would introduce or broaden a fenced class
-  does not reach `Accept forced` just because it is otherwise
-  High-severity. Record a rejected instance as a known limitation (the
-  PR body's "Follow-up issues (if any)" section), not a defect, editing
-  the body under the same safeguards as
+  does not reach `Accept forced` merely for being High-severity.
+  Record a rejected instance as a known limitation (the PR body's
+  "Follow-up issues (if any)" section), not a defect, editing the
+  body under the same safeguards as
   `idd-review-fix.instructions.md`'s E12 "PR body sync" (claim
   revalidation gate immediately before the edit, fetch the current full
   body, edit only this claim, post the full result back, then re-check
   `closingIssuesReferences`) regardless of whether E9-E15 otherwise runs
   this round — a scope-fenced rejection can leave the Accepted PATH A
   count at zero, which skips E9-E15 (E8) and E12 along with it, so this
-  edit cannot rely on being reached through that path. This is
-  a sibling of `idd-review-fix.instructions.md`'s E10 "Round-count
+  edit cannot rely on being reached through that path. This rule
+  parallels `idd-review-fix.instructions.md`'s E10 "Round-count
   heuristic for genuinely-new findings": that heuristic covers a shared
   root cause once PATH A work is already underway, while this fence
   applies at PATH A/B scoring, before that work starts.

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -62,7 +62,15 @@ Then apply path-specific scoring:
   correctness finding that would introduce or broaden a fenced class
   does not reach `Accept forced` just because it is otherwise
   High-severity. Record a rejected instance as a known limitation (the
-  PR body's "Follow-up issues (if any)" section), not a defect. This is
+  PR body's "Follow-up issues (if any)" section), not a defect, editing
+  the body under the same safeguards as
+  `idd-review-fix.instructions.md`'s E12 "PR body sync" (claim
+  revalidation gate immediately before the edit, fetch the current full
+  body, edit only this claim, post the full result back, then re-check
+  `closingIssuesReferences`) regardless of whether E9-E15 otherwise runs
+  this round — a scope-fenced rejection can leave the Accepted PATH A
+  count at zero, which skips E9-E15 (E8) and E12 along with it, so this
+  edit cannot rely on being reached through that path. This is
   a sibling of `idd-review-fix.instructions.md`'s E10 "Round-count
   heuristic for genuinely-new findings": that heuristic covers a shared
   root cause once PATH A work is already underway, while this fence

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -17,14 +17,15 @@ no-sync-required `clean`/`behind-no-conflict` exit applies the
 
 Once per triage pass (not per item), read the claimed issue's own body
 and note any explicit out-of-scope statement in it. Check the issue's
-`updatedAt` against the B2 plan comment's post time
-(`idd-work.instructions.md`) first: if the body was edited after that
-plan was posted, do not trust a new out-of-scope statement found only
-in the edited body for the scope fence below without independent
-corroboration (a maintainer comment, not another body edit) — the
-issue's original author retains edit rights throughout the claim and
-could otherwise time an edit to force-reject a legitimate finding.
-Later scoring needs this context.
+`userContentEdits` (GraphQL) for an entry whose `editedAt` postdates the
+B2 plan comment's post time (`idd-work.instructions.md`) — `updatedAt`
+is not this signal, since it also advances on comments, labels, and
+other activity unrelated to the body. A body edit after the plan was
+posted does not get trusted for a new out-of-scope statement used in
+the scope fence below without independent corroboration (a maintainer
+comment, not another body edit) — the issue's original author retains
+edit rights throughout the claim and could otherwise time an edit to
+force-reject a legitimate finding. Later scoring needs this context.
 
 For each item in ReviewItems_snapshot, first classify it:
 

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -16,16 +16,19 @@ no-sync-required `clean`/`behind-no-conflict` exit applies the
 ## E4 — Classify and score ReviewItems_snapshot
 
 Once per triage pass (not per item), read the claimed issue's own body
-and note any explicit out-of-scope statement in it. Check the issue's
-`userContentEdits` (GraphQL) for an entry whose `editedAt` postdates the
-B2 plan comment's post time (`idd-work.instructions.md`) — `updatedAt`
-is not this signal, since it also advances on comments, labels, and
-other activity unrelated to the body. A body edit after the plan was
-posted does not get trusted for a new out-of-scope statement used in
-the scope fence below without independent corroboration (a maintainer
-comment, not another body edit) — the issue's original author retains
-edit rights throughout the claim and could otherwise time an edit to
-force-reject a legitimate finding. Later scoring needs this context.
+and note any explicit out-of-scope statement in it, trusted for the
+scope fence below only if it predates the B2 plan
+(`idd-work.instructions.md`) — an author keeps edit rights throughout
+the claim and could otherwise time an edit to force-reject a legitimate
+finding. Fetch `userContentEdits` (GraphQL; `updatedAt` also moves on
+unrelated activity, so it will not do) and find the entry with the
+latest `editedAt` at or before the plan's post time; that entry's
+`diff` (or the original creation content, if none predates the plan)
+is the trusted snapshot. A statement absent from it — added later, or
+present now but not there — needs independent corroboration (a
+maintainer comment, not another edit). Treat an unavailable or failed
+`userContentEdits` read the same way: fail closed, never assume no
+post-plan edit occurred.
 
 For each item in ReviewItems_snapshot, first classify it:
 
@@ -70,20 +73,17 @@ Then apply path-specific scoring:
   overrides PATH A's High-tier `Accept forced` rule: even a
   correctness finding that would introduce or broaden a fenced class
   does not reach `Accept forced` merely for being High-severity.
-  Record a rejected instance as a known limitation (the PR body's
-  "Follow-up issues (if any)" section), not a defect, editing the
-  body under the same safeguards as the "PR body sync" subsection of
-  `idd-review-fix.instructions.md`'s E12 (claim revalidation gate
-  immediately before the edit, fetch the current full
-  body, edit only this claim, post the full result back, then re-check
-  `closingIssuesReferences`) regardless of whether E9-E15 otherwise runs
-  this round — a scope-fenced rejection can leave the Accepted PATH A
-  count at zero, which skips E9-E15 (E8) and E12 along with it, so this
-  edit cannot rely on being reached through that path. This rule
-  parallels `idd-review-fix.instructions.md`'s E10 "Round-count
-  heuristic for genuinely-new findings": that heuristic covers a shared
-  root cause once PATH A work is already underway, while this fence
-  applies at PATH A/B scoring, before that work starts.
+  Record a rejected instance as a known limitation in the PR body's
+  follow-up-issues content (`idd-pr-submit.instructions.md` — mapped
+  onto the template's "Follow-up issues" section when one exists), not
+  a defect. Edit it under E12's "PR body sync" safeguards
+  (`idd-review-fix.instructions.md`: claim revalidation first, fetch
+  the full body, edit only this claim, post the full result back,
+  re-check `closingIssuesReferences`) even when E8's zero-Accepted-
+  PATH-A skip bypasses E9-E15, and E12 with it. This rule parallels
+  E10's "Round-count heuristic for genuinely-new findings" (same file):
+  that heuristic covers a shared root cause once PATH A work is
+  underway; this fence applies earlier, at PATH A/B scoring.
 
 ## E5 — Record Accept / Reject decisions
 


### PR DESCRIPTION
## Summary

- Add a shared "Scope fence" rule to `idd-review-triage.instructions.md`'s
  E4 path-specific scoring: a finding that asks to introduce, or further
  broaden, a change class the claimed issue's own body explicitly places
  out of scope is Reject forced, regardless of technical correctness or
  tractability, overriding PATH A's High-tier `Accept forced` rule.
- Require reading the claimed issue's body once per triage pass (before
  E4 classification) for an explicit out-of-scope statement.
- Carve the same exception into E5's PATH A Accept/Reject language so it
  cannot be read as still discretionary.
- Cross-reference `idd-review-fix.instructions.md`'s E10 Round-count
  heuristic (a sibling rule for a different failure shape).

## Linked issue

Closes #2826

## Background / rationale

Two dogfooded PRs (#2760, #2757) each ran 5-7 review rounds because a
fenced-out change class was introduced once in an early round and then
scored as ordinary in-scope work for every subsequent round -- neither
PATH A nor PATH B had a way to reject a technically-correct finding that
broadened past the claimed issue's own stated fence.

## Test plan

- [x] `node scripts/audit-docs.mjs --check` passes
- [x] `npx markdownlint-cli2 "**/*.md"` passes
- [x] `bundle-review`'s `limitBytes` in `audit/sync-manifest.json` was
      not raised (93.96% utilization after this change, was 93.18%)
- [x] Independent report-only critique pass (fresh subagent, no shared
      context) found 3 real issues, all fixed: E5's unmodified
      discretionary Low-tier language undermined the "forced" mandate,
      the "(both paths)" parenthetical didn't match the file's own
      convention, and "Follow-up-issues section" didn't match the real
      PR template heading text

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated review triage guidance to require checking the claimed issue scope during each review pass.
  - Added explicit handling for findings that fall outside the stated scope, including forced rejection and recording as known limitations.
  - Clarified the required synchronization safeguards for documenting these findings in pull request descriptions.
  - Updated E5 guidance to route scope-fenced findings to forced rejection regardless of severity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->