### PR TITLE
docs(idd-discover): route a roadmap-node A0-T target to A1's root

### DIFF
--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -77,13 +77,16 @@ routing:
    authoring-held roadmap is never routed into step 2's traversal.
 2. If the target issue carries the configured roadmap label or an
    `idd-skill-roadmap-id` marker — the same test
-   **A2**'s roadmap-node/execution-leaf classification rule uses — do
-   not continue to steps 3-5. Instead:
+   **A2**'s roadmap-node/execution-leaf classification rule uses (an
+   unmarked legacy umbrella isn't recognized here — retro-label it
+   first, per A1's Legacy roots) — do not continue to steps 3-5.
+   Instead:
    - Apply **A3**'s dependency bullet to the target itself (both
      visible `Blocked by #NNN` lines and hidden blocked-by markers)
-     and its human-coordination/runtime-observation-precondition
-     bullet; a hit reports the target as blocked and stops (no
-     fallback, per the rule above). Skip A3's other bullets here:
+     and its coordination/runtime-observation-precondition bullet; a
+     dependency hit reports blocked, a coordination hit reports that
+     criterion instead — either way this run stops (no fallback, per
+     the rule above). Skip A3's other bullets here:
      **A1.5** already checks the roadmap's own blocked-by-human/
      needs-decision labels and claim state, and "no open dependent
      issues" does not apply to a root whose own children are its

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -82,11 +82,12 @@ routing:
    first, per A1's Legacy roots) — do not continue to steps 3-5.
    Instead:
    - Apply **A3**'s dependency bullet to the target itself (both
-     visible `Blocked by #NNN` lines and hidden blocked-by markers)
-     and its coordination/runtime-observation-precondition bullet; a
+     visible `Blocked by #NNN` lines and hidden
+     `idd-skill-blocked-by` markers) and its
+     coordination/runtime-observation-precondition bullet; a
      dependency hit reports blocked, a coordination hit reports that
-     criterion instead — either way this run stops (no fallback, per
-     the rule above). Skip A3's other bullets here:
+     criterion instead — either way this run stops (no fallback).
+     Skip A3's other bullets here:
      **A1.5** already checks the roadmap's own blocked-by-human/
      needs-decision labels and claim state, and "no open dependent
      issues" does not apply to a root whose own children are its

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -62,23 +62,31 @@ reason and stop without claiming. Fall back to normal discovery only when
 the operator explicitly asks for normal discovery in the same run; do not
 silently search for another issue.
 
-For a valid open target that is not itself a roadmap node (see step 1
+For a valid open target that is not itself a roadmap node (see step 2
 below), skip A0-O, A1, A1.5, A2, and candidate selection. Before A5, run
 targeted readiness and viability checks against that issue only:
 
-1. Fetch the target issue. If it carries the configured roadmap label or
-   an `idd-skill-roadmap-id` marker — the same test
+1. Fetch the target issue. If it carries the configured authoring label,
+   report `Issue #N is currently being authored`, run the
+   stale-authoring warning check above, and stop without claiming — this
+   check runs first and applies whether the target turns out to be an
+   execution leaf or a roadmap node in step 2 below, so an
+   authoring-held roadmap is never routed into step 2's traversal.
+2. If the target issue carries the configured roadmap label or an
+   `idd-skill-roadmap-id` marker — the same test
    **A2**'s roadmap-node/execution-leaf classification rule uses — do
-   not continue this targeted-readiness path. Instead, treat the
-   operator's target as scoping A1's own root selection: run a
-   single-root traversal from this issue as A2's root (skipping A1's
-   own roadmap search), then continue the normal
-   A1.5 → A2 → A3 → A3.5 → A4 → A4.5 → A5 sequence from there, ranking
-   and claiming the roadmap's own highest-suitability open children
-   first.
-2. If the target issue carries the configured authoring label, report
-   `Issue #N is currently being authored`, run the stale-authoring
-   warning check above, and stop without claiming.
+   not continue this targeted-readiness path. Instead, treat the target
+   as the root **A1** would have selected: continue with **A1.5**
+   against it, then run **A2**'s traversal scoped to this root and its
+   own descendants only (never a repository-wide search), then the
+   normal **A3** → **A3.5** → **A4** → **A4.5** → **A5** sequence over
+   that scoped candidate set, ranking and claiming the roadmap's own
+   highest-suitability open child first. This graph-scoped continuation
+   excludes **A0**'s own A0-O orphan-fallback triggers (a)/(b)/(c): if
+   this roadmap's own descendants are exhausted or unsuitable, end the
+   run the same way A0-T's other failure branches do — report and stop
+   — never falling back to an unrelated orphan issue, per the
+   no-silent-fallback rule above.
 3. Apply A3's readiness bullets to the target (the same blocked-by,
    human-coordination, and runtime-observation checks, resolved the
    same way) — plus one target-only check: no active, non-stale claim
