### PR TITLE
docs(idd-suitability): block reclaim on a standing rejection comment

### DIFF
--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -291,10 +291,10 @@ re-evaluation differs) before Check 1-7 run normally. This is now a
 hard pre-claim prohibition, so apply this workflow's
 [fail-closed default](idd-overview-core.instructions.md#fail-closed-default)
 when the scan itself cannot be completed — a comments-fetch failure, or
-a helper result carrying a rejection-collection warning with no
-conclusive answer — rather than treating an inconclusive scan the same
-as a confirmed absence: stop and report instead of proceeding to Check
-1.
+a helper result whose `existingRejectionCollectionWarnings` field
+reports a collection failure with no conclusive `existingRejection`
+value — rather than treating an inconclusive scan the same as a
+confirmed absence: stop and report instead of proceeding to Check 1.
 
 ```text
 Candidates = A4 survivor set
@@ -305,8 +305,8 @@ Loop: Rerun A4 Step 2 over Candidates to pick the next candidate
     → Non-stale rejection found → do not claim; exclude, post nothing, loop
     → Stale rejection found → post reconciliation comment → Run Check 1
     → No trusted rejection found → Run Check 1
-    → Scan inconclusive (fetch failed, or a collection warning with no
-      conclusive answer) → stop, report (fail closed)
+    → Scan inconclusive (fetch failed, or existingRejectionCollectionWarnings
+      with no conclusive existingRejection) → stop, report (fail closed)
   → Run Check 1 (Repository Fit)
     → PASS → Run Check 2
     → FAIL → Classify as out-of-scope → Report, remove from Candidates, loop

--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -303,6 +303,7 @@ Candidates = A4 survivor set
 Loop: Rerun A4 Step 2 over Candidates to pick the next candidate
   → Standing-rejection pre-check (see above)
     → Non-stale rejection found → do not claim; exclude, post nothing, loop
+      (for A0-T: report why the target is blocked, then STOP — no fallback)
     → Stale rejection found → post reconciliation comment → Run Check 1
     → No trusted rejection found → Run Check 1
     → Scan inconclusive (fetch failed, or existingRejectionCollectionWarnings

--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -226,8 +226,8 @@ convention:
 ```
 
 Never emit this marker for `needs-decision` or `blocked-by-human`: those
-two already carry a stable label (see above) and need no second
-signal. Discover's own
+two already have a dedicated label available (see above) and need no
+second signal. Discover's own
 candidate-selection pass (`idd-discover.instructions.md`) reads this
 marker to skip a previously-rejected candidate without a full manual
 comment-history read, applying the same staleness rule as every other
@@ -287,7 +287,14 @@ non-stale rejection means the session must not claim the candidate —
 label or no label — so exclude it from Candidates without posting a
 second rejection comment and loop; a stale rejection requires posting
 a one-line reconciliation comment (what changed, or why this session's
-re-evaluation differs) before Check 1-7 run normally.
+re-evaluation differs) before Check 1-7 run normally. This is now a
+hard pre-claim prohibition, so apply this workflow's
+[fail-closed default](idd-overview-core.instructions.md#fail-closed-default)
+when the scan itself cannot be completed — a comments-fetch failure, or
+a helper result carrying a rejection-collection warning with no
+conclusive answer — rather than treating an inconclusive scan the same
+as a confirmed absence: stop and report instead of proceeding to Check
+1.
 
 ```text
 Candidates = A4 survivor set
@@ -298,6 +305,8 @@ Loop: Rerun A4 Step 2 over Candidates to pick the next candidate
     → Non-stale rejection found → do not claim; exclude, post nothing, loop
     → Stale rejection found → post reconciliation comment → Run Check 1
     → No trusted rejection found → Run Check 1
+    → Scan inconclusive (fetch failed, or a collection warning with no
+      conclusive answer) → stop, report (fail closed)
   → Run Check 1 (Repository Fit)
     → PASS → Run Check 2
     → FAIL → Classify as out-of-scope → Report, remove from Candidates, loop

--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -200,7 +200,9 @@ A5 is never reached for a candidate that fails any check, labeled or not.
 
 - **Permitted**: a single diagnostic comment explaining the rejection,
   prefixed with **"A4.5 suitability gate rejection"** so it is never
-  confused with a claim or work-in-progress marker; optionally, a
+  confused with a claim or work-in-progress marker; the one-line
+  reconciliation comment the Standing-rejection pre-check (Decision
+  Flow, below) requires on a stale rejection; optionally, a
   transient `triage:{outcome}` label as a diagnostic aid for humans (this
   must never masquerade as an implementation claim); linking related
   issues as context (e.g., "Related to #NNN which addresses similar
@@ -231,7 +233,13 @@ marker to skip a previously-rejected candidate without a full manual
 comment-history read, applying the same staleness rule as every other
 evidentiary marker in this workflow: a rejection whose comment predates
 the issue's own latest substantive (title/body) edit is stale and never
-suppresses a genuinely improved issue.
+suppresses a genuinely improved issue. The Decision Flow's
+Standing-rejection pre-check (below) applies this same staleness rule
+directly to the rejection comment itself, closing the gap for
+`needs-decision`/`blocked-by-human` outcomes: A4.5 never applies their
+label itself (a maintainer does), and neither carries a marker, so a
+later session may find no signal at all — label or no label — that the
+issue was already adjudicated.
 
 ### High-confidence coordination-close (#1485)
 
@@ -267,11 +275,29 @@ risk, not a blocker on the gate above.
 
 ## Decision Flow
 
+**Standing-rejection pre-check (#2803).** Before Check 1, scan the
+candidate's existing comments for a non-stale "A4.5 suitability gate
+rejection" comment posted by a trusted marker actor — any outcome, not
+only the four carrying their own
+`idd-skill-triage-verdict` marker. Apply the same
+edit-postdates-rejection staleness rule as the Machine-readable outcome
+marker above (a recorded Groom-hearing decision counts as a body edit
+for this rule, since Groom applies it as inline body prose). A
+non-stale rejection means the session must not claim the candidate —
+label or no label — so exclude it from Candidates without posting a
+second rejection comment and loop; a stale rejection requires posting
+a one-line reconciliation comment (what changed, or why this session's
+re-evaluation differs) before Check 1-7 run normally.
+
 ```text
 Candidates = A4 survivor set
   (for A0-T: the single verified explicit target; failure = STOP, no fallback)
   (for A0-T: every "remove from Candidates, loop" branch below means: report and STOP)
 Loop: Rerun A4 Step 2 over Candidates to pick the next candidate
+  → Standing-rejection pre-check (see above)
+    → Non-stale rejection found → do not claim; exclude, post nothing, loop
+    → Stale rejection found → post reconciliation comment → Run Check 1
+    → No trusted rejection found → Run Check 1
   → Run Check 1 (Repository Fit)
     → PASS → Run Check 2
     → FAIL → Classify as out-of-scope → Report, remove from Candidates, loop

--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -275,10 +275,10 @@ risk, not a blocker on the gate above.
 
 ## Decision Flow
 
-**Standing-rejection pre-check (#2803).** Before Check 1, scan the
-candidate's existing comments for a non-stale "A4.5 suitability gate
-rejection" comment posted by a trusted marker actor — any outcome, not
-only the four carrying their own
+**Standing-rejection pre-check (kurone-kito/idd-skill#2803).** Before
+Check 1, scan the candidate's existing comments for a non-stale "A4.5
+suitability gate rejection" comment posted by a trusted marker actor —
+any outcome, not only the four carrying their own
 `idd-skill-triage-verdict` marker. Apply the same
 edit-postdates-rejection staleness rule as the Machine-readable outcome
 marker above (a recorded Groom-hearing decision counts as a body edit
@@ -303,7 +303,8 @@ Candidates = A4 survivor set
 Loop: Rerun A4 Step 2 over Candidates to pick the next candidate
   → Standing-rejection pre-check (see above)
     → Non-stale rejection found → do not claim; exclude, post nothing, loop
-      (for A0-T: report why the target is blocked, then STOP — no fallback)
+      (for A0-T: report why the target is blocked in the run output only
+      — not a second comment — then STOP, no fallback)
     → Stale rejection found → post reconciliation comment → Run Check 1
     → No trusted rejection found → Run Check 1
     → Scan inconclusive (fetch failed, or existingRejectionCollectionWarnings

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1423,7 +1423,8 @@ standing rejection goes stale (a title/body edit, including a recorded
 Groom-hearing decision), or immediately when no standing rejection
 exists. A non-stale standing rejection is not itself a gap left for
 the customization to fill: `idd-suitability.instructions.md`'s
-Standing-rejection pre-check (`#2803`) already blocks reclaim on any
+Standing-rejection pre-check (`kurone-kito/idd-skill#2803`) already
+blocks reclaim on any
 "A4.5 suitability gate rejection" comment from a trusted marker actor
 before Check 1 ever runs, building on the `existingRejection` field
 issue #1887 shipped in `suitability-triage.mjs`; a rejected candidate

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1417,14 +1417,18 @@ never the default (`idd-suitability.instructions.md`'s "Mutation
 Policy and Coordination Rule" section). Turning that customization on
 trades a faster re-scan for a manual-review cost: a wrongly-classified
 rejection then keeps the issue out of the candidate pool on every
-later pass until someone reviews the label by hand, instead of today's
-default of a fresh seven-check re-run each pass. That fresh re-run is
-not a gap left for the customization to fill -- issue #1887 shipped
-`suitability-triage.mjs`'s `existingRejection` field, which already
-surfaces any prior "A4.5 suitability gate rejection" comment from a
-trusted marker actor to every later caller, so a rejected candidate is
-neither silently retried from scratch nor permanently hidden by
-default.
+later pass until someone reviews the label by hand, instead of the
+default reconciliation path -- a fresh seven-check re-run once the
+standing rejection goes stale (a title/body edit, including a recorded
+Groom-hearing decision), or immediately when no standing rejection
+exists. A non-stale standing rejection is not itself a gap left for
+the customization to fill: `idd-suitability.instructions.md`'s
+Standing-rejection pre-check (`#2803`) already blocks reclaim on any
+"A4.5 suitability gate rejection" comment from a trusted marker actor
+before Check 1 ever runs, building on the `existingRejection` field
+issue #1887 shipped in `suitability-triage.mjs`; a rejected candidate
+is therefore neither silently retried from scratch nor permanently
+hidden by default.
 
 When confidence is low, keep the issue open and route via a concise
 comment. "Uncertain means open" is the safe default, and selection
@@ -1433,10 +1437,13 @@ stops the pass instead, though an already-reported `invalid` (a trusted
 `existingRejection` on this exact candidate, confirmed by a fresh Check 3
 failure) narrows that halt to excluding just that one candidate — see
 [`idd-suitability.instructions.md`](../.github/instructions/idd-suitability.instructions.md#failure-outcomes)'s
-Failure Outcomes table for both cases. This carve-out responds to a
-concrete incident: a 2026-09-08 false-positive `invalid` verdict
-(kurone-kito/idd-skill#2738) that the unconditional halt would have
-forced every later concurrent session to re-report, resolved by a
+Failure Outcomes table for both cases. This fresh-Check-3 path is now
+the fallback the Standing-rejection pre-check above defers to only
+once a standing rejection has gone stale; the common case is the
+pre-check's own exclusion, before Check 3 ever runs. This carve-out
+responds to a concrete incident: a 2026-09-08 false-positive `invalid`
+verdict (kurone-kito/idd-skill#2738) that the unconditional halt would
+have forced every later concurrent session to re-report, resolved by a
 2026-09-09 maintainer hearing (kurone-kito/idd-skill#2747).
 
 The configured ready label from `approvalSignals.readyLabelName`

--- a/docs/idd-autonomy-contract.md
+++ b/docs/idd-autonomy-contract.md
@@ -55,11 +55,11 @@ repeated per row.
 
 No claim exists yet in this group; every row here runs before A5.
 
-| Mutation                                                                   | Reversible / Irreversible | Undo path / Governing gate         | Source                                   |
-| -------------------------------------------------------------------------- | ------------------------- | ---------------------------------- | ---------------------------------------- |
-| Post "A4.5 suitability gate rejection" diagnostic comment                  | Reversible                | Ordinary comment; no state to undo | A4.5 (`idd-suitability.instructions.md`) |
-| Apply optional `triage:{outcome}` label                                    | Reversible                | Remove the label                   | A4.5 (`idd-suitability.instructions.md`) |
-| Post one-line reconciliation comment (Standing-rejection pre-check, #2803) | Reversible                | Ordinary comment; no state to undo | A4.5 (`idd-suitability.instructions.md`) |
+| Mutation                                                                                        | Reversible / Irreversible | Undo path / Governing gate         | Source                                   |
+| ----------------------------------------------------------------------------------------------- | ------------------------- | ---------------------------------- | ---------------------------------------- |
+| Post "A4.5 suitability gate rejection" diagnostic comment                                       | Reversible                | Ordinary comment; no state to undo | A4.5 (`idd-suitability.instructions.md`) |
+| Apply optional `triage:{outcome}` label                                                         | Reversible                | Remove the label                   | A4.5 (`idd-suitability.instructions.md`) |
+| Post one-line reconciliation comment (Standing-rejection pre-check, kurone-kito/idd-skill#2803) | Reversible                | Ordinary comment; no state to undo | A4.5 (`idd-suitability.instructions.md`) |
 
 ### Claim & ownership (A5)
 

--- a/docs/idd-autonomy-contract.md
+++ b/docs/idd-autonomy-contract.md
@@ -55,10 +55,11 @@ repeated per row.
 
 No claim exists yet in this group; every row here runs before A5.
 
-| Mutation                                                  | Reversible / Irreversible | Undo path / Governing gate         | Source                                   |
-| --------------------------------------------------------- | ------------------------- | ---------------------------------- | ---------------------------------------- |
-| Post "A4.5 suitability gate rejection" diagnostic comment | Reversible                | Ordinary comment; no state to undo | A4.5 (`idd-suitability.instructions.md`) |
-| Apply optional `triage:{outcome}` label                   | Reversible                | Remove the label                   | A4.5 (`idd-suitability.instructions.md`) |
+| Mutation                                                                   | Reversible / Irreversible | Undo path / Governing gate         | Source                                   |
+| -------------------------------------------------------------------------- | ------------------------- | ---------------------------------- | ---------------------------------------- |
+| Post "A4.5 suitability gate rejection" diagnostic comment                  | Reversible                | Ordinary comment; no state to undo | A4.5 (`idd-suitability.instructions.md`) |
+| Apply optional `triage:{outcome}` label                                    | Reversible                | Remove the label                   | A4.5 (`idd-suitability.instructions.md`) |
+| Post one-line reconciliation comment (Standing-rejection pre-check, #2803) | Reversible                | Ordinary comment; no state to undo | A4.5 (`idd-suitability.instructions.md`) |
 
 ### Claim & ownership (A5)
 

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -195,7 +195,9 @@ A5 is never reached for a candidate that fails any check, labeled or not.
 
 - **Permitted**: a single diagnostic comment explaining the rejection,
   prefixed with **"A4.5 suitability gate rejection"** so it is never
-  confused with a claim or work-in-progress marker; optionally, a
+  confused with a claim or work-in-progress marker; the one-line
+  reconciliation comment the Standing-rejection pre-check (Decision
+  Flow, below) requires on a stale rejection; optionally, a
   transient `triage:{outcome}` label as a diagnostic aid for humans (this
   must never masquerade as an implementation claim); linking related
   issues as context (e.g., "Related to #NNN which addresses similar
@@ -226,7 +228,13 @@ marker to skip a previously-rejected candidate without a full manual
 comment-history read, applying the same staleness rule as every other
 evidentiary marker in this workflow: a rejection whose comment predates
 the issue's own latest substantive (title/body) edit is stale and never
-suppresses a genuinely improved issue.
+suppresses a genuinely improved issue. The Decision Flow's
+Standing-rejection pre-check (below) applies this same staleness rule
+directly to the rejection comment itself, closing the gap for
+`needs-decision`/`blocked-by-human` outcomes: A4.5 never applies their
+label itself (a maintainer does), and neither carries a marker, so a
+later session may find no signal at all — label or no label — that the
+issue was already adjudicated.
 
 ### High-confidence coordination-close (#1485)
 
@@ -262,11 +270,29 @@ risk, not a blocker on the gate above.
 
 ## Decision Flow
 
+**Standing-rejection pre-check (#2803).** Before Check 1, scan the
+candidate's existing comments for a non-stale "A4.5 suitability gate
+rejection" comment posted by a trusted marker actor — any outcome, not
+only the four carrying their own
+`{{PROJECT_MARKER_PREFIX}}-triage-verdict` marker. Apply the same
+edit-postdates-rejection staleness rule as the Machine-readable outcome
+marker above (a recorded Groom-hearing decision counts as a body edit
+for this rule, since Groom applies it as inline body prose). A
+non-stale rejection means the session must not claim the candidate —
+label or no label — so exclude it from Candidates without posting a
+second rejection comment and loop; a stale rejection requires posting
+a one-line reconciliation comment (what changed, or why this session's
+re-evaluation differs) before Check 1-7 run normally.
+
 ```text
 Candidates = A4 survivor set
   (for A0-T: the single verified explicit target; failure = STOP, no fallback)
   (for A0-T: every "remove from Candidates, loop" branch below means: report and STOP)
 Loop: Rerun A4 Step 2 over Candidates to pick the next candidate
+  → Standing-rejection pre-check (see above)
+    → Non-stale rejection found → do not claim; exclude, post nothing, loop
+    → Stale rejection found → post reconciliation comment → Run Check 1
+    → No trusted rejection found → Run Check 1
   → Run Check 1 (Repository Fit)
     → PASS → Run Check 2
     → FAIL → Classify as out-of-scope → Report, remove from Candidates, loop

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -286,10 +286,10 @@ re-evaluation differs) before Check 1-7 run normally. This is now a
 hard pre-claim prohibition, so apply this workflow's
 [fail-closed default](idd-overview-core.instructions.md#fail-closed-default)
 when the scan itself cannot be completed — a comments-fetch failure, or
-a helper result carrying a rejection-collection warning with no
-conclusive answer — rather than treating an inconclusive scan the same
-as a confirmed absence: stop and report instead of proceeding to Check
-1.
+a helper result whose `existingRejectionCollectionWarnings` field
+reports a collection failure with no conclusive `existingRejection`
+value — rather than treating an inconclusive scan the same as a
+confirmed absence: stop and report instead of proceeding to Check 1.
 
 ```text
 Candidates = A4 survivor set
@@ -300,8 +300,8 @@ Loop: Rerun A4 Step 2 over Candidates to pick the next candidate
     → Non-stale rejection found → do not claim; exclude, post nothing, loop
     → Stale rejection found → post reconciliation comment → Run Check 1
     → No trusted rejection found → Run Check 1
-    → Scan inconclusive (fetch failed, or a collection warning with no
-      conclusive answer) → stop, report (fail closed)
+    → Scan inconclusive (fetch failed, or existingRejectionCollectionWarnings
+      with no conclusive existingRejection) → stop, report (fail closed)
   → Run Check 1 (Repository Fit)
     → PASS → Run Check 2
     → FAIL → Classify as out-of-scope → Report, remove from Candidates, loop

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -221,8 +221,8 @@ convention:
 ```
 
 Never emit this marker for `needs-decision` or `blocked-by-human`: those
-two already carry a stable label (see above) and need no second
-signal. Discover's own
+two already have a dedicated label available (see above) and need no
+second signal. Discover's own
 candidate-selection pass (`idd-discover.instructions.md`) reads this
 marker to skip a previously-rejected candidate without a full manual
 comment-history read, applying the same staleness rule as every other
@@ -282,7 +282,14 @@ non-stale rejection means the session must not claim the candidate —
 label or no label — so exclude it from Candidates without posting a
 second rejection comment and loop; a stale rejection requires posting
 a one-line reconciliation comment (what changed, or why this session's
-re-evaluation differs) before Check 1-7 run normally.
+re-evaluation differs) before Check 1-7 run normally. This is now a
+hard pre-claim prohibition, so apply this workflow's
+[fail-closed default](idd-overview-core.instructions.md#fail-closed-default)
+when the scan itself cannot be completed — a comments-fetch failure, or
+a helper result carrying a rejection-collection warning with no
+conclusive answer — rather than treating an inconclusive scan the same
+as a confirmed absence: stop and report instead of proceeding to Check
+1.
 
 ```text
 Candidates = A4 survivor set
@@ -293,6 +300,8 @@ Loop: Rerun A4 Step 2 over Candidates to pick the next candidate
     → Non-stale rejection found → do not claim; exclude, post nothing, loop
     → Stale rejection found → post reconciliation comment → Run Check 1
     → No trusted rejection found → Run Check 1
+    → Scan inconclusive (fetch failed, or a collection warning with no
+      conclusive answer) → stop, report (fail closed)
   → Run Check 1 (Repository Fit)
     → PASS → Run Check 2
     → FAIL → Classify as out-of-scope → Report, remove from Candidates, loop

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -298,6 +298,7 @@ Candidates = A4 survivor set
 Loop: Rerun A4 Step 2 over Candidates to pick the next candidate
   → Standing-rejection pre-check (see above)
     → Non-stale rejection found → do not claim; exclude, post nothing, loop
+      (for A0-T: report why the target is blocked, then STOP — no fallback)
     → Stale rejection found → post reconciliation comment → Run Check 1
     → No trusted rejection found → Run Check 1
     → Scan inconclusive (fetch failed, or existingRejectionCollectionWarnings

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -270,10 +270,10 @@ risk, not a blocker on the gate above.
 
 ## Decision Flow
 
-**Standing-rejection pre-check (#2803).** Before Check 1, scan the
-candidate's existing comments for a non-stale "A4.5 suitability gate
-rejection" comment posted by a trusted marker actor — any outcome, not
-only the four carrying their own
+**Standing-rejection pre-check (kurone-kito/idd-skill#2803).** Before
+Check 1, scan the candidate's existing comments for a non-stale "A4.5
+suitability gate rejection" comment posted by a trusted marker actor —
+any outcome, not only the four carrying their own
 `{{PROJECT_MARKER_PREFIX}}-triage-verdict` marker. Apply the same
 edit-postdates-rejection staleness rule as the Machine-readable outcome
 marker above (a recorded Groom-hearing decision counts as a body edit
@@ -298,7 +298,8 @@ Candidates = A4 survivor set
 Loop: Rerun A4 Step 2 over Candidates to pick the next candidate
   → Standing-rejection pre-check (see above)
     → Non-stale rejection found → do not claim; exclude, post nothing, loop
-      (for A0-T: report why the target is blocked, then STOP — no fallback)
+      (for A0-T: report why the target is blocked in the run output only
+      — not a second comment — then STOP, no fallback)
     → Stale rejection found → post reconciliation comment → Run Check 1
     → No trusted rejection found → Run Check 1
     → Scan inconclusive (fetch failed, or existingRejectionCollectionWarnings

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -1423,7 +1423,8 @@ standing rejection goes stale (a title/body edit, including a recorded
 Groom-hearing decision), or immediately when no standing rejection
 exists. A non-stale standing rejection is not itself a gap left for
 the customization to fill: `idd-suitability.instructions.md`'s
-Standing-rejection pre-check (`#2803`) already blocks reclaim on any
+Standing-rejection pre-check (`kurone-kito/idd-skill#2803`) already
+blocks reclaim on any
 "A4.5 suitability gate rejection" comment from a trusted marker actor
 before Check 1 ever runs, building on the `existingRejection` field
 issue #1887 shipped in `suitability-triage.mjs`; a rejected candidate

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -1417,14 +1417,18 @@ never the default (`idd-suitability.instructions.md`'s "Mutation
 Policy and Coordination Rule" section). Turning that customization on
 trades a faster re-scan for a manual-review cost: a wrongly-classified
 rejection then keeps the issue out of the candidate pool on every
-later pass until someone reviews the label by hand, instead of today's
-default of a fresh seven-check re-run each pass. That fresh re-run is
-not a gap left for the customization to fill -- issue #1887 shipped
-`suitability-triage.mjs`'s `existingRejection` field, which already
-surfaces any prior "A4.5 suitability gate rejection" comment from a
-trusted marker actor to every later caller, so a rejected candidate is
-neither silently retried from scratch nor permanently hidden by
-default.
+later pass until someone reviews the label by hand, instead of the
+default reconciliation path -- a fresh seven-check re-run once the
+standing rejection goes stale (a title/body edit, including a recorded
+Groom-hearing decision), or immediately when no standing rejection
+exists. A non-stale standing rejection is not itself a gap left for
+the customization to fill: `idd-suitability.instructions.md`'s
+Standing-rejection pre-check (`#2803`) already blocks reclaim on any
+"A4.5 suitability gate rejection" comment from a trusted marker actor
+before Check 1 ever runs, building on the `existingRejection` field
+issue #1887 shipped in `suitability-triage.mjs`; a rejected candidate
+is therefore neither silently retried from scratch nor permanently
+hidden by default.
 
 When confidence is low, keep the issue open and route via a concise
 comment. "Uncertain means open" is the safe default, and selection
@@ -1433,10 +1437,13 @@ stops the pass instead, though an already-reported `invalid` (a trusted
 `existingRejection` on this exact candidate, confirmed by a fresh Check 3
 failure) narrows that halt to excluding just that one candidate — see
 [`idd-suitability.instructions.md`](../.github/instructions/idd-suitability.instructions.md#failure-outcomes)'s
-Failure Outcomes table for both cases. This carve-out responds to a
-concrete incident: a 2026-09-08 false-positive `invalid` verdict
-(kurone-kito/idd-skill#2738) that the unconditional halt would have
-forced every later concurrent session to re-report, resolved by a
+Failure Outcomes table for both cases. This fresh-Check-3 path is now
+the fallback the Standing-rejection pre-check above defers to only
+once a standing rejection has gone stale; the common case is the
+pre-check's own exclusion, before Check 3 ever runs. This carve-out
+responds to a concrete incident: a 2026-09-08 false-positive `invalid`
+verdict (kurone-kito/idd-skill#2738) that the unconditional halt would
+have forced every later concurrent session to re-report, resolved by a
 2026-09-09 maintainer hearing (kurone-kito/idd-skill#2747).
 
 The configured ready label from `approvalSignals.readyLabelName`

--- a/idd-template/docs/idd-autonomy-contract.md
+++ b/idd-template/docs/idd-autonomy-contract.md
@@ -55,11 +55,11 @@ repeated per row.
 
 No claim exists yet in this group; every row here runs before A5.
 
-| Mutation                                                                   | Reversible / Irreversible | Undo path / Governing gate         | Source                                   |
-| -------------------------------------------------------------------------- | ------------------------- | ---------------------------------- | ---------------------------------------- |
-| Post "A4.5 suitability gate rejection" diagnostic comment                  | Reversible                | Ordinary comment; no state to undo | A4.5 (`idd-suitability.instructions.md`) |
-| Apply optional `triage:{outcome}` label                                    | Reversible                | Remove the label                   | A4.5 (`idd-suitability.instructions.md`) |
-| Post one-line reconciliation comment (Standing-rejection pre-check, #2803) | Reversible                | Ordinary comment; no state to undo | A4.5 (`idd-suitability.instructions.md`) |
+| Mutation                                                                                        | Reversible / Irreversible | Undo path / Governing gate         | Source                                   |
+| ----------------------------------------------------------------------------------------------- | ------------------------- | ---------------------------------- | ---------------------------------------- |
+| Post "A4.5 suitability gate rejection" diagnostic comment                                       | Reversible                | Ordinary comment; no state to undo | A4.5 (`idd-suitability.instructions.md`) |
+| Apply optional `triage:{outcome}` label                                                         | Reversible                | Remove the label                   | A4.5 (`idd-suitability.instructions.md`) |
+| Post one-line reconciliation comment (Standing-rejection pre-check, kurone-kito/idd-skill#2803) | Reversible                | Ordinary comment; no state to undo | A4.5 (`idd-suitability.instructions.md`) |
 
 ### Claim & ownership (A5)
 

--- a/idd-template/docs/idd-autonomy-contract.md
+++ b/idd-template/docs/idd-autonomy-contract.md
@@ -55,10 +55,11 @@ repeated per row.
 
 No claim exists yet in this group; every row here runs before A5.
 
-| Mutation                                                  | Reversible / Irreversible | Undo path / Governing gate         | Source                                   |
-| --------------------------------------------------------- | ------------------------- | ---------------------------------- | ---------------------------------------- |
-| Post "A4.5 suitability gate rejection" diagnostic comment | Reversible                | Ordinary comment; no state to undo | A4.5 (`idd-suitability.instructions.md`) |
-| Apply optional `triage:{outcome}` label                   | Reversible                | Remove the label                   | A4.5 (`idd-suitability.instructions.md`) |
+| Mutation                                                                   | Reversible / Irreversible | Undo path / Governing gate         | Source                                   |
+| -------------------------------------------------------------------------- | ------------------------- | ---------------------------------- | ---------------------------------------- |
+| Post "A4.5 suitability gate rejection" diagnostic comment                  | Reversible                | Ordinary comment; no state to undo | A4.5 (`idd-suitability.instructions.md`) |
+| Apply optional `triage:{outcome}` label                                    | Reversible                | Remove the label                   | A4.5 (`idd-suitability.instructions.md`) |
+| Post one-line reconciliation comment (Standing-rejection pre-check, #2803) | Reversible                | Ordinary comment; no state to undo | A4.5 (`idd-suitability.instructions.md`) |
 
 ### Claim & ownership (A5)
 


### PR DESCRIPTION
# Summary

`idd-suitability.instructions.md`'s A4.5 gate never applies the
`status:needs-decision`/`status:blocked-by-human` label itself (a
maintainer does, separately) and never emits a machine-readable
`triage-verdict` marker for those two outcomes, so once the label is
absent or removed, a later session has no structural signal that the
candidate was already adjudicated and can silently reclaim and re-work
it. Per the maintainer's recorded Groom-hearing decision on this
issue, this PR closes the gap with instruction-text only (no new
marker mechanism):

- Adds a **Standing-rejection pre-check** to the Decision Flow: before
  Check 1, scan for a non-stale "A4.5 suitability gate rejection"
  comment of any outcome, posted by a trusted marker actor. A
  non-stale rejection means the session must not claim the candidate —
  label or no label; a stale rejection requires a one-line
  reconciliation comment before Check 1-7 run normally. Fails closed
  (stop and report) when the scan itself cannot establish whether a
  rejection exists.
- Cross-references the new step from the "Machine-readable outcome
  marker" section.
- Extends the Mutation Policy's "Permitted" comment enumeration to
  name the reconciliation comment.
- Adds a row to `docs/idd-autonomy-contract.md`'s Discovery &
  suitability table classifying the new reconciliation comment as
  Reversible, so it isn't caught by that page's own "unlisted mutation
  defaults to irreversible" rule.
- Updates `docs/customization.md`'s Suitability Outcomes section,
  which an independent critique pass found had gone stale: its
  "today's default is a fresh seven-check re-run every pass" claim no
  longer held once the pre-check ships, so it now describes the
  pre-check and how it relates to the existing fresh-Check-3 `invalid`
  carve-out.
- Qualifies every `#2803` reference added by this PR to
  `kurone-kito/idd-skill#2803` in the `idd-template/` copies, so the
  link resolves correctly once an adopter copies these files.

## Linked issue

Closes #2803

## Follow-up issues (if any)

Recommended, not filed (each was raised and rejected as out of scope
during this PR's own review, with reasoning on the corresponding
threads):

- [ ] Recheck standing rejections immediately before the A5 claim
      write (or fold the scan into the fresh-claim gate) to close the
      residual TOCTOU window between A4.5's pre-check and A5's claim
      POST — would need to touch `idd-claim.instructions.md` and/or
      its helper, outside this PR's `idd-suitability.instructions.md`-
      only scope.
- [ ] Define a fail-closed rule for an unavailable staleness-lookup
      (title/body edit-timestamp determination) in the shared
      edit-postdates-rejection marker convention this pre-check
      reuses — affects all five outcomes that convention already
      covers, not only the two this PR closes the gap for.
- [ ] Prevent the new reconciliation comment from being reposted
      indefinitely across restarts/claim-race losses (would need
      either a new trusted marker — which the maintainer decision this
      PR implements explicitly rejected — or session-side semantic
      comparison of prior reconciliation comments, which a written
      instruction can't safely mechanize).

## Background / rationale (if material)

Field evidence from the issue: a candidate was rejected twice on the
same subjective gate several days apart, with its labels staying
empty (`[]`) both before and after both rejections, until a third
session happened to substantively exceed what the second rejection
asked for. Nothing structurally required that outcome — a less
thorough session reaching the same claim state (empty labels, no
marker, an unread standing rejection) could have shipped a weak fix.

Per the maintainer's recorded decision, this direction combines
"option 2" (an explicit Decision Flow pre-check step) with "option 3"
(a hard claim-prohibition rule) and deliberately skips "option 1" (a
new `triage-verdict` marker extension to these two outcomes) — the
label mutation-policy already carries that signal for a maintainer,
and a second marker would add code/test surface without closing a gap
the instruction-text change doesn't already close.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (biome check, dprint check, markdownlint-cli2, cspell
      lint all pass)
- [x] `pnpm test` (5643/5643 tests pass)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (`node scripts/sync-docs.mjs --apply`
      run; mirrored files regenerated and committed)
- [x] `node scripts/idd-doctor.mjs` (passed with 3 pre-existing
      environment-only warnings unrelated to this diff)

Also ran `pnpm run build:check` and `node scripts/token-cost-report.mjs
--check` (both pass) and confirmed the combined `bundle-discovery-phase`
budget (`idd-claim` + `idd-discover` + `idd-suitability`) sits at
86,919 / 92,300 bytes (94.2%), under the 95% notice threshold.

Went through five review-fix rounds (Copilot + Codex + CodeRabbit):
fixed six in-scope findings (a pre-existing "stable label" wording
contradiction the new text exposed, a fail-closed gap in the pre-check
itself, a fail-closed error-message field-name precision, an
`idd-autonomy-contract.md` classification gap, an A0-T reporting
ambiguity, and unqualified `#2803` references in `idd-template/`
copies); rejected three findings as out of scope for this issue's own
maintainer-decided direction (listed under Follow-up issues above).

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CK2SHn8Bir6VHrXrMVMdn3
