### PR TITLE
fix(idd-work): wire the user-global critique-delegate fallback into the full-profile C1 step

### DIFF
--- a/.github/instructions/idd-overview-appendix.instructions.md
+++ b/.github/instructions/idd-overview-appendix.instructions.md
@@ -143,7 +143,8 @@ assessment. For the per-agent invocation table (Copilot / Claude Code /
 Codex CLI / Antigravity CLI (formerly Gemini CLI)) and the optional
 repository-configurable `critiqueLoop.delegate` surface, see
 [`docs/idd-workflow.md` → Critique pass invocation](../../docs/idd-workflow.md#critique-pass-invocation).
-When helper runtime is enabled, resolve the effective delegate with the
+For **C1 only** — this surface does not extend to E2 or E10 — when
+helper runtime is enabled, resolve the effective delegate with the
 `idd-critique-delegate` helper documented at
 [`docs/idd-helper-scripts.md` → Effective C1 critique delegate](../../docs/idd-helper-scripts.md#effective-c1-critique-delegate).
 

--- a/.github/instructions/idd-overview-appendix.instructions.md
+++ b/.github/instructions/idd-overview-appendix.instructions.md
@@ -143,6 +143,9 @@ assessment. For the per-agent invocation table (Copilot / Claude Code /
 Codex CLI / Antigravity CLI (formerly Gemini CLI)) and the optional
 repository-configurable `critiqueLoop.delegate` surface, see
 [`docs/idd-workflow.md` → Critique pass invocation](../../docs/idd-workflow.md#critique-pass-invocation).
+When helper runtime is enabled, resolve the effective delegate with the
+`idd-critique-delegate` helper documented at
+[`docs/idd-helper-scripts.md` → Effective C1 critique delegate](../../docs/idd-helper-scripts.md#effective-c1-critique-delegate).
 
 ### Critique lenses
 

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -462,12 +462,12 @@ guards are listed in `docs/policy-constants.md`. A repository may
 configure `critiqueLoop.delegate` to point this step at a different
 reviewer instead of the per-agent mechanism. When helper runtime is
 enabled, resolve the effective `critiqueLoop.delegate` with the
-profile-selected
 [critique-delegate](../../docs/idd-helper-scripts.md#effective-c1-critique-delegate)
 helper — `node scripts/idd-critique-delegate.mjs` for source-repo /
-vendored-node profiles, or the `idd-critique-delegate` command for
-package-manager / ephemeral-npx profiles — instead of hand-deriving
-it; for `instructions-only` execution, apply the
+vendored-node profiles; for package-manager / ephemeral-npx, resolve
+the profile-selected command from `docs/idd-helper-scripts.md` rather
+than hardcoding that bare binary name — instead of hand-deriving it;
+for `instructions-only` execution, apply the
 resolution order directly instead: repo-local `critiqueLoop.delegate`
 always wins outright, and only when it is genuinely absent does a
 local runtime's user-global config file apply. A repository may also

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -462,7 +462,7 @@ guards are listed in `docs/policy-constants.md`. A repository may
 configure `critiqueLoop.delegate` to point this step at a different
 reviewer instead of the per-agent mechanism. When helper runtime is
 enabled, resolve the effective `critiqueLoop.delegate` with the
-[critique-delegate](../../docs/idd-helper-scripts.md#effective-c1-critique-delegate)
+[`idd-critique-delegate`](../../docs/idd-helper-scripts.md#effective-c1-critique-delegate)
 helper — `node scripts/idd-critique-delegate.mjs` for source-repo /
 vendored-node profiles; for package-manager / ephemeral-npx, resolve
 the profile-selected command from `docs/idd-helper-scripts.md` rather

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -460,12 +460,19 @@ problems exist. See `idd-overview-appendix.instructions.md` for per-agent
 implementation. The distributed defaults for the C-phase skip and loop
 guards are listed in `docs/policy-constants.md`. A repository may
 configure `critiqueLoop.delegate` to point this step at a different
-reviewer instead of the per-agent mechanism, or `critiqueLoop.telemetryHook`
-for a separate fire-and-forget per-round JSON record (round, repo,
-issue, PR, findings/severity/accepted/rejected counts, delegate usage,
-timestamp) that C2/C4 below invoke but that never gates control flow;
-see `docs/idd-workflow.md`'s "Critique pass invocation" section for
-both.
+reviewer instead of the per-agent mechanism. When helper runtime is
+enabled, resolve the effective `critiqueLoop.delegate` with the
+[`idd-critique-delegate`](../../docs/idd-helper-scripts.md#effective-c1-critique-delegate)
+helper (`node scripts/idd-critique-delegate.mjs`) instead of
+hand-deriving it; for `instructions-only` execution, apply the
+resolution order directly instead: repo-local `critiqueLoop.delegate`
+always wins outright, and only when it is genuinely absent does a
+local runtime's user-global config file apply. A repository may also
+configure `critiqueLoop.telemetryHook` for a separate fire-and-forget
+per-round JSON record (round, repo, issue, PR,
+findings/severity/accepted/rejected counts, delegate usage, timestamp)
+that C2/C4 below invoke but that never gates control flow; see
+`docs/idd-workflow.md`'s "Critique pass invocation" section for both.
 
 **Objective diff validation floor**: neither C2 nor C4 below may skip to
 `idd-pr-submit.instructions.md` unless **fix-validate** — the same

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -462,9 +462,12 @@ guards are listed in `docs/policy-constants.md`. A repository may
 configure `critiqueLoop.delegate` to point this step at a different
 reviewer instead of the per-agent mechanism. When helper runtime is
 enabled, resolve the effective `critiqueLoop.delegate` with the
-[`idd-critique-delegate`](../../docs/idd-helper-scripts.md#effective-c1-critique-delegate)
-helper (`node scripts/idd-critique-delegate.mjs`) instead of
-hand-deriving it; for `instructions-only` execution, apply the
+profile-selected
+[critique-delegate](../../docs/idd-helper-scripts.md#effective-c1-critique-delegate)
+helper — `node scripts/idd-critique-delegate.mjs` for source-repo /
+vendored-node profiles, or the `idd-critique-delegate` command for
+package-manager / ephemeral-npx profiles — instead of hand-deriving
+it; for `instructions-only` execution, apply the
 resolution order directly instead: repo-local `critiqueLoop.delegate`
 always wins outright, and only when it is genuinely absent does a
 local runtime's user-global config file apply. A repository may also

--- a/idd-template/.github/instructions/idd-overview-appendix.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-appendix.instructions.md
@@ -138,6 +138,9 @@ assessment. For the per-agent invocation table (Copilot / Claude Code /
 Codex CLI / Antigravity CLI (formerly Gemini CLI)) and the optional
 repository-configurable `critiqueLoop.delegate` surface, see
 [`docs/idd-workflow.md` → Critique pass invocation](../../docs/idd-workflow.md#critique-pass-invocation).
+When helper runtime is enabled, resolve the effective delegate with the
+`idd-critique-delegate` helper documented at
+[`docs/idd-helper-scripts.md` → Effective C1 critique delegate](../../docs/idd-helper-scripts.md#effective-c1-critique-delegate).
 
 ### Critique lenses
 

--- a/idd-template/.github/instructions/idd-overview-appendix.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-appendix.instructions.md
@@ -138,7 +138,8 @@ assessment. For the per-agent invocation table (Copilot / Claude Code /
 Codex CLI / Antigravity CLI (formerly Gemini CLI)) and the optional
 repository-configurable `critiqueLoop.delegate` surface, see
 [`docs/idd-workflow.md` → Critique pass invocation](../../docs/idd-workflow.md#critique-pass-invocation).
-When helper runtime is enabled, resolve the effective delegate with the
+For **C1 only** — this surface does not extend to E2 or E10 — when
+helper runtime is enabled, resolve the effective delegate with the
 `idd-critique-delegate` helper documented at
 [`docs/idd-helper-scripts.md` → Effective C1 critique delegate](../../docs/idd-helper-scripts.md#effective-c1-critique-delegate).
 

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -455,12 +455,19 @@ problems exist. See `idd-overview-appendix.instructions.md` for per-agent
 implementation. The distributed defaults for the C-phase skip and loop
 guards are listed in `docs/policy-constants.md`. A repository may
 configure `critiqueLoop.delegate` to point this step at a different
-reviewer instead of the per-agent mechanism, or `critiqueLoop.telemetryHook`
-for a separate fire-and-forget per-round JSON record (round, repo,
-issue, PR, findings/severity/accepted/rejected counts, delegate usage,
-timestamp) that C2/C4 below invoke but that never gates control flow;
-see `docs/idd-workflow.md`'s "Critique pass invocation" section for
-both.
+reviewer instead of the per-agent mechanism. When helper runtime is
+enabled, resolve the effective `critiqueLoop.delegate` with the
+[`idd-critique-delegate`](../../docs/idd-helper-scripts.md#effective-c1-critique-delegate)
+helper (`node scripts/idd-critique-delegate.mjs`) instead of
+hand-deriving it; for `instructions-only` execution, apply the
+resolution order directly instead: repo-local `critiqueLoop.delegate`
+always wins outright, and only when it is genuinely absent does a
+local runtime's user-global config file apply. A repository may also
+configure `critiqueLoop.telemetryHook` for a separate fire-and-forget
+per-round JSON record (round, repo, issue, PR,
+findings/severity/accepted/rejected counts, delegate usage, timestamp)
+that C2/C4 below invoke but that never gates control flow; see
+`docs/idd-workflow.md`'s "Critique pass invocation" section for both.
 
 **Objective diff validation floor**: neither C2 nor C4 below may skip to
 `idd-pr-submit.instructions.md` unless **fix-validate** — the same

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -457,12 +457,12 @@ guards are listed in `docs/policy-constants.md`. A repository may
 configure `critiqueLoop.delegate` to point this step at a different
 reviewer instead of the per-agent mechanism. When helper runtime is
 enabled, resolve the effective `critiqueLoop.delegate` with the
-profile-selected
 [critique-delegate](../../docs/idd-helper-scripts.md#effective-c1-critique-delegate)
 helper — `node scripts/idd-critique-delegate.mjs` for source-repo /
-vendored-node profiles, or the `idd-critique-delegate` command for
-package-manager / ephemeral-npx profiles — instead of hand-deriving
-it; for `instructions-only` execution, apply the
+vendored-node profiles; for package-manager / ephemeral-npx, resolve
+the profile-selected command from `docs/idd-helper-scripts.md` rather
+than hardcoding that bare binary name — instead of hand-deriving it;
+for `instructions-only` execution, apply the
 resolution order directly instead: repo-local `critiqueLoop.delegate`
 always wins outright, and only when it is genuinely absent does a
 local runtime's user-global config file apply. A repository may also

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -457,7 +457,7 @@ guards are listed in `docs/policy-constants.md`. A repository may
 configure `critiqueLoop.delegate` to point this step at a different
 reviewer instead of the per-agent mechanism. When helper runtime is
 enabled, resolve the effective `critiqueLoop.delegate` with the
-[critique-delegate](../../docs/idd-helper-scripts.md#effective-c1-critique-delegate)
+[`idd-critique-delegate`](../../docs/idd-helper-scripts.md#effective-c1-critique-delegate)
 helper — `node scripts/idd-critique-delegate.mjs` for source-repo /
 vendored-node profiles; for package-manager / ephemeral-npx, resolve
 the profile-selected command from `docs/idd-helper-scripts.md` rather

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -457,9 +457,12 @@ guards are listed in `docs/policy-constants.md`. A repository may
 configure `critiqueLoop.delegate` to point this step at a different
 reviewer instead of the per-agent mechanism. When helper runtime is
 enabled, resolve the effective `critiqueLoop.delegate` with the
-[`idd-critique-delegate`](../../docs/idd-helper-scripts.md#effective-c1-critique-delegate)
-helper (`node scripts/idd-critique-delegate.mjs`) instead of
-hand-deriving it; for `instructions-only` execution, apply the
+profile-selected
+[critique-delegate](../../docs/idd-helper-scripts.md#effective-c1-critique-delegate)
+helper — `node scripts/idd-critique-delegate.mjs` for source-repo /
+vendored-node profiles, or the `idd-critique-delegate` command for
+package-manager / ephemeral-npx profiles — instead of hand-deriving
+it; for `instructions-only` execution, apply the
 resolution order directly instead: repo-local `critiqueLoop.delegate`
 always wins outright, and only when it is genuinely absent does a
 local runtime's user-global config file apply. A repository may also


### PR DESCRIPTION
# Summary

`idd-work.instructions.md`'s C1 step told a worker it "may configure
`critiqueLoop.delegate` to point this step at a different reviewer,"
but never named `scripts/idd-critique-delegate.mjs` (or the
package-manager-profile `idd-critique-delegate` command) as the way to
resolve the effective value, and never restated the resolution order
for `instructions-only` execution. The lite profile
(`idd-work-lite.instructions.md`) already named the helper and the
user-global fallback explicitly, so the full profile was the one gap —
a field-feedback gist reported that a real adopter hit exactly this
gap after removing a repo-local `critiqueLoop.delegate` key on the
(correct) assumption that user-global inheritance would cover it.

This PR:

- Adds a sentence to C1 in `idd-work.instructions.md` naming and
  linking the `idd-critique-delegate` helper
  (`node scripts/idd-critique-delegate.mjs`) as the way to resolve the
  effective `critiqueLoop.delegate` when helper runtime is enabled,
  plus a second sentence restating the `instructions-only` resolution
  order inline: repo-local `critiqueLoop.delegate` always wins
  outright; the user-global config file applies only when repo-local
  is genuinely absent.
- Adds a matching cross-reference from
  `idd-overview-appendix.instructions.md`'s "Critique pass" section
  (which C1 points to for "per-agent implementation") to
  `docs/idd-helper-scripts.md`'s "Effective C1 critique delegate"
  entry.
- Edits only the canonical `idd-template/` sources and regenerates
  both `.github/instructions/` mirrors via `node scripts/sync-docs.mjs
  --apply`, per this repository's generated-mirror convention.

No changes to `docs/idd-workflow.md` or `docs/idd-helper-scripts.md` —
both already fully document the resolution chain and the helper; only
the full-profile instruction files that never pointed to that
documentation needed the new cross-references.

A B2 plan critique and a C1 self-review pass (CodeRabbit delegate: 0
findings; per-agent pass: 3 Low findings, all reject-recommended per
this repository's own C3 severity rule — none identified an unmet
acceptance criterion) both ran against this diff before this PR was
opened.

## Linked issue

Closes #2845

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

The per-agent C1 critique noted (Low, non-blocking) that the new
inline restatement simplifies the explicit-`null`/malformed
repo-local-value nuance that `docs/idd-workflow.md`'s "User-global
critique delegate default" subsection documents in full — this is
intentional (the acceptance criteria ask for a short inline
restatement, not a full copy of the doc's nuance), and the paragraph's
existing cross-reference to that section already carries the reader
the rest of the way.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`npx biome check`, `npx dprint check`, `npx markdownlint-cli2`, `npx cspell lint`)
- [x] `pnpm test` (`node --test tests/*.test.mts` — 5643 passed)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (`node scripts/sync-docs.mjs --apply` — mirrors regenerated, no residual drift)
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none — documentation-only change)
- [x] Context budget impact reviewed (`bundle-work-phase`: 28074/30100 B; `bundle-core`: 24274/26000 B combined with `idd-overview-core.instructions.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EycqtGKuWjJMpw2tUav3Tn