@@ -669,4 +677,7 @@ Do not widen issue-selection scope beyond the roadmap traversal except
 for the explicit query allowlist already defined in A0-T, A0-O, A1,
 A1.5, A3, and A4.5, or for a same-run operator opt-in per A3 step 5
 (never inferred from prior or standing instructions). A single explicit
-target authorizes only that issue.
+target authorizes only that issue, except when A0-T step 2 classifies it
+as a roadmap node: then it authorizes normal selection scoped to that
+roadmap's own descendants only, never an unrelated orphan issue (A0-O
+stays excluded, per A0-T step 2).

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -62,11 +62,20 @@ reason and stop without claiming. Fall back to normal discovery only when
 the operator explicitly asks for normal discovery in the same run; do not
 silently search for another issue.
 
-For a valid open target, skip A0-O, A1, A1.5, A2, and candidate
-selection. Before A5, run targeted readiness and viability checks against
-that issue only:
+For a valid open target that is not itself a roadmap node (see step 1
+below), skip A0-O, A1, A1.5, A2, and candidate selection. Before A5, run
+targeted readiness and viability checks against that issue only:
 
-1. Re-fetch the target issue.
+1. Fetch the target issue. If it carries the configured roadmap label or
+   an `idd-skill-roadmap-id` marker — the same test
+   **A2**'s roadmap-node/execution-leaf classification rule uses — do
+   not continue this targeted-readiness path. Instead, treat the
+   operator's target as scoping A1's own root selection: run a
+   single-root traversal from this issue as A2's root (skipping A1's
+   own roadmap search), then continue the normal
+   A1.5 → A2 → A3 → A3.5 → A4 → A4.5 → A5 sequence from there, ranking
+   and claiming the roadmap's own highest-suitability open children
+   first.
 2. If the target issue carries the configured authoring label, report
    `Issue #N is currently being authored`, run the stale-authoring
    warning check above, and stop without claiming.

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -62,9 +62,12 @@ reason and stop without claiming. Fall back to normal discovery only when
 the operator explicitly asks for normal discovery in the same run; do not
 silently search for another issue.
 
-For a valid open target that is not itself a roadmap node (see step 2
-below), skip A0-O, A1, A1.5, A2, and candidate selection. Before A5, run
-targeted readiness and viability checks against that issue only:
+Run the steps below against a valid open target. Steps 1 and 2 apply
+regardless of target type; only once step 2 confirms the target is not
+a roadmap node does this shortcut skip A0-O, A1, A1.5, A2, and
+candidate selection, continuing through steps 3-5 to A5 against that
+issue only — a roadmap-node target instead follows step 2's own
+routing:
 
 1. Fetch the target issue. If it carries the configured authoring label,
    report `Issue #N is currently being authored`, run the
@@ -77,16 +80,25 @@ targeted readiness and viability checks against that issue only:
    **A2**'s roadmap-node/execution-leaf classification rule uses — do
    not continue this targeted-readiness path. Instead, treat the target
    as the root **A1** would have selected: continue with **A1.5**
-   against it, then run **A2**'s traversal scoped to this root and its
+   against it — its own stop/close outcomes decide whether child
+   enumeration resumes, exactly as in the normal roadmap path — then,
+   only if it does, run **A2**'s traversal scoped to this root and its
    own descendants only (never a repository-wide search), then the
