### PR TITLE
docs(idd-workflow): verify Groom decisions are buildable before use

### DIFF
--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -657,7 +657,12 @@ infeasible `Maintainer decision` line rather than merely append beside
 it -- re-triage's own `hasResolvedDecision` check treats every unstruck
 occurrence as live and has no way to tell which one is current, so an
 unstruck infeasible line can keep reading as resolved alongside its
-replacement.
+replacement. Removing the label here does not itself trigger the
+appendix's usual removal-and-re-claim pairing: like the adjacent
+`triage:{outcome}` removal above, the actual re-claim happens through
+the next ordinary Discover pass reading the now-label-free issue, not
+through the Groom pass itself, which -- as already stated above --
+never claims or works the issue.
 
 **Worked example.** An issue was rejected `needs-decision` at score
 `2/5` because its acceptance criteria read "add caching, or document

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -644,15 +644,20 @@ decision-blocked again, rather than silently reinterpreting,
 downscoping, or unilaterally picking a different resolution: apply the
 configured needs-decision label and release the claim, the same
 general hold mechanism the shared Hold / suspend rules in
-`idd-overview-appendix.instructions.md` already document. Record
-exactly what made the recorded option infeasible in the hold comment,
-so the next Groom pass has the information a corrected question needs.
-That later pass removes the needs-decision label as part of applying
-its own operator's answers back onto the issue (above) -- alongside the
-`triage:{outcome}` label, the score footer, and a fresh `Maintainer
-decision` line that supersedes the infeasible one -- rather than
-leaving the label in place indefinitely or removing it without
-recording a genuinely buildable replacement.
+`.github/instructions/idd-overview-appendix.instructions.md` already
+document. Record exactly what made the recorded option infeasible in
+the hold comment, so the next Groom pass has the information a
+corrected question needs. That later pass removes the needs-decision
+label as part of applying its own operator's answers back onto the
+issue (above), alongside the `triage:{outcome}` label and the score
+footer, rather than leaving the label in place indefinitely or
+removing it without recording a genuinely buildable replacement.
+That replacement must strike through or otherwise replace the
+infeasible `Maintainer decision` line rather than merely append beside
+it -- re-triage's own `hasResolvedDecision` check treats every unstruck
+occurrence as live and has no way to tell which one is current, so an
+unstruck infeasible line can keep reading as resolved alongside its
+replacement.
 
 **Worked example.** An issue was rejected `needs-decision` at score
 `2/5` because its acceptance criteria read "add caching, or document

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -618,9 +618,11 @@ tradeoffs behind each question before asking it, rather than bundling
 several unrelated technical topics into one dense batch.
 
 **Apply the operator's answers back onto the issue**: update the score
-footer, remove or update the `triage:{outcome}` label, revise
-acceptance criteria to reflect the decision, and record the decision as
-inline prose in the issue body: `Maintainer decision (<provenance>,
+footer, remove or update the `triage:{outcome}` label -- and the
+configured needs-decision label too, when the hold-and-return rule
+below applied it to this same candidate, since nothing else removes it
+-- revise acceptance criteria to reflect the decision, and record the
+decision as inline prose in the issue body: `Maintainer decision (<provenance>,
 Groom hearing, <date>): <resolution text>` -- the shape
 `suitability-triage.mjs`'s Check 7 recognizes as a resolved
 decision (`#2661`); a comment may additionally note the decision, but the body
