### PR TITLE
docs(idd-suitability): cross-reference the needs-decision label path

### DIFF
--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -22,7 +22,8 @@ footer is a **discovery-time** ranking/routing hint consumed in
 `autopilotSuitability.floor`, default `3`; see also
 `docs/policy-constants.md`). It is **not** one of the seven checks: A4.5
 PASS/FAIL is decided solely by the qualitative checks, never by the
-score.
+score. A low or missing score never fails this gate; a high score never
+bypasses it.
 
 When helper support is enabled, use helper scripts from
 `docs/idd-helper-scripts.md` first for A4.5 evidence.
@@ -182,11 +183,12 @@ outcome (trust/safety concerns require human review):
 | `invalid` | Trust/safety concern or defect | Fresh: report, stop (do not retry). Reconfirmed (`existingRejection`: `outcome: invalid`): exclude, post nothing, loop |
 <!-- dprint-ignore-end -->
 
-Neither label is applied directly by A4.5. `status:needs-decision` is
-applied while holding the claim, per
-`idd-overview-appendix.instructions.md`'s **Needs-decision claim
-release** rule (Hold / suspend). `status:blocked-by-human` has no
-equivalent named rule documented there yet.
+Neither label is applied directly by A4.5. The holding session
+applies the configured needs-decision label
+(`labels.needsDecisionLabelName`) per the **Needs-decision claim
+release** rule (Hold / suspend,
+`idd-overview-appendix.instructions.md`); that rule never covers
+`labels.blockedByHumanLabelName`.
 
 ## Mutation Policy and Coordination Rule
 