-   normal **A3** → **A3.5** → **A4** → **A4.5** → **A5** sequence over
-   that scoped candidate set, ranking and claiming the roadmap's own
-   highest-suitability open child first. This graph-scoped continuation
-   excludes **A0**'s own A0-O orphan-fallback triggers (a)/(b)/(c): if
-   this roadmap's own descendants are exhausted or unsuitable, end the
-   run the same way A0-T's other failure branches do — report and stop
-   — never falling back to an unrelated orphan issue, per the
-   no-silent-fallback rule above.
+   normal **A3** → **A3.5** → **A4** sequence to rank that scoped set
+   down to its single highest-suitability open child, and run
+   **A4.5** → **A5** against that one child only.
+   `idd-suitability.instructions.md`'s and `idd-claim.instructions.md`'s
+   existing A0-T-keyed stop-without-fallback rules apply to that child
+   unchanged: an A3.5/A4.5 rejection or a lost A5 claim race ends this
+   run — report and stop — rather than retrying a second-ranked child;
+   extending this branch to retry additional children on a per-candidate
+   failure is a deliberate scope limit, left to a follow-up issue. This
+   graph-scoped continuation also excludes **A0**'s own A0-O
+   orphan-fallback triggers (a)/(b)/(c) throughout: an empty or
+   fully-unsuitable scoped candidate set likewise ends the run the same
+   way A0-T's other failure branches do — report and stop — never
+   falling back to an unrelated orphan issue, per the no-silent-fallback
+   rule above.
 3. Apply A3's readiness bullets to the target (the same blocked-by,
    human-coordination, and runtime-observation checks, resolved the
    same way) — plus one target-only check: no active, non-stale claim

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -78,27 +78,41 @@ routing:
 2. If the target issue carries the configured roadmap label or an
    `idd-skill-roadmap-id` marker — the same test
    **A2**'s roadmap-node/execution-leaf classification rule uses — do
-   not continue this targeted-readiness path. Instead, treat the target
-   as the root **A1** would have selected: continue with **A1.5**
-   against it — its own stop/close outcomes decide whether child
-   enumeration resumes, exactly as in the normal roadmap path — then,
-   only if it does, run **A2**'s traversal scoped to this root and its
-   own descendants only (never a repository-wide search), then the
-   normal **A3** → **A3.5** → **A4** sequence to rank that scoped set
-   down to its single highest-suitability open child, and run
-   **A4.5** → **A5** against that one child only.
-   `idd-suitability.instructions.md`'s and `idd-claim.instructions.md`'s
-   existing A0-T-keyed stop-without-fallback rules apply to that child
-   unchanged: an A3.5/A4.5 rejection or a lost A5 claim race ends this
-   run — report and stop — rather than retrying a second-ranked child;
-   extending this branch to retry additional children on a per-candidate
-   failure is a deliberate scope limit, left to a follow-up issue. This
-   graph-scoped continuation also excludes **A0**'s own A0-O
-   orphan-fallback triggers (a)/(b)/(c) throughout: an empty or
-   fully-unsuitable scoped candidate set likewise ends the run the same
-   way A0-T's other failure branches do — report and stop — never
-   falling back to an unrelated orphan issue, per the no-silent-fallback
-   rule above.
+   not continue to steps 3-5. Instead:
+   - Apply **A3**'s dependency bullet to the target itself (both
+     visible `Blocked by #NNN` lines and hidden blocked-by markers)
+     and its human-coordination/runtime-observation-precondition
+     bullet; a hit reports the target as blocked and stops (no
+     fallback, per the rule above). Skip A3's other bullets here:
+     **A1.5** already checks the roadmap's own blocked-by-human/
+     needs-decision labels and claim state, and "no open dependent
+     issues" does not apply to a root whose own children are its
+     dependents.
+   - Treat the target as the root **A1** would have selected: run
+     **A1.5** against it. A1.5's own outcome governs what happens
+     next: a close or non-autonomous-gap outcome ends this run here —
+     report and stop, never falling back to A1 the way the normal
+     roadmap path would; only a continue outcome proceeds.
+   - Run **A2**'s traversal scoped to this root and its own
+     descendants only (never a repository-wide search), then the
+     normal **A3** → **A3.5** → **A4** sequence over that scoped set:
+     A3.5 filters and continues with the remaining startable
+     candidates exactly as in the normal roadmap path — no
+     stop-without-fallback applies at this filtering step. This
+     graph-scoped continuation excludes **A0**'s own A0-O
+     orphan-fallback triggers (a)/(b)/(c) throughout: an empty or
+     fully-discarded scoped set ends the run the same way A0-T's other
+     failure branches do — report and stop.
+   - Rank the survivors down to a single highest-suitability open
+     child and run **A4.5** → **A5** against that one child only.
+     `idd-suitability.instructions.md`'s and
+     `idd-claim.instructions.md`'s existing A0-T-keyed
+     stop-without-fallback rules apply to it unchanged: an A4.5
+     rejection, a failed A5 Pre-check (a) approval re-verification, or
+     a lost A5 claim race ends this run — report and stop — rather
+     than falling back to the next-ranked survivor. Extending this
+     branch to retry a subsequent survivor on such a failure is out of
+     scope here.
 3. Apply A3's readiness bullets to the target (the same blocked-by,
    human-coordination, and runtime-observation checks, resolved the
    same way) — plus one target-only check: no active, non-stale claim

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -72,13 +72,16 @@ routing:
    authoring-held roadmap is never routed into step 2's traversal.
 2. If the target issue carries the configured roadmap label or an
    `{{PROJECT_MARKER_PREFIX}}-roadmap-id` marker — the same test
