### PR TITLE
docs(idd-autonomy-contract): fix the snapshot-sha256 formula description

### DIFF
--- a/docs/idd-autonomy-contract.md
+++ b/docs/idd-autonomy-contract.md
@@ -165,13 +165,16 @@ rewrite the body before hashing. Anchor-only `release-guard` uses
 `snapshot-sha256`.
 The originating durable hold persists, for every target, its verified
 release-marker ID, absent-label result, and expected `body-sha256`. It also
-persists the canonical set snapshot as the SHA-256 digest of the
-lexicographically sorted lines `target=<target>;body-sha256=<digest>;release-marker=<comment-id>`;
-the same `snapshot-sha256` must be carried by `release-complete`. A later
-session must re-fetch every target, recompute and compare each body digest,
-verify the release marker and absent label, and recompute the set snapshot
-before accepting `release-complete`. Missing, mismatched, or unverifiable
-snapshot evidence fails closed and leaves the hold and labels in place.
+persists the canonical set snapshot as the SHA-256 digest, over UTF-8, of the
+target set's `<owner>/<repo>#<number>:<body-sha256>` lines (one per target,
+using each target's currently-verified `body-sha256`), sorted in ascending
+issue-number order and joined with a single `\n` character with no trailing
+newline; the same `snapshot-sha256` must be carried by `release-complete`. A
+later session must re-fetch every target, recompute and compare each body
+digest, verify the release marker and absent label, and recompute the set
+snapshot before accepting `release-complete`. Missing, mismatched, or
+unverifiable snapshot evidence fails closed and leaves the hold and labels in
+place.
 Read every issue comment page and order valid markers by GitHub `created_at`,
 then comment ID. Replay that ordered log as a state machine: an
 `acquire`/`bootstrap` with `supersedes=none` starts a generation only when no

--- a/idd-template/docs/idd-autonomy-contract.md
+++ b/idd-template/docs/idd-autonomy-contract.md
@@ -165,13 +165,16 @@ rewrite the body before hashing. Anchor-only `release-guard` uses
 `snapshot-sha256`.
 The originating durable hold persists, for every target, its verified
 release-marker ID, absent-label result, and expected `body-sha256`. It also
-persists the canonical set snapshot as the SHA-256 digest of the
-lexicographically sorted lines `target=<target>;body-sha256=<digest>;release-marker=<comment-id>`;
-the same `snapshot-sha256` must be carried by `release-complete`. A later
-session must re-fetch every target, recompute and compare each body digest,
-verify the release marker and absent label, and recompute the set snapshot
-before accepting `release-complete`. Missing, mismatched, or unverifiable
-snapshot evidence fails closed and leaves the hold and labels in place.
+persists the canonical set snapshot as the SHA-256 digest, over UTF-8, of the
+target set's `<owner>/<repo>#<number>:<body-sha256>` lines (one per target,
+using each target's currently-verified `body-sha256`), sorted in ascending
+issue-number order and joined with a single `\n` character with no trailing
+newline; the same `snapshot-sha256` must be carried by `release-complete`. A
+later session must re-fetch every target, recompute and compare each body
+digest, verify the release marker and absent label, and recompute the set
+snapshot before accepting `release-complete`. Missing, mismatched, or
+unverifiable snapshot evidence fails closed and leaves the hold and labels in
+place.
 Read every issue comment page and order valid markers by GitHub `created_at`,
 then comment ID. Replay that ordered log as a state machine: an
 `acquire`/`bootstrap` with `supersedes=none` starts a generation only when no


### PR DESCRIPTION
# Summary

`docs/idd-autonomy-contract.md`'s canonical-set-snapshot formula never
matched real release practice: every posted `release-complete` marker
to date (`#2700`, `#2706`, `#2770`, `#2795`, `#2843`) instead used the
SHA-256 digest of newline-joined `<owner>/<repo>#<number>:<body-sha256>`
lines in ascending issue-number order, with no release-marker comment
ID in the hash input at all. Since `authoring-owner` markers are
append-only and every marker already carries the practice-formula's
digest, the document had to change, not practice.

This PR edits `idd-template/docs/idd-autonomy-contract.md`'s
canonical-set-snapshot paragraph to describe the formula every real
release has actually used, and regenerates the mirrored
`docs/idd-autonomy-contract.md` via `node scripts/sync-docs.mjs
--apply`. Only the formula description changed; the surrounding
verification-duty language (re-fetch, recompute, compare, fail
closed) is unchanged.

## Verification of the formula

Independently re-derived the practice formula by re-hashing
`#2857`'s own single-target `release-complete` marker
(`sha256("kurone-kito/idd-skill#2857:<body-sha256>")`) and confirming
an exact match against its posted `snapshot-sha256`. This is
corroborated by `#2700`'s own "Note for future readers" comment,
which documents the same convention
(`sha256("\n".join(f"{owner/repo#number}:{body_sha256}" for each of
this set's 4 targets, ascending issue number))`) for its 4-target
set.

Also confirmed via `grep -rn "snapshot-sha256"` that no other file in
the repository spells out this formula independently — every other
reference (`docs/issue-authoring-skill.md`,
`skills/issue-authoring/references/contract.md`,
`skills/issue-authoring/references/workflow-boundary.md`, and their
generated mirrors) only cross-references "the same `body-sha256` and
`snapshot-sha256` semantics as the portable owner protocol" without
restating the formula, so this edit's scope is exactly the one
canonical source and its regenerated mirror.

## Linked issue

Closes #2857

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

No mechanical checker currently enforces this formula
(`src/scripts/audit-authored-issue.mts` never mentions "snapshot" at
all), so this was pure documentation drift with no live blast radius
today -- but the contract text explicitly describes a future
verification duty ("recompute and compare... before accepting
`release-complete`. Missing, mismatched, or unverifiable snapshot
evidence fails closed") that would have failed closed against every
already-posted marker had a checker been built against the
previously-documented (wrong) formula.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CK2SHn8Bir6VHrXrMVMdn3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how canonical release snapshots are calculated using target identifiers and verified body digests.
  - Documented sorting and newline requirements for consistent snapshot generation.
  - Updated release completion validation to require a matching recomputed snapshot alongside per-target evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->