@@ -632,20 +634,25 @@ itself never claims or works the issue (see
 [Mutation Policy and Coordination Rule](../.github/instructions/idd-suitability.instructions.md#mutation-policy-and-coordination-rule)).
 
 **Hold when a recorded resolution proves infeasible.** The feasibility
-check above narrows this gap but does not close it -- the same field
-evidence (2026-09-10, issue `#2805`) shows infeasibility that only
-became visible once an implementing session was deep enough into the
-codebase to see it. When a session reaches implementation and finds the
-Groom-recorded resolution cannot be built as specified, it must hold
-and return the candidate to its pre-Groom decision-blocked state,
-rather than silently reinterpreting, downscoping, or unilaterally
-picking a different resolution: apply the configured needs-decision
-label and release the claim, the same general hold mechanism the shared
-Hold / suspend rules in `idd-overview-appendix.instructions.md` already
-document -- not a literal restoration of the Grooming pass's own
-`triage:{outcome}` label. Record exactly what made the recorded option
-infeasible in the hold comment, so the next Groom pass has the
-information a corrected question needs.
+check above reduces the risk of drafting an infeasible option, but does
+not eliminate it -- the same field evidence (2026-09-10, issue
+`#2805`) shows infeasibility that only became visible once an
+implementing session was deep enough into the codebase to see it. When
+a session reaches implementation and finds the Groom-recorded
+resolution cannot be built as specified, it must hold the candidate as
+decision-blocked again, rather than silently reinterpreting,
+downscoping, or unilaterally picking a different resolution: apply the
+configured needs-decision label and release the claim, the same
+general hold mechanism the shared Hold / suspend rules in
+`idd-overview-appendix.instructions.md` already document. Record
+exactly what made the recorded option infeasible in the hold comment,
+so the next Groom pass has the information a corrected question needs.
+That later pass removes the needs-decision label as part of applying
+its own operator's answers back onto the issue (above) -- alongside the
+`triage:{outcome}` label, the score footer, and a fresh `Maintainer
+decision` line that supersedes the infeasible one -- rather than
+leaving the label in place indefinitely or removing it without
+recording a genuinely buildable replacement.
 
 **Worked example.** An issue was rejected `needs-decision` at score
 `2/5` because its acceptance criteria read "add caching, or document

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -593,6 +593,20 @@ as a blocker has since closed or merged -- a cached readiness snapshot
 can be stale, and a closed blocker is a "free" suitability lever that
 costs nothing to re-apply.
 
+**Verify feasibility before drafting a question.** Before drafting a
+decision-blocked question, confirm every option it offers is actually
+buildable against the codebase's current architecture, with no
+undisclosed scope expansion -- a new persistence layer, a new
+dependency, or a change to an unrelated component's contract. A
+competing-options question can read as complete because every option
+sounds coherent in English, while only an implementing session's actual
+codebase familiarity reveals that one option needs a capability the
+architecture does not have. If an option fails this check, either drop
+it from the question or disclose the scope expansion it would require
+as part of the question itself, so the operator chooses with the same
+information an implementing session would need (field evidence observed
+2026-09-10, issue `#2805`).
+
 **Never override a deliberate decision.** When the original rejection
 recorded a genuinely deliberate empirical or product decision (not
 merely an unanswered question), grooming must never resolve it
@@ -616,6 +630,22 @@ so a re-groomed issue is not discarded before Check 7 ever sees it. The
 next ordinary Discover pass then picks the issue up normally -- grooming
 itself never claims or works the issue (see
 [Mutation Policy and Coordination Rule](../.github/instructions/idd-suitability.instructions.md#mutation-policy-and-coordination-rule)).
+
+**Hold when a recorded resolution proves infeasible.** The feasibility
+check above narrows this gap but does not close it -- the same field
+evidence (2026-09-10, issue `#2805`) shows infeasibility that only
+became visible once an implementing session was deep enough into the
+codebase to see it. When a session reaches implementation and finds the
+Groom-recorded resolution cannot be built as specified, it must hold
+and return the candidate to its pre-Groom decision-blocked state,
+rather than silently reinterpreting, downscoping, or unilaterally
+picking a different resolution: apply the configured needs-decision
+label and release the claim, the same general hold mechanism the shared
+Hold / suspend rules in `idd-overview-appendix.instructions.md` already
+document -- not a literal restoration of the Grooming pass's own
+`triage:{outcome}` label. Record exactly what made the recorded option
+infeasible in the hold comment, so the next Groom pass has the
+information a corrected question needs.
 
 **Worked example.** An issue was rejected `needs-decision` at score
 `2/5` because its acceptance criteria read "add caching, or document

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -620,8 +620,9 @@ several unrelated technical topics into one dense batch.
 **Apply the operator's answers back onto the issue**: update the score
 footer, remove or update the `triage:{outcome}` label -- and the
 configured needs-decision label too, when the hold-and-return rule
-below applied it to this same candidate, since nothing else removes it
--- revise acceptance criteria to reflect the decision, and record the
+below applied it to this same candidate, so Discover's own A3
+readiness filter stops excluding it -- revise acceptance criteria to
+reflect the decision, and record the
 decision as inline prose in the issue body: `Maintainer decision (<provenance>,
 Groom hearing, <date>): <resolution text>` -- the shape
 `suitability-triage.mjs`'s Check 7 recognizes as a resolved

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -565,6 +565,22 @@ as a blocker has since closed or merged -- a cached readiness snapshot
 can be stale, and a closed blocker is a "free" suitability lever that
 costs nothing to re-apply.
 
+**Verify feasibility before drafting a question.** Before drafting a
+decision-blocked question, confirm every option it offers is actually
+buildable against the codebase's current architecture, with no
+undisclosed scope expansion -- a new persistence layer, a new
+dependency, or a change to an unrelated component's contract. A
+competing-options question can read as complete because every option
+sounds coherent in English, while only an implementing session's actual
+codebase familiarity reveals that one option needs a capability the
+architecture does not have. If an option fails this check, either drop
+it from the question or disclose the scope expansion it would require
+as part of the question itself, so the operator chooses with the same
+information an implementing session would need (field evidence observed
+2026-09-10,
+[kurone-kito/idd-skill#2805](https://github.com/kurone-kito/idd-skill/issues/2805)
+in the source repository).
+
 **Never override a deliberate decision.** When the original rejection
 recorded a genuinely deliberate empirical or product decision (not
 merely an unanswered question), grooming must never resolve it
@@ -594,6 +610,24 @@ ordinary Discover pass then
 picks the issue up normally -- grooming itself never claims or works
 the issue (see
 [Mutation Policy and Coordination Rule](../.github/instructions/idd-suitability.instructions.md#mutation-policy-and-coordination-rule)).
+
+**Hold when a recorded resolution proves infeasible.** The feasibility
+check above narrows this gap but does not close it -- the same field
+evidence (2026-09-10,
+[kurone-kito/idd-skill#2805](https://github.com/kurone-kito/idd-skill/issues/2805)
+in the source repository) shows infeasibility that only became visible
+once an implementing session was deep enough into the codebase to see
+it. When a session reaches implementation and finds the Groom-recorded
+resolution cannot be built as specified, it must hold and return the
+candidate to its pre-Groom decision-blocked state, rather than silently
+reinterpreting, downscoping, or unilaterally picking a different
+resolution: apply the configured needs-decision label and release the
+claim, the same general hold mechanism the shared Hold / suspend rules
+in `idd-overview-appendix.instructions.md` already document -- not a
+literal restoration of the Grooming pass's own `triage:{outcome}`
+label. Record exactly what made the recorded option infeasible in the
+hold comment, so the next Groom pass has the information a corrected
+question needs.
 
 **Worked example.** An issue was rejected `needs-decision` at score
 `2/5` because its acceptance criteria read "add caching, or document

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -592,9 +592,11 @@ tradeoffs behind each question before asking it, rather than bundling
 several unrelated technical topics into one dense batch.
 
 **Apply the operator's answers back onto the issue**: update the score
-footer, remove or update the `triage:{outcome}` label, revise
-acceptance criteria to reflect the decision, and record the decision as
-inline prose in the issue body: `Maintainer decision (<provenance>,
+footer, remove or update the `triage:{outcome}` label -- and the
+configured needs-decision label too, when the hold-and-return rule
+below applied it to this same candidate, since nothing else removes it
+-- revise acceptance criteria to reflect the decision, and record the
+decision as inline prose in the issue body: `Maintainer decision (<provenance>,
 Groom hearing, <date>): <resolution text>` -- the shape
 `suitability-triage.mjs`'s Check 7 recognizes as a resolved
 decision
@@ -612,22 +614,26 @@ the issue (see
 [Mutation Policy and Coordination Rule](../.github/instructions/idd-suitability.instructions.md#mutation-policy-and-coordination-rule)).
 
 **Hold when a recorded resolution proves infeasible.** The feasibility
-check above narrows this gap but does not close it -- the same field
-evidence (2026-09-10,
+check above reduces the risk of drafting an infeasible option, but does
+not eliminate it -- the same field evidence (2026-09-10,
 [kurone-kito/idd-skill#2805](https://github.com/kurone-kito/idd-skill/issues/2805)
 in the source repository) shows infeasibility that only became visible
 once an implementing session was deep enough into the codebase to see
 it. When a session reaches implementation and finds the Groom-recorded
-resolution cannot be built as specified, it must hold and return the
-candidate to its pre-Groom decision-blocked state, rather than silently
-reinterpreting, downscoping, or unilaterally picking a different
-resolution: apply the configured needs-decision label and release the
-claim, the same general hold mechanism the shared Hold / suspend rules
-in `idd-overview-appendix.instructions.md` already document -- not a
-literal restoration of the Grooming pass's own `triage:{outcome}`
-label. Record exactly what made the recorded option infeasible in the
-hold comment, so the next Groom pass has the information a corrected
-question needs.
+resolution cannot be built as specified, it must hold the candidate as
+decision-blocked again, rather than silently reinterpreting,
+downscoping, or unilaterally picking a different resolution: apply the
+configured needs-decision label and release the claim, the same
+general hold mechanism the shared Hold / suspend rules in
+`idd-overview-appendix.instructions.md` already document. Record
+exactly what made the recorded option infeasible in the hold comment,
+so the next Groom pass has the information a corrected question needs.
+That later pass removes the needs-decision label as part of applying
+its own operator's answers back onto the issue (above) -- alongside the
+`triage:{outcome}` label, the score footer, and a fresh `Maintainer
+decision` line that supersedes the infeasible one -- rather than
+leaving the label in place indefinitely or removing it without
+recording a genuinely buildable replacement.
 
 **Worked example.** An issue was rejected `needs-decision` at score
 `2/5` because its acceptance criteria read "add caching, or document

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -638,7 +638,12 @@ infeasible `Maintainer decision` line rather than merely append beside
 it -- re-triage's own `hasResolvedDecision` check treats every unstruck
 occurrence as live and has no way to tell which one is current, so an
 unstruck infeasible line can keep reading as resolved alongside its
-replacement.
+replacement. Removing the label here does not itself trigger the
+appendix's usual removal-and-re-claim pairing: like the adjacent
+`triage:{outcome}` removal above, the actual re-claim happens through
+the next ordinary Discover pass reading the now-label-free issue, not
+through the Groom pass itself, which -- as already stated above --
+never claims or works the issue.
 
 **Worked example.** An issue was rejected `needs-decision` at score
 `2/5` because its acceptance criteria read "add caching, or document

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -594,8 +594,9 @@ several unrelated technical topics into one dense batch.
 **Apply the operator's answers back onto the issue**: update the score
 footer, remove or update the `triage:{outcome}` label -- and the
 configured needs-decision label too, when the hold-and-return rule
-below applied it to this same candidate, since nothing else removes it
--- revise acceptance criteria to reflect the decision, and record the
+below applied it to this same candidate, so Discover's own A3
+readiness filter stops excluding it -- revise acceptance criteria to
+reflect the decision, and record the
 decision as inline prose in the issue body: `Maintainer decision (<provenance>,
 Groom hearing, <date>): <resolution text>` -- the shape
 `suitability-triage.mjs`'s Check 7 recognizes as a resolved

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -625,15 +625,20 @@ decision-blocked again, rather than silently reinterpreting,
 downscoping, or unilaterally picking a different resolution: apply the
 configured needs-decision label and release the claim, the same
 general hold mechanism the shared Hold / suspend rules in
-`idd-overview-appendix.instructions.md` already document. Record
-exactly what made the recorded option infeasible in the hold comment,
-so the next Groom pass has the information a corrected question needs.
-That later pass removes the needs-decision label as part of applying
-its own operator's answers back onto the issue (above) -- alongside the
-`triage:{outcome}` label, the score footer, and a fresh `Maintainer
-decision` line that supersedes the infeasible one -- rather than
-leaving the label in place indefinitely or removing it without
-recording a genuinely buildable replacement.
+`.github/instructions/idd-overview-appendix.instructions.md` already
+document. Record exactly what made the recorded option infeasible in
+the hold comment, so the next Groom pass has the information a
+corrected question needs. That later pass removes the needs-decision
+label as part of applying its own operator's answers back onto the
+issue (above), alongside the `triage:{outcome}` label and the score
+footer, rather than leaving the label in place indefinitely or
+removing it without recording a genuinely buildable replacement.
+That replacement must strike through or otherwise replace the
+infeasible `Maintainer decision` line rather than merely append beside
+it -- re-triage's own `hasResolvedDecision` check treats every unstruck
+occurrence as live and has no way to tell which one is current, so an
+unstruck infeasible line can keep reading as resolved alongside its
+replacement.
 
 **Worked example.** An issue was rejected `needs-decision` at score
 `2/5` because its acceptance criteria read "add caching, or document


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

A Groom hearing can record a decision-blocked candidate's resolution
without checking that every offered option is actually buildable
against the codebase's current architecture, and an implementing
session that later finds a recorded resolution infeasible had no
documented rule against silently reinterpreting or downscoping it
instead of raising the gap back to a human.

This PR adds two paragraphs to the "Grooming pass for rejected and
below-floor issues (optional)" section of `docs/idd-workflow.md` (and
the canonical `idd-template/docs/idd-workflow.md` copy, kept in sync
per `audit/sync-manifest.json`'s `structure`-mode pair):

1. **Verify feasibility before drafting a question** — before drafting
   a decision-blocked question, confirm every option it offers is
   actually buildable against the codebase's current architecture with
   no undisclosed scope expansion (a new persistence layer, a new
   dependency, a change to an unrelated component's contract). Drop or
   disclose an option that fails this check.
2. **Hold when a recorded resolution proves infeasible** — the
   symmetric implementing-session rule: when a session reaches
   implementation and finds the Groom-recorded resolution cannot be
   built as specified, hold and return the candidate to its pre-Groom
   decision-blocked state (applying the configured needs-decision label
   and releasing the claim, per the existing shared Hold / suspend
   rules) instead of silently reinterpreting, downscoping, or
   unilaterally picking a different resolution.

No new headings are introduced, so the `structure`-mode heading-sync
check between the two copies is unaffected.

## Linked issue

Closes #2805

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

The issue's own Background section already narrates the motivating
field evidence (a Groom-recorded authority-check option that assumed
persisted state a stateless helper does not have); this PR cites that
evidence by issue number and date, following this repository's
"cite the observed incident" convention
(`docs/idd-design-rationale.md#cite-the-observed-incident`), since the
incident itself has no separate tracking issue of its own.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EycqtGKuWjJMpw2tUav3Tn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated grooming guidance to require feasibility checks for decision-blocked options before presenting them for approval.
  * Clarified that options requiring unsupported architecture or additional scope must be disclosed or removed.
  * Documented automatic handling of the configured `needs-decision` label when decisions are applied.
  * Added guidance for re-grooming when implementation reveals an infeasible decision, including documenting the cause and replacing obsolete resolutions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->