-   **A2**'s roadmap-node/execution-leaf classification rule uses — do
-   not continue to steps 3-5. Instead:
+   **A2**'s roadmap-node/execution-leaf classification rule uses (an
+   unmarked legacy umbrella isn't recognized here — retro-label it
+   first, per A1's Legacy roots) — do not continue to steps 3-5.
+   Instead:
    - Apply **A3**'s dependency bullet to the target itself (both
      visible `Blocked by #NNN` lines and hidden blocked-by markers)
-     and its human-coordination/runtime-observation-precondition
-     bullet; a hit reports the target as blocked and stops (no
-     fallback, per the rule above). Skip A3's other bullets here:
+     and its coordination/runtime-observation-precondition bullet; a
+     dependency hit reports blocked, a coordination hit reports that
+     criterion instead — either way this run stops (no fallback, per
+     the rule above). Skip A3's other bullets here:
      **A1.5** already checks the roadmap's own blocked-by-human/
      needs-decision labels and claim state, and "no open dependent
      issues" does not apply to a root whose own children are its

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -57,11 +57,20 @@ reason and stop without claiming. Fall back to normal discovery only when
 the operator explicitly asks for normal discovery in the same run; do not
 silently search for another issue.
 
-For a valid open target, skip A0-O, A1, A1.5, A2, and candidate
-selection. Before A5, run targeted readiness and viability checks against
-that issue only:
+For a valid open target that is not itself a roadmap node (see step 1
+below), skip A0-O, A1, A1.5, A2, and candidate selection. Before A5, run
+targeted readiness and viability checks against that issue only:
 
-1. Re-fetch the target issue.
+1. Fetch the target issue. If it carries the configured roadmap label or
+   an `{{PROJECT_MARKER_PREFIX}}-roadmap-id` marker — the same test
+   **A2**'s roadmap-node/execution-leaf classification rule uses — do
+   not continue this targeted-readiness path. Instead, treat the
+   operator's target as scoping A1's own root selection: run a
+   single-root traversal from this issue as A2's root (skipping A1's
+   own roadmap search), then continue the normal
+   A1.5 → A2 → A3 → A3.5 → A4 → A4.5 → A5 sequence from there, ranking
+   and claiming the roadmap's own highest-suitability open children
+   first.
 2. If the target issue carries the configured authoring label, report
    `Issue #N is currently being authored`, run the stale-authoring
    warning check above, and stop without claiming.

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -57,23 +57,31 @@ reason and stop without claiming. Fall back to normal discovery only when
 the operator explicitly asks for normal discovery in the same run; do not
 silently search for another issue.
 
