### PR TITLE
docs(idd-claim): require non-context-inheriting delegation

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -497,10 +497,21 @@ recognizing the brief reassigns it to a single-issue worker role. The
 delegation brief must state explicitly that the delegate is the sole
 worker for the named issue, that no peer workers exist for it to
 coordinate with or wait on, and that it must perform the implementation
-work itself rather than re-delegate or wait for a reply (#2179). Prefer
-a non-context-inheriting mechanism instead, when the tool offers one —
-see [docs/idd-workflow.md's Orchestrator fan-out
+work itself rather than re-delegate or wait for a reply (#2179). Use a
+non-context-inheriting mechanism whenever the tool offers one — this
+is a strong preference, not a suggestion; a context-inheriting
+mechanism (e.g. forking the orchestrator's own conversation) is a
+fallback only when no non-context-inheriting option exists. See
+[docs/idd-workflow.md's Orchestrator fan-out
 variant](../../docs/idd-workflow.md#orchestrator-fan-out-variant).
+
+**Known limitation.** Neither this wording nor an added negative
+instruction reliably stops a context-inheriting delegate from
+misreading itself as a sub-orchestrator waiting on a nonexistent
+sub-worker (#2802) — an accepted residual risk of the fallback path;
+see
+[docs/idd-design-rationale.md](../../docs/idd-design-rationale.md#context-inheriting-delegation-residual-risk)
+for the field evidence.
 
 **Restate the CI/advisory-wait topology-safety condition; use the
 snapshot-then-stop pattern.** Carry — verbatim or by reference — the

--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -414,6 +414,55 @@ own narrower question. This record moved here from
 kurone-kito/idd-skill#2000, which stayed open only as a findable record
 until one of the revisit triggers above fires.
 
+### Context-inheriting delegation residual risk
+
+kurone-kito/idd-skill#2624 adopted a documented positive-framed
+mitigation for the [Orchestrator delegation](../.github/instructions/idd-claim.instructions.md#orchestrator-delegation)
+context-inheriting fallback: the delegation brief must state
+explicitly that the delegate is the sole worker for the named issue,
+with no peer workers to coordinate with or wait on. `#2624` itself was
+scoped to the wake-up-discipline stall pattern and did not evaluate
+this mitigation against a different, related failure mode: a
+context-inheriting delegate mistaking itself for the orchestrator that
+dispatched it, rather than the worker the brief names it as.
+
+kurone-kito/idd-skill#2802 recorded direct field evidence that neither
+that positive-framed mitigation, nor an added explicit negative
+instruction naming the failure mode directly, reliably prevents it.
+Three independent occurrences: a context-inheriting fork (sharing the
+orchestrator's full transcript) whose brief opened with the documented
+positive-framed statement nearly verbatim still produced a first-turn
+status line functionally identical to the orchestrator's own
+immediately-preceding turn-ending text — "I dispatched a worker and am
+waiting for its completion notification" — despite there being no such
+sub-worker, in two independent occurrences (each corrected mid-session
+only by an explicit follow-up message naming the confusion directly).
+A third occurrence, during the authoring pass that drafted `#2802`
+itself (2026-09-09), added an explicit negative instruction ("you are
+not an orchestrator, there is no sub-worker, YOU are the worker") to
+the brief; the fork still ended its first turn describing having
+"delegated to a background fork" and "waiting for a completion
+notification," with zero tool calls made, and a second differently
+worded attempt with the same negative framing reproduced the identical
+zero-tool-call echo. Only abandoning delegation and performing the
+work directly in the orchestrating session's own turns made forward
+progress. After switching away from the context-inheriting mechanism
+in the originally reported session, the failure mode did not recur
+across roughly 13 further delegated dispatches in that session — a
+small, uncontrolled sample, but consistent with a non-context-inheriting
+mechanism addressing the failure at its root rather than through
+better-worded briefs.
+
+**Maintainer decision** (Groom hearing, 2026-09-10): adopt both
+mitigations together rather than continuing to iterate on brief
+wording the evidence shows does not reliably work. State the
+non-context-inheriting delegation mechanism as a strong preference,
+not merely a suggestion, whenever the calling tool offers one, and
+record the context-inheriting fallback's residual role-misread risk
+explicitly as a known, accepted limitation in both
+`idd-claim.instructions.md` and `docs/idd-workflow.md`'s Orchestrator
+fan-out variant section.
+
 ## Work and self-review
 
 ### B1 Step 3 — install-deps silent under-install detection

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -765,19 +765,24 @@ external scheduler.
 Running this variant safely requires:
 
 - **A non-context-inheriting delegation mechanism for the full
-  B-through-F4 worker role, when the calling tool offers one.** A
-  context-inheriting worker (e.g. Claude Code's `fork` subagent) can let
-  the orchestrator's own recent framing compete with, and sometimes
-  override, the delegation brief's own role statement — the same
-  problem [Critique pass invocation](#critique-pass-invocation) already
-  avoids for Claude Code's narrower critique-pass role, since that row
-  also picks a fresh `general-purpose` agent rather than a
+  B-through-F4 worker role, whenever the calling tool offers one — a
+  strong preference, not merely a suggestion, per
+  [Orchestrator delegation](../.github/instructions/idd-claim.instructions.md#orchestrator-delegation).**
+  A context-inheriting worker (e.g. Claude Code's `fork` subagent) can
+  let the orchestrator's own recent framing compete with, and
+  sometimes override, the delegation brief's own role statement — the
+  same problem [Critique pass invocation](#critique-pass-invocation)
+  already avoids for Claude Code's narrower critique-pass role, since
+  that row also picks a fresh `general-purpose` agent rather than a
   context-inheriting one. Extend that same preference to this full
-  worker role, whenever the tool exposes the choice, and fall back to
-  the explicit role-statement wording in
-  [Orchestrator delegation](../.github/instructions/idd-claim.instructions.md#orchestrator-delegation)
-  as defense-in-depth when only a context-inheriting mechanism is
-  available (kurone-kito/idd-skill#2221, kurone-kito/idd-skill#2624).
+  worker role whenever the tool exposes the choice; a
+  context-inheriting mechanism is a fallback only for when no
+  non-context-inheriting alternative exists, and even careful brief
+  wording (the explicit role-statement text in
+  [Orchestrator delegation](../.github/instructions/idd-claim.instructions.md#orchestrator-delegation))
+  does not reliably close its residual role-misread risk — a
+  documented known limitation (kurone-kito/idd-skill#2221,
+  kurone-kito/idd-skill#2624, kurone-kito/idd-skill#2802).
 - **A small concurrency cap**, sized against CI-minute cost and
   shared-file contention rather than raised without bound. The optional
   `discover-shared-file-overlap` helper (see

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -492,10 +492,21 @@ recognizing the brief reassigns it to a single-issue worker role. The
 delegation brief must state explicitly that the delegate is the sole
 worker for the named issue, that no peer workers exist for it to
 coordinate with or wait on, and that it must perform the implementation
-work itself rather than re-delegate or wait for a reply (#2179). Prefer
-a non-context-inheriting mechanism instead, when the tool offers one —
-see [docs/idd-workflow.md's Orchestrator fan-out
+work itself rather than re-delegate or wait for a reply (#2179). Use a
+non-context-inheriting mechanism whenever the tool offers one — this
+is a strong preference, not a suggestion; a context-inheriting
+mechanism (e.g. forking the orchestrator's own conversation) is a
+fallback only when no non-context-inheriting option exists. See
+[docs/idd-workflow.md's Orchestrator fan-out
 variant](../../docs/idd-workflow.md#orchestrator-fan-out-variant).
+
+**Known limitation.** Neither this wording nor an added negative
+instruction reliably stops a context-inheriting delegate from
+misreading itself as a sub-orchestrator waiting on a nonexistent
+sub-worker (#2802) — an accepted residual risk of the fallback path;
+see
+[docs/idd-design-rationale.md](../../docs/idd-design-rationale.md#context-inheriting-delegation-residual-risk)
+for the field evidence.
 
 **Restate the CI/advisory-wait topology-safety condition; use the
 snapshot-then-stop pattern.** Carry — verbatim or by reference — the

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -426,6 +426,41 @@ own narrower question. This record moved here from
 kurone-kito/idd-skill#2000, which stayed open only as a findable record
 until one of the revisit triggers above fires.
 
+### Context-inheriting delegation residual risk
+
+kurone-kito/idd-skill#2624 adopted a documented positive-framed
+mitigation for the [Orchestrator delegation](../.github/instructions/idd-claim.instructions.md#orchestrator-delegation)
+context-inheriting fallback: the delegation brief must state
+explicitly that the delegate is the sole worker for the named issue,
+with no peer workers to coordinate with or wait on. That issue was
+scoped to the wake-up-discipline stall pattern and did not evaluate
+this mitigation against a different, related failure mode: a
+context-inheriting delegate mistaking itself for the orchestrator that
+dispatched it, rather than the worker the brief names it as.
+
+kurone-kito/idd-skill#2802 recorded direct field evidence, from this
+project's own dogfooding, that neither that positive-framed
+mitigation, nor an added explicit negative instruction naming the
+failure mode directly, reliably prevents it: three independent
+occurrences of a context-inheriting delegate (sharing the
+orchestrator's own full conversation transcript) opening its first
+turn by describing having delegated to, and now waiting on, a
+sub-worker that did not exist — the delegate itself was the intended
+worker — even when the brief's role-reassignment wording matched the
+documented mitigation nearly verbatim, and even when a further attempt
+added an explicit negative instruction naming the confusion directly.
+Each occurrence needed an explicit follow-up message (or abandoning
+delegation entirely) to correct. See kurone-kito/idd-skill#2802 for the
+full narrative and observation counts.
+
+**Adopted mitigation**: state the non-context-inheriting delegation
+mechanism as a strong preference, not merely a suggestion, whenever
+the calling tool offers one, and record the context-inheriting
+fallback's residual role-misread risk explicitly as a known, accepted
+limitation next to the delegation-brief wording, rather than
+continuing to iterate on brief wording that field evidence shows does
+not reliably close the gap.
+
 ## Work and self-review
 
 ### B1 Step 3 — install-deps silent under-install detection

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -746,8 +746,10 @@ external scheduler.
 Running this variant safely requires:
 
 - **A non-context-inheriting delegation mechanism for the full
-  B-through-F4 worker role, when the calling tool offers one.** A
-  context-inheriting worker (one that receives the orchestrator's
+  B-through-F4 worker role, whenever the calling tool offers one — a
+  strong preference, not merely a suggestion, per
+  [Orchestrator delegation](../.github/instructions/idd-claim.instructions.md#orchestrator-delegation).**
+  A context-inheriting worker (one that receives the orchestrator's
   complete conversation, such as Claude Code's `fork` subagent) can let
   the orchestrator's own recent framing compete with, and sometimes
   override, the delegation brief's own role statement — the same
@@ -755,10 +757,13 @@ Running this variant safely requires:
   avoids for Claude Code's narrower critique-pass role, since that row
   also picks a fresh `general-purpose` agent rather than a
   context-inheriting one. Extend that same preference to this full
-  worker role, whenever the tool exposes the choice, and fall back to
-  the explicit role-statement wording in [Orchestrator delegation](../.github/instructions/idd-claim.instructions.md#orchestrator-delegation)
-  as defense-in-depth when only a context-inheriting mechanism is
-  available.
+  worker role whenever the tool exposes the choice; a
+  context-inheriting mechanism is a fallback only for when no
+  non-context-inheriting alternative exists, and even careful brief
+  wording (the explicit role-statement text in
+  [Orchestrator delegation](../.github/instructions/idd-claim.instructions.md#orchestrator-delegation))
+  does not reliably close its residual role-misread risk — a
+  documented known limitation.
 - **A small concurrency cap**, sized against CI-minute cost and
   shared-file contention rather than raised without bound. The optional
   `discover-shared-file-overlap` helper (see


### PR DESCRIPTION
# Summary

Field evidence collected while drafting this very issue showed that
neither the documented positive-framed delegation-brief mitigation
(`#2624`) nor an added explicit negative instruction reliably stops a
context-inheriting delegate (e.g. a forked conversation sharing the
orchestrator's full transcript) from misreading itself as a
sub-orchestrator waiting on a nonexistent sub-worker — three
independent occurrences, one from this issue's own authoring pass. Per
the maintainer decision recorded in the issue (Groom hearing,
2026-09-10), this PR:

- Strengthens `idd-claim.instructions.md`'s "Orchestrator delegation"
  section: using a non-context-inheriting delegation mechanism
  whenever the tool offers one is now stated as a strong preference,
  not merely a suggestion.
- Adds an adjacent "Known limitation" note recording the
  context-inheriting fallback's residual role-misread risk as a known,
  accepted limitation, citing `#2802`.
- Mirrors both changes in `docs/idd-workflow.md`'s Orchestrator
  fan-out variant bullet, and in the distributed
  `idd-template/` copies of both files (`idd-template/docs/idd-workflow.md`'s
  sync mode is `structure`, so mirroring there is not mechanically
  required, but the guidance is generic and not source-repo-specific —
  matching the precedent set by an earlier related change).
- Adds a new `docs/idd-design-rationale.md` entry (mirrored in
  `idd-template/docs/idd-design-rationale.md` to keep the two files'
  heading structure in sync per `audit/sync-manifest.json`'s
  `idd-design-rationale-doc` pair) with the full field-evidence
  narrative, since `idd-claim.instructions.md` sits close to its
  per-file byte budget (36000 bytes; 880 bytes of headroom before this
  change) and this repository's "cite the observed incident"
  convention routes full incident narratives to the budget-exempt
  design-rationale doc for near-ceiling instruction files.

## Linked issue

Closes #2802

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

See the issue body's "Background" and "Maintainer decision" sections,
and the new `docs/idd-design-rationale.md#context-inheriting-delegation-residual-risk`
entry this PR adds for the full three-occurrence narrative.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `npx biome check`
- [x] `node --test tests/*.test.mts` (5643 tests pass)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `npx dprint check "**/*.md"` / `npx markdownlint-cli2 "**/*.md"`
- [x] `node scripts/audit-code-span-wrap.mjs`
- [x] `pnpm run build:check`
- [x] `node scripts/idd-doctor.mjs` (passed with pre-existing,
  unrelated environmental warnings only)
- [x] `node scripts/token-cost-report.mjs --check`

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none — docs/instructions only)
- [x] Context budget impact reviewed (`idd-claim.instructions.md`
  stays under its 36000-byte per-file budget with ~291 bytes of
  headroom remaining; `bundle-discovery-phase` stays well under its
  92300-byte bundle budget)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EycqtGKuWjJMpw2tUav3Tn