--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -223,8 +223,8 @@ convention:
 
 Never emit this marker for `needs-decision` or `blocked-by-human`: those
 two already carry a stable label (applied while holding the claim, per
-`idd-overview-appendix.instructions.md`'s Hold / suspend section above)
-and need no second signal. Discover's own
+`idd-overview-appendix.instructions.md`'s Hold / suspend section) and
+need no second signal. Discover's own
 candidate-selection pass (`idd-discover.instructions.md`) reads this
 marker to skip a previously-rejected candidate without a full manual
 comment-history read, applying the same staleness rule as every other

--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -183,6 +183,11 @@ outcome (trust/safety concerns require human review):
 | `invalid` | Trust/safety concern or defect | Fresh: report, stop (do not retry). Reconfirmed (`existingRejection`: `outcome: invalid`): exclude, post nothing, loop |
 <!-- dprint-ignore-end -->
 
+Applying the `status:needs-decision` / `status:blocked-by-human` label
+uses the **Needs-decision claim release** rule in
+`idd-overview-appendix.instructions.md` (Hold / suspend) — a held
+claim is required first.
+
 ## Mutation Policy and Coordination Rule
 
 **A4.5 is a triage gate, not an execution claim.** The gate determines
@@ -217,7 +222,9 @@ convention:
 ```
 
 Never emit this marker for `needs-decision` or `blocked-by-human`: those
-two already carry a stable label and need no second signal. Discover's own
+two already carry a stable label (via **Needs-decision claim release**
+in `idd-overview-appendix.instructions.md`, Hold / suspend) and need no
+second signal. Discover's own
 candidate-selection pass (`idd-discover.instructions.md`) reads this
 marker to skip a previously-rejected candidate without a full manual
 comment-history read, applying the same staleness rule as every other
@@ -337,11 +344,6 @@ candidates follow the Failure Outcomes section above.
 
 ## Optional: grooming a rejected/below-floor backlog
 
-A4.5 decides only at claim time; it never revisits a past rejection.
-An optional, human-initiated Groom phase for periodically
-batch-reviewing the rejected/below-floor backlog -- classifying each
-candidate execution-blocked / decision-blocked / fact-blocked,
-re-checking whether a cited blocker has since closed, and applying the
-operator's answers back onto the issue rather than resolving a
-deliberate decision unilaterally -- is documented in
+A4.5 decides only at claim time. An optional Groom phase for that
+backlog is documented in
 [the IDD workflow guide](../../docs/idd-workflow.md#grooming-pass-for-rejected-and-below-floor-issues-optional).

--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -22,8 +22,7 @@ footer is a **discovery-time** ranking/routing hint consumed in
 `autopilotSuitability.floor`, default `3`; see also
 `docs/policy-constants.md`). It is **not** one of the seven checks: A4.5
 PASS/FAIL is decided solely by the qualitative checks, never by the
-score. A low or missing score never fails this gate; a high score never
-bypasses it.
+score.
 
 When helper support is enabled, use helper scripts from
 `docs/idd-helper-scripts.md` first for A4.5 evidence.
@@ -183,10 +182,11 @@ outcome (trust/safety concerns require human review):
 | `invalid` | Trust/safety concern or defect | Fresh: report, stop (do not retry). Reconfirmed (`existingRejection`: `outcome: invalid`): exclude, post nothing, loop |
 <!-- dprint-ignore-end -->
 
-Applying the `status:needs-decision` / `status:blocked-by-human` label
-uses the **Needs-decision claim release** rule in
-`idd-overview-appendix.instructions.md` (Hold / suspend) — a held
-claim is required first.
+Applying either label happens while holding the claim, per
+`idd-overview-appendix.instructions.md` (Hold / suspend) — the
+**Needs-decision claim release** sub-rule covers
+`status:needs-decision` specifically; `status:blocked-by-human` follows
+the same shape.
 
 ## Mutation Policy and Coordination Rule
 
@@ -222,9 +222,9 @@ convention:
 ```
 
 Never emit this marker for `needs-decision` or `blocked-by-human`: those
-two already carry a stable label (via **Needs-decision claim release**
-in `idd-overview-appendix.instructions.md`, Hold / suspend) and need no
-second signal. Discover's own
+two already carry a stable label (applied while holding the claim, per
+`idd-overview-appendix.instructions.md`'s Hold / suspend section above)
+and need no second signal. Discover's own
 candidate-selection pass (`idd-discover.instructions.md`) reads this
 marker to skip a previously-rejected candidate without a full manual
 comment-history read, applying the same staleness rule as every other

--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -182,11 +182,11 @@ outcome (trust/safety concerns require human review):
 | `invalid` | Trust/safety concern or defect | Fresh: report, stop (do not retry). Reconfirmed (`existingRejection`: `outcome: invalid`): exclude, post nothing, loop |
 <!-- dprint-ignore-end -->
 
-Applying either label happens while holding the claim, per
-`idd-overview-appendix.instructions.md` (Hold / suspend) — the
-**Needs-decision claim release** sub-rule covers
-`status:needs-decision` specifically; `status:blocked-by-human` follows
-the same shape.
+Neither label is applied directly by A4.5. `status:needs-decision` is
+applied while holding the claim, per
+`idd-overview-appendix.instructions.md`'s **Needs-decision claim
+release** rule (Hold / suspend). `status:blocked-by-human` has no
+equivalent named rule documented there yet.
 
 ## Mutation Policy and Coordination Rule
 
@@ -222,9 +222,8 @@ convention:
 ```
 
 Never emit this marker for `needs-decision` or `blocked-by-human`: those
-two already carry a stable label (applied while holding the claim, per
-`idd-overview-appendix.instructions.md`'s Hold / suspend section) and
-need no second signal. Discover's own
+two already carry a stable label (see above) and need no second
+signal. Discover's own
 candidate-selection pass (`idd-discover.instructions.md`) reads this
 marker to skip a previously-rejected candidate without a full manual
 comment-history read, applying the same staleness rule as every other

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -17,8 +17,7 @@ footer is a **discovery-time** ranking/routing hint consumed in
 `autopilotSuitability.floor`, default `3`; see also
 `docs/policy-constants.md`). It is **not** one of the seven checks: A4.5
 PASS/FAIL is decided solely by the qualitative checks, never by the
-score. A low or missing score never fails this gate; a high score never
-bypasses it.
+score.
 
 When helper support is enabled, use helper scripts from
 `docs/idd-helper-scripts.md` first for A4.5 evidence.
@@ -178,10 +177,11 @@ outcome (trust/safety concerns require human review):
 | `invalid` | Trust/safety concern or defect | Fresh: report, stop (do not retry). Reconfirmed (`existingRejection`: `outcome: invalid`): exclude, post nothing, loop |
 <!-- dprint-ignore-end -->
 
-Applying the `status:needs-decision` / `status:blocked-by-human` label
-uses the **Needs-decision claim release** rule in
-`idd-overview-appendix.instructions.md` (Hold / suspend) — a held
-claim is required first.
+Applying either label happens while holding the claim, per
+`idd-overview-appendix.instructions.md` (Hold / suspend) — the
+**Needs-decision claim release** sub-rule covers
+`status:needs-decision` specifically; `status:blocked-by-human` follows
+the same shape.
 
 ## Mutation Policy and Coordination Rule
 
@@ -217,9 +217,9 @@ convention:
 ```
 
 Never emit this marker for `needs-decision` or `blocked-by-human`: those
-two already carry a stable label (via **Needs-decision claim release**
-in `idd-overview-appendix.instructions.md`, Hold / suspend) and need no
-second signal. Discover's own
+two already carry a stable label (applied while holding the claim, per
+`idd-overview-appendix.instructions.md`'s Hold / suspend section above)
+and need no second signal. Discover's own
 candidate-selection pass (`idd-discover.instructions.md`) reads this
 marker to skip a previously-rejected candidate without a full manual
 comment-history read, applying the same staleness rule as every other

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -178,6 +178,11 @@ outcome (trust/safety concerns require human review):
 | `invalid` | Trust/safety concern or defect | Fresh: report, stop (do not retry). Reconfirmed (`existingRejection`: `outcome: invalid`): exclude, post nothing, loop |
 <!-- dprint-ignore-end -->
 
+Applying the `status:needs-decision` / `status:blocked-by-human` label
+uses the **Needs-decision claim release** rule in
+`idd-overview-appendix.instructions.md` (Hold / suspend) — a held
+claim is required first.
+
 ## Mutation Policy and Coordination Rule
 
 **A4.5 is a triage gate, not an execution claim.** The gate determines
@@ -212,7 +217,9 @@ convention:
 ```
 
 Never emit this marker for `needs-decision` or `blocked-by-human`: those
-two already carry a stable label and need no second signal. Discover's own
+two already carry a stable label (via **Needs-decision claim release**
+in `idd-overview-appendix.instructions.md`, Hold / suspend) and need no
+second signal. Discover's own
 candidate-selection pass (`idd-discover.instructions.md`) reads this
 marker to skip a previously-rejected candidate without a full manual
 comment-history read, applying the same staleness rule as every other
@@ -332,11 +339,6 @@ candidates follow the Failure Outcomes section above.
 
 ## Optional: grooming a rejected/below-floor backlog
 
-A4.5 decides only at claim time; it never revisits a past rejection.
-An optional, human-initiated Groom phase for periodically
-batch-reviewing the rejected/below-floor backlog -- classifying each
-candidate execution-blocked / decision-blocked / fact-blocked,
-re-checking whether a cited blocker has since closed, and applying the
-operator's answers back onto the issue rather than resolving a
-deliberate decision unilaterally -- is documented in
+A4.5 decides only at claim time. An optional Groom phase for that
+backlog is documented in
 [the IDD workflow guide](../../docs/idd-workflow.md#grooming-pass-for-rejected-and-below-floor-issues-optional).

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -218,8 +218,8 @@ convention:
 
 Never emit this marker for `needs-decision` or `blocked-by-human`: those
 two already carry a stable label (applied while holding the claim, per
-`idd-overview-appendix.instructions.md`'s Hold / suspend section above)
-and need no second signal. Discover's own
+`idd-overview-appendix.instructions.md`'s Hold / suspend section) and
+need no second signal. Discover's own
 candidate-selection pass (`idd-discover.instructions.md`) reads this
 marker to skip a previously-rejected candidate without a full manual
 comment-history read, applying the same staleness rule as every other

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -17,7 +17,8 @@ footer is a **discovery-time** ranking/routing hint consumed in
 `autopilotSuitability.floor`, default `3`; see also
 `docs/policy-constants.md`). It is **not** one of the seven checks: A4.5
 PASS/FAIL is decided solely by the qualitative checks, never by the
-score.
+score. A low or missing score never fails this gate; a high score never
+bypasses it.
 
 When helper support is enabled, use helper scripts from
 `docs/idd-helper-scripts.md` first for A4.5 evidence.
@@ -177,11 +178,12 @@ outcome (trust/safety concerns require human review):
 | `invalid` | Trust/safety concern or defect | Fresh: report, stop (do not retry). Reconfirmed (`existingRejection`: `outcome: invalid`): exclude, post nothing, loop |
 <!-- dprint-ignore-end -->
 
-Neither label is applied directly by A4.5. `status:needs-decision` is
-applied while holding the claim, per
-`idd-overview-appendix.instructions.md`'s **Needs-decision claim
-release** rule (Hold / suspend). `status:blocked-by-human` has no
-equivalent named rule documented there yet.
+Neither label is applied directly by A4.5. The holding session
+applies the configured needs-decision label
+(`labels.needsDecisionLabelName`) per the **Needs-decision claim
+release** rule (Hold / suspend,
+`idd-overview-appendix.instructions.md`); that rule never covers
+`labels.blockedByHumanLabelName`.
 
 ## Mutation Policy and Coordination Rule
 

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -177,11 +177,11 @@ outcome (trust/safety concerns require human review):
 | `invalid` | Trust/safety concern or defect | Fresh: report, stop (do not retry). Reconfirmed (`existingRejection`: `outcome: invalid`): exclude, post nothing, loop |
 <!-- dprint-ignore-end -->
 
-Applying either label happens while holding the claim, per
-`idd-overview-appendix.instructions.md` (Hold / suspend) — the
-**Needs-decision claim release** sub-rule covers
-`status:needs-decision` specifically; `status:blocked-by-human` follows
-the same shape.
+Neither label is applied directly by A4.5. `status:needs-decision` is
+applied while holding the claim, per
+`idd-overview-appendix.instructions.md`'s **Needs-decision claim
+release** rule (Hold / suspend). `status:blocked-by-human` has no
+equivalent named rule documented there yet.
 
 ## Mutation Policy and Coordination Rule
 
@@ -217,9 +217,8 @@ convention:
 ```
 
 Never emit this marker for `needs-decision` or `blocked-by-human`: those
-two already carry a stable label (applied while holding the claim, per
-`idd-overview-appendix.instructions.md`'s Hold / suspend section) and
-need no second signal. Discover's own
+two already carry a stable label (see above) and need no second
+signal. Discover's own
 candidate-selection pass (`idd-discover.instructions.md`) reads this
 marker to skip a previously-rejected candidate without a full manual
 comment-history read, applying the same staleness rule as every other


### PR DESCRIPTION
# Summary

A4.5's Failure Outcomes table and Mutation Policy section in
`idd-suitability.instructions.md` both imply the `status:needs-decision`
/ `status:blocked-by-human` label is applied somewhere, without saying
where or how. The only documented mechanism is
`idd-overview-appendix.instructions.md`'s Needs-decision claim release
protocol (Hold / suspend section), which requires holding a claim
first — something a reader following only
`idd-suitability.instructions.md` would not discover on their own. This
adds that cross-reference in both places, in the canonical
`idd-template/` source and its generated mirror, using the configured
label keys (`labels.needsDecisionLabelName` /
`labels.blockedByHumanLabelName`) rather than their default values, to
match this file's existing style.

`idd-suitability.instructions.md` is a member of
`audit/sync-manifest.json`'s `bundle-discovery` budget, which was
already at 97.99% utilization (9 bytes of headroom) against the hard
98% `context-ceiling-200k` cap before this change. Per
`docs/policy-constants.md`'s near-ceiling exception, this PR offsets
the addition by tightening the "Optional: grooming" section's pointer
paragraph instead of raising `limitBytes` — the
execution-blocked/decision-blocked/fact-blocked detail it restated
already lives at `docs/idd-workflow.md`'s own grooming-pass section, so
no information is lost. Net effect: `bundle-discovery` moves from
97.99% to 97.96% (48 bytes of headroom remaining), confirmed by
`node scripts/audit-docs.mjs --check`.

## Linked issue

Closes #2842

## Follow-up issues (if any)

- [x] Copilot and Codex review both correctly pointed out a pre-existing
      gap this PR's wording makes newly visible, but does not itself
      create or need to fix: A4.5's Decision Flow never proceeds to A5
      (claim) on a `needs-decision` / `blocked-by-human` outcome — it
      reports and moves to the next candidate — so there is no
      "holding session" available at that moment to invoke the
      Needs-decision claim release rule for a *fresh* rejection, and
      the Mutation Policy section explicitly forbids emitting a
      persistent `triage:` marker for these two outcomes. A later
      Discover pass can therefore re-surface the same candidate with no
      persistent signal until some other session (one already holding
      a claim, or A1.5 on a roadmap) happens to apply the real label.
      Closing this gap means changing A4.5's own behavior (authorizing
      a pre-claim marker, or routing through a claim before reporting),
      which is out of scope here per #2842's own stated scope ("no
      change to what actually happens, only to what the instructions
      state") — recorded here as a candidate for a follow-up issue
      rather than fixed in this docs-only PR. Observed live on this
      issue during this PR's own execution: `claude-idd2-1506c0ce`
      (claim `claude-idd2-20260910T013840-80db0f2f`) claimed #2842,
      hit the same `bundle-discovery` budget wall with a different
      draft, applied `status:needs-decision`, and released at
      01:40:33Z; this session's fresh-claim gate correctly saw the
      issue as claimable four minutes later at 01:44:18Z with no
      re-check of that label, and the stale label sat on the issue
      until manually removed after a budget-compliant draft landed
      (see the issue's own comment thread for the full resolution).

## Background / rationale (if material)

This issue's rationale cites issue #2702 as the precedent for the
claim → hold-comment → release protocol being documented here. Verified
directly against #2702's own comment history during B2 planning: it
was claimed, held via a "Needs-decision hold" comment (citing this same
`bundle-discovery` budget constraint), then released via
`unclaimed-by` — matching the documented mechanism exactly.

Across review, Copilot and Codex both flagged (and this PR corrected
across several rounds) that the cross-reference must not assert
`status:blocked-by-human` is covered by the same appendix rule as
`status:needs-decision` — the appendix only documents the
needs-decision label. The current wording states plainly that the
Needs-decision claim release rule never covers
`labels.blockedByHumanLabelName`, rather than implying an equivalent
mechanism exists.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CK2SHn8Bir6VHrXrMVMdn3