-For a valid open target that is not itself a roadmap node (see step 1
+For a valid open target that is not itself a roadmap node (see step 2
 below), skip A0-O, A1, A1.5, A2, and candidate selection. Before A5, run
 targeted readiness and viability checks against that issue only:
 
-1. Fetch the target issue. If it carries the configured roadmap label or
-   an `{{PROJECT_MARKER_PREFIX}}-roadmap-id` marker — the same test
+1. Fetch the target issue. If it carries the configured authoring label,
+   report `Issue #N is currently being authored`, run the
+   stale-authoring warning check above, and stop without claiming — this
+   check runs first and applies whether the target turns out to be an
+   execution leaf or a roadmap node in step 2 below, so an
+   authoring-held roadmap is never routed into step 2's traversal.
+2. If the target issue carries the configured roadmap label or an
+   `{{PROJECT_MARKER_PREFIX}}-roadmap-id` marker — the same test
    **A2**'s roadmap-node/execution-leaf classification rule uses — do
-   not continue this targeted-readiness path. Instead, treat the
-   operator's target as scoping A1's own root selection: run a
-   single-root traversal from this issue as A2's root (skipping A1's
-   own roadmap search), then continue the normal
-   A1.5 → A2 → A3 → A3.5 → A4 → A4.5 → A5 sequence from there, ranking
-   and claiming the roadmap's own highest-suitability open children
-   first.
-2. If the target issue carries the configured authoring label, report
-   `Issue #N is currently being authored`, run the stale-authoring
-   warning check above, and stop without claiming.
+   not continue this targeted-readiness path. Instead, treat the target
+   as the root **A1** would have selected: continue with **A1.5**
+   against it, then run **A2**'s traversal scoped to this root and its
+   own descendants only (never a repository-wide search), then the
+   normal **A3** → **A3.5** → **A4** → **A4.5** → **A5** sequence over
+   that scoped candidate set, ranking and claiming the roadmap's own
+   highest-suitability open child first. This graph-scoped continuation
+   excludes **A0**'s own A0-O orphan-fallback triggers (a)/(b)/(c): if
+   this roadmap's own descendants are exhausted or unsuitable, end the
+   run the same way A0-T's other failure branches do — report and stop
+   — never falling back to an unrelated orphan issue, per the
+   no-silent-fallback rule above.
 3. Apply A3's readiness bullets to the target (the same blocked-by,
    human-coordination, and runtime-observation checks, resolved the
    same way) — plus one target-only check: no active, non-stale claim
@@ -664,4 +672,7 @@ Do not widen issue-selection scope beyond the roadmap traversal except
 for the explicit query allowlist already defined in A0-T, A0-O, A1,
 A1.5, A3, and A4.5, or for a same-run operator opt-in per A3 step 5
 (never inferred from prior or standing instructions). A single explicit
-target authorizes only that issue.
+target authorizes only that issue, except when A0-T step 2 classifies it
+as a roadmap node: then it authorizes normal selection scoped to that
+roadmap's own descendants only, never an unrelated orphan issue (A0-O
+stays excluded, per A0-T step 2).

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -73,27 +73,41 @@ routing:
 2. If the target issue carries the configured roadmap label or an
    `{{PROJECT_MARKER_PREFIX}}-roadmap-id` marker — the same test
    **A2**'s roadmap-node/execution-leaf classification rule uses — do
-   not continue this targeted-readiness path. Instead, treat the target
-   as the root **A1** would have selected: continue with **A1.5**
-   against it — its own stop/close outcomes decide whether child
-   enumeration resumes, exactly as in the normal roadmap path — then,
-   only if it does, run **A2**'s traversal scoped to this root and its
-   own descendants only (never a repository-wide search), then the
-   normal **A3** → **A3.5** → **A4** sequence to rank that scoped set
-   down to its single highest-suitability open child, and run
-   **A4.5** → **A5** against that one child only.
-   `idd-suitability.instructions.md`'s and `idd-claim.instructions.md`'s
-   existing A0-T-keyed stop-without-fallback rules apply to that child
-   unchanged: an A3.5/A4.5 rejection or a lost A5 claim race ends this
-   run — report and stop — rather than retrying a second-ranked child;
-   extending this branch to retry additional children on a per-candidate
-   failure is a deliberate scope limit, left to a follow-up issue. This
-   graph-scoped continuation also excludes **A0**'s own A0-O
-   orphan-fallback triggers (a)/(b)/(c) throughout: an empty or
-   fully-unsuitable scoped candidate set likewise ends the run the same
-   way A0-T's other failure branches do — report and stop — never
-   falling back to an unrelated orphan issue, per the no-silent-fallback
-   rule above.
+   not continue to steps 3-5. Instead:
+   - Apply **A3**'s dependency bullet to the target itself (both
+     visible `Blocked by #NNN` lines and hidden blocked-by markers)
+     and its human-coordination/runtime-observation-precondition
+     bullet; a hit reports the target as blocked and stops (no
+     fallback, per the rule above). Skip A3's other bullets here:
+     **A1.5** already checks the roadmap's own blocked-by-human/
+     needs-decision labels and claim state, and "no open dependent
+     issues" does not apply to a root whose own children are its
+     dependents.
+   - Treat the target as the root **A1** would have selected: run
+     **A1.5** against it. A1.5's own outcome governs what happens
+     next: a close or non-autonomous-gap outcome ends this run here —
+     report and stop, never falling back to A1 the way the normal
+     roadmap path would; only a continue outcome proceeds.
+   - Run **A2**'s traversal scoped to this root and its own
+     descendants only (never a repository-wide search), then the
+     normal **A3** → **A3.5** → **A4** sequence over that scoped set:
+     A3.5 filters and continues with the remaining startable
+     candidates exactly as in the normal roadmap path — no
+     stop-without-fallback applies at this filtering step. This
+     graph-scoped continuation excludes **A0**'s own A0-O
+     orphan-fallback triggers (a)/(b)/(c) throughout: an empty or
+     fully-discarded scoped set ends the run the same way A0-T's other
+     failure branches do — report and stop.
+   - Rank the survivors down to a single highest-suitability open
+     child and run **A4.5** → **A5** against that one child only.
+     `idd-suitability.instructions.md`'s and
+     `idd-claim.instructions.md`'s existing A0-T-keyed
+     stop-without-fallback rules apply to it unchanged: an A4.5
+     rejection, a failed A5 Pre-check (a) approval re-verification, or
+     a lost A5 claim race ends this run — report and stop — rather
+     than falling back to the next-ranked survivor. Extending this
+     branch to retry a subsequent survivor on such a failure is out of
+     scope here.
 3. Apply A3's readiness bullets to the target (the same blocked-by,
    human-coordination, and runtime-observation checks, resolved the
    same way) — plus one target-only check: no active, non-stale claim

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -77,11 +77,12 @@ routing:
    first, per A1's Legacy roots) — do not continue to steps 3-5.
    Instead:
    - Apply **A3**'s dependency bullet to the target itself (both
