### PR TITLE
ci(idd-advisory-convergence): add pull_request_target trigger (Phase 1)

### DIFF
--- a/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/.github/workflows/idd-advisory-convergence-comment.yml
@@ -11,14 +11,21 @@
 # existing pull_request-family required run for the current HEAD SHA.
 # It never asserts `ready` itself.
 #
-# Two trigger families land here (#2411): `pull_request_review_comment`
-# (inline review-thread comments) and `issue_comment` (regular PR
-# comments -- where post-idd-marker.mjs and
-# disposition-non-review-notices.mjs actually post every marker/
-# disposition type, since both use the issues-comments API). `issue_comment`
-# also fires for a comment on a plain issue, not only a PR; the job-level
-# `if:` below skips those (`github.event.issue.pull_request` is only
-# present when the commented-on issue is a PR).
+# Three trigger families land here: `pull_request_review_comment` (inline
+# review-thread comments) and `issue_comment` (regular PR comments --
+# where post-idd-marker.mjs and disposition-non-review-notices.mjs
+# actually post every marker/disposition type, since both use the
+# issues-comments API), both from #2411; and `pull_request_review`
+# (review submissions, #2764 Phase 1) -- moved here from
+# idd-advisory-convergence.yml's own trigger list so a same-repository
+# PR cannot edit that workflow's copy to control when its own required
+# run re-asserts. Unlike the two comment families, a review submission
+# always reruns the gate unconditionally (see "Classify review comment"
+# below): it is not filtered by IDD-originated content, matching the
+# gate's own former unconditional `pull_request_review` trigger exactly.
+# `issue_comment` also fires for a comment on a plain issue, not only a
+# PR; the job-level `if:` below skips those (`github.event.issue.pull_request`
+# is only present when the commented-on issue is a PR).
 #
 # Job id is deliberately NOT `idd-advisory-convergence`.
 #
@@ -52,6 +59,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
 name: IDD advisory-convergence comment refresh
 on:
+  pull_request_review:
+    types:
+      - submitted
   pull_request_review_comment:
     types:
       - created
@@ -100,17 +110,30 @@ jobs:
       - name: Classify review comment
         id: origin
         env:
-          COMMENT_BODY: ${{ github.event.comment.body }}
+          # A pull_request_review event carries its free-text summary at
+          # github.event.review.body, not github.event.comment.body (no
+          # `comment` object exists for that event). Feeding it through
+          # the same classifier costs nothing -- a review body can itself
+          # carry an IDD marker (a session's own review-ack, or a bot's
+          # stamped review) -- but a review submission always qualifies
+          # for a rerun regardless of this classifier's verdict; see the
+          # `if:` conditions below, which OR in `pull_request_review`
+          # explicitly rather than relying on content classification.
+          COMMENT_BODY: ${{ github.event.review.body || github.event.comment.body }}
         run: node scripts/review-comment-origin.mjs
       - name: Check for newer qualifying event
         id: debounce
-        if: steps.origin.outputs.idd_originated == 'true'
+        if: steps.origin.outputs.idd_originated == 'true' || github.event_name == 'pull_request_review'
         env:
           GH_TOKEN: ${{ github.token }}
           GH_ENTERPRISE_TOKEN: ${{ github.token }}
-          # Same dual-trigger-family PR-number resolution as the rerun
+          # Same three-trigger-family PR-number resolution as the rerun
           # step below.
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          # pull_request_review and pull_request_review_comment both
+          # carry github.event.pull_request.number; issue_comment carries
+          # github.event.issue.number instead (#2411).
+          #
           # Both pull_request_review_comment and issue_comment carry the
           # triggering comment's own timestamps at github.event.comment
           # (matching COMMENT_BODY above). Prefer updated_at:
@@ -121,16 +144,24 @@ jobs:
           # "newer than the trigger" and wrongly skip this run.
           # updated_at equals created_at for a never-edited comment, so
           # this is safe for the created-event case too (#2650 review,
-          # Copilot).
-          TRIGGERED_AT: ${{ github.event.comment.updated_at || github.event.comment.created_at }}
+          # Copilot). pull_request_review carries its own timestamp at
+          # github.event.review.submitted_at instead -- there is no
+          # comment object to fall back to for that event. This helper's
+          # own live data collection does not query PR reviews (only
+          # issue and review-thread comments), so it can never find a
+          # "newer review" specifically; it can still find a newer
+          # IDD-originated *comment* that landed after this review, which
+          # is real, useful debounce signal even on a review-triggered
+          # run.
+          TRIGGERED_AT: ${{ github.event.review.submitted_at || github.event.comment.updated_at || github.event.comment.created_at }}
         run: node scripts/advisory-comment-debounce.mjs --pr "$PR_NUMBER" --triggered-at "$TRIGGERED_AT"
       - name: Rerun required HEAD check
-        if: steps.origin.outputs.idd_originated == 'true' && steps.debounce.outputs.skip != 'true'
+        if: (steps.origin.outputs.idd_originated == 'true' || github.event_name == 'pull_request_review') && steps.debounce.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           GH_ENTERPRISE_TOKEN: ${{ github.token }}
-          # pull_request_review_comment carries the PR number at
-          # github.event.pull_request.number; issue_comment (#2411)
-          # carries it at github.event.issue.number instead.
+          # pull_request_review and pull_request_review_comment carry the
+          # PR number at github.event.pull_request.number; issue_comment
+          # (#2411) carries it at github.event.issue.number instead.
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: node scripts/rerun-advisory-convergence.mjs --pr "$PR_NUMBER" --apply

--- a/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/.github/workflows/idd-advisory-convergence-comment.yml
@@ -171,25 +171,30 @@ permissions:
 jobs:
   refresh-if-idd-originated:
     runs-on: ubuntu-slim
-    # 35, not the required gate's own 10 (Codex P1, PR #2855 review): a
+    # 55, not the required gate's own 10 (Codex P1, PR #2855 review): a
     # `pull_request_review` submission can land while the required gate's
     # own run is still mid-flight, and `--refresh-latest --apply` then
-    # blocks inside `waitForRunCompletion` for up to that run's own
-    # remaining lifetime (bounded by ITS `timeout-minutes: 10` in
-    # idd-advisory-convergence.yml) before issuing its own sequential
-    # reruns (`rerun-advisory-convergence.mts` reruns EVERY resolvable
-    # pull_request-family instance for this HEAD, not a fixed count --
-    # typically `pull_request` plus `pull_request_target` under Phase 1,
-    # #1381). GitHub kills the job outright at this timeout regardless of
-    # what step is running, so a shorter bound here would silently drop
-    # a deferred rerun before it ever fires -- exactly the scenario
-    # `--refresh-latest` exists to prevent. 35 = 10 (waiting out the
-    # original run) + 2x10 (the typical Phase 1 case of two sequential
-    # reruns, `rerunAndWait`'s own poll bounded by the same 10-minute
-    # gate timeout each -- not a hard upper bound; more concurrent
-    # family instances for one HEAD would need more) + 5 headroom for
-    # setup/checkout and the steps preceding this wait.
-    timeout-minutes: 35
+    # blocks inside `waitForRunCompletion` and (per rerun)
+    # `rerunAndWait`'s own `waitForNewAttempt`, each bounded by
+    # `rerun-advisory-convergence.mts`'s OWN internal 15-minute safety
+    # bound (`APPLY_POLL_TIMEOUT_MS`/`PENDING_RUN_POLL_TIMEOUT_MS`) --
+    # not the gate's shorter 10-minute job timeout that internal bound
+    # deliberately exceeds as its own margin (Codex P1, PR #2855 review,
+    # round 8, correcting this comment's own prior 10-minute-per-wait
+    # arithmetic). GitHub kills THIS job outright at ITS OWN timeout
+    # regardless of what step is running, so a bound smaller than the sum
+    # of the internal waits it wraps would silently drop a deferred rerun
+    # before those internal waits ever gave up gracefully -- exactly the
+    # scenario `--refresh-latest` exists to prevent. 55 = 15 (waiting out
+    # the original run, if still pending) + 2x15 (the typical Phase 1
+    # case of two sequential reruns, `rerunAndWait`'s own poll bounded by
+    # the same 15-minute internal safety margin each -- not a hard upper
+    # bound; more concurrent family instances for one HEAD would need
+    # more, since `rerun-advisory-convergence.mts` reruns EVERY resolvable
+    # pull_request-family instance for this HEAD, not a fixed count,
+    # #1381) + 10 headroom for setup/checkout and the steps preceding
+    # this wait.
+    timeout-minutes: 55
     if: github.event_name != 'issue_comment' || github.event.issue.pull_request != null
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/.github/workflows/idd-advisory-convergence-comment.yml
@@ -248,13 +248,16 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_ENTERPRISE_TOKEN: ${{ github.token }}
-          # Same three-trigger-family PR-number resolution as the rerun
-          # step below.
-          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
-          # pull_request_review and pull_request_review_comment both
-          # carry github.event.pull_request.number; issue_comment carries
+          # Same PR-number resolution as the rerun step below, though
+          # this step itself only ever runs for pull_request_review_comment
+          # or issue_comment -- its own `if:` above excludes
+          # pull_request_review entirely (Copilot, PR #2855 review: an
+          # earlier revision's comments here still described
+          # review-specific behavior even after that exclusion landed).
+          # pull_request_review_comment carries
+          # github.event.pull_request.number; issue_comment carries
           # github.event.issue.number instead (#2411).
-          #
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           # Both pull_request_review_comment and issue_comment carry the
           # triggering comment's own timestamps at github.event.comment
           # (matching COMMENT_BODY above). Prefer updated_at:
@@ -265,16 +268,8 @@ jobs:
           # "newer than the trigger" and wrongly skip this run.
           # updated_at equals created_at for a never-edited comment, so
           # this is safe for the created-event case too (#2650 review,
-          # Copilot). pull_request_review carries its own timestamp at
-          # github.event.review.submitted_at instead -- there is no
-          # comment object to fall back to for that event. This helper's
-          # own live data collection does not query PR reviews (only
-          # issue and review-thread comments), so it can never find a
-          # "newer review" specifically; it can still find a newer
-          # IDD-originated *comment* that landed after this review, which
-          # is real, useful debounce signal even on a review-triggered
-          # run.
-          TRIGGERED_AT: ${{ github.event.review.submitted_at || github.event.comment.updated_at || github.event.comment.created_at }}
+          # Copilot).
+          TRIGGERED_AT: ${{ github.event.comment.updated_at || github.event.comment.created_at }}
         run: node scripts/advisory-comment-debounce.mjs --pr "$PR_NUMBER" --triggered-at "$TRIGGERED_AT"
       - name: Rerun required HEAD check
         # A review submission always proceeds, bypassing the debounce

--- a/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/.github/workflows/idd-advisory-convergence-comment.yml
@@ -176,17 +176,19 @@ jobs:
     # own run is still mid-flight, and `--refresh-latest --apply` then
     # blocks inside `waitForRunCompletion` for up to that run's own
     # remaining lifetime (bounded by ITS `timeout-minutes: 10` in
-    # idd-advisory-convergence.yml) before issuing up to two sequential
-    # reruns (`rerun-advisory-convergence.mts` reruns every
-    # pull_request-family instance for this HEAD, not only one, since
-    # #1381 -- typically `pull_request` plus `pull_request_target` under
-    # Phase 1). GitHub kills the job outright at this timeout regardless
-    # of what step is running, so a shorter bound here would silently
-    # drop the deferred rerun before it ever fires -- exactly the
-    # scenario `--refresh-latest` exists to prevent. 35 = 10 (waiting out
-    # the original run) + 2x10 (two sequential reruns, `rerunAndWait`'s
-    # own poll bounded by the same 10-minute gate timeout each) + 5
-    # headroom for setup/checkout and the steps preceding this wait.
+    # idd-advisory-convergence.yml) before issuing its own sequential
+    # reruns (`rerun-advisory-convergence.mts` reruns EVERY resolvable
+    # pull_request-family instance for this HEAD, not a fixed count --
+    # typically `pull_request` plus `pull_request_target` under Phase 1,
+    # #1381). GitHub kills the job outright at this timeout regardless of
+    # what step is running, so a shorter bound here would silently drop
+    # a deferred rerun before it ever fires -- exactly the scenario
+    # `--refresh-latest` exists to prevent. 35 = 10 (waiting out the
+    # original run) + 2x10 (the typical Phase 1 case of two sequential
+    # reruns, `rerunAndWait`'s own poll bounded by the same 10-minute
+    # gate timeout each -- not a hard upper bound; more concurrent
+    # family instances for one HEAD would need more) + 5 headroom for
+    # setup/checkout and the steps preceding this wait.
     timeout-minutes: 35
     if: github.event_name != 'issue_comment' || github.event.issue.pull_request != null
     steps:

--- a/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/.github/workflows/idd-advisory-convergence-comment.yml
@@ -52,6 +52,27 @@
 # push, or a human/session review-thread reply), exactly as it always
 # has; see `idd-ci.instructions.md` §Rerun mechanics for the manual
 # recovery command if a stuck rollup needs one sooner.
+#
+# Fork-originated PRs (Codex P1, PR #2855 review): a `pull_request_review`
+# run whose PR is from a fork gets a read-only `GITHUB_TOKEN` from GitHub
+# regardless of this workflow's declared `actions: write` permission --
+# the same restriction `docs/customization.md`'s
+# `strip-untrusted-labels.yml` trust-model section documents for
+# `pull_request`, and `pull_request_review_comment` (this workflow's own
+# pre-existing #2136/#2411 trigger) already shares it. The former
+# `pull_request_review` trigger (directly on the required workflow) never
+# hit this, because recomputing its own verdict needed only read access;
+# routing through `gh run rerun` here needs write, which a fork PR's
+# token cannot have -- the mutation step fails visibly (a 403), not
+# silently. No trusted writable review event exists for this case (there
+# is no `pull_request_review_target`), and putting `pull_request_review`
+# back on the required workflow to get one would reopen the exact vector
+# this move closes for same-repository PRs (a PR-evaluated trigger on the
+# *required* workflow can forge its own green conclusion; a tampered
+# companion can only issue or withhold a rerun). Recovery is the same as
+# any other stuck rollup: a maintainer's manual `gh run rerun`, the next
+# push, or (past the configured deadline) this repository's
+# `ciGate.externalCheckWaivers` mechanism.
 # `issue_comment` also fires for a comment on a plain issue, not only a
 # PR; the job-level `if:` below skips those (`github.event.issue.pull_request`
 # is only present when the commented-on issue is a PR).

--- a/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/.github/workflows/idd-advisory-convergence-comment.yml
@@ -17,25 +17,41 @@
 # actually post every marker/disposition type, since both use the
 # issues-comments API), both from #2411; and `pull_request_review`
 # (review submissions, #2764 Phase 1) -- moved here from
-# idd-advisory-convergence.yml's own trigger list so a same-repository
-# PR cannot edit that workflow's copy to control when its own required
-# run re-asserts. Unlike the two comment families, a review submission
-# always reruns the gate unconditionally (see "Classify review comment"
-# below): it is not filtered by IDD-originated content, matching the
-# gate's own former unconditional `pull_request_review` trigger exactly
-# -- and, per that same "always" guarantee, "Rerun required HEAD check"
-# below routes it through `rerun-advisory-convergence.mjs --refresh-latest
-# --apply` instead of the two comment families' plain `--apply`: the
-# ordinary `--apply` path only reruns a `rerun-eligible` instance
-# (excludes anything already `pass` and enforces the rerun-once budget),
-# which would leave a same-HEAD review that lands after the gate already
-# went green -- or after its one rerun was already spent -- unable to
-# force a fresh evaluation (Codex P1, PR #2855 review). `--refresh-latest`
-# reruns the latest pull_request-family instance unconditionally instead,
-# restoring the former direct-trigger's "every review gets a fresh
-# evaluation" guarantee; see `RefreshLatestPlan`'s doc comment in
-# `rerun-advisory-convergence.mts` for why this is a separate mode rather
-# than changing `--apply`'s own budget for every caller.
+# idd-advisory-convergence.yml's own trigger list, alongside the content-
+# filtering reason below. NOT for tamper-resistance: this workflow is
+# just as PR-editable as the required workflow's own former trigger was
+# (there is no `pull_request_review_target` -- GitHub's `_target` variant
+# exists only for `pull_request`), so a same-repository PR can still
+# disable or alter this step. What actually stays trusted is the push-
+# triggered gate itself, via `pull_request_target` (this same #2764
+# Phase 1 change, on `idd-advisory-convergence.yml`); this review-refresh
+# path is deliberately best-effort on top of that, not a second trusted
+# surface -- a tampered copy can only delay a fresh green, never force
+# one, since the gate's own verdict is still computed independently on
+# every push. Unlike the two comment families, a review submission is
+# not filtered by IDD-originated content (see "Classify review comment"
+# below) and "Rerun required HEAD check" routes it through
+# `rerun-advisory-convergence.mjs --refresh-latest --apply` instead of
+# the two comment families' plain `--apply`: the ordinary `--apply` path
+# only reruns a `rerun-eligible` instance (excludes anything already
+# `pass` and enforces the rerun-once budget), which would leave a
+# same-HEAD review that lands after the gate already went green -- or
+# after its one rerun was already spent -- unable to force a fresh
+# evaluation (Codex P1, PR #2855 review). `--refresh-latest` reruns the
+# latest pull_request-family instance unconditionally instead (still
+# honoring ciWait.rerunPolicy: "hold"); see `RefreshLatestPlan`'s doc
+# comment in `rerun-advisory-convergence.mts` for why this is a separate
+# mode rather than changing `--apply`'s own budget for every caller.
+# This step still cannot reach `pull_request_review` submitted BY the
+# configured primary bot itself (Copilot, by this repository's default):
+# GitHub gates any workflow run a bot actor triggers to `action_required`
+# regardless of which workflow it lands on (`idd-ci.instructions.md`
+# lines 222-231), so the job never reaches this step for that submission
+# -- unchanged from the former direct trigger, which was equally gated
+# for the same actor. That gap self-heals on the next non-bot trigger (a
+# push, or a human/session review-thread reply), exactly as it always
+# has; see `idd-ci.instructions.md` §Rerun mechanics for the manual
+# recovery command if a stuck rollup needs one sooner.
 # `issue_comment` also fires for a comment on a plain issue, not only a
 # PR; the job-level `if:` below skips those (`github.event.issue.pull_request`
 # is only present when the commented-on issue is a PR).
@@ -177,12 +193,18 @@ jobs:
           # PR number at github.event.pull_request.number; issue_comment
           # (#2411) carries it at github.event.issue.number instead.
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
-          # A review submission always reruns unconditionally (module
-          # header above), including when the gate is already `pass` or
-          # its rerun-once budget is already spent -- neither of the two
-          # comment families needs that: they are already filtered to
-          # IDD-originated content and share the ordinary rerun-once
-          # budget deliberately (#2643 comment-burst protection).
+          # A review submission reruns unconditionally (module header
+          # above) when this job itself runs, including when the gate is
+          # already `pass` or its rerun-once budget is already spent --
+          # neither of the two comment families needs that: they are
+          # already filtered to IDD-originated content and share the
+          # ordinary rerun-once budget deliberately (#2643 comment-burst
+          # protection). "When this job itself runs" is doing real work
+          # here: the primary bot's own review submission is gated to
+          # `action_required` before any step executes (module header
+          # above) -- unconditional refers to bypassing pass/budget
+          # classification once this step runs, not to every review
+          # submission reaching it.
           EVENT_NAME: ${{ github.event_name }}
         run: |
           if [ "$EVENT_NAME" = "pull_request_review" ]; then

--- a/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/.github/workflows/idd-advisory-convergence-comment.yml
@@ -171,7 +171,7 @@ permissions:
 jobs:
   refresh-if-idd-originated:
     runs-on: ubuntu-slim
-    # 30, not the required gate's own 10 (Codex P1, PR #2855 review): a
+    # 35, not the required gate's own 10 (Codex P1, PR #2855 review): a
     # `pull_request_review` submission can land while the required gate's
     # own run is still mid-flight, and `--refresh-latest --apply` then
     # blocks inside `waitForRunCompletion` for up to that run's own
@@ -183,11 +183,11 @@ jobs:
     # Phase 1). GitHub kills the job outright at this timeout regardless
     # of what step is running, so a shorter bound here would silently
     # drop the deferred rerun before it ever fires -- exactly the
-    # scenario `--refresh-latest` exists to prevent. 30 covers 10
-    # (waiting out the original run) plus roughly 2x10 (two sequential
-    # reruns, `rerunAndWait`'s own poll bounded by the same 10-minute gate
-    # timeout each) with headroom for setup/checkout.
-    timeout-minutes: 30
+    # scenario `--refresh-latest` exists to prevent. 35 = 10 (waiting out
+    # the original run) + 2x10 (two sequential reruns, `rerunAndWait`'s
+    # own poll bounded by the same 10-minute gate timeout each) + 5
+    # headroom for setup/checkout and the steps preceding this wait.
+    timeout-minutes: 35
     if: github.event_name != 'issue_comment' || github.event.issue.pull_request != null
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/.github/workflows/idd-advisory-convergence-comment.yml
@@ -37,11 +37,15 @@
 # `pass` and enforces the rerun-once budget), which would leave a
 # same-HEAD review that lands after the gate already went green -- or
 # after its one rerun was already spent -- unable to force a fresh
-# evaluation (Codex P1, PR #2855 review). `--refresh-latest` reruns the
-# latest pull_request-family instance unconditionally instead (still
-# honoring ciWait.rerunPolicy: "hold"); see `RefreshLatestPlan`'s doc
-# comment in `rerun-advisory-convergence.mts` for why this is a separate
-# mode rather than changing `--apply`'s own budget for every caller.
+# evaluation (Codex P1, PR #2855 review). `--refresh-latest` reruns every
+# resolvable pull_request-family instance for this HEAD unconditionally
+# instead (still honoring ciWait.rerunPolicy: "hold") -- not only the
+# most recently started one, since the required rollup can stay pinned
+# to an earlier instance even after a later one for the same SHA
+# completes (kurone-kito/idd-skill#1381, Codex P1, PR #2855 review); see
+# `RefreshLatestPlan`'s doc comment in `rerun-advisory-convergence.mts`
+# for why this is a separate mode rather than changing `--apply`'s own
+# budget for every caller.
 # This step still cannot reach `pull_request_review` submitted BY the
 # configured primary bot itself (Copilot, by this repository's default):
 # GitHub gates any workflow run a bot actor triggers to `action_required`
@@ -167,7 +171,23 @@ permissions:
 jobs:
   refresh-if-idd-originated:
     runs-on: ubuntu-slim
-    timeout-minutes: 10
+    # 30, not the required gate's own 10 (Codex P1, PR #2855 review): a
+    # `pull_request_review` submission can land while the required gate's
+    # own run is still mid-flight, and `--refresh-latest --apply` then
+    # blocks inside `waitForRunCompletion` for up to that run's own
+    # remaining lifetime (bounded by ITS `timeout-minutes: 10` in
+    # idd-advisory-convergence.yml) before issuing up to two sequential
+    # reruns (`rerun-advisory-convergence.mts` reruns every
+    # pull_request-family instance for this HEAD, not only one, since
+    # #1381 -- typically `pull_request` plus `pull_request_target` under
+    # Phase 1). GitHub kills the job outright at this timeout regardless
+    # of what step is running, so a shorter bound here would silently
+    # drop the deferred rerun before it ever fires -- exactly the
+    # scenario `--refresh-latest` exists to prevent. 30 covers 10
+    # (waiting out the original run) plus roughly 2x10 (two sequential
+    # reruns, `rerunAndWait`'s own poll bounded by the same 10-minute gate
+    # timeout each) with headroom for setup/checkout.
+    timeout-minutes: 30
     if: github.event_name != 'issue_comment' || github.event.issue.pull_request != null
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/.github/workflows/idd-advisory-convergence-comment.yml
@@ -22,7 +22,20 @@
 # run re-asserts. Unlike the two comment families, a review submission
 # always reruns the gate unconditionally (see "Classify review comment"
 # below): it is not filtered by IDD-originated content, matching the
-# gate's own former unconditional `pull_request_review` trigger exactly.
+# gate's own former unconditional `pull_request_review` trigger exactly
+# -- and, per that same "always" guarantee, "Rerun required HEAD check"
+# below routes it through `rerun-advisory-convergence.mjs --refresh-latest
+# --apply` instead of the two comment families' plain `--apply`: the
+# ordinary `--apply` path only reruns a `rerun-eligible` instance
+# (excludes anything already `pass` and enforces the rerun-once budget),
+# which would leave a same-HEAD review that lands after the gate already
+# went green -- or after its one rerun was already spent -- unable to
+# force a fresh evaluation (Codex P1, PR #2855 review). `--refresh-latest`
+# reruns the latest pull_request-family instance unconditionally instead,
+# restoring the former direct-trigger's "every review gets a fresh
+# evaluation" guarantee; see `RefreshLatestPlan`'s doc comment in
+# `rerun-advisory-convergence.mts` for why this is a separate mode rather
+# than changing `--apply`'s own budget for every caller.
 # `issue_comment` also fires for a comment on a plain issue, not only a
 # PR; the job-level `if:` below skips those (`github.event.issue.pull_request`
 # is only present when the commented-on issue is a PR).
@@ -164,4 +177,16 @@ jobs:
           # PR number at github.event.pull_request.number; issue_comment
           # (#2411) carries it at github.event.issue.number instead.
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
-        run: node scripts/rerun-advisory-convergence.mjs --pr "$PR_NUMBER" --apply
+          # A review submission always reruns unconditionally (module
+          # header above), including when the gate is already `pass` or
+          # its rerun-once budget is already spent -- neither of the two
+          # comment families needs that: they are already filtered to
+          # IDD-originated content and share the ordinary rerun-once
+          # budget deliberately (#2643 comment-burst protection).
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request_review" ]; then
+            node scripts/rerun-advisory-convergence.mjs --pr "$PR_NUMBER" --refresh-latest --apply
+          else
+            node scripts/rerun-advisory-convergence.mjs --pr "$PR_NUMBER" --apply
+          fi

--- a/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/.github/workflows/idd-advisory-convergence-comment.yml
@@ -117,6 +117,30 @@
 # -- so this workflow does not need debounce protection for reviews at
 # all; "Rerun required HEAD check" below always proceeds for a review
 # submission instead of consulting the debounce step's output.
+#
+# Residual NOT closed by the above (Codex P1, PR #2855 review): the
+# pending-run-replacement gap this same module header already discloses
+# a few paragraphs up (a *queued*, not-yet-started run can still be
+# evicted and replaced by a newer trigger sharing this same
+# `concurrency.group`, before debounce -- which only judges an
+# ALREADY-STARTED run -- ever gets a say) applies to a review-triggered
+# run exactly as it does to a comment-triggered one: if a comment run
+# is already in-flight when a review lands, the review's own run queues
+# behind it, and a THIRD event landing before that queue slot is served
+# evicts the review's queued run in favor of the newer one, which never
+# carries `--refresh-latest`. This is not new to reviews -- it is the
+# same already-documented, already-accepted gap the pre-existing
+# comment-burst case already lived with -- and splitting this workflow
+# into a separate concurrency group per trigger family was already
+# considered and rejected for the analogous rollup-ordering race
+# `idd-advisory-convergence.yml`'s own "Concurrency-hardening
+# investigation" note documents: it would defeat the deliberate
+# cross-trigger debouncing this workflow depends on, without actually
+# closing the underlying queue-depth-of-one platform limitation. No safe
+# mechanical fix was found within this PR's scope; recovery is the same
+# manual `rerun-advisory-convergence.mjs --refresh-latest --apply` this
+# file's header already documents for the `action_required` and
+# fork-PR-token cases above.
 concurrency:
   # Do not cancel: a later human LGTM must not abort an in-flight
   # IDD-originated refresh before it reruns the required check (#2136).
@@ -190,8 +214,17 @@ jobs:
         id: debounce
         # `pull_request_review` deliberately excluded -- see the Debounce
         # module-header paragraph above for why a review must not be
-        # debounced in favor of a later comment-triggered run.
-        if: steps.origin.outputs.idd_originated == 'true'
+        # debounced in favor of a later comment-triggered run. The
+        # `github.event_name != 'pull_request_review'` conjunct is load-
+        # bearing, not redundant (Copilot + Codex P1, PR #2855 review): a
+        # review body that happens to classify as IDD-originated (it is
+        # fed through the same classifier as a comment, for the reason
+        # documented on "Classify review comment" above) would otherwise
+        # still satisfy `idd_originated == 'true'` and run this step for
+        # a review -- and if this step's own `gh api` calls then failed,
+        # the job would stop here (module header above), never reaching
+        # "Rerun required HEAD check" at all for that review.
+        if: steps.origin.outputs.idd_originated == 'true' && github.event_name != 'pull_request_review'
         env:
           GH_TOKEN: ${{ github.token }}
           GH_ENTERPRISE_TOKEN: ${{ github.token }}

--- a/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/.github/workflows/idd-advisory-convergence-comment.yml
@@ -63,24 +63,39 @@
 # once per comment, exhausting every same-HEAD instance's one-time rerun
 # budget mid-burst. The "Check for newer qualifying event" step below
 # waits a short quiet window, then re-queries whether a newer
-# IDD-originated comment/review has since landed on the same PR; if so,
-# this run skips its own `--apply` call and leaves it to the
-# later-triggered run (which asks the same question in turn). This is a
-# job-body-level check -- it does not alter `cancel-in-progress: false`
-# below, which stays exactly as #2136 established it. (Note on that
-# setting's actual scope, corrected from an earlier draft of this
-# comment: it protects only the currently in-progress run in this
-# group from cancellation; a merely *pending*, not-yet-started run is
-# still cancelled and replaced by the newest pending run when another
-# is queued behind it, since no `queue:` key is set here -- the
-# debounce below exists for the case where a run has already started
-# and must itself decide whether a newer event supersedes it, which
-# that pending-run replacement does not cover.) If the debounce step's
-# own `gh api` calls fail, the step fails and GitHub Actions' default
-# sequential-failure behavior skips "Rerun required HEAD check"
-# entirely for that run -- safe, since this is a non-required companion
-# refresh, and a later qualifying event (or the required check's own
-# polling) will trigger a fresh attempt.
+# IDD-originated comment has since landed on the same PR; if so, this
+# run skips its own `--apply` call and leaves it to the later-triggered
+# run (which asks the same question in turn). This is a job-body-level
+# check -- it does not alter `cancel-in-progress: false` below, which
+# stays exactly as #2136 established it. (Note on that setting's actual
+# scope, corrected from an earlier draft of this comment: it protects
+# only the currently in-progress run in this group from cancellation; a
+# merely *pending*, not-yet-started run is still cancelled and replaced
+# by the newest pending run when another is queued behind it, since no
+# `queue:` key is set here -- the debounce below exists for the case
+# where a run has already started and must itself decide whether a
+# newer event supersedes it, which that pending-run replacement does
+# not cover.) If the debounce step's own `gh api` calls fail, the step
+# fails and GitHub Actions' default sequential-failure behavior skips
+# "Rerun required HEAD check" entirely for that run -- safe, since this
+# is a non-required companion refresh, and a later qualifying event (or
+# the required check's own polling) will trigger a fresh attempt.
+#
+# `pull_request_review` deliberately skips debounce entirely (Codex P1,
+# PR #2855 review): the two comment families need it because a burst of
+# them all ask the SAME question (plain `--apply`), so skipping in favor
+# of a later one is safe -- but a review's `--refresh-latest` is a
+# STRONGER question a superseding comment-triggered run cannot answer on
+# its behalf (comment-triggered runs never carry `--refresh-latest`). A
+# review superseded by debounce would silently downgrade to whatever the
+# later comment run does, which could leave an already-green gate green
+# even though the review added new blocking findings. Debounce exists
+# purely to protect the rerun-once budget from a comment burst
+# (#2643) -- a hazard `--refresh-latest` does not share (it bypasses that
+# budget already) and reviews do not produce (human-paced, not bursty)
+# -- so this workflow does not need debounce protection for reviews at
+# all; "Rerun required HEAD check" below always proceeds for a review
+# submission instead of consulting the debounce step's output.
 concurrency:
   # Do not cancel: a later human LGTM must not abort an in-flight
   # IDD-originated refresh before it reruns the required check (#2136).
@@ -152,7 +167,10 @@ jobs:
         run: node scripts/review-comment-origin.mjs
       - name: Check for newer qualifying event
         id: debounce
-        if: steps.origin.outputs.idd_originated == 'true' || github.event_name == 'pull_request_review'
+        # `pull_request_review` deliberately excluded -- see the Debounce
+        # module-header paragraph above for why a review must not be
+        # debounced in favor of a later comment-triggered run.
+        if: steps.origin.outputs.idd_originated == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           GH_ENTERPRISE_TOKEN: ${{ github.token }}
@@ -185,7 +203,13 @@ jobs:
           TRIGGERED_AT: ${{ github.event.review.submitted_at || github.event.comment.updated_at || github.event.comment.created_at }}
         run: node scripts/advisory-comment-debounce.mjs --pr "$PR_NUMBER" --triggered-at "$TRIGGERED_AT"
       - name: Rerun required HEAD check
-        if: (steps.origin.outputs.idd_originated == 'true' || github.event_name == 'pull_request_review') && steps.debounce.outputs.skip != 'true'
+        # A review submission always proceeds, bypassing the debounce
+        # step's output entirely (module header above) -- it is not
+        # consulted for `pull_request_review` at all (that step's own
+        # `if:` excludes it), so a review is never superseded by a later
+        # comment-triggered run that cannot provide the same
+        # `--refresh-latest` guarantee.
+        if: github.event_name == 'pull_request_review' || (steps.origin.outputs.idd_originated == 'true' && steps.debounce.outputs.skip != 'true')
         env:
           GH_TOKEN: ${{ github.token }}
           GH_ENTERPRISE_TOKEN: ${{ github.token }}

--- a/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/.github/workflows/idd-advisory-convergence-comment.yml
@@ -284,8 +284,23 @@ jobs:
         # consulted for `pull_request_review` at all (that step's own
         # `if:` excludes it), so a review is never superseded by a later
         # comment-triggered run that cannot provide the same
-        # `--refresh-latest` guarantee.
-        if: github.event_name == 'pull_request_review' || (steps.origin.outputs.idd_originated == 'true' && steps.debounce.outputs.skip != 'true')
+        # `--refresh-latest` guarantee. The explicit `success() &&` on
+        # the comment-family branch is load-bearing, not redundant
+        # (Codex P1, PR #2855 review): GitHub Actions implicitly
+        # prepends `success()` to a step's own `if:` UNLESS the
+        # expression itself already calls one of success()/failure()/
+        # always() -- so without an explicit call here, a failure in
+        # "Classify review comment" above (its own `review-comment-
+        # origin.mjs` throwing, e.g. on a malformed review body) would
+        # implicitly skip this ENTIRE step, silently defeating the
+        # review branch's own "always proceeds" guarantee for the exact
+        # trigger that guarantee exists to protect. Calling success()
+        # explicitly here suppresses that implicit prepend and lets the
+        # `pull_request_review` disjunct genuinely short-circuit
+        # regardless of any earlier step's own outcome, while the
+        # comment-family branch still requires it, matching this step's
+        # pre-existing (implicit) behavior for that path unchanged.
+        if: github.event_name == 'pull_request_review' || (success() && steps.origin.outputs.idd_originated == 'true' && steps.debounce.outputs.skip != 'true')
         env:
           GH_TOKEN: ${{ github.token }}
           GH_ENTERPRISE_TOKEN: ${{ github.token }}

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -1,12 +1,12 @@
 concurrency:
   cancel-in-progress: true
-  # Grouped by PR number, not github.ref: pull_request_review is not
-  # a pull_request-family event, so github.ref is not guaranteed to
-  # resolve the same way for it as it does for a pull_request-only
-  # workflow (see idd-doctor.yml / lint.yml). Review-thread comments
-  # live in a separate non-required workflow (#2136) and must not
-  # share this group. workflow_dispatch has no pull_request context
-  # either, so it falls back to its own inputs.
+  # Grouped by PR number, not github.ref: pull_request_target resolves
+  # github.ref to the base branch (refs/heads/main), the same value for
+  # every PR targeting it, so grouping by ref would collapse unrelated
+  # PRs into one concurrency slot. workflow_dispatch has no pull_request
+  # context either, so it falls back to its own inputs. Review-thread
+  # comments and review submissions live in a separate non-required
+  # workflow (#2136, #2764 Phase 1) and must not share this group.
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr_number }}
 name: IDD advisory-convergence gate
 # Required-check gate (#1341): asserts that the primary advisory bot's
@@ -15,6 +15,23 @@ name: IDD advisory-convergence gate
 # with --assert. This turns the F2 advisory/disposition sub-gate from a
 # judgment the execution model must choose to honor into a
 # non-bypassable required status check -- see roadmap #1342.
+#
+# Trigger-migration transition state (#2764 Phase 1): this workflow's
+# own copy of `on:` below is evaluated against the pull request's merge
+# ref for `pull_request` -- exactly the trust gap `pull_request_target`
+# closes, since THAT trigger is evaluated against the base branch's own
+# workflow YAML instead, so a same-repository PR cannot edit its copy of
+# this file to force its own required check green. Both `pull_request`
+# and `pull_request_target` are active simultaneously during Phase 1
+# (same activity types on both) so the implementing PR itself stays
+# normally mergeable -- `pull_request_target` cannot fire against the
+# PR that first defines it, only against PRs opened after it merges to
+# `main`. A follow-up issue (Phase 2, filed once Phase 1 has run cleanly
+# on production PRs for a period) will remove the now-redundant
+# `pull_request` trigger. The accepted, bounded cost of this transition
+# window is two required-check runs per PR under the same check name,
+# temporarily widening `#1381`'s known same-SHA-multiple-runs race (see
+# the concurrency-hardening investigation below) from rare to routine.
 #
 # Read-only: contents: read + issues: read + pull-requests: read. The
 # helper only queries the GitHub API (via `gh`) for reviews, review
@@ -55,14 +72,17 @@ name: IDD advisory-convergence gate
 #
 # CI topology: unlike lint.yml/idd-doctor.yml's pull_request-only
 # trigger, convergence can also change WITHOUT a new push when Copilot
-# submits its review (`pull_request_review`). That trigger stays here
-# on the required job. Review-thread *comments* do not: a casual
+# submits its review (`pull_request_review`). That trigger ran directly
+# on this required job before #2764 Phase 1; a same-repository PR could
+# edit this file's own copy of the trigger list to control when its
+# review-triggered run re-asserted, the same tamper path
+# `pull_request_target` closes for pushes -- so review submissions now
+# refresh the existing HEAD-associated required run from the companion
+# `idd-advisory-convergence-comment.yml` workflow instead, via
+# `rerun-advisory-convergence --apply`, the same mechanism review-thread
+# *comments* already used for the identical reason (#2136): a casual
 # human reply used to start this same required job, overwrite or
-# cancel the SHA's verdict, and show up as "the reply got linted"
-# (#2136). IDD-originated comments (disposition / stamp / operational
-# marker) refresh the existing HEAD-associated required run from the
-# companion `idd-advisory-convergence-comment.yml` workflow instead,
-# via `rerun-advisory-convergence --apply`.
+# cancel the SHA's verdict, and show up as "the reply got linted".
 #
 # Known gap vs. the issue's original three-trigger proposal:
 # `pull_request_review_thread` (thread resolved/unresolved) is a real
@@ -94,11 +114,15 @@ name: IDD advisory-convergence gate
 #
 # Bounded poll for the "not reviewed yet" race (#2015): the
 # `pull_request` `synchronize` trigger above fires the instant a push
-# lands, independent of the separate `pull_request_review` trigger,
-# which only fires once the primary bot's own review actually lands
-# (typically 10-40s later) -- so a push that also needed a fresh review
-# used to get asserted, and fail, before that review existed, costing an
-# external rerun most of the time (the exact recovery documented a few
+# lands, well before the primary bot's own review typically lands
+# (10-40s later) -- originally via the separate `pull_request_review`
+# trigger this workflow declared directly; that trigger moved to the
+# companion workflow in #2764 Phase 1, but the timing gap this poll
+# exists for is unchanged, since the push-triggered run still starts
+# immediately regardless of where the review's own signal now arrives
+# from -- so a push that also needed a fresh review used to get
+# asserted, and fail, before that review existed, costing an external
+# rerun most of the time (the exact recovery documented a few
 # paragraphs below). `advisory-convergence.mjs`'s CLI entry point now
 # runs `runAdvisoryConvergenceWithPoll` instead of asserting
 # immediately: when (and ONLY when) the verdict's sole blocking reason
@@ -115,26 +139,29 @@ name: IDD advisory-convergence gate
 # not landed by the end of the window, or lands with outstanding items,
 # the job fails exactly as it always has.
 #
-# Known residual (PR #2023 review): this job's own concurrency group
-# (below) is keyed by PR number ALONE across all three of its triggers,
-# with `cancel-in-progress: true`. If the primary bot's review actually
-# lands WHILE this poll is asleep, that submission starts a fresh
-# `pull_request_review`-triggered run in the SAME group, which cancels
-# THIS run before its next scheduled re-check ever observes the review
-# -- this run ends CANCELLED, and the fresh run becomes the one
-# responsible for reflecting convergence, subject to the exact same
-# stale-rollup risk `#1381` documents a few paragraphs below (whose
-# recovery, `rerun-advisory-convergence.mjs`, already handles a stale
-# CANCELLED sibling instance, not only a FAILURE one -- see "Rerun
-# mechanics" in `idd-ci.instructions.md`). Not a regression versus the
-# pre-#2015 baseline (before this change, the run always finished
-# FAILURE well before the review landed, so cancellation essentially
-# never happened, but the later review-triggered run's rollup update
-# was ALREADY subject to this same `#1381` risk) -- only a narrower win
-# than "no external rerun ever needed." See
+# Known residual (PR #2023 review), reshaped by #2764 Phase 1: this
+# job's own concurrency group (below) is keyed by PR number ALONE
+# across all three of its triggers, with `cancel-in-progress: true`.
+# Originally, if the primary bot's review landed WHILE this poll was
+# asleep, that submission started a fresh `pull_request_review`-triggered
+# run directly in the SAME group, cancelling this run before its next
+# scheduled re-check ever observed the review. `pull_request_review` no
+# longer triggers this workflow directly (#2764 Phase 1 moved it to the
+# companion `idd-advisory-convergence-comment.yml` workflow); a review
+# submission now reaches this job only indirectly, via the companion's
+# `rerun-advisory-convergence.mjs --apply` reissuing `gh run rerun` on
+# an already-terminal instance, not by entering this concurrency group
+# as a fresh trigger while a sibling is still polling. Whether a
+# rerun re-entering this group while another instance is still polling
+# can still cancel it is not re-derived here -- this note corrects the
+# outdated trigger description without re-litigating the underlying
+# race, which is the same one `#1381` documents a few paragraphs below
+# (whose recovery, `rerun-advisory-convergence.mjs`, already handles a
+# stale CANCELLED sibling instance, not only a FAILURE one -- see
+# "Rerun mechanics" in `idd-ci.instructions.md`). See
 # `runAdvisoryConvergenceWithPoll`'s own doc comment
-# (`src/scripts/advisory-convergence.mts`) for the full analysis; no
-# safe mechanical fix was found within #2015's scope.
+# (`src/scripts/advisory-convergence.mts`) for the full #2015 analysis;
+# no safe mechanical fix was found within that issue's scope.
 #
 # Correction (kurone-kito/idd-skill#1381): in practice, workflow_dispatch
 # does NOT reliably flip the PR's required-check rollup for its own HEAD
@@ -149,7 +176,7 @@ name: IDD advisory-convergence gate
 # associated with the default branch instead of the intended branch, so
 # it never surfaces in that PR's required-check rollup at all even when
 # the run itself succeeds. The verified recovery is `gh run rerun
-# <run-id>` on the *existing* pull_request / pull_request_review /
+# <run-id>` on the *existing* pull_request / pull_request_target /
 # pull_request_review_comment-triggered run for the current HEAD SHA --
 # found via `gh run list --workflow=idd-advisory-convergence.yml --json
 # databaseId,headSha,event,url` filtered to that exact SHA (not merely
@@ -256,9 +283,11 @@ on:
       - opened
       - reopened
       - synchronize
-  pull_request_review:
+  pull_request_target:
     types:
-      - submitted
+      - opened
+      - reopened
+      - synchronize
   workflow_dispatch:
     inputs:
       pr_number:

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -113,18 +113,19 @@ name: IDD advisory-convergence gate
 # generic "re-run failed jobs".
 #
 # Bounded poll for the "not reviewed yet" race (#2015): the
-# `pull_request` `synchronize` trigger above fires the instant a push
-# lands, well before the primary bot's own review typically lands
-# (10-40s later) -- originally via the separate `pull_request_review`
-# trigger this workflow declared directly; that trigger moved to the
-# companion workflow in #2764 Phase 1, but the timing gap this poll
-# exists for is unchanged, since the push-triggered run still starts
-# immediately regardless of where the review's own signal now arrives
-# from -- so a push that also needed a fresh review used to get
-# asserted, and fail, before that review existed, costing an external
-# rerun most of the time (the exact recovery documented a few
-# paragraphs below). `advisory-convergence.mjs`'s CLI entry point now
-# runs `runAdvisoryConvergenceWithPoll` instead of asserting
+# `pull_request`/`pull_request_target` `synchronize` trigger above
+# fires the instant a push lands, well before the primary bot's own
+# review typically lands (10-40s later) -- originally via the separate
+# `pull_request_review` trigger this workflow declared directly; that
+# trigger moved to the companion workflow in #2764 Phase 1, but the
+# timing gap this poll exists for is unchanged, since the
+# push-triggered run still starts immediately regardless of where the
+# review's own signal now arrives from -- so a push that also needed a
+# fresh review used to get asserted, and fail, before that review
+# existed, costing an external rerun most of the time (the exact
+# recovery documented a few paragraphs below).
+# `advisory-convergence.mjs`'s CLI entry point now runs
+# `runAdvisoryConvergenceWithPoll` instead of asserting
 # immediately: when (and ONLY when) the verdict's sole blocking reason
 # is literally "{bot} has not reviewed this pull request yet" --
 # `isSoleCopilotNotReviewedYetReason` in the .mts source -- it polls a

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -78,9 +78,13 @@ name: IDD advisory-convergence gate
 # review-triggered run re-asserted, the same tamper path
 # `pull_request_target` closes for pushes -- so review submissions now
 # refresh the existing HEAD-associated required run from the companion
-# `idd-advisory-convergence-comment.yml` workflow instead, via
-# `rerun-advisory-convergence --apply`, the same mechanism review-thread
-# *comments* already used for the identical reason (#2136): a casual
+# `idd-advisory-convergence-comment.yml` workflow instead: a review
+# submission reruns via `rerun-advisory-convergence --refresh-latest
+# --apply` (Codex P1, PR #2855 review, after `--apply` alone turned out
+# to silently skip an already-passing or budget-exhausted instance --
+# see `RefreshLatestPlan`'s doc comment in `rerun-advisory-convergence.mts`),
+# while review-thread *comments* keep the plain `--apply` mechanism
+# they already used for a related but distinct reason (#2136): a casual
 # human reply used to start this same required job, overwrite or
 # cancel the SHA's verdict, and show up as "the reply got linted".
 #

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -154,8 +154,10 @@ name: IDD advisory-convergence gate
 # longer triggers this workflow directly (#2764 Phase 1 moved it to the
 # companion `idd-advisory-convergence-comment.yml` workflow); a review
 # submission now reaches this job only indirectly, via the companion's
-# `rerun-advisory-convergence.mjs --apply` reissuing `gh run rerun` on
-# an already-terminal instance, not by entering this concurrency group
+# `rerun-advisory-convergence.mjs --refresh-latest --apply` (Copilot,
+# PR #2855 review -- not the plain `--apply` the two comment-family
+# triggers use) reissuing `gh run rerun` on an already-terminal
+# instance, not by entering this concurrency group
 # as a fresh trigger while a sibling is still polling. Whether a
 # rerun re-entering this group while another instance is still polling
 # can still cancel it is not re-derived here -- this note corrects the

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -181,10 +181,13 @@ name: IDD advisory-convergence gate
 # associated with the default branch instead of the intended branch, so
 # it never surfaces in that PR's required-check rollup at all even when
 # the run itself succeeds. The verified recovery is `gh run rerun
-# <run-id>` on the *existing* pull_request / pull_request_target /
-# pull_request_review_comment-triggered run for the current HEAD SHA --
-# found via `gh run list --workflow=idd-advisory-convergence.yml --json
-# databaseId,headSha,event,url` filtered to that exact SHA (not merely
+# <run-id>` on the *existing* pull_request / pull_request_target-
+# triggered run for the current HEAD SHA (Copilot, PR #2855 review: this
+# required workflow's own `on:` above has never included
+# `pull_request_review_comment` -- that trigger belongs to the
+# non-required companion `idd-advisory-convergence-comment.yml`
+# instead) -- found via `gh run list --workflow=idd-advisory-convergence.yml
+# --json databaseId,headSha,event,url` filtered to that exact SHA (not merely
 # a run that happens to share it, and not an older run for an earlier
 # HEAD on the same PR), or the Checks API -- because re-running that
 # run object preserves its original pull_request-family association, so

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -494,8 +494,10 @@ once `ciGate.externalCheckWaivers.mode` is `maintainer-authorized`
 external check never silently makes this one waivable too. **Posting a
 waiver comment does not by itself turn the check green**: a waiver is
 a regular PR conversation comment, which is not one of the required
-workflow's triggers (`pull_request` push or `pull_request_review`
-submission), so after posting a waiver a maintainer must also
+workflow's triggers (`pull_request`/`pull_request_target` push --
+`pull_request_review` submission is not one either, since #2764 Phase
+1 moved it to the non-required companion), so after posting a waiver
+a maintainer must also
 **re-run the existing** PR-linked check run **for the current HEAD
 SHA** — the Actions UI "Re-run jobs" button, or
 `gh run rerun <run-id>` — for the required check to actually
@@ -2006,8 +2008,9 @@ endpoints, filtered by the pull request's head branch, to attribute cost the
 same way for your own workflows. A branch-name filter alone can include an
 unrelated run -- a reused branch name, or a same-repository `push` /
 `workflow_dispatch` run against that branch outside this pull request --
-so also restrict to `pull_request`/`pull_request_review`/
-`pull_request_review_comment`-triggered runs and check each run's own
+so also restrict to `pull_request`/`pull_request_target`/
+`pull_request_review`/`pull_request_review_comment`-triggered runs and
+check each run's own
 `pull_requests[].number` against the target pull request (empty for a
 fork-originated pull request, where GitHub never populates that field).
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -2497,10 +2497,17 @@ reflexively as any other CLI option.
   via a direct `pull_request_review` trigger on the hosting workflow
   itself; that trigger now lives on the non-required companion
   `idd-advisory-convergence-comment.yml` instead, which reruns the
-  existing required run via `rerun-advisory-convergence.mjs --apply` --
-  a same-repository PR could otherwise edit the required workflow's own
-  copy to control when its `pull_request_review`-triggered run
-  re-asserted.) Every other
+  existing required run via
+  `rerun-advisory-convergence.mjs --refresh-latest --apply` (not the
+  budget-gated plain `--apply` the two comment-family triggers share) --
+  see that flag's own doc comment in `rerun-advisory-convergence.mts`
+  for why a review submission needs the stronger mode. This move keeps
+  the required workflow's own trigger list free of a same-repository
+  PR's ability to disable or reshape a review-triggered rerun of its
+  required check, though the companion itself stays exactly as
+  PR-editable as that former direct trigger was; the push-triggered
+  gate (via `pull_request_target`, also `#2764`) is what actually stays
+  trusted.) Every other
   not-ready reason (an off-HEAD review, unresolved threads, an
   indeterminate claim scope, a deadline/terminal reason, etc.) still fails
   immediately with no wait, exactly as before this addition — the

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -2490,8 +2490,17 @@ reflexively as any other CLI option.
   `DEFAULT_COPILOT_REVIEW_POLL_INTERVAL_MS`, default 7.5s, up to
   `DEFAULT_COPILOT_REVIEW_POLL_MAX_WAIT_MS`, default 60s) before its real
   `--assert`-driven exit, absorbing the common race where the hosting
-  workflow's `pull_request` `synchronize` trigger fires before the
-  separate `pull_request_review` trigger's review has landed. Every other
+  workflow's `pull_request`/`pull_request_target` `synchronize` trigger
+  fires before the primary bot's own review has landed. (Through
+  Phase 1 of the shipped `idd-advisory-convergence.yml` template's own
+  trigger topology, `#2764`, a review landing refreshed this same run
+  via a direct `pull_request_review` trigger on the hosting workflow
+  itself; that trigger now lives on the non-required companion
+  `idd-advisory-convergence-comment.yml` instead, which reruns the
+  existing required run via `rerun-advisory-convergence.mjs --apply` --
+  a same-repository PR could otherwise edit the required workflow's own
+  copy to control when its `pull_request_review`-triggered run
+  re-asserted.) Every other
   not-ready reason (an off-HEAD review, unresolved threads, an
   indeterminate claim scope, a deadline/terminal reason, etc.) still fails
   immediately with no wait, exactly as before this addition — the
@@ -2505,12 +2514,14 @@ reflexively as any other CLI option.
   120s for a paginated call, `#1675`), not by `maxWaitMs` — closing that
   gap would mean threading a remaining-budget deadline into every `gh`
   call inside `collectFromGitHub`, out of scope for this narrow poll
-  wrapper; (2) a review that lands while this poll is asleep can still
-  start a fresh `pull_request_review`-triggered run in the hosting
-  workflow's own PR-scoped `cancel-in-progress` concurrency group,
-  cancelling this run before it observes the review — a narrower win than
-  "never needs an external rerun again"; see the full analysis in
-  `runAdvisoryConvergenceWithPoll`'s doc comment
+  wrapper; (2) as of `#2764` Phase 1, a review landing while this poll
+  is asleep no longer starts a fresh trigger directly in the hosting
+  workflow's own PR-scoped `cancel-in-progress` concurrency group (see
+  the parenthetical above) — it instead reaches this run only
+  indirectly, via the companion's `gh run rerun` on an already-terminal
+  instance. Whether that indirect path can still race and cancel a
+  still-polling sibling is not re-derived here; see the full poll
+  analysis in `runAdvisoryConvergenceWithPoll`'s doc comment
   (`src/scripts/advisory-convergence.mts`).
 - **Deadlock / deadline policy**: while the primary bot has not reviewed
   the current HEAD, `pending` is `true` and the gate is not ready. After

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -343,9 +343,15 @@ to bind to and are effectively not waivable in practice -- see
 short, bounded poll `advisory-convergence.mjs` itself runs when the
 `idd-advisory-convergence` required check's only blocking reason is that
 the primary bot has not reviewed the pull request at all yet -- absorbing
-the common race between the `pull_request: synchronize` trigger (fires
-immediately on push) and the separate `pull_request_review` trigger
-(fires once the bot's review actually lands). This is a **distinct
+the common race between the `pull_request`/`pull_request_target:
+synchronize` trigger (fires immediately on push) and the primary bot's
+own review landing shortly after. The bot's review submission
+(`pull_request_review`) does not trigger this required workflow directly
+-- it moved to the non-required companion
+`idd-advisory-convergence-comment.yml` workflow (`--refresh-latest
+--apply`, #2764 Phase 1) -- so this poll, not a same-job trigger, is
+what actually absorbs a review landing within its own bounded window.
+This is a **distinct
 config subtree from `advisoryWait.pollInterval`** above: that key governs
 the whole-minute-only E-phase advisory-wait protocol's own longer-horizon
 wait loop, entered only after this check has already resolved; this

--- a/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
@@ -11,13 +11,20 @@
 # existing pull_request-family required run for the current HEAD SHA.
 # It never asserts `ready` itself.
 #
-# Two trigger families land here (#2411): `pull_request_review_comment`
-# (inline review-thread comments) and `issue_comment` (regular PR
-# comments -- where post-idd-marker.mjs and
-# disposition-non-review-notices.mjs actually post every marker/
-# disposition type, since both use the issues-comments API).
-# `issue_comment` also fires for a comment on a plain issue, not only a
-# PR; the job-level `if:` below skips those (`github.event.issue.pull_request`
+# Three trigger families land here: `pull_request_review_comment` (inline
+# review-thread comments) and `issue_comment` (regular PR comments --
+# where post-idd-marker.mjs and disposition-non-review-notices.mjs
+# actually post every marker/disposition type, since both use the
+# issues-comments API), both from #2411; and `pull_request_review`
+# (review submissions) -- moved here from idd-advisory-convergence.yml's
+# own trigger list so a same-repository PR cannot edit that workflow's
+# copy to control when its own required run re-asserts. Unlike the two
+# comment families, a review submission always reruns the gate
+# unconditionally (see "Classify review comment" below): it is not
+# filtered by IDD-originated content, matching the gate's own former
+# unconditional `pull_request_review` trigger exactly. `issue_comment`
+# also fires for a comment on a plain issue, not only a PR; the
+# job-level `if:` below skips those (`github.event.issue.pull_request`
 # is only present when the commented-on issue is a PR).
 #
 # Job id is deliberately NOT `idd-advisory-convergence`.
@@ -65,6 +72,8 @@ concurrency:
   cancel-in-progress: false
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
 on:
+  pull_request_review:
+    types: [submitted]
   pull_request_review_comment:
     types: [created, edited, deleted]
   issue_comment:
@@ -221,7 +230,16 @@ jobs:
         id: origin
         if: steps.profile.outputs.profile != 'instructions-only' && steps.manager.outputs.manager != 'ambiguous'
         env:
-          COMMENT_BODY: ${{ github.event.comment.body }}
+          # A pull_request_review event carries its free-text summary at
+          # github.event.review.body, not github.event.comment.body (no
+          # `comment` object exists for that event). Feeding it through
+          # the same classifier costs nothing -- a review body can itself
+          # carry an IDD marker -- but a review submission always
+          # qualifies for a rerun regardless of this classifier's
+          # verdict; see the `if:` conditions below, which OR in
+          # `pull_request_review` explicitly rather than relying on
+          # content classification.
+          COMMENT_BODY: ${{ github.event.review.body || github.event.comment.body }}
           PROFILE: ${{ steps.profile.outputs.profile }}
           PACKAGE_SPEC: ${{ steps.profile.outputs.package-spec }}
           MANAGER: ${{ steps.manager.outputs.manager }}
@@ -250,13 +268,17 @@ jobs:
           esac
       - name: Check for newer qualifying event
         id: debounce
-        if: steps.origin.outputs.idd_originated == 'true'
+        if: steps.origin.outputs.idd_originated == 'true' || github.event_name == 'pull_request_review'
         env:
           GH_TOKEN: ${{ github.token }}
           GH_ENTERPRISE_TOKEN: ${{ github.token }}
-          # Same dual-trigger-family PR-number resolution as the rerun
+          # Same three-trigger-family PR-number resolution as the rerun
           # step below.
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          # pull_request_review and pull_request_review_comment both
+          # carry github.event.pull_request.number; issue_comment carries
+          # github.event.issue.number instead (#2411).
+          #
           # Both pull_request_review_comment and issue_comment carry the
           # triggering comment's own timestamps at github.event.comment
           # (matching COMMENT_BODY above). Prefer updated_at:
@@ -267,8 +289,16 @@ jobs:
           # "newer than the trigger" and wrongly skip this run.
           # updated_at equals created_at for a never-edited comment, so
           # this is safe for the created-event case too (#2650 review,
-          # Copilot).
-          TRIGGERED_AT: ${{ github.event.comment.updated_at || github.event.comment.created_at }}
+          # Copilot). pull_request_review carries its own timestamp at
+          # github.event.review.submitted_at instead -- there is no
+          # comment object to fall back to for that event. This helper's
+          # own live data collection does not query PR reviews (only
+          # issue and review-thread comments), so it can never find a
+          # "newer review" specifically; it can still find a newer
+          # IDD-originated *comment* that landed after this review, which
+          # is real, useful debounce signal even on a review-triggered
+          # run.
+          TRIGGERED_AT: ${{ github.event.review.submitted_at || github.event.comment.updated_at || github.event.comment.created_at }}
           PROFILE: ${{ steps.profile.outputs.profile }}
           PACKAGE_SPEC: ${{ steps.profile.outputs.package-spec }}
           MANAGER: ${{ steps.manager.outputs.manager }}
@@ -296,13 +326,13 @@ jobs:
               ;;
           esac
       - name: Rerun required HEAD check
-        if: steps.origin.outputs.idd_originated == 'true' && steps.debounce.outputs.skip != 'true'
+        if: (steps.origin.outputs.idd_originated == 'true' || github.event_name == 'pull_request_review') && steps.debounce.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           GH_ENTERPRISE_TOKEN: ${{ github.token }}
-          # pull_request_review_comment carries the PR number at
-          # github.event.pull_request.number; issue_comment (#2411)
-          # carries it at github.event.issue.number instead.
+          # pull_request_review and pull_request_review_comment carry the
+          # PR number at github.event.pull_request.number; issue_comment
+          # (#2411) carries it at github.event.issue.number instead.
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           PROFILE: ${{ steps.profile.outputs.profile }}
           PACKAGE_SPEC: ${{ steps.profile.outputs.package-spec }}

--- a/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
@@ -178,7 +178,7 @@ defaults:
 jobs:
   refresh-if-idd-originated:
     runs-on: ${{ vars.CI_RUNNER_LABEL || 'ubuntu-slim' }}
-    # 30, not the required gate's own 10 (Codex P1, kurone-kito/idd-skill#2855
+    # 35, not the required gate's own 10 (Codex P1, kurone-kito/idd-skill#2855
     # review): a `pull_request_review` submission can land while the
     # required gate's own run is still mid-flight, and
     # `--refresh-latest --apply` then blocks inside `waitForRunCompletion`
@@ -191,10 +191,11 @@ jobs:
     # at this timeout regardless of what step is running, so a shorter
     # bound here would silently drop the deferred rerun before it ever
     # fires -- exactly the scenario `--refresh-latest` exists to prevent.
-    # 30 covers 10 (waiting out the original run) plus roughly 2x10 (two
-    # sequential reruns, `rerunAndWait`'s own poll bounded by the same
-    # 10-minute gate timeout each) with headroom for setup/checkout.
-    timeout-minutes: 30
+    # 35 = 10 (waiting out the original run) + 2x10 (two sequential
+    # reruns, `rerunAndWait`'s own poll bounded by the same 10-minute gate
+    # timeout each) + 5 headroom for setup/checkout and the steps
+    # preceding this wait.
+    timeout-minutes: 35
     if: github.event_name != 'issue_comment' || github.event.issue.pull_request != null
     steps:
       - uses: actions/checkout@v4

--- a/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
@@ -463,8 +463,25 @@ jobs:
         # not consulted for `pull_request_review` at all (that step's own
         # `if:` excludes it), so a review is never superseded by a later
         # comment-triggered run that cannot provide the same
-        # `--refresh-latest` guarantee.
-        if: steps.profile.outputs.profile != 'instructions-only' && steps.manager.outputs.manager != 'ambiguous' && (github.event_name == 'pull_request_review' || (steps.origin.outputs.idd_originated == 'true' && steps.debounce.outputs.skip != 'true'))
+        # `--refresh-latest` guarantee. The explicit `success() &&` on
+        # the comment-family branch is load-bearing, not redundant
+        # (Codex P1, kurone-kito/idd-skill#2855 review): GitHub Actions
+        # implicitly prepends `success()` to a step's own `if:` UNLESS
+        # the expression itself already calls one of success()/failure()/
+        # always() -- so without an explicit call here, a failure in
+        # "Classify review comment" above (its own `review-comment-
+        # origin.mjs` throwing, e.g. on a malformed review body) would
+        # implicitly skip this ENTIRE step, silently defeating the
+        # review branch's own "always proceeds" guarantee for the exact
+        # trigger that guarantee exists to protect. Calling success()
+        # explicitly here suppresses that implicit prepend and lets the
+        # `pull_request_review` disjunct genuinely short-circuit
+        # regardless of any earlier step's own outcome (profile/manager
+        # readiness still applies to both branches via the leading
+        # `&&`), while the comment-family branch still requires it,
+        # matching this step's pre-existing (implicit) behavior for
+        # that path unchanged.
+        if: steps.profile.outputs.profile != 'instructions-only' && steps.manager.outputs.manager != 'ambiguous' && (github.event_name == 'pull_request_review' || (success() && steps.origin.outputs.idd_originated == 'true' && steps.debounce.outputs.skip != 'true'))
         env:
           GH_TOKEN: ${{ github.token }}
           GH_ENTERPRISE_TOKEN: ${{ github.token }}

--- a/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
@@ -184,17 +184,19 @@ jobs:
     # `--refresh-latest --apply` then blocks inside `waitForRunCompletion`
     # for up to that run's own remaining lifetime (bounded by ITS
     # `timeout-minutes: 10` in idd-advisory-convergence.yml) before issuing
-    # up to two sequential reruns (`rerun-advisory-convergence.mts` reruns
-    # every pull_request-family instance for this HEAD, not only one,
-    # since kurone-kito/idd-skill#1381 -- typically `pull_request` plus
-    # `pull_request_target` under Phase 1). GitHub kills the job outright
-    # at this timeout regardless of what step is running, so a shorter
-    # bound here would silently drop the deferred rerun before it ever
-    # fires -- exactly the scenario `--refresh-latest` exists to prevent.
-    # 35 = 10 (waiting out the original run) + 2x10 (two sequential
-    # reruns, `rerunAndWait`'s own poll bounded by the same 10-minute gate
-    # timeout each) + 5 headroom for setup/checkout and the steps
-    # preceding this wait.
+    # its own sequential reruns (`rerun-advisory-convergence.mts` reruns
+    # EVERY resolvable pull_request-family instance for this HEAD, not a
+    # fixed count -- typically `pull_request` plus `pull_request_target`
+    # under Phase 1, kurone-kito/idd-skill#1381). GitHub kills the job
+    # outright at this timeout regardless of what step is running, so a
+    # shorter bound here would silently drop a deferred rerun before it
+    # ever fires -- exactly the scenario `--refresh-latest` exists to
+    # prevent. 35 = 10 (waiting out the original run) + 2x10 (the typical
+    # Phase 1 case of two sequential reruns, `rerunAndWait`'s own poll
+    # bounded by the same 10-minute gate timeout each -- not a hard upper
+    # bound; more concurrent family instances for one HEAD would need
+    # more) + 5 headroom for setup/checkout and the steps preceding this
+    # wait.
     timeout-minutes: 35
     if: github.event_name != 'issue_comment' || github.event.issue.pull_request != null
     steps:

--- a/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
@@ -22,10 +22,23 @@
 # comment families, a review submission always reruns the gate
 # unconditionally (see "Classify review comment" below): it is not
 # filtered by IDD-originated content, matching the gate's own former
-# unconditional `pull_request_review` trigger exactly. `issue_comment`
-# also fires for a comment on a plain issue, not only a PR; the
-# job-level `if:` below skips those (`github.event.issue.pull_request`
-# is only present when the commented-on issue is a PR).
+# unconditional `pull_request_review` trigger exactly -- and, per that
+# same "always" guarantee, "Rerun required HEAD check" below adds
+# `--refresh-latest` for this one trigger family: the ordinary `--apply`
+# alone only reruns a `rerun-eligible` instance (excludes anything
+# already `pass` and enforces the rerun-once budget), which would leave a
+# same-HEAD review landing after the gate already went green -- or after
+# its one rerun was already spent -- unable to force a fresh evaluation
+# (Codex P1, kurone-kito/idd-skill#2855 review). `--refresh-latest` reruns
+# the latest pull_request-family instance unconditionally instead,
+# restoring the former direct-trigger's "every review gets a fresh
+# evaluation" guarantee; see `RefreshLatestPlan`'s doc comment in the
+# canonical source repository's `rerun-advisory-convergence.mts` for why
+# this is a separate mode rather than changing `--apply`'s own budget for
+# every caller. `issue_comment` also fires for a comment on a plain
+# issue, not only a PR; the job-level `if:` below skips those
+# (`github.event.issue.pull_request` is only present when the
+# commented-on issue is a PR).
 #
 # Job id is deliberately NOT `idd-advisory-convergence`.
 #
@@ -337,6 +350,15 @@ jobs:
           PROFILE: ${{ steps.profile.outputs.profile }}
           PACKAGE_SPEC: ${{ steps.profile.outputs.package-spec }}
           MANAGER: ${{ steps.manager.outputs.manager }}
+          # A review submission always reruns unconditionally (module
+          # header above), including when the gate is already `pass` or
+          # its rerun-once budget is already spent -- neither of the two
+          # comment families needs that: they are already filtered to
+          # IDD-originated content and share the ordinary rerun-once
+          # budget deliberately (#2643 comment-burst protection). Single
+          # word, no spaces -- safe to expand unquoted below (omitted
+          # entirely, not an empty-string argument, when empty).
+          REFRESH_FLAG: ${{ github.event_name == 'pull_request_review' && '--refresh-latest' || '' }}
         run: |
           if [ -z "$PR_NUMBER" ]; then
             echo "::error::PR_NUMBER is empty"
@@ -344,24 +366,30 @@ jobs:
           fi
           case "$PROFILE" in
             vendored-node)
-              node scripts/rerun-advisory-convergence.mjs --pr "$PR_NUMBER" --apply
+              # shellcheck disable=SC2086 # REFRESH_FLAG is a single
+              # trusted word ("--refresh-latest" or empty); see env: above.
+              node scripts/rerun-advisory-convergence.mjs --pr "$PR_NUMBER" $REFRESH_FLAG --apply
               ;;
             package-manager)
               case "$MANAGER" in
                 pnpm)
-                  pnpm exec idd-rerun-advisory-convergence --pr "$PR_NUMBER" --apply
+                  # shellcheck disable=SC2086
+                  pnpm exec idd-rerun-advisory-convergence --pr "$PR_NUMBER" $REFRESH_FLAG --apply
                   ;;
                 yarn)
-                  yarn idd-rerun-advisory-convergence --pr "$PR_NUMBER" --apply
+                  # shellcheck disable=SC2086
+                  yarn idd-rerun-advisory-convergence --pr "$PR_NUMBER" $REFRESH_FLAG --apply
                   ;;
                 *)
-                  npm exec idd-rerun-advisory-convergence -- --pr "$PR_NUMBER" --apply
+                  # shellcheck disable=SC2086
+                  npm exec idd-rerun-advisory-convergence -- --pr "$PR_NUMBER" $REFRESH_FLAG --apply
                   ;;
               esac
               ;;
             ephemeral-npx)
               SPEC="${PACKAGE_SPEC:-https://codeload.github.com/kurone-kito/idd-skill/tar.gz/refs/heads/main}"
-              npx --yes --package "$SPEC" idd-rerun-advisory-convergence --pr "$PR_NUMBER" --apply
+              # shellcheck disable=SC2086
+              npx --yes --package "$SPEC" idd-rerun-advisory-convergence --pr "$PR_NUMBER" $REFRESH_FLAG --apply
               ;;
             *)
               echo "::error::unrecognized helper-runtime profile \"$PROFILE\""

--- a/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
@@ -396,13 +396,16 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_ENTERPRISE_TOKEN: ${{ github.token }}
-          # Same three-trigger-family PR-number resolution as the rerun
-          # step below.
-          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
-          # pull_request_review and pull_request_review_comment both
-          # carry github.event.pull_request.number; issue_comment carries
+          # Same PR-number resolution as the rerun step below, though
+          # this step itself only ever runs for pull_request_review_comment
+          # or issue_comment -- its own `if:` above excludes
+          # pull_request_review entirely (Copilot, PR #2855 review: an
+          # earlier revision's comments here still described
+          # review-specific behavior even after that exclusion landed).
+          # pull_request_review_comment carries
+          # github.event.pull_request.number; issue_comment carries
           # github.event.issue.number instead (#2411).
-          #
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           # Both pull_request_review_comment and issue_comment carry the
           # triggering comment's own timestamps at github.event.comment
           # (matching COMMENT_BODY above). Prefer updated_at:
@@ -413,16 +416,8 @@ jobs:
           # "newer than the trigger" and wrongly skip this run.
           # updated_at equals created_at for a never-edited comment, so
           # this is safe for the created-event case too (#2650 review,
-          # Copilot). pull_request_review carries its own timestamp at
-          # github.event.review.submitted_at instead -- there is no
-          # comment object to fall back to for that event. This helper's
-          # own live data collection does not query PR reviews (only
-          # issue and review-thread comments), so it can never find a
-          # "newer review" specifically; it can still find a newer
-          # IDD-originated *comment* that landed after this review, which
-          # is real, useful debounce signal even on a review-triggered
-          # run.
-          TRIGGERED_AT: ${{ github.event.review.submitted_at || github.event.comment.updated_at || github.event.comment.created_at }}
+          # Copilot).
+          TRIGGERED_AT: ${{ github.event.comment.updated_at || github.event.comment.created_at }}
           PROFILE: ${{ steps.profile.outputs.profile }}
           PACKAGE_SPEC: ${{ steps.profile.outputs.package-spec }}
           MANAGER: ${{ steps.manager.outputs.manager }}

--- a/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
@@ -17,25 +17,38 @@
 # actually post every marker/disposition type, since both use the
 # issues-comments API), both from #2411; and `pull_request_review`
 # (review submissions) -- moved here from idd-advisory-convergence.yml's
-# own trigger list so a same-repository PR cannot edit that workflow's
-# copy to control when its own required run re-asserts. Unlike the two
-# comment families, a review submission always reruns the gate
-# unconditionally (see "Classify review comment" below): it is not
-# filtered by IDD-originated content, matching the gate's own former
-# unconditional `pull_request_review` trigger exactly -- and, per that
-# same "always" guarantee, "Rerun required HEAD check" below adds
+# own trigger list, alongside the content-filtering reason below. NOT for
+# tamper-resistance: this workflow is just as PR-editable as the
+# required workflow's own former trigger was (there is no
+# `pull_request_review_target` -- GitHub's `_target` variant exists only
+# for `pull_request`), so a same-repository PR can still disable or
+# alter this step. What actually stays trusted is the push-triggered
+# gate itself, via `pull_request_target` on `idd-advisory-convergence.yml`;
+# this review-refresh path is deliberately best-effort on top of that,
+# not a second trusted surface -- a tampered copy can only delay a fresh
+# green, never force one, since the gate's own verdict is still computed
+# independently on every push. Unlike the two comment families, a review
+# submission is not filtered by IDD-originated content (see "Classify
+# review comment" below), and "Rerun required HEAD check" below adds
 # `--refresh-latest` for this one trigger family: the ordinary `--apply`
 # alone only reruns a `rerun-eligible` instance (excludes anything
 # already `pass` and enforces the rerun-once budget), which would leave a
 # same-HEAD review landing after the gate already went green -- or after
 # its one rerun was already spent -- unable to force a fresh evaluation
 # (Codex P1, kurone-kito/idd-skill#2855 review). `--refresh-latest` reruns
-# the latest pull_request-family instance unconditionally instead,
-# restoring the former direct-trigger's "every review gets a fresh
-# evaluation" guarantee; see `RefreshLatestPlan`'s doc comment in the
-# canonical source repository's `rerun-advisory-convergence.mts` for why
-# this is a separate mode rather than changing `--apply`'s own budget for
-# every caller. `issue_comment` also fires for a comment on a plain
+# the latest pull_request-family instance unconditionally instead (still
+# honoring ciWait.rerunPolicy: "hold"); see `RefreshLatestPlan`'s doc
+# comment in the canonical source repository's
+# `rerun-advisory-convergence.mts` for why this is a separate mode
+# rather than changing `--apply`'s own budget for every caller. This
+# step still cannot reach `pull_request_review` submitted BY the primary
+# bot itself: GitHub gates any workflow run a bot actor triggers to
+# `action_required` regardless of which workflow it lands on, so the job
+# never reaches this step for that submission -- unchanged from the
+# former direct trigger, which was equally gated for the same actor.
+# That gap self-heals on the next non-bot trigger (a push, or a
+# human/session review-thread reply), exactly as it always has.
+# `issue_comment` also fires for a comment on a plain
 # issue, not only a PR; the job-level `if:` below skips those
 # (`github.event.issue.pull_request` is only present when the
 # commented-on issue is a PR).
@@ -350,14 +363,20 @@ jobs:
           PROFILE: ${{ steps.profile.outputs.profile }}
           PACKAGE_SPEC: ${{ steps.profile.outputs.package-spec }}
           MANAGER: ${{ steps.manager.outputs.manager }}
-          # A review submission always reruns unconditionally (module
-          # header above), including when the gate is already `pass` or
-          # its rerun-once budget is already spent -- neither of the two
-          # comment families needs that: they are already filtered to
-          # IDD-originated content and share the ordinary rerun-once
-          # budget deliberately (#2643 comment-burst protection). Single
-          # word, no spaces -- safe to expand unquoted below (omitted
-          # entirely, not an empty-string argument, when empty).
+          # A review submission reruns unconditionally (module header
+          # above) when this job itself runs, including when the gate is
+          # already `pass` or its rerun-once budget is already spent --
+          # neither of the two comment families needs that: they are
+          # already filtered to IDD-originated content and share the
+          # ordinary rerun-once budget deliberately (#2643 comment-burst
+          # protection). "When this job itself runs" is doing real work
+          # here: the primary bot's own review submission is gated to
+          # `action_required` before any step executes (module header
+          # above) -- unconditional refers to bypassing pass/budget
+          # classification once this step runs, not to every review
+          # submission reaching it. Single word, no spaces -- safe to
+          # expand unquoted below (omitted entirely, not an empty-string
+          # argument, when empty).
           REFRESH_FLAG: ${{ github.event_name == 'pull_request_review' && '--refresh-latest' || '' }}
         run: |
           if [ -z "$PR_NUMBER" ]; then

--- a/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
@@ -178,26 +178,31 @@ defaults:
 jobs:
   refresh-if-idd-originated:
     runs-on: ${{ vars.CI_RUNNER_LABEL || 'ubuntu-slim' }}
-    # 35, not the required gate's own 10 (Codex P1, kurone-kito/idd-skill#2855
+    # 55, not the required gate's own 10 (Codex P1, kurone-kito/idd-skill#2855
     # review): a `pull_request_review` submission can land while the
     # required gate's own run is still mid-flight, and
     # `--refresh-latest --apply` then blocks inside `waitForRunCompletion`
-    # for up to that run's own remaining lifetime (bounded by ITS
-    # `timeout-minutes: 10` in idd-advisory-convergence.yml) before issuing
-    # its own sequential reruns (`rerun-advisory-convergence.mts` reruns
-    # EVERY resolvable pull_request-family instance for this HEAD, not a
-    # fixed count -- typically `pull_request` plus `pull_request_target`
-    # under Phase 1, kurone-kito/idd-skill#1381). GitHub kills the job
-    # outright at this timeout regardless of what step is running, so a
-    # shorter bound here would silently drop a deferred rerun before it
-    # ever fires -- exactly the scenario `--refresh-latest` exists to
-    # prevent. 35 = 10 (waiting out the original run) + 2x10 (the typical
-    # Phase 1 case of two sequential reruns, `rerunAndWait`'s own poll
-    # bounded by the same 10-minute gate timeout each -- not a hard upper
+    # and (per rerun) `rerunAndWait`'s own `waitForNewAttempt`, each
+    # bounded by `rerun-advisory-convergence.mts`'s OWN internal
+    # 15-minute safety bound (`APPLY_POLL_TIMEOUT_MS`/
+    # `PENDING_RUN_POLL_TIMEOUT_MS`) -- not the gate's shorter 10-minute
+    # job timeout that internal bound deliberately exceeds as its own
+    # margin (Codex P1, kurone-kito/idd-skill#2855 review, round 8,
+    # correcting this comment's own prior 10-minute-per-wait arithmetic).
+    # GitHub kills THIS job outright at ITS OWN timeout regardless of
+    # what step is running, so a bound smaller than the sum of the
+    # internal waits it wraps would silently drop a deferred rerun before
+    # those internal waits ever gave up gracefully -- exactly the
+    # scenario `--refresh-latest` exists to prevent. 55 = 15 (waiting out
+    # the original run, if still pending) + 2x15 (the typical Phase 1
+    # case of two sequential reruns, `rerunAndWait`'s own poll bounded by
+    # the same 15-minute internal safety margin each -- not a hard upper
     # bound; more concurrent family instances for one HEAD would need
-    # more) + 5 headroom for setup/checkout and the steps preceding this
-    # wait.
-    timeout-minutes: 35
+    # more, since `rerun-advisory-convergence.mts` reruns EVERY
+    # resolvable pull_request-family instance for this HEAD, not a fixed
+    # count, kurone-kito/idd-skill#1381) + 10 headroom for setup/checkout
+    # and the steps preceding this wait.
+    timeout-minutes: 55
     if: github.event_name != 'issue_comment' || github.event.issue.pull_request != null
     steps:
       - uses: actions/checkout@v4

--- a/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
@@ -74,23 +74,39 @@
 # once per comment, exhausting every same-HEAD instance's one-time rerun
 # budget mid-burst. The "Check for newer qualifying event" step below
 # waits a short quiet window, then re-queries whether a newer
-# IDD-originated comment/review has since landed on the same PR; if so,
-# this run skips its own `--apply` call and leaves it to the
-# later-triggered run (which asks the same question in turn). This is a
-# job-body-level check -- it does not alter `cancel-in-progress: false`
-# below, which stays exactly as #2136 established it. (Note on that
-# setting's actual scope: it protects only the currently in-progress
-# run in this group from cancellation; a merely *pending*, not-yet-
-# started run is still cancelled and replaced by the newest pending run
-# when another is queued behind it, since no `queue:` key is set here
-# -- the debounce below exists for the case where a run has already
-# started and must itself decide whether a newer event supersedes it,
-# which that pending-run replacement does not cover.) If the debounce
-# step's own live-data collection fails, the step fails and GitHub
-# Actions' default sequential-failure behavior skips "Rerun required
-# HEAD check" entirely for that run -- safe, since this is a
-# non-required companion refresh, and a later qualifying event (or the
-# required check's own polling) will trigger a fresh attempt.
+# IDD-originated comment has since landed on the same PR; if so, this
+# run skips its own `--apply` call and leaves it to the later-triggered
+# run (which asks the same question in turn). This is a job-body-level
+# check -- it does not alter `cancel-in-progress: false` below, which
+# stays exactly as #2136 established it. (Note on that setting's actual
+# scope: it protects only the currently in-progress run in this group
+# from cancellation; a merely *pending*, not-yet-started run is still
+# cancelled and replaced by the newest pending run when another is
+# queued behind it, since no `queue:` key is set here -- the debounce
+# below exists for the case where a run has already started and must
+# itself decide whether a newer event supersedes it, which that
+# pending-run replacement does not cover.) If the debounce step's own
+# live-data collection fails, the step fails and GitHub Actions'
+# default sequential-failure behavior skips "Rerun required HEAD check"
+# entirely for that run -- safe, since this is a non-required companion
+# refresh, and a later qualifying event (or the required check's own
+# polling) will trigger a fresh attempt.
+#
+# `pull_request_review` deliberately skips debounce entirely (Codex P1,
+# PR #2855 review): the two comment families need it because a burst of
+# them all ask the SAME question (plain `--apply`), so skipping in favor
+# of a later one is safe -- but a review's `--refresh-latest` is a
+# STRONGER question a superseding comment-triggered run cannot answer on
+# its behalf (comment-triggered runs never carry `--refresh-latest`). A
+# review superseded by debounce would silently downgrade to whatever the
+# later comment run does, which could leave an already-green gate green
+# even though the review added new blocking findings. Debounce exists
+# purely to protect the rerun-once budget from a comment burst (#2643)
+# -- a hazard `--refresh-latest` does not share (it bypasses that budget
+# already) and reviews do not produce (human-paced, not bursty) -- so
+# this workflow does not need debounce protection for reviews at all;
+# "Rerun required HEAD check" below always proceeds for a review
+# submission instead of consulting the debounce step's output.
 name: IDD advisory-convergence comment refresh
 concurrency:
   # Do not cancel: a later human LGTM must not abort an in-flight
@@ -294,7 +310,15 @@ jobs:
           esac
       - name: Check for newer qualifying event
         id: debounce
-        if: steps.origin.outputs.idd_originated == 'true' || github.event_name == 'pull_request_review'
+        # `pull_request_review` deliberately excluded -- see the Debounce
+        # module-header paragraph above for why a review must not be
+        # debounced in favor of a later comment-triggered run. Depending
+        # only on `steps.origin.outputs.idd_originated` (never set under
+        # `instructions-only`/`ambiguous` -- "Classify review comment"
+        # above already gates on profile/manager) keeps this step's own
+        # `if:` correctly gated for the comment families it still serves,
+        # with no separate profile/manager check needed here.
+        if: steps.origin.outputs.idd_originated == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           GH_ENTERPRISE_TOKEN: ${{ github.token }}
@@ -352,7 +376,19 @@ jobs:
               ;;
           esac
       - name: Rerun required HEAD check
-        if: (steps.origin.outputs.idd_originated == 'true' || github.event_name == 'pull_request_review') && steps.debounce.outputs.skip != 'true'
+        # Profile/manager readiness guard (CodeRabbit review, PR #2855):
+        # required unconditionally, including for `pull_request_review`
+        # -- under `instructions-only`/`ambiguous` there is no helper
+        # runtime to execute this step's `run:` case statement with
+        # regardless of trigger family, so "always proceeds" below means
+        # only "bypasses debounce," never "bypasses readiness." A review
+        # submission always proceeds once readiness holds, ignoring the
+        # debounce step's output entirely (module header above) -- it is
+        # not consulted for `pull_request_review` at all (that step's own
+        # `if:` excludes it), so a review is never superseded by a later
+        # comment-triggered run that cannot provide the same
+        # `--refresh-latest` guarantee.
+        if: steps.profile.outputs.profile != 'instructions-only' && steps.manager.outputs.manager != 'ambiguous' && (github.event_name == 'pull_request_review' || (steps.origin.outputs.idd_originated == 'true' && steps.debounce.outputs.skip != 'true'))
         env:
           GH_TOKEN: ${{ github.token }}
           GH_ENTERPRISE_TOKEN: ${{ github.token }}

--- a/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
@@ -35,17 +35,21 @@
 # already `pass` and enforces the rerun-once budget), which would leave a
 # same-HEAD review landing after the gate already went green -- or after
 # its one rerun was already spent -- unable to force a fresh evaluation
-# (Codex P1, kurone-kito/idd-skill#2855 review). `--refresh-latest` reruns
-# the latest pull_request-family instance unconditionally instead (still
-# honoring ciWait.rerunPolicy: "hold"); see `RefreshLatestPlan`'s doc
-# comment in the canonical source repository's
-# `rerun-advisory-convergence.mts` for why this is a separate mode
-# rather than changing `--apply`'s own budget for every caller. This
-# step still cannot reach `pull_request_review` submitted BY the primary
-# bot itself: GitHub gates any workflow run a bot actor triggers to
-# `action_required` regardless of which workflow it lands on, so the job
-# never reaches this step for that submission -- unchanged from the
-# former direct trigger, which was equally gated for the same actor.
+# (Codex P1, kurone-kito/idd-skill#2855 review). `--refresh-latest`
+# reruns every resolvable pull_request-family instance for this HEAD
+# unconditionally instead (still honoring ciWait.rerunPolicy: "hold") --
+# not only the most recently started one, since the required rollup can
+# stay pinned to an earlier instance even after a later one for the same
+# SHA completes (Codex P1, kurone-kito/idd-skill#2855 review, citing
+# kurone-kito/idd-skill#1381); see `RefreshLatestPlan`'s doc comment in
+# the canonical source repository's `rerun-advisory-convergence.mts` for
+# why this is a separate mode rather than changing `--apply`'s own budget
+# for every caller. This step still cannot reach `pull_request_review`
+# submitted BY the primary bot itself: GitHub gates any workflow run a
+# bot actor triggers to `action_required` regardless of which workflow it
+# lands on, so the job never reaches this step for that submission --
+# unchanged from the former direct trigger, which was equally gated for
+# the same actor.
 # That gap self-heals on the next non-bot trigger (a push, or a
 # human/session review-thread reply), exactly as it always has.
 #
@@ -174,7 +178,23 @@ defaults:
 jobs:
   refresh-if-idd-originated:
     runs-on: ${{ vars.CI_RUNNER_LABEL || 'ubuntu-slim' }}
-    timeout-minutes: 10
+    # 30, not the required gate's own 10 (Codex P1, kurone-kito/idd-skill#2855
+    # review): a `pull_request_review` submission can land while the
+    # required gate's own run is still mid-flight, and
+    # `--refresh-latest --apply` then blocks inside `waitForRunCompletion`
+    # for up to that run's own remaining lifetime (bounded by ITS
+    # `timeout-minutes: 10` in idd-advisory-convergence.yml) before issuing
+    # up to two sequential reruns (`rerun-advisory-convergence.mts` reruns
+    # every pull_request-family instance for this HEAD, not only one,
+    # since kurone-kito/idd-skill#1381 -- typically `pull_request` plus
+    # `pull_request_target` under Phase 1). GitHub kills the job outright
+    # at this timeout regardless of what step is running, so a shorter
+    # bound here would silently drop the deferred rerun before it ever
+    # fires -- exactly the scenario `--refresh-latest` exists to prevent.
+    # 30 covers 10 (waiting out the original run) plus roughly 2x10 (two
+    # sequential reruns, `rerunAndWait`'s own poll bounded by the same
+    # 10-minute gate timeout each) with headroom for setup/checkout.
+    timeout-minutes: 30
     if: github.event_name != 'issue_comment' || github.event.issue.pull_request != null
     steps:
       - uses: actions/checkout@v4

--- a/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
@@ -48,6 +48,25 @@
 # former direct trigger, which was equally gated for the same actor.
 # That gap self-heals on the next non-bot trigger (a push, or a
 # human/session review-thread reply), exactly as it always has.
+#
+# Fork-originated PRs (Codex P1, kurone-kito/idd-skill#2855 review): a
+# `pull_request_review` run whose PR is from a fork gets a read-only
+# `GITHUB_TOKEN` from GitHub regardless of this workflow's declared
+# `actions: write` permission -- the same restriction the canonical
+# source repository's `docs/customization.md`
+# (`strip-untrusted-labels.yml` trust-model section) documents for
+# `pull_request`, and `pull_request_review_comment` (this workflow's own
+# pre-existing trigger) already shares it. The former `pull_request_review`
+# trigger (directly on the required workflow) never hit this, because
+# recomputing its own verdict needed only read access; routing through
+# `gh run rerun` here needs write, which a fork PR's token cannot have --
+# the mutation step fails visibly (a 403), not silently. No trusted
+# writable review event exists for this case (there is no
+# `pull_request_review_target`), and putting `pull_request_review` back
+# on the required workflow to get one would reopen the exact vector this
+# move closes for same-repository PRs. Recovery is the same as any other
+# stuck rollup: a maintainer's manual `gh run rerun`, the next push, or a
+# configured external-check waiver.
 # `issue_comment` also fires for a comment on a plain
 # issue, not only a PR; the job-level `if:` below skips those
 # (`github.event.issue.pull_request` is only present when the

--- a/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
@@ -126,6 +126,30 @@
 # this workflow does not need debounce protection for reviews at all;
 # "Rerun required HEAD check" below always proceeds for a review
 # submission instead of consulting the debounce step's output.
+#
+# Residual NOT closed by the above (Codex P1, kurone-kito/idd-skill#2855
+# review): the pending-run-replacement gap this same module header
+# already discloses a few paragraphs up (a *queued*, not-yet-started run
+# can still be evicted and replaced by a newer trigger sharing this same
+# `concurrency.group`, before debounce -- which only judges an
+# ALREADY-STARTED run -- ever gets a say) applies to a review-triggered
+# run exactly as it does to a comment-triggered one: if a comment run is
+# already in-flight when a review lands, the review's own run queues
+# behind it, and a THIRD event landing before that queue slot is served
+# evicts the review's queued run in favor of the newer one, which never
+# carries `--refresh-latest`. This is not new to reviews -- it is the
+# same already-documented, already-accepted gap the pre-existing
+# comment-burst case already lived with -- and splitting this workflow
+# into a separate concurrency group per trigger family was already
+# considered and rejected for the analogous rollup-ordering race the
+# canonical source repository's `idd-advisory-convergence.yml` documents:
+# it would defeat the deliberate cross-trigger debouncing this workflow
+# depends on, without actually closing the underlying queue-depth-of-one
+# platform limitation. No safe mechanical fix was found within this
+# issue's scope; recovery is the same manual
+# `rerun-advisory-convergence --refresh-latest --apply` this file's
+# header already documents for the `action_required` and fork-PR-token
+# cases above.
 name: IDD advisory-convergence comment refresh
 concurrency:
   # Do not cancel: a later human LGTM must not abort an in-flight
@@ -331,13 +355,23 @@ jobs:
         id: debounce
         # `pull_request_review` deliberately excluded -- see the Debounce
         # module-header paragraph above for why a review must not be
-        # debounced in favor of a later comment-triggered run. Depending
-        # only on `steps.origin.outputs.idd_originated` (never set under
-        # `instructions-only`/`ambiguous` -- "Classify review comment"
-        # above already gates on profile/manager) keeps this step's own
-        # `if:` correctly gated for the comment families it still serves,
-        # with no separate profile/manager check needed here.
-        if: steps.origin.outputs.idd_originated == 'true'
+        # debounced in favor of a later comment-triggered run. The
+        # `github.event_name != 'pull_request_review'` conjunct is load-
+        # bearing, not redundant (Copilot + Codex P1, PR #2855 review): a
+        # review body that happens to classify as IDD-originated (it is
+        # fed through the same classifier as a comment, for the reason
+        # documented on "Classify review comment" above) would otherwise
+        # still satisfy `idd_originated == 'true'` and run this step for
+        # a review -- and if this step's own live-data collection then
+        # failed, the job would stop here (module header above), never
+        # reaching "Rerun required HEAD check" at all for that review.
+        # Depending on `steps.origin.outputs.idd_originated` at all (never
+        # set under `instructions-only`/`ambiguous` -- "Classify review
+        # comment" above already gates on profile/manager) keeps this
+        # step's own `if:` correctly gated for the comment families it
+        # still serves, with no separate profile/manager check needed
+        # here.
+        if: steps.origin.outputs.idd_originated == 'true' && github.event_name != 'pull_request_review'
         env:
           GH_TOKEN: ${{ github.token }}
           GH_ENTERPRISE_TOKEN: ${{ github.token }}

--- a/idd-template/.github/workflows/idd-advisory-convergence.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence.yml
@@ -47,20 +47,32 @@ name: IDD advisory-convergence gate
 # job outright rather than silently skipping.
 concurrency:
   cancel-in-progress: true
-  # Grouped by PR number, not github.ref: pull_request_review is not a
-  # pull_request-family event, so github.ref does not resolve the same
-  # way for it as it does for a pull_request-only workflow.
-  # Review-thread comments live in the companion
+  # Grouped by PR number, not github.ref: pull_request_target resolves
+  # github.ref to the base branch (the same value for every PR targeting
+  # it), so grouping by ref would collapse unrelated PRs into one slot.
+  # Review-thread comments and review submissions live in the companion
   # idd-advisory-convergence-comment.yml workflow and must not share
-  # this group. Keep pull_request and pull_request_review in their
+  # this group. Keep pull_request and pull_request_target in their
   # existing group, but isolate workflow_dispatch so a manual re-check
   # cannot cancel an in-flight PR-linked run.
   group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && format('dispatch-{0}', inputs.pr_number) || github.event.pull_request.number || inputs.pr_number }}
 on:
+  # Trigger-migration transition state: pull_request is evaluated
+  # against the pull request's own merge ref, so a same-repository PR
+  # could edit this file's copy to force its own required check green.
+  # pull_request_target closes that gap -- it is evaluated against the
+  # base branch's own workflow YAML instead -- but cannot fire against
+  # the PR that first adds or edits this trigger, only against PRs
+  # opened afterward, so both stay active together rather than a
+  # single-PR replacement that would leave the implementing PR unable
+  # to satisfy its own required check. Drop pull_request once this has
+  # run cleanly on production PRs for a period. pull_request_review
+  # moved to the companion idd-advisory-convergence-comment.yml
+  # workflow instead of staying here, for the identical reason.
   pull_request:
     types: [opened, reopened, synchronize]
-  pull_request_review:
-    types: [submitted]
+  pull_request_target:
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
     inputs:
       pr_number:

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -494,8 +494,10 @@ once `ciGate.externalCheckWaivers.mode` is `maintainer-authorized`
 external check never silently makes this one waivable too. **Posting a
 waiver comment does not by itself turn the check green**: a waiver is
 a regular PR conversation comment, which is not one of the required
-workflow's triggers (`pull_request` push or `pull_request_review`
-submission), so after posting a waiver a maintainer must also
+workflow's triggers (`pull_request`/`pull_request_target` push --
+`pull_request_review` submission is not one either, since #2764 Phase
+1 moved it to the non-required companion), so after posting a waiver
+a maintainer must also
 **re-run the existing** PR-linked check run **for the current HEAD
 SHA** — the Actions UI "Re-run jobs" button, or
 `gh run rerun <run-id>` — for the required check to actually
@@ -2006,8 +2008,9 @@ endpoints, filtered by the pull request's head branch, to attribute cost the
 same way for your own workflows. A branch-name filter alone can include an
 unrelated run -- a reused branch name, or a same-repository `push` /
 `workflow_dispatch` run against that branch outside this pull request --
-so also restrict to `pull_request`/`pull_request_review`/
-`pull_request_review_comment`-triggered runs and check each run's own
+so also restrict to `pull_request`/`pull_request_target`/
+`pull_request_review`/`pull_request_review_comment`-triggered runs and
+check each run's own
 `pull_requests[].number` against the target pull request (empty for a
 fork-originated pull request, where GitHub never populates that field).
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -2497,10 +2497,17 @@ reflexively as any other CLI option.
   via a direct `pull_request_review` trigger on the hosting workflow
   itself; that trigger now lives on the non-required companion
   `idd-advisory-convergence-comment.yml` instead, which reruns the
-  existing required run via `rerun-advisory-convergence.mjs --apply` --
-  a same-repository PR could otherwise edit the required workflow's own
-  copy to control when its `pull_request_review`-triggered run
-  re-asserted.) Every other
+  existing required run via
+  `rerun-advisory-convergence.mjs --refresh-latest --apply` (not the
+  budget-gated plain `--apply` the two comment-family triggers share) --
+  see that flag's own doc comment in `rerun-advisory-convergence.mts`
+  for why a review submission needs the stronger mode. This move keeps
+  the required workflow's own trigger list free of a same-repository
+  PR's ability to disable or reshape a review-triggered rerun of its
+  required check, though the companion itself stays exactly as
+  PR-editable as that former direct trigger was; the push-triggered
+  gate (via `pull_request_target`, also `#2764`) is what actually stays
+  trusted.) Every other
   not-ready reason (an off-HEAD review, unresolved threads, an
   indeterminate claim scope, a deadline/terminal reason, etc.) still fails
   immediately with no wait, exactly as before this addition — the

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -2490,8 +2490,17 @@ reflexively as any other CLI option.
   `DEFAULT_COPILOT_REVIEW_POLL_INTERVAL_MS`, default 7.5s, up to
   `DEFAULT_COPILOT_REVIEW_POLL_MAX_WAIT_MS`, default 60s) before its real
   `--assert`-driven exit, absorbing the common race where the hosting
-  workflow's `pull_request` `synchronize` trigger fires before the
-  separate `pull_request_review` trigger's review has landed. Every other
+  workflow's `pull_request`/`pull_request_target` `synchronize` trigger
+  fires before the primary bot's own review has landed. (Through
+  Phase 1 of the shipped `idd-advisory-convergence.yml` template's own
+  trigger topology, `#2764`, a review landing refreshed this same run
+  via a direct `pull_request_review` trigger on the hosting workflow
+  itself; that trigger now lives on the non-required companion
+  `idd-advisory-convergence-comment.yml` instead, which reruns the
+  existing required run via `rerun-advisory-convergence.mjs --apply` --
+  a same-repository PR could otherwise edit the required workflow's own
+  copy to control when its `pull_request_review`-triggered run
+  re-asserted.) Every other
   not-ready reason (an off-HEAD review, unresolved threads, an
   indeterminate claim scope, a deadline/terminal reason, etc.) still fails
   immediately with no wait, exactly as before this addition — the
@@ -2505,12 +2514,14 @@ reflexively as any other CLI option.
   120s for a paginated call, `#1675`), not by `maxWaitMs` — closing that
   gap would mean threading a remaining-budget deadline into every `gh`
   call inside `collectFromGitHub`, out of scope for this narrow poll
-  wrapper; (2) a review that lands while this poll is asleep can still
-  start a fresh `pull_request_review`-triggered run in the hosting
-  workflow's own PR-scoped `cancel-in-progress` concurrency group,
-  cancelling this run before it observes the review — a narrower win than
-  "never needs an external rerun again"; see the full analysis in
-  `runAdvisoryConvergenceWithPoll`'s doc comment
+  wrapper; (2) as of `#2764` Phase 1, a review landing while this poll
+  is asleep no longer starts a fresh trigger directly in the hosting
+  workflow's own PR-scoped `cancel-in-progress` concurrency group (see
+  the parenthetical above) — it instead reaches this run only
+  indirectly, via the companion's `gh run rerun` on an already-terminal
+  instance. Whether that indirect path can still race and cancel a
+  still-polling sibling is not re-derived here; see the full poll
+  analysis in `runAdvisoryConvergenceWithPoll`'s doc comment
   (`src/scripts/advisory-convergence.mts`).
 - **Deadlock / deadline policy**: while the primary bot has not reviewed
   the current HEAD, `pending` is `true` and the gate is not ready. After

--- a/idd-template/docs/onboarding/optional-host-setup.md
+++ b/idd-template/docs/onboarding/optional-host-setup.md
@@ -594,14 +594,22 @@ comments), independent of what is checked out locally, so pinning the
 checkout to the trusted branch costs nothing functionally.
 
 Two automatic trigger types keep the required verdict current:
-`pull_request` for the normal push case, and `pull_request_review` for
-Copilot's review submission. Review-thread comments are **not** on
-that required job. IDD-originated comments (a disposition prefix, the
-reply-identity stamp, or an operational marker the check already
-honors) refresh the existing HEAD-associated required run from the
-companion `idd-advisory-convergence-comment.yml` workflow, which
-calls `rerun-advisory-convergence --apply` and never reports
-`ready` itself. Ordinary human prose (`LGTM`) does not create or
+`pull_request` for the normal push case, and `pull_request_target` as
+its tamper-resistant counterpart (see Trusted-code checkout above --
+a same-repository PR cannot edit `pull_request_target`'s own copy of
+this workflow file, unlike `pull_request`). Review-thread comments are
+**not** on that required job, and neither is Copilot's review
+submission (`pull_request_review`) — both instead refresh the
+existing HEAD-associated required run from the non-required companion
+`idd-advisory-convergence-comment.yml` workflow: an IDD-originated
+comment (a disposition prefix, the reply-identity stamp, or an
+operational marker the check already honors) calls
+`rerun-advisory-convergence --apply`, while a review submission calls
+`rerun-advisory-convergence --refresh-latest --apply` instead — a
+review needs a fresh evaluation even if the gate is already green or
+its rerun-once budget is already spent, which the plain `--apply`
+path does not provide. Neither call reports `ready` itself. Ordinary
+human prose (`LGTM`) does not create or
 cancel the required check.
 
 A thread being resolved or unresolved via the "Resolve conversation"

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -343,9 +343,15 @@ to bind to and are effectively not waivable in practice -- see
 short, bounded poll `advisory-convergence.mjs` itself runs when the
 `idd-advisory-convergence` required check's only blocking reason is that
 the primary bot has not reviewed the pull request at all yet -- absorbing
-the common race between the `pull_request: synchronize` trigger (fires
-immediately on push) and the separate `pull_request_review` trigger
-(fires once the bot's review actually lands). This is a **distinct
+the common race between the `pull_request`/`pull_request_target:
+synchronize` trigger (fires immediately on push) and the primary bot's
+own review landing shortly after. The bot's review submission
+(`pull_request_review`) does not trigger this required workflow directly
+-- it moved to the non-required companion
+`idd-advisory-convergence-comment.yml` workflow (`--refresh-latest
+--apply`, #2764 Phase 1) -- so this poll, not a same-job trigger, is
+what actually absorbs a review landing within its own bounded window.
+This is a **distinct
 config subtree from `advisoryWait.pollInterval`** above: that key governs
 the whole-minute-only E-phase advisory-wait protocol's own longer-horizon
 wait loop, entered only after this check has already resolved; this

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -63,13 +63,19 @@
 // and how much budget remains.
 //
 // #2015: bounded poll for the "not reviewed yet" race. The hosting
-// workflow's `pull_request` `synchronize` trigger fires the instant a push
-// lands, independent of the separate `pull_request_review` trigger, which
-// only fires once the primary bot's own review actually lands (typically
-// 10-40s later) -- so a push that also needs a fresh review used to get
-// asserted, and fail, before that review existed, costing an external
-// rerun most of the time. The CLI entry point at the bottom of this file
-// now runs through `runAdvisoryConvergenceWithPoll` instead of
+// workflow's `pull_request`/`pull_request_target` `synchronize` trigger
+// fires the instant a push lands, well before the primary bot's own
+// review typically lands (10-40s later) -- originally via the separate
+// `pull_request_review` trigger the hosting workflow declared directly;
+// #2764 Phase 1 moved that trigger to a companion workflow instead (a
+// same-repository PR could otherwise edit the required workflow's own
+// copy to control when its review-triggered run re-asserted), but the
+// timing gap this poll exists for is unchanged, since the push-triggered
+// run still starts immediately regardless of where the review's own
+// signal now arrives from -- so a push that also needs a fresh review
+// used to get asserted, and fail, before that review existed, costing an
+// external rerun most of the time. The CLI entry point at the bottom of
+// this file now runs through `runAdvisoryConvergenceWithPoll` instead of
 // `runAdvisoryConvergence` directly: when (and ONLY when) the verdict's
 // sole blocking reason is that the primary bot has not reviewed the PR AT
 // ALL yet (`isSoleCopilotNotReviewedYetReason` -- excludes a stale-HEAD
@@ -1383,10 +1389,10 @@ function sleepSync(ms) {
 /**
  * #2015: wraps {@link runAdvisoryConvergence} with a short, bounded poll
  * for the narrow case {@link isSoleCopilotNotReviewedYetReason} identifies
- * -- absorbing the common race where the `pull_request` `synchronize`
- * trigger fires (and this CLI runs) before the separate
- * `pull_request_review` trigger's review has actually landed (typically
- * 10-40s later). Every other not-ready reason still fails on the very
+ * -- absorbing the common race where the `pull_request`/`pull_request_target`
+ * `synchronize` trigger fires (and this CLI runs) before the primary
+ * bot's own review has actually landed (typically 10-40s later). Every
+ * other not-ready reason still fails on the very
  * first pass with no wait, exactly as {@link runAdvisoryConvergence} alone
  * already does -- this wrapper adds no new pass path, only absorbs a
  * latency this one specific reason is known to resolve on its own. Does
@@ -1426,18 +1432,24 @@ function sleepSync(ms) {
  * first sleep alone exhausts the budget) -- an edge case only reachable via
  * an explicit non-default override, never the production defaults below.
  *
- * KNOWN RESIDUAL (PR #2023 review, Codex P1): the hosting workflow's
- * concurrency group is keyed by PR number ALONE across all three of its
- * triggers, with `cancel-in-progress: true` (see
- * `idd-advisory-convergence.yml`'s own header). If the primary bot's review
- * actually lands WHILE this poll is still sleeping, that submission starts
- * a fresh `pull_request_review`-triggered run in the SAME concurrency
- * group, which cancels this run before its next scheduled re-check ever
- * observes the review -- this run ends CANCELLED, not SUCCESS, and the
- * fresh run becomes the one responsible for reflecting the converged
- * state. No safe mechanical fix was found for this within #2015's scope:
- * narrowing the concurrency group would defeat the deliberate cross-trigger
- * debouncing the workflow's own "Concurrency-hardening investigation"
+ * KNOWN RESIDUAL (PR #2023 review, Codex P1), reshaped by #2764 Phase 1:
+ * the hosting workflow's concurrency group is keyed by PR number ALONE
+ * across all three of its triggers, with `cancel-in-progress: true` (see
+ * `idd-advisory-convergence.yml`'s own header). Originally, if the
+ * primary bot's review landed WHILE this poll was still sleeping, that
+ * submission started a fresh `pull_request_review`-triggered run
+ * directly in the SAME concurrency group, cancelling this run before its
+ * next scheduled re-check ever observed the review. `pull_request_review`
+ * no longer triggers the hosting workflow directly (#2764 Phase 1 moved
+ * it to a companion workflow); a review now reaches this run only
+ * indirectly, via the companion's `gh run rerun` on an already-terminal
+ * instance, not by entering this concurrency group as a fresh trigger
+ * while a sibling is still polling. Whether a rerun re-entering this
+ * group while another instance is still polling can still cancel it is
+ * not re-derived here. No safe mechanical fix was found for the original
+ * race within #2015's scope: narrowing the concurrency group would
+ * defeat the deliberate cross-trigger debouncing the workflow's own
+ * "Concurrency-hardening investigation"
  * comment already documents as load-bearing, and there is no way for a
  * script to detect an imminent cancellation from inside the run it is
  * about to lose. This is NOT a regression versus the pre-#2015 baseline,

--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -577,16 +577,12 @@ export function computeRefreshLatestPlan(input, options) {
   const owner = String(input.owner ?? '').trim();
   const repo = String(input.repo ?? '').trim();
   const repoFlag = owner && repo ? ` -R ${owner}/${repo}` : '';
-  // `pendingCommand: null` by default -- only the still-running branch
-  // below overrides it; every other branch's `...header` spread inherits
-  // this default so it never needs repeating at each return site.
   const header = {
     protocolVersion: '1',
     prNumber: Number(input.prNumber),
     prHeadSha,
     checkName,
     now,
-    pendingCommand: null,
   };
   // Honored, not bypassed (Copilot review, PR #2855): a "hold" policy is
   // a repository's explicit opt-out of every automatic rerun, checked
@@ -597,7 +593,8 @@ export function computeRefreshLatestPlan(input, options) {
   if (rerunPolicy === 'hold') {
     return {
       ...header,
-      command: null,
+      commands: [],
+      pendingCommands: [],
       reason:
         'ciWait.rerunPolicy is "hold": this repository has opted out of automatic reruns, including --refresh-latest -- a maintainer must manually decide (see idd-ci.instructions.md §Rerun mechanics)',
     };
@@ -612,16 +609,76 @@ export function computeRefreshLatestPlan(input, options) {
   if (familyInstances.length === 0) {
     return {
       ...header,
-      command: null,
+      commands: [],
+      pendingCommands: [],
       reason:
         'no pull_request-family check-run instance exists yet for this HEAD; nothing to refresh -- a future pull_request/pull_request_target trigger will create the first instance',
     };
   }
-  // Latest by startedAt (unknown/empty sorts LAST -- the opposite of
-  // buildOrderedPlan's own earliest-first, more-cautious ordering -- since
-  // this selects the single most-recent instance rather than building a
-  // deterministic multi-entry plan); numeric checkRunId breaks a tie.
-  const [latest] = [...familyInstances].sort((left, right) => {
+  // Mirrors classifyInstance steps 4-5: never guess a rerun target from an
+  // unresolvable run identity -- but (Codex P1, PR #2855 review) applied
+  // per-instance now, not just to a single "latest" pick: an instance
+  // whose own identity can't be trusted is skipped rather than aborting
+  // every OTHER instance's refresh. Deduplicated by runId: two check-run
+  // instances can briefly resolve to the same underlying workflow run
+  // (e.g. one instance's `gh api` lookup racing another's), and rerunning
+  // the same run id twice in one pass is redundant, not merely harmless.
+  const seenRunIds = new Set();
+  const unresolvableReasons = [];
+  const resolvedCommands = [];
+  const pendingResolvedCommands = [];
+  for (const instance of familyInstances) {
+    if (instance.runId === null) {
+      unresolvableReasons.push(
+        `check-run ${instance.checkRunId} has no resolvable workflow run id`,
+      );
+      continue;
+    }
+    if (instance.runLookupFailed) {
+      unresolvableReasons.push(
+        `the underlying workflow run for check-run ${instance.checkRunId} could not be fetched (network/permission/transient failure)`,
+      );
+      continue;
+    }
+    if (seenRunIds.has(instance.runId)) {
+      continue;
+    }
+    seenRunIds.add(instance.runId);
+    const status = String(instance.status ?? '')
+      .trim()
+      .toLowerCase();
+    const conclusion = instance.conclusion
+      ? String(instance.conclusion).trim().toLowerCase()
+      : null;
+    const resolvedCommand = {
+      runId: instance.runId,
+      command: `gh run rerun ${instance.runId}${repoFlag}`,
+      checkRunIds: [instance.checkRunId],
+      startedAt: instance.startedAt ?? '',
+    };
+    // Mirrors classifyInstance step 2's "rerunning a still-running
+    // instance cancels it instead of refreshing it" -- but unlike
+    // classifyInstance, this does NOT assume the live run will already
+    // reflect this review once it finishes (Codex P1, PR #2855 review):
+    // that run's own evidence was fetched at whatever point during ITS
+    // execution the query happened to run, which can be BEFORE this
+    // review landed, and nothing else is guaranteed to trigger a fresh
+    // evaluation afterward. `pendingCommands` carries the same resolved
+    // command for the caller to rerun ONCE this run reaches a terminal
+    // state, rather than declining to act on it at all.
+    if (!conclusion && PENDING_STATUSES.has(status)) {
+      pendingResolvedCommands.push(resolvedCommand);
+    } else {
+      resolvedCommands.push(resolvedCommand);
+    }
+  }
+  // Newest-`startedAt` first (unknown/empty sorts LAST) purely for a
+  // stable, readable summary -- unlike the single-instance selection this
+  // replaced, every entry in both lists is acted on, so this ordering has
+  // no bearing on correctness (unlike buildOrderedPlan's own
+  // earliest-first, rerun-budget-driven ordering). Numeric checkRunId
+  // breaks a tie.
+  const byStartedAtDesc = (left, right) => {
     const leftStarted = left.startedAt ?? '';
     const rightStarted = right.startedAt ?? '';
     if (leftStarted !== rightStarted) {
@@ -629,63 +686,30 @@ export function computeRefreshLatestPlan(input, options) {
       if (!rightStarted) return -1;
       return leftStarted < rightStarted ? 1 : -1;
     }
-    return Number(right.checkRunId) - Number(left.checkRunId);
-  });
-  const status = String(latest.status ?? '')
-    .trim()
-    .toLowerCase();
-  const conclusion = latest.conclusion
-    ? String(latest.conclusion).trim().toLowerCase()
-    : null;
-  // Mirrors classifyInstance steps 4-5: never guess a rerun target from an
-  // unresolvable run identity. Checked BEFORE the pending-status branch
-  // below so that branch can always build a `pendingCommand` from an
-  // already-validated runId.
-  if (latest.runId === null) {
-    return {
-      ...header,
-      command: null,
-      pendingCommand: null,
-      reason: `the latest pull_request-family instance (check-run ${latest.checkRunId}) has no resolvable workflow run id; inspect manually`,
-    };
-  }
-  if (latest.runLookupFailed) {
-    return {
-      ...header,
-      command: null,
-      pendingCommand: null,
-      reason: `the underlying workflow run for the latest pull_request-family instance (check-run ${latest.checkRunId}) could not be fetched (network/permission/transient failure); inspect manually`,
-    };
-  }
-  const resolvedCommand = {
-    runId: latest.runId,
-    command: `gh run rerun ${latest.runId}${repoFlag}`,
-    checkRunIds: [latest.checkRunId],
-    startedAt: latest.startedAt ?? '',
+    return Number(right.checkRunIds[0]) - Number(left.checkRunIds[0]);
   };
-  // Mirrors classifyInstance step 2's "rerunning a still-running instance
-  // cancels it instead of refreshing it" -- but unlike classifyInstance,
-  // this does NOT assume the live run will already reflect this review
-  // once it finishes (Codex P1, PR #2855 review): that run's own
-  // evidence was fetched at whatever point during ITS execution the
-  // query happened to run, which can be BEFORE this review landed, and
-  // nothing else is guaranteed to trigger a fresh evaluation afterward.
-  // `pendingCommand` carries the same resolved command for the caller to
-  // rerun ONCE this run reaches a terminal state, rather than declining
-  // to act at all.
-  if (!conclusion && PENDING_STATUSES.has(status)) {
+  resolvedCommands.sort(byStartedAtDesc);
+  pendingResolvedCommands.sort(byStartedAtDesc);
+  if (resolvedCommands.length === 0 && pendingResolvedCommands.length === 0) {
     return {
       ...header,
-      command: null,
-      pendingCommand: resolvedCommand,
-      reason: `the latest pull_request-family instance (check-run ${latest.checkRunId}) is still running ("${status}"); rerunning a live run now would cancel it instead of refreshing it -- wait for it to reach a terminal state, then rerun it (see pendingCommand)`,
+      commands: [],
+      pendingCommands: [],
+      reason: `no resolvable pull_request-family instance for this HEAD -- ${unresolvableReasons.join('; ')}; inspect manually`,
     };
   }
+  const unresolvableSuffix =
+    unresolvableReasons.length > 0
+      ? ` (skipped ${unresolvableReasons.length} unresolvable instance(s): ${unresolvableReasons.join('; ')})`
+      : '';
   return {
     ...header,
-    command: resolvedCommand,
-    pendingCommand: null,
-    reason: '',
+    commands: resolvedCommands,
+    pendingCommands: pendingResolvedCommands,
+    reason:
+      pendingResolvedCommands.length > 0
+        ? `${pendingResolvedCommands.length} pull_request-family instance(s) for this HEAD are still running; rerunning a live run now would cancel it instead of refreshing it -- wait for each to reach a terminal state, then rerun it (see pendingCommands)${unresolvableSuffix}`
+        : unresolvableSuffix.trim(),
   };
 }
 /**
@@ -1545,24 +1569,27 @@ Omitting this flag keeps output byte-identical to before this flag
 existed.
 
 --refresh-latest replaces the whole plan/budget computation above with a
-single, much narrower question: which pull_request-family instance for
-this HEAD started most recently, and is it safe to rerun unconditionally
-right now? Unlike the default mode, it does NOT classify pass /
-bot-gated-skip / rerun-budget-held -- it reruns the latest instance
-regardless of any of those, UNLESS that instance is still running (which
-would cancel it) or its run id could not be resolved. It still honors
-ciWait.rerunPolicy, though: a "hold" policy returns no command here
-either, the same as the default mode -- bypassing pass/bot-gated/budget
-classification is not license to override a repository's own explicit
-no-automatic-reruns policy. Intended only for the narrow #2764 Phase 1
-case where a fresh pull_request_review submission must get a fresh
-evaluation even if the gate is already green or its rerun-once budget is
-already spent -- see the RefreshLatestPlan doc comment in the .mts
-source. With --apply, executes that single rerun (via the same "gh run
-rerun" mechanism as the default --apply path) instead of only printing
-it. Mutually exclusive in effect with the default plan computation: when
-given, --refresh-latest's own JSON document replaces the ordinary plan
-document on stdout.
+single, much narrower question: which pull_request-family instances for
+this HEAD are safe to rerun unconditionally right now? Unlike the
+default mode, it does NOT classify pass / bot-gated-skip /
+rerun-budget-held -- it reruns EVERY resolvable pull_request-family
+instance for this HEAD (not only the most recently started one -- the
+required rollup can stay pinned to an earlier instance even after a
+later one for the same SHA completes, kurone-kito/idd-skill#1381), each
+UNLESS it is still running (which would cancel it instead -- queued for
+a deferred rerun once it finishes) or its run id could not be resolved.
+It still honors ciWait.rerunPolicy, though: a "hold" policy returns
+nothing to rerun here either, the same as the default mode -- bypassing
+pass/bot-gated/budget classification is not license to override a
+repository's own explicit no-automatic-reruns policy. Intended only for
+the narrow #2764 Phase 1 case where a fresh pull_request_review
+submission must get a fresh evaluation even if the gate is already green
+or its rerun-once budget is already spent -- see the RefreshLatestPlan
+doc comment in the .mts source. With --apply, executes each rerun
+sequentially (via the same "gh run rerun" mechanism as the default
+--apply path) instead of only printing them. Mutually exclusive in
+effect with the default plan computation: when given, --refresh-latest's
+own JSON document replaces the ordinary plan document on stdout.
 
 Honors the inspected repository's configured ciWait.rerunPolicy: when
 it is "hold", both the rerun plan and the recovery-refresh plan stay
@@ -2212,11 +2239,14 @@ function waitForNewAttempt(owner, repo, runId, priorAttempt) {
  * `idd-advisory-convergence.yml`) already exceeds any bound shorter than
  * 10 minutes -- a wait that gives up before the gate's own allowed
  * lifetime elapses would misreport a still-legitimately-running gate as
- * stuck. The companion workflow's OWN `timeout-minutes: 10` being
- * smaller than either of this file's two internal wait budgets is a
- * pre-existing property of `waitForNewAttempt`/`rerunAndWait` this
- * function does not change -- GitHub's own job timeout is the backstop
- * in that case, not this function's throw. */
+ * stuck. The companion workflow's own job `timeout-minutes` must in turn
+ * exceed THIS bound plus however long the subsequent reruns themselves
+ * take (Codex P1, PR #2855 review, a second round on the same
+ * mechanism): GitHub kills the job outright at its own timeout
+ * regardless of what step is running, so a caller whose own timeout is
+ * shorter than this wait would never actually issue the deferred rerun
+ * -- see `idd-advisory-convergence-comment.yml`'s `timeout-minutes: 30`
+ * (and its `idd-template/` copy) for the derivation. */
 const PENDING_RUN_POLL_TIMEOUT_MS = APPLY_POLL_TIMEOUT_MS;
 /**
  * Blocks until `runId` (within `owner`/`repo`) reports
@@ -2335,72 +2365,97 @@ if (import.meta.main) {
     // Same stdout/stderr split as the ordinary plan below: JSON only on
     // stdout, human-readable summary on stderr.
     process.stdout.write(`${JSON.stringify(refreshLatestPlan, null, 2)}\n`);
-    if (refreshLatestPlan.command) {
-      process.stderr.write(
-        `\n--refresh-latest selected: ${refreshLatestPlan.command.command}\n`,
-      );
-      if (args.apply) {
-        buildProductionApplyDeps(args).rerunAndWait(refreshLatestPlan.command);
+    if (
+      refreshLatestPlan.commands.length === 0 &&
+      refreshLatestPlan.pendingCommands.length === 0
+    ) {
+      process.stderr.write(`\n${refreshLatestPlan.reason}\n`);
+    } else {
+      if (refreshLatestPlan.reason) {
+        process.stderr.write(`\n${refreshLatestPlan.reason}\n`);
+      }
+      for (const command of refreshLatestPlan.commands) {
         process.stderr.write(
-          `\n--refresh-latest --apply: executed ${refreshLatestPlan.command.command}.\n`,
+          `\n--refresh-latest selected: ${command.command}\n`,
         );
       }
-    } else if (refreshLatestPlan.pendingCommand) {
-      process.stderr.write(`\n${refreshLatestPlan.reason}\n`);
-      if (args.apply) {
-        // The still-running run this deferred is NOT touched by
-        // rerunAndWait's own pre-rerun run_attempt capture -- this waits
-        // for ITS completion first (waitForRunCompletion), then issues
-        // the actual rerun through the same production apply deps every
-        // other --apply path uses, preserving one code path for the
-        // mutation itself.
-        const { owner, repo } = resolveOwnerRepo(args);
-        waitForRunCompletion(
-          owner,
-          repo,
-          refreshLatestPlan.pendingCommand.runId,
+      for (const command of refreshLatestPlan.pendingCommands) {
+        process.stderr.write(
+          `\n--refresh-latest deferred (still running): ${command.command}\n`,
         );
-        // Re-check the PR's current HEAD before firing the deferred
-        // rerun (Codex P1, PR #2855 review): the wait above can take
-        // several minutes, during which the PR can advance to a new
-        // HEAD. `gh run rerun` on the captured (now-stale) run would
-        // still fire -- and the required gate's own concurrency group
-        // has `cancel-in-progress: true` keyed by PR number alone, so
-        // that stale rerun could CANCEL a legitimate, already-running
-        // gate instance for the new HEAD, leaving it without a passing
-        // required check and no guaranteed later refresh. Abort instead
-        // of recomputing the whole plan: a HEAD change means a fresh
-        // pull_request/pull_request_target trigger already fired for
-        // the new HEAD on its own, independent of this deferred rerun.
-        const currentHeadSha = ghText(
-          [
-            'pr',
-            'view',
-            String(args.prNumber),
-            '-R',
-            `${owner}/${repo}`,
-            '--json',
-            'headRefOid',
-            '--jq',
-            '.headRefOid',
-          ],
-          GH_TEXT_LOOP_TIMEOUT_OPTIONS,
-        ).toLowerCase();
-        if (currentHeadSha !== refreshLatestPlan.prHeadSha) {
+      }
+      if (args.apply) {
+        const { owner, repo } = resolveOwnerRepo(args);
+        const applyDeps = buildProductionApplyDeps(args);
+        // Re-checks the PR's current HEAD immediately before firing a
+        // rerun (Codex P1, PR #2855 review): both `waitForRunCompletion`
+        // and `rerunAndWait` itself can take several minutes, during
+        // which the PR can advance to a new HEAD. `gh run rerun` on a
+        // now-stale run would still fire -- and the required gate's own
+        // concurrency group has `cancel-in-progress: true` keyed by PR
+        // number alone, so a stale rerun could CANCEL a legitimate,
+        // already-running gate instance for the new HEAD, leaving it
+        // without a passing required check and no guaranteed later
+        // refresh. Checked before EACH command below, not once for the
+        // whole batch -- every wait is its own multi-minute window the
+        // HEAD can move within. Skips just that one command instead of
+        // aborting the batch: a HEAD change means a fresh
+        // pull_request/pull_request_target trigger already fired for the
+        // new HEAD on its own, independent of this refresh.
+        const headStillMatches = (command) => {
+          const currentHeadSha = ghText(
+            [
+              'pr',
+              'view',
+              String(args.prNumber),
+              '-R',
+              `${owner}/${repo}`,
+              '--json',
+              'headRefOid',
+              '--jq',
+              '.headRefOid',
+            ],
+            GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+          ).toLowerCase();
+          if (currentHeadSha === refreshLatestPlan.prHeadSha) {
+            return true;
+          }
           process.stderr.write(
-            `\n--refresh-latest --apply: the PR HEAD moved from ${refreshLatestPlan.prHeadSha} to ${currentHeadSha} while waiting for the pending run to complete -- skipping the now-stale rerun (a fresh trigger already fired for the new HEAD).\n`,
+            `\n--refresh-latest --apply: the PR HEAD moved from ${refreshLatestPlan.prHeadSha} to ${currentHeadSha} -- skipping the now-stale rerun of ${command.command} (a fresh trigger already fired for the new HEAD).\n`,
           );
-        } else {
-          buildProductionApplyDeps(args).rerunAndWait(
-            refreshLatestPlan.pendingCommand,
-          );
+          return false;
+        };
+        // Pending instances first, one at a time: each must reach a
+        // terminal state before it is safe to rerun without cancelling
+        // it. Sequential, not parallel -- `waitForRunCompletion` and
+        // `rerunAndWait` both poll synchronously, and this file's own
+        // `planCaveat` already documents why a rerun burst must stay
+        // serialized rather than racing multiple `gh run rerun` calls
+        // against the same PR's shared concurrency group.
+        for (const pendingCommand of refreshLatestPlan.pendingCommands) {
+          waitForRunCompletion(owner, repo, pendingCommand.runId);
+          if (!headStillMatches(pendingCommand)) {
+            continue;
+          }
+          applyDeps.rerunAndWait(pendingCommand);
           process.stderr.write(
-            `\n--refresh-latest --apply: executed ${refreshLatestPlan.pendingCommand.command} after it reached a terminal state.\n`,
+            `\n--refresh-latest --apply: executed ${pendingCommand.command} after it reached a terminal state.\n`,
+          );
+        }
+        // Every already-terminal instance next (Codex P1, PR #2855
+        // review) rather than guessing which one controls the required
+        // rollup -- see this file's own #1381 recovery guidance cited
+        // above `computeRefreshLatestPlan`.
+        for (const command of refreshLatestPlan.commands) {
+          if (!headStillMatches(command)) {
+            continue;
+          }
+          applyDeps.rerunAndWait(command);
+          process.stderr.write(
+            `\n--refresh-latest --apply: executed ${command.command}.\n`,
           );
         }
       }
-    } else {
-      process.stderr.write(`\n${refreshLatestPlan.reason}\n`);
     }
   } else if (plan) {
     // stdout carries ONLY the JSON document -- nothing else -- so the

--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -663,11 +663,29 @@ export function computeRefreshLatestPlan(input, options) {
     const resolvedRunEvent = String(instance.runEvent ?? '')
       .trim()
       .toLowerCase();
+    if (!resolvedRunEvent) {
+      // Fail closed (Copilot, PR #2855 review, "previously missed"): the
+      // run id resolved and its lookup succeeded (both checked above), but
+      // the run's own `event` field still came back empty/unset -- a
+      // genuinely UNKNOWN triggering event, not a genuinely DIFFERENT,
+      // identified one. Treating this the same as the `nonFamilyEvents`
+      // case below would silently drop the sole instance for a HEAD into
+      // "nothing has triggered yet", the exact false reassurance the
+      // doc comment above this loop already guards against for the
+      // runId/runLookupFailed cases -- this closes the same gap for a
+      // resolved-but-unlabeled run. Mirrors classifyInstance step 6's
+      // "unknown triggering event => unresolved/inspect manually" for the
+      // ordinary --apply path.
+      unresolvableReasons.push(
+        `check-run ${instance.checkRunId} resolved to run id ${instance.runId} but its triggering event could not be determined`,
+      );
+      continue;
+    }
     if (!PULL_REQUEST_FAMILY_EVENTS.has(resolvedRunEvent)) {
       // Resolved, but genuinely a different (non-family) trigger for
       // this same check-run name -- not ours to touch, and not
       // unresolvable either.
-      nonFamilyEvents.add(resolvedRunEvent || '(unknown)');
+      nonFamilyEvents.add(resolvedRunEvent);
       continue;
     }
     const status = String(instance.status ?? '')

--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -583,6 +583,11 @@ export function computeRefreshLatestPlan(input, options) {
     prHeadSha,
     checkName,
     now,
+    // Overridden below only once `unresolvableReasons` has actually been
+    // computed; every earlier return (hold policy, no instance at all)
+    // never reaches a state where an instance could have been skipped as
+    // unresolvable.
+    unresolvedInstanceCount: 0,
   };
   // Honored, not bypassed (Copilot review, PR #2855): a "hold" policy is
   // a repository's explicit opt-out of every automatic rerun, checked
@@ -623,15 +628,24 @@ export function computeRefreshLatestPlan(input, options) {
   // but (Codex P1, PR #2855 review) applied per-instance, not just to a
   // single "latest" pick: one instance's unresolvable identity is
   // reported and skipped rather than aborting every OTHER instance's
-  // refresh. Deduplicated by runId: two check-run instances can briefly
-  // resolve to the same underlying workflow run (e.g. one instance's
-  // `gh api` lookup racing another's), and rerunning the same run id
-  // twice in one pass is redundant, not merely harmless.
-  const seenRunIds = new Set();
+  // refresh.
   const unresolvableReasons = [];
   const nonFamilyEvents = new Set();
-  const resolvedCommands = [];
-  const pendingResolvedCommands = [];
+  // Keyed by runId, not deduplicated away (Copilot, PR #2855 review,
+  // round 6): two check-run instances can briefly resolve to the same
+  // underlying workflow run (e.g. one instance's `gh api` lookup racing
+  // another's), and rerunning the same run id twice in one pass is
+  // redundant, not merely harmless -- but silently DROPPING the
+  // duplicate's own check-run id broke `RerunPlanCommand.checkRunIds`'s
+  // own documented contract ("every check-run id that contributed to
+  // this run id"). A duplicate's checkRunId is merged into the
+  // already-tracked command instead, keeping the earliest known
+  // `startedAt` between the two (matches this function's own
+  // newest-first sort semantics: an unknown/empty startedAt already
+  // sorts last, so preferring the known, earlier value is the more
+  // informative choice when a later-fetched duplicate turns out to have
+  // a smaller or missing startedAt).
+  const commandsByRunId = new Map();
   for (const instance of allInstances) {
     if (instance.runId === null) {
       unresolvableReasons.push(
@@ -655,10 +669,19 @@ export function computeRefreshLatestPlan(input, options) {
       nonFamilyEvents.add(resolvedRunEvent || '(unknown)');
       continue;
     }
-    if (seenRunIds.has(instance.runId)) {
+    const existing = commandsByRunId.get(instance.runId);
+    if (existing) {
+      existing.command.checkRunIds.push(instance.checkRunId);
+      const instanceStartedAt = instance.startedAt ?? '';
+      if (
+        instanceStartedAt &&
+        (!existing.command.startedAt ||
+          instanceStartedAt < existing.command.startedAt)
+      ) {
+        existing.command.startedAt = instanceStartedAt;
+      }
       continue;
     }
-    seenRunIds.add(instance.runId);
     const status = String(instance.status ?? '')
       .trim()
       .toLowerCase();
@@ -680,12 +703,19 @@ export function computeRefreshLatestPlan(input, options) {
     // review landed, and nothing else is guaranteed to trigger a fresh
     // evaluation afterward. `pendingCommands` carries the same resolved
     // command for the caller to rerun ONCE this run reaches a terminal
-    // state, rather than declining to act on it at all.
-    if (!conclusion && PENDING_STATUSES.has(status)) {
-      pendingResolvedCommands.push(resolvedCommand);
-    } else {
-      resolvedCommands.push(resolvedCommand);
-    }
+    // state, rather than declining to act on it at all. Classified once,
+    // from the FIRST instance seen for this runId -- a duplicate sharing
+    // the identical runId shares the identical underlying workflow run,
+    // so its own status/conclusion cannot meaningfully disagree.
+    commandsByRunId.set(instance.runId, {
+      command: resolvedCommand,
+      pending: !conclusion && PENDING_STATUSES.has(status),
+    });
+  }
+  const resolvedCommands = [];
+  const pendingResolvedCommands = [];
+  for (const { command, pending } of commandsByRunId.values()) {
+    (pending ? pendingResolvedCommands : resolvedCommands).push(command);
   }
   // Newest-`startedAt` first (unknown/empty sorts LAST) purely for a
   // stable, readable summary -- unlike the single-instance selection this
@@ -723,6 +753,7 @@ export function computeRefreshLatestPlan(input, options) {
         unresolvableReasons.length > 0
           ? `no resolvable pull_request-family instance for this HEAD -- ${unresolvableReasons.join('; ')}; inspect manually`
           : `no pull_request-family check-run instance exists yet for this HEAD (found: ${[...nonFamilyEvents].join(', ')}); nothing to refresh -- a future pull_request/pull_request_target trigger will create the first instance`,
+      unresolvedInstanceCount: unresolvableReasons.length,
     };
   }
   const unresolvableSuffix =
@@ -737,6 +768,7 @@ export function computeRefreshLatestPlan(input, options) {
       pendingResolvedCommands.length > 0
         ? `${pendingResolvedCommands.length} pull_request-family instance(s) for this HEAD are still running; rerunning a live run now would cancel it instead of refreshing it -- wait for each to reach a terminal state, then rerun it (see pendingCommands)${unresolvableSuffix}`
         : unresolvableSuffix.trim(),
+    unresolvedInstanceCount: unresolvableReasons.length,
   };
 }
 /**
@@ -2463,6 +2495,7 @@ if (import.meta.main) {
     // Same stdout/stderr split as the ordinary plan below: JSON only on
     // stdout, human-readable summary on stderr.
     process.stdout.write(`${JSON.stringify(refreshLatestPlan, null, 2)}\n`);
+    let applyFailedCount = 0;
     if (
       refreshLatestPlan.commands.length === 0 &&
       refreshLatestPlan.pendingCommands.length === 0
@@ -2512,23 +2545,30 @@ if (import.meta.main) {
         // `planCaveat` already documents why a rerun burst must stay
         // serialized rather than racing multiple `gh run rerun` calls
         // against the same PR's shared concurrency group.
-        //
-        // A non-empty `failed` means at least one independent instance
-        // for this HEAD was NOT refreshed despite --apply having run
-        // (CodeRabbit, PR #2855 review) -- exit non-zero so the
-        // companion job surfaces that instead of reporting green while
-        // the required gate may still be stuck. Deliberately NOT the
-        // same convention as the ordinary --apply path below (which
-        // always exits 0, even when its own budget is exhausted
-        // unresolved): that path's "not yet resolved" is an expected,
-        // bounded policy limit with its own recovery text, whereas a
-        // `failed` entry here is an actual thrown error (network/gh
-        // failure, or a wait timeout) on an otherwise-independent
-        // instance -- a different, more actionable severity.
-        if (refreshResult.failed.length > 0) {
-          process.exitCode = 1;
-        }
+        applyFailedCount = refreshResult.failed.length;
       }
+    }
+    // A non-empty `failed`, or a non-zero `unresolvedInstanceCount`, both
+    // mean at least one instance for this HEAD was NOT refreshed despite
+    // --apply having run (CodeRabbit + Codex P1, PR #2855 review) --
+    // exit non-zero so the companion job surfaces that instead of
+    // reporting green while the required gate may still be stuck. Checked
+    // unconditionally here, not only inside the `else` branch above: an
+    // unresolved instance can be the ONLY instance for this HEAD, in
+    // which case `commands`/`pendingCommands` are both empty and the
+    // apply block above never even runs -- that must fail closed too,
+    // not silently report success on a plan with nothing left to try.
+    // Deliberately NOT the same convention as the ordinary --apply path
+    // below (which always exits 0, even when its own budget is exhausted
+    // unresolved): that path's "not yet resolved" is an expected,
+    // bounded policy limit with its own recovery text, whereas either
+    // condition here is a genuine risk that the instance actually
+    // controlling the required rollup was never attempted.
+    if (
+      args.apply &&
+      (applyFailedCount > 0 || refreshLatestPlan.unresolvedInstanceCount > 0)
+    ) {
+      process.exitCode = 1;
     }
   } else if (plan) {
     // stdout carries ONLY the JSON document -- nothing else -- so the

--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -577,12 +577,16 @@ export function computeRefreshLatestPlan(input, options) {
   const owner = String(input.owner ?? '').trim();
   const repo = String(input.repo ?? '').trim();
   const repoFlag = owner && repo ? ` -R ${owner}/${repo}` : '';
+  // `pendingCommand: null` by default -- only the still-running branch
+  // below overrides it; every other branch's `...header` spread inherits
+  // this default so it never needs repeating at each return site.
   const header = {
     protocolVersion: '1',
     prNumber: Number(input.prNumber),
     prHeadSha,
     checkName,
     now,
+    pendingCommand: null,
   };
   // Honored, not bypassed (Copilot review, PR #2855): a "hold" policy is
   // a repository's explicit opt-out of every automatic rerun, checked
@@ -633,21 +637,15 @@ export function computeRefreshLatestPlan(input, options) {
   const conclusion = latest.conclusion
     ? String(latest.conclusion).trim().toLowerCase()
     : null;
-  // Mirrors classifyInstance step 2: rerunning a still-running instance
-  // cancels it instead of refreshing it.
-  if (!conclusion && PENDING_STATUSES.has(status)) {
-    return {
-      ...header,
-      command: null,
-      reason: `the latest pull_request-family instance (check-run ${latest.checkRunId}) is still running ("${status}"); rerunning a live run would cancel it instead of refreshing it -- once it completes, it will already reflect this review`,
-    };
-  }
   // Mirrors classifyInstance steps 4-5: never guess a rerun target from an
-  // unresolvable run identity.
+  // unresolvable run identity. Checked BEFORE the pending-status branch
+  // below so that branch can always build a `pendingCommand` from an
+  // already-validated runId.
   if (latest.runId === null) {
     return {
       ...header,
       command: null,
+      pendingCommand: null,
       reason: `the latest pull_request-family instance (check-run ${latest.checkRunId}) has no resolvable workflow run id; inspect manually`,
     };
   }
@@ -655,17 +653,38 @@ export function computeRefreshLatestPlan(input, options) {
     return {
       ...header,
       command: null,
+      pendingCommand: null,
       reason: `the underlying workflow run for the latest pull_request-family instance (check-run ${latest.checkRunId}) could not be fetched (network/permission/transient failure); inspect manually`,
+    };
+  }
+  const resolvedCommand = {
+    runId: latest.runId,
+    command: `gh run rerun ${latest.runId}${repoFlag}`,
+    checkRunIds: [latest.checkRunId],
+    startedAt: latest.startedAt ?? '',
+  };
+  // Mirrors classifyInstance step 2's "rerunning a still-running instance
+  // cancels it instead of refreshing it" -- but unlike classifyInstance,
+  // this does NOT assume the live run will already reflect this review
+  // once it finishes (Codex P1, PR #2855 review): that run's own
+  // evidence was fetched at whatever point during ITS execution the
+  // query happened to run, which can be BEFORE this review landed, and
+  // nothing else is guaranteed to trigger a fresh evaluation afterward.
+  // `pendingCommand` carries the same resolved command for the caller to
+  // rerun ONCE this run reaches a terminal state, rather than declining
+  // to act at all.
+  if (!conclusion && PENDING_STATUSES.has(status)) {
+    return {
+      ...header,
+      command: null,
+      pendingCommand: resolvedCommand,
+      reason: `the latest pull_request-family instance (check-run ${latest.checkRunId}) is still running ("${status}"); rerunning a live run now would cancel it instead of refreshing it -- wait for it to reach a terminal state, then rerun it (see pendingCommand)`,
     };
   }
   return {
     ...header,
-    command: {
-      runId: latest.runId,
-      command: `gh run rerun ${latest.runId}${repoFlag}`,
-      checkRunIds: [latest.checkRunId],
-      startedAt: latest.startedAt ?? '',
-    },
+    command: resolvedCommand,
+    pendingCommand: null,
     reason: '',
   };
 }
@@ -2184,6 +2203,50 @@ function waitForNewAttempt(owner, repo, runId, priorAttempt) {
     sleepSync(APPLY_POLL_INTERVAL_MS);
   }
 }
+/** Safety bound: {@link waitForRunCompletion} fails closed (throws)
+ * instead of polling forever when a still-running instance never
+ * reaches a terminal state within this window. Shorter than {@link
+ * APPLY_POLL_TIMEOUT_MS} (which waits for a NEW attempt after `gh run
+ * rerun` already started one) -- this instead waits for the ORIGINAL,
+ * already-in-flight run this helper never touched, so a bound comfortably
+ * inside the companion workflow's own job `timeout-minutes: 10` (see
+ * `idd-advisory-convergence-comment.yml`) matters more here: a wait that
+ * outlives the job's own timeout would be silently killed with no
+ * visible error, defeating the throw-on-timeout contract entirely. */
+const PENDING_RUN_POLL_TIMEOUT_MS = 5 * 60_000;
+/**
+ * Blocks until `runId` (within `owner`/`repo`) reports
+ * `status === 'completed'` -- i.e. the run {@link
+ * computeRefreshLatestPlan}'s `pendingCommand` deferred (it was still
+ * running when the plan was computed) has reached a terminal state, safe
+ * to rerun without cancelling it. Companion to {@link waitForNewAttempt}
+ * (same `ghText` + polling shape), but waits for the ORIGINAL run's own
+ * completion rather than a NEW attempt after an already-issued rerun --
+ * this function issues no mutation itself; the caller reruns `runId`
+ * only after this returns (Codex P1, PR #2855 review: `pendingCommand`'s
+ * own doc comment explains why declining to act at all is not safe
+ * here).
+ */
+function waitForRunCompletion(owner, repo, runId) {
+  const deadline = Date.now() + PENDING_RUN_POLL_TIMEOUT_MS;
+  for (;;) {
+    const payload = JSON.parse(
+      ghText(
+        ['api', `repos/${owner}/${repo}/actions/runs/${runId}`],
+        GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+      ),
+    );
+    if (payload.status === 'completed') {
+      return;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `timed out waiting for run ${runId} (${owner}/${repo}) to reach a terminal state before rerunning it`,
+      );
+    }
+    sleepSync(APPLY_POLL_INTERVAL_MS);
+  }
+}
 /** Resolves `{owner, repo}` the same way {@link collectFromGitHub} does
  * (explicit `--owner`/`--repo` first, else `gh repo view` auto-detection)
  * -- duplicated as these two lines rather than extracted into a shared
@@ -2276,6 +2339,28 @@ if (import.meta.main) {
         buildProductionApplyDeps(args).rerunAndWait(refreshLatestPlan.command);
         process.stderr.write(
           `\n--refresh-latest --apply: executed ${refreshLatestPlan.command.command}.\n`,
+        );
+      }
+    } else if (refreshLatestPlan.pendingCommand) {
+      process.stderr.write(`\n${refreshLatestPlan.reason}\n`);
+      if (args.apply) {
+        // The still-running run this deferred is NOT touched by
+        // rerunAndWait's own pre-rerun run_attempt capture -- this waits
+        // for ITS completion first (waitForRunCompletion), then issues
+        // the actual rerun through the same production apply deps every
+        // other --apply path uses, preserving one code path for the
+        // mutation itself.
+        const { owner, repo } = resolveOwnerRepo(args);
+        waitForRunCompletion(
+          owner,
+          repo,
+          refreshLatestPlan.pendingCommand.runId,
+        );
+        buildProductionApplyDeps(args).rerunAndWait(
+          refreshLatestPlan.pendingCommand,
+        );
+        process.stderr.write(
+          `\n--refresh-latest --apply: executed ${refreshLatestPlan.pendingCommand.command} after it reached a terminal state.\n`,
         );
       }
     } else {

--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -631,6 +631,7 @@ export function computeRefreshLatestPlan(input, options) {
   // refresh.
   const unresolvableReasons = [];
   const nonFamilyEvents = new Set();
+  const botGatedCheckRunIds = [];
   // Keyed by runId, not deduplicated away (Copilot, PR #2855 review,
   // round 6): two check-run instances can briefly resolve to the same
   // underlying workflow run (e.g. one instance's `gh api` lookup racing
@@ -669,6 +670,32 @@ export function computeRefreshLatestPlan(input, options) {
       nonFamilyEvents.add(resolvedRunEvent || '(unknown)');
       continue;
     }
+    const status = String(instance.status ?? '')
+      .trim()
+      .toLowerCase();
+    const conclusion = instance.conclusion
+      ? String(instance.conclusion).trim().toLowerCase()
+      : null;
+    // Mirrors classifyInstance step 3's `bot-gated-skip` (Codex P1, PR
+    // #2855 review): `idd-ci.instructions.md` §Rerun mechanics documents
+    // that rerunning an `action_required`-conclusion instance preserves
+    // the original bot actor's privileges and simply re-enters
+    // `action_required` -- never clearing it, only spending this loop's
+    // sequential budget (and, via `pendingCommands`, the deferred-wait
+    // budget too) on a rerun that cannot help. Unlike
+    // `computeRerunPlan`/`--apply`'s classification, `--refresh-latest`
+    // otherwise bypasses pass/budget on purpose (see this function's own
+    // doc comment above) -- but bot-gating is not a policy choice this
+    // mode exists to override, the same distinction already drawn for
+    // `ciWait.rerunPolicy: "hold"`. A separate non-bot family instance
+    // for this same HEAD (if one exists) still gets its own entry here
+    // and can clear the rollup per that same doc's recovery guidance;
+    // this exclusion only withholds the gated instance itself.
+    if (conclusion === 'action_required') {
+      botGatedCheckRunIds.push(instance.checkRunId);
+      continue;
+    }
+    const pending = !conclusion && PENDING_STATUSES.has(status);
     const existing = commandsByRunId.get(instance.runId);
     if (existing) {
       existing.command.checkRunIds.push(instance.checkRunId);
@@ -680,14 +707,23 @@ export function computeRefreshLatestPlan(input, options) {
       ) {
         existing.command.startedAt = instanceStartedAt;
       }
+      // Any pending row wins (Codex P1, PR #2855 review): two check-run
+      // rows sharing a runId are NOT guaranteed to report the identical
+      // status -- this file's own #1381 precedent already establishes
+      // that GitHub's check-runs-for-ref response can carry a stale row
+      // alongside a fresher one for the same underlying run. Rerunning a
+      // duplicate this function mistakenly classified as terminal (from
+      // an earlier-seen COMPLETED row) while a later-seen row for the
+      // identical runId is still IN_PROGRESS would cancel that live run
+      // instead of refreshing it -- the exact hazard `pendingCommands`
+      // exists to prevent. Once true, never flips back to false: a
+      // still-pending sibling row is reason enough to wait, regardless
+      // of processing order.
+      if (pending) {
+        existing.pending = true;
+      }
       continue;
     }
-    const status = String(instance.status ?? '')
-      .trim()
-      .toLowerCase();
-    const conclusion = instance.conclusion
-      ? String(instance.conclusion).trim().toLowerCase()
-      : null;
     const resolvedCommand = {
       runId: instance.runId,
       command: `gh run rerun ${instance.runId}${repoFlag}`,
@@ -703,13 +739,10 @@ export function computeRefreshLatestPlan(input, options) {
     // review landed, and nothing else is guaranteed to trigger a fresh
     // evaluation afterward. `pendingCommands` carries the same resolved
     // command for the caller to rerun ONCE this run reaches a terminal
-    // state, rather than declining to act on it at all. Classified once,
-    // from the FIRST instance seen for this runId -- a duplicate sharing
-    // the identical runId shares the identical underlying workflow run,
-    // so its own status/conclusion cannot meaningfully disagree.
+    // state, rather than declining to act on it at all.
     commandsByRunId.set(instance.runId, {
       command: resolvedCommand,
-      pending: !conclusion && PENDING_STATUSES.has(status),
+      pending,
     });
   }
   const resolvedCommands = [];
@@ -736,23 +769,27 @@ export function computeRefreshLatestPlan(input, options) {
   resolvedCommands.sort(byStartedAtDesc);
   pendingResolvedCommands.sort(byStartedAtDesc);
   if (resolvedCommands.length === 0 && pendingResolvedCommands.length === 0) {
-    // Two genuinely different "nothing to rerun" causes (Copilot, PR
-    // #2855 review): an unresolvable instance MIGHT be a family one we
-    // simply couldn't verify (actionable -- inspect manually), whereas
+    // Three genuinely different "nothing to rerun" causes (Copilot +
+    // Codex P1, PR #2855 review), in priority order: an unresolvable
+    // instance MIGHT be a family one we simply couldn't verify
+    // (actionable -- inspect manually, the most urgent); a bot-gated
+    // (`action_required`) instance IS a family one, but rerunning it
+    // cannot clear the rollup (idd-ci.instructions.md §Rerun mechanics
+    // -- a non-bot instance is needed instead, and none exists here);
     // every instance resolving to a confirmed non-family event is the
     // ordinary "this HEAD just hasn't had a pull_request-family trigger
-    // yet" case the original message described. Prefer the unresolvable
-    // reason whenever both are present: an operator investigating a
-    // stuck rollup needs to know verification failed, not just that no
-    // family instance was found.
+    // yet" case the original message described.
+    const reason =
+      unresolvableReasons.length > 0
+        ? `no resolvable pull_request-family instance for this HEAD -- ${unresolvableReasons.join('; ')}; inspect manually`
+        : botGatedCheckRunIds.length > 0
+          ? `every pull_request-family instance for this HEAD is bot-gated (action_required: check-run(s) ${botGatedCheckRunIds.join(', ')}) -- rerunning re-enters action_required per idd-ci.instructions.md §Rerun mechanics; a non-bot pull_request-family instance is needed to clear the rollup, and none currently exists for this HEAD`
+          : `no pull_request-family check-run instance exists yet for this HEAD (found: ${[...nonFamilyEvents].join(', ')}); nothing to refresh -- a future pull_request/pull_request_target trigger will create the first instance`;
     return {
       ...header,
       commands: [],
       pendingCommands: [],
-      reason:
-        unresolvableReasons.length > 0
-          ? `no resolvable pull_request-family instance for this HEAD -- ${unresolvableReasons.join('; ')}; inspect manually`
-          : `no pull_request-family check-run instance exists yet for this HEAD (found: ${[...nonFamilyEvents].join(', ')}); nothing to refresh -- a future pull_request/pull_request_target trigger will create the first instance`,
+      reason,
       unresolvedInstanceCount: unresolvableReasons.length,
     };
   }
@@ -760,14 +797,18 @@ export function computeRefreshLatestPlan(input, options) {
     unresolvableReasons.length > 0
       ? ` (skipped ${unresolvableReasons.length} unresolvable instance(s): ${unresolvableReasons.join('; ')})`
       : '';
+  const botGatedSuffix =
+    botGatedCheckRunIds.length > 0
+      ? ` (also skipped ${botGatedCheckRunIds.length} bot-gated action_required instance(s): ${botGatedCheckRunIds.join(', ')} -- rerunning them cannot clear action_required, per idd-ci.instructions.md §Rerun mechanics)`
+      : '';
   return {
     ...header,
     commands: resolvedCommands,
     pendingCommands: pendingResolvedCommands,
     reason:
       pendingResolvedCommands.length > 0
-        ? `${pendingResolvedCommands.length} pull_request-family instance(s) for this HEAD are still running; rerunning a live run now would cancel it instead of refreshing it -- wait for each to reach a terminal state, then rerun it (see pendingCommands)${unresolvableSuffix}`
-        : unresolvableSuffix.trim(),
+        ? `${pendingResolvedCommands.length} pull_request-family instance(s) for this HEAD are still running; rerunning a live run now would cancel it instead of refreshing it -- wait for each to reach a terminal state, then rerun it (see pendingCommands)${unresolvableSuffix}${botGatedSuffix}`
+        : `${unresolvableSuffix}${botGatedSuffix}`.trim(),
     unresolvedInstanceCount: unresolvableReasons.length,
   };
 }
@@ -2304,7 +2345,7 @@ function waitForNewAttempt(owner, repo, runId, priorAttempt) {
  * mechanism): GitHub kills the job outright at its own timeout
  * regardless of what step is running, so a caller whose own timeout is
  * shorter than this wait would never actually issue the deferred rerun
- * -- see `idd-advisory-convergence-comment.yml`'s `timeout-minutes: 35`
+ * -- see `idd-advisory-convergence-comment.yml`'s `timeout-minutes: 55`
  * (and its `idd-template/` copy) for the derivation. */
 const PENDING_RUN_POLL_TIMEOUT_MS = APPLY_POLL_TIMEOUT_MS;
 /**

--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -599,35 +599,40 @@ export function computeRefreshLatestPlan(input, options) {
         'ciWait.rerunPolicy is "hold": this repository has opted out of automatic reruns, including --refresh-latest -- a maintainer must manually decide (see idd-ci.instructions.md §Rerun mechanics)',
     };
   }
-  const familyInstances = (input.instances ?? []).filter((instance) =>
-    PULL_REQUEST_FAMILY_EVENTS.has(
-      String(instance.runEvent ?? '')
-        .trim()
-        .toLowerCase(),
-    ),
-  );
-  if (familyInstances.length === 0) {
+  const allInstances = input.instances ?? [];
+  if (allInstances.length === 0) {
     return {
       ...header,
       commands: [],
       pendingCommands: [],
       reason:
-        'no pull_request-family check-run instance exists yet for this HEAD; nothing to refresh -- a future pull_request/pull_request_target trigger will create the first instance',
+        'no check-run instance exists yet for this HEAD; nothing to refresh -- a future pull_request/pull_request_target trigger will create the first instance',
     };
   }
-  // Mirrors classifyInstance steps 4-5: never guess a rerun target from an
-  // unresolvable run identity -- but (Codex P1, PR #2855 review) applied
-  // per-instance now, not just to a single "latest" pick: an instance
-  // whose own identity can't be trusted is skipped rather than aborting
-  // every OTHER instance's refresh. Deduplicated by runId: two check-run
-  // instances can briefly resolve to the same underlying workflow run
-  // (e.g. one instance's `gh api` lookup racing another's), and rerunning
-  // the same run id twice in one pass is redundant, not merely harmless.
+  // Checked BEFORE the family-event filter, not after (Copilot, PR #2855
+  // review, "previously missed"): an instance whose run id is
+  // unresolvable, or whose underlying run lookup failed, has `runEvent:
+  // null` (see the enrichment in `collectFromGitHub`) -- filtering by
+  // family membership FIRST would silently treat that instance the same
+  // as one that genuinely belongs to a different, non-family event
+  // (`workflow_dispatch`, say), collapsing "this HEAD has an
+  // unverifiable check-run instance, inspect manually" into the far more
+  // reassuring "nothing has triggered yet for this HEAD" whenever every
+  // instance happened to be unresolvable. Mirrors classifyInstance steps
+  // 4-5: never guess a rerun target from an unresolvable run identity --
+  // but (Codex P1, PR #2855 review) applied per-instance, not just to a
+  // single "latest" pick: one instance's unresolvable identity is
+  // reported and skipped rather than aborting every OTHER instance's
+  // refresh. Deduplicated by runId: two check-run instances can briefly
+  // resolve to the same underlying workflow run (e.g. one instance's
+  // `gh api` lookup racing another's), and rerunning the same run id
+  // twice in one pass is redundant, not merely harmless.
   const seenRunIds = new Set();
   const unresolvableReasons = [];
+  const nonFamilyEvents = new Set();
   const resolvedCommands = [];
   const pendingResolvedCommands = [];
-  for (const instance of familyInstances) {
+  for (const instance of allInstances) {
     if (instance.runId === null) {
       unresolvableReasons.push(
         `check-run ${instance.checkRunId} has no resolvable workflow run id`,
@@ -638,6 +643,16 @@ export function computeRefreshLatestPlan(input, options) {
       unresolvableReasons.push(
         `the underlying workflow run for check-run ${instance.checkRunId} could not be fetched (network/permission/transient failure)`,
       );
+      continue;
+    }
+    const resolvedRunEvent = String(instance.runEvent ?? '')
+      .trim()
+      .toLowerCase();
+    if (!PULL_REQUEST_FAMILY_EVENTS.has(resolvedRunEvent)) {
+      // Resolved, but genuinely a different (non-family) trigger for
+      // this same check-run name -- not ours to touch, and not
+      // unresolvable either.
+      nonFamilyEvents.add(resolvedRunEvent || '(unknown)');
       continue;
     }
     if (seenRunIds.has(instance.runId)) {
@@ -691,11 +706,23 @@ export function computeRefreshLatestPlan(input, options) {
   resolvedCommands.sort(byStartedAtDesc);
   pendingResolvedCommands.sort(byStartedAtDesc);
   if (resolvedCommands.length === 0 && pendingResolvedCommands.length === 0) {
+    // Two genuinely different "nothing to rerun" causes (Copilot, PR
+    // #2855 review): an unresolvable instance MIGHT be a family one we
+    // simply couldn't verify (actionable -- inspect manually), whereas
+    // every instance resolving to a confirmed non-family event is the
+    // ordinary "this HEAD just hasn't had a pull_request-family trigger
+    // yet" case the original message described. Prefer the unresolvable
+    // reason whenever both are present: an operator investigating a
+    // stuck rollup needs to know verification failed, not just that no
+    // family instance was found.
     return {
       ...header,
       commands: [],
       pendingCommands: [],
-      reason: `no resolvable pull_request-family instance for this HEAD -- ${unresolvableReasons.join('; ')}; inspect manually`,
+      reason:
+        unresolvableReasons.length > 0
+          ? `no resolvable pull_request-family instance for this HEAD -- ${unresolvableReasons.join('; ')}; inspect manually`
+          : `no pull_request-family check-run instance exists yet for this HEAD (found: ${[...nonFamilyEvents].join(', ')}); nothing to refresh -- a future pull_request/pull_request_target trigger will create the first instance`,
     };
   }
   const unresolvableSuffix =

--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -187,14 +187,19 @@ const PENDING_STATUSES = new Set([
  * PR's required-check rollup on rerun, matching the events
  * `idd-advisory-convergence` itself subscribes to (its own header comment,
  * mirrored in `idd-ci.instructions.md` §Rerun mechanics): `pull_request`,
- * `pull_request_review`, `pull_request_review_comment`. A run triggered by
- * any other event -- most notably `workflow_dispatch` -- has no
- * `pull_request` context of its own and is documented as NOT reliably
- * associated with the PR's HEAD SHA, so rerunning it would not dependably
- * clear a stuck rollup even though the run itself is otherwise a plain,
- * non-bot failure. */
+ * `pull_request_target` (#2764 -- evaluated against the base branch's own
+ * workflow YAML, but its check-runs are still attached to the PR's real
+ * HEAD SHA, exactly like the other members here; the commit check-runs API
+ * this helper queries is scoped by SHA, not by triggering event, so no
+ * separate SHA-resolution path is needed), `pull_request_review`,
+ * `pull_request_review_comment`. A run triggered by any other event --
+ * most notably `workflow_dispatch` -- has no `pull_request` context of its
+ * own and is documented as NOT reliably associated with the PR's HEAD SHA,
+ * so rerunning it would not dependably clear a stuck rollup even though
+ * the run itself is otherwise a plain, non-bot failure. */
 const PULL_REQUEST_FAMILY_EVENTS = new Set([
   'pull_request',
+  'pull_request_target',
   'pull_request_review',
   'pull_request_review_comment',
 ]);
@@ -735,7 +740,7 @@ function classifyInstance(instance, options) {
       ...instance,
       classification: 'unresolved',
       reason: runEvent
-        ? `triggering event "${runEvent}" is not pull_request-family (pull_request / pull_request_review / pull_request_review_comment); rerunning it is not a reliable way to refresh the PR's required-check rollup -- inspect manually`
+        ? `triggering event "${runEvent}" is not pull_request-family (pull_request / pull_request_target / pull_request_review / pull_request_review_comment); rerunning it is not a reliable way to refresh the PR's required-check rollup -- inspect manually`
         : 'triggering event is unknown; inspect manually rather than assuming it is safe to rerun',
     };
   }

--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -695,7 +695,20 @@ export function computeRefreshLatestPlan(input, options) {
       botGatedCheckRunIds.push(instance.checkRunId);
       continue;
     }
-    const pending = !conclusion && PENDING_STATUSES.has(status);
+    // Also consult the workflow run's own live status (Codex P1, PR #2855
+    // review), not just this check-run row's own status/conclusion: a row
+    // fetched moments after an already-issued rerun for this same runId
+    // can still report the PRIOR attempt's terminal conclusion before the
+    // new attempt's row catches up. `runStatus` reflects the authoritative
+    // `GET .../actions/runs/{run_id}` state instead, so it wins even over
+    // a present (possibly stale) `conclusion` -- see
+    // `RerunPlanRawInstance.runStatus`'s own doc comment.
+    const runStatus = instance.runStatus
+      ? String(instance.runStatus).trim().toLowerCase()
+      : null;
+    const pending =
+      (!conclusion && PENDING_STATUSES.has(status)) ||
+      (runStatus !== null && PENDING_STATUSES.has(runStatus));
     const existing = commandsByRunId.get(instance.runId);
     if (existing) {
       existing.command.checkRunIds.push(instance.checkRunId);
@@ -2134,6 +2147,7 @@ function collectFromGitHub(args) {
           Number.isInteger(runPayload.run_attempt)
             ? runPayload.run_attempt
             : null,
+        status: runPayload.status ? String(runPayload.status) : null,
       });
     } catch {
       runMetaById.set(runId, null);
@@ -2185,6 +2199,7 @@ function collectFromGitHub(args) {
       runAttempt: meta?.runAttempt ?? null,
       verdictReasons:
         runId !== null ? (verdictReasonsByRunId.get(runId) ?? null) : null,
+      runStatus: meta?.status ?? null,
     };
   });
   // Fetched from owner/repo's TRUSTED DEFAULT BRANCH, unconditionally --

--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -549,6 +549,104 @@ export function computeRerunPlan(input, options) {
   };
 }
 /**
+ * Compute {@link RefreshLatestPlan} from the same already-fetched,
+ * already-enriched instances {@link computeRerunPlan} consumes -- pure, no
+ * I/O, directly unit-testable with fixtures, mirroring `computeRerunPlan`'s
+ * own DI shape.
+ */
+export function computeRefreshLatestPlan(input, options) {
+  const now = String(options.now ?? '');
+  if (!isValidIsoTimestamp(now)) {
+    throw new Error('now must be an ISO 8601 UTC timestamp');
+  }
+  const prHeadSha = String(input.prHeadSha ?? '').toLowerCase();
+  if (!/^[0-9a-f]{40}$/.test(prHeadSha)) {
+    throw new Error('prHeadSha must be a 40-character hexadecimal commit SHA');
+  }
+  const checkName =
+    String(input.checkName ?? '').trim() || RERUN_PLAN_CHECK_NAME;
+  const owner = String(input.owner ?? '').trim();
+  const repo = String(input.repo ?? '').trim();
+  const repoFlag = owner && repo ? ` -R ${owner}/${repo}` : '';
+  const header = {
+    protocolVersion: '1',
+    prNumber: Number(input.prNumber),
+    prHeadSha,
+    checkName,
+    now,
+  };
+  const familyInstances = (input.instances ?? []).filter((instance) =>
+    PULL_REQUEST_FAMILY_EVENTS.has(
+      String(instance.runEvent ?? '')
+        .trim()
+        .toLowerCase(),
+    ),
+  );
+  if (familyInstances.length === 0) {
+    return {
+      ...header,
+      command: null,
+      reason:
+        'no pull_request-family check-run instance exists yet for this HEAD; nothing to refresh -- a future pull_request/pull_request_target trigger will create the first instance',
+    };
+  }
+  // Latest by startedAt (unknown/empty sorts LAST -- the opposite of
+  // buildOrderedPlan's own earliest-first, more-cautious ordering -- since
+  // this selects the single most-recent instance rather than building a
+  // deterministic multi-entry plan); numeric checkRunId breaks a tie.
+  const [latest] = [...familyInstances].sort((left, right) => {
+    const leftStarted = left.startedAt ?? '';
+    const rightStarted = right.startedAt ?? '';
+    if (leftStarted !== rightStarted) {
+      if (!leftStarted) return 1;
+      if (!rightStarted) return -1;
+      return leftStarted < rightStarted ? 1 : -1;
+    }
+    return Number(right.checkRunId) - Number(left.checkRunId);
+  });
+  const status = String(latest.status ?? '')
+    .trim()
+    .toLowerCase();
+  const conclusion = latest.conclusion
+    ? String(latest.conclusion).trim().toLowerCase()
+    : null;
+  // Mirrors classifyInstance step 2: rerunning a still-running instance
+  // cancels it instead of refreshing it.
+  if (!conclusion && PENDING_STATUSES.has(status)) {
+    return {
+      ...header,
+      command: null,
+      reason: `the latest pull_request-family instance (check-run ${latest.checkRunId}) is still running ("${status}"); rerunning a live run would cancel it instead of refreshing it -- once it completes, it will already reflect this review`,
+    };
+  }
+  // Mirrors classifyInstance steps 4-5: never guess a rerun target from an
+  // unresolvable run identity.
+  if (latest.runId === null) {
+    return {
+      ...header,
+      command: null,
+      reason: `the latest pull_request-family instance (check-run ${latest.checkRunId}) has no resolvable workflow run id; inspect manually`,
+    };
+  }
+  if (latest.runLookupFailed) {
+    return {
+      ...header,
+      command: null,
+      reason: `the underlying workflow run for the latest pull_request-family instance (check-run ${latest.checkRunId}) could not be fetched (network/permission/transient failure); inspect manually`,
+    };
+  }
+  return {
+    ...header,
+    command: {
+      runId: latest.runId,
+      command: `gh run rerun ${latest.runId}${repoFlag}`,
+      checkRunIds: [latest.checkRunId],
+      startedAt: latest.startedAt ?? '',
+    },
+    reason: '',
+  };
+}
+/**
  * Resolve whether `instance` may still be rerun under `rerunPolicy`, given
  * its own `runAttempt`. Reuses {@link resolveCiRerunDecision}
  * (ci-wait-policy.mts) -- the same rerun-once-budget decision
@@ -1094,6 +1192,7 @@ const RERUN_ADVISORY_CONVERGENCE_FLAG_SPEC = {
   '--help': { type: 'boolean', short: 'h' },
   '--apply': { type: 'boolean', default: false },
   '--check-name': { type: 'string', default: '' },
+  '--refresh-latest': { type: 'boolean', default: false },
 };
 /**
  * Mechanical CLI-argument parsing is delegated to the shared
@@ -1132,6 +1231,7 @@ export function parseArgs(argv) {
       help: true,
       apply: false,
       checkName: '',
+      refreshLatest: false,
     };
   }
   const owner = String(values.owner ?? '').trim();
@@ -1185,6 +1285,7 @@ export function parseArgs(argv) {
     help: false,
     apply: Boolean(values.apply),
     checkName: String(values['check-name'] ?? '').trim(),
+    refreshLatest: Boolean(values['refresh-latest']),
   };
 }
 /**
@@ -1346,7 +1447,7 @@ export function buildRerunPlanTextSections(plan) {
 }
 function printHelp() {
   process.stdout.write(`Usage:
-  node scripts/rerun-advisory-convergence.mjs --pr <number> [--owner <owner> --repo <repo>] [--now <ISO8601>] [--check-name <name>] [--apply] [--help]
+  node scripts/rerun-advisory-convergence.mjs --pr <number> [--owner <owner> --repo <repo>] [--now <ISO8601>] [--check-name <name>] [--apply] [--refresh-latest] [--help]
 
 By default (without --apply): read-only. Fetches every
 "${RERUN_PLAN_CHECK_NAME}" check-run instance for the PR's current HEAD SHA
@@ -1401,6 +1502,22 @@ finds nothing (field-reported, #1935; see the job-definition comment in
 Omitting this flag keeps output byte-identical to before this flag
 existed.
 
+--refresh-latest replaces the whole plan/budget computation above with a
+single, much narrower question: which pull_request-family instance for
+this HEAD started most recently, and is it safe to rerun unconditionally
+right now? Unlike the default mode, it does NOT classify pass /
+bot-gated-skip / rerun-budget-held -- it reruns the latest instance
+regardless of any of those, UNLESS that instance is still running (which
+would cancel it) or its run id could not be resolved. Intended only for
+the narrow #2764 Phase 1 case where a fresh pull_request_review submission
+must get a fresh evaluation even if the gate is already green or its
+rerun-once budget is already spent -- see the RefreshLatestPlan doc
+comment in the .mts source. With --apply, executes that single rerun (via
+the same "gh run rerun" mechanism as the default --apply path) instead of
+only printing it. Mutually exclusive in effect with the default plan
+computation: when given, --refresh-latest's own JSON document replaces
+the ordinary plan document on stdout.
+
 Honors the inspected repository's configured ciWait.rerunPolicy: when
 it is "hold", both the rerun plan and the recovery-refresh plan stay
 empty (with a notice explaining why) instead of recommending reruns a
@@ -1424,14 +1541,18 @@ const defaultDeps = { collect: collectFromGitHub };
 export function runRerunAdvisoryConvergence(argv, deps = defaultDeps) {
   const args = parseArgs(argv);
   if (args.help) {
-    return { plan: null, help: true, args };
+    return { plan: null, refreshLatestPlan: null, help: true, args };
   }
   if (!args.prNumber) {
     throw new Error('missing required --pr <number> argument');
   }
   const { input, options } = deps.collect(args);
+  if (args.refreshLatest) {
+    const refreshLatestPlan = computeRefreshLatestPlan(input, options);
+    return { plan: null, refreshLatestPlan, help: false, args };
+  }
   const plan = computeRerunPlan(input, options);
-  return { plan, help: false, args };
+  return { plan, refreshLatestPlan: null, help: false, args };
 }
 // --- --apply: execute the plan's rerun-eligible instances ---------------
 /** Safety bound on how many `gh run rerun` invocations {@link
@@ -2111,11 +2232,28 @@ function buildProductionApplyDeps(args) {
 // so importing this module (for unit tests) never parses process.argv,
 // prints usage, or makes a `gh` call.
 if (import.meta.main) {
-  const { plan, help, args } = runRerunAdvisoryConvergence(
+  const { plan, refreshLatestPlan, help, args } = runRerunAdvisoryConvergence(
     process.argv.slice(2),
   );
   if (help) {
     printHelp();
+  } else if (refreshLatestPlan) {
+    // Same stdout/stderr split as the ordinary plan below: JSON only on
+    // stdout, human-readable summary on stderr.
+    process.stdout.write(`${JSON.stringify(refreshLatestPlan, null, 2)}\n`);
+    if (refreshLatestPlan.command) {
+      process.stderr.write(
+        `\n--refresh-latest selected: ${refreshLatestPlan.command.command}\n`,
+      );
+      if (args.apply) {
+        buildProductionApplyDeps(args).rerunAndWait(refreshLatestPlan.command);
+        process.stderr.write(
+          `\n--refresh-latest --apply: executed ${refreshLatestPlan.command.command}.\n`,
+        );
+      }
+    } else {
+      process.stderr.write(`\n${refreshLatestPlan.reason}\n`);
+    }
   } else if (plan) {
     // stdout carries ONLY the JSON document -- nothing else -- so the
     // overall stdout stream stays valid, machine-parseable JSON (e.g.

--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -183,20 +183,29 @@ const PENDING_STATUSES = new Set([
   'waiting',
   'pending',
 ]);
-/** Workflow-run trigger events this helper trusts to reliably refresh the
- * PR's required-check rollup on rerun, matching the events
- * `idd-advisory-convergence` itself subscribes to (its own header comment,
- * mirrored in `idd-ci.instructions.md` §Rerun mechanics): `pull_request`,
- * `pull_request_target` (#2764 -- evaluated against the base branch's own
- * workflow YAML, but its check-runs are still attached to the PR's real
- * HEAD SHA, exactly like the other members here; the commit check-runs API
- * this helper queries is scoped by SHA, not by triggering event, so no
- * separate SHA-resolution path is needed), `pull_request_review`,
- * `pull_request_review_comment`. A run triggered by any other event --
- * most notably `workflow_dispatch` -- has no `pull_request` context of its
- * own and is documented as NOT reliably associated with the PR's HEAD SHA,
- * so rerunning it would not dependably clear a stuck rollup even though
- * the run itself is otherwise a plain, non-bot failure. */
+/** This helper's own "pull_request-family" allowlist: trigger events whose
+ * check-runs are expected to attach reliably to the PR's real HEAD SHA, so
+ * rerunning them can refresh the required-check rollup (Copilot review, PR
+ * #2855) -- `pull_request`, `pull_request_target` (#2764 -- evaluated
+ * against the base branch's own workflow YAML, but its check-runs are
+ * still attached to the PR's real HEAD SHA, exactly like the other
+ * members here; the commit check-runs API this helper queries is scoped by
+ * SHA, not by triggering event, so no separate SHA-resolution path is
+ * needed), `pull_request_review`, `pull_request_review_comment`. Not
+ * necessarily identical to which of these `idd-advisory-convergence`
+ * itself currently subscribes to directly -- #2764 Phase 1 moved
+ * `pull_request_review` off that workflow's own trigger list onto a
+ * companion (see `idd-advisory-convergence-comment.yml`), but a
+ * `pull_request_review`-triggered instance can still exist for a HEAD (via
+ * that companion's own rerun of an existing run) and remains just as
+ * reliably associated with the PR's HEAD SHA as before, so it stays in
+ * this set; `idd-ci.instructions.md` §Rerun mechanics documents the
+ * cross-file contract this set and the required workflow's own triggers
+ * both honor. A run triggered by any other event -- most notably
+ * `workflow_dispatch` -- has no `pull_request` context of its own and is
+ * documented as NOT reliably associated with the PR's HEAD SHA, so
+ * rerunning it would not dependably clear a stuck rollup even though the
+ * run itself is otherwise a plain, non-bot failure. */
 const PULL_REQUEST_FAMILY_EVENTS = new Set([
   'pull_request',
   'pull_request_target',

--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -2204,16 +2204,20 @@ function waitForNewAttempt(owner, repo, runId, priorAttempt) {
   }
 }
 /** Safety bound: {@link waitForRunCompletion} fails closed (throws)
- * instead of polling forever when a still-running instance never
- * reaches a terminal state within this window. Shorter than {@link
- * APPLY_POLL_TIMEOUT_MS} (which waits for a NEW attempt after `gh run
- * rerun` already started one) -- this instead waits for the ORIGINAL,
- * already-in-flight run this helper never touched, so a bound comfortably
- * inside the companion workflow's own job `timeout-minutes: 10` (see
- * `idd-advisory-convergence-comment.yml`) matters more here: a wait that
- * outlives the job's own timeout would be silently killed with no
- * visible error, defeating the throw-on-timeout contract entirely. */
-const PENDING_RUN_POLL_TIMEOUT_MS = 5 * 60_000;
+ * instead of polling forever when a still-running instance never reaches
+ * a terminal state within this window. Reuses {@link APPLY_POLL_TIMEOUT_MS}
+ * (15 minutes) rather than a shorter bound of its own (Codex P1, PR #2855
+ * review, correcting this constant's own prior reasoning): the run being
+ * waited on is the REQUIRED gate job, whose own `timeout-minutes: 10` (see
+ * `idd-advisory-convergence.yml`) already exceeds any bound shorter than
+ * 10 minutes -- a wait that gives up before the gate's own allowed
+ * lifetime elapses would misreport a still-legitimately-running gate as
+ * stuck. The companion workflow's OWN `timeout-minutes: 10` being
+ * smaller than either of this file's two internal wait budgets is a
+ * pre-existing property of `waitForNewAttempt`/`rerunAndWait` this
+ * function does not change -- GitHub's own job timeout is the backstop
+ * in that case, not this function's throw. */
+const PENDING_RUN_POLL_TIMEOUT_MS = APPLY_POLL_TIMEOUT_MS;
 /**
  * Blocks until `runId` (within `owner`/`repo`) reports
  * `status === 'completed'` -- i.e. the run {@link
@@ -2356,12 +2360,44 @@ if (import.meta.main) {
           repo,
           refreshLatestPlan.pendingCommand.runId,
         );
-        buildProductionApplyDeps(args).rerunAndWait(
-          refreshLatestPlan.pendingCommand,
-        );
-        process.stderr.write(
-          `\n--refresh-latest --apply: executed ${refreshLatestPlan.pendingCommand.command} after it reached a terminal state.\n`,
-        );
+        // Re-check the PR's current HEAD before firing the deferred
+        // rerun (Codex P1, PR #2855 review): the wait above can take
+        // several minutes, during which the PR can advance to a new
+        // HEAD. `gh run rerun` on the captured (now-stale) run would
+        // still fire -- and the required gate's own concurrency group
+        // has `cancel-in-progress: true` keyed by PR number alone, so
+        // that stale rerun could CANCEL a legitimate, already-running
+        // gate instance for the new HEAD, leaving it without a passing
+        // required check and no guaranteed later refresh. Abort instead
+        // of recomputing the whole plan: a HEAD change means a fresh
+        // pull_request/pull_request_target trigger already fired for
+        // the new HEAD on its own, independent of this deferred rerun.
+        const currentHeadSha = ghText(
+          [
+            'pr',
+            'view',
+            String(args.prNumber),
+            '-R',
+            `${owner}/${repo}`,
+            '--json',
+            'headRefOid',
+            '--jq',
+            '.headRefOid',
+          ],
+          GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+        ).toLowerCase();
+        if (currentHeadSha !== refreshLatestPlan.prHeadSha) {
+          process.stderr.write(
+            `\n--refresh-latest --apply: the PR HEAD moved from ${refreshLatestPlan.prHeadSha} to ${currentHeadSha} while waiting for the pending run to complete -- skipping the now-stale rerun (a fresh trigger already fired for the new HEAD).\n`,
+          );
+        } else {
+          buildProductionApplyDeps(args).rerunAndWait(
+            refreshLatestPlan.pendingCommand,
+          );
+          process.stderr.write(
+            `\n--refresh-latest --apply: executed ${refreshLatestPlan.pendingCommand.command} after it reached a terminal state.\n`,
+          );
+        }
       }
     } else {
       process.stderr.write(`\n${refreshLatestPlan.reason}\n`);

--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -575,6 +575,20 @@ export function computeRefreshLatestPlan(input, options) {
     checkName,
     now,
   };
+  // Honored, not bypassed (Copilot review, PR #2855): a "hold" policy is
+  // a repository's explicit opt-out of every automatic rerun, checked
+  // before instance selection so it can never be reached even
+  // incidentally -- see this function's own doc comment above.
+  const rerunPolicy =
+    String(options.rerunPolicy ?? '').trim() === 'hold' ? 'hold' : 'rerun-once';
+  if (rerunPolicy === 'hold') {
+    return {
+      ...header,
+      command: null,
+      reason:
+        'ciWait.rerunPolicy is "hold": this repository has opted out of automatic reruns, including --refresh-latest -- a maintainer must manually decide (see idd-ci.instructions.md §Rerun mechanics)',
+    };
+  }
   const familyInstances = (input.instances ?? []).filter((instance) =>
     PULL_REQUEST_FAMILY_EVENTS.has(
       String(instance.runEvent ?? '')
@@ -1508,15 +1522,19 @@ this HEAD started most recently, and is it safe to rerun unconditionally
 right now? Unlike the default mode, it does NOT classify pass /
 bot-gated-skip / rerun-budget-held -- it reruns the latest instance
 regardless of any of those, UNLESS that instance is still running (which
-would cancel it) or its run id could not be resolved. Intended only for
-the narrow #2764 Phase 1 case where a fresh pull_request_review submission
-must get a fresh evaluation even if the gate is already green or its
-rerun-once budget is already spent -- see the RefreshLatestPlan doc
-comment in the .mts source. With --apply, executes that single rerun (via
-the same "gh run rerun" mechanism as the default --apply path) instead of
-only printing it. Mutually exclusive in effect with the default plan
-computation: when given, --refresh-latest's own JSON document replaces
-the ordinary plan document on stdout.
+would cancel it) or its run id could not be resolved. It still honors
+ciWait.rerunPolicy, though: a "hold" policy returns no command here
+either, the same as the default mode -- bypassing pass/bot-gated/budget
+classification is not license to override a repository's own explicit
+no-automatic-reruns policy. Intended only for the narrow #2764 Phase 1
+case where a fresh pull_request_review submission must get a fresh
+evaluation even if the gate is already green or its rerun-once budget is
+already spent -- see the RefreshLatestPlan doc comment in the .mts
+source. With --apply, executes that single rerun (via the same "gh run
+rerun" mechanism as the default --apply path) instead of only printing
+it. Mutually exclusive in effect with the default plan computation: when
+given, --refresh-latest's own JSON document replaces the ordinary plan
+document on stdout.
 
 Honors the inspected repository's configured ciWait.rerunPolicy: when
 it is "hold", both the rerun plan and the recovery-refresh plan stay

--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -2281,6 +2281,77 @@ function waitForRunCompletion(owner, repo, runId) {
     sleepSync(APPLY_POLL_INTERVAL_MS);
   }
 }
+/**
+ * Execute every command in `plan.pendingCommands` (waiting for each to
+ * reach a terminal state first) then every command in `plan.commands`,
+ * isolating one command's failure from the rest (CodeRabbit, PR #2855
+ * review): `plan.commands`/`plan.pendingCommands` are INDEPENDENT
+ * instances (typically `pull_request` and `pull_request_target` under
+ * #2764 Phase 1) whose own rerun outcome has no bearing on any other
+ * entry's -- unlike {@link applyRerunPlan}'s single evolving target,
+ * where a thrown error aborting the whole loop is the correct behavior.
+ * A HEAD re-check immediately precedes every individual rerun (Codex P1,
+ * PR #2855 review): both `waitForRunCompletion` and `rerunAndWait`
+ * themselves can take several minutes, during which the PR can advance
+ * to a new HEAD -- `gh run rerun` on a now-stale run would still fire,
+ * and the required gate's own concurrency group has
+ * `cancel-in-progress: true` keyed by PR number alone, so a stale rerun
+ * could CANCEL a legitimate, already-running gate instance for the new
+ * HEAD. Pure aside from the injected `deps` (no direct I/O of its own),
+ * mirroring {@link applyRerunPlan}'s own separation of policy from I/O.
+ */
+export function applyRefreshLatestPlan(plan, deps) {
+  const executed = [];
+  const skippedStaleHead = [];
+  const failed = [];
+  const headStillMatches = (command) => {
+    const currentHeadSha = deps.fetchCurrentHead().toLowerCase();
+    if (currentHeadSha === plan.prHeadSha) {
+      return true;
+    }
+    deps.log(
+      `\n--refresh-latest --apply: the PR HEAD moved from ${plan.prHeadSha} to ${currentHeadSha} -- skipping the now-stale rerun of ${command.command} (a fresh trigger already fired for the new HEAD).\n`,
+    );
+    skippedStaleHead.push(command);
+    return false;
+  };
+  for (const pendingCommand of plan.pendingCommands) {
+    try {
+      deps.waitForRunCompletion(pendingCommand.runId);
+      if (!headStillMatches(pendingCommand)) {
+        continue;
+      }
+      deps.rerunAndWait(pendingCommand);
+      executed.push(pendingCommand);
+      deps.log(
+        `\n--refresh-latest --apply: executed ${pendingCommand.command} after it reached a terminal state.\n`,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      deps.log(
+        `\n--refresh-latest --apply: ${pendingCommand.command} failed -- ${message} -- continuing with the remaining instances.\n`,
+      );
+      failed.push({ command: pendingCommand, error: message });
+    }
+  }
+  for (const command of plan.commands) {
+    try {
+      if (!headStillMatches(command)) {
+        continue;
+      }
+      deps.rerunAndWait(command);
+      executed.push(command);
+      deps.log(`\n--refresh-latest --apply: executed ${command.command}.\n`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      deps.log(
+        `\n--refresh-latest --apply: ${command.command} failed -- ${message} -- continuing with the remaining instances.\n`,
+      );
+      failed.push({ command, error: message });
+    }
+  }
+  return { executed, skippedStaleHead, failed };
+}
 /** Resolves `{owner, repo}` the same way {@link collectFromGitHub} does
  * (explicit `--owner`/`--repo` first, else `gh repo view` auto-detection)
  * -- duplicated as these two lines rather than extracted into a shared
@@ -2387,73 +2458,48 @@ if (import.meta.main) {
       if (args.apply) {
         const { owner, repo } = resolveOwnerRepo(args);
         const applyDeps = buildProductionApplyDeps(args);
-        // Re-checks the PR's current HEAD immediately before firing a
-        // rerun (Codex P1, PR #2855 review): both `waitForRunCompletion`
-        // and `rerunAndWait` itself can take several minutes, during
-        // which the PR can advance to a new HEAD. `gh run rerun` on a
-        // now-stale run would still fire -- and the required gate's own
-        // concurrency group has `cancel-in-progress: true` keyed by PR
-        // number alone, so a stale rerun could CANCEL a legitimate,
-        // already-running gate instance for the new HEAD, leaving it
-        // without a passing required check and no guaranteed later
-        // refresh. Checked before EACH command below, not once for the
-        // whole batch -- every wait is its own multi-minute window the
-        // HEAD can move within. Skips just that one command instead of
-        // aborting the batch: a HEAD change means a fresh
-        // pull_request/pull_request_target trigger already fired for the
-        // new HEAD on its own, independent of this refresh.
-        const headStillMatches = (command) => {
-          const currentHeadSha = ghText(
-            [
-              'pr',
-              'view',
-              String(args.prNumber),
-              '-R',
-              `${owner}/${repo}`,
-              '--json',
-              'headRefOid',
-              '--jq',
-              '.headRefOid',
-            ],
-            GH_TEXT_LOOP_TIMEOUT_OPTIONS,
-          ).toLowerCase();
-          if (currentHeadSha === refreshLatestPlan.prHeadSha) {
-            return true;
-          }
-          process.stderr.write(
-            `\n--refresh-latest --apply: the PR HEAD moved from ${refreshLatestPlan.prHeadSha} to ${currentHeadSha} -- skipping the now-stale rerun of ${command.command} (a fresh trigger already fired for the new HEAD).\n`,
-          );
-          return false;
-        };
-        // Pending instances first, one at a time: each must reach a
-        // terminal state before it is safe to rerun without cancelling
-        // it. Sequential, not parallel -- `waitForRunCompletion` and
+        const refreshResult = applyRefreshLatestPlan(refreshLatestPlan, {
+          waitForRunCompletion: (runId) =>
+            waitForRunCompletion(owner, repo, runId),
+          fetchCurrentHead: () =>
+            ghText(
+              [
+                'pr',
+                'view',
+                String(args.prNumber),
+                '-R',
+                `${owner}/${repo}`,
+                '--json',
+                'headRefOid',
+                '--jq',
+                '.headRefOid',
+              ],
+              GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+            ),
+          rerunAndWait: applyDeps.rerunAndWait,
+          log: (message) => process.stderr.write(message),
+        });
+        // Sequential, not parallel (both loops inside
+        // applyRefreshLatestPlan) -- `waitForRunCompletion` and
         // `rerunAndWait` both poll synchronously, and this file's own
         // `planCaveat` already documents why a rerun burst must stay
         // serialized rather than racing multiple `gh run rerun` calls
         // against the same PR's shared concurrency group.
-        for (const pendingCommand of refreshLatestPlan.pendingCommands) {
-          waitForRunCompletion(owner, repo, pendingCommand.runId);
-          if (!headStillMatches(pendingCommand)) {
-            continue;
-          }
-          applyDeps.rerunAndWait(pendingCommand);
-          process.stderr.write(
-            `\n--refresh-latest --apply: executed ${pendingCommand.command} after it reached a terminal state.\n`,
-          );
-        }
-        // Every already-terminal instance next (Codex P1, PR #2855
-        // review) rather than guessing which one controls the required
-        // rollup -- see this file's own #1381 recovery guidance cited
-        // above `computeRefreshLatestPlan`.
-        for (const command of refreshLatestPlan.commands) {
-          if (!headStillMatches(command)) {
-            continue;
-          }
-          applyDeps.rerunAndWait(command);
-          process.stderr.write(
-            `\n--refresh-latest --apply: executed ${command.command}.\n`,
-          );
+        //
+        // A non-empty `failed` means at least one independent instance
+        // for this HEAD was NOT refreshed despite --apply having run
+        // (CodeRabbit, PR #2855 review) -- exit non-zero so the
+        // companion job surfaces that instead of reporting green while
+        // the required gate may still be stuck. Deliberately NOT the
+        // same convention as the ordinary --apply path below (which
+        // always exits 0, even when its own budget is exhausted
+        // unresolved): that path's "not yet resolved" is an expected,
+        // bounded policy limit with its own recovery text, whereas a
+        // `failed` entry here is an actual thrown error (network/gh
+        // failure, or a wait timeout) on an otherwise-independent
+        // instance -- a different, more actionable severity.
+        if (refreshResult.failed.length > 0) {
+          process.exitCode = 1;
         }
       }
     }
@@ -2528,5 +2574,12 @@ if (import.meta.main) {
   // before a large stdout write finishes flushing through a pipe (a
   // well-established Node.js footgun, confirmed empirically during
   // review), silently truncating the emitted JSON or recovery plan.
-  process.exitCode = 0;
+  // Guarded (CodeRabbit, PR #2855 review): the --refresh-latest --apply
+  // branch above may already have set exitCode to 1 for a genuine
+  // per-instance failure -- this default must not clobber that back to
+  // 0. Every other path never sets exitCode before reaching here, so
+  // this preserves that path's existing always-0 behavior unchanged.
+  if (process.exitCode === undefined) {
+    process.exitCode = 0;
+  }
 }

--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -2245,7 +2245,7 @@ function waitForNewAttempt(owner, repo, runId, priorAttempt) {
  * mechanism): GitHub kills the job outright at its own timeout
  * regardless of what step is running, so a caller whose own timeout is
  * shorter than this wait would never actually issue the deferred rerun
- * -- see `idd-advisory-convergence-comment.yml`'s `timeout-minutes: 30`
+ * -- see `idd-advisory-convergence-comment.yml`'s `timeout-minutes: 35`
  * (and its `idd-template/` copy) for the derivation. */
 const PENDING_RUN_POLL_TIMEOUT_MS = APPLY_POLL_TIMEOUT_MS;
 /**

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -63,13 +63,19 @@
 // and how much budget remains.
 //
 // #2015: bounded poll for the "not reviewed yet" race. The hosting
-// workflow's `pull_request` `synchronize` trigger fires the instant a push
-// lands, independent of the separate `pull_request_review` trigger, which
-// only fires once the primary bot's own review actually lands (typically
-// 10-40s later) -- so a push that also needs a fresh review used to get
-// asserted, and fail, before that review existed, costing an external
-// rerun most of the time. The CLI entry point at the bottom of this file
-// now runs through `runAdvisoryConvergenceWithPoll` instead of
+// workflow's `pull_request`/`pull_request_target` `synchronize` trigger
+// fires the instant a push lands, well before the primary bot's own
+// review typically lands (10-40s later) -- originally via the separate
+// `pull_request_review` trigger the hosting workflow declared directly;
+// #2764 Phase 1 moved that trigger to a companion workflow instead (a
+// same-repository PR could otherwise edit the required workflow's own
+// copy to control when its review-triggered run re-asserted), but the
+// timing gap this poll exists for is unchanged, since the push-triggered
+// run still starts immediately regardless of where the review's own
+// signal now arrives from -- so a push that also needs a fresh review
+// used to get asserted, and fail, before that review existed, costing an
+// external rerun most of the time. The CLI entry point at the bottom of
+// this file now runs through `runAdvisoryConvergenceWithPoll` instead of
 // `runAdvisoryConvergence` directly: when (and ONLY when) the verdict's
 // sole blocking reason is that the primary bot has not reviewed the PR AT
 // ALL yet (`isSoleCopilotNotReviewedYetReason` -- excludes a stale-HEAD
@@ -1949,10 +1955,10 @@ function sleepSync(ms: number): void {
 /**
  * #2015: wraps {@link runAdvisoryConvergence} with a short, bounded poll
  * for the narrow case {@link isSoleCopilotNotReviewedYetReason} identifies
- * -- absorbing the common race where the `pull_request` `synchronize`
- * trigger fires (and this CLI runs) before the separate
- * `pull_request_review` trigger's review has actually landed (typically
- * 10-40s later). Every other not-ready reason still fails on the very
+ * -- absorbing the common race where the `pull_request`/`pull_request_target`
+ * `synchronize` trigger fires (and this CLI runs) before the primary
+ * bot's own review has actually landed (typically 10-40s later). Every
+ * other not-ready reason still fails on the very
  * first pass with no wait, exactly as {@link runAdvisoryConvergence} alone
  * already does -- this wrapper adds no new pass path, only absorbs a
  * latency this one specific reason is known to resolve on its own. Does
@@ -1992,18 +1998,24 @@ function sleepSync(ms: number): void {
  * first sleep alone exhausts the budget) -- an edge case only reachable via
  * an explicit non-default override, never the production defaults below.
  *
- * KNOWN RESIDUAL (PR #2023 review, Codex P1): the hosting workflow's
- * concurrency group is keyed by PR number ALONE across all three of its
- * triggers, with `cancel-in-progress: true` (see
- * `idd-advisory-convergence.yml`'s own header). If the primary bot's review
- * actually lands WHILE this poll is still sleeping, that submission starts
- * a fresh `pull_request_review`-triggered run in the SAME concurrency
- * group, which cancels this run before its next scheduled re-check ever
- * observes the review -- this run ends CANCELLED, not SUCCESS, and the
- * fresh run becomes the one responsible for reflecting the converged
- * state. No safe mechanical fix was found for this within #2015's scope:
- * narrowing the concurrency group would defeat the deliberate cross-trigger
- * debouncing the workflow's own "Concurrency-hardening investigation"
+ * KNOWN RESIDUAL (PR #2023 review, Codex P1), reshaped by #2764 Phase 1:
+ * the hosting workflow's concurrency group is keyed by PR number ALONE
+ * across all three of its triggers, with `cancel-in-progress: true` (see
+ * `idd-advisory-convergence.yml`'s own header). Originally, if the
+ * primary bot's review landed WHILE this poll was still sleeping, that
+ * submission started a fresh `pull_request_review`-triggered run
+ * directly in the SAME concurrency group, cancelling this run before its
+ * next scheduled re-check ever observed the review. `pull_request_review`
+ * no longer triggers the hosting workflow directly (#2764 Phase 1 moved
+ * it to a companion workflow); a review now reaches this run only
+ * indirectly, via the companion's `gh run rerun` on an already-terminal
+ * instance, not by entering this concurrency group as a fresh trigger
+ * while a sibling is still polling. Whether a rerun re-entering this
+ * group while another instance is still polling can still cancel it is
+ * not re-derived here. No safe mechanical fix was found for the original
+ * race within #2015's scope: narrowing the concurrency group would
+ * defeat the deliberate cross-trigger debouncing the workflow's own
+ * "Concurrency-hardening investigation"
  * comment already documents as load-bearing, and there is no way for a
  * script to detect an imminent cancellation from inside the run it is
  * about to lose. This is NOT a regression versus the pre-#2015 baseline,

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -924,10 +924,21 @@ export interface RefreshLatestPlan {
   /** The single instance selected for an unconditional rerun, or `null`
    * when there is nothing safe/useful to rerun -- see `reason`. */
   command: RerunPlanCommand | null;
-  /** Empty when `command` is set; otherwise explains why (a `"hold"`
-   * rerunPolicy, no pull_request-family instance exists yet for this
-   * HEAD, the latest one is still running, or its underlying run id
-   * could not be resolved). */
+  /** Set (with `command` left `null`) only when the latest instance is
+   * still running (Codex P1, PR #2855 review): the CLI's `--apply` path
+   * waits for this run to reach a terminal state, THEN reruns it --
+   * never treats "it's already running" as equivalent to "it will
+   * already reflect this review." A live run's evidence was fetched at
+   * whatever point during ITS OWN execution the query happened to run,
+   * which can be BEFORE this review landed; nothing else is guaranteed
+   * to trigger a fresh evaluation afterward once this function declines
+   * to act. `null` in every other case, including every case where
+   * `command` is itself set. */
+  pendingCommand: RerunPlanCommand | null;
+  /** Empty when `command` or `pendingCommand` is set; otherwise explains
+   * why (a `"hold"` rerunPolicy, no pull_request-family instance exists
+   * yet for this HEAD, or the latest instance's run id could not be
+   * resolved). */
   reason: string;
 }
 
@@ -955,12 +966,16 @@ export function computeRefreshLatestPlan(
   const repo = String(input.repo ?? '').trim();
   const repoFlag = owner && repo ? ` -R ${owner}/${repo}` : '';
 
+  // `pendingCommand: null` by default -- only the still-running branch
+  // below overrides it; every other branch's `...header` spread inherits
+  // this default so it never needs repeating at each return site.
   const header = {
     protocolVersion: '1' as const,
     prNumber: Number(input.prNumber),
     prHeadSha,
     checkName,
     now,
+    pendingCommand: null as RerunPlanCommand | null,
   };
 
   // Honored, not bypassed (Copilot review, PR #2855): a "hold" policy is
@@ -1015,21 +1030,15 @@ export function computeRefreshLatestPlan(
   const conclusion = latest.conclusion
     ? String(latest.conclusion).trim().toLowerCase()
     : null;
-  // Mirrors classifyInstance step 2: rerunning a still-running instance
-  // cancels it instead of refreshing it.
-  if (!conclusion && PENDING_STATUSES.has(status)) {
-    return {
-      ...header,
-      command: null,
-      reason: `the latest pull_request-family instance (check-run ${latest.checkRunId}) is still running ("${status}"); rerunning a live run would cancel it instead of refreshing it -- once it completes, it will already reflect this review`,
-    };
-  }
   // Mirrors classifyInstance steps 4-5: never guess a rerun target from an
-  // unresolvable run identity.
+  // unresolvable run identity. Checked BEFORE the pending-status branch
+  // below so that branch can always build a `pendingCommand` from an
+  // already-validated runId.
   if (latest.runId === null) {
     return {
       ...header,
       command: null,
+      pendingCommand: null,
       reason: `the latest pull_request-family instance (check-run ${latest.checkRunId}) has no resolvable workflow run id; inspect manually`,
     };
   }
@@ -1037,18 +1046,41 @@ export function computeRefreshLatestPlan(
     return {
       ...header,
       command: null,
+      pendingCommand: null,
       reason: `the underlying workflow run for the latest pull_request-family instance (check-run ${latest.checkRunId}) could not be fetched (network/permission/transient failure); inspect manually`,
+    };
+  }
+
+  const resolvedCommand: RerunPlanCommand = {
+    runId: latest.runId,
+    command: `gh run rerun ${latest.runId}${repoFlag}`,
+    checkRunIds: [latest.checkRunId],
+    startedAt: latest.startedAt ?? '',
+  };
+
+  // Mirrors classifyInstance step 2's "rerunning a still-running instance
+  // cancels it instead of refreshing it" -- but unlike classifyInstance,
+  // this does NOT assume the live run will already reflect this review
+  // once it finishes (Codex P1, PR #2855 review): that run's own
+  // evidence was fetched at whatever point during ITS execution the
+  // query happened to run, which can be BEFORE this review landed, and
+  // nothing else is guaranteed to trigger a fresh evaluation afterward.
+  // `pendingCommand` carries the same resolved command for the caller to
+  // rerun ONCE this run reaches a terminal state, rather than declining
+  // to act at all.
+  if (!conclusion && PENDING_STATUSES.has(status)) {
+    return {
+      ...header,
+      command: null,
+      pendingCommand: resolvedCommand,
+      reason: `the latest pull_request-family instance (check-run ${latest.checkRunId}) is still running ("${status}"); rerunning a live run now would cancel it instead of refreshing it -- wait for it to reach a terminal state, then rerun it (see pendingCommand)`,
     };
   }
 
   return {
     ...header,
-    command: {
-      runId: latest.runId,
-      command: `gh run rerun ${latest.runId}${repoFlag}`,
-      checkRunIds: [latest.checkRunId],
-      startedAt: latest.startedAt ?? '',
-    },
+    command: resolvedCommand,
+    pendingCommand: null,
     reason: '',
   };
 }
@@ -2861,6 +2893,56 @@ function waitForNewAttempt(
   }
 }
 
+/** Safety bound: {@link waitForRunCompletion} fails closed (throws)
+ * instead of polling forever when a still-running instance never
+ * reaches a terminal state within this window. Shorter than {@link
+ * APPLY_POLL_TIMEOUT_MS} (which waits for a NEW attempt after `gh run
+ * rerun` already started one) -- this instead waits for the ORIGINAL,
+ * already-in-flight run this helper never touched, so a bound comfortably
+ * inside the companion workflow's own job `timeout-minutes: 10` (see
+ * `idd-advisory-convergence-comment.yml`) matters more here: a wait that
+ * outlives the job's own timeout would be silently killed with no
+ * visible error, defeating the throw-on-timeout contract entirely. */
+const PENDING_RUN_POLL_TIMEOUT_MS = 5 * 60_000;
+
+/**
+ * Blocks until `runId` (within `owner`/`repo`) reports
+ * `status === 'completed'` -- i.e. the run {@link
+ * computeRefreshLatestPlan}'s `pendingCommand` deferred (it was still
+ * running when the plan was computed) has reached a terminal state, safe
+ * to rerun without cancelling it. Companion to {@link waitForNewAttempt}
+ * (same `ghText` + polling shape), but waits for the ORIGINAL run's own
+ * completion rather than a NEW attempt after an already-issued rerun --
+ * this function issues no mutation itself; the caller reruns `runId`
+ * only after this returns (Codex P1, PR #2855 review: `pendingCommand`'s
+ * own doc comment explains why declining to act at all is not safe
+ * here).
+ */
+function waitForRunCompletion(
+  owner: string,
+  repo: string,
+  runId: string,
+): void {
+  const deadline = Date.now() + PENDING_RUN_POLL_TIMEOUT_MS;
+  for (;;) {
+    const payload = JSON.parse(
+      ghText(
+        ['api', `repos/${owner}/${repo}/actions/runs/${runId}`],
+        GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+      ),
+    ) as RawWorkflowRunPayload;
+    if (payload.status === 'completed') {
+      return;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `timed out waiting for run ${runId} (${owner}/${repo}) to reach a terminal state before rerunning it`,
+      );
+    }
+    sleepSync(APPLY_POLL_INTERVAL_MS);
+  }
+}
+
 /** Resolves `{owner, repo}` the same way {@link collectFromGitHub} does
  * (explicit `--owner`/`--repo` first, else `gh repo view` auto-detection)
  * -- duplicated as these two lines rather than extracted into a shared
@@ -2958,6 +3040,28 @@ if (import.meta.main) {
         buildProductionApplyDeps(args).rerunAndWait(refreshLatestPlan.command);
         process.stderr.write(
           `\n--refresh-latest --apply: executed ${refreshLatestPlan.command.command}.\n`,
+        );
+      }
+    } else if (refreshLatestPlan.pendingCommand) {
+      process.stderr.write(`\n${refreshLatestPlan.reason}\n`);
+      if (args.apply) {
+        // The still-running run this deferred is NOT touched by
+        // rerunAndWait's own pre-rerun run_attempt capture -- this waits
+        // for ITS completion first (waitForRunCompletion), then issues
+        // the actual rerun through the same production apply deps every
+        // other --apply path uses, preserving one code path for the
+        // mutation itself.
+        const { owner, repo } = resolveOwnerRepo(args);
+        waitForRunCompletion(
+          owner,
+          repo,
+          refreshLatestPlan.pendingCommand.runId,
+        );
+        buildProductionApplyDeps(args).rerunAndWait(
+          refreshLatestPlan.pendingCommand,
+        );
+        process.stderr.write(
+          `\n--refresh-latest --apply: executed ${refreshLatestPlan.pendingCommand.command} after it reached a terminal state.\n`,
         );
       }
     } else {

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -2994,6 +2994,128 @@ function waitForRunCompletion(
   }
 }
 
+/** One command `applyRefreshLatestPlan` could not execute -- the run it
+ * targeted either errored (network/permission/transient `gh` failure, or
+ * {@link waitForRunCompletion}'s own timeout) or was itself a still-
+ * pending instance that never reached a terminal state within budget. */
+export interface RefreshLatestApplyFailure {
+  command: RerunPlanCommand;
+  error: string;
+}
+
+/** Result of {@link applyRefreshLatestPlan}. */
+export interface RefreshLatestApplyResult {
+  /** Commands that were rerun successfully (their own `rerunAndWait`
+   * returned without throwing). */
+  executed: RerunPlanCommand[];
+  /** Commands skipped because the PR's HEAD had moved by the time this
+   * command's turn came (see `fetchCurrentHead` below) -- not a failure,
+   * since a fresh trigger already fired for the new HEAD on its own. */
+  skippedStaleHead: RerunPlanCommand[];
+  /** Commands whose wait or rerun threw. Non-empty means at least one
+   * instance for this HEAD was NOT refreshed and may still need manual
+   * attention -- see the CLI's own exit-code handling. */
+  failed: RefreshLatestApplyFailure[];
+}
+
+/** Dependencies injected by tests; production defaults perform real I/O
+ * (see the `import.meta.main` wiring below). Mirrors {@link
+ * RerunApplyDeps}'s DI pattern. */
+export interface RefreshLatestApplyDeps {
+  /** Blocks until `runId` reaches a terminal state (see {@link
+   * waitForRunCompletion}); throws on timeout or a propagated `gh`
+   * error. */
+  waitForRunCompletion: (runId: string) => void;
+  /** Returns the PR's CURRENT head SHA (lowercased), fetched fresh --
+   * never a cached/boolean comparison, so a test can assert exactly what
+   * SHA this function observed. */
+  fetchCurrentHead: () => string;
+  /** Executes one command and blocks until its run reaches a terminal
+   * state, regardless of its own conclusion (matches {@link
+   * RerunApplyDeps.rerunAndWait}). */
+  rerunAndWait: (command: RerunPlanCommand) => void;
+  /** Human-readable progress line, written to stderr in production. */
+  log: (message: string) => void;
+}
+
+/**
+ * Execute every command in `plan.pendingCommands` (waiting for each to
+ * reach a terminal state first) then every command in `plan.commands`,
+ * isolating one command's failure from the rest (CodeRabbit, PR #2855
+ * review): `plan.commands`/`plan.pendingCommands` are INDEPENDENT
+ * instances (typically `pull_request` and `pull_request_target` under
+ * #2764 Phase 1) whose own rerun outcome has no bearing on any other
+ * entry's -- unlike {@link applyRerunPlan}'s single evolving target,
+ * where a thrown error aborting the whole loop is the correct behavior.
+ * A HEAD re-check immediately precedes every individual rerun (Codex P1,
+ * PR #2855 review): both `waitForRunCompletion` and `rerunAndWait`
+ * themselves can take several minutes, during which the PR can advance
+ * to a new HEAD -- `gh run rerun` on a now-stale run would still fire,
+ * and the required gate's own concurrency group has
+ * `cancel-in-progress: true` keyed by PR number alone, so a stale rerun
+ * could CANCEL a legitimate, already-running gate instance for the new
+ * HEAD. Pure aside from the injected `deps` (no direct I/O of its own),
+ * mirroring {@link applyRerunPlan}'s own separation of policy from I/O.
+ */
+export function applyRefreshLatestPlan(
+  plan: RefreshLatestPlan,
+  deps: RefreshLatestApplyDeps,
+): RefreshLatestApplyResult {
+  const executed: RerunPlanCommand[] = [];
+  const skippedStaleHead: RerunPlanCommand[] = [];
+  const failed: RefreshLatestApplyFailure[] = [];
+
+  const headStillMatches = (command: RerunPlanCommand): boolean => {
+    const currentHeadSha = deps.fetchCurrentHead().toLowerCase();
+    if (currentHeadSha === plan.prHeadSha) {
+      return true;
+    }
+    deps.log(
+      `\n--refresh-latest --apply: the PR HEAD moved from ${plan.prHeadSha} to ${currentHeadSha} -- skipping the now-stale rerun of ${command.command} (a fresh trigger already fired for the new HEAD).\n`,
+    );
+    skippedStaleHead.push(command);
+    return false;
+  };
+
+  for (const pendingCommand of plan.pendingCommands) {
+    try {
+      deps.waitForRunCompletion(pendingCommand.runId);
+      if (!headStillMatches(pendingCommand)) {
+        continue;
+      }
+      deps.rerunAndWait(pendingCommand);
+      executed.push(pendingCommand);
+      deps.log(
+        `\n--refresh-latest --apply: executed ${pendingCommand.command} after it reached a terminal state.\n`,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      deps.log(
+        `\n--refresh-latest --apply: ${pendingCommand.command} failed -- ${message} -- continuing with the remaining instances.\n`,
+      );
+      failed.push({ command: pendingCommand, error: message });
+    }
+  }
+  for (const command of plan.commands) {
+    try {
+      if (!headStillMatches(command)) {
+        continue;
+      }
+      deps.rerunAndWait(command);
+      executed.push(command);
+      deps.log(`\n--refresh-latest --apply: executed ${command.command}.\n`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      deps.log(
+        `\n--refresh-latest --apply: ${command.command} failed -- ${message} -- continuing with the remaining instances.\n`,
+      );
+      failed.push({ command, error: message });
+    }
+  }
+
+  return { executed, skippedStaleHead, failed };
+}
+
 /** Resolves `{owner, repo}` the same way {@link collectFromGitHub} does
  * (explicit `--owner`/`--repo` first, else `gh repo view` auto-detection)
  * -- duplicated as these two lines rather than extracted into a shared
@@ -3105,73 +3227,48 @@ if (import.meta.main) {
       if (args.apply) {
         const { owner, repo } = resolveOwnerRepo(args);
         const applyDeps = buildProductionApplyDeps(args);
-        // Re-checks the PR's current HEAD immediately before firing a
-        // rerun (Codex P1, PR #2855 review): both `waitForRunCompletion`
-        // and `rerunAndWait` itself can take several minutes, during
-        // which the PR can advance to a new HEAD. `gh run rerun` on a
-        // now-stale run would still fire -- and the required gate's own
-        // concurrency group has `cancel-in-progress: true` keyed by PR
-        // number alone, so a stale rerun could CANCEL a legitimate,
-        // already-running gate instance for the new HEAD, leaving it
-        // without a passing required check and no guaranteed later
-        // refresh. Checked before EACH command below, not once for the
-        // whole batch -- every wait is its own multi-minute window the
-        // HEAD can move within. Skips just that one command instead of
-        // aborting the batch: a HEAD change means a fresh
-        // pull_request/pull_request_target trigger already fired for the
-        // new HEAD on its own, independent of this refresh.
-        const headStillMatches = (command: RerunPlanCommand): boolean => {
-          const currentHeadSha = ghText(
-            [
-              'pr',
-              'view',
-              String(args.prNumber),
-              '-R',
-              `${owner}/${repo}`,
-              '--json',
-              'headRefOid',
-              '--jq',
-              '.headRefOid',
-            ],
-            GH_TEXT_LOOP_TIMEOUT_OPTIONS,
-          ).toLowerCase();
-          if (currentHeadSha === refreshLatestPlan.prHeadSha) {
-            return true;
-          }
-          process.stderr.write(
-            `\n--refresh-latest --apply: the PR HEAD moved from ${refreshLatestPlan.prHeadSha} to ${currentHeadSha} -- skipping the now-stale rerun of ${command.command} (a fresh trigger already fired for the new HEAD).\n`,
-          );
-          return false;
-        };
-        // Pending instances first, one at a time: each must reach a
-        // terminal state before it is safe to rerun without cancelling
-        // it. Sequential, not parallel -- `waitForRunCompletion` and
+        const refreshResult = applyRefreshLatestPlan(refreshLatestPlan, {
+          waitForRunCompletion: (runId) =>
+            waitForRunCompletion(owner, repo, runId),
+          fetchCurrentHead: () =>
+            ghText(
+              [
+                'pr',
+                'view',
+                String(args.prNumber),
+                '-R',
+                `${owner}/${repo}`,
+                '--json',
+                'headRefOid',
+                '--jq',
+                '.headRefOid',
+              ],
+              GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+            ),
+          rerunAndWait: applyDeps.rerunAndWait,
+          log: (message) => process.stderr.write(message),
+        });
+        // Sequential, not parallel (both loops inside
+        // applyRefreshLatestPlan) -- `waitForRunCompletion` and
         // `rerunAndWait` both poll synchronously, and this file's own
         // `planCaveat` already documents why a rerun burst must stay
         // serialized rather than racing multiple `gh run rerun` calls
         // against the same PR's shared concurrency group.
-        for (const pendingCommand of refreshLatestPlan.pendingCommands) {
-          waitForRunCompletion(owner, repo, pendingCommand.runId);
-          if (!headStillMatches(pendingCommand)) {
-            continue;
-          }
-          applyDeps.rerunAndWait(pendingCommand);
-          process.stderr.write(
-            `\n--refresh-latest --apply: executed ${pendingCommand.command} after it reached a terminal state.\n`,
-          );
-        }
-        // Every already-terminal instance next (Codex P1, PR #2855
-        // review) rather than guessing which one controls the required
-        // rollup -- see this file's own #1381 recovery guidance cited
-        // above `computeRefreshLatestPlan`.
-        for (const command of refreshLatestPlan.commands) {
-          if (!headStillMatches(command)) {
-            continue;
-          }
-          applyDeps.rerunAndWait(command);
-          process.stderr.write(
-            `\n--refresh-latest --apply: executed ${command.command}.\n`,
-          );
+        //
+        // A non-empty `failed` means at least one independent instance
+        // for this HEAD was NOT refreshed despite --apply having run
+        // (CodeRabbit, PR #2855 review) -- exit non-zero so the
+        // companion job surfaces that instead of reporting green while
+        // the required gate may still be stuck. Deliberately NOT the
+        // same convention as the ordinary --apply path below (which
+        // always exits 0, even when its own budget is exhausted
+        // unresolved): that path's "not yet resolved" is an expected,
+        // bounded policy limit with its own recovery text, whereas a
+        // `failed` entry here is an actual thrown error (network/gh
+        // failure, or a wait timeout) on an otherwise-independent
+        // instance -- a different, more actionable severity.
+        if (refreshResult.failed.length > 0) {
+          process.exitCode = 1;
         }
       }
     }
@@ -3246,5 +3343,12 @@ if (import.meta.main) {
   // before a large stdout write finishes flushing through a pipe (a
   // well-established Node.js footgun, confirmed empirically during
   // review), silently truncating the emitted JSON or recovery plan.
-  process.exitCode = 0;
+  // Guarded (CodeRabbit, PR #2855 review): the --refresh-latest --apply
+  // branch above may already have set exitCode to 1 for a genuine
+  // per-instance failure -- this default must not clobber that back to
+  // 0. Every other path never sets exitCode before reaching here, so
+  // this preserves that path's existing always-0 behavior unchanged.
+  if (process.exitCode === undefined) {
+    process.exitCode = 0;
+  }
 }

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -870,6 +870,157 @@ export function computeRerunPlan(
 }
 
 /**
+ * Full JSON document printed by `--refresh-latest`, an alternate CLI mode
+ * from {@link computeRerunPlan}'s own budget/classification-gated `plan`
+ * (Codex P1, PR #2855 review). #2764 Phase 1 moved `pull_request_review`
+ * off `idd-advisory-convergence.yml`'s own trigger list onto the
+ * non-required companion workflow, which now reruns the existing required
+ * run via this helper instead of a fresh direct trigger -- but the
+ * ordinary `--apply` path only reruns a `rerun-eligible` instance, which
+ * EXCLUDES anything already classified `pass` and enforces the
+ * rerun-once budget: a same-HEAD review landing after the gate already
+ * went green (or after its one rerun was already spent) would leave a
+ * stale verdict standing even though the review may have raised new
+ * blocking findings, silently losing the pre-#2764 guarantee that EVERY
+ * review submission gets a fresh evaluation -- the former direct
+ * `pull_request_review` trigger always started a brand-new run, regardless
+ * of any prior instance's own conclusion or attempt count.
+ * `--refresh-latest` restores that guarantee narrowly: it selects the
+ * single most-recently-started pull_request-family instance for this HEAD
+ * and (unless it is still running) reruns it unconditionally, bypassing
+ * {@link classifyInstance}'s pass/bot-gated/budget classification
+ * entirely. Deliberately NOT folded into `computeRerunPlan`/`--apply`
+ * itself: that budget exists to protect against a genuine comment-burst
+ * hazard (#2643) a review submission does not share (rare, human-paced,
+ * and already separately debounced by the companion workflow's own
+ * `advisory-comment-debounce.mjs` step) -- so the comment-family `--apply`
+ * path, and every existing test/invariant built around its budget, stays
+ * completely unchanged; only the companion workflow's
+ * `pull_request_review` step opts into this mode.
+ */
+export interface RefreshLatestPlan {
+  protocolVersion: '1';
+  prNumber: number;
+  prHeadSha: string;
+  checkName: string;
+  now: string;
+  /** The single instance selected for an unconditional rerun, or `null`
+   * when there is nothing safe/useful to rerun -- see `reason`. */
+  command: RerunPlanCommand | null;
+  /** Empty when `command` is set; otherwise explains why (no
+   * pull_request-family instance exists yet for this HEAD, the latest one
+   * is still running, or its underlying run id could not be resolved). */
+  reason: string;
+}
+
+/**
+ * Compute {@link RefreshLatestPlan} from the same already-fetched,
+ * already-enriched instances {@link computeRerunPlan} consumes -- pure, no
+ * I/O, directly unit-testable with fixtures, mirroring `computeRerunPlan`'s
+ * own DI shape.
+ */
+export function computeRefreshLatestPlan(
+  input: RerunPlanInput,
+  options: Pick<RerunPlanOptions, 'now'>,
+): RefreshLatestPlan {
+  const now = String(options.now ?? '');
+  if (!isValidIsoTimestamp(now)) {
+    throw new Error('now must be an ISO 8601 UTC timestamp');
+  }
+  const prHeadSha = String(input.prHeadSha ?? '').toLowerCase();
+  if (!/^[0-9a-f]{40}$/.test(prHeadSha)) {
+    throw new Error('prHeadSha must be a 40-character hexadecimal commit SHA');
+  }
+  const checkName =
+    String(input.checkName ?? '').trim() || RERUN_PLAN_CHECK_NAME;
+  const owner = String(input.owner ?? '').trim();
+  const repo = String(input.repo ?? '').trim();
+  const repoFlag = owner && repo ? ` -R ${owner}/${repo}` : '';
+
+  const header = {
+    protocolVersion: '1' as const,
+    prNumber: Number(input.prNumber),
+    prHeadSha,
+    checkName,
+    now,
+  };
+
+  const familyInstances = (input.instances ?? []).filter((instance) =>
+    PULL_REQUEST_FAMILY_EVENTS.has(
+      String(instance.runEvent ?? '')
+        .trim()
+        .toLowerCase(),
+    ),
+  );
+  if (familyInstances.length === 0) {
+    return {
+      ...header,
+      command: null,
+      reason:
+        'no pull_request-family check-run instance exists yet for this HEAD; nothing to refresh -- a future pull_request/pull_request_target trigger will create the first instance',
+    };
+  }
+
+  // Latest by startedAt (unknown/empty sorts LAST -- the opposite of
+  // buildOrderedPlan's own earliest-first, more-cautious ordering -- since
+  // this selects the single most-recent instance rather than building a
+  // deterministic multi-entry plan); numeric checkRunId breaks a tie.
+  const [latest] = [...familyInstances].sort((left, right) => {
+    const leftStarted = left.startedAt ?? '';
+    const rightStarted = right.startedAt ?? '';
+    if (leftStarted !== rightStarted) {
+      if (!leftStarted) return 1;
+      if (!rightStarted) return -1;
+      return leftStarted < rightStarted ? 1 : -1;
+    }
+    return Number(right.checkRunId) - Number(left.checkRunId);
+  });
+
+  const status = String(latest.status ?? '')
+    .trim()
+    .toLowerCase();
+  const conclusion = latest.conclusion
+    ? String(latest.conclusion).trim().toLowerCase()
+    : null;
+  // Mirrors classifyInstance step 2: rerunning a still-running instance
+  // cancels it instead of refreshing it.
+  if (!conclusion && PENDING_STATUSES.has(status)) {
+    return {
+      ...header,
+      command: null,
+      reason: `the latest pull_request-family instance (check-run ${latest.checkRunId}) is still running ("${status}"); rerunning a live run would cancel it instead of refreshing it -- once it completes, it will already reflect this review`,
+    };
+  }
+  // Mirrors classifyInstance steps 4-5: never guess a rerun target from an
+  // unresolvable run identity.
+  if (latest.runId === null) {
+    return {
+      ...header,
+      command: null,
+      reason: `the latest pull_request-family instance (check-run ${latest.checkRunId}) has no resolvable workflow run id; inspect manually`,
+    };
+  }
+  if (latest.runLookupFailed) {
+    return {
+      ...header,
+      command: null,
+      reason: `the underlying workflow run for the latest pull_request-family instance (check-run ${latest.checkRunId}) could not be fetched (network/permission/transient failure); inspect manually`,
+    };
+  }
+
+  return {
+    ...header,
+    command: {
+      runId: latest.runId,
+      command: `gh run rerun ${latest.runId}${repoFlag}`,
+      checkRunIds: [latest.checkRunId],
+      startedAt: latest.startedAt ?? '',
+    },
+    reason: '',
+  };
+}
+
+/**
  * Resolve whether `instance` may still be rerun under `rerunPolicy`, given
  * its own `runAttempt`. Reuses {@link resolveCiRerunDecision}
  * (ci-wait-policy.mts) -- the same rerun-once-budget decision
@@ -1465,6 +1616,10 @@ interface RerunPlanArgs {
    * via `gh run rerun` instead of only diagnosing them. See
    * {@link applyRerunPlan}. */
   apply: boolean;
+  /** When `true`, bypass `computeRerunPlan` entirely and compute
+   * {@link RefreshLatestPlan} instead -- see that type's own doc comment
+   * for why (#2764 Phase 1, Codex P1 review on PR #2855). */
+  refreshLatest: boolean;
   /** Raw `--check-name` value, trimmed but NOT yet defaulted -- an empty
    * string means the flag was either omitted or given a
    * whitespace-only value (indistinguishable after trimming, and
@@ -1504,6 +1659,7 @@ const RERUN_ADVISORY_CONVERGENCE_FLAG_SPEC = {
   '--help': { type: 'boolean', short: 'h' },
   '--apply': { type: 'boolean', default: false },
   '--check-name': { type: 'string', default: '' },
+  '--refresh-latest': { type: 'boolean', default: false },
 } as const;
 
 /**
@@ -1544,6 +1700,7 @@ export function parseArgs(argv: string[]): RerunPlanArgs {
       help: true,
       apply: false,
       checkName: '',
+      refreshLatest: false,
     };
   }
 
@@ -1601,6 +1758,7 @@ export function parseArgs(argv: string[]): RerunPlanArgs {
     help: false,
     apply: Boolean(values.apply),
     checkName: String(values['check-name'] ?? '').trim(),
+    refreshLatest: Boolean(values['refresh-latest']),
   };
 }
 
@@ -1778,7 +1936,7 @@ export function buildRerunPlanTextSections(
 
 function printHelp(): void {
   process.stdout.write(`Usage:
-  node scripts/rerun-advisory-convergence.mjs --pr <number> [--owner <owner> --repo <repo>] [--now <ISO8601>] [--check-name <name>] [--apply] [--help]
+  node scripts/rerun-advisory-convergence.mjs --pr <number> [--owner <owner> --repo <repo>] [--now <ISO8601>] [--check-name <name>] [--apply] [--refresh-latest] [--help]
 
 By default (without --apply): read-only. Fetches every
 "${RERUN_PLAN_CHECK_NAME}" check-run instance for the PR's current HEAD SHA
@@ -1833,6 +1991,22 @@ finds nothing (field-reported, #1935; see the job-definition comment in
 Omitting this flag keeps output byte-identical to before this flag
 existed.
 
+--refresh-latest replaces the whole plan/budget computation above with a
+single, much narrower question: which pull_request-family instance for
+this HEAD started most recently, and is it safe to rerun unconditionally
+right now? Unlike the default mode, it does NOT classify pass /
+bot-gated-skip / rerun-budget-held -- it reruns the latest instance
+regardless of any of those, UNLESS that instance is still running (which
+would cancel it) or its run id could not be resolved. Intended only for
+the narrow #2764 Phase 1 case where a fresh pull_request_review submission
+must get a fresh evaluation even if the gate is already green or its
+rerun-once budget is already spent -- see the RefreshLatestPlan doc
+comment in the .mts source. With --apply, executes that single rerun (via
+the same "gh run rerun" mechanism as the default --apply path) instead of
+only printing it. Mutually exclusive in effect with the default plan
+computation: when given, --refresh-latest's own JSON document replaces
+the ordinary plan document on stdout.
+
 Honors the inspected repository's configured ciWait.rerunPolicy: when
 it is "hold", both the rerun plan and the recovery-refresh plan stay
 empty (with a notice explaining why) instead of recommending reruns a
@@ -1868,20 +2042,27 @@ export function runRerunAdvisoryConvergence(
   deps: RerunPlanDeps = defaultDeps,
 ): {
   plan: RerunAdvisoryConvergencePlan | null;
+  /** Populated instead of `plan` when `--refresh-latest` was given; see
+   * {@link computeRefreshLatestPlan}. */
+  refreshLatestPlan: RefreshLatestPlan | null;
   help: boolean;
   args: RerunPlanArgs;
 } {
   const args = parseArgs(argv);
   if (args.help) {
-    return { plan: null, help: true, args };
+    return { plan: null, refreshLatestPlan: null, help: true, args };
   }
   if (!args.prNumber) {
     throw new Error('missing required --pr <number> argument');
   }
 
   const { input, options } = deps.collect(args);
+  if (args.refreshLatest) {
+    const refreshLatestPlan = computeRefreshLatestPlan(input, options);
+    return { plan: null, refreshLatestPlan, help: false, args };
+  }
   const plan = computeRerunPlan(input, options);
-  return { plan, help: false, args };
+  return { plan, refreshLatestPlan: null, help: false, args };
 }
 
 // --- --apply: execute the plan's rerun-eligible instances ---------------
@@ -2723,11 +2904,28 @@ function buildProductionApplyDeps(args: RerunPlanArgs): RerunApplyDeps {
 // so importing this module (for unit tests) never parses process.argv,
 // prints usage, or makes a `gh` call.
 if (import.meta.main) {
-  const { plan, help, args } = runRerunAdvisoryConvergence(
+  const { plan, refreshLatestPlan, help, args } = runRerunAdvisoryConvergence(
     process.argv.slice(2),
   );
   if (help) {
     printHelp();
+  } else if (refreshLatestPlan) {
+    // Same stdout/stderr split as the ordinary plan below: JSON only on
+    // stdout, human-readable summary on stderr.
+    process.stdout.write(`${JSON.stringify(refreshLatestPlan, null, 2)}\n`);
+    if (refreshLatestPlan.command) {
+      process.stderr.write(
+        `\n--refresh-latest selected: ${refreshLatestPlan.command.command}\n`,
+      );
+      if (args.apply) {
+        buildProductionApplyDeps(args).rerunAndWait(refreshLatestPlan.command);
+        process.stderr.write(
+          `\n--refresh-latest --apply: executed ${refreshLatestPlan.command.command}.\n`,
+        );
+      }
+    } else {
+      process.stderr.write(`\n${refreshLatestPlan.reason}\n`);
+    }
   } else if (plan) {
     // stdout carries ONLY the JSON document -- nothing else -- so the
     // overall stdout stream stays valid, machine-parseable JSON (e.g.

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -1006,36 +1006,41 @@ export function computeRefreshLatestPlan(
     };
   }
 
-  const familyInstances = (input.instances ?? []).filter((instance) =>
-    PULL_REQUEST_FAMILY_EVENTS.has(
-      String(instance.runEvent ?? '')
-        .trim()
-        .toLowerCase(),
-    ),
-  );
-  if (familyInstances.length === 0) {
+  const allInstances = input.instances ?? [];
+  if (allInstances.length === 0) {
     return {
       ...header,
       commands: [],
       pendingCommands: [],
       reason:
-        'no pull_request-family check-run instance exists yet for this HEAD; nothing to refresh -- a future pull_request/pull_request_target trigger will create the first instance',
+        'no check-run instance exists yet for this HEAD; nothing to refresh -- a future pull_request/pull_request_target trigger will create the first instance',
     };
   }
 
-  // Mirrors classifyInstance steps 4-5: never guess a rerun target from an
-  // unresolvable run identity -- but (Codex P1, PR #2855 review) applied
-  // per-instance now, not just to a single "latest" pick: an instance
-  // whose own identity can't be trusted is skipped rather than aborting
-  // every OTHER instance's refresh. Deduplicated by runId: two check-run
-  // instances can briefly resolve to the same underlying workflow run
-  // (e.g. one instance's `gh api` lookup racing another's), and rerunning
-  // the same run id twice in one pass is redundant, not merely harmless.
+  // Checked BEFORE the family-event filter, not after (Copilot, PR #2855
+  // review, "previously missed"): an instance whose run id is
+  // unresolvable, or whose underlying run lookup failed, has `runEvent:
+  // null` (see the enrichment in `collectFromGitHub`) -- filtering by
+  // family membership FIRST would silently treat that instance the same
+  // as one that genuinely belongs to a different, non-family event
+  // (`workflow_dispatch`, say), collapsing "this HEAD has an
+  // unverifiable check-run instance, inspect manually" into the far more
+  // reassuring "nothing has triggered yet for this HEAD" whenever every
+  // instance happened to be unresolvable. Mirrors classifyInstance steps
+  // 4-5: never guess a rerun target from an unresolvable run identity --
+  // but (Codex P1, PR #2855 review) applied per-instance, not just to a
+  // single "latest" pick: one instance's unresolvable identity is
+  // reported and skipped rather than aborting every OTHER instance's
+  // refresh. Deduplicated by runId: two check-run instances can briefly
+  // resolve to the same underlying workflow run (e.g. one instance's
+  // `gh api` lookup racing another's), and rerunning the same run id
+  // twice in one pass is redundant, not merely harmless.
   const seenRunIds = new Set<string>();
   const unresolvableReasons: string[] = [];
+  const nonFamilyEvents = new Set<string>();
   const resolvedCommands: RerunPlanCommand[] = [];
   const pendingResolvedCommands: RerunPlanCommand[] = [];
-  for (const instance of familyInstances) {
+  for (const instance of allInstances) {
     if (instance.runId === null) {
       unresolvableReasons.push(
         `check-run ${instance.checkRunId} has no resolvable workflow run id`,
@@ -1046,6 +1051,16 @@ export function computeRefreshLatestPlan(
       unresolvableReasons.push(
         `the underlying workflow run for check-run ${instance.checkRunId} could not be fetched (network/permission/transient failure)`,
       );
+      continue;
+    }
+    const resolvedRunEvent = String(instance.runEvent ?? '')
+      .trim()
+      .toLowerCase();
+    if (!PULL_REQUEST_FAMILY_EVENTS.has(resolvedRunEvent)) {
+      // Resolved, but genuinely a different (non-family) trigger for
+      // this same check-run name -- not ours to touch, and not
+      // unresolvable either.
+      nonFamilyEvents.add(resolvedRunEvent || '(unknown)');
       continue;
     }
     if (seenRunIds.has(instance.runId)) {
@@ -1102,11 +1117,23 @@ export function computeRefreshLatestPlan(
   pendingResolvedCommands.sort(byStartedAtDesc);
 
   if (resolvedCommands.length === 0 && pendingResolvedCommands.length === 0) {
+    // Two genuinely different "nothing to rerun" causes (Copilot, PR
+    // #2855 review): an unresolvable instance MIGHT be a family one we
+    // simply couldn't verify (actionable -- inspect manually), whereas
+    // every instance resolving to a confirmed non-family event is the
+    // ordinary "this HEAD just hasn't had a pull_request-family trigger
+    // yet" case the original message described. Prefer the unresolvable
+    // reason whenever both are present: an operator investigating a
+    // stuck rollup needs to know verification failed, not just that no
+    // family instance was found.
     return {
       ...header,
       commands: [],
       pendingCommands: [],
-      reason: `no resolvable pull_request-family instance for this HEAD -- ${unresolvableReasons.join('; ')}; inspect manually`,
+      reason:
+        unresolvableReasons.length > 0
+          ? `no resolvable pull_request-family instance for this HEAD -- ${unresolvableReasons.join('; ')}; inspect manually`
+          : `no pull_request-family check-run instance exists yet for this HEAD (found: ${[...nonFamilyEvents].join(', ')}); nothing to refresh -- a future pull_request/pull_request_target trigger will create the first instance`,
     };
   }
 

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -894,18 +894,30 @@ export function computeRerunPlan(
  * review submission gets a fresh evaluation -- the former direct
  * `pull_request_review` trigger always started a brand-new run, regardless
  * of any prior instance's own conclusion or attempt count.
- * `--refresh-latest` restores that guarantee narrowly: it selects the
- * single most-recently-started pull_request-family instance for this HEAD
- * and (unless it is still running) reruns it unconditionally, bypassing
- * {@link classifyInstance}'s pass/bot-gated/budget classification
- * entirely. Deliberately NOT folded into `computeRerunPlan`/`--apply`
- * itself: that budget exists to protect against a genuine comment-burst
- * hazard (#2643) a review submission does not share (rare, human-paced,
- * and already separately debounced by the companion workflow's own
- * `advisory-comment-debounce.mjs` step) -- so the comment-family `--apply`
- * path, and every existing test/invariant built around its budget, stays
- * completely unchanged; only the companion workflow's
- * `pull_request_review` step opts into this mode.
+ * `--refresh-latest` restores that guarantee narrowly: it reruns every
+ * resolvable pull_request-family instance for this HEAD unconditionally,
+ * bypassing {@link classifyInstance}'s pass/bot-gated/budget
+ * classification entirely. Deliberately NOT folded into
+ * `computeRerunPlan`/`--apply` itself: that budget exists to protect
+ * against a genuine comment-burst hazard (#2643) a review submission does
+ * not share (rare, human-paced, and already separately debounced by the
+ * companion workflow's own `advisory-comment-debounce.mjs` step) -- so
+ * the comment-family `--apply` path, and every existing test/invariant
+ * built around its budget, stays completely unchanged; only the
+ * companion workflow's `pull_request_review` step opts into this mode.
+ *
+ * Reruns every instance rather than only the newest one (Codex P1,
+ * PR #2855 review): `idd-advisory-convergence.yml`'s own #1381 incident
+ * documents the required rollup staying pinned to an EARLIER instance's
+ * check-run object even after a genuinely later instance for the
+ * identical SHA completes with SUCCESS, and that file's own recovery
+ * guidance for an unclear case is "rerun every run for that HEAD SHA
+ * rather than guessing -- rerunning an already-successful run is a
+ * harmless no-op, but rerunning the wrong one leaves the rollup stuck."
+ * A "select the newest instance" heuristic can rerun the survivor of a
+ * `cancel-in-progress` collision while the rollup stays pinned to the
+ * cancelled instance it never touches -- exactly the case that file's
+ * own docs warn against guessing around.
  *
  * One classification IS still honored, not bypassed (Copilot review,
  * PR #2855): the resolved `ciWait.rerunPolicy`. A repository that
@@ -921,24 +933,28 @@ export interface RefreshLatestPlan {
   prHeadSha: string;
   checkName: string;
   now: string;
-  /** The single instance selected for an unconditional rerun, or `null`
-   * when there is nothing safe/useful to rerun -- see `reason`. */
-  command: RerunPlanCommand | null;
-  /** Set (with `command` left `null`) only when the latest instance is
+  /** Every resolvable, already-terminal pull_request-family instance for
+   * this HEAD, selected for an unconditional rerun -- empty when there is
+   * nothing safe/useful to rerun yet, see `reason`. Newest-`startedAt`
+   * first, purely for a stable, readable summary: every entry here is
+   * acted on, so order has no bearing on correctness. */
+  commands: RerunPlanCommand[];
+  /** Every resolvable pull_request-family instance for this HEAD that is
    * still running (Codex P1, PR #2855 review): the CLI's `--apply` path
-   * waits for this run to reach a terminal state, THEN reruns it --
-   * never treats "it's already running" as equivalent to "it will
-   * already reflect this review." A live run's evidence was fetched at
-   * whatever point during ITS OWN execution the query happened to run,
-   * which can be BEFORE this review landed; nothing else is guaranteed
-   * to trigger a fresh evaluation afterward once this function declines
-   * to act. `null` in every other case, including every case where
-   * `command` is itself set. */
-  pendingCommand: RerunPlanCommand | null;
-  /** Empty when `command` or `pendingCommand` is set; otherwise explains
-   * why (a `"hold"` rerunPolicy, no pull_request-family instance exists
-   * yet for this HEAD, or the latest instance's run id could not be
-   * resolved). */
+   * waits for each to reach a terminal state, THEN reruns it -- never
+   * treats "it's already running" as equivalent to "it will already
+   * reflect this review." A live run's evidence was fetched at whatever
+   * point during ITS OWN execution the query happened to run, which can
+   * be BEFORE this review landed; nothing else is guaranteed to trigger a
+   * fresh evaluation afterward once this function declines to act on it.
+   * Disjoint from `commands` -- an instance is never in both. */
+  pendingCommands: RerunPlanCommand[];
+  /** Empty only when every family instance for this HEAD rerun cleanly
+   * with nothing else worth noting. Otherwise explains what happened: a
+   * `"hold"` rerunPolicy, no pull_request-family instance exists yet for
+   * this HEAD, every instance's run id was unresolvable, some instances
+   * are still running (see `pendingCommands`), and/or some instances were
+   * skipped as unresolvable alongside others that DID rerun. */
   reason: string;
 }
 
@@ -966,16 +982,12 @@ export function computeRefreshLatestPlan(
   const repo = String(input.repo ?? '').trim();
   const repoFlag = owner && repo ? ` -R ${owner}/${repo}` : '';
 
-  // `pendingCommand: null` by default -- only the still-running branch
-  // below overrides it; every other branch's `...header` spread inherits
-  // this default so it never needs repeating at each return site.
   const header = {
     protocolVersion: '1' as const,
     prNumber: Number(input.prNumber),
     prHeadSha,
     checkName,
     now,
-    pendingCommand: null as RerunPlanCommand | null,
   };
 
   // Honored, not bypassed (Copilot review, PR #2855): a "hold" policy is
@@ -987,7 +999,8 @@ export function computeRefreshLatestPlan(
   if (rerunPolicy === 'hold') {
     return {
       ...header,
-      command: null,
+      commands: [],
+      pendingCommands: [],
       reason:
         'ciWait.rerunPolicy is "hold": this repository has opted out of automatic reruns, including --refresh-latest -- a maintainer must manually decide (see idd-ci.instructions.md §Rerun mechanics)',
     };
@@ -1003,17 +1016,79 @@ export function computeRefreshLatestPlan(
   if (familyInstances.length === 0) {
     return {
       ...header,
-      command: null,
+      commands: [],
+      pendingCommands: [],
       reason:
         'no pull_request-family check-run instance exists yet for this HEAD; nothing to refresh -- a future pull_request/pull_request_target trigger will create the first instance',
     };
   }
 
-  // Latest by startedAt (unknown/empty sorts LAST -- the opposite of
-  // buildOrderedPlan's own earliest-first, more-cautious ordering -- since
-  // this selects the single most-recent instance rather than building a
-  // deterministic multi-entry plan); numeric checkRunId breaks a tie.
-  const [latest] = [...familyInstances].sort((left, right) => {
+  // Mirrors classifyInstance steps 4-5: never guess a rerun target from an
+  // unresolvable run identity -- but (Codex P1, PR #2855 review) applied
+  // per-instance now, not just to a single "latest" pick: an instance
+  // whose own identity can't be trusted is skipped rather than aborting
+  // every OTHER instance's refresh. Deduplicated by runId: two check-run
+  // instances can briefly resolve to the same underlying workflow run
+  // (e.g. one instance's `gh api` lookup racing another's), and rerunning
+  // the same run id twice in one pass is redundant, not merely harmless.
+  const seenRunIds = new Set<string>();
+  const unresolvableReasons: string[] = [];
+  const resolvedCommands: RerunPlanCommand[] = [];
+  const pendingResolvedCommands: RerunPlanCommand[] = [];
+  for (const instance of familyInstances) {
+    if (instance.runId === null) {
+      unresolvableReasons.push(
+        `check-run ${instance.checkRunId} has no resolvable workflow run id`,
+      );
+      continue;
+    }
+    if (instance.runLookupFailed) {
+      unresolvableReasons.push(
+        `the underlying workflow run for check-run ${instance.checkRunId} could not be fetched (network/permission/transient failure)`,
+      );
+      continue;
+    }
+    if (seenRunIds.has(instance.runId)) {
+      continue;
+    }
+    seenRunIds.add(instance.runId);
+
+    const status = String(instance.status ?? '')
+      .trim()
+      .toLowerCase();
+    const conclusion = instance.conclusion
+      ? String(instance.conclusion).trim().toLowerCase()
+      : null;
+    const resolvedCommand: RerunPlanCommand = {
+      runId: instance.runId,
+      command: `gh run rerun ${instance.runId}${repoFlag}`,
+      checkRunIds: [instance.checkRunId],
+      startedAt: instance.startedAt ?? '',
+    };
+    // Mirrors classifyInstance step 2's "rerunning a still-running
+    // instance cancels it instead of refreshing it" -- but unlike
+    // classifyInstance, this does NOT assume the live run will already
+    // reflect this review once it finishes (Codex P1, PR #2855 review):
+    // that run's own evidence was fetched at whatever point during ITS
+    // execution the query happened to run, which can be BEFORE this
+    // review landed, and nothing else is guaranteed to trigger a fresh
+    // evaluation afterward. `pendingCommands` carries the same resolved
+    // command for the caller to rerun ONCE this run reaches a terminal
+    // state, rather than declining to act on it at all.
+    if (!conclusion && PENDING_STATUSES.has(status)) {
+      pendingResolvedCommands.push(resolvedCommand);
+    } else {
+      resolvedCommands.push(resolvedCommand);
+    }
+  }
+
+  // Newest-`startedAt` first (unknown/empty sorts LAST) purely for a
+  // stable, readable summary -- unlike the single-instance selection this
+  // replaced, every entry in both lists is acted on, so this ordering has
+  // no bearing on correctness (unlike buildOrderedPlan's own
+  // earliest-first, rerun-budget-driven ordering). Numeric checkRunId
+  // breaks a tie.
+  const byStartedAtDesc = (left: RerunPlanCommand, right: RerunPlanCommand) => {
     const leftStarted = left.startedAt ?? '';
     const rightStarted = right.startedAt ?? '';
     if (leftStarted !== rightStarted) {
@@ -1021,67 +1096,33 @@ export function computeRefreshLatestPlan(
       if (!rightStarted) return -1;
       return leftStarted < rightStarted ? 1 : -1;
     }
-    return Number(right.checkRunId) - Number(left.checkRunId);
-  });
-
-  const status = String(latest.status ?? '')
-    .trim()
-    .toLowerCase();
-  const conclusion = latest.conclusion
-    ? String(latest.conclusion).trim().toLowerCase()
-    : null;
-  // Mirrors classifyInstance steps 4-5: never guess a rerun target from an
-  // unresolvable run identity. Checked BEFORE the pending-status branch
-  // below so that branch can always build a `pendingCommand` from an
-  // already-validated runId.
-  if (latest.runId === null) {
-    return {
-      ...header,
-      command: null,
-      pendingCommand: null,
-      reason: `the latest pull_request-family instance (check-run ${latest.checkRunId}) has no resolvable workflow run id; inspect manually`,
-    };
-  }
-  if (latest.runLookupFailed) {
-    return {
-      ...header,
-      command: null,
-      pendingCommand: null,
-      reason: `the underlying workflow run for the latest pull_request-family instance (check-run ${latest.checkRunId}) could not be fetched (network/permission/transient failure); inspect manually`,
-    };
-  }
-
-  const resolvedCommand: RerunPlanCommand = {
-    runId: latest.runId,
-    command: `gh run rerun ${latest.runId}${repoFlag}`,
-    checkRunIds: [latest.checkRunId],
-    startedAt: latest.startedAt ?? '',
+    return Number(right.checkRunIds[0]) - Number(left.checkRunIds[0]);
   };
+  resolvedCommands.sort(byStartedAtDesc);
+  pendingResolvedCommands.sort(byStartedAtDesc);
 
-  // Mirrors classifyInstance step 2's "rerunning a still-running instance
-  // cancels it instead of refreshing it" -- but unlike classifyInstance,
-  // this does NOT assume the live run will already reflect this review
-  // once it finishes (Codex P1, PR #2855 review): that run's own
-  // evidence was fetched at whatever point during ITS execution the
-  // query happened to run, which can be BEFORE this review landed, and
-  // nothing else is guaranteed to trigger a fresh evaluation afterward.
-  // `pendingCommand` carries the same resolved command for the caller to
-  // rerun ONCE this run reaches a terminal state, rather than declining
-  // to act at all.
-  if (!conclusion && PENDING_STATUSES.has(status)) {
+  if (resolvedCommands.length === 0 && pendingResolvedCommands.length === 0) {
     return {
       ...header,
-      command: null,
-      pendingCommand: resolvedCommand,
-      reason: `the latest pull_request-family instance (check-run ${latest.checkRunId}) is still running ("${status}"); rerunning a live run now would cancel it instead of refreshing it -- wait for it to reach a terminal state, then rerun it (see pendingCommand)`,
+      commands: [],
+      pendingCommands: [],
+      reason: `no resolvable pull_request-family instance for this HEAD -- ${unresolvableReasons.join('; ')}; inspect manually`,
     };
   }
+
+  const unresolvableSuffix =
+    unresolvableReasons.length > 0
+      ? ` (skipped ${unresolvableReasons.length} unresolvable instance(s): ${unresolvableReasons.join('; ')})`
+      : '';
 
   return {
     ...header,
-    command: resolvedCommand,
-    pendingCommand: null,
-    reason: '',
+    commands: resolvedCommands,
+    pendingCommands: pendingResolvedCommands,
+    reason:
+      pendingResolvedCommands.length > 0
+        ? `${pendingResolvedCommands.length} pull_request-family instance(s) for this HEAD are still running; rerunning a live run now would cancel it instead of refreshing it -- wait for each to reach a terminal state, then rerun it (see pendingCommands)${unresolvableSuffix}`
+        : unresolvableSuffix.trim(),
   };
 }
 
@@ -2057,24 +2098,27 @@ Omitting this flag keeps output byte-identical to before this flag
 existed.
 
 --refresh-latest replaces the whole plan/budget computation above with a
-single, much narrower question: which pull_request-family instance for
-this HEAD started most recently, and is it safe to rerun unconditionally
-right now? Unlike the default mode, it does NOT classify pass /
-bot-gated-skip / rerun-budget-held -- it reruns the latest instance
-regardless of any of those, UNLESS that instance is still running (which
-would cancel it) or its run id could not be resolved. It still honors
-ciWait.rerunPolicy, though: a "hold" policy returns no command here
-either, the same as the default mode -- bypassing pass/bot-gated/budget
-classification is not license to override a repository's own explicit
-no-automatic-reruns policy. Intended only for the narrow #2764 Phase 1
-case where a fresh pull_request_review submission must get a fresh
-evaluation even if the gate is already green or its rerun-once budget is
-already spent -- see the RefreshLatestPlan doc comment in the .mts
-source. With --apply, executes that single rerun (via the same "gh run
-rerun" mechanism as the default --apply path) instead of only printing
-it. Mutually exclusive in effect with the default plan computation: when
-given, --refresh-latest's own JSON document replaces the ordinary plan
-document on stdout.
+single, much narrower question: which pull_request-family instances for
+this HEAD are safe to rerun unconditionally right now? Unlike the
+default mode, it does NOT classify pass / bot-gated-skip /
+rerun-budget-held -- it reruns EVERY resolvable pull_request-family
+instance for this HEAD (not only the most recently started one -- the
+required rollup can stay pinned to an earlier instance even after a
+later one for the same SHA completes, kurone-kito/idd-skill#1381), each
+UNLESS it is still running (which would cancel it instead -- queued for
+a deferred rerun once it finishes) or its run id could not be resolved.
+It still honors ciWait.rerunPolicy, though: a "hold" policy returns
+nothing to rerun here either, the same as the default mode -- bypassing
+pass/bot-gated/budget classification is not license to override a
+repository's own explicit no-automatic-reruns policy. Intended only for
+the narrow #2764 Phase 1 case where a fresh pull_request_review
+submission must get a fresh evaluation even if the gate is already green
+or its rerun-once budget is already spent -- see the RefreshLatestPlan
+doc comment in the .mts source. With --apply, executes each rerun
+sequentially (via the same "gh run rerun" mechanism as the default
+--apply path) instead of only printing them. Mutually exclusive in
+effect with the default plan computation: when given, --refresh-latest's
+own JSON document replaces the ordinary plan document on stdout.
 
 Honors the inspected repository's configured ciWait.rerunPolicy: when
 it is "hold", both the rerun plan and the recovery-refresh plan stay
@@ -2902,11 +2946,14 @@ function waitForNewAttempt(
  * `idd-advisory-convergence.yml`) already exceeds any bound shorter than
  * 10 minutes -- a wait that gives up before the gate's own allowed
  * lifetime elapses would misreport a still-legitimately-running gate as
- * stuck. The companion workflow's OWN `timeout-minutes: 10` being
- * smaller than either of this file's two internal wait budgets is a
- * pre-existing property of `waitForNewAttempt`/`rerunAndWait` this
- * function does not change -- GitHub's own job timeout is the backstop
- * in that case, not this function's throw. */
+ * stuck. The companion workflow's own job `timeout-minutes` must in turn
+ * exceed THIS bound plus however long the subsequent reruns themselves
+ * take (Codex P1, PR #2855 review, a second round on the same
+ * mechanism): GitHub kills the job outright at its own timeout
+ * regardless of what step is running, so a caller whose own timeout is
+ * shorter than this wait would never actually issue the deferred rerun
+ * -- see `idd-advisory-convergence-comment.yml`'s `timeout-minutes: 30`
+ * (and its `idd-template/` copy) for the derivation. */
 const PENDING_RUN_POLL_TIMEOUT_MS = APPLY_POLL_TIMEOUT_MS;
 
 /**
@@ -3036,72 +3083,97 @@ if (import.meta.main) {
     // Same stdout/stderr split as the ordinary plan below: JSON only on
     // stdout, human-readable summary on stderr.
     process.stdout.write(`${JSON.stringify(refreshLatestPlan, null, 2)}\n`);
-    if (refreshLatestPlan.command) {
-      process.stderr.write(
-        `\n--refresh-latest selected: ${refreshLatestPlan.command.command}\n`,
-      );
-      if (args.apply) {
-        buildProductionApplyDeps(args).rerunAndWait(refreshLatestPlan.command);
+    if (
+      refreshLatestPlan.commands.length === 0 &&
+      refreshLatestPlan.pendingCommands.length === 0
+    ) {
+      process.stderr.write(`\n${refreshLatestPlan.reason}\n`);
+    } else {
+      if (refreshLatestPlan.reason) {
+        process.stderr.write(`\n${refreshLatestPlan.reason}\n`);
+      }
+      for (const command of refreshLatestPlan.commands) {
         process.stderr.write(
-          `\n--refresh-latest --apply: executed ${refreshLatestPlan.command.command}.\n`,
+          `\n--refresh-latest selected: ${command.command}\n`,
         );
       }
-    } else if (refreshLatestPlan.pendingCommand) {
-      process.stderr.write(`\n${refreshLatestPlan.reason}\n`);
-      if (args.apply) {
-        // The still-running run this deferred is NOT touched by
-        // rerunAndWait's own pre-rerun run_attempt capture -- this waits
-        // for ITS completion first (waitForRunCompletion), then issues
-        // the actual rerun through the same production apply deps every
-        // other --apply path uses, preserving one code path for the
-        // mutation itself.
-        const { owner, repo } = resolveOwnerRepo(args);
-        waitForRunCompletion(
-          owner,
-          repo,
-          refreshLatestPlan.pendingCommand.runId,
+      for (const command of refreshLatestPlan.pendingCommands) {
+        process.stderr.write(
+          `\n--refresh-latest deferred (still running): ${command.command}\n`,
         );
-        // Re-check the PR's current HEAD before firing the deferred
-        // rerun (Codex P1, PR #2855 review): the wait above can take
-        // several minutes, during which the PR can advance to a new
-        // HEAD. `gh run rerun` on the captured (now-stale) run would
-        // still fire -- and the required gate's own concurrency group
-        // has `cancel-in-progress: true` keyed by PR number alone, so
-        // that stale rerun could CANCEL a legitimate, already-running
-        // gate instance for the new HEAD, leaving it without a passing
-        // required check and no guaranteed later refresh. Abort instead
-        // of recomputing the whole plan: a HEAD change means a fresh
-        // pull_request/pull_request_target trigger already fired for
-        // the new HEAD on its own, independent of this deferred rerun.
-        const currentHeadSha = ghText(
-          [
-            'pr',
-            'view',
-            String(args.prNumber),
-            '-R',
-            `${owner}/${repo}`,
-            '--json',
-            'headRefOid',
-            '--jq',
-            '.headRefOid',
-          ],
-          GH_TEXT_LOOP_TIMEOUT_OPTIONS,
-        ).toLowerCase();
-        if (currentHeadSha !== refreshLatestPlan.prHeadSha) {
+      }
+      if (args.apply) {
+        const { owner, repo } = resolveOwnerRepo(args);
+        const applyDeps = buildProductionApplyDeps(args);
+        // Re-checks the PR's current HEAD immediately before firing a
+        // rerun (Codex P1, PR #2855 review): both `waitForRunCompletion`
+        // and `rerunAndWait` itself can take several minutes, during
+        // which the PR can advance to a new HEAD. `gh run rerun` on a
+        // now-stale run would still fire -- and the required gate's own
+        // concurrency group has `cancel-in-progress: true` keyed by PR
+        // number alone, so a stale rerun could CANCEL a legitimate,
+        // already-running gate instance for the new HEAD, leaving it
+        // without a passing required check and no guaranteed later
+        // refresh. Checked before EACH command below, not once for the
+        // whole batch -- every wait is its own multi-minute window the
+        // HEAD can move within. Skips just that one command instead of
+        // aborting the batch: a HEAD change means a fresh
+        // pull_request/pull_request_target trigger already fired for the
+        // new HEAD on its own, independent of this refresh.
+        const headStillMatches = (command: RerunPlanCommand): boolean => {
+          const currentHeadSha = ghText(
+            [
+              'pr',
+              'view',
+              String(args.prNumber),
+              '-R',
+              `${owner}/${repo}`,
+              '--json',
+              'headRefOid',
+              '--jq',
+              '.headRefOid',
+            ],
+            GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+          ).toLowerCase();
+          if (currentHeadSha === refreshLatestPlan.prHeadSha) {
+            return true;
+          }
           process.stderr.write(
-            `\n--refresh-latest --apply: the PR HEAD moved from ${refreshLatestPlan.prHeadSha} to ${currentHeadSha} while waiting for the pending run to complete -- skipping the now-stale rerun (a fresh trigger already fired for the new HEAD).\n`,
+            `\n--refresh-latest --apply: the PR HEAD moved from ${refreshLatestPlan.prHeadSha} to ${currentHeadSha} -- skipping the now-stale rerun of ${command.command} (a fresh trigger already fired for the new HEAD).\n`,
           );
-        } else {
-          buildProductionApplyDeps(args).rerunAndWait(
-            refreshLatestPlan.pendingCommand,
-          );
+          return false;
+        };
+        // Pending instances first, one at a time: each must reach a
+        // terminal state before it is safe to rerun without cancelling
+        // it. Sequential, not parallel -- `waitForRunCompletion` and
+        // `rerunAndWait` both poll synchronously, and this file's own
+        // `planCaveat` already documents why a rerun burst must stay
+        // serialized rather than racing multiple `gh run rerun` calls
+        // against the same PR's shared concurrency group.
+        for (const pendingCommand of refreshLatestPlan.pendingCommands) {
+          waitForRunCompletion(owner, repo, pendingCommand.runId);
+          if (!headStillMatches(pendingCommand)) {
+            continue;
+          }
+          applyDeps.rerunAndWait(pendingCommand);
           process.stderr.write(
-            `\n--refresh-latest --apply: executed ${refreshLatestPlan.pendingCommand.command} after it reached a terminal state.\n`,
+            `\n--refresh-latest --apply: executed ${pendingCommand.command} after it reached a terminal state.\n`,
+          );
+        }
+        // Every already-terminal instance next (Codex P1, PR #2855
+        // review) rather than guessing which one controls the required
+        // rollup -- see this file's own #1381 recovery guidance cited
+        // above `computeRefreshLatestPlan`.
+        for (const command of refreshLatestPlan.commands) {
+          if (!headStillMatches(command)) {
+            continue;
+          }
+          applyDeps.rerunAndWait(command);
+          process.stderr.write(
+            `\n--refresh-latest --apply: executed ${command.command}.\n`,
           );
         }
       }
-    } else {
-      process.stderr.write(`\n${refreshLatestPlan.reason}\n`);
     }
   } else if (plan) {
     // stdout carries ONLY the JSON document -- nothing else -- so the

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -190,20 +190,29 @@ const PENDING_STATUSES = new Set([
   'pending',
 ]);
 
-/** Workflow-run trigger events this helper trusts to reliably refresh the
- * PR's required-check rollup on rerun, matching the events
- * `idd-advisory-convergence` itself subscribes to (its own header comment,
- * mirrored in `idd-ci.instructions.md` §Rerun mechanics): `pull_request`,
- * `pull_request_target` (#2764 -- evaluated against the base branch's own
- * workflow YAML, but its check-runs are still attached to the PR's real
- * HEAD SHA, exactly like the other members here; the commit check-runs API
- * this helper queries is scoped by SHA, not by triggering event, so no
- * separate SHA-resolution path is needed), `pull_request_review`,
- * `pull_request_review_comment`. A run triggered by any other event --
- * most notably `workflow_dispatch` -- has no `pull_request` context of its
- * own and is documented as NOT reliably associated with the PR's HEAD SHA,
- * so rerunning it would not dependably clear a stuck rollup even though
- * the run itself is otherwise a plain, non-bot failure. */
+/** This helper's own "pull_request-family" allowlist: trigger events whose
+ * check-runs are expected to attach reliably to the PR's real HEAD SHA, so
+ * rerunning them can refresh the required-check rollup (Copilot review, PR
+ * #2855) -- `pull_request`, `pull_request_target` (#2764 -- evaluated
+ * against the base branch's own workflow YAML, but its check-runs are
+ * still attached to the PR's real HEAD SHA, exactly like the other
+ * members here; the commit check-runs API this helper queries is scoped by
+ * SHA, not by triggering event, so no separate SHA-resolution path is
+ * needed), `pull_request_review`, `pull_request_review_comment`. Not
+ * necessarily identical to which of these `idd-advisory-convergence`
+ * itself currently subscribes to directly -- #2764 Phase 1 moved
+ * `pull_request_review` off that workflow's own trigger list onto a
+ * companion (see `idd-advisory-convergence-comment.yml`), but a
+ * `pull_request_review`-triggered instance can still exist for a HEAD (via
+ * that companion's own rerun of an existing run) and remains just as
+ * reliably associated with the PR's HEAD SHA as before, so it stays in
+ * this set; `idd-ci.instructions.md` §Rerun mechanics documents the
+ * cross-file contract this set and the required workflow's own triggers
+ * both honor. A run triggered by any other event -- most notably
+ * `workflow_dispatch` -- has no `pull_request` context of its own and is
+ * documented as NOT reliably associated with the PR's HEAD SHA, so
+ * rerunning it would not dependably clear a stuck rollup even though the
+ * run itself is otherwise a plain, non-bot failure. */
 const PULL_REQUEST_FAMILY_EVENTS = new Set([
   'pull_request',
   'pull_request_target',

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -194,14 +194,19 @@ const PENDING_STATUSES = new Set([
  * PR's required-check rollup on rerun, matching the events
  * `idd-advisory-convergence` itself subscribes to (its own header comment,
  * mirrored in `idd-ci.instructions.md` §Rerun mechanics): `pull_request`,
- * `pull_request_review`, `pull_request_review_comment`. A run triggered by
- * any other event -- most notably `workflow_dispatch` -- has no
- * `pull_request` context of its own and is documented as NOT reliably
- * associated with the PR's HEAD SHA, so rerunning it would not dependably
- * clear a stuck rollup even though the run itself is otherwise a plain,
- * non-bot failure. */
+ * `pull_request_target` (#2764 -- evaluated against the base branch's own
+ * workflow YAML, but its check-runs are still attached to the PR's real
+ * HEAD SHA, exactly like the other members here; the commit check-runs API
+ * this helper queries is scoped by SHA, not by triggering event, so no
+ * separate SHA-resolution path is needed), `pull_request_review`,
+ * `pull_request_review_comment`. A run triggered by any other event --
+ * most notably `workflow_dispatch` -- has no `pull_request` context of its
+ * own and is documented as NOT reliably associated with the PR's HEAD SHA,
+ * so rerunning it would not dependably clear a stuck rollup even though
+ * the run itself is otherwise a plain, non-bot failure. */
 const PULL_REQUEST_FAMILY_EVENTS = new Set([
   'pull_request',
+  'pull_request_target',
   'pull_request_review',
   'pull_request_review_comment',
 ]);
@@ -1085,7 +1090,7 @@ function classifyInstance(
       ...instance,
       classification: 'unresolved',
       reason: runEvent
-        ? `triggering event "${runEvent}" is not pull_request-family (pull_request / pull_request_review / pull_request_review_comment); rerunning it is not a reliable way to refresh the PR's required-check rollup -- inspect manually`
+        ? `triggering event "${runEvent}" is not pull_request-family (pull_request / pull_request_target / pull_request_review / pull_request_review_comment); rerunning it is not a reliable way to refresh the PR's required-check rollup -- inspect manually`
         : 'triggering event is unknown; inspect manually rather than assuming it is safe to rerun',
     };
   }

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -2952,7 +2952,7 @@ function waitForNewAttempt(
  * mechanism): GitHub kills the job outright at its own timeout
  * regardless of what step is running, so a caller whose own timeout is
  * shorter than this wait would never actually issue the deferred rerun
- * -- see `idd-advisory-convergence-comment.yml`'s `timeout-minutes: 30`
+ * -- see `idd-advisory-convergence-comment.yml`'s `timeout-minutes: 35`
  * (and its `idd-template/` copy) for the derivation. */
 const PENDING_RUN_POLL_TIMEOUT_MS = APPLY_POLL_TIMEOUT_MS;
 

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -300,6 +300,25 @@ export interface RerunPlanRawInstance {
    * {@link collectFromGitHub} fills it for non-pass terminal instances.
    */
   verdictReasons?: string[] | null;
+  /**
+   * The underlying workflow run's own live `status` (from
+   * `GET .../actions/runs/{run_id}`), independent of this check-run row's
+   * own (possibly stale) `status`/`conclusion` pair. Consulted only by
+   * {@link computeRefreshLatestPlan} (Codex P1, PR #2855 review): when a
+   * review arrives while an already-issued rerun for this same `runId` is
+   * still spinning up, the check-runs-for-ref endpoint can keep exposing
+   * the PRIOR attempt's completed row for a short window before the new
+   * attempt's own row/status propagates -- the same kind of
+   * stale-row-vs-fresh-row lag this file's own #1381 precedent already
+   * documents across TWO rows sharing a runId, but here there is only one
+   * row and its `status`/`conclusion` are themselves what's stale. Without
+   * this field, that stale conclusion alone would classify the instance as
+   * immediately rerun-eligible and fire another `gh run rerun` against a
+   * run that is, per the authoritative workflow-run endpoint, already
+   * live -- cancelling it instead of waiting for it. `null` when unset
+   * (tests) or when the per-run lookup failed (`runLookupFailed`).
+   */
+  runStatus?: string | null;
 }
 
 /** {@link RerunPlanRawInstance} plus the assigned classification and a
@@ -1122,7 +1141,20 @@ export function computeRefreshLatestPlan(
       botGatedCheckRunIds.push(instance.checkRunId);
       continue;
     }
-    const pending = !conclusion && PENDING_STATUSES.has(status);
+    // Also consult the workflow run's own live status (Codex P1, PR #2855
+    // review), not just this check-run row's own status/conclusion: a row
+    // fetched moments after an already-issued rerun for this same runId
+    // can still report the PRIOR attempt's terminal conclusion before the
+    // new attempt's row catches up. `runStatus` reflects the authoritative
+    // `GET .../actions/runs/{run_id}` state instead, so it wins even over
+    // a present (possibly stale) `conclusion` -- see
+    // `RerunPlanRawInstance.runStatus`'s own doc comment.
+    const runStatus = instance.runStatus
+      ? String(instance.runStatus).trim().toLowerCase()
+      : null;
+    const pending =
+      (!conclusion && PENDING_STATUSES.has(status)) ||
+      (runStatus !== null && PENDING_STATUSES.has(runStatus));
 
     const existing = commandsByRunId.get(instance.runId);
     if (existing) {
@@ -2466,8 +2498,14 @@ interface RawWorkflowRunPayload {
   /** 1 for the original run; increments on the SAME run id after `gh run
    * rerun` -- see {@link RerunPlanRawInstance.runAttempt}. */
   run_attempt?: number | null;
-  /** Consulted only by {@link waitForNewAttempt} (the `--apply` polling
-   * loop); every other reader of this payload shape ignores it. */
+  /** Consulted by {@link waitForNewAttempt} (the `--apply` polling loop)
+   * and, via {@link RerunPlanRawInstance.runStatus}, by
+   * {@link computeRefreshLatestPlan}'s pending classification (Codex P1,
+   * PR #2855 review): this is the authoritative live status of the
+   * workflow run itself, whereas a check-run row's own `status` can lag
+   * behind a rerun this function already knows was issued for the same
+   * `runId` -- see `runStatus`'s own doc comment for the race this
+   * closes. */
   status?: string | null;
 }
 
@@ -2814,6 +2852,8 @@ function collectFromGitHub(args: RerunPlanArgs): {
       triggeringActorLogin: string | null;
       triggeringActorType: string | null;
       runAttempt: number | null;
+      /** See {@link RerunPlanRawInstance.runStatus}. */
+      status: string | null;
     } | null // null means the per-run lookup itself failed
   >();
   // GH_TEXT_LOOP_TIMEOUT_OPTIONS (stdin ignored, 30s timeout), not a bare
@@ -2844,6 +2884,7 @@ function collectFromGitHub(args: RerunPlanArgs): {
           Number.isInteger(runPayload.run_attempt)
             ? runPayload.run_attempt
             : null,
+        status: runPayload.status ? String(runPayload.status) : null,
       });
     } catch {
       runMetaById.set(runId, null);
@@ -2897,6 +2938,7 @@ function collectFromGitHub(args: RerunPlanArgs): {
       runAttempt: meta?.runAttempt ?? null,
       verdictReasons:
         runId !== null ? (verdictReasonsByRunId.get(runId) ?? null) : null,
+      runStatus: meta?.status ?? null,
     };
   });
 

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -966,7 +966,10 @@ export interface RefreshLatestPlan {
    * actually pinned to. The CLI's `--apply` path exits non-zero when this
    * is non-zero, the same as a `RefreshLatestApplyResult.failed` entry,
    * rather than reporting success while a potentially-blocking instance
-   * was never even attempted. */
+   * was never even attempted. Deliberately excludes a bot-gated
+   * (`action_required`) instance: that one IS identified, not unknowable
+   * -- rerunning it is simply documented to be futile (idd-ci
+   * .instructions.md), not a gap in what this function could verify. */
   unresolvedInstanceCount: number;
 }
 
@@ -1051,6 +1054,7 @@ export function computeRefreshLatestPlan(
   // refresh.
   const unresolvableReasons: string[] = [];
   const nonFamilyEvents = new Set<string>();
+  const botGatedCheckRunIds: string[] = [];
   // Keyed by runId, not deduplicated away (Copilot, PR #2855 review,
   // round 6): two check-run instances can briefly resolve to the same
   // underlying workflow run (e.g. one instance's `gh api` lookup racing
@@ -1093,6 +1097,33 @@ export function computeRefreshLatestPlan(
       continue;
     }
 
+    const status = String(instance.status ?? '')
+      .trim()
+      .toLowerCase();
+    const conclusion = instance.conclusion
+      ? String(instance.conclusion).trim().toLowerCase()
+      : null;
+    // Mirrors classifyInstance step 3's `bot-gated-skip` (Codex P1, PR
+    // #2855 review): `idd-ci.instructions.md` §Rerun mechanics documents
+    // that rerunning an `action_required`-conclusion instance preserves
+    // the original bot actor's privileges and simply re-enters
+    // `action_required` -- never clearing it, only spending this loop's
+    // sequential budget (and, via `pendingCommands`, the deferred-wait
+    // budget too) on a rerun that cannot help. Unlike
+    // `computeRerunPlan`/`--apply`'s classification, `--refresh-latest`
+    // otherwise bypasses pass/budget on purpose (see this function's own
+    // doc comment above) -- but bot-gating is not a policy choice this
+    // mode exists to override, the same distinction already drawn for
+    // `ciWait.rerunPolicy: "hold"`. A separate non-bot family instance
+    // for this same HEAD (if one exists) still gets its own entry here
+    // and can clear the rollup per that same doc's recovery guidance;
+    // this exclusion only withholds the gated instance itself.
+    if (conclusion === 'action_required') {
+      botGatedCheckRunIds.push(instance.checkRunId);
+      continue;
+    }
+    const pending = !conclusion && PENDING_STATUSES.has(status);
+
     const existing = commandsByRunId.get(instance.runId);
     if (existing) {
       existing.command.checkRunIds.push(instance.checkRunId);
@@ -1104,15 +1135,24 @@ export function computeRefreshLatestPlan(
       ) {
         existing.command.startedAt = instanceStartedAt;
       }
+      // Any pending row wins (Codex P1, PR #2855 review): two check-run
+      // rows sharing a runId are NOT guaranteed to report the identical
+      // status -- this file's own #1381 precedent already establishes
+      // that GitHub's check-runs-for-ref response can carry a stale row
+      // alongside a fresher one for the same underlying run. Rerunning a
+      // duplicate this function mistakenly classified as terminal (from
+      // an earlier-seen COMPLETED row) while a later-seen row for the
+      // identical runId is still IN_PROGRESS would cancel that live run
+      // instead of refreshing it -- the exact hazard `pendingCommands`
+      // exists to prevent. Once true, never flips back to false: a
+      // still-pending sibling row is reason enough to wait, regardless
+      // of processing order.
+      if (pending) {
+        existing.pending = true;
+      }
       continue;
     }
 
-    const status = String(instance.status ?? '')
-      .trim()
-      .toLowerCase();
-    const conclusion = instance.conclusion
-      ? String(instance.conclusion).trim().toLowerCase()
-      : null;
     const resolvedCommand: RerunPlanCommand = {
       runId: instance.runId,
       command: `gh run rerun ${instance.runId}${repoFlag}`,
@@ -1128,13 +1168,10 @@ export function computeRefreshLatestPlan(
     // review landed, and nothing else is guaranteed to trigger a fresh
     // evaluation afterward. `pendingCommands` carries the same resolved
     // command for the caller to rerun ONCE this run reaches a terminal
-    // state, rather than declining to act on it at all. Classified once,
-    // from the FIRST instance seen for this runId -- a duplicate sharing
-    // the identical runId shares the identical underlying workflow run,
-    // so its own status/conclusion cannot meaningfully disagree.
+    // state, rather than declining to act on it at all.
     commandsByRunId.set(instance.runId, {
       command: resolvedCommand,
-      pending: !conclusion && PENDING_STATUSES.has(status),
+      pending,
     });
   }
   const resolvedCommands: RerunPlanCommand[] = [];
@@ -1163,23 +1200,27 @@ export function computeRefreshLatestPlan(
   pendingResolvedCommands.sort(byStartedAtDesc);
 
   if (resolvedCommands.length === 0 && pendingResolvedCommands.length === 0) {
-    // Two genuinely different "nothing to rerun" causes (Copilot, PR
-    // #2855 review): an unresolvable instance MIGHT be a family one we
-    // simply couldn't verify (actionable -- inspect manually), whereas
+    // Three genuinely different "nothing to rerun" causes (Copilot +
+    // Codex P1, PR #2855 review), in priority order: an unresolvable
+    // instance MIGHT be a family one we simply couldn't verify
+    // (actionable -- inspect manually, the most urgent); a bot-gated
+    // (`action_required`) instance IS a family one, but rerunning it
+    // cannot clear the rollup (idd-ci.instructions.md §Rerun mechanics
+    // -- a non-bot instance is needed instead, and none exists here);
     // every instance resolving to a confirmed non-family event is the
     // ordinary "this HEAD just hasn't had a pull_request-family trigger
-    // yet" case the original message described. Prefer the unresolvable
-    // reason whenever both are present: an operator investigating a
-    // stuck rollup needs to know verification failed, not just that no
-    // family instance was found.
+    // yet" case the original message described.
+    const reason =
+      unresolvableReasons.length > 0
+        ? `no resolvable pull_request-family instance for this HEAD -- ${unresolvableReasons.join('; ')}; inspect manually`
+        : botGatedCheckRunIds.length > 0
+          ? `every pull_request-family instance for this HEAD is bot-gated (action_required: check-run(s) ${botGatedCheckRunIds.join(', ')}) -- rerunning re-enters action_required per idd-ci.instructions.md §Rerun mechanics; a non-bot pull_request-family instance is needed to clear the rollup, and none currently exists for this HEAD`
+          : `no pull_request-family check-run instance exists yet for this HEAD (found: ${[...nonFamilyEvents].join(', ')}); nothing to refresh -- a future pull_request/pull_request_target trigger will create the first instance`;
     return {
       ...header,
       commands: [],
       pendingCommands: [],
-      reason:
-        unresolvableReasons.length > 0
-          ? `no resolvable pull_request-family instance for this HEAD -- ${unresolvableReasons.join('; ')}; inspect manually`
-          : `no pull_request-family check-run instance exists yet for this HEAD (found: ${[...nonFamilyEvents].join(', ')}); nothing to refresh -- a future pull_request/pull_request_target trigger will create the first instance`,
+      reason,
       unresolvedInstanceCount: unresolvableReasons.length,
     };
   }
@@ -1188,6 +1229,10 @@ export function computeRefreshLatestPlan(
     unresolvableReasons.length > 0
       ? ` (skipped ${unresolvableReasons.length} unresolvable instance(s): ${unresolvableReasons.join('; ')})`
       : '';
+  const botGatedSuffix =
+    botGatedCheckRunIds.length > 0
+      ? ` (also skipped ${botGatedCheckRunIds.length} bot-gated action_required instance(s): ${botGatedCheckRunIds.join(', ')} -- rerunning them cannot clear action_required, per idd-ci.instructions.md §Rerun mechanics)`
+      : '';
 
   return {
     ...header,
@@ -1195,8 +1240,8 @@ export function computeRefreshLatestPlan(
     pendingCommands: pendingResolvedCommands,
     reason:
       pendingResolvedCommands.length > 0
-        ? `${pendingResolvedCommands.length} pull_request-family instance(s) for this HEAD are still running; rerunning a live run now would cancel it instead of refreshing it -- wait for each to reach a terminal state, then rerun it (see pendingCommands)${unresolvableSuffix}`
-        : unresolvableSuffix.trim(),
+        ? `${pendingResolvedCommands.length} pull_request-family instance(s) for this HEAD are still running; rerunning a live run now would cancel it instead of refreshing it -- wait for each to reach a terminal state, then rerun it (see pendingCommands)${unresolvableSuffix}${botGatedSuffix}`
+        : `${unresolvableSuffix}${botGatedSuffix}`.trim(),
     unresolvedInstanceCount: unresolvableReasons.length,
   };
 }
@@ -3027,7 +3072,7 @@ function waitForNewAttempt(
  * mechanism): GitHub kills the job outright at its own timeout
  * regardless of what step is running, so a caller whose own timeout is
  * shorter than this wait would never actually issue the deferred rerun
- * -- see `idd-advisory-convergence-comment.yml`'s `timeout-minutes: 35`
+ * -- see `idd-advisory-convergence-comment.yml`'s `timeout-minutes: 55`
  * (and its `idd-template/` copy) for the derivation. */
 const PENDING_RUN_POLL_TIMEOUT_MS = APPLY_POLL_TIMEOUT_MS;
 

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -956,6 +956,18 @@ export interface RefreshLatestPlan {
    * are still running (see `pendingCommands`), and/or some instances were
    * skipped as unresolvable alongside others that DID rerun. */
   reason: string;
+  /** Count of check-run instances for this HEAD skipped because their run
+   * id could not be resolved, or the underlying run lookup itself failed
+   * -- each MIGHT have been a pull_request-family instance this HEAD
+   * needed refreshed, but this function cannot tell (Codex P1, PR #2855
+   * review): a non-zero count here is a genuinely different risk than an
+   * empty `commands`/`pendingCommands` for a resolved non-family reason,
+   * since the omitted instance could be the one the required rollup is
+   * actually pinned to. The CLI's `--apply` path exits non-zero when this
+   * is non-zero, the same as a `RefreshLatestApplyResult.failed` entry,
+   * rather than reporting success while a potentially-blocking instance
+   * was never even attempted. */
+  unresolvedInstanceCount: number;
 }
 
 /**
@@ -988,6 +1000,11 @@ export function computeRefreshLatestPlan(
     prHeadSha,
     checkName,
     now,
+    // Overridden below only once `unresolvableReasons` has actually been
+    // computed; every earlier return (hold policy, no instance at all)
+    // never reaches a state where an instance could have been skipped as
+    // unresolvable.
+    unresolvedInstanceCount: 0,
   };
 
   // Honored, not bypassed (Copilot review, PR #2855): a "hold" policy is
@@ -1031,15 +1048,27 @@ export function computeRefreshLatestPlan(
   // but (Codex P1, PR #2855 review) applied per-instance, not just to a
   // single "latest" pick: one instance's unresolvable identity is
   // reported and skipped rather than aborting every OTHER instance's
-  // refresh. Deduplicated by runId: two check-run instances can briefly
-  // resolve to the same underlying workflow run (e.g. one instance's
-  // `gh api` lookup racing another's), and rerunning the same run id
-  // twice in one pass is redundant, not merely harmless.
-  const seenRunIds = new Set<string>();
+  // refresh.
   const unresolvableReasons: string[] = [];
   const nonFamilyEvents = new Set<string>();
-  const resolvedCommands: RerunPlanCommand[] = [];
-  const pendingResolvedCommands: RerunPlanCommand[] = [];
+  // Keyed by runId, not deduplicated away (Copilot, PR #2855 review,
+  // round 6): two check-run instances can briefly resolve to the same
+  // underlying workflow run (e.g. one instance's `gh api` lookup racing
+  // another's), and rerunning the same run id twice in one pass is
+  // redundant, not merely harmless -- but silently DROPPING the
+  // duplicate's own check-run id broke `RerunPlanCommand.checkRunIds`'s
+  // own documented contract ("every check-run id that contributed to
+  // this run id"). A duplicate's checkRunId is merged into the
+  // already-tracked command instead, keeping the earliest known
+  // `startedAt` between the two (matches this function's own
+  // newest-first sort semantics: an unknown/empty startedAt already
+  // sorts last, so preferring the known, earlier value is the more
+  // informative choice when a later-fetched duplicate turns out to have
+  // a smaller or missing startedAt).
+  const commandsByRunId = new Map<
+    string,
+    { command: RerunPlanCommand; pending: boolean }
+  >();
   for (const instance of allInstances) {
     if (instance.runId === null) {
       unresolvableReasons.push(
@@ -1063,10 +1092,20 @@ export function computeRefreshLatestPlan(
       nonFamilyEvents.add(resolvedRunEvent || '(unknown)');
       continue;
     }
-    if (seenRunIds.has(instance.runId)) {
+
+    const existing = commandsByRunId.get(instance.runId);
+    if (existing) {
+      existing.command.checkRunIds.push(instance.checkRunId);
+      const instanceStartedAt = instance.startedAt ?? '';
+      if (
+        instanceStartedAt &&
+        (!existing.command.startedAt ||
+          instanceStartedAt < existing.command.startedAt)
+      ) {
+        existing.command.startedAt = instanceStartedAt;
+      }
       continue;
     }
-    seenRunIds.add(instance.runId);
 
     const status = String(instance.status ?? '')
       .trim()
@@ -1089,12 +1128,19 @@ export function computeRefreshLatestPlan(
     // review landed, and nothing else is guaranteed to trigger a fresh
     // evaluation afterward. `pendingCommands` carries the same resolved
     // command for the caller to rerun ONCE this run reaches a terminal
-    // state, rather than declining to act on it at all.
-    if (!conclusion && PENDING_STATUSES.has(status)) {
-      pendingResolvedCommands.push(resolvedCommand);
-    } else {
-      resolvedCommands.push(resolvedCommand);
-    }
+    // state, rather than declining to act on it at all. Classified once,
+    // from the FIRST instance seen for this runId -- a duplicate sharing
+    // the identical runId shares the identical underlying workflow run,
+    // so its own status/conclusion cannot meaningfully disagree.
+    commandsByRunId.set(instance.runId, {
+      command: resolvedCommand,
+      pending: !conclusion && PENDING_STATUSES.has(status),
+    });
+  }
+  const resolvedCommands: RerunPlanCommand[] = [];
+  const pendingResolvedCommands: RerunPlanCommand[] = [];
+  for (const { command, pending } of commandsByRunId.values()) {
+    (pending ? pendingResolvedCommands : resolvedCommands).push(command);
   }
 
   // Newest-`startedAt` first (unknown/empty sorts LAST) purely for a
@@ -1134,6 +1180,7 @@ export function computeRefreshLatestPlan(
         unresolvableReasons.length > 0
           ? `no resolvable pull_request-family instance for this HEAD -- ${unresolvableReasons.join('; ')}; inspect manually`
           : `no pull_request-family check-run instance exists yet for this HEAD (found: ${[...nonFamilyEvents].join(', ')}); nothing to refresh -- a future pull_request/pull_request_target trigger will create the first instance`,
+      unresolvedInstanceCount: unresolvableReasons.length,
     };
   }
 
@@ -1150,6 +1197,7 @@ export function computeRefreshLatestPlan(
       pendingResolvedCommands.length > 0
         ? `${pendingResolvedCommands.length} pull_request-family instance(s) for this HEAD are still running; rerunning a live run now would cancel it instead of refreshing it -- wait for each to reach a terminal state, then rerun it (see pendingCommands)${unresolvableSuffix}`
         : unresolvableSuffix.trim(),
+    unresolvedInstanceCount: unresolvableReasons.length,
   };
 }
 
@@ -3232,6 +3280,7 @@ if (import.meta.main) {
     // Same stdout/stderr split as the ordinary plan below: JSON only on
     // stdout, human-readable summary on stderr.
     process.stdout.write(`${JSON.stringify(refreshLatestPlan, null, 2)}\n`);
+    let applyFailedCount = 0;
     if (
       refreshLatestPlan.commands.length === 0 &&
       refreshLatestPlan.pendingCommands.length === 0
@@ -3281,23 +3330,30 @@ if (import.meta.main) {
         // `planCaveat` already documents why a rerun burst must stay
         // serialized rather than racing multiple `gh run rerun` calls
         // against the same PR's shared concurrency group.
-        //
-        // A non-empty `failed` means at least one independent instance
-        // for this HEAD was NOT refreshed despite --apply having run
-        // (CodeRabbit, PR #2855 review) -- exit non-zero so the
-        // companion job surfaces that instead of reporting green while
-        // the required gate may still be stuck. Deliberately NOT the
-        // same convention as the ordinary --apply path below (which
-        // always exits 0, even when its own budget is exhausted
-        // unresolved): that path's "not yet resolved" is an expected,
-        // bounded policy limit with its own recovery text, whereas a
-        // `failed` entry here is an actual thrown error (network/gh
-        // failure, or a wait timeout) on an otherwise-independent
-        // instance -- a different, more actionable severity.
-        if (refreshResult.failed.length > 0) {
-          process.exitCode = 1;
-        }
+        applyFailedCount = refreshResult.failed.length;
       }
+    }
+    // A non-empty `failed`, or a non-zero `unresolvedInstanceCount`, both
+    // mean at least one instance for this HEAD was NOT refreshed despite
+    // --apply having run (CodeRabbit + Codex P1, PR #2855 review) --
+    // exit non-zero so the companion job surfaces that instead of
+    // reporting green while the required gate may still be stuck. Checked
+    // unconditionally here, not only inside the `else` branch above: an
+    // unresolved instance can be the ONLY instance for this HEAD, in
+    // which case `commands`/`pendingCommands` are both empty and the
+    // apply block above never even runs -- that must fail closed too,
+    // not silently report success on a plan with nothing left to try.
+    // Deliberately NOT the same convention as the ordinary --apply path
+    // below (which always exits 0, even when its own budget is exhausted
+    // unresolved): that path's "not yet resolved" is an expected,
+    // bounded policy limit with its own recovery text, whereas either
+    // condition here is a genuine risk that the instance actually
+    // controlling the required rollup was never attempted.
+    if (
+      args.apply &&
+      (applyFailedCount > 0 || refreshLatestPlan.unresolvedInstanceCount > 0)
+    ) {
+      process.exitCode = 1;
     }
   } else if (plan) {
     // stdout carries ONLY the JSON document -- nothing else -- so the

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -1108,11 +1108,29 @@ export function computeRefreshLatestPlan(
     const resolvedRunEvent = String(instance.runEvent ?? '')
       .trim()
       .toLowerCase();
+    if (!resolvedRunEvent) {
+      // Fail closed (Copilot, PR #2855 review, "previously missed"): the
+      // run id resolved and its lookup succeeded (both checked above), but
+      // the run's own `event` field still came back empty/unset -- a
+      // genuinely UNKNOWN triggering event, not a genuinely DIFFERENT,
+      // identified one. Treating this the same as the `nonFamilyEvents`
+      // case below would silently drop the sole instance for a HEAD into
+      // "nothing has triggered yet", the exact false reassurance the
+      // doc comment above this loop already guards against for the
+      // runId/runLookupFailed cases -- this closes the same gap for a
+      // resolved-but-unlabeled run. Mirrors classifyInstance step 6's
+      // "unknown triggering event => unresolved/inspect manually" for the
+      // ordinary --apply path.
+      unresolvableReasons.push(
+        `check-run ${instance.checkRunId} resolved to run id ${instance.runId} but its triggering event could not be determined`,
+      );
+      continue;
+    }
     if (!PULL_REQUEST_FAMILY_EVENTS.has(resolvedRunEvent)) {
       // Resolved, but genuinely a different (non-family) trigger for
       // this same check-run name -- not ours to touch, and not
       // unresolvable either.
-      nonFamilyEvents.add(resolvedRunEvent || '(unknown)');
+      nonFamilyEvents.add(resolvedRunEvent);
       continue;
     }
 

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -2894,16 +2894,20 @@ function waitForNewAttempt(
 }
 
 /** Safety bound: {@link waitForRunCompletion} fails closed (throws)
- * instead of polling forever when a still-running instance never
- * reaches a terminal state within this window. Shorter than {@link
- * APPLY_POLL_TIMEOUT_MS} (which waits for a NEW attempt after `gh run
- * rerun` already started one) -- this instead waits for the ORIGINAL,
- * already-in-flight run this helper never touched, so a bound comfortably
- * inside the companion workflow's own job `timeout-minutes: 10` (see
- * `idd-advisory-convergence-comment.yml`) matters more here: a wait that
- * outlives the job's own timeout would be silently killed with no
- * visible error, defeating the throw-on-timeout contract entirely. */
-const PENDING_RUN_POLL_TIMEOUT_MS = 5 * 60_000;
+ * instead of polling forever when a still-running instance never reaches
+ * a terminal state within this window. Reuses {@link APPLY_POLL_TIMEOUT_MS}
+ * (15 minutes) rather than a shorter bound of its own (Codex P1, PR #2855
+ * review, correcting this constant's own prior reasoning): the run being
+ * waited on is the REQUIRED gate job, whose own `timeout-minutes: 10` (see
+ * `idd-advisory-convergence.yml`) already exceeds any bound shorter than
+ * 10 minutes -- a wait that gives up before the gate's own allowed
+ * lifetime elapses would misreport a still-legitimately-running gate as
+ * stuck. The companion workflow's OWN `timeout-minutes: 10` being
+ * smaller than either of this file's two internal wait budgets is a
+ * pre-existing property of `waitForNewAttempt`/`rerunAndWait` this
+ * function does not change -- GitHub's own job timeout is the backstop
+ * in that case, not this function's throw. */
+const PENDING_RUN_POLL_TIMEOUT_MS = APPLY_POLL_TIMEOUT_MS;
 
 /**
  * Blocks until `runId` (within `owner`/`repo`) reports
@@ -3057,12 +3061,44 @@ if (import.meta.main) {
           repo,
           refreshLatestPlan.pendingCommand.runId,
         );
-        buildProductionApplyDeps(args).rerunAndWait(
-          refreshLatestPlan.pendingCommand,
-        );
-        process.stderr.write(
-          `\n--refresh-latest --apply: executed ${refreshLatestPlan.pendingCommand.command} after it reached a terminal state.\n`,
-        );
+        // Re-check the PR's current HEAD before firing the deferred
+        // rerun (Codex P1, PR #2855 review): the wait above can take
+        // several minutes, during which the PR can advance to a new
+        // HEAD. `gh run rerun` on the captured (now-stale) run would
+        // still fire -- and the required gate's own concurrency group
+        // has `cancel-in-progress: true` keyed by PR number alone, so
+        // that stale rerun could CANCEL a legitimate, already-running
+        // gate instance for the new HEAD, leaving it without a passing
+        // required check and no guaranteed later refresh. Abort instead
+        // of recomputing the whole plan: a HEAD change means a fresh
+        // pull_request/pull_request_target trigger already fired for
+        // the new HEAD on its own, independent of this deferred rerun.
+        const currentHeadSha = ghText(
+          [
+            'pr',
+            'view',
+            String(args.prNumber),
+            '-R',
+            `${owner}/${repo}`,
+            '--json',
+            'headRefOid',
+            '--jq',
+            '.headRefOid',
+          ],
+          GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+        ).toLowerCase();
+        if (currentHeadSha !== refreshLatestPlan.prHeadSha) {
+          process.stderr.write(
+            `\n--refresh-latest --apply: the PR HEAD moved from ${refreshLatestPlan.prHeadSha} to ${currentHeadSha} while waiting for the pending run to complete -- skipping the now-stale rerun (a fresh trigger already fired for the new HEAD).\n`,
+          );
+        } else {
+          buildProductionApplyDeps(args).rerunAndWait(
+            refreshLatestPlan.pendingCommand,
+          );
+          process.stderr.write(
+            `\n--refresh-latest --apply: executed ${refreshLatestPlan.pendingCommand.command} after it reached a terminal state.\n`,
+          );
+        }
       }
     } else {
       process.stderr.write(`\n${refreshLatestPlan.reason}\n`);

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -897,6 +897,14 @@ export function computeRerunPlan(
  * path, and every existing test/invariant built around its budget, stays
  * completely unchanged; only the companion workflow's
  * `pull_request_review` step opts into this mode.
+ *
+ * One classification IS still honored, not bypassed (Copilot review,
+ * PR #2855): the resolved `ciWait.rerunPolicy`. A repository that
+ * explicitly opted out of every automatic rerun (`"hold"`) must stay
+ * opted out here too -- bypassing pass/bot-gated/budget classification is
+ * about restoring a fresh-evaluation guarantee, never about overriding a
+ * repository's own explicit no-automatic-reruns policy. See
+ * `computeRefreshLatestPlan`'s own hold check below.
  */
 export interface RefreshLatestPlan {
   protocolVersion: '1';
@@ -907,9 +915,10 @@ export interface RefreshLatestPlan {
   /** The single instance selected for an unconditional rerun, or `null`
    * when there is nothing safe/useful to rerun -- see `reason`. */
   command: RerunPlanCommand | null;
-  /** Empty when `command` is set; otherwise explains why (no
-   * pull_request-family instance exists yet for this HEAD, the latest one
-   * is still running, or its underlying run id could not be resolved). */
+  /** Empty when `command` is set; otherwise explains why (a `"hold"`
+   * rerunPolicy, no pull_request-family instance exists yet for this
+   * HEAD, the latest one is still running, or its underlying run id
+   * could not be resolved). */
   reason: string;
 }
 
@@ -921,7 +930,7 @@ export interface RefreshLatestPlan {
  */
 export function computeRefreshLatestPlan(
   input: RerunPlanInput,
-  options: Pick<RerunPlanOptions, 'now'>,
+  options: Pick<RerunPlanOptions, 'now' | 'rerunPolicy'>,
 ): RefreshLatestPlan {
   const now = String(options.now ?? '');
   if (!isValidIsoTimestamp(now)) {
@@ -944,6 +953,21 @@ export function computeRefreshLatestPlan(
     checkName,
     now,
   };
+
+  // Honored, not bypassed (Copilot review, PR #2855): a "hold" policy is
+  // a repository's explicit opt-out of every automatic rerun, checked
+  // before instance selection so it can never be reached even
+  // incidentally -- see this function's own doc comment above.
+  const rerunPolicy =
+    String(options.rerunPolicy ?? '').trim() === 'hold' ? 'hold' : 'rerun-once';
+  if (rerunPolicy === 'hold') {
+    return {
+      ...header,
+      command: null,
+      reason:
+        'ciWait.rerunPolicy is "hold": this repository has opted out of automatic reruns, including --refresh-latest -- a maintainer must manually decide (see idd-ci.instructions.md §Rerun mechanics)',
+    };
+  }
 
   const familyInstances = (input.instances ?? []).filter((instance) =>
     PULL_REQUEST_FAMILY_EVENTS.has(
@@ -1997,15 +2021,19 @@ this HEAD started most recently, and is it safe to rerun unconditionally
 right now? Unlike the default mode, it does NOT classify pass /
 bot-gated-skip / rerun-budget-held -- it reruns the latest instance
 regardless of any of those, UNLESS that instance is still running (which
-would cancel it) or its run id could not be resolved. Intended only for
-the narrow #2764 Phase 1 case where a fresh pull_request_review submission
-must get a fresh evaluation even if the gate is already green or its
-rerun-once budget is already spent -- see the RefreshLatestPlan doc
-comment in the .mts source. With --apply, executes that single rerun (via
-the same "gh run rerun" mechanism as the default --apply path) instead of
-only printing it. Mutually exclusive in effect with the default plan
-computation: when given, --refresh-latest's own JSON document replaces
-the ordinary plan document on stdout.
+would cancel it) or its run id could not be resolved. It still honors
+ciWait.rerunPolicy, though: a "hold" policy returns no command here
+either, the same as the default mode -- bypassing pass/bot-gated/budget
+classification is not license to override a repository's own explicit
+no-automatic-reruns policy. Intended only for the narrow #2764 Phase 1
+case where a fresh pull_request_review submission must get a fresh
+evaluation even if the gate is already green or its rerun-once budget is
+already spent -- see the RefreshLatestPlan doc comment in the .mts
+source. With --apply, executes that single rerun (via the same "gh run
+rerun" mechanism as the default --apply path) instead of only printing
+it. Mutually exclusive in effect with the default plan computation: when
+given, --refresh-latest's own JSON document replaces the ordinary plan
+document on stdout.
 
 Honors the inspected repository's configured ciWait.rerunPolicy: when
 it is "hold", both the rerun plan and the recovery-refresh plan stay

--- a/tests/advisory-convergence-comment-workflow.test.mts
+++ b/tests/advisory-convergence-comment-workflow.test.mts
@@ -267,3 +267,97 @@ test('comment-refresh workflows debounce the rerun call and preserve cancel-in-p
     );
   }
 });
+
+// Codex P1 review, PR #2855: a review superseded by debounce would
+// silently downgrade to whatever a later comment-triggered run does
+// (plain `--apply`, never `--refresh-latest`), which could leave an
+// already-green gate green even though the review added new blocking
+// findings. `pull_request_review` must bypass debounce entirely, not
+// merely be exempted from the origin-classification half of the gate.
+test('comment-refresh workflows never let debounce suppress a pull_request_review rerun', () => {
+  for (const path of COMMENT_PATHS) {
+    const text = readWorkflow(path);
+    const debounceIndex = text.indexOf(
+      '- name: Check for newer qualifying event',
+    );
+    const rerunIndex = text.indexOf('- name: Rerun required HEAD check');
+    assert.ok(debounceIndex !== -1 && rerunIndex !== -1);
+
+    const debounceStepText = text.slice(debounceIndex, rerunIndex);
+    const debounceIfLine = debounceStepText
+      .split('\n')
+      .find((line) => line.trim().startsWith('if:'));
+    assert.ok(
+      debounceIfLine,
+      `${path} debounce step must have an if: condition`,
+    );
+    assert.doesNotMatch(
+      debounceIfLine as string,
+      /pull_request_review/,
+      `${path} debounce step's if: must not run for pull_request_review -- its skip output must never be consulted for a review`,
+    );
+
+    const rerunStepText = text.slice(
+      rerunIndex,
+      text.indexOf('\n      - name:', rerunIndex + 1) === -1
+        ? undefined
+        : text.indexOf('\n      - name:', rerunIndex + 1),
+    );
+    const rerunIfLine = rerunStepText
+      .split('\n')
+      .find((line) => line.trim().startsWith('if:'));
+    assert.ok(rerunIfLine, `${path} rerun step must have an if: condition`);
+    // The pull_request_review disjunct must stand on its own, never
+    // conjoined with `steps.debounce.outputs.skip` -- a regex anchored on
+    // "pull_request_review' &&...debounce" (in either operand order)
+    // would indicate the bypass regressed back to being debounce-gated.
+    assert.doesNotMatch(
+      rerunIfLine as string,
+      /pull_request_review'\s*&&[^|]*debounce/,
+      `${path} rerun step's pull_request_review branch must not be gated by debounce.outputs.skip`,
+    );
+    assert.doesNotMatch(
+      rerunIfLine as string,
+      /debounce\.outputs\.skip[^|]*&&[^)]*pull_request_review/,
+      `${path} rerun step's pull_request_review branch must not be gated by debounce.outputs.skip`,
+    );
+  }
+});
+
+// CodeRabbit review, PR #2855: idd-template's helper-runtime profile
+// guard ("Classify review comment" step's own if:) must still apply to
+// the debounce and rerun steps even though pull_request_review bypasses
+// origin classification -- an instructions-only install has no helper
+// runtime to execute either step's run: case statement with, regardless
+// of which trigger family reaches it.
+test('idd-template comment-refresh workflow keeps the profile/manager guard on debounce and rerun steps', () => {
+  const path =
+    'idd-template/.github/workflows/idd-advisory-convergence-comment.yml';
+  const text = readWorkflow(path);
+  const debounceIndex = text.indexOf(
+    '- name: Check for newer qualifying event',
+  );
+  const rerunIndex = text.indexOf('- name: Rerun required HEAD check');
+  assert.ok(debounceIndex !== -1 && rerunIndex !== -1);
+
+  const rerunStepText = text.slice(
+    rerunIndex,
+    text.indexOf('\n      - name:', rerunIndex + 1) === -1
+      ? undefined
+      : text.indexOf('\n      - name:', rerunIndex + 1),
+  );
+  const rerunIfLine = rerunStepText
+    .split('\n')
+    .find((line) => line.trim().startsWith('if:'));
+  assert.ok(rerunIfLine, `${path} rerun step must have an if: condition`);
+  assert.match(
+    rerunIfLine as string,
+    /steps\.profile\.outputs\.profile\s*!=\s*'instructions-only'/,
+    `${path} rerun step's if: must still exclude instructions-only`,
+  );
+  assert.match(
+    rerunIfLine as string,
+    /steps\.manager\.outputs\.manager\s*!=\s*'ambiguous'/,
+    `${path} rerun step's if: must still exclude an ambiguous package manager`,
+  );
+});

--- a/tests/advisory-convergence-comment-workflow.test.mts
+++ b/tests/advisory-convergence-comment-workflow.test.mts
@@ -268,6 +268,51 @@ test('comment-refresh workflows debounce the rerun call and preserve cancel-in-p
   }
 });
 
+// Codex P1 review, PR #2855, round 9: GitHub Actions implicitly prepends
+// `success()` to a step's own if: UNLESS the expression itself already
+// calls one of success()/failure()/always() -- so without an explicit
+// call, a failure in the preceding "Classify review comment" step (its
+// own review-comment-origin.mjs throwing) would silently skip this
+// ENTIRE step, defeating the pull_request_review disjunct's own "always
+// proceeds regardless of debounce" guarantee for the exact trigger that
+// guarantee exists to protect.
+test('comment-refresh workflows call success() explicitly so a classifier failure cannot silently skip a pull_request_review rerun', () => {
+  for (const path of COMMENT_PATHS) {
+    const text = readWorkflow(path);
+    const rerunIndex = text.indexOf('- name: Rerun required HEAD check');
+    assert.notEqual(rerunIndex, -1);
+    const rerunStepText = text.slice(
+      rerunIndex,
+      text.indexOf('\n      - name:', rerunIndex + 1) === -1
+        ? undefined
+        : text.indexOf('\n      - name:', rerunIndex + 1),
+    );
+    const ifLine = rerunStepText
+      .split('\n')
+      .find((line) => line.trim().startsWith('if:')) as string;
+    assert.ok(ifLine, `${path} rerun step must have an if: condition`);
+    assert.match(
+      ifLine,
+      /success\(\)/,
+      `${path} rerun step's if: must call success() explicitly to suppress GitHub's implicit prepend`,
+    );
+    // The pull_request_review disjunct itself must stay outside any
+    // success() gating -- a regex anchored on "pull_request_review' &&
+    // success()" (either operand order) would indicate success() ended
+    // up gating the review branch instead of only the comment branch.
+    assert.doesNotMatch(
+      ifLine,
+      /pull_request_review'\s*&&\s*success\(\)/,
+      `${path} rerun step's pull_request_review branch must not itself be gated by success()`,
+    );
+    assert.doesNotMatch(
+      ifLine,
+      /success\(\)\s*&&\s*\(?\s*github\.event_name\s*==\s*'pull_request_review'/,
+      `${path} rerun step's pull_request_review branch must not itself be gated by success()`,
+    );
+  }
+});
+
 // Codex P1 review, PR #2855: a review superseded by debounce would
 // silently downgrade to whatever a later comment-triggered run does
 // (plain `--apply`, never `--refresh-latest`), which could leave an

--- a/tests/advisory-convergence-comment-workflow.test.mts
+++ b/tests/advisory-convergence-comment-workflow.test.mts
@@ -291,10 +291,16 @@ test('comment-refresh workflows never let debounce suppress a pull_request_revie
       debounceIfLine,
       `${path} debounce step must have an if: condition`,
     );
-    assert.doesNotMatch(
+    // Copilot + Codex P1 review, PR #2855: merely not MENTIONING
+    // pull_request_review is not enough -- a review body that happens to
+    // classify as IDD-originated (it is fed through the same classifier
+    // as a comment) would otherwise still satisfy
+    // `idd_originated == 'true'` and run this step for a review anyway.
+    // The exclusion must be explicit and load-bearing, not incidental.
+    assert.match(
       debounceIfLine as string,
-      /pull_request_review/,
-      `${path} debounce step's if: must not run for pull_request_review -- its skip output must never be consulted for a review`,
+      /github\.event_name\s*!=\s*'pull_request_review'/,
+      `${path} debounce step's if: must explicitly exclude pull_request_review, not merely omit mentioning it`,
     );
 
     const rerunStepText = text.slice(

--- a/tests/advisory-convergence-comment-workflow.test.mts
+++ b/tests/advisory-convergence-comment-workflow.test.mts
@@ -49,7 +49,40 @@ test('required advisory-convergence workflows no longer trigger on review commen
       `${path} on: must not include issue_comment`,
     );
     assert.match(onBlock, /pull_request:/);
-    assert.match(onBlock, /pull_request_review:/);
+  }
+});
+
+// #2764 Phase 1: pull_request_review moved to the companion workflow (a
+// PR-edited copy of this file could otherwise control when its own
+// required check re-asserts); pull_request_target was added alongside
+// the existing pull_request trigger so the implementing PR itself stays
+// normally mergeable (pull_request_target cannot fire against its own
+// defining PR -- verification of its attachment is deferred to the
+// first PR opened after this change merges).
+test('required advisory-convergence workflows moved pull_request_review to pull_request_target', () => {
+  for (const path of REQUIRED_PATHS) {
+    const text = readWorkflow(path);
+    const onBlock = text.slice(
+      text.indexOf('\non:'),
+      text.indexOf('\npermissions:'),
+    );
+    assert.doesNotMatch(
+      onBlock,
+      /(?<!_)pull_request_review:/,
+      `${path} on: must not include pull_request_review (moved to the companion workflow)`,
+    );
+    assert.match(
+      onBlock,
+      /pull_request_target:/,
+      `${path} on: must include pull_request_target`,
+    );
+    // Still checks out only the trusted default branch, for every
+    // trigger including the new one -- see the module-header rationale.
+    assert.match(
+      text,
+      /ref:\s*main/,
+      `${path} checkout must stay pinned to ref: main`,
+    );
   }
 });
 
@@ -113,6 +146,50 @@ test('comment-refresh workflows also trigger on issue_comment and guard non-PR i
       prNumberAssignment[1],
       /github\.event\.pull_request\.number\s*\|\|\s*github\.event\.issue\.number/,
       `${path} PR_NUMBER must resolve from either event shape`,
+    );
+  }
+});
+
+// #2764 Phase 1: pull_request_review submissions now refresh the gate
+// through this companion instead of running a PR-controlled copy of the
+// gate workflow directly.
+test('comment-refresh workflows now trigger on pull_request_review submissions', () => {
+  for (const path of COMMENT_PATHS) {
+    const text = readWorkflow(path);
+    const onBlock = text.slice(
+      text.indexOf('\non:'),
+      text.indexOf('\npermissions:'),
+    );
+    assert.match(
+      onBlock,
+      /pull_request_review:/,
+      `${path} on: must include pull_request_review`,
+    );
+    // The rerun/debounce steps' if: conditions must OR in the review
+    // trigger explicitly, not rely on content classification -- a
+    // review's own body is not filtered through the IDD-origin marker
+    // check the way a comment's is (#2764 review floor: silently
+    // routing review events through unchanged idd_originated-only
+    // conditions would never actually rerun the gate on a review).
+    const rerunIndex = text.indexOf('- name: Rerun required HEAD check');
+    assert.notEqual(rerunIndex, -1);
+    const rerunStepText = text.slice(
+      rerunIndex,
+      text.indexOf('\n      - name:', rerunIndex + 1) === -1
+        ? undefined
+        : text.indexOf('\n      - name:', rerunIndex + 1),
+    );
+    const ifLine = rerunStepText
+      .split('\n')
+      .find((line) => line.trim().startsWith('if:'));
+    assert.ok(
+      ifLine,
+      `${path} Rerun required HEAD check step must have an if:`,
+    );
+    assert.match(
+      ifLine as string,
+      /github\.event_name\s*==\s*'pull_request_review'/,
+      `${path} rerun step's if: must OR in pull_request_review explicitly`,
     );
   }
 });

--- a/tests/advisory-convergence-comment-workflow.test.mts
+++ b/tests/advisory-convergence-comment-workflow.test.mts
@@ -59,7 +59,7 @@ test('required advisory-convergence workflows no longer trigger on review commen
 // normally mergeable (pull_request_target cannot fire against its own
 // defining PR -- verification of its attachment is deferred to the
 // first PR opened after this change merges).
-test('required advisory-convergence workflows moved pull_request_review to pull_request_target', () => {
+test('required advisory-convergence workflows add pull_request_target and drop pull_request_review', () => {
   for (const path of REQUIRED_PATHS) {
     const text = readWorkflow(path);
     const onBlock = text.slice(

--- a/tests/rerun-advisory-convergence.test.mts
+++ b/tests/rerun-advisory-convergence.test.mts
@@ -2809,11 +2809,20 @@ test('computeRefreshLatestPlan: selects the most-recently-started pull_request-f
   assert.deepEqual(plan.command?.checkRunIds, ['1002']);
 });
 
-test('computeRefreshLatestPlan: a still-running latest instance is left alone (never cancelled)', () => {
+// Codex P1 review, PR #2855: a still-running instance is NOT the same as
+// "will already reflect this review" -- its own evidence was fetched at
+// whatever point during its execution the live query happened to run,
+// which can be before this review landed. `pendingCommand` carries the
+// resolved rerun for the caller to issue once the run actually completes
+// (see the CLI's --refresh-latest --apply wiring), rather than declining
+// to act at all.
+test('computeRefreshLatestPlan: a still-running latest instance is left alone (never cancelled), but its rerun is deferred via pendingCommand', () => {
   const plan = computeRefreshLatestPlan(
     baseInput({
       instances: [
         baseInstance({
+          checkRunId: '1001',
+          runId: '5001',
           status: 'in_progress',
           conclusion: null,
         }),
@@ -2823,6 +2832,44 @@ test('computeRefreshLatestPlan: a still-running latest instance is left alone (n
   );
   assert.equal(plan.command, null);
   assert.match(plan.reason, /still running/);
+  assert.doesNotMatch(
+    plan.reason,
+    /it will already reflect this review/,
+    'the reason must not assert the very claim the still-running instance cannot guarantee',
+  );
+  assert.equal(plan.pendingCommand?.runId, '5001');
+  assert.equal(plan.pendingCommand?.command, 'gh run rerun 5001');
+});
+
+test('computeRefreshLatestPlan: pendingCommand is null whenever command is resolved', () => {
+  const plan = computeRefreshLatestPlan(
+    baseInput({
+      instances: [baseInstance({ conclusion: 'success' })],
+    }),
+    baseOptions(),
+  );
+  assert.notEqual(plan.command, null);
+  assert.equal(plan.pendingCommand, null);
+});
+
+test('computeRefreshLatestPlan: pendingCommand is null for every no-op reason (hold policy, no instance, unresolvable run id)', () => {
+  const held = computeRefreshLatestPlan(
+    baseInput({ instances: [baseInstance({ conclusion: 'success' })] }),
+    baseOptions({ rerunPolicy: 'hold' }),
+  );
+  assert.equal(held.pendingCommand, null);
+
+  const noInstance = computeRefreshLatestPlan(
+    baseInput({ instances: [baseInstance({ runEvent: 'workflow_dispatch' })] }),
+    baseOptions(),
+  );
+  assert.equal(noInstance.pendingCommand, null);
+
+  const unresolvable = computeRefreshLatestPlan(
+    baseInput({ instances: [baseInstance({ runId: null })] }),
+    baseOptions(),
+  );
+  assert.equal(unresolvable.pendingCommand, null);
 });
 
 test('computeRefreshLatestPlan: fails closed on an unresolvable run id', () => {

--- a/tests/rerun-advisory-convergence.test.mts
+++ b/tests/rerun-advisory-convergence.test.mts
@@ -3056,6 +3056,113 @@ test('computeRefreshLatestPlan: two instances sharing a runId merge into one com
   assert.equal(plan.commands[0]?.startedAt, '2026-07-16T10:00:00Z');
 });
 
+// Codex P1 review, PR #2855, round 8: two check-run rows sharing a runId
+// are not guaranteed to report the identical status -- this file's own
+// #1381 precedent establishes a stale row can coexist with a fresher one
+// for the same underlying run. If the first-seen row happened to be
+// COMPLETED while a later-seen row for the identical runId is still
+// IN_PROGRESS, classifying by the first row alone would rerun a live run
+// instead of waiting for it.
+test('computeRefreshLatestPlan: a pending row wins when it shares a runId with an already-seen terminal row', () => {
+  const plan = computeRefreshLatestPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          checkRunId: '1001',
+          runId: '5001',
+          status: 'completed',
+          conclusion: 'success',
+        }),
+        baseInstance({
+          checkRunId: '1002',
+          runId: '5001',
+          status: 'in_progress',
+          conclusion: null,
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.deepEqual(plan.commands, []);
+  assert.equal(plan.pendingCommands.length, 1);
+  assert.deepEqual(plan.pendingCommands[0]?.checkRunIds, ['1001', '1002']);
+});
+
+test('computeRefreshLatestPlan: a pending row wins regardless of which order the two rows are seen in', () => {
+  const plan = computeRefreshLatestPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          checkRunId: '1001',
+          runId: '5001',
+          status: 'in_progress',
+          conclusion: null,
+        }),
+        baseInstance({
+          checkRunId: '1002',
+          runId: '5001',
+          status: 'completed',
+          conclusion: 'success',
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.deepEqual(plan.commands, []);
+  assert.equal(plan.pendingCommands.length, 1);
+});
+
+// Codex P1 review, PR #2855, round 8: idd-ci.instructions.md documents
+// that rerunning an action_required-conclusion instance preserves the
+// original bot actor's privileges and simply re-enters action_required --
+// classifyInstance already excludes it as bot-gated-skip, but
+// --refresh-latest's "rerun everything" bypass had not been narrowed to
+// exclude it too.
+test('computeRefreshLatestPlan: excludes a bot-gated action_required instance from both commands and pendingCommands', () => {
+  const plan = computeRefreshLatestPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          checkRunId: '1001',
+          runId: '5001',
+          conclusion: 'action_required',
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.deepEqual(plan.commands, []);
+  assert.deepEqual(plan.pendingCommands, []);
+  assert.match(plan.reason, /bot-gated \(action_required/);
+  assert.match(plan.reason, /check-run\(s\) 1001/);
+  // Bot-gating is a known, documented case -- not an unresolvable one.
+  assert.equal(plan.unresolvedInstanceCount, 0);
+});
+
+test('computeRefreshLatestPlan: a bot-gated instance does not block a resolvable sibling', () => {
+  const plan = computeRefreshLatestPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          checkRunId: '1001',
+          runId: '5001',
+          conclusion: 'action_required',
+        }),
+        baseInstance({
+          checkRunId: '1002',
+          runId: '5002',
+          runEvent: 'pull_request_target',
+          conclusion: 'success',
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.equal(plan.commands.length, 1);
+  assert.equal(plan.commands[0]?.runId, '5002');
+  assert.match(plan.reason, /bot-gated action_required instance/);
+});
+
 // Copilot review (PR #2855, round 5, "previously missed"): an instance
 // whose run id is unresolvable (or whose run lookup failed) carries
 // `runEvent: null` in production (see `collectFromGitHub`'s enrichment --

--- a/tests/rerun-advisory-convergence.test.mts
+++ b/tests/rerun-advisory-convergence.test.mts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import {
+  applyRefreshLatestPlan,
   applyRerunPlan,
   buildCheckRunsForRefArgs,
   buildRerunPlanTextSections,
@@ -2993,6 +2994,168 @@ test('computeRefreshLatestPlan: -R owner/repo is embedded in every generated com
     plan.commands[0]?.command,
     'gh run rerun 5001 -R kurone-kito/idd-skill',
   );
+});
+
+// --- applyRefreshLatestPlan (CodeRabbit, PR #2855 review) ------------------
+//
+// computeRefreshLatestPlan's `commands`/`pendingCommands` are INDEPENDENT
+// instances (typically `pull_request` and `pull_request_target` under
+// #2764 Phase 1): one instance's wait/rerun failing must not prevent the
+// OTHER instance from still being refreshed, unlike applyRerunPlan's
+// single evolving target where an uncaught error aborting the whole loop
+// is correct.
+
+function refreshLatestPlan(
+  overrides: Partial<
+    Pick<
+      ReturnType<typeof computeRefreshLatestPlan>,
+      'commands' | 'pendingCommands' | 'prHeadSha'
+    >
+  > = {},
+) {
+  return {
+    protocolVersion: '1' as const,
+    prNumber: 1431,
+    prHeadSha: HEAD,
+    checkName: RERUN_PLAN_CHECK_NAME,
+    now: NOW,
+    commands: [],
+    pendingCommands: [],
+    reason: '',
+    ...overrides,
+  };
+}
+
+test('applyRefreshLatestPlan: a thrown wait failure on one pending instance does not block the rest of the batch', () => {
+  const failing = {
+    runId: '5001',
+    command: 'gh run rerun 5001',
+    checkRunIds: ['1001'],
+    startedAt: '',
+  };
+  const okPending = {
+    runId: '5002',
+    command: 'gh run rerun 5002',
+    checkRunIds: ['1002'],
+    startedAt: '',
+  };
+  const okTerminal = {
+    runId: '5003',
+    command: 'gh run rerun 5003',
+    checkRunIds: ['1003'],
+    startedAt: '',
+  };
+  const waited: string[] = [];
+  const reran: string[] = [];
+  const result = applyRefreshLatestPlan(
+    refreshLatestPlan({
+      pendingCommands: [failing, okPending],
+      commands: [okTerminal],
+    }),
+    {
+      waitForRunCompletion: (runId) => {
+        waited.push(runId);
+        if (runId === failing.runId) {
+          throw new Error('timed out waiting for run 5001 to complete');
+        }
+      },
+      fetchCurrentHead: () => HEAD,
+      rerunAndWait: (command) => {
+        reran.push(command.runId);
+      },
+      log: () => {},
+    },
+  );
+  assert.deepEqual(waited, ['5001', '5002']);
+  assert.deepEqual(reran, ['5002', '5003']);
+  assert.deepEqual(result.executed, [okPending, okTerminal]);
+  assert.equal(result.failed.length, 1);
+  assert.equal(result.failed[0]?.command.runId, '5001');
+  assert.match(result.failed[0]?.error ?? '', /timed out waiting/);
+});
+
+test('applyRefreshLatestPlan: a rerunAndWait failure on a terminal instance is isolated the same way', () => {
+  const okTerminal = {
+    runId: '5001',
+    command: 'gh run rerun 5001',
+    checkRunIds: ['1001'],
+    startedAt: '',
+  };
+  const failingTerminal = {
+    runId: '5002',
+    command: 'gh run rerun 5002',
+    checkRunIds: ['1002'],
+    startedAt: '',
+  };
+  const result = applyRefreshLatestPlan(
+    refreshLatestPlan({ commands: [okTerminal, failingTerminal] }),
+    {
+      waitForRunCompletion: () => {},
+      fetchCurrentHead: () => HEAD,
+      rerunAndWait: (command) => {
+        if (command.runId === failingTerminal.runId) {
+          throw new Error('gh: request failed');
+        }
+      },
+      log: () => {},
+    },
+  );
+  assert.deepEqual(result.executed, [okTerminal]);
+  assert.equal(result.failed.length, 1);
+  assert.equal(result.failed[0]?.command.runId, '5002');
+  assert.match(result.failed[0]?.error ?? '', /gh: request failed/);
+});
+
+test('applyRefreshLatestPlan: skips a command whose HEAD moved, without treating it as a failure', () => {
+  const command = {
+    runId: '5001',
+    command: 'gh run rerun 5001',
+    checkRunIds: ['1001'],
+    startedAt: '',
+  };
+  const rerunCalls: string[] = [];
+  const result = applyRefreshLatestPlan(
+    refreshLatestPlan({ commands: [command] }),
+    {
+      waitForRunCompletion: () => {},
+      fetchCurrentHead: () => '2222222222222222222222222222222222222222',
+      rerunAndWait: (c) => {
+        rerunCalls.push(c.runId);
+      },
+      log: () => {},
+    },
+  );
+  assert.deepEqual(rerunCalls, []);
+  assert.deepEqual(result.executed, []);
+  assert.deepEqual(result.skippedStaleHead, [command]);
+  assert.deepEqual(result.failed, []);
+});
+
+test('applyRefreshLatestPlan: a fully successful batch has no failures and no stale skips', () => {
+  const pending = {
+    runId: '5001',
+    command: 'gh run rerun 5001',
+    checkRunIds: ['1001'],
+    startedAt: '',
+  };
+  const terminal = {
+    runId: '5002',
+    command: 'gh run rerun 5002',
+    checkRunIds: ['1002'],
+    startedAt: '',
+  };
+  const result = applyRefreshLatestPlan(
+    refreshLatestPlan({ pendingCommands: [pending], commands: [terminal] }),
+    {
+      waitForRunCompletion: () => {},
+      fetchCurrentHead: () => HEAD,
+      rerunAndWait: () => {},
+      log: () => {},
+    },
+  );
+  assert.deepEqual(result.executed, [pending, terminal]);
+  assert.deepEqual(result.skippedStaleHead, []);
+  assert.deepEqual(result.failed, []);
 });
 
 // --- runRerunAdvisoryConvergence: --refresh-latest ------------------------

--- a/tests/rerun-advisory-convergence.test.mts
+++ b/tests/rerun-advisory-convergence.test.mts
@@ -3112,6 +3112,55 @@ test('computeRefreshLatestPlan: a pending row wins regardless of which order the
   assert.equal(plan.pendingCommands.length, 1);
 });
 
+// Codex P1 review, PR #2855, round 11: a single check-run row's own
+// status/conclusion can itself be stale -- not just stale relative to a
+// SIBLING row (the pending-row-wins tests above), but stale relative to
+// the underlying workflow run's own live state, when a rerun for this
+// same runId was already issued moments earlier and its new attempt's row
+// has not propagated yet. `runStatus` (fetched from the authoritative
+// `GET .../actions/runs/{run_id}` endpoint) must win even over a present
+// terminal `conclusion` on the row itself, or the plan would re-issue
+// `gh run rerun` against a run that is, per the live workflow-run
+// endpoint, already running -- cancelling it instead of waiting for it.
+test('computeRefreshLatestPlan: a stale terminal conclusion on the only row for a runId still defers via pendingCommands when the live workflow run is running', () => {
+  const plan = computeRefreshLatestPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          checkRunId: '1001',
+          runId: '5001',
+          status: 'completed',
+          conclusion: 'failure',
+          runStatus: 'in_progress',
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.deepEqual(plan.commands, []);
+  assert.equal(plan.pendingCommands.length, 1);
+  assert.equal(plan.pendingCommands[0]?.runId, '5001');
+});
+
+test('computeRefreshLatestPlan: runStatus null (lookup unresolved or genuinely terminal) leaves the pre-existing conclusion-only classification unchanged', () => {
+  const plan = computeRefreshLatestPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          checkRunId: '1001',
+          runId: '5001',
+          status: 'completed',
+          conclusion: 'failure',
+          runStatus: null,
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.equal(plan.commands.length, 1);
+  assert.deepEqual(plan.pendingCommands, []);
+});
+
 // Codex P1 review, PR #2855, round 8: idd-ci.instructions.md documents
 // that rerunning an action_required-conclusion instance preserves the
 // original bot actor's privileges and simply re-enters action_required --

--- a/tests/rerun-advisory-convergence.test.mts
+++ b/tests/rerun-advisory-convergence.test.mts
@@ -2763,6 +2763,27 @@ test('computeRefreshLatestPlan: reruns the latest instance even when it already 
   assert.equal(plan.reason, '');
 });
 
+// Copilot review (PR #2855): --refresh-latest bypasses pass/bot-gated/
+// budget classification, but a "hold" rerunPolicy is a repository's
+// explicit opt-out of every automatic rerun, not one of those three --
+// it must still be honored here exactly as computeRerunPlan honors it.
+test('computeRefreshLatestPlan: a "hold" rerunPolicy suppresses the rerun, even for an otherwise-reruns-anyway pass instance', () => {
+  const plan = computeRefreshLatestPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          checkRunId: '1001',
+          runId: '5001',
+          conclusion: 'success',
+        }),
+      ],
+    }),
+    baseOptions({ rerunPolicy: 'hold' }),
+  );
+  assert.equal(plan.command, null);
+  assert.match(plan.reason, /ciWait\.rerunPolicy is "hold"/);
+});
+
 test('computeRefreshLatestPlan: selects the most-recently-started pull_request-family instance among several', () => {
   const plan = computeRefreshLatestPlan(
     baseInput({
@@ -2820,16 +2841,6 @@ test('computeRefreshLatestPlan: fails closed when the underlying run lookup fail
   );
   assert.equal(plan.command, null);
   assert.match(plan.reason, /could not be fetched/);
-});
-
-test('computeRefreshLatestPlan: includes -R owner/repo when both are known', () => {
-  const plan = computeRefreshLatestPlan(
-    baseInput({ owner: 'kurone-kito', repo: 'idd-skill' }),
-    baseOptions(),
-  );
-  // No instances at all here -- command stays null; this test only
-  // exercises the header fields, covered separately below.
-  assert.equal(plan.prHeadSha, HEAD);
 });
 
 test('computeRefreshLatestPlan: -R owner/repo is embedded in the generated command', () => {

--- a/tests/rerun-advisory-convergence.test.mts
+++ b/tests/rerun-advisory-convergence.test.mts
@@ -2979,6 +2979,81 @@ test('computeRefreshLatestPlan: skips an unresolvable instance without blocking 
   assert.equal(plan.commands[0]?.runId, '5002');
   assert.match(plan.reason, /skipped 1 unresolvable instance/);
   assert.match(plan.reason, /check-run 1001/);
+  assert.equal(plan.unresolvedInstanceCount, 1);
+});
+
+// Codex P1 review, PR #2855, round 6: an unresolved instance could be the
+// one the required rollup is actually pinned to -- computeRefreshLatestPlan
+// itself cannot tell, so it exposes the count structurally rather than
+// only inside the free-text `reason`, letting the CLI's --apply path fail
+// closed on it.
+test('computeRefreshLatestPlan: unresolvedInstanceCount is 0 whenever nothing was skipped as unresolvable', () => {
+  const clean = computeRefreshLatestPlan(
+    baseInput({ instances: [baseInstance({ conclusion: 'success' })] }),
+    baseOptions(),
+  );
+  assert.equal(clean.unresolvedInstanceCount, 0);
+
+  const nonFamilyOnly = computeRefreshLatestPlan(
+    baseInput({ instances: [baseInstance({ runEvent: 'workflow_dispatch' })] }),
+    baseOptions(),
+  );
+  assert.equal(nonFamilyOnly.unresolvedInstanceCount, 0);
+
+  const held = computeRefreshLatestPlan(
+    baseInput({ instances: [baseInstance({ conclusion: 'success' })] }),
+    baseOptions({ rerunPolicy: 'hold' }),
+  );
+  assert.equal(held.unresolvedInstanceCount, 0);
+});
+
+test('computeRefreshLatestPlan: unresolvedInstanceCount reflects every skipped instance when nothing resolved at all', () => {
+  const plan = computeRefreshLatestPlan(
+    baseInput({
+      instances: [
+        baseInstance({ checkRunId: '1001', runId: null }),
+        baseInstance({
+          checkRunId: '1002',
+          runId: '5002',
+          runLookupFailed: true,
+          runEvent: null,
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.deepEqual(plan.commands, []);
+  assert.equal(plan.unresolvedInstanceCount, 2);
+});
+
+// Copilot review, PR #2855, round 6: two check-run instances resolving to
+// the SAME runId must not drop the duplicate's own checkRunId --
+// RerunPlanCommand.checkRunIds is documented as "every check-run id that
+// contributed to this run id."
+test('computeRefreshLatestPlan: two instances sharing a runId merge into one command with both checkRunIds', () => {
+  const plan = computeRefreshLatestPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          checkRunId: '1001',
+          runId: '5001',
+          startedAt: '2026-07-16T10:05:00Z',
+          conclusion: 'success',
+        }),
+        baseInstance({
+          checkRunId: '1002',
+          runId: '5001',
+          startedAt: '2026-07-16T10:00:00Z',
+          conclusion: 'success',
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.equal(plan.commands.length, 1);
+  assert.deepEqual(plan.commands[0]?.checkRunIds, ['1001', '1002']);
+  // The earlier of the two known startedAt values is kept.
+  assert.equal(plan.commands[0]?.startedAt, '2026-07-16T10:00:00Z');
 });
 
 // Copilot review (PR #2855, round 5, "previously missed"): an instance
@@ -3094,6 +3169,7 @@ function refreshLatestPlan(
     commands: [],
     pendingCommands: [],
     reason: '',
+    unresolvedInstanceCount: 0,
     ...overrides,
   };
 }

--- a/tests/rerun-advisory-convergence.test.mts
+++ b/tests/rerun-advisory-convergence.test.mts
@@ -2981,6 +2981,78 @@ test('computeRefreshLatestPlan: skips an unresolvable instance without blocking 
   assert.match(plan.reason, /check-run 1001/);
 });
 
+// Copilot review (PR #2855, round 5, "previously missed"): an instance
+// whose run id is unresolvable (or whose run lookup failed) carries
+// `runEvent: null` in production (see `collectFromGitHub`'s enrichment --
+// `runEvent: meta?.event ?? null`, and `meta` is only populated for a
+// successfully resolved run). Filtering by family membership BEFORE
+// checking resolvability used to silently drop such an instance out of
+// consideration entirely, so the sole check-run instance for this HEAD
+// being unverifiable was misreported as "nothing has triggered yet"
+// rather than "inspect manually".
+test('computeRefreshLatestPlan: an unresolvable instance (matching its real runEvent: null shape) is reported as unresolvable, not as "no instance exists"', () => {
+  const plan = computeRefreshLatestPlan(
+    baseInput({
+      instances: [baseInstance({ runId: null, runEvent: null })],
+    }),
+    baseOptions(),
+  );
+  assert.deepEqual(plan.commands, []);
+  assert.deepEqual(plan.pendingCommands, []);
+  assert.match(plan.reason, /no resolvable workflow run id/);
+  assert.doesNotMatch(
+    plan.reason,
+    /nothing has triggered|check-run instance exists yet/,
+    'an unresolvable instance must not be reported as though this HEAD has no check-run instance at all',
+  );
+});
+
+test('computeRefreshLatestPlan: a run-lookup failure (matching its real runEvent: null shape) is reported as unresolvable too', () => {
+  const plan = computeRefreshLatestPlan(
+    baseInput({
+      instances: [baseInstance({ runLookupFailed: true, runEvent: null })],
+    }),
+    baseOptions(),
+  );
+  assert.deepEqual(plan.commands, []);
+  assert.match(plan.reason, /could not be fetched/);
+});
+
+test('computeRefreshLatestPlan: every instance resolving to a genuinely different event names that event in the reason', () => {
+  const plan = computeRefreshLatestPlan(
+    baseInput({
+      instances: [baseInstance({ runEvent: 'workflow_dispatch' })],
+    }),
+    baseOptions(),
+  );
+  assert.match(plan.reason, /found: workflow_dispatch/);
+});
+
+test('computeRefreshLatestPlan: a genuinely non-family instance alongside a family one is ignored, not treated as unresolvable', () => {
+  const plan = computeRefreshLatestPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          checkRunId: '1001',
+          runId: '5001',
+          runEvent: 'workflow_dispatch',
+          conclusion: 'success',
+        }),
+        baseInstance({
+          checkRunId: '1002',
+          runId: '5002',
+          runEvent: 'pull_request',
+          conclusion: 'success',
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.equal(plan.commands.length, 1);
+  assert.equal(plan.commands[0]?.runId, '5002');
+  assert.doesNotMatch(plan.reason, /unresolvable/);
+});
+
 test('computeRefreshLatestPlan: -R owner/repo is embedded in every generated command', () => {
   const plan = computeRefreshLatestPlan(
     baseInput({

--- a/tests/rerun-advisory-convergence.test.mts
+++ b/tests/rerun-advisory-convergence.test.mts
@@ -427,6 +427,7 @@ test('classifies an instance with an unknown/empty triggering event as unresolve
 
 for (const event of [
   'pull_request',
+  'pull_request_target',
   'pull_request_review',
   'pull_request_review_comment',
 ]) {

--- a/tests/rerun-advisory-convergence.test.mts
+++ b/tests/rerun-advisory-convergence.test.mts
@@ -6,6 +6,7 @@ import {
   buildCheckRunsForRefArgs,
   buildRerunPlanTextSections,
   buildRunViewLogArgs,
+  computeRefreshLatestPlan,
   computeRerunPlan,
   describeNoActionState,
   describeOutstandingStates,
@@ -2338,6 +2339,7 @@ test('parseArgs parses --pr, --owner, --repo, --now', () => {
     help: false,
     apply: false,
     checkName: '',
+    refreshLatest: false,
   });
 });
 
@@ -2423,6 +2425,14 @@ test('parseArgs recognizes --help', () => {
 test('parseArgs recognizes --apply, defaulting to false when omitted', () => {
   assert.equal(parseArgs(['--pr', '1431']).apply, false);
   assert.equal(parseArgs(['--pr', '1431', '--apply']).apply, true);
+});
+
+test('parseArgs recognizes --refresh-latest, defaulting to false when omitted', () => {
+  assert.equal(parseArgs(['--pr', '1431']).refreshLatest, false);
+  assert.equal(
+    parseArgs(['--pr', '1431', '--refresh-latest']).refreshLatest,
+    true,
+  );
 });
 
 // --- --check-name (#1935: escape hatch for a job `name:` override) ------
@@ -2712,6 +2722,156 @@ test('runRerunAdvisoryConvergence leaves checkName empty (default) when --check-
     },
   });
   assert.equal(receivedCheckName, '');
+});
+
+// --- computeRefreshLatestPlan (#2764 Phase 1, Codex P1 review on PR #2855) --
+//
+// The ordinary computeRerunPlan/--apply path only reruns a
+// rerun-eligible instance -- it never touches anything already `pass`,
+// and enforces the rerun-once budget. --refresh-latest exists precisely
+// to bypass both for the narrow pull_request_review case, so its own
+// tests deliberately probe those two exclusions computeRerunPlan itself
+// would apply.
+
+test('computeRefreshLatestPlan: no command and an explanatory reason when no pull_request-family instance exists', () => {
+  const plan = computeRefreshLatestPlan(
+    baseInput({
+      instances: [baseInstance({ runEvent: 'workflow_dispatch' })],
+    }),
+    baseOptions(),
+  );
+  assert.equal(plan.command, null);
+  assert.match(plan.reason, /nothing to refresh/);
+});
+
+test('computeRefreshLatestPlan: reruns the latest instance even when it already classifies pass (the regression this mode exists to fix)', () => {
+  const plan = computeRefreshLatestPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          checkRunId: '1001',
+          runId: '5001',
+          startedAt: '2026-07-16T10:00:00Z',
+          conclusion: 'success',
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.equal(plan.command?.runId, '5001');
+  assert.equal(plan.command?.command, 'gh run rerun 5001');
+  assert.equal(plan.reason, '');
+});
+
+test('computeRefreshLatestPlan: selects the most-recently-started pull_request-family instance among several', () => {
+  const plan = computeRefreshLatestPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          checkRunId: '1001',
+          runId: '5001',
+          startedAt: '2026-07-16T10:00:00Z',
+          conclusion: 'success',
+        }),
+        baseInstance({
+          checkRunId: '1002',
+          runId: '5002',
+          startedAt: '2026-07-16T10:05:00Z',
+          conclusion: 'failure',
+          runEvent: 'pull_request_target',
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.equal(plan.command?.runId, '5002');
+  assert.deepEqual(plan.command?.checkRunIds, ['1002']);
+});
+
+test('computeRefreshLatestPlan: a still-running latest instance is left alone (never cancelled)', () => {
+  const plan = computeRefreshLatestPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          status: 'in_progress',
+          conclusion: null,
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.equal(plan.command, null);
+  assert.match(plan.reason, /still running/);
+});
+
+test('computeRefreshLatestPlan: fails closed on an unresolvable run id', () => {
+  const plan = computeRefreshLatestPlan(
+    baseInput({ instances: [baseInstance({ runId: null })] }),
+    baseOptions(),
+  );
+  assert.equal(plan.command, null);
+  assert.match(plan.reason, /no resolvable workflow run id/);
+});
+
+test('computeRefreshLatestPlan: fails closed when the underlying run lookup failed', () => {
+  const plan = computeRefreshLatestPlan(
+    baseInput({ instances: [baseInstance({ runLookupFailed: true })] }),
+    baseOptions(),
+  );
+  assert.equal(plan.command, null);
+  assert.match(plan.reason, /could not be fetched/);
+});
+
+test('computeRefreshLatestPlan: includes -R owner/repo when both are known', () => {
+  const plan = computeRefreshLatestPlan(
+    baseInput({ owner: 'kurone-kito', repo: 'idd-skill' }),
+    baseOptions(),
+  );
+  // No instances at all here -- command stays null; this test only
+  // exercises the header fields, covered separately below.
+  assert.equal(plan.prHeadSha, HEAD);
+});
+
+test('computeRefreshLatestPlan: -R owner/repo is embedded in the generated command', () => {
+  const plan = computeRefreshLatestPlan(
+    baseInput({
+      owner: 'kurone-kito',
+      repo: 'idd-skill',
+      instances: [baseInstance({ conclusion: 'success' })],
+    }),
+    baseOptions(),
+  );
+  assert.equal(
+    plan.command?.command,
+    'gh run rerun 5001 -R kurone-kito/idd-skill',
+  );
+});
+
+// --- runRerunAdvisoryConvergence: --refresh-latest ------------------------
+
+test('runRerunAdvisoryConvergence: --refresh-latest returns refreshLatestPlan instead of plan', () => {
+  const result = runRerunAdvisoryConvergence(
+    ['--pr', '1431', '--refresh-latest'],
+    {
+      collect: () => ({
+        input: baseInput({
+          instances: [baseInstance({ conclusion: 'success' })],
+        }),
+        options: baseOptions(),
+      }),
+    },
+  );
+  assert.equal(result.plan, null);
+  assert.equal(result.refreshLatestPlan?.command?.runId, '5001');
+  assert.equal(result.args.refreshLatest, true);
+});
+
+test('runRerunAdvisoryConvergence: omitting --refresh-latest leaves refreshLatestPlan null', () => {
+  const result = runRerunAdvisoryConvergence(['--pr', '1431'], {
+    collect: () => ({ input: baseInput(), options: baseOptions() }),
+  });
+  assert.equal(result.refreshLatestPlan, null);
+  assert.equal(result.args.refreshLatest, false);
 });
 
 // --- applyRerunPlan -------------------------------------------------------

--- a/tests/rerun-advisory-convergence.test.mts
+++ b/tests/rerun-advisory-convergence.test.mts
@@ -3249,6 +3249,39 @@ test('computeRefreshLatestPlan: a run-lookup failure (matching its real runEvent
   assert.match(plan.reason, /could not be fetched/);
 });
 
+// Copilot review (PR #2855, round 11, "previously missed"): a run that
+// resolved successfully (runId set, runLookupFailed: false) can still
+// carry an empty runEvent -- the run lookup itself succeeded, but
+// GitHub's own `event` field on that run came back unset. This is
+// distinct from the two unresolvable shapes above (runId: null,
+// runLookupFailed: true), which both already carry runEvent: null as a
+// SIDE EFFECT of the failed/missing lookup -- here the lookup worked and
+// the event is what's genuinely missing. Must fail closed like those
+// cases, not fall into the "genuinely different, known event" bucket.
+test('computeRefreshLatestPlan: a resolved run whose own event field is empty is reported as unresolvable, not as a genuinely different event', () => {
+  const plan = computeRefreshLatestPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          runId: '5001',
+          runLookupFailed: false,
+          runEvent: null,
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.deepEqual(plan.commands, []);
+  assert.deepEqual(plan.pendingCommands, []);
+  assert.match(plan.reason, /triggering event could not be determined/);
+  assert.doesNotMatch(
+    plan.reason,
+    /nothing has triggered|check-run instance exists yet/,
+    'a resolved-but-unlabeled run must not be reported as though this HEAD has no check-run instance at all',
+  );
+  assert.equal(plan.unresolvedInstanceCount, 1);
+});
+
 test('computeRefreshLatestPlan: every instance resolving to a genuinely different event names that event in the reason', () => {
   const plan = computeRefreshLatestPlan(
     baseInput({

--- a/tests/rerun-advisory-convergence.test.mts
+++ b/tests/rerun-advisory-convergence.test.mts
@@ -2733,18 +2733,19 @@ test('runRerunAdvisoryConvergence leaves checkName empty (default) when --check-
 // tests deliberately probe those two exclusions computeRerunPlan itself
 // would apply.
 
-test('computeRefreshLatestPlan: no command and an explanatory reason when no pull_request-family instance exists', () => {
+test('computeRefreshLatestPlan: no commands and an explanatory reason when no pull_request-family instance exists', () => {
   const plan = computeRefreshLatestPlan(
     baseInput({
       instances: [baseInstance({ runEvent: 'workflow_dispatch' })],
     }),
     baseOptions(),
   );
-  assert.equal(plan.command, null);
+  assert.deepEqual(plan.commands, []);
+  assert.deepEqual(plan.pendingCommands, []);
   assert.match(plan.reason, /nothing to refresh/);
 });
 
-test('computeRefreshLatestPlan: reruns the latest instance even when it already classifies pass (the regression this mode exists to fix)', () => {
+test('computeRefreshLatestPlan: reruns an instance even when it already classifies pass (the regression this mode exists to fix)', () => {
   const plan = computeRefreshLatestPlan(
     baseInput({
       instances: [
@@ -2758,8 +2759,8 @@ test('computeRefreshLatestPlan: reruns the latest instance even when it already 
     }),
     baseOptions(),
   );
-  assert.equal(plan.command?.runId, '5001');
-  assert.equal(plan.command?.command, 'gh run rerun 5001');
+  assert.equal(plan.commands[0]?.runId, '5001');
+  assert.equal(plan.commands[0]?.command, 'gh run rerun 5001');
   assert.equal(plan.reason, '');
 });
 
@@ -2767,7 +2768,7 @@ test('computeRefreshLatestPlan: reruns the latest instance even when it already 
 // budget classification, but a "hold" rerunPolicy is a repository's
 // explicit opt-out of every automatic rerun, not one of those three --
 // it must still be honored here exactly as computeRerunPlan honors it.
-test('computeRefreshLatestPlan: a "hold" rerunPolicy suppresses the rerun, even for an otherwise-reruns-anyway pass instance', () => {
+test('computeRefreshLatestPlan: a "hold" rerunPolicy suppresses every rerun, even for an otherwise-reruns-anyway pass instance', () => {
   const plan = computeRefreshLatestPlan(
     baseInput({
       instances: [
@@ -2780,11 +2781,18 @@ test('computeRefreshLatestPlan: a "hold" rerunPolicy suppresses the rerun, even 
     }),
     baseOptions({ rerunPolicy: 'hold' }),
   );
-  assert.equal(plan.command, null);
+  assert.deepEqual(plan.commands, []);
+  assert.deepEqual(plan.pendingCommands, []);
   assert.match(plan.reason, /ciWait\.rerunPolicy is "hold"/);
 });
 
-test('computeRefreshLatestPlan: selects the most-recently-started pull_request-family instance among several', () => {
+// Codex P1 review, PR #2855, round 2: selecting only the most-recently-
+// started instance can rerun the wrong one -- idd-advisory-
+// convergence.yml's own #1381 incident documents the required rollup
+// staying pinned to an EARLIER instance even after a later instance for
+// the identical SHA completes with SUCCESS. This mode reruns every
+// resolvable instance instead of guessing which one the rollup follows.
+test('computeRefreshLatestPlan: reruns every resolvable terminal instance for this HEAD, not only the most recently started one', () => {
   const plan = computeRefreshLatestPlan(
     baseInput({
       instances: [
@@ -2805,18 +2813,47 @@ test('computeRefreshLatestPlan: selects the most-recently-started pull_request-f
     }),
     baseOptions(),
   );
-  assert.equal(plan.command?.runId, '5002');
-  assert.deepEqual(plan.command?.checkRunIds, ['1002']);
+  assert.equal(plan.commands.length, 2);
+  // Newest-startedAt first -- a readability ordering only, not a
+  // correctness one, since both entries are acted on.
+  assert.equal(plan.commands[0]?.runId, '5002');
+  assert.deepEqual(plan.commands[0]?.checkRunIds, ['1002']);
+  assert.equal(plan.commands[1]?.runId, '5001');
+  assert.deepEqual(plan.commands[1]?.checkRunIds, ['1001']);
+});
+
+test('computeRefreshLatestPlan: deduplicates instances that resolve to the same run id', () => {
+  const plan = computeRefreshLatestPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          checkRunId: '1001',
+          runId: '5001',
+          startedAt: '2026-07-16T10:00:00Z',
+          conclusion: 'success',
+        }),
+        baseInstance({
+          checkRunId: '1002',
+          runId: '5001',
+          startedAt: '2026-07-16T10:00:05Z',
+          conclusion: 'success',
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.equal(plan.commands.length, 1);
+  assert.equal(plan.commands[0]?.runId, '5001');
 });
 
 // Codex P1 review, PR #2855: a still-running instance is NOT the same as
 // "will already reflect this review" -- its own evidence was fetched at
 // whatever point during its execution the live query happened to run,
-// which can be before this review landed. `pendingCommand` carries the
+// which can be before this review landed. `pendingCommands` carries the
 // resolved rerun for the caller to issue once the run actually completes
 // (see the CLI's --refresh-latest --apply wiring), rather than declining
 // to act at all.
-test('computeRefreshLatestPlan: a still-running latest instance is left alone (never cancelled), but its rerun is deferred via pendingCommand', () => {
+test('computeRefreshLatestPlan: a still-running instance is left alone (never cancelled), but its rerun is deferred via pendingCommands', () => {
   const plan = computeRefreshLatestPlan(
     baseInput({
       instances: [
@@ -2830,46 +2867,75 @@ test('computeRefreshLatestPlan: a still-running latest instance is left alone (n
     }),
     baseOptions(),
   );
-  assert.equal(plan.command, null);
+  assert.deepEqual(plan.commands, []);
   assert.match(plan.reason, /still running/);
   assert.doesNotMatch(
     plan.reason,
     /it will already reflect this review/,
     'the reason must not assert the very claim the still-running instance cannot guarantee',
   );
-  assert.equal(plan.pendingCommand?.runId, '5001');
-  assert.equal(plan.pendingCommand?.command, 'gh run rerun 5001');
+  assert.equal(plan.pendingCommands[0]?.runId, '5001');
+  assert.equal(plan.pendingCommands[0]?.command, 'gh run rerun 5001');
 });
 
-test('computeRefreshLatestPlan: pendingCommand is null whenever command is resolved', () => {
+test('computeRefreshLatestPlan: a still-running instance never lands in commands alongside a terminal one in pendingCommands', () => {
+  const plan = computeRefreshLatestPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          checkRunId: '1001',
+          runId: '5001',
+          conclusion: 'success',
+        }),
+        baseInstance({
+          checkRunId: '1002',
+          runId: '5002',
+          runEvent: 'pull_request_target',
+          status: 'in_progress',
+          conclusion: null,
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.equal(plan.commands.length, 1);
+  assert.equal(plan.commands[0]?.runId, '5001');
+  assert.equal(plan.pendingCommands.length, 1);
+  assert.equal(plan.pendingCommands[0]?.runId, '5002');
+});
+
+test('computeRefreshLatestPlan: pendingCommands is empty whenever every instance resolved to commands', () => {
   const plan = computeRefreshLatestPlan(
     baseInput({
       instances: [baseInstance({ conclusion: 'success' })],
     }),
     baseOptions(),
   );
-  assert.notEqual(plan.command, null);
-  assert.equal(plan.pendingCommand, null);
+  assert.notEqual(plan.commands.length, 0);
+  assert.deepEqual(plan.pendingCommands, []);
 });
 
-test('computeRefreshLatestPlan: pendingCommand is null for every no-op reason (hold policy, no instance, unresolvable run id)', () => {
+test('computeRefreshLatestPlan: both commands and pendingCommands are empty for every no-op reason (hold policy, no instance, unresolvable run id)', () => {
   const held = computeRefreshLatestPlan(
     baseInput({ instances: [baseInstance({ conclusion: 'success' })] }),
     baseOptions({ rerunPolicy: 'hold' }),
   );
-  assert.equal(held.pendingCommand, null);
+  assert.deepEqual(held.commands, []);
+  assert.deepEqual(held.pendingCommands, []);
 
   const noInstance = computeRefreshLatestPlan(
     baseInput({ instances: [baseInstance({ runEvent: 'workflow_dispatch' })] }),
     baseOptions(),
   );
-  assert.equal(noInstance.pendingCommand, null);
+  assert.deepEqual(noInstance.commands, []);
+  assert.deepEqual(noInstance.pendingCommands, []);
 
   const unresolvable = computeRefreshLatestPlan(
     baseInput({ instances: [baseInstance({ runId: null })] }),
     baseOptions(),
   );
-  assert.equal(unresolvable.pendingCommand, null);
+  assert.deepEqual(unresolvable.commands, []);
+  assert.deepEqual(unresolvable.pendingCommands, []);
 });
 
 test('computeRefreshLatestPlan: fails closed on an unresolvable run id', () => {
@@ -2877,7 +2943,7 @@ test('computeRefreshLatestPlan: fails closed on an unresolvable run id', () => {
     baseInput({ instances: [baseInstance({ runId: null })] }),
     baseOptions(),
   );
-  assert.equal(plan.command, null);
+  assert.deepEqual(plan.commands, []);
   assert.match(plan.reason, /no resolvable workflow run id/);
 });
 
@@ -2886,11 +2952,35 @@ test('computeRefreshLatestPlan: fails closed when the underlying run lookup fail
     baseInput({ instances: [baseInstance({ runLookupFailed: true })] }),
     baseOptions(),
   );
-  assert.equal(plan.command, null);
+  assert.deepEqual(plan.commands, []);
   assert.match(plan.reason, /could not be fetched/);
 });
 
-test('computeRefreshLatestPlan: -R owner/repo is embedded in the generated command', () => {
+// An unresolvable instance alongside a resolvable one must not block the
+// resolvable one's rerun (Codex P1, PR #2855 review, round 2): only the
+// unresolvable instance is skipped, noted in `reason`.
+test('computeRefreshLatestPlan: skips an unresolvable instance without blocking a resolvable sibling', () => {
+  const plan = computeRefreshLatestPlan(
+    baseInput({
+      instances: [
+        baseInstance({ checkRunId: '1001', runId: null }),
+        baseInstance({
+          checkRunId: '1002',
+          runId: '5002',
+          runEvent: 'pull_request_target',
+          conclusion: 'success',
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.equal(plan.commands.length, 1);
+  assert.equal(plan.commands[0]?.runId, '5002');
+  assert.match(plan.reason, /skipped 1 unresolvable instance/);
+  assert.match(plan.reason, /check-run 1001/);
+});
+
+test('computeRefreshLatestPlan: -R owner/repo is embedded in every generated command', () => {
   const plan = computeRefreshLatestPlan(
     baseInput({
       owner: 'kurone-kito',
@@ -2900,7 +2990,7 @@ test('computeRefreshLatestPlan: -R owner/repo is embedded in the generated comma
     baseOptions(),
   );
   assert.equal(
-    plan.command?.command,
+    plan.commands[0]?.command,
     'gh run rerun 5001 -R kurone-kito/idd-skill',
   );
 });
@@ -2920,7 +3010,7 @@ test('runRerunAdvisoryConvergence: --refresh-latest returns refreshLatestPlan in
     },
   );
   assert.equal(result.plan, null);
-  assert.equal(result.refreshLatestPlan?.command?.runId, '5001');
+  assert.equal(result.refreshLatestPlan?.commands[0]?.runId, '5001');
   assert.equal(result.args.refreshLatest, true);
 });
 


### PR DESCRIPTION
# Summary

`.github/workflows/idd-advisory-convergence.yml`'s own checkout was
already pinned to the trusted default branch, but its trigger list was
not: it ran on `pull_request` and `pull_request_review`, both of which
GitHub evaluates against the pull request's own (possibly edited) copy
of the workflow YAML, never `main`'s. A same-repository PR could edit
this file's trigger list to control when -- or whether -- its own
required check re-asserts, the one gap roadmap #1342's "make the gate
non-bypassable" goal never closed.

**Phase 1 of a two-step rollout** (maintainer decision, Groom hearing,
2026-09-10, following a prior claim attempt's findings -- see the
issue's own Background): add `pull_request_target` alongside the
existing `pull_request` trigger, same activity types, so the
implementing PR itself stays normally mergeable (`pull_request_target`
cannot fire against the PR that first adds it). Move
`pull_request_review` to the non-required companion workflow instead
of leaving it on the required job, for the identical reason -- it now
reruns the existing required run for the current HEAD SHA (a review's
own body is not filtered through the same IDD-origin content
classifier the two comment trigger families use). Fix
`rerun-advisory-convergence.mts`'s `PULL_REQUEST_FAMILY_EVENTS`
allowlist gap the prior claim attempt found, so a
`pull_request_target`-triggered instance is recognized as
rerun-eligible instead of silently falling through to `unresolved`.

Review round (Codex P1): routing the review-submission rerun through
the ordinary `--apply` path turned out to silently drop the former
direct trigger's "every review gets a fresh evaluation" guarantee --
`--apply`'s plan only reruns a `rerun-eligible` instance, excluding
anything already `pass` and enforcing the rerun-once budget, so a
same-HEAD review landing after the gate already went green (or after
its one rerun was spent) could no longer force a fresh check. Added a
narrow `--refresh-latest` mode to `rerun-advisory-convergence.mts`
that bypasses that pass/bot-gated/budget classification and reruns the
latest pull_request-family instance instead (skipping only a
still-running one, to avoid cancelling it, and still honoring
`ciWait.rerunPolicy: "hold"` -- a repository-wide opt-out of automatic
reruns, a different thing from the classification it otherwise
bypasses); only the companion workflow's `pull_request_review` step
uses it -- the two comment-family triggers keep the ordinary
budget-gated `--apply` unchanged, since that budget protects against a
comment-burst hazard (#2643) a review submission does not share.

Second review round (Codex P1) on that same fix caught two more gaps,
both corrected without reverting the mechanism above: the header
comment overclaimed that moving `pull_request_review` to the companion
closes the same tamper gap `pull_request_target` closes for
`pull_request` -- it does not (there is no
`pull_request_review_target`; the companion is exactly as PR-editable
as the required workflow's own former trigger was). The push-triggered
gate itself is what stays trusted; this review-refresh path is
deliberately best-effort on top of that. Separately, GitHub gates any
workflow run a bot actor triggers to `action_required` regardless of
which workflow it lands on (pre-existing, `idd-ci.instructions.md`),
so this companion step can never actually run for a review submitted
by the configured primary bot itself -- unchanged from the former
direct trigger, equally gated for that actor; it self-heals on the
next non-bot trigger, as it always has. Both header comments (dogfood
and `idd-template`) now say this precisely instead of overclaiming.

Third review round (Copilot + Codex + CodeRabbit) found four more real
issues, all fixed without reverting the mechanism: debounce was
silently downgrading a review's `--refresh-latest` to a superseding
comment's plain `--apply` when the two landed within the same quiet
window -- `pull_request_review` now bypasses debounce entirely, since
the hazard debounce protects against (a comment burst spending the
rerun-once budget, #2643) doesn't apply to reviews (`--refresh-latest`
doesn't share that budget; reviews aren't bursty). The added
`|| pull_request_review` disjunct on `idd-template`'s debounce/rerun
steps had also bypassed the helper-runtime profile/manager readiness
guard, restored (and no longer needed on the debounce step once
`pull_request_review` was removed from its own `if:`). Two smaller
wording/example fixes. `computeRefreshLatestPlan`'s still-running
branch also asserted the live instance "will already reflect this
review" without a guarantee -- it now defers via a new
`pendingCommand`, and the CLI waits for that run's completion before
rerunning it. A read-only-`GITHUB_TOKEN`-for-fork-PRs limitation
(pre-existing, shared with this companion's own
`pull_request_review_comment` trigger) is now documented rather than
silently hit.

Fourth review round (Codex P1) found the "select the newest instance"
heuristic itself could rerun the wrong one:
`idd-advisory-convergence.yml`'s own #1381 incident documents the
required rollup staying pinned to an *earlier* instance's check-run
object even after a genuinely later instance for the identical SHA
completes with SUCCESS -- exactly the ambiguity that file's own
recovery guidance resolves by rerunning every run for the HEAD rather
than guessing. `computeRefreshLatestPlan` now reruns every resolvable
pull_request-family instance for the current HEAD instead of picking
one (deduplicated by run id; a still-running instance still defers
into `pendingCommands` rather than being cancelled), and the CLI's
`--apply` path executes each sequentially with a HEAD re-check before
every individual rerun. A second finding on the same round: raising
the internal wait to 15 minutes left both companion workflows'
`timeout-minutes: 10` unchanged, so GitHub could kill the companion
job before the deferred rerun ever fired -- raised to 35 in both
copies (10 to wait out the original run, plus 2x10 for up to two
sequential reruns, plus 5 headroom -- a self-review pass caught the
first attempt's 30 leaving no actual headroom despite claiming to),
with a derivation comment.

Fifth review round (Copilot + CodeRabbit) found three smaller issues
after the rerun-all refactor landed: two doc-only leftovers (a
debounce-step comment/env-var still describing review-specific
timestamp behavior after `pull_request_review` was excluded from that
step entirely; a recovery paragraph naming
`pull_request_review_comment` as a rerunnable trigger for this
required workflow, which has never actually triggered it), and one
real robustness gap CodeRabbit caught: `--refresh-latest --apply` now
processes multiple independent instances per HEAD, but a thrown error
waiting on the first one aborted the whole batch, leaving a second
pending instance and every already-terminal instance unrefreshed.
Extracted `applyRefreshLatestPlan` (mirroring `applyRerunPlan`'s own
DI shape) to isolate each instance's failure and continue with the
rest, setting a non-zero exit code only when something genuinely
failed.

Sixth review round (Copilot) caught one more real gap in
`computeRefreshLatestPlan` itself: it filtered instances by
pull_request-family membership before checking whether each one's run
id/lookup actually resolved. An unresolvable instance carries
`runEvent: null` in production, so that ordering silently dropped it
out of consideration -- if every instance for a HEAD happened to be
unresolvable, the reason wrongly claimed nothing had triggered yet
instead of surfacing the real problem. Unresolvability is now checked
first, over every instance, regardless of its resolved event.

Seventh review round (Copilot + Codex P1) found two more issues in
that same restructuring: the runId-deduplication logic dropped a
duplicate instance's own `checkRunId` entirely, breaking
`RerunPlanCommand.checkRunIds`'s own documented "every check-run id
that contributed to this run id" contract -- a duplicate now merges
into the already-tracked command instead. Separately, an unresolvable
instance is omitted from both `commands`/`pendingCommands` with only a
free-text `reason` noting it, yet `--refresh-latest --apply` exited 0
regardless of whether the omitted instance was the one actually
controlling the required rollup -- `RefreshLatestPlan` now exposes
`unresolvedInstanceCount` structurally so the CLI can fail closed on
it, including when every instance for a HEAD is unresolvable and the
apply block never runs at all.

Eighth review round (Copilot, "previously missed"): one required-
workflow header comment still described the review-refresh path as
plain `--apply` instead of `--refresh-latest --apply`, a leftover from
before that flag existed. Doc-only fix.

Ninth review round: after fixing the eighth round's finding, a full
sweep of every unresolved review thread on this PR (not just each
push's own latest review, which this session had been relying on)
surfaced three genuine Codex P1 findings from an earlier round that
had gone unaddressed, plus one Codex P2. `computeRefreshLatestPlan`
queued a bot-gated `action_required` instance for rerun like any other
terminal instance, even though rerunning it only re-enters
`action_required` (idd-ci.instructions.md §Rerun mechanics) -- now
excluded, mirroring `classifyInstance`'s own `bot-gated-skip`. Two
check-run rows sharing a runId are not guaranteed to report the
identical status (this file's own #1381 precedent); classifying a
duplicate from whichever row was seen first risked rerunning an
actually-live attempt from a stale COMPLETED row -- a pending row now
wins the merge regardless of order. The companion timeout derivation
had budgeted each wait at the gate's 10-minute job timeout instead of
this file's own internal 15-minute safety bound the code actually
polls against -- raised from 35 to 55 in both copies. Separately, four
adopter-facing doc locations (onboarding guide, two policy/
customization references, a usage-report filter) still described the
pre-Phase-1 trigger topology; updated.

Tenth review round (Codex P1): GitHub Actions implicitly prepends
`success()` to a step's own `if:` unless the expression already calls
`success()`/`failure()`/`always()` -- "Rerun required HEAD check"'s
`if:` never did, so a failure in the preceding "Classify review
comment" step (its own script throwing, e.g. on a malformed review
body) would have silently skipped the entire rerun step even for
`pull_request_review`, defeating the exact "always proceeds" guarantee
that disjunct exists to provide. `success()` is now called explicitly
on the comment-family branch only, so the review branch genuinely
short-circuits regardless of any earlier step's outcome.

A follow-up issue (Phase 2, filed once this has run cleanly on
production PRs for a period) will remove the now-redundant
`pull_request` trigger.

Eleventh review round (Codex P1): `computeRefreshLatestPlan` classified
pending state solely from a check-run row's own `status`/`conclusion`.
When a review lands moments after an already-issued rerun for the same
run id, that row can still show the prior attempt's terminal
conclusion before the new attempt's row propagates, so the plan could
put a live run into `commands` and re-issue `gh run rerun` against
it -- cancelling it instead of waiting for it, the same class of
hazard already guarded against across two rows sharing a run id, but
here on a single row whose own fields are what's stale. The workflow
run's own live status was already being fetched (for `run_attempt`/
`event`) but dropped before reaching this classification; it is now
carried through as `runStatus` and wins over a present-but-stale
`conclusion`, so the plan defers via `pendingCommands` instead.

Twelfth review round (Copilot "previously missed" + Codex P1). Copilot:
the family-event filter treated a resolved run (id resolved, lookup
succeeded) whose own `event` field came back empty the same as a
genuinely different, identified non-family trigger, silently dropping
it -- the sole instance for a HEAD hitting this shape would be
misreported as "nothing has triggered yet" instead of "inspect
manually", the same false-reassurance failure mode the
runId/runLookupFailed checks earlier in the same loop already guard
against. Split out to fail closed into `unresolvedInstanceCount`,
matching `classifyInstance`'s existing "unknown event => unresolved"
rule for the ordinary `--apply` path. Codex raised that
`timeout-minutes: 55` only budgets for the typical Phase 1
two-instance case, so a PR repeatedly closed/reopened without a HEAD
change (each `reopened` event adding another same-HEAD instance pair)
could exceed it before every instance is rerun -- rejected: the
timeout's own derivation comment already documents this as a
deliberate typical-case budget, not a hard bound, and closing it for
real needs a job-level resumption/parallelization mechanism, which is
real rearchitecture out of scope for this Phase 1 PR. Noting as
Phase 2 follow-up material alongside the trigger-consolidation item
below.

## Linked issue

Closes #2764

## Follow-up issues (if any)

- [ ] Phase 2: remove the now-redundant `pull_request` trigger from
      `idd-advisory-convergence.yml` once Phase 1 (this PR) has run
      cleanly on production PRs for a period, per the maintainer
      decision recorded on #2764. Not yet filed as of this PR --
      requires confirming Phase 1's `pull_request_target` attachment
      on the first PR opened after this merges first.
- [ ] Give `refresh-if-idd-originated`'s `timeout-minutes: 55` budget
      (or the underlying `--refresh-latest --apply` mechanism) a way
      to cover more than the typical two-instance case -- a job-level
      resumption or parallelized-rerun approach -- instead of a fixed
      typical-case time budget, so a HEAD with many same-HEAD
      instances (e.g. from repeated close/reopen without a HEAD
      change) can't exceed the job timeout before every instance is
      rerun (Codex P1, PR #2855 review round 12; rejected as in-scope
      for this PR since it needs real rearchitecture).
- [ ] `pre-merge-readiness.mjs`'s `secondaryQuietWindow` computation
      shortened to 5 minutes on this PR's own merge despite the last
      `coderabbitai[bot]` review being an empty-body, rate-limited
      placeholder on a stale commit (`59b91c3a`, not the merge HEAD) --
      it appears to be treating that rate-limited review object as a
      "genuine review for the current HEAD" for the purpose of
      AGENTS.md's short-buffer exception. Same class of gap as the
      sibling "recognize a third CodeRabbit ack shape" fix in flight
      elsewhere; not fixed here (out of scope for this PR, and likely
      superseded by that sibling fix). Waited out the full configured
      `PT1H` window manually before merging, per the policy's actual
      intent, rather than trusting the tool's shortcut.

## Background / rationale (if material)

Maintainer decision recorded on #2764 (Groom hearing, 2026-09-10),
following a prior claim attempt's documented structural findings (a
single-PR trigger replacement is self-blocking, since
`pull_request_target` cannot fire against the PR that first defines
it; the rerun-eligibility allowlist gap). This PR's own required
`idd-advisory-convergence` check therefore runs via its existing
`pull_request` trigger only -- `pull_request_target` cannot exercise
itself against this PR, per that same structural finding. Verification
of the new trigger's attachment is deferred to the first PR opened
after this merges to `main` (`gh run list --workflow
idd-advisory-convergence.yml` should then show two runs under the same
required check name for that PR).

A review round on this PR (Codex P1) separately questioned whether a
`pull_request_target`-triggered run's check-runs attach to the PR's
real head SHA at all. Verified empirically against this repository's
own history rather than relying on documentation alone:
`post-merge-cleanup.yml` (also `pull_request_target`, same checkout
shape) produced a run for merged PR #2852 whose reported `head_sha`
exactly matched that PR's own `headRefOid` (not the merge commit), and
the SHA-scoped commit check-runs endpoint this PR's own helper queries
returned that run's check-run under that exact SHA -- confirming the
association this PR's design (and `PULL_REQUEST_FAMILY_EVENTS`'s own
doc comment) already assumed. See the review thread for the full
evidence trail.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDJpTELrY2SnjHW9m5Aw7i


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Pull-request reviews can now refresh the latest advisory-convergence check automatically.
  - Pull-request lifecycle events are handled through trusted workflow execution, improving consistency during advisory checks.
  - Refresh processing can safely identify and rerun the latest eligible check while avoiding active or unresolved runs.

- **Documentation**
  - Updated workflow and polling guidance to explain review-triggered reruns, migration behavior, concurrency considerations, and recovery steps.

- **Tests**
  - Added coverage for review-triggered workflows, trusted pull-request handling, and latest-check refresh scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->