-     visible `Blocked by #NNN` lines and hidden blocked-by markers)
-     and its coordination/runtime-observation-precondition bullet; a
+     visible `Blocked by #NNN` lines and hidden
+     `{{PROJECT_MARKER_PREFIX}}-blocked-by` markers) and its
+     coordination/runtime-observation-precondition bullet; a
      dependency hit reports blocked, a coordination hit reports that
-     criterion instead — either way this run stops (no fallback, per
-     the rule above). Skip A3's other bullets here:
+     criterion instead — either way this run stops (no fallback).
+     Skip A3's other bullets here:
      **A1.5** already checks the roadmap's own blocked-by-human/
      needs-decision labels and claim state, and "no open dependent
      issues" does not apply to a root whose own children are its

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -57,9 +57,12 @@ reason and stop without claiming. Fall back to normal discovery only when
 the operator explicitly asks for normal discovery in the same run; do not
 silently search for another issue.
 
-For a valid open target that is not itself a roadmap node (see step 2
-below), skip A0-O, A1, A1.5, A2, and candidate selection. Before A5, run
-targeted readiness and viability checks against that issue only:
+Run the steps below against a valid open target. Steps 1 and 2 apply
+regardless of target type; only once step 2 confirms the target is not
+a roadmap node does this shortcut skip A0-O, A1, A1.5, A2, and
+candidate selection, continuing through steps 3-5 to A5 against that
+issue only — a roadmap-node target instead follows step 2's own
+routing:
 
 1. Fetch the target issue. If it carries the configured authoring label,
    report `Issue #N is currently being authored`, run the
@@ -72,16 +75,25 @@ targeted readiness and viability checks against that issue only:
    **A2**'s roadmap-node/execution-leaf classification rule uses — do
    not continue this targeted-readiness path. Instead, treat the target
    as the root **A1** would have selected: continue with **A1.5**
-   against it, then run **A2**'s traversal scoped to this root and its
+   against it — its own stop/close outcomes decide whether child
+   enumeration resumes, exactly as in the normal roadmap path — then,
+   only if it does, run **A2**'s traversal scoped to this root and its
    own descendants only (never a repository-wide search), then the
-   normal **A3** → **A3.5** → **A4** → **A4.5** → **A5** sequence over
-   that scoped candidate set, ranking and claiming the roadmap's own
-   highest-suitability open child first. This graph-scoped continuation
-   excludes **A0**'s own A0-O orphan-fallback triggers (a)/(b)/(c): if
-   this roadmap's own descendants are exhausted or unsuitable, end the
-   run the same way A0-T's other failure branches do — report and stop
-   — never falling back to an unrelated orphan issue, per the
-   no-silent-fallback rule above.
+   normal **A3** → **A3.5** → **A4** sequence to rank that scoped set
+   down to its single highest-suitability open child, and run
+   **A4.5** → **A5** against that one child only.
+   `idd-suitability.instructions.md`'s and `idd-claim.instructions.md`'s
+   existing A0-T-keyed stop-without-fallback rules apply to that child
+   unchanged: an A3.5/A4.5 rejection or a lost A5 claim race ends this
+   run — report and stop — rather than retrying a second-ranked child;
+   extending this branch to retry additional children on a per-candidate
+   failure is a deliberate scope limit, left to a follow-up issue. This
+   graph-scoped continuation also excludes **A0**'s own A0-O
+   orphan-fallback triggers (a)/(b)/(c) throughout: an empty or
+   fully-unsuitable scoped candidate set likewise ends the run the same
+   way A0-T's other failure branches do — report and stop — never
+   falling back to an unrelated orphan issue, per the no-silent-fallback
+   rule above.
 3. Apply A3's readiness bullets to the target (the same blocked-by,
    human-coordination, and runtime-observation checks, resolved the
    same way) — plus one target-only check: no active, non-stale claim


### PR DESCRIPTION
# Summary

`idd-discover.instructions.md`'s A0-T targeted-readiness shortcut ran
A3/A4/A4.5 directly against any valid open single-issue target with no
check for the configured roadmap label or `idd-skill-roadmap-id`
marker, even though A2's own classification rule states unconditionally
that a roadmap-node issue must never advance to A3/A4/A4.5/A5. Nothing
in A0-T cross-referenced that rule.

Adds a new branch to A0-T's step 2: fetch the target and, if it carries
the roadmap label or roadmap-id marker (A2's own test), skip the
execution-leaf claim path (steps 3-5) and instead scope A1's own root
selection to that issue, restoring the target-dependency/coordination
checks step 3 used to run unconditionally, then running A1.5, a
graph-scoped A2 traversal, and the normal A3 -> A3.5 -> A4 sequence
(A3.5 filters the candidate set exactly as in the normal roadmap path)
down to a single highest-suitability child, then A4.5 -> A5 against
that one child only. This documents the interpretation a prior session
already had to infer independently in the field (see the issue's own
Background), rather than changing runtime behavior for the common case.

## Linked issue

Closes #2804

## Follow-up issues (if any)

- [ ] Retry a subsequent ranked child when the top-ranked survivor
      fails A4.5 or loses its A5 claim race, instead of ending the
      A0-T run outright. Deliberately out of scope here: extending it
      requires either widening `idd-suitability.instructions.md`'s and
      `idd-claim.instructions.md`'s A0-T-keyed stop-without-fallback
      rules to distinguish this branch's derived candidates from a
      literal single explicit target, or an equivalent in-branch loop
      -- both non-trivial enough to warrant their own issue rather than
      growing this one further. Not yet filed as of this PR.
- [ ] An unmarked legacy umbrella (recognized only via A1's own
      judgment-based "recognizing it as an umbrella issue", not by
      label or marker) still falls through A0-T's step 2 into the
      execution-leaf path. Not a regression -- A2's own
      roadmap-node/execution-leaf rule, which step 2 deliberately
      mirrors (#2804 AC #2), has the identical gap for normal roadmap
      traversal. A real fix needs a maintainer decision defining
      umbrella recognition for A2 and A0-T together (or a
      `discover.legacyRoots`-style allowlist for A0-T specifically),
      not a unilateral A0-T-only widening that would make it stricter
      than A2. Not yet filed as of this PR.
- [ ] `idd-roadmap-audit.instructions.md` (A1.5) has no authoring-label
      check on any mutation target it audits/closes, root or nested --
      a recursive hierarchy can let it close an authoring-held nested
      roadmap. Pre-existing for the normal A1 -> A1.5 path too, not
      introduced by this branch; A0-T routing into A1.5 is #2804's own
      maintainer decision, and the fix belongs in
      `idd-roadmap-audit.instructions.md` itself, alongside its
      existing per-mutation-target claim re-validation, so every A1.5
      caller benefits. Not yet filed as of this PR.

## Background / rationale (if material)

Maintainer decision recorded on #2804 (Groom hearing, 2026-09-10). The
edit targets `idd-discover.instructions.md`, a `bundle-discovery-phase`
member (post-#2789 split), currently at 94.01% utilization after this
change (below the 95% near-ceiling notice threshold).

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDJpTELrY2SnjHW9m5Aw7i


