### PR TITLE
fix(protocol-helpers): recognize a third CodeRabbit ack shape

### DIFF
--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1348,8 +1348,9 @@ const CODERABBIT_ACK_OPENING_RE = new RegExp(
 //    a hedged, non-committal acknowledgment that would otherwise pass on
 //    structure alone.
 // 4. **No backtracking past an earlier same-sentence "concern"/"finding"**
-//    (round 3, Codex; now a natural consequence of guards 1-2's token
-//    grammar rather than a separate per-character lookahead): "`@user`,
+//    (round 3, Codex; largely a consequence of guards 1-2's token
+//    grammar rather than a separate per-character lookahead, but not
+//    unconditionally so -- see the precise bound stated below): "`@user`,
 //    confirmed. This addresses the original concern but reveals another
 //    finding.\n\n🐇 ✓" has a genuinely new finding joined by "but" in the
 //    SAME sentence. Reaching the later "finding" would require consuming
@@ -1357,7 +1358,15 @@ const CODERABBIT_ACK_OPENING_RE = new RegExp(
 //    before even reaching "another finding", already past the `{0,3}`
 //    cap guard 1 enforces -- so no valid parse reaches the second
 //    occurrence; the match fails at the first "concern" instead, exactly
-//    as guard 3's tail check requires.
+//    as guard 3's tail check requires. This holds whenever reaching the
+//    second occurrence needs MORE than 3 modifier tokens; a short,
+//    non-contrastive conjunctive bridge can still consume an earlier
+//    occurrence as a plain token within budget and reach a second one --
+//    "addresses the concern and finding.\n\n🐇 ✓" matches by treating
+//    "concern" as modifier-token #1 (self-critique, E2 pass on this PR).
+//    Not treated as a precision bug: "X addresses the concern and
+//    finding" reads as a benign compound object (both were addressed),
+//    not a hidden new concern, unlike the "but"-joined case above.
 // 5. **Hedge-adverb guard, both before "addresses" and inside the gap**
 //    (round 2, Codex; scoping fixed round 3, Copilot; extended into the
 //    gap itself, round 7, Codex): "`@user`, confirmed. This partially
@@ -1420,6 +1429,20 @@ const CODERABBIT_ACK_STRONG_CLOSURE_RE =
   /✅\s*Review thread resolved\.|I couldn't resolve this review thread on the repository platform/i;
 const CODERABBIT_ACK_HEDGE_WORDS_SOURCE =
   'partially|partly|somewhat|mostly|largely|barely|slightly|arguably|in\\s+part|to\\s+some\\s+extent|not\\s+(?:fully|entirely|completely|really)';
+// Sibling enumeration to the degree-adverb list above, for the SAME
+// hedged/non-committal semantic class but the ADJECTIVE part of speech
+// (self-critique, E2 pass on this PR, PR #2868): the adverb list above
+// modifies a VERB ("partially addresses"); a lead-in noun phrase instead
+// takes an ADJECTIVE modifying its noun ("The partial workaround
+// addresses...", "The temporary fix addresses..."). Grammatically
+// distinct from the adverb list, so it is its own enumeration rather
+// than folded in, but the SAME bounded philosophy: a small, closed set
+// of English words describing partial/provisional completeness -- not
+// the open-ended CONTRASTIVE-adjective class (residual gap (a) above,
+// "wrong", "different", "unrelated") that states something was done
+// incorrectly rather than only partially or temporarily.
+const CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE =
+  'partial|temporary|interim|provisional|tentative|preliminary|stopgap|incomplete';
 // CodeRabbit review, PR #2868, round 4: two mechanical bypasses in the
 // pattern below, both closed by widening two sub-patterns from singular-
 // only to also accept the plural/multi-space form, exactly the same
@@ -1646,10 +1669,29 @@ const CODERABBIT_ACK_ADDRESSES_CLOSURE_RE = new RegExp(
 //    DECISION, which this file's own reasoning above already treats as
 //    unable to co-occur with a new concern in the same reply, so they
 //    keep the whole-body `.test()` they always had.
+//
+// 7. **Hedge words excluded from the lead-in's own noun-phrase tokens
+//    too** (self-critique, E2 pass on this PR): guard 5's hedge-adverb
+//    enumeration reaches the internal "addresses the ... concern" gap
+//    (guard 5 above) but never reached the LEAD-IN's own "the" plus
+//    1-2 word slots, since that whitelist was designed purely as a
+//    structural check (pronoun / short noun phrase / commit SHA), not a
+//    semantic filter. "`@user`, confirmed. The partial workaround
+//    addresses the wording concern.\n\n🐇 ✓" matched despite "partial"
+//    being exactly the hedged, non-committal shape guard 5 exists to
+//    reject elsewhere. Applying the same per-token negative lookahead
+//    used in the internal gap closes this location too. Excludes BOTH
+//    enumerations (adverb and adjective forms), since a lead-in noun
+//    phrase's modifier is grammatically an adjective ("partial",
+//    "temporary") even though the internal gap's is an adverb
+//    ("partially") -- the first attempt at this fix reused only the
+//    adverb list and still let "partial"/"temporary" straight through,
+//    caught empirically before this ever reached review.
 const CODERABBIT_ACK_CLOSURE_LEADIN_RE = new RegExp(
   '^[.!]\\s+(?:' +
     'this|that|it|' +
-    'the\\s+[\\w-]+(?:\\s+[\\w-]+){0,1}|' +
+    `the\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE})\\b)[\\w-]+` +
+    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE})\\b)[\\w-]+){0,1}|` +
     'commit\\s+`[0-9a-f]{7,40}`' +
     ')\\s+$',
   'i',

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1433,34 +1433,65 @@ const CODERABBIT_ACK_ADDRESSES_CLOSURE_RE = new RegExp(
 // This helper matches CodeRabbit's own stated decision; it cannot second-
 // guess a wrong decision CodeRabbit reports about itself.
 //
-// 6. **Opening-to-closure anchor, scoped to the weaker "addresses the ..."
-//    form only** (Codex review, PR #2868, round 4): every guard above
-//    narrows what counts as a closure WITHIN a matched span, but neither
-//    closure regex was ever anchored to where the opening ends --
-//    `.test(body)` searches the WHOLE body, so an entirely separate
-//    sentence carrying genuinely new, unresolved feedback between the
-//    opening and the closure was invisible to it. Concretely: "`@user`,
-//    confirmed. However, the null-check remains unresolved. The
-//    documentation update addresses the wording concern.\n\n🐇 ✓" has an
-//    explicit "remains unresolved" sentence the closure guards never
-//    look at, yet the ADDRESSES form still matches later in the body.
-//    A real sampled reply (kurone-kito/idd-skill#2853, tests above) shows
-//    the closure is legitimately its OWN sentence, separate from the
-//    opening's -- "confirmed. The repository-qualified reference
-//    addresses the ... concern." -- so requiring the closure to start
-//    immediately after the opening (same sentence) would reject a real,
-//    observed template. The bound that holds both true is a COUNT, not
-//    a position: the text between the end of the opening match and the
-//    start of the closure match must contain at most one sentence
-//    terminator (`.`/`!`/`?`) -- the one that legitimately closes the
-//    opening's own "confirmed."/"thanks." sentence before the closure's
-//    lead-in clause begins. Two or more means at least one additional,
-//    independent sentence sits in between, exactly Codex's demonstrated
-//    shape. Scoped to `CODERABBIT_ACK_ADDRESSES_CLOSURE_RE` only, not the
-//    two strong forms: those report CodeRabbit's own resolve-attempt
+// 6. **Opening-to-closure lead-in whitelist, scoped to the weaker
+//    "addresses the ..." form only** (Codex review, PR #2868, rounds 4
+//    and 5): every guard above narrows what counts as a closure WITHIN a
+//    matched span, but neither closure regex was ever anchored to where
+//    the opening ends -- `.test(body)` searches the WHOLE body, so an
+//    entirely separate sentence carrying genuinely new, unresolved
+//    feedback between the opening and the closure was invisible to it.
+//    Round 4 tried a NEGATIVE bound: at most one sentence terminator
+//    (`.`/`!`/`?`) between the opening and the closure match, on the
+//    theory that a second terminator means a second, independent
+//    sentence sits in between. Round 5 disproved it: natural language
+//    can join an unresolved clause to the closure without ANY second
+//    terminator at all -- "`@user`, confirmed. The null-check remains
+//    unresolved; this update addresses the wording concern.\n\n🐇 ✓"
+//    joins with a semicolon and leaves the terminator count at exactly
+//    one. An em dash or a bare coordinating conjunction ("and") work
+//    the same way. Any guard defined by what the gap must NOT contain is
+//    probeable forever against open-ended prose -- guard 5's own
+//    reasoning already said so; the round-4 terminator count was the one
+//    guard in this file that violated it anyway.
+//
+//    The fix flips to a POSITIVE whitelist, the same style as
+//    `CODERABBIT_ACK_OPENING_RE`'s own closed verb list and guard 5's
+//    closed adverb list: instead of asking "does the gap avoid
+//    disallowed punctuation," ask "does the gap match one of the small
+//    number of lead-in shapes the real observed samples actually use."
+//    Both observed samples (kurone-kito/idd-skill#2853, tests above) are
+//    a bare, short noun-phrase subject referring back to the fix -- "The
+//    repository-qualified reference", "Commit `80c936a7`" -- never a
+//    clause with its own verb describing outstanding status.
+//    `CODERABBIT_ACK_CLOSURE_LEADIN_RE`, below, requires the ENTIRE gap
+//    (the opening's own terminating `.`/`!`, then this lead-in, then
+//    nothing else) to match one of: a bare pronoun ("this"/"that"/"it"),
+//    "the" plus one or two more words, or "commit" plus a short hex
+//    SHA -- deliberately not a free `[^...]` class anywhere.
+//
+//    This intentionally FAILS CLOSED on any lead-in shape not in the
+//    list, including a legitimate one not yet observed: given this
+//    repository's `fully_autonomous_merge` policy, an unrecognized
+//    lead-in should route to a human-authored disposition rather than
+//    risk silently accepting hidden feedback behind an ack-shaped reply.
+//    That is the intended failure mode, not a defect to widen away the
+//    next time a real reply is rejected -- widen the enumeration
+//    (bounded, reviewable) rather than reopening a `[^...]` gap
+//    (unbounded, the class of bug this guard exists to close).
+//
+//    Scoped to `CODERABBIT_ACK_ADDRESSES_CLOSURE_RE` only, not the two
+//    strong forms: those report CodeRabbit's own resolve-attempt
 //    DECISION, which this file's own reasoning above already treats as
 //    unable to co-occur with a new concern in the same reply, so they
 //    keep the whole-body `.test()` they always had.
+const CODERABBIT_ACK_CLOSURE_LEADIN_RE = new RegExp(
+  '^[.!]\\s+(?:' +
+    'this|that|it|' +
+    'the\\s+[\\w-]+(?:\\s+[\\w-]+){0,1}|' +
+    'commit\\s+`[0-9a-f]{7,40}`' +
+    ')\\s+$',
+  'i',
+);
 function isKnownAdvisoryAckTemplate(comment) {
   const authorLogin = String(comment.author?.login ?? '');
   const body = String(comment.body ?? '');
@@ -1475,9 +1506,9 @@ function isKnownAdvisoryAckTemplate(comment) {
   // checked on the whole body with no further guard -- see the comment
   // above `CODERABBIT_ACK_STRONG_CLOSURE_RE` for why the weaker third
   // form's guards (locality, sentence-boundary, hedge-adverb, opening-
-  // to-closure anchor) must never apply here, even when unrelated
-  // hedge-shaped wording happens to appear elsewhere in the same reply
-  // (e.g. a Learnings-used block).
+  // to-closure lead-in whitelist) must never apply here, even when
+  // unrelated hedge-shaped wording happens to appear elsewhere in the
+  // same reply (e.g. a Learnings-used block).
   if (CODERABBIT_ACK_STRONG_CLOSURE_RE.test(body)) {
     return true;
   }
@@ -1487,8 +1518,7 @@ function isKnownAdvisoryAckTemplate(comment) {
   }
   const openingEnd = openingMatch.index + openingMatch[0].length;
   const gapToClosure = body.slice(openingEnd, addressesMatch.index);
-  const sentenceTerminatorCount = (gapToClosure.match(/[.!?]/g) ?? []).length;
-  return sentenceTerminatorCount <= 1;
+  return CODERABBIT_ACK_CLOSURE_LEADIN_RE.test(gapToClosure);
 }
 // Codex usage / quota exhaustion for code reviews. Token-anchored on all
 // three of "Codex usage limit(s)", a reach/exceed/hit-family verb, and "for

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1310,33 +1310,49 @@ const CODERABBIT_ACK_OPENING_RE = new RegExp(
 // blocklist was tried here and reverted (see above) precisely because it
 // cannot keep up with natural language, so this shape is instead
 // recognized the same way as the other two -- a structural fingerprint of
-// CodeRabbit's own reply template, not a semantic read of the prose.
-// Requiring the closure sentence to end in a period immediately followed
-// by known CodeRabbit reply boilerplate (the 🐇 sign-off, the `---` +
-// Learnings-used separator, the auto-generated-reply marker, or the
-// "You are interacting with an AI system" disclaimer) or the end of the
-// body rejects a reply that goes on to raise a new, unrelated concern in
-// the next sentence (e.g. "...addresses the concern, but also X" has no
-// period before "but", so it never reaches the tail check) while still
-// matching both real observed replies, where the closure sentence is
-// immediately followed by that same boilerplate.
+// CodeRabbit's own reply template, not a semantic read of the prose. Two
+// structural constraints, both narrowed further after Codex review found
+// concrete false-positive constructions in this same PR (#2858):
+//
+// 1. The gap between "addresses the" and "concern"/"finding" excludes
+//    sentence-terminating punctuation (`[^.!?]`), not just any character.
+//    A plain `[\s\S]` gap let the match cross a sentence boundary
+//    entirely -- "This addresses the requested change. However, I still
+//    have a concern." has its own genuinely new, unrelated concern in a
+//    SECOND sentence, but the un-narrowed gap could reach that later
+//    "concern" anyway, since nothing stopped it from skipping the period
+//    in between. Excluding `.!?` from the gap forces "concern"/"finding"
+//    to appear in the SAME sentence as "addresses the", as in both real
+//    observed replies.
+// 2. The closure sentence must end in a period immediately followed by
+//    known CodeRabbit reply boilerplate (the 🐇 sign-off, the `---` +
+//    Learnings-used separator, the auto-generated-reply marker, or the
+//    "You are interacting with an AI system" disclaimer) -- no bare
+//    end-of-body fallback. Every sampled reply (all 20: the original 18
+//    plus these 2) carries real trailing boilerplate, so requiring it
+//    unconditionally costs no real match; dropping the end-of-body
+//    fallback closes a single-sentence reply with nothing following it,
+//    such as "`@user`, confirmed. This partially addresses the concern."
+//    with no footer at all -- a hedged, non-committal acknowledgment that
+//    would otherwise pass on structure alone. This also independently
+//    keeps out the cross-sentence example above, since "However, ..." is
+//    not one of the known boilerplate forms.
 //
 // Residual risk, stated rather than papered over -- NOT the same class as
 // the two forms above: those report CodeRabbit's own resolve-attempt
 // DECISION, which by this file's own reasoning cannot co-occur with a new
 // substantive concern in the same reply. This third form reads prose with
-// no such structural barrier, so it is strictly weaker: a reply that
-// raises a new concern and ends that exact sentence with a period
-// immediately before CodeRabbit's own boilerplate (e.g. "...addresses the
-// concern. However, X is still unresolved.<!-- auto-generated reply -->")
-// would still misclassify. No sampled reply has done this, and the tail
-// anchor above already closes the two adversarial shapes actually tried
-// against it (a trailing clause joined by a comma, and a genuinely new
-// concern anywhere within the 80-character locality bound) -- only the
-// narrower period-immediately-before-boilerplate combination remains
-// open.
+// no such structural barrier, so it is strictly weaker: a reply whose
+// SAME sentence both hedges ("partially", "mostly", ...) or raises a
+// concern and still ends with a period immediately before genuine
+// CodeRabbit boilerplate (e.g. "This addresses the concern, mostly.
+// <!-- auto-generated reply -->") would still misclassify. No sampled
+// reply has done this. An enumerated hedge-word guard was considered and
+// rejected for the same reason the new-concern blocklist above was: it
+// does not generalize, and this file's own philosophy prefers a stated,
+// bounded residual risk over an unbounded semantic blocklist.
 const CODERABBIT_ACK_CLOSURE_RE =
-  /✅\s*Review thread resolved\.|I couldn't resolve this review thread on the repository platform|\baddresses\s+the\b[\s\S]{0,80}?\b(?:concern|finding)\b\.\s*(?:🐇|---|<details|<!--|_You are interacting|$)/i;
+  /✅\s*Review thread resolved\.|I couldn't resolve this review thread on the repository platform|\baddresses\s+the\b[^.!?]{0,80}?\b(?:concern|finding)\b\.\s*(?:🐇|---|<details|<!--|_You are interacting)/i;
 // Explicit `isCodeRabbitLogin` author check (Copilot review, #2649,
 // round 4): the closure phrase is CodeRabbit's own resolution decision in
 // practice, but it is still literal text a differently-configured

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1338,19 +1338,39 @@ const CODERABBIT_ACK_OPENING_RE = new RegExp(
 //    keeps out the cross-sentence example above, since "However, ..." is
 //    not one of the known boilerplate forms.
 //
+// Hedge-adverb guard (Codex review round 2, PR #2868, #2858): even with
+// both constraints above, "`@user`, confirmed. This partially addresses
+// the concern.\n\n🐇 ✓" still matched -- genuine boilerplate immediately
+// follows, and "partially" sits inside the matched sentence rather than
+// crossing a sentence boundary, so neither guard above catches it. This
+// is a materially different problem class from the reverted "new
+// concern" blocklist above: that attempt tried to recognize an
+// open-ended, arbitrarily-phrased NEW substantive finding appended after
+// a genuine ack (unbounded -- natural language has unlimited ways to
+// raise a concern). A hedge adverb directly modifying "addresses" itself
+// is a small, closed, well-known class of English degree adverbs -- the
+// same kind of narrow enumeration `CODERABBIT_ACK_OPENING_RE` already
+// uses for its own confirmation verbs (thanks/confirmed/agreed). Given
+// this repository's `fully_autonomous_merge` policy (AGENTS.md), a
+// hedged "addresses" is exactly the shape most likely to hide real
+// outstanding feedback behind an ack-shaped reply, so closing the
+// specific, demonstrated case outweighs leaving it as stated residual
+// risk the way the new-concern class above still is.
+const CODERABBIT_ACK_HEDGE_RE =
+  /\b(?:partially|partly|somewhat|mostly|largely|barely|slightly|arguably|in\s+part|to\s+some\s+extent|not\s+(?:fully|entirely|completely|really))\s+addresses\s+the\b/i;
 // Residual risk, stated rather than papered over -- NOT the same class as
 // the two forms above: those report CodeRabbit's own resolve-attempt
 // DECISION, which by this file's own reasoning cannot co-occur with a new
 // substantive concern in the same reply. This third form reads prose with
-// no such structural barrier, so it is strictly weaker: a reply whose
-// SAME sentence both hedges ("partially", "mostly", ...) or raises a
-// concern and still ends with a period immediately before genuine
-// CodeRabbit boilerplate (e.g. "This addresses the concern, mostly.
-// <!-- auto-generated reply -->") would still misclassify. No sampled
-// reply has done this. An enumerated hedge-word guard was considered and
-// rejected for the same reason the new-concern blocklist above was: it
-// does not generalize, and this file's own philosophy prefers a stated,
-// bounded residual risk over an unbounded semantic blocklist.
+// no such structural barrier, so it is strictly weaker: a hedge word this
+// enumeration does not cover (e.g. "kind of", "sort of", or a novel
+// phrasing), or a reply whose SAME sentence both raises a concern in some
+// non-hedge-adverb way and still ends with a period immediately before
+// genuine CodeRabbit boilerplate, would still misclassify. No sampled
+// reply has done either. Extending the hedge-adverb enumeration further
+// is a bounded, reviewable change; recognizing arbitrary new-concern
+// phrasing is not -- that line is why the guard above stops at degree
+// adverbs and does not attempt the open-ended problem.
 const CODERABBIT_ACK_CLOSURE_RE =
   /✅\s*Review thread resolved\.|I couldn't resolve this review thread on the repository platform|\baddresses\s+the\b[^.!?]{0,80}?\b(?:concern|finding)\b\.\s*(?:🐇|---|<details|<!--|_You are interacting)/i;
 // Explicit `isCodeRabbitLogin` author check (Copilot review, #2649,
@@ -1380,7 +1400,8 @@ function isKnownAdvisoryAckTemplate(comment) {
     isCodeRabbitLogin(authorLogin) &&
     !!body &&
     CODERABBIT_ACK_OPENING_RE.test(body) &&
-    CODERABBIT_ACK_CLOSURE_RE.test(body)
+    CODERABBIT_ACK_CLOSURE_RE.test(body) &&
+    !CODERABBIT_ACK_HEDGE_RE.test(body)
   );
 }
 // Codex usage / quota exhaustion for code reviews. Token-anchored on all

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1483,18 +1483,41 @@ const CODERABBIT_ACK_NEGATION_WORDS_SOURCE =
 //
 // **Closing statement for this whole family of enumerations**: degree
 // (hedge), adjectival-degree, negation, and epistemic are the closed
-// function-word classes this guard enumerates, each independently
-// motivated by a distinct semantic relationship to the acknowledgment
-// ("to what degree," "was it done at all," "should the claim itself be
-// trusted"). A further member surfacing within one of these four
-// existing classes (a synonym for an adverb already covered, an
-// idiomatic variant) is a bounded widening, fixed in place the same way
-// this pass fixed `seldom`. A genuinely NEW semantic class (distinct
-// from all four) is a design question for issue #2858, the same
-// escalation path residual gap (a) already used -- not something to
-// keep discovering ad hoc inside this PR's review-fix loop.
+// SEMANTIC function-word classes this guard enumerates, each
+// independently motivated by a distinct relationship to the
+// acknowledgment ("to what degree," "was it done at all," "should the
+// claim itself be trusted"). A fifth, GRAMMATICAL (not semantic) class
+// -- coordinating conjunctions -- is enumerated separately below
+// (`CODERABBIT_ACK_CONJUNCTION_WORDS_SOURCE`) for a structural reason,
+// not a meaning-based one. A further member surfacing within one of
+// these five existing classes (a synonym for an adverb already covered,
+// an idiomatic variant) is a bounded widening, fixed in place the same
+// way round 12 fixed `seldom` and round 13 fixed `perhaps`/`possibly`/
+// `maybe`/`presumably` below. A genuinely NEW class -- distinct from all
+// five, and from the coordinating-conjunction structural fix -- is a
+// design question for issue #2858, the same escalation path residual
+// gap (a) already used -- not something to keep discovering ad hoc
+// inside this PR's review-fix loop.
 const CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE =
-  'supposedly|allegedly|ostensibly|nominally|purportedly|seemingly|apparently';
+  'supposedly|allegedly|ostensibly|nominally|purportedly|seemingly|apparently|perhaps|possibly|maybe|presumably';
+// A GRAMMATICAL (not semantic) closed class (Codex review, PR #2868,
+// round 13): the seven English coordinating conjunctions ("FANBOYS":
+// for/and/nor/but/or/yet/so) are excluded from the internal gap's
+// modifier tokens, closing a compact variant of the round-7 "but
+// reveals another finding" bypass that fits within the `{0,3}` token
+// cap: "`@user`, confirmed. This addresses the concern but raises
+// concerns.\n\n🐇 ✓" consumes "concern", "but", "raises" as three
+// modifier tokens (all within budget, unlike round 7's 5-token example)
+// and reaches the second, plural "concerns" as the closure target.
+// Tightening the token CAP further cannot close this in general: real
+// samples already need up to 2 tokens, and a 2-token variant of the same
+// bypass exists ("concern yet concerns"), so no finite cap excludes the
+// attack while still admitting real noun phrases. Excluding coordinating
+// conjunctions specifically is the right bound instead, because English
+// has EXACTLY seven of them -- a closed set fixed by the language's
+// grammar, not an open-ended vocabulary list -- and a genuine noun-phrase
+// modifier never needs one (neither real observed sample does).
+const CODERABBIT_ACK_CONJUNCTION_WORDS_SOURCE = 'for|and|nor|but|or|yet|so';
 // CodeRabbit review, PR #2868, round 4: two mechanical bypasses in the
 // pattern below, both closed by widening two sub-patterns from singular-
 // only to also accept the plural/multi-space form, exactly the same
@@ -1645,7 +1668,7 @@ const CODERABBIT_ACK_CLOSURE_TAIL_SOURCE =
 const CODERABBIT_ACK_ADDRESSES_CLOSURE_RE = new RegExp(
   `(?<!\\b(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE})\\s+)` +
     '\\baddresses\\s+the\\b' +
-    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE})\\b)[\\w-]+){0,3}` +
+    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE}|${CODERABBIT_ACK_CONJUNCTION_WORDS_SOURCE})\\b)[\\w-]+){0,3}` +
     '\\s+\\b(?:concerns?|findings?)\\b\\.\\s*' +
     CODERABBIT_ACK_CLOSURE_TAIL_SOURCE,
   'i',
@@ -1759,22 +1782,46 @@ const CODERABBIT_ACK_ADDRESSES_CLOSURE_RE = new RegExp(
 //    guard 7's own dual adverb/adjective exclusion above.
 // 9. **Epistemic-adverb enumeration, added proactively rather than
 //    waiting for a review round** (self-critique, same pass as round
-//    12's negation widening): `CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE`
-//    above closes a fourth, distinct semantic relationship -- casting
-//    doubt on whether the claimed fix genuinely happened at all
-//    ("supposedly", "allegedly") -- neither a degree (hedge) nor an
-//    outright denial (negation). Wired into the same three locations as
-//    guards 5, 7, and 8. See the closing statement in that constant's
-//    own doc comment for why this is treated as the natural end of this
-//    enumeration family rather than an invitation to keep widening ad
-//    hoc: degree, epistemic, and negation are the closed function-word
-//    classes; a genuinely new semantic class is a design question for
-//    issue #2858, not another review round here.
+//    12's negation widening; widened round 13):
+//    `CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE` above closes a fourth,
+//    distinct semantic relationship -- casting doubt on whether the
+//    claimed fix genuinely happened at all ("supposedly", "allegedly")
+//    -- neither a degree (hedge) nor an outright denial (negation).
+//    Wired into the same three locations as guards 5, 7, and 8. Round
+//    13 (Codex) found the initial enumeration omitted "perhaps"; widened
+//    the same pass to also cover "possibly"/"maybe"/"presumably". See
+//    the closing statement in that constant's own doc comment for why
+//    this is treated as the natural end of the SEMANTIC enumeration
+//    family (guard 10 below is a separate, GRAMMATICAL closed class, not
+//    a sixth semantic one).
+// 10. **Coordinating-conjunction exclusion, a grammatical rather than
+//     semantic closed class** (Codex review, PR #2868, round 13): the
+//     `{0,3}` token cap alone cannot close every conjunction-joined
+//     bypass, because a COMPACT one fits within budget where round 7's
+//     original 5-token example did not -- "confirmed. This addresses
+//     the concern but raises concerns.\n\n🐇 ✓" consumes "concern",
+//     "but", "raises" as three modifier tokens (within the cap) and
+//     reaches the second, plural "concerns" as the closure target.
+//     Tightening the cap further cannot close this in general: a
+//     2-token variant of the same bypass exists ("concern yet
+//     concerns"), and real samples already need up to 2 tokens, so no
+//     finite cap excludes the attack while still admitting real noun
+//     phrases. `CODERABBIT_ACK_CONJUNCTION_WORDS_SOURCE` excludes
+//     English's seven coordinating conjunctions ("FANBOYS") instead --
+//     a set fixed by the language's grammar, not open-ended vocabulary,
+//     so this is not the same class of fix as the semantic
+//     enumerations above and does not reopen the open-ended
+//     new-concern-blocklist problem. Wired into the internal gap (the
+//     demonstrated bypass) and the lead-in (defense-in-depth,
+//     consistent with guards 7-9); not the immediate pre-"addresses"
+//     lookbehind, since a bare conjunction directly before "addresses"
+//     ("confirmed. But addresses...") is not a coherent English
+//     sentence in the first place.
 const CODERABBIT_ACK_CLOSURE_LEADIN_RE = new RegExp(
   '^[.!]\\s+(?:' +
     'this|that|it|' +
-    `the\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE})\\b)[\\w-]+` +
-    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE})\\b)[\\w-]+){0,1}|` +
+    `the\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE}|${CODERABBIT_ACK_CONJUNCTION_WORDS_SOURCE})\\b)[\\w-]+` +
+    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE}|${CODERABBIT_ACK_CONJUNCTION_WORDS_SOURCE})\\b)[\\w-]+){0,1}|` +
     'commit\\s+`[0-9a-f]{7,40}`' +
     ')\\s+$',
   'i',

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1289,8 +1289,54 @@ const CODERABBIT_ACK_OPENING_RE = new RegExp(
 // "I couldn't resolve this review thread on the repository platform..."
 // fallback trailer (the same API call failed, so CodeRabbit reports the
 // attempt instead).
+//
+// #2858: a THIRD, weaker-in-kind shape -- observed on
+// kurone-kito/idd-skill#2853's review thread on the issue-reference
+// template link (2 samples from that one already-agent-resolved thread,
+// not the 18/18 sample above): "...addresses the template
+// link-resolution concern." /
+// "...addresses the template issue-reference finding." Unlike the two
+// forms above, this is prose describing an outcome, not CodeRabbit's own
+// resolve-attempt decision: CodeRabbit never attempted (or reported
+// failing) to resolve this thread, because it was already resolved
+// independently (e.g. by the IDD agent's own resolve-review-thread.mjs)
+// before CodeRabbit replied, so it had no attempt of its own to report.
+// Bounded to a short gap (`{0,80}`) so it matches only the same
+// single-clause shape actually observed, not an incidental "concern" or
+// "finding" mention far away in the same reply's trailing
+// Learnings-used block.
+//
+// Sentence-boundary tail anchor: an enumerated negation/new-concern
+// blocklist was tried here and reverted (see above) precisely because it
+// cannot keep up with natural language, so this shape is instead
+// recognized the same way as the other two -- a structural fingerprint of
+// CodeRabbit's own reply template, not a semantic read of the prose.
+// Requiring the closure sentence to end in a period immediately followed
+// by known CodeRabbit reply boilerplate (the 🐇 sign-off, the `---` +
+// Learnings-used separator, the auto-generated-reply marker, or the
+// "You are interacting with an AI system" disclaimer) or the end of the
+// body rejects a reply that goes on to raise a new, unrelated concern in
+// the next sentence (e.g. "...addresses the concern, but also X" has no
+// period before "but", so it never reaches the tail check) while still
+// matching both real observed replies, where the closure sentence is
+// immediately followed by that same boilerplate.
+//
+// Residual risk, stated rather than papered over -- NOT the same class as
+// the two forms above: those report CodeRabbit's own resolve-attempt
+// DECISION, which by this file's own reasoning cannot co-occur with a new
+// substantive concern in the same reply. This third form reads prose with
+// no such structural barrier, so it is strictly weaker: a reply that
+// raises a new concern and ends that exact sentence with a period
+// immediately before CodeRabbit's own boilerplate (e.g. "...addresses the
+// concern. However, X is still unresolved.<!-- auto-generated reply -->")
+// would still misclassify. No sampled reply has done this, and the tail
+// anchor above already closes the two adversarial shapes actually tried
+// against it (a trailing clause joined by a comma, and a genuinely new
+// concern anywhere within the 80-character locality bound) -- only the
+// narrower period-immediately-before-boilerplate combination remains
+// open.
 const CODERABBIT_ACK_CLOSURE_RE =
-  /✅\s*Review thread resolved\.|I couldn't resolve this review thread on the repository platform/i;
+  /✅\s*Review thread resolved\.|I couldn't resolve this review thread on the repository platform|\baddresses\s+the\b[\s\S]{0,80}?\b(?:concern|finding)\b\.\s*(?:🐇|---|<details|<!--|_You are interacting|$)/i;
 // Explicit `isCodeRabbitLogin` author check (Copilot review, #2649,
 // round 4): the closure phrase is CodeRabbit's own resolution decision in
 // practice, but it is still literal text a differently-configured

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1386,11 +1386,30 @@ const CODERABBIT_ACK_STRONG_CLOSURE_RE =
   /✅\s*Review thread resolved\.|I couldn't resolve this review thread on the repository platform/i;
 const CODERABBIT_ACK_HEDGE_WORDS_SOURCE =
   'partially|partly|somewhat|mostly|largely|barely|slightly|arguably|in\\s+part|to\\s+some\\s+extent|not\\s+(?:fully|entirely|completely|really)';
+// CodeRabbit review, PR #2868, round 4: two mechanical bypasses in the
+// pattern below, both closed by widening two sub-patterns from singular-
+// only to also accept the plural/multi-space form, exactly the same
+// narrow-enumeration style as every other guard here:
+// 1. The gap's negative lookahead and the final anchor only recognized
+//    the SINGULAR "concern"/"finding". A plural first occurrence
+//    ("concerns"/"findings") does not satisfy `\b(?:concern|finding)\b`
+//    (no word boundary between "concern" and its trailing "s"), so the
+//    lookahead's `(?!...)` trivially succeeds there and the engine keeps
+//    consuming characters as if no candidate occurrence existed --
+//    resurfacing guard 4's own "backtrack past the first occurrence"
+//    class of bug, but for plural nouns specifically. Both sub-patterns
+//    now accept an optional trailing "s".
+// 2. The hedge lookbehind ended in a single `\s`, so "partially  addresses"
+//    (two spaces) fell outside the lookbehind's fixed one-character gap
+//    and bypassed the guard entirely. Widened to `\s+`; V8's lookbehind
+//    supports variable-length alternatives (confirmed empirically on
+//    this exact Node floor after Copilot's round-5 finding to the
+//    contrary was rejected, above), so this is a safe, narrow widening.
 const CODERABBIT_ACK_ADDRESSES_CLOSURE_RE = new RegExp(
-  `(?<!\\b(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE})\\s)` +
+  `(?<!\\b(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE})\\s+)` +
     '\\baddresses\\s+the\\b' +
-    '(?:(?!\\b(?:concern|finding)\\b)[^.!?]){0,80}' +
-    '\\b(?:concern|finding)\\b\\.\\s*' +
+    '(?:(?!\\b(?:concerns?|findings?)\\b)[^.!?]){0,80}' +
+    '\\b(?:concerns?|findings?)\\b\\.\\s*' +
     '(?:🐇|---|<details|<!--|_You are interacting)',
   'i',
 );
@@ -1413,25 +1432,63 @@ const CODERABBIT_ACK_ADDRESSES_CLOSURE_RE = new RegExp(
 // acknowledgment (a CodeRabbit-side defect) would still misclassify here.
 // This helper matches CodeRabbit's own stated decision; it cannot second-
 // guess a wrong decision CodeRabbit reports about itself.
+//
+// 6. **Opening-to-closure anchor, scoped to the weaker "addresses the ..."
+//    form only** (Codex review, PR #2868, round 4): every guard above
+//    narrows what counts as a closure WITHIN a matched span, but neither
+//    closure regex was ever anchored to where the opening ends --
+//    `.test(body)` searches the WHOLE body, so an entirely separate
+//    sentence carrying genuinely new, unresolved feedback between the
+//    opening and the closure was invisible to it. Concretely: "`@user`,
+//    confirmed. However, the null-check remains unresolved. The
+//    documentation update addresses the wording concern.\n\n🐇 ✓" has an
+//    explicit "remains unresolved" sentence the closure guards never
+//    look at, yet the ADDRESSES form still matches later in the body.
+//    A real sampled reply (kurone-kito/idd-skill#2853, tests above) shows
+//    the closure is legitimately its OWN sentence, separate from the
+//    opening's -- "confirmed. The repository-qualified reference
+//    addresses the ... concern." -- so requiring the closure to start
+//    immediately after the opening (same sentence) would reject a real,
+//    observed template. The bound that holds both true is a COUNT, not
+//    a position: the text between the end of the opening match and the
+//    start of the closure match must contain at most one sentence
+//    terminator (`.`/`!`/`?`) -- the one that legitimately closes the
+//    opening's own "confirmed."/"thanks." sentence before the closure's
+//    lead-in clause begins. Two or more means at least one additional,
+//    independent sentence sits in between, exactly Codex's demonstrated
+//    shape. Scoped to `CODERABBIT_ACK_ADDRESSES_CLOSURE_RE` only, not the
+//    two strong forms: those report CodeRabbit's own resolve-attempt
+//    DECISION, which this file's own reasoning above already treats as
+//    unable to co-occur with a new concern in the same reply, so they
+//    keep the whole-body `.test()` they always had.
 function isKnownAdvisoryAckTemplate(comment) {
   const authorLogin = String(comment.author?.login ?? '');
   const body = String(comment.body ?? '');
   if (!authorLogin || !isCodeRabbitLogin(authorLogin) || !body) {
     return false;
   }
-  if (!CODERABBIT_ACK_OPENING_RE.test(body)) {
+  const openingMatch = CODERABBIT_ACK_OPENING_RE.exec(body);
+  if (!openingMatch) {
     return false;
   }
   // The two strong forms (CodeRabbit's own resolve-attempt decision) are
   // checked on the whole body with no further guard -- see the comment
   // above `CODERABBIT_ACK_STRONG_CLOSURE_RE` for why the weaker third
-  // form's guards (locality, sentence-boundary, hedge-adverb) must never
-  // apply here, even when unrelated hedge-shaped wording happens to
-  // appear elsewhere in the same reply (e.g. a Learnings-used block).
+  // form's guards (locality, sentence-boundary, hedge-adverb, opening-
+  // to-closure anchor) must never apply here, even when unrelated
+  // hedge-shaped wording happens to appear elsewhere in the same reply
+  // (e.g. a Learnings-used block).
   if (CODERABBIT_ACK_STRONG_CLOSURE_RE.test(body)) {
     return true;
   }
-  return CODERABBIT_ACK_ADDRESSES_CLOSURE_RE.test(body);
+  const addressesMatch = CODERABBIT_ACK_ADDRESSES_CLOSURE_RE.exec(body);
+  if (!addressesMatch) {
+    return false;
+  }
+  const openingEnd = openingMatch.index + openingMatch[0].length;
+  const gapToClosure = body.slice(openingEnd, addressesMatch.index);
+  const sentenceTerminatorCount = (gapToClosure.match(/[.!?]/g) ?? []).length;
+  return sentenceTerminatorCount <= 1;
 }
 // Codex usage / quota exhaustion for code reviews. Token-anchored on all
 // three of "Codex usage limit(s)", a reach/exceed/hit-family verb, and "for

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1301,78 +1301,99 @@ const CODERABBIT_ACK_OPENING_RE = new RegExp(
 // failing) to resolve this thread, because it was already resolved
 // independently (e.g. by the IDD agent's own resolve-review-thread.mjs)
 // before CodeRabbit replied, so it had no attempt of its own to report.
-// Bounded to a short gap (`{0,80}`) so it matches only the same
-// single-clause shape actually observed, not an incidental "concern" or
-// "finding" mention far away in the same reply's trailing
-// Learnings-used block.
+// Kept as its own regex (`CODERABBIT_ACK_ADDRESSES_CLOSURE_RE`, below,
+// tested only after the two strong forms above fail) rather than folded
+// into one `|`-alternation, specifically so its own guards -- narrowed
+// across three rounds of Codex/Copilot review on this same PR (#2858,
+// PR #2868) -- never apply to the two strong, structurally-safe forms:
 //
-// Sentence-boundary tail anchor: an enumerated negation/new-concern
-// blocklist was tried here and reverted (see above) precisely because it
-// cannot keep up with natural language, so this shape is instead
-// recognized the same way as the other two -- a structural fingerprint of
-// CodeRabbit's own reply template, not a semantic read of the prose. Two
-// structural constraints, both narrowed further after Codex review found
-// concrete false-positive constructions in this same PR (#2858):
+// 1. **Locality bound** (`{0,80}`): the gap between "addresses the" and
+//    "concern"/"finding" is capped so an incidental "concern"/"finding"
+//    mention far away in the same reply's trailing Learnings-used block
+//    can't retroactively create a false closure signal.
+// 2. **Sentence-boundary exclusion** (`[^.!?]` in the gap, round 1): a
+//    plain `[\s\S]` gap let the match cross a sentence boundary entirely
+//    -- "This addresses the requested change. However, I still have a
+//    concern." has its own genuinely new, unrelated concern in a SECOND
+//    sentence, but an un-narrowed gap could reach that later "concern"
+//    anyway. Excluding `.!?` forces "concern"/"finding" into the SAME
+//    sentence as "addresses the", as in both real observed replies.
+// 3. **Mandatory boilerplate tail, no bare end-of-body fallback**
+//    (round 1): the closure sentence must end in a period immediately
+//    followed by known CodeRabbit reply boilerplate (the 🐇 sign-off,
+//    the `---` + Learnings-used separator, the auto-generated-reply
+//    marker, or the "You are interacting with an AI system" disclaimer).
+//    Every sampled reply (all 20: the original 18 plus these 2) carries
+//    real trailing boilerplate, so requiring it unconditionally costs no
+//    real match; this also rejects a single-sentence reply with nothing
+//    following it at all, such as "`@user`, confirmed. This partially
+//    addresses the concern." with no footer -- a hedged, non-committal
+//    acknowledgment that would otherwise pass on structure alone.
+// 4. **No backtracking past an earlier same-sentence "concern"/"finding"**
+//    (round 3, Codex): a plain lazy `[^.!?]{0,80}?` gap still let the
+//    regex engine skip an EARLIER "concern"/"finding" occurrence that
+//    failed the boilerplate-tail check, to find a LATER one that
+//    succeeds -- "`@user`, confirmed. This addresses the original
+//    concern but reveals another finding.\n\n🐇 ✓" has a genuinely new
+//    finding joined by "but" in the SAME sentence, yet the gap could
+//    still stretch past the first "concern" (not followed by a period)
+//    to match the later "finding." instead. The gap is rewritten as
+//    `(?:(?!\b(?:concern|finding)\b)[^.!?]){0,80}` -- consume characters
+//    only while the upcoming text is NOT the start of "concern" or
+//    "finding" -- so the match is pinned to the FIRST such occurrence in
+//    the sentence; the whole alternative fails if that first occurrence
+//    isn't immediately followed by the boilerplate tail, rather than
+//    scanning ahead for a second one that is.
+// 5. **Hedge-adverb guard, scoped to only this alternative** (round 2,
+//    Codex; scoping fixed round 3, Copilot): even with all of the above,
+//    "`@user`, confirmed. This partially addresses the concern.\n\n🐇 ✓"
+//    still matched -- genuine boilerplate immediately follows, no
+//    sentence boundary is crossed, and "concern" is the first and only
+//    candidate, so guards 1-4 don't catch it. A small, closed set of
+//    English degree adverbs immediately before "addresses" -- the same
+//    narrow-enumeration style `CODERABBIT_ACK_OPENING_RE` already uses
+//    for its own confirmation verbs (thanks/confirmed/agreed) -- is
+//    materially different from the open-ended "new concern" blocklist
+//    already tried and reverted above: that attempt tried to recognize
+//    arbitrarily-phrased new substantive content (unbounded), while this
+//    is a small, well-known closed class of adverbs modifying
+//    "addresses" itself. Implemented as a negative lookbehind directly on
+//    this alternative (not a separate whole-body check) so it can never
+//    reject the two strong forms merely because unrelated hedge-shaped
+//    wording happens to appear elsewhere in the same reply's boilerplate
+//    (e.g. a Learnings-used block quoting a past PR's discussion) --
+//    Copilot's round-3 finding on the round-2 fix. Given this
+//    repository's `fully_autonomous_merge` policy (AGENTS.md), a hedged
+//    "addresses" is exactly the shape most likely to hide real
+//    outstanding feedback behind an ack-shaped reply, so closing this
+//    demonstrated case outweighs leaving it as stated residual risk the
+//    way the new-concern class above still is.
 //
-// 1. The gap between "addresses the" and "concern"/"finding" excludes
-//    sentence-terminating punctuation (`[^.!?]`), not just any character.
-//    A plain `[\s\S]` gap let the match cross a sentence boundary
-//    entirely -- "This addresses the requested change. However, I still
-//    have a concern." has its own genuinely new, unrelated concern in a
-//    SECOND sentence, but the un-narrowed gap could reach that later
-//    "concern" anyway, since nothing stopped it from skipping the period
-//    in between. Excluding `.!?` from the gap forces "concern"/"finding"
-//    to appear in the SAME sentence as "addresses the", as in both real
-//    observed replies.
-// 2. The closure sentence must end in a period immediately followed by
-//    known CodeRabbit reply boilerplate (the 🐇 sign-off, the `---` +
-//    Learnings-used separator, the auto-generated-reply marker, or the
-//    "You are interacting with an AI system" disclaimer) -- no bare
-//    end-of-body fallback. Every sampled reply (all 20: the original 18
-//    plus these 2) carries real trailing boilerplate, so requiring it
-//    unconditionally costs no real match; dropping the end-of-body
-//    fallback closes a single-sentence reply with nothing following it,
-//    such as "`@user`, confirmed. This partially addresses the concern."
-//    with no footer at all -- a hedged, non-committal acknowledgment that
-//    would otherwise pass on structure alone. This also independently
-//    keeps out the cross-sentence example above, since "However, ..." is
-//    not one of the known boilerplate forms.
-//
-// Hedge-adverb guard (issue #2858, Codex round-2 review on PR #2868): even with
-// both constraints above, "`@user`, confirmed. This partially addresses
-// the concern.\n\n🐇 ✓" still matched -- genuine boilerplate immediately
-// follows, and "partially" sits inside the matched sentence rather than
-// crossing a sentence boundary, so neither guard above catches it. This
-// is a materially different problem class from the reverted "new
-// concern" blocklist above: that attempt tried to recognize an
-// open-ended, arbitrarily-phrased NEW substantive finding appended after
-// a genuine ack (unbounded -- natural language has unlimited ways to
-// raise a concern). A hedge adverb directly modifying "addresses" itself
-// is a small, closed, well-known class of English degree adverbs -- the
-// same kind of narrow enumeration `CODERABBIT_ACK_OPENING_RE` already
-// uses for its own confirmation verbs (thanks/confirmed/agreed). Given
-// this repository's `fully_autonomous_merge` policy (AGENTS.md), a
-// hedged "addresses" is exactly the shape most likely to hide real
-// outstanding feedback behind an ack-shaped reply, so closing the
-// specific, demonstrated case outweighs leaving it as stated residual
-// risk the way the new-concern class above still is.
-const CODERABBIT_ACK_HEDGE_RE =
-  /\b(?:partially|partly|somewhat|mostly|largely|barely|slightly|arguably|in\s+part|to\s+some\s+extent|not\s+(?:fully|entirely|completely|really))\s+addresses\s+the\b/i;
 // Residual risk, stated rather than papered over -- NOT the same class as
-// the two forms above: those report CodeRabbit's own resolve-attempt
+// the two strong forms: those report CodeRabbit's own resolve-attempt
 // DECISION, which by this file's own reasoning cannot co-occur with a new
 // substantive concern in the same reply. This third form reads prose with
-// no such structural barrier, so it is strictly weaker: a hedge word this
-// enumeration does not cover (e.g. "kind of", "sort of", or a novel
-// phrasing), or a reply whose SAME sentence both raises a concern in some
-// non-hedge-adverb way and still ends with a period immediately before
-// genuine CodeRabbit boilerplate, would still misclassify. No sampled
-// reply has done either. Extending the hedge-adverb enumeration further
-// is a bounded, reviewable change; recognizing arbitrary new-concern
-// phrasing is not -- that line is why the guard above stops at degree
-// adverbs and does not attempt the open-ended problem.
-const CODERABBIT_ACK_CLOSURE_RE =
-  /✅\s*Review thread resolved\.|I couldn't resolve this review thread on the repository platform|\baddresses\s+the\b[^.!?]{0,80}?\b(?:concern|finding)\b\.\s*(?:🐇|---|<details|<!--|_You are interacting)/i;
+// no such structural barrier, so it is strictly weaker: a hedge word the
+// enumeration above does not cover (e.g. "kind of", "sort of", or a novel
+// phrasing), or a new concern joined to the acknowledgment some way other
+// than a mid-sentence conjunction guard 4 already closes, would still
+// misclassify. No sampled reply has done either. Extending the
+// hedge-adverb enumeration further is a bounded, reviewable change;
+// recognizing arbitrary new-concern phrasing is not -- that line is why
+// guard 5 stops at degree adverbs and does not attempt the open-ended
+// problem.
+const CODERABBIT_ACK_STRONG_CLOSURE_RE =
+  /✅\s*Review thread resolved\.|I couldn't resolve this review thread on the repository platform/i;
+const CODERABBIT_ACK_HEDGE_WORDS_SOURCE =
+  'partially|partly|somewhat|mostly|largely|barely|slightly|arguably|in\\s+part|to\\s+some\\s+extent|not\\s+(?:fully|entirely|completely|really)';
+const CODERABBIT_ACK_ADDRESSES_CLOSURE_RE = new RegExp(
+  `(?<!\\b(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE})\\s)` +
+    '\\baddresses\\s+the\\b' +
+    '(?:(?!\\b(?:concern|finding)\\b)[^.!?]){0,80}' +
+    '\\b(?:concern|finding)\\b\\.\\s*' +
+    '(?:🐇|---|<details|<!--|_You are interacting)',
+  'i',
+);
 // Explicit `isCodeRabbitLogin` author check (Copilot review, #2649,
 // round 4): the closure phrase is CodeRabbit's own resolution decision in
 // practice, but it is still literal text a differently-configured
@@ -1395,14 +1416,22 @@ const CODERABBIT_ACK_CLOSURE_RE =
 function isKnownAdvisoryAckTemplate(comment) {
   const authorLogin = String(comment.author?.login ?? '');
   const body = String(comment.body ?? '');
-  return (
-    !!authorLogin &&
-    isCodeRabbitLogin(authorLogin) &&
-    !!body &&
-    CODERABBIT_ACK_OPENING_RE.test(body) &&
-    CODERABBIT_ACK_CLOSURE_RE.test(body) &&
-    !CODERABBIT_ACK_HEDGE_RE.test(body)
-  );
+  if (!authorLogin || !isCodeRabbitLogin(authorLogin) || !body) {
+    return false;
+  }
+  if (!CODERABBIT_ACK_OPENING_RE.test(body)) {
+    return false;
+  }
+  // The two strong forms (CodeRabbit's own resolve-attempt decision) are
+  // checked on the whole body with no further guard -- see the comment
+  // above `CODERABBIT_ACK_STRONG_CLOSURE_RE` for why the weaker third
+  // form's guards (locality, sentence-boundary, hedge-adverb) must never
+  // apply here, even when unrelated hedge-shaped wording happens to
+  // appear elsewhere in the same reply (e.g. a Learnings-used block).
+  if (CODERABBIT_ACK_STRONG_CLOSURE_RE.test(body)) {
+    return true;
+  }
+  return CODERABBIT_ACK_ADDRESSES_CLOSURE_RE.test(body);
 }
 // Codex usage / quota exhaustion for code reviews. Token-anchored on all
 // three of "Codex usage limit(s)", a reach/exceed/hit-family verb, and "for

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1307,52 +1307,66 @@ const CODERABBIT_ACK_OPENING_RE = new RegExp(
 // across three rounds of Codex/Copilot review on this same PR (#2858,
 // PR #2868) -- never apply to the two strong, structurally-safe forms:
 //
-// 1. **Locality bound** (`{0,80}`): the gap between "addresses the" and
-//    "concern"/"finding" is capped so an incidental "concern"/"finding"
-//    mention far away in the same reply's trailing Learnings-used block
-//    can't retroactively create a false closure signal.
-// 2. **Sentence-boundary exclusion** (`[^.!?]` in the gap, round 1): a
-//    plain `[\s\S]` gap let the match cross a sentence boundary entirely
-//    -- "This addresses the requested change. However, I still have a
-//    concern." has its own genuinely new, unrelated concern in a SECOND
-//    sentence, but an un-narrowed gap could reach that later "concern"
-//    anyway. Excluding `.!?` forces "concern"/"finding" into the SAME
-//    sentence as "addresses the", as in both real observed replies.
+// Guard history below reflects the CURRENT implementation as of round 7
+// (Codex/CodeRabbit review on PR #2868) -- Copilot's round-8 review
+// flagged an earlier revision of this comment block for still describing
+// the pre-round-7 `{0,80}`/`[^.!?]` mechanism after the code had already
+// moved on, which is exactly the kind of drift this file's own extensive
+// documentation is meant to prevent. Each guard below states what it
+// does NOW, with the specific round/finding that shaped it for
+// traceability, not a literal transcript of an earlier regex.
+//
+// 1. **Locality bound, tokenized** (originally a `{0,80}` character
+//    count; replaced by a `{0,3}` modifier-TOKEN count, round 7, Codex):
+//    the gap between "addresses the" and "concern"/"finding" is capped
+//    so an incidental "concern"/"finding" mention far away in the same
+//    reply's trailing Learnings-used block can't retroactively create a
+//    false closure signal. Both real observed replies use a 2-token
+//    noun-phrase modifier ("template link-resolution", "template
+//    issue-reference"); the cap allows one token of headroom beyond
+//    that, since a coherent conjunction-based topic change realistically
+//    needs 4+ words (round 7's own adversarial example needed 5).
+// 2. **Word/hyphen-only tokens, no sentence-boundary or comma crossing**
+//    (originally `[^.!?]` exclusion, round 1, Codex; superseded by the
+//    `[\w-]+` token grammar, round 7): restricting each gap token to
+//    word and hyphen characters, separated only by whitespace, means
+//    neither a comma nor a sentence terminator (`.`/`!`/`?`) can appear
+//    inside the gap at all -- either one breaks the token chain outright.
+//    This subsumes the original round-1 finding ("This addresses the
+//    requested change. However, I still have a concern." must not reach
+//    the second sentence's "concern") without a separate exclusion rule.
 // 3. **Mandatory boilerplate tail, no bare end-of-body fallback**
-//    (round 1): the closure sentence must end in a period immediately
-//    followed by known CodeRabbit reply boilerplate (the 🐇 sign-off,
-//    the `---` + Learnings-used separator, the auto-generated-reply
-//    marker, or the "You are interacting with an AI system" disclaimer).
-//    Every sampled reply (all 20: the original 18 plus these 2) carries
-//    real trailing boilerplate, so requiring it unconditionally costs no
-//    real match; this also rejects a single-sentence reply with nothing
-//    following it at all, such as "`@user`, confirmed. This partially
-//    addresses the concern." with no footer -- a hedged, non-committal
-//    acknowledgment that would otherwise pass on structure alone.
+//    (round 1, Codex; tail shape fully anchored to end-of-body, round 6,
+//    Codex): the closure sentence must end in a period immediately
+//    followed by the complete recognized boilerplate shape (see
+//    `CODERABBIT_ACK_CLOSURE_TAIL_SOURCE` below), not merely start with
+//    one of its markers. Every sampled reply (all 20: the original 18
+//    plus these 2) carries real trailing boilerplate, so requiring it
+//    unconditionally costs no real match; this also rejects a single-
+//    sentence reply with nothing following it at all, such as "`@user`,
+//    confirmed. This partially addresses the concern." with no footer --
+//    a hedged, non-committal acknowledgment that would otherwise pass on
+//    structure alone.
 // 4. **No backtracking past an earlier same-sentence "concern"/"finding"**
-//    (round 3, Codex): a plain lazy `[^.!?]{0,80}?` gap still let the
-//    regex engine skip an EARLIER "concern"/"finding" occurrence that
-//    failed the boilerplate-tail check, to find a LATER one that
-//    succeeds -- "`@user`, confirmed. This addresses the original
-//    concern but reveals another finding.\n\n🐇 ✓" has a genuinely new
-//    finding joined by "but" in the SAME sentence, yet the gap could
-//    still stretch past the first "concern" (not followed by a period)
-//    to match the later "finding." instead. The gap is rewritten as
-//    `(?:(?!\b(?:concern|finding)\b)[^.!?]){0,80}` -- consume characters
-//    only while the upcoming text is NOT the start of "concern" or
-//    "finding" -- so the match is pinned to the FIRST such occurrence in
-//    the sentence; the whole alternative fails if that first occurrence
-//    isn't immediately followed by the boilerplate tail, rather than
-//    scanning ahead for a second one that is.
-// 5. **Hedge-adverb guard, scoped to only this alternative** (round 2,
-//    Codex; scoping fixed round 3, Copilot): even with all of the above,
-//    "`@user`, confirmed. This partially addresses the concern.\n\n🐇 ✓"
-//    still matched -- genuine boilerplate immediately follows, no
-//    sentence boundary is crossed, and "concern" is the first and only
-//    candidate, so guards 1-4 don't catch it. A small, closed set of
-//    English degree adverbs immediately before "addresses" -- the same
-//    narrow-enumeration style `CODERABBIT_ACK_OPENING_RE` already uses
-//    for its own confirmation verbs (thanks/confirmed/agreed) -- is
+//    (round 3, Codex; now a natural consequence of guards 1-2's token
+//    grammar rather than a separate per-character lookahead): "`@user`,
+//    confirmed. This addresses the original concern but reveals another
+//    finding.\n\n🐇 ✓" has a genuinely new finding joined by "but" in the
+//    SAME sentence. Reaching the later "finding" would require consuming
+//    "concern", "but", and "reveals" as modifier tokens first -- 3 tokens
+//    before even reaching "another finding", already past the `{0,3}`
+//    cap guard 1 enforces -- so no valid parse reaches the second
+//    occurrence; the match fails at the first "concern" instead, exactly
+//    as guard 3's tail check requires.
+// 5. **Hedge-adverb guard, both before "addresses" and inside the gap**
+//    (round 2, Codex; scoping fixed round 3, Copilot; extended into the
+//    gap itself, round 7, Codex): "`@user`, confirmed. This partially
+//    addresses the concern.\n\n🐇 ✓" has genuine boilerplate immediately
+//    following, crosses no sentence boundary, and "concern" is the first
+//    and only candidate, so guards 1-4 don't catch it. A small, closed
+//    set of English degree adverbs immediately before "addresses" -- the
+//    same narrow-enumeration style `CODERABBIT_ACK_OPENING_RE` already
+//    uses for its own confirmation verbs (thanks/confirmed/agreed) -- is
 //    materially different from the open-ended "new concern" blocklist
 //    already tried and reverted above: that attempt tried to recognize
 //    arbitrarily-phrased new substantive content (unbounded), while this
@@ -1362,7 +1376,10 @@ const CODERABBIT_ACK_OPENING_RE = new RegExp(
 //    reject the two strong forms merely because unrelated hedge-shaped
 //    wording happens to appear elsewhere in the same reply's boilerplate
 //    (e.g. a Learnings-used block quoting a past PR's discussion) --
-//    Copilot's round-3 finding on the round-2 fix. Given this
+//    Copilot's round-3 finding on the round-2 fix. Round 7 additionally
+//    checks each gap token against the same enumeration, since a hedge
+//    word can also hide INSIDE the gap ("addresses the partially
+//    resolved concern") where the lookbehind never looks. Given this
 //    repository's `fully_autonomous_merge` policy (AGENTS.md), a hedged
 //    "addresses" is exactly the shape most likely to hide real
 //    outstanding feedback behind an ack-shaped reply, so closing this
@@ -1373,15 +1390,32 @@ const CODERABBIT_ACK_OPENING_RE = new RegExp(
 // the two strong forms: those report CodeRabbit's own resolve-attempt
 // DECISION, which by this file's own reasoning cannot co-occur with a new
 // substantive concern in the same reply. This third form reads prose with
-// no such structural barrier, so it is strictly weaker: a hedge word the
-// enumeration above does not cover (e.g. "kind of", "sort of", or a novel
-// phrasing), or a new concern joined to the acknowledgment some way other
-// than a mid-sentence conjunction guard 4 already closes, would still
-// misclassify. No sampled reply has done either. Extending the
-// hedge-adverb enumeration further is a bounded, reviewable change;
-// recognizing arbitrary new-concern phrasing is not -- that line is why
-// guard 5 stops at degree adverbs and does not attempt the open-ended
-// problem.
+// no such structural barrier, so it is strictly weaker. Two residual gaps
+// remain, both raised as a design question on issue #2858 rather than
+// chased further here:
+//
+// (a) **Contrastive/evaluative adjectives within the `{0,3}` token
+//     window** (Codex round 8, PR #2868): degree adverbs (guard 5) are a
+//     closed, enumerable class -- English has roughly a dozen. A
+//     CONTRASTIVE adjective is not: "wrong", "different", "other",
+//     "unrelated", "remaining", "outstanding", "unaddressed" all read as
+//     coherent, grammatically ordinary English inside the gap --
+//     "`@user`, thanks. This addresses the wrong security
+//     concern.\n\n🐇 ✓" is a coherent sentence stating the fix missed the
+//     mark, yet matches structurally. Enumerating this class would be
+//     the exact open-ended "new concern" blocklist this file's own
+//     history already tried and reverted (guard 5's comment above); it
+//     is not the same shape as a short, closed adverb list. This is the
+//     third form's irreducible limit for recognizing a prose closure via
+//     structure rather than genuine language understanding, not a gap
+//     guards 1-5 failed to close. Both real observed samples use plain
+//     noun-attributive modifiers naming the topic ("template",
+//     "link-resolution"), never an evaluative adjective -- no sampled
+//     reply has used this shape to hide misclassified feedback.
+// (b) The `<details>` block's interior (see
+//     `CODERABBIT_ACK_CLOSURE_DETAILS_SOURCE` below) is intentionally
+//     opaque, quoted text; a concern hidden there rather than as sibling
+//     prose would also still misclassify, for the same reason.
 const CODERABBIT_ACK_STRONG_CLOSURE_RE =
   /✅\s*Review thread resolved\.|I couldn't resolve this review thread on the repository platform/i;
 const CODERABBIT_ACK_HEDGE_WORDS_SOURCE =
@@ -1519,14 +1553,20 @@ const CODERABBIT_ACK_CLOSURE_TAIL_SOURCE =
 // text immediately preceding "addresses") entirely.
 //
 // Residual risk, stated rather than papered over, the same standard as
-// every guard above: within the 3-token cap, a semantically incoherent
-// but structurally valid modifier sequence -- e.g. "addresses the
-// concern finding." (treating "concern" itself as a 1-token modifier of
-// "finding") -- would still match. No sampled reply has produced word
-// salad like this; recognizing that a modifier sequence is not
-// grammatically sensible is the same open-ended natural-language
-// problem this file has repeatedly declared out of scope, the same
-// class as the `<details>` block's opaque interior above.
+// every guard above -- and corrected here after an earlier revision of
+// this paragraph understated it (Codex round 8, PR #2868, below): within
+// the 3-token cap, the token content itself is not semantically
+// restricted beyond the closed hedge-adverb enumeration. This is not
+// limited to ungrammatical "word salad" like "addresses the concern
+// finding." -- a CONTRASTIVE adjective reads as perfectly ordinary
+// English while still meaning the opposite of an acknowledgment:
+// "addresses the wrong security concern" is coherent and structurally
+// matches. See residual gap (a) in the comment above
+// `CODERABBIT_ACK_STRONG_CLOSURE_RE` for why this class (contrastive
+// adjectives: "wrong", "different", "unrelated", "remaining", and
+// similar) is NOT enumerable the way the degree-adverb hedge list is,
+// and is raised as a design question on issue #2858 rather than chased
+// with an open-ended list here.
 const CODERABBIT_ACK_ADDRESSES_CLOSURE_RE = new RegExp(
   `(?<!\\b(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE})\\s+)` +
     '\\baddresses\\s+the\\b' +

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1480,11 +1480,58 @@ const CODERABBIT_ACK_CLOSURE_TAIL_SOURCE =
   `(?:\\s*${CODERABBIT_ACK_CLOSURE_MARKER_SOURCE})?` +
   `|${CODERABBIT_ACK_CLOSURE_MARKER_SOURCE})` +
   '\\s*$';
+// Internal gap tokenized, capped at 3 modifier words, hedge words
+// excluded per token (Codex review, PR #2868, round 7): the previous
+// `(?:(?!\b(?:concerns?|findings?)\b)[^.!?]){0,80}` gap was a NEGATIVE
+// bound again -- any non-period, non-concern/finding character was
+// allowed, for up to 80 of them -- and Codex demonstrated it accepts a
+// coordinating conjunction that silently swaps in a genuinely different,
+// unaddressed concern: "confirmed. This addresses the documentation
+// issue but leaves a security concern.\n\n🐇 ✓" has only ONE "concern"
+// occurrence (so guard 4's no-backtrack protection never engages), and
+// it is immediately followed by the required boilerplate, so the old
+// gap matched it as a clean acknowledgment even though "but leaves a"
+// means the opposite.
+//
+// Both real observed samples (kurone-kito/idd-skill#2853) show the gap
+// is a SHORT, plain noun-phrase modifier with no verbs or conjunctions
+// at all: "template link-resolution" and "template issue-reference" (2
+// tokens each). The fix flips this gap to the same positive-shape style
+// as guard 6's lead-in whitelist: the gap may consist of at most 3
+// space-separated `[\w-]+` tokens (one more than either real sample
+// needs, since a coherent conjunction-based "flip" needs a verb plus a
+// new subject -- realistically 4 or more words -- to read as a genuine
+// change of topic; Codex's own example needs 5). Restricting tokens to
+// `[\w-]+` also subsumes guards 2 and 4 for free: neither a comma nor a
+// sentence-terminating `.`/`!`/`?` is a word character or whitespace, so
+// either one breaks the token chain outright, and reaching a SECOND,
+// later "concern"/"finding" now requires consuming more modifier tokens
+// than the cap allows (verified against round 3's own "addresses the
+// original concern but reveals another finding" fixture below, still
+// rejected under the new grammar with no separate backtrack guard
+// needed).
+//
+// Each token is additionally checked against the same closed hedge-word
+// enumeration as the lookbehind below, via a per-token negative
+// lookahead: without this, "addresses the partially resolved concern"
+// would let a hedge word hide INSIDE the gap rather than immediately
+// before "addresses", bypassing the lookbehind (which only inspects the
+// text immediately preceding "addresses") entirely.
+//
+// Residual risk, stated rather than papered over, the same standard as
+// every guard above: within the 3-token cap, a semantically incoherent
+// but structurally valid modifier sequence -- e.g. "addresses the
+// concern finding." (treating "concern" itself as a 1-token modifier of
+// "finding") -- would still match. No sampled reply has produced word
+// salad like this; recognizing that a modifier sequence is not
+// grammatically sensible is the same open-ended natural-language
+// problem this file has repeatedly declared out of scope, the same
+// class as the `<details>` block's opaque interior above.
 const CODERABBIT_ACK_ADDRESSES_CLOSURE_RE = new RegExp(
   `(?<!\\b(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE})\\s+)` +
     '\\baddresses\\s+the\\b' +
-    '(?:(?!\\b(?:concerns?|findings?)\\b)[^.!?]){0,80}' +
-    '\\b(?:concerns?|findings?)\\b\\.\\s*' +
+    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE})\\b)[\\w-]+){0,3}` +
+    '\\s+\\b(?:concerns?|findings?)\\b\\.\\s*' +
     CODERABBIT_ACK_CLOSURE_TAIL_SOURCE,
   'i',
 );

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1405,12 +1405,87 @@ const CODERABBIT_ACK_HEDGE_WORDS_SOURCE =
 //    supports variable-length alternatives (confirmed empirically on
 //    this exact Node floor after Copilot's round-5 finding to the
 //    contrary was rejected, above), so this is a safe, narrow widening.
+//
+// Tail grammar, anchored to end-of-body (Codex review, PR #2868, round 6):
+// the boilerplate-tail alternation used to validate only the FIRST
+// recognized token (`🐇`, `---`, `<details`, `<!--`, or
+// `_You are interacting`) and accept whatever followed unexamined --
+// itself a prefix match, the same "validated a fragment, not the whole
+// shape" bug rounds 4-5 already closed on the opening side. Demonstrated:
+// "`@user`, confirmed. This addresses the wording concern.\n\n---\n\n
+// However, the null-check remains unresolved." matched, because "---"
+// satisfies the alternation even though genuine new feedback follows it.
+// Every one of the four alternatives had the same flaw.
+//
+// Fixed by replacing the prefix alternation with the fixed-order,
+// fully-optional tail grammar the two real observed samples
+// (kurone-kito/idd-skill#2853) actually have -- sign-off, then a
+// `---`-delimited `<details>...</details>` block (the Learnings-used
+// container; its interior is opaque quoted text and is NOT re-validated,
+// see residual risk below), then the AI-system disclaimer, then the
+// auto-generated-reply marker (single-sourced via
+// `CODERABBIT_AUTO_GENERATED_REPLY_MARKER` so it cannot drift from
+// `CODERABBIT_ACK_OPENING_RE`'s own use of the same literal) -- anchored
+// to `$` so nothing can follow any of them unexamined.
+//
+// Residual risk, stated rather than papered over: the `<details>` block's
+// interior is intentionally NOT validated -- real templates quote
+// arbitrary past-PR text there (see the two real fixtures below), so
+// requiring it to match a known shape is not feasible. A genuinely new
+// concern hidden INSIDE a collapsed Learnings-used block, rather than as
+// plain sibling prose, would still misclassify. This is a structural
+// container CodeRabbit uses for inert quotation, not a shape any sampled
+// reply has used to hide substantive feedback -- the same "no sampled
+// reply has done this" standard the hedge-adverb guard's own residual
+// risk above already applies.
+//
+// Note on the four-branch alternation below: each of the four elements
+// (sign-off, details block, disclaimer, marker) is individually optional
+// -- no single one is present in every sample -- but making all four
+// optional independently would let an empty tail (nothing at all after
+// the closure period) match too, reopening exactly the "hedged reply with
+// no footer" gap guard 3 already closed. The alternation instead
+// enumerates the four valid ENTRY points (start at the sign-off, or skip
+// straight to the details block, or the disclaimer, or the bare marker),
+// each requiring at least that one element to be genuinely present, with
+// everything after it in the fixed real-sample order still optional.
+//
+// The details block's interior uses the same no-backtrack-past-the-
+// first-occurrence technique as guard 4's `concern`/`finding` gap above,
+// not a plain lazy `[\s\S]*?`: a lazy quantifier still backtracks FORWARD
+// past the first "</details>" to a later one if the rest of the pattern
+// fails at the first (regression test added alongside this fix,
+// self-caught before this ever reached review) -- a second, unrelated
+// details block later in the tail let a lazy match swallow genuine prose
+// sandwiched between the two as if it were all one details block's
+// content. The per-character negative lookahead forbids consuming past
+// the first "</details>" at all, so no such backtrack is possible.
+const CODERABBIT_ACK_CLOSURE_SIGNOFF_SOURCE = '🐇(?:\\s*✓)?';
+const CODERABBIT_ACK_CLOSURE_DETAILS_SOURCE =
+  '---\\s*<details>(?:(?!<\\/details>)[\\s\\S])*<\\/details>';
+const CODERABBIT_ACK_CLOSURE_DISCLAIMER_SOURCE =
+  '_You are interacting with an AI system\\._';
+const CODERABBIT_ACK_CLOSURE_MARKER_SOURCE = escapeRegExp(
+  CODERABBIT_AUTO_GENERATED_REPLY_MARKER,
+);
+const CODERABBIT_ACK_CLOSURE_TAIL_SOURCE =
+  `(?:${CODERABBIT_ACK_CLOSURE_SIGNOFF_SOURCE}` +
+  `(?:\\s*${CODERABBIT_ACK_CLOSURE_DETAILS_SOURCE})?` +
+  `(?:\\s*${CODERABBIT_ACK_CLOSURE_DISCLAIMER_SOURCE})?` +
+  `(?:\\s*${CODERABBIT_ACK_CLOSURE_MARKER_SOURCE})?` +
+  `|${CODERABBIT_ACK_CLOSURE_DETAILS_SOURCE}` +
+  `(?:\\s*${CODERABBIT_ACK_CLOSURE_DISCLAIMER_SOURCE})?` +
+  `(?:\\s*${CODERABBIT_ACK_CLOSURE_MARKER_SOURCE})?` +
+  `|${CODERABBIT_ACK_CLOSURE_DISCLAIMER_SOURCE}` +
+  `(?:\\s*${CODERABBIT_ACK_CLOSURE_MARKER_SOURCE})?` +
+  `|${CODERABBIT_ACK_CLOSURE_MARKER_SOURCE})` +
+  '\\s*$';
 const CODERABBIT_ACK_ADDRESSES_CLOSURE_RE = new RegExp(
   `(?<!\\b(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE})\\s+)` +
     '\\baddresses\\s+the\\b' +
     '(?:(?!\\b(?:concerns?|findings?)\\b)[^.!?]){0,80}' +
     '\\b(?:concerns?|findings?)\\b\\.\\s*' +
-    '(?:🐇|---|<details|<!--|_You are interacting)',
+    CODERABBIT_ACK_CLOSURE_TAIL_SOURCE,
   'i',
 );
 // Explicit `isCodeRabbitLogin` author check (Copilot review, #2649,

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1443,6 +1443,24 @@ const CODERABBIT_ACK_HEDGE_WORDS_SOURCE =
 // incorrectly rather than only partially or temporarily.
 const CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE =
   'partial|temporary|interim|provisional|tentative|preliminary|stopgap|incomplete';
+// A THIRD, semantically distinct closed enumeration (Codex review, PR
+// #2868, round 10): hedge words (adverb and adjective forms above) say
+// something was done to a DEGREE; negation words say it was NOT done at
+// all -- a strictly stronger, more severe inversion, not a variant of
+// hedging. "The fix never addresses the security concern.\n\n🐇 ✓"
+// matched: "never" sits immediately before "addresses" the same way a
+// hedge adverb would, but neither hedge enumeration includes it (hedging
+// and negating are different speech acts), so the lookbehind below
+// passed it through untouched. English negation adverbs occurring
+// directly before a verb are a small, well-known closed class -- the
+// same narrow-enumeration standard as the two hedge lists above, not the
+// open-ended contrastive-adjective problem (residual gap (a)): negation
+// is a grammatical function word category, not free descriptive
+// vocabulary. `no\s+longer` is included as a two-word negation idiom;
+// `barely` is deliberately NOT duplicated here since it is already in
+// the hedge-adverb list above (a "small degree," not "zero," semantic).
+const CODERABBIT_ACK_NEGATION_WORDS_SOURCE =
+  'never|not|nor|hardly|scarcely|rarely|no\\s+longer';
 // CodeRabbit review, PR #2868, round 4: two mechanical bypasses in the
 // pattern below, both closed by widening two sub-patterns from singular-
 // only to also accept the plural/multi-space form, exactly the same
@@ -1591,9 +1609,9 @@ const CODERABBIT_ACK_CLOSURE_TAIL_SOURCE =
 // and is raised as a design question on issue #2858 rather than chased
 // with an open-ended list here.
 const CODERABBIT_ACK_ADDRESSES_CLOSURE_RE = new RegExp(
-  `(?<!\\b(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE})\\s+)` +
+  `(?<!\\b(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE})\\s+)` +
     '\\baddresses\\s+the\\b' +
-    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE})\\b)[\\w-]+){0,3}` +
+    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE})\\b)[\\w-]+){0,3}` +
     '\\s+\\b(?:concerns?|findings?)\\b\\.\\s*' +
     CODERABBIT_ACK_CLOSURE_TAIL_SOURCE,
   'i',
@@ -1687,11 +1705,27 @@ const CODERABBIT_ACK_ADDRESSES_CLOSURE_RE = new RegExp(
 //    ("partially") -- the first attempt at this fix reused only the
 //    adverb list and still let "partial"/"temporary" straight through,
 //    caught empirically before this ever reached review.
+// 8. **Negation words excluded everywhere a free token or a hedge
+//    lookbehind already exists** (Codex review, PR #2868, round 10):
+//    hedge words (guards 5 and 7) say something was done to a DEGREE;
+//    negation words say it was NOT done at all -- a stronger, more
+//    severe inversion, not a hedging variant, so it is its own
+//    enumeration (`CODERABBIT_ACK_NEGATION_WORDS_SOURCE` above) rather
+//    than folded into either hedge list. "`@user`, confirmed. The fix
+//    never addresses the security concern.\n\n🐇 ✓" matched: "never"
+//    sits immediately before "addresses" the same way a hedge adverb
+//    would, but neither hedge enumeration includes negation words, so
+//    every guard passed it through untouched. Wired into all three
+//    locations a hedge check already exists -- the lookbehind
+//    immediately before "addresses" (guard 5), the internal gap's
+//    per-token exclusion (guard 5), and the lead-in's per-token
+//    exclusion (guard 7) -- for the same defense-in-depth reasoning as
+//    guard 7's own dual adverb/adjective exclusion above.
 const CODERABBIT_ACK_CLOSURE_LEADIN_RE = new RegExp(
   '^[.!]\\s+(?:' +
     'this|that|it|' +
-    `the\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE})\\b)[\\w-]+` +
-    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE})\\b)[\\w-]+){0,1}|` +
+    `the\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE})\\b)[\\w-]+` +
+    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE})\\b)[\\w-]+){0,1}|` +
     'commit\\s+`[0-9a-f]{7,40}`' +
     ')\\s+$',
   'i',

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1338,7 +1338,7 @@ const CODERABBIT_ACK_OPENING_RE = new RegExp(
 //    keeps out the cross-sentence example above, since "However, ..." is
 //    not one of the known boilerplate forms.
 //
-// Hedge-adverb guard (Codex review round 2, PR #2868, #2858): even with
+// Hedge-adverb guard (issue #2858, Codex round-2 review on PR #2868): even with
 // both constraints above, "`@user`, confirmed. This partially addresses
 // the concern.\n\n🐇 ✓" still matched -- genuine boilerplate immediately
 // follows, and "partially" sits inside the matched sentence rather than

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1444,23 +1444,57 @@ const CODERABBIT_ACK_HEDGE_WORDS_SOURCE =
 const CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE =
   'partial|temporary|interim|provisional|tentative|preliminary|stopgap|incomplete';
 // A THIRD, semantically distinct closed enumeration (Codex review, PR
-// #2868, round 10): hedge words (adverb and adjective forms above) say
-// something was done to a DEGREE; negation words say it was NOT done at
-// all -- a strictly stronger, more severe inversion, not a variant of
-// hedging. "The fix never addresses the security concern.\n\n🐇 ✓"
-// matched: "never" sits immediately before "addresses" the same way a
-// hedge adverb would, but neither hedge enumeration includes it (hedging
-// and negating are different speech acts), so the lookbehind below
-// passed it through untouched. English negation adverbs occurring
-// directly before a verb are a small, well-known closed class -- the
-// same narrow-enumeration standard as the two hedge lists above, not the
-// open-ended contrastive-adjective problem (residual gap (a)): negation
-// is a grammatical function word category, not free descriptive
-// vocabulary. `no\s+longer` is included as a two-word negation idiom;
-// `barely` is deliberately NOT duplicated here since it is already in
-// the hedge-adverb list above (a "small degree," not "zero," semantic).
+// #2868, round 10; widened round 12): hedge words (adverb and adjective
+// forms above) say something was done to a DEGREE; negation words say
+// it was NOT done at all -- a strictly stronger, more severe inversion,
+// not a variant of hedging. "The fix never addresses the security
+// concern.\n\n🐇 ✓" matched: "never" sits immediately before "addresses"
+// the same way a hedge adverb would, but neither hedge enumeration
+// includes it (hedging and negating are different speech acts), so the
+// lookbehind below passed it through untouched. English negation
+// adverbs occurring directly before a verb are a small, well-known
+// closed class -- the same narrow-enumeration standard as the two hedge
+// lists above, not the open-ended contrastive-adjective problem
+// (residual gap (a)): negation is a grammatical function word category,
+// not free descriptive vocabulary. `no\s+longer` is included as a
+// two-word negation idiom; `barely` is deliberately NOT duplicated here
+// since it is already in the hedge-adverb list above (a "small degree,"
+// not "zero," semantic). Round 12 (Codex) found the initial enumeration
+// still omitted `seldom` (a negative-frequency adverb, the same class as
+// `rarely`/`hardly`); widened the same pass to also cover the two
+// negation IDIOMS `in\s+no\s+way` and `by\s+no\s+means`, completing the
+// small set of common English negation function words/idioms rather
+// than waiting for each to surface as its own review round -- see the
+// closing statement below `CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE` for
+// where further membership widening of this closed class belongs.
 const CODERABBIT_ACK_NEGATION_WORDS_SOURCE =
-  'never|not|nor|hardly|scarcely|rarely|no\\s+longer';
+  'never|not|nor|hardly|scarcely|rarely|seldom|no\\s+longer|in\\s+no\\s+way|by\\s+no\\s+means';
+// A FOURTH closed enumeration, added proactively in the same pass as the
+// round-12 negation widening above rather than waiting for its own
+// review round: EPISTEMIC adverbs, which cast doubt on whether a claimed
+// action genuinely happened at all, distinct from both hedging (a
+// partial degree) and negation (an outright denial). "`@user`,
+// confirmed. This supposedly addresses the concern.\n\n🐇 ✓" reads as
+// the acknowledgment itself casting doubt on its own claim -- CodeRabbit
+// (or a reply mimicking its template) questioning whether the fix
+// really works, not confirming that it does. A small, well-known closed
+// class of English evidentiality adverbs, the same bounded standard as
+// the three enumerations above.
+//
+// **Closing statement for this whole family of enumerations**: degree
+// (hedge), adjectival-degree, negation, and epistemic are the closed
+// function-word classes this guard enumerates, each independently
+// motivated by a distinct semantic relationship to the acknowledgment
+// ("to what degree," "was it done at all," "should the claim itself be
+// trusted"). A further member surfacing within one of these four
+// existing classes (a synonym for an adverb already covered, an
+// idiomatic variant) is a bounded widening, fixed in place the same way
+// this pass fixed `seldom`. A genuinely NEW semantic class (distinct
+// from all four) is a design question for issue #2858, the same
+// escalation path residual gap (a) already used -- not something to
+// keep discovering ad hoc inside this PR's review-fix loop.
+const CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE =
+  'supposedly|allegedly|ostensibly|nominally|purportedly|seemingly|apparently';
 // CodeRabbit review, PR #2868, round 4: two mechanical bypasses in the
 // pattern below, both closed by widening two sub-patterns from singular-
 // only to also accept the plural/multi-space form, exactly the same
@@ -1609,9 +1643,9 @@ const CODERABBIT_ACK_CLOSURE_TAIL_SOURCE =
 // and is raised as a design question on issue #2858 rather than chased
 // with an open-ended list here.
 const CODERABBIT_ACK_ADDRESSES_CLOSURE_RE = new RegExp(
-  `(?<!\\b(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE})\\s+)` +
+  `(?<!\\b(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE})\\s+)` +
     '\\baddresses\\s+the\\b' +
-    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE})\\b)[\\w-]+){0,3}` +
+    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE})\\b)[\\w-]+){0,3}` +
     '\\s+\\b(?:concerns?|findings?)\\b\\.\\s*' +
     CODERABBIT_ACK_CLOSURE_TAIL_SOURCE,
   'i',
@@ -1706,26 +1740,41 @@ const CODERABBIT_ACK_ADDRESSES_CLOSURE_RE = new RegExp(
 //    adverb list and still let "partial"/"temporary" straight through,
 //    caught empirically before this ever reached review.
 // 8. **Negation words excluded everywhere a free token or a hedge
-//    lookbehind already exists** (Codex review, PR #2868, round 10):
-//    hedge words (guards 5 and 7) say something was done to a DEGREE;
-//    negation words say it was NOT done at all -- a stronger, more
-//    severe inversion, not a hedging variant, so it is its own
-//    enumeration (`CODERABBIT_ACK_NEGATION_WORDS_SOURCE` above) rather
-//    than folded into either hedge list. "`@user`, confirmed. The fix
-//    never addresses the security concern.\n\n🐇 ✓" matched: "never"
-//    sits immediately before "addresses" the same way a hedge adverb
-//    would, but neither hedge enumeration includes negation words, so
-//    every guard passed it through untouched. Wired into all three
-//    locations a hedge check already exists -- the lookbehind
+//    lookbehind already exists** (Codex review, PR #2868, round 10,
+//    widened round 12): hedge words (guards 5 and 7) say something was
+//    done to a DEGREE; negation words say it was NOT done at all -- a
+//    stronger, more severe inversion, not a hedging variant, so it is
+//    its own enumeration (`CODERABBIT_ACK_NEGATION_WORDS_SOURCE` above)
+//    rather than folded into either hedge list. "`@user`, confirmed.
+//    The fix never addresses the security concern.\n\n🐇 ✓" matched:
+//    "never" sits immediately before "addresses" the same way a hedge
+//    adverb would, but neither hedge enumeration includes negation
+//    words, so every guard passed it through untouched. Round 12 found
+//    the initial enumeration still omitted `seldom`; widened in the same
+//    pass to also cover `in no way` / `by no means`. Wired into all
+//    three locations a hedge check already exists -- the lookbehind
 //    immediately before "addresses" (guard 5), the internal gap's
 //    per-token exclusion (guard 5), and the lead-in's per-token
 //    exclusion (guard 7) -- for the same defense-in-depth reasoning as
 //    guard 7's own dual adverb/adjective exclusion above.
+// 9. **Epistemic-adverb enumeration, added proactively rather than
+//    waiting for a review round** (self-critique, same pass as round
+//    12's negation widening): `CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE`
+//    above closes a fourth, distinct semantic relationship -- casting
+//    doubt on whether the claimed fix genuinely happened at all
+//    ("supposedly", "allegedly") -- neither a degree (hedge) nor an
+//    outright denial (negation). Wired into the same three locations as
+//    guards 5, 7, and 8. See the closing statement in that constant's
+//    own doc comment for why this is treated as the natural end of this
+//    enumeration family rather than an invitation to keep widening ad
+//    hoc: degree, epistemic, and negation are the closed function-word
+//    classes; a genuinely new semantic class is a design question for
+//    issue #2858, not another review round here.
 const CODERABBIT_ACK_CLOSURE_LEADIN_RE = new RegExp(
   '^[.!]\\s+(?:' +
     'this|that|it|' +
-    `the\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE})\\b)[\\w-]+` +
-    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE})\\b)[\\w-]+){0,1}|` +
+    `the\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE})\\b)[\\w-]+` +
+    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE})\\b)[\\w-]+){0,1}|` +
     'commit\\s+`[0-9a-f]{7,40}`' +
     ')\\s+$',
   'i',

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2261,18 +2261,42 @@ const CODERABBIT_ACK_NEGATION_WORDS_SOURCE =
 //
 // **Closing statement for this whole family of enumerations**: degree
 // (hedge), adjectival-degree, negation, and epistemic are the closed
-// function-word classes this guard enumerates, each independently
-// motivated by a distinct semantic relationship to the acknowledgment
-// ("to what degree," "was it done at all," "should the claim itself be
-// trusted"). A further member surfacing within one of these four
-// existing classes (a synonym for an adverb already covered, an
-// idiomatic variant) is a bounded widening, fixed in place the same way
-// this pass fixed `seldom`. A genuinely NEW semantic class (distinct
-// from all four) is a design question for issue #2858, the same
-// escalation path residual gap (a) already used -- not something to
-// keep discovering ad hoc inside this PR's review-fix loop.
+// SEMANTIC function-word classes this guard enumerates, each
+// independently motivated by a distinct relationship to the
+// acknowledgment ("to what degree," "was it done at all," "should the
+// claim itself be trusted"). A fifth, GRAMMATICAL (not semantic) class
+// -- coordinating conjunctions -- is enumerated separately below
+// (`CODERABBIT_ACK_CONJUNCTION_WORDS_SOURCE`) for a structural reason,
+// not a meaning-based one. A further member surfacing within one of
+// these five existing classes (a synonym for an adverb already covered,
+// an idiomatic variant) is a bounded widening, fixed in place the same
+// way round 12 fixed `seldom` and round 13 fixed `perhaps`/`possibly`/
+// `maybe`/`presumably` below. A genuinely NEW class -- distinct from all
+// five, and from the coordinating-conjunction structural fix -- is a
+// design question for issue #2858, the same escalation path residual
+// gap (a) already used -- not something to keep discovering ad hoc
+// inside this PR's review-fix loop.
 const CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE =
-  'supposedly|allegedly|ostensibly|nominally|purportedly|seemingly|apparently';
+  'supposedly|allegedly|ostensibly|nominally|purportedly|seemingly|apparently|perhaps|possibly|maybe|presumably';
+
+// A GRAMMATICAL (not semantic) closed class (Codex review, PR #2868,
+// round 13): the seven English coordinating conjunctions ("FANBOYS":
+// for/and/nor/but/or/yet/so) are excluded from the internal gap's
+// modifier tokens, closing a compact variant of the round-7 "but
+// reveals another finding" bypass that fits within the `{0,3}` token
+// cap: "`@user`, confirmed. This addresses the concern but raises
+// concerns.\n\n🐇 ✓" consumes "concern", "but", "raises" as three
+// modifier tokens (all within budget, unlike round 7's 5-token example)
+// and reaches the second, plural "concerns" as the closure target.
+// Tightening the token CAP further cannot close this in general: real
+// samples already need up to 2 tokens, and a 2-token variant of the same
+// bypass exists ("concern yet concerns"), so no finite cap excludes the
+// attack while still admitting real noun phrases. Excluding coordinating
+// conjunctions specifically is the right bound instead, because English
+// has EXACTLY seven of them -- a closed set fixed by the language's
+// grammar, not an open-ended vocabulary list -- and a genuine noun-phrase
+// modifier never needs one (neither real observed sample does).
+const CODERABBIT_ACK_CONJUNCTION_WORDS_SOURCE = 'for|and|nor|but|or|yet|so';
 
 // CodeRabbit review, PR #2868, round 4: two mechanical bypasses in the
 // pattern below, both closed by widening two sub-patterns from singular-
@@ -2424,7 +2448,7 @@ const CODERABBIT_ACK_CLOSURE_TAIL_SOURCE =
 const CODERABBIT_ACK_ADDRESSES_CLOSURE_RE = new RegExp(
   `(?<!\\b(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE})\\s+)` +
     '\\baddresses\\s+the\\b' +
-    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE})\\b)[\\w-]+){0,3}` +
+    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE}|${CODERABBIT_ACK_CONJUNCTION_WORDS_SOURCE})\\b)[\\w-]+){0,3}` +
     '\\s+\\b(?:concerns?|findings?)\\b\\.\\s*' +
     CODERABBIT_ACK_CLOSURE_TAIL_SOURCE,
   'i',
@@ -2539,22 +2563,46 @@ const CODERABBIT_ACK_ADDRESSES_CLOSURE_RE = new RegExp(
 //    guard 7's own dual adverb/adjective exclusion above.
 // 9. **Epistemic-adverb enumeration, added proactively rather than
 //    waiting for a review round** (self-critique, same pass as round
-//    12's negation widening): `CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE`
-//    above closes a fourth, distinct semantic relationship -- casting
-//    doubt on whether the claimed fix genuinely happened at all
-//    ("supposedly", "allegedly") -- neither a degree (hedge) nor an
-//    outright denial (negation). Wired into the same three locations as
-//    guards 5, 7, and 8. See the closing statement in that constant's
-//    own doc comment for why this is treated as the natural end of this
-//    enumeration family rather than an invitation to keep widening ad
-//    hoc: degree, epistemic, and negation are the closed function-word
-//    classes; a genuinely new semantic class is a design question for
-//    issue #2858, not another review round here.
+//    12's negation widening; widened round 13):
+//    `CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE` above closes a fourth,
+//    distinct semantic relationship -- casting doubt on whether the
+//    claimed fix genuinely happened at all ("supposedly", "allegedly")
+//    -- neither a degree (hedge) nor an outright denial (negation).
+//    Wired into the same three locations as guards 5, 7, and 8. Round
+//    13 (Codex) found the initial enumeration omitted "perhaps"; widened
+//    the same pass to also cover "possibly"/"maybe"/"presumably". See
+//    the closing statement in that constant's own doc comment for why
+//    this is treated as the natural end of the SEMANTIC enumeration
+//    family (guard 10 below is a separate, GRAMMATICAL closed class, not
+//    a sixth semantic one).
+// 10. **Coordinating-conjunction exclusion, a grammatical rather than
+//     semantic closed class** (Codex review, PR #2868, round 13): the
+//     `{0,3}` token cap alone cannot close every conjunction-joined
+//     bypass, because a COMPACT one fits within budget where round 7's
+//     original 5-token example did not -- "confirmed. This addresses
+//     the concern but raises concerns.\n\n🐇 ✓" consumes "concern",
+//     "but", "raises" as three modifier tokens (within the cap) and
+//     reaches the second, plural "concerns" as the closure target.
+//     Tightening the cap further cannot close this in general: a
+//     2-token variant of the same bypass exists ("concern yet
+//     concerns"), and real samples already need up to 2 tokens, so no
+//     finite cap excludes the attack while still admitting real noun
+//     phrases. `CODERABBIT_ACK_CONJUNCTION_WORDS_SOURCE` excludes
+//     English's seven coordinating conjunctions ("FANBOYS") instead --
+//     a set fixed by the language's grammar, not open-ended vocabulary,
+//     so this is not the same class of fix as the semantic
+//     enumerations above and does not reopen the open-ended
+//     new-concern-blocklist problem. Wired into the internal gap (the
+//     demonstrated bypass) and the lead-in (defense-in-depth,
+//     consistent with guards 7-9); not the immediate pre-"addresses"
+//     lookbehind, since a bare conjunction directly before "addresses"
+//     ("confirmed. But addresses...") is not a coherent English
+//     sentence in the first place.
 const CODERABBIT_ACK_CLOSURE_LEADIN_RE = new RegExp(
   '^[.!]\\s+(?:' +
     'this|that|it|' +
-    `the\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE})\\b)[\\w-]+` +
-    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE})\\b)[\\w-]+){0,1}|` +
+    `the\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE}|${CODERABBIT_ACK_CONJUNCTION_WORDS_SOURCE})\\b)[\\w-]+` +
+    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE}|${CODERABBIT_ACK_CONJUNCTION_WORDS_SOURCE})\\b)[\\w-]+){0,1}|` +
     'commit\\s+`[0-9a-f]{7,40}`' +
     ')\\s+$',
   'i',

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2063,8 +2063,54 @@ const CODERABBIT_ACK_OPENING_RE = new RegExp(
 // "I couldn't resolve this review thread on the repository platform..."
 // fallback trailer (the same API call failed, so CodeRabbit reports the
 // attempt instead).
+//
+// #2858: a THIRD, weaker-in-kind shape -- observed on
+// kurone-kito/idd-skill#2853's review thread on the issue-reference
+// template link (2 samples from that one already-agent-resolved thread,
+// not the 18/18 sample above): "...addresses the template
+// link-resolution concern." /
+// "...addresses the template issue-reference finding." Unlike the two
+// forms above, this is prose describing an outcome, not CodeRabbit's own
+// resolve-attempt decision: CodeRabbit never attempted (or reported
+// failing) to resolve this thread, because it was already resolved
+// independently (e.g. by the IDD agent's own resolve-review-thread.mjs)
+// before CodeRabbit replied, so it had no attempt of its own to report.
+// Bounded to a short gap (`{0,80}`) so it matches only the same
+// single-clause shape actually observed, not an incidental "concern" or
+// "finding" mention far away in the same reply's trailing
+// Learnings-used block.
+//
+// Sentence-boundary tail anchor: an enumerated negation/new-concern
+// blocklist was tried here and reverted (see above) precisely because it
+// cannot keep up with natural language, so this shape is instead
+// recognized the same way as the other two -- a structural fingerprint of
+// CodeRabbit's own reply template, not a semantic read of the prose.
+// Requiring the closure sentence to end in a period immediately followed
+// by known CodeRabbit reply boilerplate (the 🐇 sign-off, the `---` +
+// Learnings-used separator, the auto-generated-reply marker, or the
+// "You are interacting with an AI system" disclaimer) or the end of the
+// body rejects a reply that goes on to raise a new, unrelated concern in
+// the next sentence (e.g. "...addresses the concern, but also X" has no
+// period before "but", so it never reaches the tail check) while still
+// matching both real observed replies, where the closure sentence is
+// immediately followed by that same boilerplate.
+//
+// Residual risk, stated rather than papered over -- NOT the same class as
+// the two forms above: those report CodeRabbit's own resolve-attempt
+// DECISION, which by this file's own reasoning cannot co-occur with a new
+// substantive concern in the same reply. This third form reads prose with
+// no such structural barrier, so it is strictly weaker: a reply that
+// raises a new concern and ends that exact sentence with a period
+// immediately before CodeRabbit's own boilerplate (e.g. "...addresses the
+// concern. However, X is still unresolved.<!-- auto-generated reply -->")
+// would still misclassify. No sampled reply has done this, and the tail
+// anchor above already closes the two adversarial shapes actually tried
+// against it (a trailing clause joined by a comma, and a genuinely new
+// concern anywhere within the 80-character locality bound) -- only the
+// narrower period-immediately-before-boilerplate combination remains
+// open.
 const CODERABBIT_ACK_CLOSURE_RE =
-  /✅\s*Review thread resolved\.|I couldn't resolve this review thread on the repository platform/i;
+  /✅\s*Review thread resolved\.|I couldn't resolve this review thread on the repository platform|\baddresses\s+the\b[\s\S]{0,80}?\b(?:concern|finding)\b\.\s*(?:🐇|---|<details|<!--|_You are interacting|$)/i;
 
 // Explicit `isCodeRabbitLogin` author check (Copilot review, #2649,
 // round 4): the closure phrase is CodeRabbit's own resolution decision in

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2084,33 +2084,49 @@ const CODERABBIT_ACK_OPENING_RE = new RegExp(
 // blocklist was tried here and reverted (see above) precisely because it
 // cannot keep up with natural language, so this shape is instead
 // recognized the same way as the other two -- a structural fingerprint of
-// CodeRabbit's own reply template, not a semantic read of the prose.
-// Requiring the closure sentence to end in a period immediately followed
-// by known CodeRabbit reply boilerplate (the 🐇 sign-off, the `---` +
-// Learnings-used separator, the auto-generated-reply marker, or the
-// "You are interacting with an AI system" disclaimer) or the end of the
-// body rejects a reply that goes on to raise a new, unrelated concern in
-// the next sentence (e.g. "...addresses the concern, but also X" has no
-// period before "but", so it never reaches the tail check) while still
-// matching both real observed replies, where the closure sentence is
-// immediately followed by that same boilerplate.
+// CodeRabbit's own reply template, not a semantic read of the prose. Two
+// structural constraints, both narrowed further after Codex review found
+// concrete false-positive constructions in this same PR (#2858):
+//
+// 1. The gap between "addresses the" and "concern"/"finding" excludes
+//    sentence-terminating punctuation (`[^.!?]`), not just any character.
+//    A plain `[\s\S]` gap let the match cross a sentence boundary
+//    entirely -- "This addresses the requested change. However, I still
+//    have a concern." has its own genuinely new, unrelated concern in a
+//    SECOND sentence, but the un-narrowed gap could reach that later
+//    "concern" anyway, since nothing stopped it from skipping the period
+//    in between. Excluding `.!?` from the gap forces "concern"/"finding"
+//    to appear in the SAME sentence as "addresses the", as in both real
+//    observed replies.
+// 2. The closure sentence must end in a period immediately followed by
+//    known CodeRabbit reply boilerplate (the 🐇 sign-off, the `---` +
+//    Learnings-used separator, the auto-generated-reply marker, or the
+//    "You are interacting with an AI system" disclaimer) -- no bare
+//    end-of-body fallback. Every sampled reply (all 20: the original 18
+//    plus these 2) carries real trailing boilerplate, so requiring it
+//    unconditionally costs no real match; dropping the end-of-body
+//    fallback closes a single-sentence reply with nothing following it,
+//    such as "`@user`, confirmed. This partially addresses the concern."
+//    with no footer at all -- a hedged, non-committal acknowledgment that
+//    would otherwise pass on structure alone. This also independently
+//    keeps out the cross-sentence example above, since "However, ..." is
+//    not one of the known boilerplate forms.
 //
 // Residual risk, stated rather than papered over -- NOT the same class as
 // the two forms above: those report CodeRabbit's own resolve-attempt
 // DECISION, which by this file's own reasoning cannot co-occur with a new
 // substantive concern in the same reply. This third form reads prose with
-// no such structural barrier, so it is strictly weaker: a reply that
-// raises a new concern and ends that exact sentence with a period
-// immediately before CodeRabbit's own boilerplate (e.g. "...addresses the
-// concern. However, X is still unresolved.<!-- auto-generated reply -->")
-// would still misclassify. No sampled reply has done this, and the tail
-// anchor above already closes the two adversarial shapes actually tried
-// against it (a trailing clause joined by a comma, and a genuinely new
-// concern anywhere within the 80-character locality bound) -- only the
-// narrower period-immediately-before-boilerplate combination remains
-// open.
+// no such structural barrier, so it is strictly weaker: a reply whose
+// SAME sentence both hedges ("partially", "mostly", ...) or raises a
+// concern and still ends with a period immediately before genuine
+// CodeRabbit boilerplate (e.g. "This addresses the concern, mostly.
+// <!-- auto-generated reply -->") would still misclassify. No sampled
+// reply has done this. An enumerated hedge-word guard was considered and
+// rejected for the same reason the new-concern blocklist above was: it
+// does not generalize, and this file's own philosophy prefers a stated,
+// bounded residual risk over an unbounded semantic blocklist.
 const CODERABBIT_ACK_CLOSURE_RE =
-  /✅\s*Review thread resolved\.|I couldn't resolve this review thread on the repository platform|\baddresses\s+the\b[\s\S]{0,80}?\b(?:concern|finding)\b\.\s*(?:🐇|---|<details|<!--|_You are interacting|$)/i;
+  /✅\s*Review thread resolved\.|I couldn't resolve this review thread on the repository platform|\baddresses\s+the\b[^.!?]{0,80}?\b(?:concern|finding)\b\.\s*(?:🐇|---|<details|<!--|_You are interacting)/i;
 
 // Explicit `isCodeRabbitLogin` author check (Copilot review, #2649,
 // round 4): the closure phrase is CodeRabbit's own resolution decision in

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2221,23 +2221,58 @@ const CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE =
   'partial|temporary|interim|provisional|tentative|preliminary|stopgap|incomplete';
 
 // A THIRD, semantically distinct closed enumeration (Codex review, PR
-// #2868, round 10): hedge words (adverb and adjective forms above) say
-// something was done to a DEGREE; negation words say it was NOT done at
-// all -- a strictly stronger, more severe inversion, not a variant of
-// hedging. "The fix never addresses the security concern.\n\n🐇 ✓"
-// matched: "never" sits immediately before "addresses" the same way a
-// hedge adverb would, but neither hedge enumeration includes it (hedging
-// and negating are different speech acts), so the lookbehind below
-// passed it through untouched. English negation adverbs occurring
-// directly before a verb are a small, well-known closed class -- the
-// same narrow-enumeration standard as the two hedge lists above, not the
-// open-ended contrastive-adjective problem (residual gap (a)): negation
-// is a grammatical function word category, not free descriptive
-// vocabulary. `no\s+longer` is included as a two-word negation idiom;
-// `barely` is deliberately NOT duplicated here since it is already in
-// the hedge-adverb list above (a "small degree," not "zero," semantic).
+// #2868, round 10; widened round 12): hedge words (adverb and adjective
+// forms above) say something was done to a DEGREE; negation words say
+// it was NOT done at all -- a strictly stronger, more severe inversion,
+// not a variant of hedging. "The fix never addresses the security
+// concern.\n\n🐇 ✓" matched: "never" sits immediately before "addresses"
+// the same way a hedge adverb would, but neither hedge enumeration
+// includes it (hedging and negating are different speech acts), so the
+// lookbehind below passed it through untouched. English negation
+// adverbs occurring directly before a verb are a small, well-known
+// closed class -- the same narrow-enumeration standard as the two hedge
+// lists above, not the open-ended contrastive-adjective problem
+// (residual gap (a)): negation is a grammatical function word category,
+// not free descriptive vocabulary. `no\s+longer` is included as a
+// two-word negation idiom; `barely` is deliberately NOT duplicated here
+// since it is already in the hedge-adverb list above (a "small degree,"
+// not "zero," semantic). Round 12 (Codex) found the initial enumeration
+// still omitted `seldom` (a negative-frequency adverb, the same class as
+// `rarely`/`hardly`); widened the same pass to also cover the two
+// negation IDIOMS `in\s+no\s+way` and `by\s+no\s+means`, completing the
+// small set of common English negation function words/idioms rather
+// than waiting for each to surface as its own review round -- see the
+// closing statement below `CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE` for
+// where further membership widening of this closed class belongs.
 const CODERABBIT_ACK_NEGATION_WORDS_SOURCE =
-  'never|not|nor|hardly|scarcely|rarely|no\\s+longer';
+  'never|not|nor|hardly|scarcely|rarely|seldom|no\\s+longer|in\\s+no\\s+way|by\\s+no\\s+means';
+
+// A FOURTH closed enumeration, added proactively in the same pass as the
+// round-12 negation widening above rather than waiting for its own
+// review round: EPISTEMIC adverbs, which cast doubt on whether a claimed
+// action genuinely happened at all, distinct from both hedging (a
+// partial degree) and negation (an outright denial). "`@user`,
+// confirmed. This supposedly addresses the concern.\n\n🐇 ✓" reads as
+// the acknowledgment itself casting doubt on its own claim -- CodeRabbit
+// (or a reply mimicking its template) questioning whether the fix
+// really works, not confirming that it does. A small, well-known closed
+// class of English evidentiality adverbs, the same bounded standard as
+// the three enumerations above.
+//
+// **Closing statement for this whole family of enumerations**: degree
+// (hedge), adjectival-degree, negation, and epistemic are the closed
+// function-word classes this guard enumerates, each independently
+// motivated by a distinct semantic relationship to the acknowledgment
+// ("to what degree," "was it done at all," "should the claim itself be
+// trusted"). A further member surfacing within one of these four
+// existing classes (a synonym for an adverb already covered, an
+// idiomatic variant) is a bounded widening, fixed in place the same way
+// this pass fixed `seldom`. A genuinely NEW semantic class (distinct
+// from all four) is a design question for issue #2858, the same
+// escalation path residual gap (a) already used -- not something to
+// keep discovering ad hoc inside this PR's review-fix loop.
+const CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE =
+  'supposedly|allegedly|ostensibly|nominally|purportedly|seemingly|apparently';
 
 // CodeRabbit review, PR #2868, round 4: two mechanical bypasses in the
 // pattern below, both closed by widening two sub-patterns from singular-
@@ -2387,9 +2422,9 @@ const CODERABBIT_ACK_CLOSURE_TAIL_SOURCE =
 // and is raised as a design question on issue #2858 rather than chased
 // with an open-ended list here.
 const CODERABBIT_ACK_ADDRESSES_CLOSURE_RE = new RegExp(
-  `(?<!\\b(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE})\\s+)` +
+  `(?<!\\b(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE})\\s+)` +
     '\\baddresses\\s+the\\b' +
-    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE})\\b)[\\w-]+){0,3}` +
+    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE})\\b)[\\w-]+){0,3}` +
     '\\s+\\b(?:concerns?|findings?)\\b\\.\\s*' +
     CODERABBIT_ACK_CLOSURE_TAIL_SOURCE,
   'i',
@@ -2485,26 +2520,41 @@ const CODERABBIT_ACK_ADDRESSES_CLOSURE_RE = new RegExp(
 //    adverb list and still let "partial"/"temporary" straight through,
 //    caught empirically before this ever reached review.
 // 8. **Negation words excluded everywhere a free token or a hedge
-//    lookbehind already exists** (Codex review, PR #2868, round 10):
-//    hedge words (guards 5 and 7) say something was done to a DEGREE;
-//    negation words say it was NOT done at all -- a stronger, more
-//    severe inversion, not a hedging variant, so it is its own
-//    enumeration (`CODERABBIT_ACK_NEGATION_WORDS_SOURCE` above) rather
-//    than folded into either hedge list. "`@user`, confirmed. The fix
-//    never addresses the security concern.\n\n🐇 ✓" matched: "never"
-//    sits immediately before "addresses" the same way a hedge adverb
-//    would, but neither hedge enumeration includes negation words, so
-//    every guard passed it through untouched. Wired into all three
-//    locations a hedge check already exists -- the lookbehind
+//    lookbehind already exists** (Codex review, PR #2868, round 10,
+//    widened round 12): hedge words (guards 5 and 7) say something was
+//    done to a DEGREE; negation words say it was NOT done at all -- a
+//    stronger, more severe inversion, not a hedging variant, so it is
+//    its own enumeration (`CODERABBIT_ACK_NEGATION_WORDS_SOURCE` above)
+//    rather than folded into either hedge list. "`@user`, confirmed.
+//    The fix never addresses the security concern.\n\n🐇 ✓" matched:
+//    "never" sits immediately before "addresses" the same way a hedge
+//    adverb would, but neither hedge enumeration includes negation
+//    words, so every guard passed it through untouched. Round 12 found
+//    the initial enumeration still omitted `seldom`; widened in the same
+//    pass to also cover `in no way` / `by no means`. Wired into all
+//    three locations a hedge check already exists -- the lookbehind
 //    immediately before "addresses" (guard 5), the internal gap's
 //    per-token exclusion (guard 5), and the lead-in's per-token
 //    exclusion (guard 7) -- for the same defense-in-depth reasoning as
 //    guard 7's own dual adverb/adjective exclusion above.
+// 9. **Epistemic-adverb enumeration, added proactively rather than
+//    waiting for a review round** (self-critique, same pass as round
+//    12's negation widening): `CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE`
+//    above closes a fourth, distinct semantic relationship -- casting
+//    doubt on whether the claimed fix genuinely happened at all
+//    ("supposedly", "allegedly") -- neither a degree (hedge) nor an
+//    outright denial (negation). Wired into the same three locations as
+//    guards 5, 7, and 8. See the closing statement in that constant's
+//    own doc comment for why this is treated as the natural end of this
+//    enumeration family rather than an invitation to keep widening ad
+//    hoc: degree, epistemic, and negation are the closed function-word
+//    classes; a genuinely new semantic class is a design question for
+//    issue #2858, not another review round here.
 const CODERABBIT_ACK_CLOSURE_LEADIN_RE = new RegExp(
   '^[.!]\\s+(?:' +
     'this|that|it|' +
-    `the\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE})\\b)[\\w-]+` +
-    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE})\\b)[\\w-]+){0,1}|` +
+    `the\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE})\\b)[\\w-]+` +
+    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE})\\b)[\\w-]+){0,1}|` +
     'commit\\s+`[0-9a-f]{7,40}`' +
     ')\\s+$',
   'i',

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2162,11 +2162,30 @@ const CODERABBIT_ACK_STRONG_CLOSURE_RE =
 const CODERABBIT_ACK_HEDGE_WORDS_SOURCE =
   'partially|partly|somewhat|mostly|largely|barely|slightly|arguably|in\\s+part|to\\s+some\\s+extent|not\\s+(?:fully|entirely|completely|really)';
 
+// CodeRabbit review, PR #2868, round 4: two mechanical bypasses in the
+// pattern below, both closed by widening two sub-patterns from singular-
+// only to also accept the plural/multi-space form, exactly the same
+// narrow-enumeration style as every other guard here:
+// 1. The gap's negative lookahead and the final anchor only recognized
+//    the SINGULAR "concern"/"finding". A plural first occurrence
+//    ("concerns"/"findings") does not satisfy `\b(?:concern|finding)\b`
+//    (no word boundary between "concern" and its trailing "s"), so the
+//    lookahead's `(?!...)` trivially succeeds there and the engine keeps
+//    consuming characters as if no candidate occurrence existed --
+//    resurfacing guard 4's own "backtrack past the first occurrence"
+//    class of bug, but for plural nouns specifically. Both sub-patterns
+//    now accept an optional trailing "s".
+// 2. The hedge lookbehind ended in a single `\s`, so "partially  addresses"
+//    (two spaces) fell outside the lookbehind's fixed one-character gap
+//    and bypassed the guard entirely. Widened to `\s+`; V8's lookbehind
+//    supports variable-length alternatives (confirmed empirically on
+//    this exact Node floor after Copilot's round-5 finding to the
+//    contrary was rejected, above), so this is a safe, narrow widening.
 const CODERABBIT_ACK_ADDRESSES_CLOSURE_RE = new RegExp(
-  `(?<!\\b(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE})\\s)` +
+  `(?<!\\b(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE})\\s+)` +
     '\\baddresses\\s+the\\b' +
-    '(?:(?!\\b(?:concern|finding)\\b)[^.!?]){0,80}' +
-    '\\b(?:concern|finding)\\b\\.\\s*' +
+    '(?:(?!\\b(?:concerns?|findings?)\\b)[^.!?]){0,80}' +
+    '\\b(?:concerns?|findings?)\\b\\.\\s*' +
     '(?:🐇|---|<details|<!--|_You are interacting)',
   'i',
 );
@@ -2190,6 +2209,35 @@ const CODERABBIT_ACK_ADDRESSES_CLOSURE_RE = new RegExp(
 // acknowledgment (a CodeRabbit-side defect) would still misclassify here.
 // This helper matches CodeRabbit's own stated decision; it cannot second-
 // guess a wrong decision CodeRabbit reports about itself.
+//
+// 6. **Opening-to-closure anchor, scoped to the weaker "addresses the ..."
+//    form only** (Codex review, PR #2868, round 4): every guard above
+//    narrows what counts as a closure WITHIN a matched span, but neither
+//    closure regex was ever anchored to where the opening ends --
+//    `.test(body)` searches the WHOLE body, so an entirely separate
+//    sentence carrying genuinely new, unresolved feedback between the
+//    opening and the closure was invisible to it. Concretely: "`@user`,
+//    confirmed. However, the null-check remains unresolved. The
+//    documentation update addresses the wording concern.\n\n🐇 ✓" has an
+//    explicit "remains unresolved" sentence the closure guards never
+//    look at, yet the ADDRESSES form still matches later in the body.
+//    A real sampled reply (kurone-kito/idd-skill#2853, tests above) shows
+//    the closure is legitimately its OWN sentence, separate from the
+//    opening's -- "confirmed. The repository-qualified reference
+//    addresses the ... concern." -- so requiring the closure to start
+//    immediately after the opening (same sentence) would reject a real,
+//    observed template. The bound that holds both true is a COUNT, not
+//    a position: the text between the end of the opening match and the
+//    start of the closure match must contain at most one sentence
+//    terminator (`.`/`!`/`?`) -- the one that legitimately closes the
+//    opening's own "confirmed."/"thanks." sentence before the closure's
+//    lead-in clause begins. Two or more means at least one additional,
+//    independent sentence sits in between, exactly Codex's demonstrated
+//    shape. Scoped to `CODERABBIT_ACK_ADDRESSES_CLOSURE_RE` only, not the
+//    two strong forms: those report CodeRabbit's own resolve-attempt
+//    DECISION, which this file's own reasoning above already treats as
+//    unable to co-occur with a new concern in the same reply, so they
+//    keep the whole-body `.test()` they always had.
 function isKnownAdvisoryAckTemplate(comment: {
   author?: { login?: string | null } | null;
   body?: string | null;
@@ -2199,19 +2247,28 @@ function isKnownAdvisoryAckTemplate(comment: {
   if (!authorLogin || !isCodeRabbitLogin(authorLogin) || !body) {
     return false;
   }
-  if (!CODERABBIT_ACK_OPENING_RE.test(body)) {
+  const openingMatch = CODERABBIT_ACK_OPENING_RE.exec(body);
+  if (!openingMatch) {
     return false;
   }
   // The two strong forms (CodeRabbit's own resolve-attempt decision) are
   // checked on the whole body with no further guard -- see the comment
   // above `CODERABBIT_ACK_STRONG_CLOSURE_RE` for why the weaker third
-  // form's guards (locality, sentence-boundary, hedge-adverb) must never
-  // apply here, even when unrelated hedge-shaped wording happens to
-  // appear elsewhere in the same reply (e.g. a Learnings-used block).
+  // form's guards (locality, sentence-boundary, hedge-adverb, opening-
+  // to-closure anchor) must never apply here, even when unrelated
+  // hedge-shaped wording happens to appear elsewhere in the same reply
+  // (e.g. a Learnings-used block).
   if (CODERABBIT_ACK_STRONG_CLOSURE_RE.test(body)) {
     return true;
   }
-  return CODERABBIT_ACK_ADDRESSES_CLOSURE_RE.test(body);
+  const addressesMatch = CODERABBIT_ACK_ADDRESSES_CLOSURE_RE.exec(body);
+  if (!addressesMatch) {
+    return false;
+  }
+  const openingEnd = openingMatch.index + openingMatch[0].length;
+  const gapToClosure = body.slice(openingEnd, addressesMatch.index);
+  const sentenceTerminatorCount = (gapToClosure.match(/[.!?]/g) ?? []).length;
+  return sentenceTerminatorCount <= 1;
 }
 
 // Codex usage / quota exhaustion for code reviews. Token-anchored on all

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2181,12 +2181,87 @@ const CODERABBIT_ACK_HEDGE_WORDS_SOURCE =
 //    supports variable-length alternatives (confirmed empirically on
 //    this exact Node floor after Copilot's round-5 finding to the
 //    contrary was rejected, above), so this is a safe, narrow widening.
+//
+// Tail grammar, anchored to end-of-body (Codex review, PR #2868, round 6):
+// the boilerplate-tail alternation used to validate only the FIRST
+// recognized token (`🐇`, `---`, `<details`, `<!--`, or
+// `_You are interacting`) and accept whatever followed unexamined --
+// itself a prefix match, the same "validated a fragment, not the whole
+// shape" bug rounds 4-5 already closed on the opening side. Demonstrated:
+// "`@user`, confirmed. This addresses the wording concern.\n\n---\n\n
+// However, the null-check remains unresolved." matched, because "---"
+// satisfies the alternation even though genuine new feedback follows it.
+// Every one of the four alternatives had the same flaw.
+//
+// Fixed by replacing the prefix alternation with the fixed-order,
+// fully-optional tail grammar the two real observed samples
+// (kurone-kito/idd-skill#2853) actually have -- sign-off, then a
+// `---`-delimited `<details>...</details>` block (the Learnings-used
+// container; its interior is opaque quoted text and is NOT re-validated,
+// see residual risk below), then the AI-system disclaimer, then the
+// auto-generated-reply marker (single-sourced via
+// `CODERABBIT_AUTO_GENERATED_REPLY_MARKER` so it cannot drift from
+// `CODERABBIT_ACK_OPENING_RE`'s own use of the same literal) -- anchored
+// to `$` so nothing can follow any of them unexamined.
+//
+// Residual risk, stated rather than papered over: the `<details>` block's
+// interior is intentionally NOT validated -- real templates quote
+// arbitrary past-PR text there (see the two real fixtures below), so
+// requiring it to match a known shape is not feasible. A genuinely new
+// concern hidden INSIDE a collapsed Learnings-used block, rather than as
+// plain sibling prose, would still misclassify. This is a structural
+// container CodeRabbit uses for inert quotation, not a shape any sampled
+// reply has used to hide substantive feedback -- the same "no sampled
+// reply has done this" standard the hedge-adverb guard's own residual
+// risk above already applies.
+//
+// Note on the four-branch alternation below: each of the four elements
+// (sign-off, details block, disclaimer, marker) is individually optional
+// -- no single one is present in every sample -- but making all four
+// optional independently would let an empty tail (nothing at all after
+// the closure period) match too, reopening exactly the "hedged reply with
+// no footer" gap guard 3 already closed. The alternation instead
+// enumerates the four valid ENTRY points (start at the sign-off, or skip
+// straight to the details block, or the disclaimer, or the bare marker),
+// each requiring at least that one element to be genuinely present, with
+// everything after it in the fixed real-sample order still optional.
+//
+// The details block's interior uses the same no-backtrack-past-the-
+// first-occurrence technique as guard 4's `concern`/`finding` gap above,
+// not a plain lazy `[\s\S]*?`: a lazy quantifier still backtracks FORWARD
+// past the first "</details>" to a later one if the rest of the pattern
+// fails at the first (regression test added alongside this fix,
+// self-caught before this ever reached review) -- a second, unrelated
+// details block later in the tail let a lazy match swallow genuine prose
+// sandwiched between the two as if it were all one details block's
+// content. The per-character negative lookahead forbids consuming past
+// the first "</details>" at all, so no such backtrack is possible.
+const CODERABBIT_ACK_CLOSURE_SIGNOFF_SOURCE = '🐇(?:\\s*✓)?';
+const CODERABBIT_ACK_CLOSURE_DETAILS_SOURCE =
+  '---\\s*<details>(?:(?!<\\/details>)[\\s\\S])*<\\/details>';
+const CODERABBIT_ACK_CLOSURE_DISCLAIMER_SOURCE =
+  '_You are interacting with an AI system\\._';
+const CODERABBIT_ACK_CLOSURE_MARKER_SOURCE = escapeRegExp(
+  CODERABBIT_AUTO_GENERATED_REPLY_MARKER,
+);
+const CODERABBIT_ACK_CLOSURE_TAIL_SOURCE =
+  `(?:${CODERABBIT_ACK_CLOSURE_SIGNOFF_SOURCE}` +
+  `(?:\\s*${CODERABBIT_ACK_CLOSURE_DETAILS_SOURCE})?` +
+  `(?:\\s*${CODERABBIT_ACK_CLOSURE_DISCLAIMER_SOURCE})?` +
+  `(?:\\s*${CODERABBIT_ACK_CLOSURE_MARKER_SOURCE})?` +
+  `|${CODERABBIT_ACK_CLOSURE_DETAILS_SOURCE}` +
+  `(?:\\s*${CODERABBIT_ACK_CLOSURE_DISCLAIMER_SOURCE})?` +
+  `(?:\\s*${CODERABBIT_ACK_CLOSURE_MARKER_SOURCE})?` +
+  `|${CODERABBIT_ACK_CLOSURE_DISCLAIMER_SOURCE}` +
+  `(?:\\s*${CODERABBIT_ACK_CLOSURE_MARKER_SOURCE})?` +
+  `|${CODERABBIT_ACK_CLOSURE_MARKER_SOURCE})` +
+  '\\s*$';
 const CODERABBIT_ACK_ADDRESSES_CLOSURE_RE = new RegExp(
   `(?<!\\b(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE})\\s+)` +
     '\\baddresses\\s+the\\b' +
     '(?:(?!\\b(?:concerns?|findings?)\\b)[^.!?]){0,80}' +
     '\\b(?:concerns?|findings?)\\b\\.\\s*' +
-    '(?:🐇|---|<details|<!--|_You are interacting)',
+    CODERABBIT_ACK_CLOSURE_TAIL_SOURCE,
   'i',
 );
 

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2081,52 +2081,66 @@ const CODERABBIT_ACK_OPENING_RE = new RegExp(
 // across three rounds of Codex/Copilot review on this same PR (#2858,
 // PR #2868) -- never apply to the two strong, structurally-safe forms:
 //
-// 1. **Locality bound** (`{0,80}`): the gap between "addresses the" and
-//    "concern"/"finding" is capped so an incidental "concern"/"finding"
-//    mention far away in the same reply's trailing Learnings-used block
-//    can't retroactively create a false closure signal.
-// 2. **Sentence-boundary exclusion** (`[^.!?]` in the gap, round 1): a
-//    plain `[\s\S]` gap let the match cross a sentence boundary entirely
-//    -- "This addresses the requested change. However, I still have a
-//    concern." has its own genuinely new, unrelated concern in a SECOND
-//    sentence, but an un-narrowed gap could reach that later "concern"
-//    anyway. Excluding `.!?` forces "concern"/"finding" into the SAME
-//    sentence as "addresses the", as in both real observed replies.
+// Guard history below reflects the CURRENT implementation as of round 7
+// (Codex/CodeRabbit review on PR #2868) -- Copilot's round-8 review
+// flagged an earlier revision of this comment block for still describing
+// the pre-round-7 `{0,80}`/`[^.!?]` mechanism after the code had already
+// moved on, which is exactly the kind of drift this file's own extensive
+// documentation is meant to prevent. Each guard below states what it
+// does NOW, with the specific round/finding that shaped it for
+// traceability, not a literal transcript of an earlier regex.
+//
+// 1. **Locality bound, tokenized** (originally a `{0,80}` character
+//    count; replaced by a `{0,3}` modifier-TOKEN count, round 7, Codex):
+//    the gap between "addresses the" and "concern"/"finding" is capped
+//    so an incidental "concern"/"finding" mention far away in the same
+//    reply's trailing Learnings-used block can't retroactively create a
+//    false closure signal. Both real observed replies use a 2-token
+//    noun-phrase modifier ("template link-resolution", "template
+//    issue-reference"); the cap allows one token of headroom beyond
+//    that, since a coherent conjunction-based topic change realistically
+//    needs 4+ words (round 7's own adversarial example needed 5).
+// 2. **Word/hyphen-only tokens, no sentence-boundary or comma crossing**
+//    (originally `[^.!?]` exclusion, round 1, Codex; superseded by the
+//    `[\w-]+` token grammar, round 7): restricting each gap token to
+//    word and hyphen characters, separated only by whitespace, means
+//    neither a comma nor a sentence terminator (`.`/`!`/`?`) can appear
+//    inside the gap at all -- either one breaks the token chain outright.
+//    This subsumes the original round-1 finding ("This addresses the
+//    requested change. However, I still have a concern." must not reach
+//    the second sentence's "concern") without a separate exclusion rule.
 // 3. **Mandatory boilerplate tail, no bare end-of-body fallback**
-//    (round 1): the closure sentence must end in a period immediately
-//    followed by known CodeRabbit reply boilerplate (the 🐇 sign-off,
-//    the `---` + Learnings-used separator, the auto-generated-reply
-//    marker, or the "You are interacting with an AI system" disclaimer).
-//    Every sampled reply (all 20: the original 18 plus these 2) carries
-//    real trailing boilerplate, so requiring it unconditionally costs no
-//    real match; this also rejects a single-sentence reply with nothing
-//    following it at all, such as "`@user`, confirmed. This partially
-//    addresses the concern." with no footer -- a hedged, non-committal
-//    acknowledgment that would otherwise pass on structure alone.
+//    (round 1, Codex; tail shape fully anchored to end-of-body, round 6,
+//    Codex): the closure sentence must end in a period immediately
+//    followed by the complete recognized boilerplate shape (see
+//    `CODERABBIT_ACK_CLOSURE_TAIL_SOURCE` below), not merely start with
+//    one of its markers. Every sampled reply (all 20: the original 18
+//    plus these 2) carries real trailing boilerplate, so requiring it
+//    unconditionally costs no real match; this also rejects a single-
+//    sentence reply with nothing following it at all, such as "`@user`,
+//    confirmed. This partially addresses the concern." with no footer --
+//    a hedged, non-committal acknowledgment that would otherwise pass on
+//    structure alone.
 // 4. **No backtracking past an earlier same-sentence "concern"/"finding"**
-//    (round 3, Codex): a plain lazy `[^.!?]{0,80}?` gap still let the
-//    regex engine skip an EARLIER "concern"/"finding" occurrence that
-//    failed the boilerplate-tail check, to find a LATER one that
-//    succeeds -- "`@user`, confirmed. This addresses the original
-//    concern but reveals another finding.\n\n🐇 ✓" has a genuinely new
-//    finding joined by "but" in the SAME sentence, yet the gap could
-//    still stretch past the first "concern" (not followed by a period)
-//    to match the later "finding." instead. The gap is rewritten as
-//    `(?:(?!\b(?:concern|finding)\b)[^.!?]){0,80}` -- consume characters
-//    only while the upcoming text is NOT the start of "concern" or
-//    "finding" -- so the match is pinned to the FIRST such occurrence in
-//    the sentence; the whole alternative fails if that first occurrence
-//    isn't immediately followed by the boilerplate tail, rather than
-//    scanning ahead for a second one that is.
-// 5. **Hedge-adverb guard, scoped to only this alternative** (round 2,
-//    Codex; scoping fixed round 3, Copilot): even with all of the above,
-//    "`@user`, confirmed. This partially addresses the concern.\n\n🐇 ✓"
-//    still matched -- genuine boilerplate immediately follows, no
-//    sentence boundary is crossed, and "concern" is the first and only
-//    candidate, so guards 1-4 don't catch it. A small, closed set of
-//    English degree adverbs immediately before "addresses" -- the same
-//    narrow-enumeration style `CODERABBIT_ACK_OPENING_RE` already uses
-//    for its own confirmation verbs (thanks/confirmed/agreed) -- is
+//    (round 3, Codex; now a natural consequence of guards 1-2's token
+//    grammar rather than a separate per-character lookahead): "`@user`,
+//    confirmed. This addresses the original concern but reveals another
+//    finding.\n\n🐇 ✓" has a genuinely new finding joined by "but" in the
+//    SAME sentence. Reaching the later "finding" would require consuming
+//    "concern", "but", and "reveals" as modifier tokens first -- 3 tokens
+//    before even reaching "another finding", already past the `{0,3}`
+//    cap guard 1 enforces -- so no valid parse reaches the second
+//    occurrence; the match fails at the first "concern" instead, exactly
+//    as guard 3's tail check requires.
+// 5. **Hedge-adverb guard, both before "addresses" and inside the gap**
+//    (round 2, Codex; scoping fixed round 3, Copilot; extended into the
+//    gap itself, round 7, Codex): "`@user`, confirmed. This partially
+//    addresses the concern.\n\n🐇 ✓" has genuine boilerplate immediately
+//    following, crosses no sentence boundary, and "concern" is the first
+//    and only candidate, so guards 1-4 don't catch it. A small, closed
+//    set of English degree adverbs immediately before "addresses" -- the
+//    same narrow-enumeration style `CODERABBIT_ACK_OPENING_RE` already
+//    uses for its own confirmation verbs (thanks/confirmed/agreed) -- is
 //    materially different from the open-ended "new concern" blocklist
 //    already tried and reverted above: that attempt tried to recognize
 //    arbitrarily-phrased new substantive content (unbounded), while this
@@ -2136,7 +2150,10 @@ const CODERABBIT_ACK_OPENING_RE = new RegExp(
 //    reject the two strong forms merely because unrelated hedge-shaped
 //    wording happens to appear elsewhere in the same reply's boilerplate
 //    (e.g. a Learnings-used block quoting a past PR's discussion) --
-//    Copilot's round-3 finding on the round-2 fix. Given this
+//    Copilot's round-3 finding on the round-2 fix. Round 7 additionally
+//    checks each gap token against the same enumeration, since a hedge
+//    word can also hide INSIDE the gap ("addresses the partially
+//    resolved concern") where the lookbehind never looks. Given this
 //    repository's `fully_autonomous_merge` policy (AGENTS.md), a hedged
 //    "addresses" is exactly the shape most likely to hide real
 //    outstanding feedback behind an ack-shaped reply, so closing this
@@ -2147,15 +2164,32 @@ const CODERABBIT_ACK_OPENING_RE = new RegExp(
 // the two strong forms: those report CodeRabbit's own resolve-attempt
 // DECISION, which by this file's own reasoning cannot co-occur with a new
 // substantive concern in the same reply. This third form reads prose with
-// no such structural barrier, so it is strictly weaker: a hedge word the
-// enumeration above does not cover (e.g. "kind of", "sort of", or a novel
-// phrasing), or a new concern joined to the acknowledgment some way other
-// than a mid-sentence conjunction guard 4 already closes, would still
-// misclassify. No sampled reply has done either. Extending the
-// hedge-adverb enumeration further is a bounded, reviewable change;
-// recognizing arbitrary new-concern phrasing is not -- that line is why
-// guard 5 stops at degree adverbs and does not attempt the open-ended
-// problem.
+// no such structural barrier, so it is strictly weaker. Two residual gaps
+// remain, both raised as a design question on issue #2858 rather than
+// chased further here:
+//
+// (a) **Contrastive/evaluative adjectives within the `{0,3}` token
+//     window** (Codex round 8, PR #2868): degree adverbs (guard 5) are a
+//     closed, enumerable class -- English has roughly a dozen. A
+//     CONTRASTIVE adjective is not: "wrong", "different", "other",
+//     "unrelated", "remaining", "outstanding", "unaddressed" all read as
+//     coherent, grammatically ordinary English inside the gap --
+//     "`@user`, thanks. This addresses the wrong security
+//     concern.\n\n🐇 ✓" is a coherent sentence stating the fix missed the
+//     mark, yet matches structurally. Enumerating this class would be
+//     the exact open-ended "new concern" blocklist this file's own
+//     history already tried and reverted (guard 5's comment above); it
+//     is not the same shape as a short, closed adverb list. This is the
+//     third form's irreducible limit for recognizing a prose closure via
+//     structure rather than genuine language understanding, not a gap
+//     guards 1-5 failed to close. Both real observed samples use plain
+//     noun-attributive modifiers naming the topic ("template",
+//     "link-resolution"), never an evaluative adjective -- no sampled
+//     reply has used this shape to hide misclassified feedback.
+// (b) The `<details>` block's interior (see
+//     `CODERABBIT_ACK_CLOSURE_DETAILS_SOURCE` below) is intentionally
+//     opaque, quoted text; a concern hidden there rather than as sibling
+//     prose would also still misclassify, for the same reason.
 const CODERABBIT_ACK_STRONG_CLOSURE_RE =
   /✅\s*Review thread resolved\.|I couldn't resolve this review thread on the repository platform/i;
 
@@ -2295,14 +2329,20 @@ const CODERABBIT_ACK_CLOSURE_TAIL_SOURCE =
 // text immediately preceding "addresses") entirely.
 //
 // Residual risk, stated rather than papered over, the same standard as
-// every guard above: within the 3-token cap, a semantically incoherent
-// but structurally valid modifier sequence -- e.g. "addresses the
-// concern finding." (treating "concern" itself as a 1-token modifier of
-// "finding") -- would still match. No sampled reply has produced word
-// salad like this; recognizing that a modifier sequence is not
-// grammatically sensible is the same open-ended natural-language
-// problem this file has repeatedly declared out of scope, the same
-// class as the `<details>` block's opaque interior above.
+// every guard above -- and corrected here after an earlier revision of
+// this paragraph understated it (Codex round 8, PR #2868, below): within
+// the 3-token cap, the token content itself is not semantically
+// restricted beyond the closed hedge-adverb enumeration. This is not
+// limited to ungrammatical "word salad" like "addresses the concern
+// finding." -- a CONTRASTIVE adjective reads as perfectly ordinary
+// English while still meaning the opposite of an acknowledgment:
+// "addresses the wrong security concern" is coherent and structurally
+// matches. See residual gap (a) in the comment above
+// `CODERABBIT_ACK_STRONG_CLOSURE_RE` for why this class (contrastive
+// adjectives: "wrong", "different", "unrelated", "remaining", and
+// similar) is NOT enumerable the way the degree-adverb hedge list is,
+// and is raised as a design question on issue #2858 rather than chased
+// with an open-ended list here.
 const CODERABBIT_ACK_ADDRESSES_CLOSURE_RE = new RegExp(
   `(?<!\\b(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE})\\s+)` +
     '\\baddresses\\s+the\\b' +

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2210,34 +2210,66 @@ const CODERABBIT_ACK_ADDRESSES_CLOSURE_RE = new RegExp(
 // This helper matches CodeRabbit's own stated decision; it cannot second-
 // guess a wrong decision CodeRabbit reports about itself.
 //
-// 6. **Opening-to-closure anchor, scoped to the weaker "addresses the ..."
-//    form only** (Codex review, PR #2868, round 4): every guard above
-//    narrows what counts as a closure WITHIN a matched span, but neither
-//    closure regex was ever anchored to where the opening ends --
-//    `.test(body)` searches the WHOLE body, so an entirely separate
-//    sentence carrying genuinely new, unresolved feedback between the
-//    opening and the closure was invisible to it. Concretely: "`@user`,
-//    confirmed. However, the null-check remains unresolved. The
-//    documentation update addresses the wording concern.\n\n🐇 ✓" has an
-//    explicit "remains unresolved" sentence the closure guards never
-//    look at, yet the ADDRESSES form still matches later in the body.
-//    A real sampled reply (kurone-kito/idd-skill#2853, tests above) shows
-//    the closure is legitimately its OWN sentence, separate from the
-//    opening's -- "confirmed. The repository-qualified reference
-//    addresses the ... concern." -- so requiring the closure to start
-//    immediately after the opening (same sentence) would reject a real,
-//    observed template. The bound that holds both true is a COUNT, not
-//    a position: the text between the end of the opening match and the
-//    start of the closure match must contain at most one sentence
-//    terminator (`.`/`!`/`?`) -- the one that legitimately closes the
-//    opening's own "confirmed."/"thanks." sentence before the closure's
-//    lead-in clause begins. Two or more means at least one additional,
-//    independent sentence sits in between, exactly Codex's demonstrated
-//    shape. Scoped to `CODERABBIT_ACK_ADDRESSES_CLOSURE_RE` only, not the
-//    two strong forms: those report CodeRabbit's own resolve-attempt
+// 6. **Opening-to-closure lead-in whitelist, scoped to the weaker
+//    "addresses the ..." form only** (Codex review, PR #2868, rounds 4
+//    and 5): every guard above narrows what counts as a closure WITHIN a
+//    matched span, but neither closure regex was ever anchored to where
+//    the opening ends -- `.test(body)` searches the WHOLE body, so an
+//    entirely separate sentence carrying genuinely new, unresolved
+//    feedback between the opening and the closure was invisible to it.
+//    Round 4 tried a NEGATIVE bound: at most one sentence terminator
+//    (`.`/`!`/`?`) between the opening and the closure match, on the
+//    theory that a second terminator means a second, independent
+//    sentence sits in between. Round 5 disproved it: natural language
+//    can join an unresolved clause to the closure without ANY second
+//    terminator at all -- "`@user`, confirmed. The null-check remains
+//    unresolved; this update addresses the wording concern.\n\n🐇 ✓"
+//    joins with a semicolon and leaves the terminator count at exactly
+//    one. An em dash or a bare coordinating conjunction ("and") work
+//    the same way. Any guard defined by what the gap must NOT contain is
+//    probeable forever against open-ended prose -- guard 5's own
+//    reasoning already said so; the round-4 terminator count was the one
+//    guard in this file that violated it anyway.
+//
+//    The fix flips to a POSITIVE whitelist, the same style as
+//    `CODERABBIT_ACK_OPENING_RE`'s own closed verb list and guard 5's
+//    closed adverb list: instead of asking "does the gap avoid
+//    disallowed punctuation," ask "does the gap match one of the small
+//    number of lead-in shapes the real observed samples actually use."
+//    Both observed samples (kurone-kito/idd-skill#2853, tests above) are
+//    a bare, short noun-phrase subject referring back to the fix -- "The
+//    repository-qualified reference", "Commit `80c936a7`" -- never a
+//    clause with its own verb describing outstanding status.
+//    `CODERABBIT_ACK_CLOSURE_LEADIN_RE`, below, requires the ENTIRE gap
+//    (the opening's own terminating `.`/`!`, then this lead-in, then
+//    nothing else) to match one of: a bare pronoun ("this"/"that"/"it"),
+//    "the" plus one or two more words, or "commit" plus a short hex
+//    SHA -- deliberately not a free `[^...]` class anywhere.
+//
+//    This intentionally FAILS CLOSED on any lead-in shape not in the
+//    list, including a legitimate one not yet observed: given this
+//    repository's `fully_autonomous_merge` policy, an unrecognized
+//    lead-in should route to a human-authored disposition rather than
+//    risk silently accepting hidden feedback behind an ack-shaped reply.
+//    That is the intended failure mode, not a defect to widen away the
+//    next time a real reply is rejected -- widen the enumeration
+//    (bounded, reviewable) rather than reopening a `[^...]` gap
+//    (unbounded, the class of bug this guard exists to close).
+//
+//    Scoped to `CODERABBIT_ACK_ADDRESSES_CLOSURE_RE` only, not the two
+//    strong forms: those report CodeRabbit's own resolve-attempt
 //    DECISION, which this file's own reasoning above already treats as
 //    unable to co-occur with a new concern in the same reply, so they
 //    keep the whole-body `.test()` they always had.
+const CODERABBIT_ACK_CLOSURE_LEADIN_RE = new RegExp(
+  '^[.!]\\s+(?:' +
+    'this|that|it|' +
+    'the\\s+[\\w-]+(?:\\s+[\\w-]+){0,1}|' +
+    'commit\\s+`[0-9a-f]{7,40}`' +
+    ')\\s+$',
+  'i',
+);
+
 function isKnownAdvisoryAckTemplate(comment: {
   author?: { login?: string | null } | null;
   body?: string | null;
@@ -2255,9 +2287,9 @@ function isKnownAdvisoryAckTemplate(comment: {
   // checked on the whole body with no further guard -- see the comment
   // above `CODERABBIT_ACK_STRONG_CLOSURE_RE` for why the weaker third
   // form's guards (locality, sentence-boundary, hedge-adverb, opening-
-  // to-closure anchor) must never apply here, even when unrelated
-  // hedge-shaped wording happens to appear elsewhere in the same reply
-  // (e.g. a Learnings-used block).
+  // to-closure lead-in whitelist) must never apply here, even when
+  // unrelated hedge-shaped wording happens to appear elsewhere in the
+  // same reply (e.g. a Learnings-used block).
   if (CODERABBIT_ACK_STRONG_CLOSURE_RE.test(body)) {
     return true;
   }
@@ -2267,8 +2299,7 @@ function isKnownAdvisoryAckTemplate(comment: {
   }
   const openingEnd = openingMatch.index + openingMatch[0].length;
   const gapToClosure = body.slice(openingEnd, addressesMatch.index);
-  const sentenceTerminatorCount = (gapToClosure.match(/[.!?]/g) ?? []).length;
-  return sentenceTerminatorCount <= 1;
+  return CODERABBIT_ACK_CLOSURE_LEADIN_RE.test(gapToClosure);
 }
 
 // Codex usage / quota exhaustion for code reviews. Token-anchored on all

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2220,6 +2220,25 @@ const CODERABBIT_ACK_HEDGE_WORDS_SOURCE =
 const CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE =
   'partial|temporary|interim|provisional|tentative|preliminary|stopgap|incomplete';
 
+// A THIRD, semantically distinct closed enumeration (Codex review, PR
+// #2868, round 10): hedge words (adverb and adjective forms above) say
+// something was done to a DEGREE; negation words say it was NOT done at
+// all -- a strictly stronger, more severe inversion, not a variant of
+// hedging. "The fix never addresses the security concern.\n\n🐇 ✓"
+// matched: "never" sits immediately before "addresses" the same way a
+// hedge adverb would, but neither hedge enumeration includes it (hedging
+// and negating are different speech acts), so the lookbehind below
+// passed it through untouched. English negation adverbs occurring
+// directly before a verb are a small, well-known closed class -- the
+// same narrow-enumeration standard as the two hedge lists above, not the
+// open-ended contrastive-adjective problem (residual gap (a)): negation
+// is a grammatical function word category, not free descriptive
+// vocabulary. `no\s+longer` is included as a two-word negation idiom;
+// `barely` is deliberately NOT duplicated here since it is already in
+// the hedge-adverb list above (a "small degree," not "zero," semantic).
+const CODERABBIT_ACK_NEGATION_WORDS_SOURCE =
+  'never|not|nor|hardly|scarcely|rarely|no\\s+longer';
+
 // CodeRabbit review, PR #2868, round 4: two mechanical bypasses in the
 // pattern below, both closed by widening two sub-patterns from singular-
 // only to also accept the plural/multi-space form, exactly the same
@@ -2368,9 +2387,9 @@ const CODERABBIT_ACK_CLOSURE_TAIL_SOURCE =
 // and is raised as a design question on issue #2858 rather than chased
 // with an open-ended list here.
 const CODERABBIT_ACK_ADDRESSES_CLOSURE_RE = new RegExp(
-  `(?<!\\b(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE})\\s+)` +
+  `(?<!\\b(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE})\\s+)` +
     '\\baddresses\\s+the\\b' +
-    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE})\\b)[\\w-]+){0,3}` +
+    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE})\\b)[\\w-]+){0,3}` +
     '\\s+\\b(?:concerns?|findings?)\\b\\.\\s*' +
     CODERABBIT_ACK_CLOSURE_TAIL_SOURCE,
   'i',
@@ -2465,11 +2484,27 @@ const CODERABBIT_ACK_ADDRESSES_CLOSURE_RE = new RegExp(
 //    ("partially") -- the first attempt at this fix reused only the
 //    adverb list and still let "partial"/"temporary" straight through,
 //    caught empirically before this ever reached review.
+// 8. **Negation words excluded everywhere a free token or a hedge
+//    lookbehind already exists** (Codex review, PR #2868, round 10):
+//    hedge words (guards 5 and 7) say something was done to a DEGREE;
+//    negation words say it was NOT done at all -- a stronger, more
+//    severe inversion, not a hedging variant, so it is its own
+//    enumeration (`CODERABBIT_ACK_NEGATION_WORDS_SOURCE` above) rather
+//    than folded into either hedge list. "`@user`, confirmed. The fix
+//    never addresses the security concern.\n\n🐇 ✓" matched: "never"
+//    sits immediately before "addresses" the same way a hedge adverb
+//    would, but neither hedge enumeration includes negation words, so
+//    every guard passed it through untouched. Wired into all three
+//    locations a hedge check already exists -- the lookbehind
+//    immediately before "addresses" (guard 5), the internal gap's
+//    per-token exclusion (guard 5), and the lead-in's per-token
+//    exclusion (guard 7) -- for the same defense-in-depth reasoning as
+//    guard 7's own dual adverb/adjective exclusion above.
 const CODERABBIT_ACK_CLOSURE_LEADIN_RE = new RegExp(
   '^[.!]\\s+(?:' +
     'this|that|it|' +
-    `the\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE})\\b)[\\w-]+` +
-    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE})\\b)[\\w-]+){0,1}|` +
+    `the\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE})\\b)[\\w-]+` +
+    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE})\\b)[\\w-]+){0,1}|` +
     'commit\\s+`[0-9a-f]{7,40}`' +
     ')\\s+$',
   'i',

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2122,8 +2122,9 @@ const CODERABBIT_ACK_OPENING_RE = new RegExp(
 //    a hedged, non-committal acknowledgment that would otherwise pass on
 //    structure alone.
 // 4. **No backtracking past an earlier same-sentence "concern"/"finding"**
-//    (round 3, Codex; now a natural consequence of guards 1-2's token
-//    grammar rather than a separate per-character lookahead): "`@user`,
+//    (round 3, Codex; largely a consequence of guards 1-2's token
+//    grammar rather than a separate per-character lookahead, but not
+//    unconditionally so -- see the precise bound stated below): "`@user`,
 //    confirmed. This addresses the original concern but reveals another
 //    finding.\n\n🐇 ✓" has a genuinely new finding joined by "but" in the
 //    SAME sentence. Reaching the later "finding" would require consuming
@@ -2131,7 +2132,15 @@ const CODERABBIT_ACK_OPENING_RE = new RegExp(
 //    before even reaching "another finding", already past the `{0,3}`
 //    cap guard 1 enforces -- so no valid parse reaches the second
 //    occurrence; the match fails at the first "concern" instead, exactly
-//    as guard 3's tail check requires.
+//    as guard 3's tail check requires. This holds whenever reaching the
+//    second occurrence needs MORE than 3 modifier tokens; a short,
+//    non-contrastive conjunctive bridge can still consume an earlier
+//    occurrence as a plain token within budget and reach a second one --
+//    "addresses the concern and finding.\n\n🐇 ✓" matches by treating
+//    "concern" as modifier-token #1 (self-critique, E2 pass on this PR).
+//    Not treated as a precision bug: "X addresses the concern and
+//    finding" reads as a benign compound object (both were addressed),
+//    not a hidden new concern, unlike the "but"-joined case above.
 // 5. **Hedge-adverb guard, both before "addresses" and inside the gap**
 //    (round 2, Codex; scoping fixed round 3, Copilot; extended into the
 //    gap itself, round 7, Codex): "`@user`, confirmed. This partially
@@ -2195,6 +2204,21 @@ const CODERABBIT_ACK_STRONG_CLOSURE_RE =
 
 const CODERABBIT_ACK_HEDGE_WORDS_SOURCE =
   'partially|partly|somewhat|mostly|largely|barely|slightly|arguably|in\\s+part|to\\s+some\\s+extent|not\\s+(?:fully|entirely|completely|really)';
+
+// Sibling enumeration to the degree-adverb list above, for the SAME
+// hedged/non-committal semantic class but the ADJECTIVE part of speech
+// (self-critique, E2 pass on this PR, PR #2868): the adverb list above
+// modifies a VERB ("partially addresses"); a lead-in noun phrase instead
+// takes an ADJECTIVE modifying its noun ("The partial workaround
+// addresses...", "The temporary fix addresses..."). Grammatically
+// distinct from the adverb list, so it is its own enumeration rather
+// than folded in, but the SAME bounded philosophy: a small, closed set
+// of English words describing partial/provisional completeness -- not
+// the open-ended CONTRASTIVE-adjective class (residual gap (a) above,
+// "wrong", "different", "unrelated") that states something was done
+// incorrectly rather than only partially or temporarily.
+const CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE =
+  'partial|temporary|interim|provisional|tentative|preliminary|stopgap|incomplete';
 
 // CodeRabbit review, PR #2868, round 4: two mechanical bypasses in the
 // pattern below, both closed by widening two sub-patterns from singular-
@@ -2423,10 +2447,29 @@ const CODERABBIT_ACK_ADDRESSES_CLOSURE_RE = new RegExp(
 //    DECISION, which this file's own reasoning above already treats as
 //    unable to co-occur with a new concern in the same reply, so they
 //    keep the whole-body `.test()` they always had.
+//
+// 7. **Hedge words excluded from the lead-in's own noun-phrase tokens
+//    too** (self-critique, E2 pass on this PR): guard 5's hedge-adverb
+//    enumeration reaches the internal "addresses the ... concern" gap
+//    (guard 5 above) but never reached the LEAD-IN's own "the" plus
+//    1-2 word slots, since that whitelist was designed purely as a
+//    structural check (pronoun / short noun phrase / commit SHA), not a
+//    semantic filter. "`@user`, confirmed. The partial workaround
+//    addresses the wording concern.\n\n🐇 ✓" matched despite "partial"
+//    being exactly the hedged, non-committal shape guard 5 exists to
+//    reject elsewhere. Applying the same per-token negative lookahead
+//    used in the internal gap closes this location too. Excludes BOTH
+//    enumerations (adverb and adjective forms), since a lead-in noun
+//    phrase's modifier is grammatically an adjective ("partial",
+//    "temporary") even though the internal gap's is an adverb
+//    ("partially") -- the first attempt at this fix reused only the
+//    adverb list and still let "partial"/"temporary" straight through,
+//    caught empirically before this ever reached review.
 const CODERABBIT_ACK_CLOSURE_LEADIN_RE = new RegExp(
   '^[.!]\\s+(?:' +
     'this|that|it|' +
-    'the\\s+[\\w-]+(?:\\s+[\\w-]+){0,1}|' +
+    `the\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE})\\b)[\\w-]+` +
+    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_HEDGE_ADJECTIVES_SOURCE})\\b)[\\w-]+){0,1}|` +
     'commit\\s+`[0-9a-f]{7,40}`' +
     ')\\s+$',
   'i',

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2112,7 +2112,7 @@ const CODERABBIT_ACK_OPENING_RE = new RegExp(
 //    keeps out the cross-sentence example above, since "However, ..." is
 //    not one of the known boilerplate forms.
 //
-// Hedge-adverb guard (Codex review round 2, PR #2868, #2858): even with
+// Hedge-adverb guard (issue #2858, Codex round-2 review on PR #2868): even with
 // both constraints above, "`@user`, confirmed. This partially addresses
 // the concern.\n\n🐇 ✓" still matched -- genuine boilerplate immediately
 // follows, and "partially" sits inside the matched sentence rather than

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2075,79 +2075,101 @@ const CODERABBIT_ACK_OPENING_RE = new RegExp(
 // failing) to resolve this thread, because it was already resolved
 // independently (e.g. by the IDD agent's own resolve-review-thread.mjs)
 // before CodeRabbit replied, so it had no attempt of its own to report.
-// Bounded to a short gap (`{0,80}`) so it matches only the same
-// single-clause shape actually observed, not an incidental "concern" or
-// "finding" mention far away in the same reply's trailing
-// Learnings-used block.
+// Kept as its own regex (`CODERABBIT_ACK_ADDRESSES_CLOSURE_RE`, below,
+// tested only after the two strong forms above fail) rather than folded
+// into one `|`-alternation, specifically so its own guards -- narrowed
+// across three rounds of Codex/Copilot review on this same PR (#2858,
+// PR #2868) -- never apply to the two strong, structurally-safe forms:
 //
-// Sentence-boundary tail anchor: an enumerated negation/new-concern
-// blocklist was tried here and reverted (see above) precisely because it
-// cannot keep up with natural language, so this shape is instead
-// recognized the same way as the other two -- a structural fingerprint of
-// CodeRabbit's own reply template, not a semantic read of the prose. Two
-// structural constraints, both narrowed further after Codex review found
-// concrete false-positive constructions in this same PR (#2858):
+// 1. **Locality bound** (`{0,80}`): the gap between "addresses the" and
+//    "concern"/"finding" is capped so an incidental "concern"/"finding"
+//    mention far away in the same reply's trailing Learnings-used block
+//    can't retroactively create a false closure signal.
+// 2. **Sentence-boundary exclusion** (`[^.!?]` in the gap, round 1): a
+//    plain `[\s\S]` gap let the match cross a sentence boundary entirely
+//    -- "This addresses the requested change. However, I still have a
+//    concern." has its own genuinely new, unrelated concern in a SECOND
+//    sentence, but an un-narrowed gap could reach that later "concern"
+//    anyway. Excluding `.!?` forces "concern"/"finding" into the SAME
+//    sentence as "addresses the", as in both real observed replies.
+// 3. **Mandatory boilerplate tail, no bare end-of-body fallback**
+//    (round 1): the closure sentence must end in a period immediately
+//    followed by known CodeRabbit reply boilerplate (the 🐇 sign-off,
+//    the `---` + Learnings-used separator, the auto-generated-reply
+//    marker, or the "You are interacting with an AI system" disclaimer).
+//    Every sampled reply (all 20: the original 18 plus these 2) carries
+//    real trailing boilerplate, so requiring it unconditionally costs no
+//    real match; this also rejects a single-sentence reply with nothing
+//    following it at all, such as "`@user`, confirmed. This partially
+//    addresses the concern." with no footer -- a hedged, non-committal
+//    acknowledgment that would otherwise pass on structure alone.
+// 4. **No backtracking past an earlier same-sentence "concern"/"finding"**
+//    (round 3, Codex): a plain lazy `[^.!?]{0,80}?` gap still let the
+//    regex engine skip an EARLIER "concern"/"finding" occurrence that
+//    failed the boilerplate-tail check, to find a LATER one that
+//    succeeds -- "`@user`, confirmed. This addresses the original
+//    concern but reveals another finding.\n\n🐇 ✓" has a genuinely new
+//    finding joined by "but" in the SAME sentence, yet the gap could
+//    still stretch past the first "concern" (not followed by a period)
+//    to match the later "finding." instead. The gap is rewritten as
+//    `(?:(?!\b(?:concern|finding)\b)[^.!?]){0,80}` -- consume characters
+//    only while the upcoming text is NOT the start of "concern" or
+//    "finding" -- so the match is pinned to the FIRST such occurrence in
+//    the sentence; the whole alternative fails if that first occurrence
+//    isn't immediately followed by the boilerplate tail, rather than
+//    scanning ahead for a second one that is.
+// 5. **Hedge-adverb guard, scoped to only this alternative** (round 2,
+//    Codex; scoping fixed round 3, Copilot): even with all of the above,
+//    "`@user`, confirmed. This partially addresses the concern.\n\n🐇 ✓"
+//    still matched -- genuine boilerplate immediately follows, no
+//    sentence boundary is crossed, and "concern" is the first and only
+//    candidate, so guards 1-4 don't catch it. A small, closed set of
+//    English degree adverbs immediately before "addresses" -- the same
+//    narrow-enumeration style `CODERABBIT_ACK_OPENING_RE` already uses
+//    for its own confirmation verbs (thanks/confirmed/agreed) -- is
+//    materially different from the open-ended "new concern" blocklist
+//    already tried and reverted above: that attempt tried to recognize
+//    arbitrarily-phrased new substantive content (unbounded), while this
+//    is a small, well-known closed class of adverbs modifying
+//    "addresses" itself. Implemented as a negative lookbehind directly on
+//    this alternative (not a separate whole-body check) so it can never
+//    reject the two strong forms merely because unrelated hedge-shaped
+//    wording happens to appear elsewhere in the same reply's boilerplate
+//    (e.g. a Learnings-used block quoting a past PR's discussion) --
+//    Copilot's round-3 finding on the round-2 fix. Given this
+//    repository's `fully_autonomous_merge` policy (AGENTS.md), a hedged
+//    "addresses" is exactly the shape most likely to hide real
+//    outstanding feedback behind an ack-shaped reply, so closing this
+//    demonstrated case outweighs leaving it as stated residual risk the
+//    way the new-concern class above still is.
 //
-// 1. The gap between "addresses the" and "concern"/"finding" excludes
-//    sentence-terminating punctuation (`[^.!?]`), not just any character.
-//    A plain `[\s\S]` gap let the match cross a sentence boundary
-//    entirely -- "This addresses the requested change. However, I still
-//    have a concern." has its own genuinely new, unrelated concern in a
-//    SECOND sentence, but the un-narrowed gap could reach that later
-//    "concern" anyway, since nothing stopped it from skipping the period
-//    in between. Excluding `.!?` from the gap forces "concern"/"finding"
-//    to appear in the SAME sentence as "addresses the", as in both real
-//    observed replies.
-// 2. The closure sentence must end in a period immediately followed by
-//    known CodeRabbit reply boilerplate (the 🐇 sign-off, the `---` +
-//    Learnings-used separator, the auto-generated-reply marker, or the
-//    "You are interacting with an AI system" disclaimer) -- no bare
-//    end-of-body fallback. Every sampled reply (all 20: the original 18
-//    plus these 2) carries real trailing boilerplate, so requiring it
-//    unconditionally costs no real match; dropping the end-of-body
-//    fallback closes a single-sentence reply with nothing following it,
-//    such as "`@user`, confirmed. This partially addresses the concern."
-//    with no footer at all -- a hedged, non-committal acknowledgment that
-//    would otherwise pass on structure alone. This also independently
-//    keeps out the cross-sentence example above, since "However, ..." is
-//    not one of the known boilerplate forms.
-//
-// Hedge-adverb guard (issue #2858, Codex round-2 review on PR #2868): even with
-// both constraints above, "`@user`, confirmed. This partially addresses
-// the concern.\n\n🐇 ✓" still matched -- genuine boilerplate immediately
-// follows, and "partially" sits inside the matched sentence rather than
-// crossing a sentence boundary, so neither guard above catches it. This
-// is a materially different problem class from the reverted "new
-// concern" blocklist above: that attempt tried to recognize an
-// open-ended, arbitrarily-phrased NEW substantive finding appended after
-// a genuine ack (unbounded -- natural language has unlimited ways to
-// raise a concern). A hedge adverb directly modifying "addresses" itself
-// is a small, closed, well-known class of English degree adverbs -- the
-// same kind of narrow enumeration `CODERABBIT_ACK_OPENING_RE` already
-// uses for its own confirmation verbs (thanks/confirmed/agreed). Given
-// this repository's `fully_autonomous_merge` policy (AGENTS.md), a
-// hedged "addresses" is exactly the shape most likely to hide real
-// outstanding feedback behind an ack-shaped reply, so closing the
-// specific, demonstrated case outweighs leaving it as stated residual
-// risk the way the new-concern class above still is.
-const CODERABBIT_ACK_HEDGE_RE =
-  /\b(?:partially|partly|somewhat|mostly|largely|barely|slightly|arguably|in\s+part|to\s+some\s+extent|not\s+(?:fully|entirely|completely|really))\s+addresses\s+the\b/i;
-
 // Residual risk, stated rather than papered over -- NOT the same class as
-// the two forms above: those report CodeRabbit's own resolve-attempt
+// the two strong forms: those report CodeRabbit's own resolve-attempt
 // DECISION, which by this file's own reasoning cannot co-occur with a new
 // substantive concern in the same reply. This third form reads prose with
-// no such structural barrier, so it is strictly weaker: a hedge word this
-// enumeration does not cover (e.g. "kind of", "sort of", or a novel
-// phrasing), or a reply whose SAME sentence both raises a concern in some
-// non-hedge-adverb way and still ends with a period immediately before
-// genuine CodeRabbit boilerplate, would still misclassify. No sampled
-// reply has done either. Extending the hedge-adverb enumeration further
-// is a bounded, reviewable change; recognizing arbitrary new-concern
-// phrasing is not -- that line is why the guard above stops at degree
-// adverbs and does not attempt the open-ended problem.
-const CODERABBIT_ACK_CLOSURE_RE =
-  /✅\s*Review thread resolved\.|I couldn't resolve this review thread on the repository platform|\baddresses\s+the\b[^.!?]{0,80}?\b(?:concern|finding)\b\.\s*(?:🐇|---|<details|<!--|_You are interacting)/i;
+// no such structural barrier, so it is strictly weaker: a hedge word the
+// enumeration above does not cover (e.g. "kind of", "sort of", or a novel
+// phrasing), or a new concern joined to the acknowledgment some way other
+// than a mid-sentence conjunction guard 4 already closes, would still
+// misclassify. No sampled reply has done either. Extending the
+// hedge-adverb enumeration further is a bounded, reviewable change;
+// recognizing arbitrary new-concern phrasing is not -- that line is why
+// guard 5 stops at degree adverbs and does not attempt the open-ended
+// problem.
+const CODERABBIT_ACK_STRONG_CLOSURE_RE =
+  /✅\s*Review thread resolved\.|I couldn't resolve this review thread on the repository platform/i;
+
+const CODERABBIT_ACK_HEDGE_WORDS_SOURCE =
+  'partially|partly|somewhat|mostly|largely|barely|slightly|arguably|in\\s+part|to\\s+some\\s+extent|not\\s+(?:fully|entirely|completely|really)';
+
+const CODERABBIT_ACK_ADDRESSES_CLOSURE_RE = new RegExp(
+  `(?<!\\b(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE})\\s)` +
+    '\\baddresses\\s+the\\b' +
+    '(?:(?!\\b(?:concern|finding)\\b)[^.!?]){0,80}' +
+    '\\b(?:concern|finding)\\b\\.\\s*' +
+    '(?:🐇|---|<details|<!--|_You are interacting)',
+  'i',
+);
 
 // Explicit `isCodeRabbitLogin` author check (Copilot review, #2649,
 // round 4): the closure phrase is CodeRabbit's own resolution decision in
@@ -2174,14 +2196,22 @@ function isKnownAdvisoryAckTemplate(comment: {
 }): boolean {
   const authorLogin = String(comment.author?.login ?? '');
   const body = String(comment.body ?? '');
-  return (
-    !!authorLogin &&
-    isCodeRabbitLogin(authorLogin) &&
-    !!body &&
-    CODERABBIT_ACK_OPENING_RE.test(body) &&
-    CODERABBIT_ACK_CLOSURE_RE.test(body) &&
-    !CODERABBIT_ACK_HEDGE_RE.test(body)
-  );
+  if (!authorLogin || !isCodeRabbitLogin(authorLogin) || !body) {
+    return false;
+  }
+  if (!CODERABBIT_ACK_OPENING_RE.test(body)) {
+    return false;
+  }
+  // The two strong forms (CodeRabbit's own resolve-attempt decision) are
+  // checked on the whole body with no further guard -- see the comment
+  // above `CODERABBIT_ACK_STRONG_CLOSURE_RE` for why the weaker third
+  // form's guards (locality, sentence-boundary, hedge-adverb) must never
+  // apply here, even when unrelated hedge-shaped wording happens to
+  // appear elsewhere in the same reply (e.g. a Learnings-used block).
+  if (CODERABBIT_ACK_STRONG_CLOSURE_RE.test(body)) {
+    return true;
+  }
+  return CODERABBIT_ACK_ADDRESSES_CLOSURE_RE.test(body);
 }
 
 // Codex usage / quota exhaustion for code reviews. Token-anchored on all

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2256,11 +2256,58 @@ const CODERABBIT_ACK_CLOSURE_TAIL_SOURCE =
   `(?:\\s*${CODERABBIT_ACK_CLOSURE_MARKER_SOURCE})?` +
   `|${CODERABBIT_ACK_CLOSURE_MARKER_SOURCE})` +
   '\\s*$';
+// Internal gap tokenized, capped at 3 modifier words, hedge words
+// excluded per token (Codex review, PR #2868, round 7): the previous
+// `(?:(?!\b(?:concerns?|findings?)\b)[^.!?]){0,80}` gap was a NEGATIVE
+// bound again -- any non-period, non-concern/finding character was
+// allowed, for up to 80 of them -- and Codex demonstrated it accepts a
+// coordinating conjunction that silently swaps in a genuinely different,
+// unaddressed concern: "confirmed. This addresses the documentation
+// issue but leaves a security concern.\n\n🐇 ✓" has only ONE "concern"
+// occurrence (so guard 4's no-backtrack protection never engages), and
+// it is immediately followed by the required boilerplate, so the old
+// gap matched it as a clean acknowledgment even though "but leaves a"
+// means the opposite.
+//
+// Both real observed samples (kurone-kito/idd-skill#2853) show the gap
+// is a SHORT, plain noun-phrase modifier with no verbs or conjunctions
+// at all: "template link-resolution" and "template issue-reference" (2
+// tokens each). The fix flips this gap to the same positive-shape style
+// as guard 6's lead-in whitelist: the gap may consist of at most 3
+// space-separated `[\w-]+` tokens (one more than either real sample
+// needs, since a coherent conjunction-based "flip" needs a verb plus a
+// new subject -- realistically 4 or more words -- to read as a genuine
+// change of topic; Codex's own example needs 5). Restricting tokens to
+// `[\w-]+` also subsumes guards 2 and 4 for free: neither a comma nor a
+// sentence-terminating `.`/`!`/`?` is a word character or whitespace, so
+// either one breaks the token chain outright, and reaching a SECOND,
+// later "concern"/"finding" now requires consuming more modifier tokens
+// than the cap allows (verified against round 3's own "addresses the
+// original concern but reveals another finding" fixture below, still
+// rejected under the new grammar with no separate backtrack guard
+// needed).
+//
+// Each token is additionally checked against the same closed hedge-word
+// enumeration as the lookbehind below, via a per-token negative
+// lookahead: without this, "addresses the partially resolved concern"
+// would let a hedge word hide INSIDE the gap rather than immediately
+// before "addresses", bypassing the lookbehind (which only inspects the
+// text immediately preceding "addresses") entirely.
+//
+// Residual risk, stated rather than papered over, the same standard as
+// every guard above: within the 3-token cap, a semantically incoherent
+// but structurally valid modifier sequence -- e.g. "addresses the
+// concern finding." (treating "concern" itself as a 1-token modifier of
+// "finding") -- would still match. No sampled reply has produced word
+// salad like this; recognizing that a modifier sequence is not
+// grammatically sensible is the same open-ended natural-language
+// problem this file has repeatedly declared out of scope, the same
+// class as the `<details>` block's opaque interior above.
 const CODERABBIT_ACK_ADDRESSES_CLOSURE_RE = new RegExp(
   `(?<!\\b(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE})\\s+)` +
     '\\baddresses\\s+the\\b' +
-    '(?:(?!\\b(?:concerns?|findings?)\\b)[^.!?]){0,80}' +
-    '\\b(?:concerns?|findings?)\\b\\.\\s*' +
+    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE})\\b)[\\w-]+){0,3}` +
+    '\\s+\\b(?:concerns?|findings?)\\b\\.\\s*' +
     CODERABBIT_ACK_CLOSURE_TAIL_SOURCE,
   'i',
 );

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2112,19 +2112,40 @@ const CODERABBIT_ACK_OPENING_RE = new RegExp(
 //    keeps out the cross-sentence example above, since "However, ..." is
 //    not one of the known boilerplate forms.
 //
+// Hedge-adverb guard (Codex review round 2, PR #2868, #2858): even with
+// both constraints above, "`@user`, confirmed. This partially addresses
+// the concern.\n\n🐇 ✓" still matched -- genuine boilerplate immediately
+// follows, and "partially" sits inside the matched sentence rather than
+// crossing a sentence boundary, so neither guard above catches it. This
+// is a materially different problem class from the reverted "new
+// concern" blocklist above: that attempt tried to recognize an
+// open-ended, arbitrarily-phrased NEW substantive finding appended after
+// a genuine ack (unbounded -- natural language has unlimited ways to
+// raise a concern). A hedge adverb directly modifying "addresses" itself
+// is a small, closed, well-known class of English degree adverbs -- the
+// same kind of narrow enumeration `CODERABBIT_ACK_OPENING_RE` already
+// uses for its own confirmation verbs (thanks/confirmed/agreed). Given
+// this repository's `fully_autonomous_merge` policy (AGENTS.md), a
+// hedged "addresses" is exactly the shape most likely to hide real
+// outstanding feedback behind an ack-shaped reply, so closing the
+// specific, demonstrated case outweighs leaving it as stated residual
+// risk the way the new-concern class above still is.
+const CODERABBIT_ACK_HEDGE_RE =
+  /\b(?:partially|partly|somewhat|mostly|largely|barely|slightly|arguably|in\s+part|to\s+some\s+extent|not\s+(?:fully|entirely|completely|really))\s+addresses\s+the\b/i;
+
 // Residual risk, stated rather than papered over -- NOT the same class as
 // the two forms above: those report CodeRabbit's own resolve-attempt
 // DECISION, which by this file's own reasoning cannot co-occur with a new
 // substantive concern in the same reply. This third form reads prose with
-// no such structural barrier, so it is strictly weaker: a reply whose
-// SAME sentence both hedges ("partially", "mostly", ...) or raises a
-// concern and still ends with a period immediately before genuine
-// CodeRabbit boilerplate (e.g. "This addresses the concern, mostly.
-// <!-- auto-generated reply -->") would still misclassify. No sampled
-// reply has done this. An enumerated hedge-word guard was considered and
-// rejected for the same reason the new-concern blocklist above was: it
-// does not generalize, and this file's own philosophy prefers a stated,
-// bounded residual risk over an unbounded semantic blocklist.
+// no such structural barrier, so it is strictly weaker: a hedge word this
+// enumeration does not cover (e.g. "kind of", "sort of", or a novel
+// phrasing), or a reply whose SAME sentence both raises a concern in some
+// non-hedge-adverb way and still ends with a period immediately before
+// genuine CodeRabbit boilerplate, would still misclassify. No sampled
+// reply has done either. Extending the hedge-adverb enumeration further
+// is a bounded, reviewable change; recognizing arbitrary new-concern
+// phrasing is not -- that line is why the guard above stops at degree
+// adverbs and does not attempt the open-ended problem.
 const CODERABBIT_ACK_CLOSURE_RE =
   /✅\s*Review thread resolved\.|I couldn't resolve this review thread on the repository platform|\baddresses\s+the\b[^.!?]{0,80}?\b(?:concern|finding)\b\.\s*(?:🐇|---|<details|<!--|_You are interacting)/i;
 
@@ -2158,7 +2179,8 @@ function isKnownAdvisoryAckTemplate(comment: {
     isCodeRabbitLogin(authorLogin) &&
     !!body &&
     CODERABBIT_ACK_OPENING_RE.test(body) &&
-    CODERABBIT_ACK_CLOSURE_RE.test(body)
+    CODERABBIT_ACK_CLOSURE_RE.test(body) &&
+    !CODERABBIT_ACK_HEDGE_RE.test(body)
   );
 }
 

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -1464,10 +1464,11 @@ test('classifyThreadAckOnlyPostDisposition rejects genuinely new feedback append
 });
 
 test('classifyThreadAckOnlyPostDisposition rejects genuinely new feedback sandwiched between two "<details>" blocks (regression guard, #2858)', () => {
-  // The details-block sub-pattern uses a LAZY `[\s\S]*?` so it stops at
+  // The details-block sub-pattern forbids consuming past the first
+  // "</details>" via a per-character negative lookahead, so it stops at
   // the first "</details>" rather than the last -- confirms a second,
   // unrelated details block later in the tail cannot be used to smuggle
-  // prose past the lazy match by making the whole tail look like "one
+  // prose past the match by making the whole tail look like "one
   // details block" when it is actually two with substantive text between
   // them.
   const thread = {

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -2007,6 +2007,88 @@ test('classifyThreadAckOnlyPostDisposition safely rejects the "Thanks for the fi
   assert.equal(classification.ackOnlyPostDisposition, false);
 });
 
+test('classifyThreadAckOnlyPostDisposition rejects a negation adverb immediately before "addresses" in the lead-in (Codex round 10, #2868)', () => {
+  // Codex's round-10 finding on PR #2868: hedge words (guards 5, 7) say
+  // something was done to a DEGREE; negation words say it was NOT done
+  // at all -- a stronger inversion, not a hedging variant. "The fix
+  // never addresses the security concern.\n\n🐇 ✓" matched: "never" sits
+  // immediately before "addresses" the same way a hedge adverb would,
+  // but neither hedge enumeration includes negation words, so every
+  // guard passed it through untouched. This is Codex's exact
+  // adversarial example.
+  const thread = {
+    id: 'thread-negation-never-addresses',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'NV-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'NV-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@user`, confirmed. The fix never addresses the ' +
+            'security concern.\n\n🐇 ✓',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
+test('classifyThreadAckOnlyPostDisposition rejects a "does not address" negation immediately before "addresses" (regression guard, #2858)', () => {
+  // Same class as the round-10 finding, with a different negation word
+  // ("not") to confirm the fix is not overfit to "never" alone.
+  const thread = {
+    id: 'thread-negation-not-addresses',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'NT-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'NT-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@user`, confirmed. This does not addresses the ' +
+            'wording concern.\n\n🐇 ✓',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
 // Codex review findings on this PR (#2014), both verified against source
 // before accepting.
 

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -2144,7 +2144,7 @@ test('classifyThreadAckOnlyPostDisposition rejects the "in no way" and "by no me
     iddAgentLogins: ['idd-bot'],
     advisoryBotLogins: ['coderabbitai[bot]'],
   };
-  const mkThread = (id, body) => ({
+  const mkThread = (id: string, body: string) => ({
     id,
     isResolved: true,
     updatedAt: '',
@@ -2243,7 +2243,7 @@ test('classifyThreadAckOnlyPostDisposition rejects "perhaps" and "possibly" as m
     iddAgentLogins: ['idd-bot'],
     advisoryBotLogins: ['coderabbitai[bot]'],
   };
-  const mkThread = (id, body) => ({
+  const mkThread = (id: string, body: string) => ({
     id,
     isResolved: true,
     updatedAt: '',

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -841,19 +841,23 @@ test('classifyThreadAckOnlyPostDisposition recognizes the "addresses the ... fin
   assert.equal(classification.ackOnlyPostDisposition, true);
 });
 
-test('classifyThreadAckOnlyPostDisposition rejects the "addresses the ... concern" shape when "concern" sits more than 80 characters away, in the SAME sentence, immediately before genuine boilerplate (Copilot review, #2858)', () => {
-  // Locality guard: the third closure shape is bounded (`{0,80}`) so a
-  // "concern"/"finding" mention too far from "addresses the" does not
-  // create a false closure signal. Copilot review flagged the original
-  // version of this test: its fixture put "finding" in a different
+test('classifyThreadAckOnlyPostDisposition rejects the "addresses the ... concern" shape when "concern" sits more than 3 modifier tokens away, in the SAME sentence, immediately before genuine boilerplate (Copilot review, #2858; token-count bound since Codex round 7)', () => {
+  // Locality guard: the third closure shape's internal gap is bounded so
+  // a "concern"/"finding" mention too far from "addresses the" does not
+  // create a false closure signal. Originally an 80-character bound;
+  // Codex's round 7 replaced it with a 3-modifier-token cap (see the doc
+  // comment above `CODERABBIT_ACK_ADDRESSES_CLOSURE_RE`), so this fixture
+  // now uses 4 plain noun-phrase tokens -- one over the cap -- rather
+  // than an unrealistic 45-token filler, to exercise the actual boundary
+  // instead of an arbitrary excess. Copilot's original review on this
+  // test flagged that its first version put "finding" in a different
   // sentence with no boilerplate anywhere, so it failed for those two
-  // reasons regardless of the 80-char bound, never actually exercising
+  // reasons regardless of the distance bound, never actually exercising
   // it. This fixture keeps "concern" in the SAME sentence (no `.!?`
   // between them, so the sentence-boundary guard does not fire) and adds
   // genuine boilerplate immediately after it (so the boilerplate-tail
-  // guard does not fire either) -- the >80-character gap is the only
+  // guard does not fire either) -- the over-cap token count is the only
   // remaining reason this must still be rejected.
-  const filler = 'x '.repeat(45); // 90 chars, no sentence-terminating punctuation
   const thread = {
     id: 'thread-addresses-far-from-concern',
     isResolved: true,
@@ -871,7 +875,9 @@ test('classifyThreadAckOnlyPostDisposition rejects the "addresses the ... concer
         {
           id: 'FA-2',
           author: { login: 'coderabbitai[bot]' },
-          body: `\`@kurone-kito\`, confirmed. This addresses the ${filler}concern.\n\n🐇 ✓`,
+          body:
+            '`@kurone-kito`, confirmed. This addresses the very ' +
+            'long compound noun concern.\n\n🐇 ✓',
           createdAt: '2026-05-12T02:00:00Z',
           updatedAt: '2026-05-12T02:00:00Z',
         },
@@ -1484,6 +1490,92 @@ test('classifyThreadAckOnlyPostDisposition rejects genuinely new feedback sandwi
             '</details>\n\nHowever, the null-check remains ' +
             'unresolved.\n\n<details>\n<summary>bar</summary>\n' +
             '</details>',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
+test('classifyThreadAckOnlyPostDisposition rejects a coordinating conjunction that swaps in a genuinely different, unaddressed concern (Codex round 7, #2868)', () => {
+  // Codex's round-7 finding on PR #2868: the internal gap between
+  // "addresses the" and "concern"/"finding" had no positive shape at
+  // all -- only "not a period, not concern/finding, within 80 chars" --
+  // so a coordinating conjunction could silently swap the addressed
+  // topic for a genuinely different one, with only ONE "concern"
+  // occurrence (so guard 4's no-backtrack protection never engages) that
+  // is immediately followed by genuine boilerplate. This is Codex's
+  // exact adversarial example.
+  const thread = {
+    id: 'thread-addresses-but-leaves-different-concern',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'BL-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'BL-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@user`, confirmed. This addresses the documentation ' +
+            'issue but leaves a security concern.\n\n🐇 ✓',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
+test('classifyThreadAckOnlyPostDisposition rejects a hedge word hidden inside the internal gap rather than immediately before "addresses" (regression guard, #2858)', () => {
+  // The hedge lookbehind only inspects the text immediately preceding
+  // "addresses" -- without also excluding hedge words from the internal
+  // gap's own token set, "addresses the partially resolved concern"
+  // would hide the same hedge inside the gap and bypass the lookbehind
+  // entirely. Each gap token is checked against the same closed hedge
+  // enumeration via a per-token negative lookahead.
+  const thread = {
+    id: 'thread-addresses-hedge-inside-gap',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'HG-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'HG-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@kurone-kito`, confirmed. This addresses the partially ' +
+            'resolved concern.\n\n🐇 ✓',
           createdAt: '2026-05-12T02:00:00Z',
           updatedAt: '2026-05-12T02:00:00Z',
         },

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -970,6 +970,93 @@ test('classifyThreadAckOnlyPostDisposition rejects an "addresses the ... concern
   assert.equal(classification.ackOnlyPostDisposition, false);
 });
 
+// Codex review findings on this PR (#2858), both verified against source
+// before accepting: a legitimate structural gap, not the semantic
+// "new concern" phrasing this file already documents as out of scope.
+
+test('classifyThreadAckOnlyPostDisposition rejects a hedged closure sentence with no trailing boilerplate at all (Codex P1, #2858)', () => {
+  // Codex's exact adversarial example: a single-sentence reply --
+  // "confirmed. This partially addresses the concern." -- with nothing
+  // following it. Every sampled real reply (20/20) carries genuine
+  // trailing boilerplate, so the tail anchor no longer accepts a bare
+  // end-of-body as a substitute; a hedged, non-committal acknowledgment
+  // with no footer at all must not pass on structure alone.
+  const thread = {
+    id: 'thread-hedged-no-boilerplate',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'HN-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'HN-2',
+          author: { login: 'coderabbitai[bot]' },
+          body: '`@kurone-kito`, confirmed. This partially addresses the concern.',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
+test('classifyThreadAckOnlyPostDisposition rejects a genuinely new concern in a second sentence, even though "concern" itself is not in the first sentence (Codex P1, #2858)', () => {
+  // Codex's second adversarial example: "This addresses the requested
+  // change. However, I still have a concern." -- the first sentence has
+  // no "concern"/"finding" word at all, so an un-narrowed gap could still
+  // reach the word "concern" in the unrelated SECOND sentence, since
+  // nothing stopped it from skipping the period in between. The gap must
+  // exclude sentence-terminating punctuation so "concern"/"finding" is
+  // required to appear in the SAME sentence as "addresses the".
+  const thread = {
+    id: 'thread-cross-sentence-unrelated-concern',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'CX-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'CX-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@kurone-kito`, confirmed. This addresses the requested ' +
+            'change. However, I still have a concern.',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
 // Codex review findings on this PR (#2014), both verified against source
 // before accepting.
 

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -2052,11 +2052,18 @@ test('classifyThreadAckOnlyPostDisposition rejects a negation adverb immediately
   assert.equal(classification.ackOnlyPostDisposition, false);
 });
 
-test('classifyThreadAckOnlyPostDisposition rejects a "does not address" negation immediately before "addresses" (regression guard, #2858)', () => {
-  // Same class as the round-10 finding, with a different negation word
-  // ("not") to confirm the fix is not overfit to "never" alone.
+test('classifyThreadAckOnlyPostDisposition rejects a "no longer addresses" negation idiom immediately before "addresses" (regression guard, #2858)', () => {
+  // Same class as the round-10 finding, with a different negation
+  // member (the two-word idiom "no longer") to confirm the fix is not
+  // overfit to "never" alone. Copilot's round-12 review flagged the
+  // original version of this test: its fixture used "does not
+  // addresses" (ungrammatical -- "does not address" is the correct verb
+  // form), which placed the negation word immediately before the
+  // literal "addresses" token this regex matches but did not read as
+  // real English. "No longer addresses" is grammatical and exercises
+  // the `no\s+longer` idiom directly.
   const thread = {
-    id: 'thread-negation-not-addresses',
+    id: 'thread-negation-no-longer-addresses',
     isResolved: true,
     updatedAt: '',
     comments: {
@@ -2073,7 +2080,143 @@ test('classifyThreadAckOnlyPostDisposition rejects a "does not address" negation
           id: 'NT-2',
           author: { login: 'coderabbitai[bot]' },
           body:
-            '`@user`, confirmed. This does not addresses the ' +
+            '`@user`, confirmed. This no longer addresses the ' +
+            'wording concern.\n\n🐇 ✓',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
+test('classifyThreadAckOnlyPostDisposition rejects "seldom" before the closure verb (Codex round 12, #2868)', () => {
+  // Codex's round-12 finding on PR #2868: the initial negation
+  // enumeration (round 10) omitted "seldom", a negative-frequency
+  // adverb in the same class as "rarely"/"hardly" already covered. This
+  // is Codex's exact adversarial example.
+  const thread = {
+    id: 'thread-negation-seldom-addresses',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'SL-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'SL-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@user`, confirmed. The fix seldom addresses the ' +
+            'security concern.\n\n🐇 ✓',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
+test('classifyThreadAckOnlyPostDisposition rejects the "in no way" and "by no means" negation idioms (self-critique, same pass as round 12, #2858)', () => {
+  // Widened alongside the "seldom" fix rather than waiting for each
+  // idiom to surface as its own review round.
+  const opts = {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  };
+  const mkThread = (id, body) => ({
+    id,
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: `${id}-1`,
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: `${id}-2`,
+          author: { login: 'coderabbitai[bot]' },
+          body,
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  });
+
+  const inNoWay = mkThread(
+    'thread-negation-in-no-way',
+    '`@user`, confirmed. This in no way addresses the wording ' +
+      'concern.\n\n🐇 ✓',
+  );
+  const byNoMeans = mkThread(
+    'thread-negation-by-no-means',
+    '`@user`, confirmed. This by no means addresses the wording ' +
+      'concern.\n\n🐇 ✓',
+  );
+
+  assert.equal(
+    classifyThreadAckOnlyPostDisposition(inNoWay, opts).ackOnlyPostDisposition,
+    false,
+  );
+  assert.equal(
+    classifyThreadAckOnlyPostDisposition(byNoMeans, opts)
+      .ackOnlyPostDisposition,
+    false,
+  );
+});
+
+test('classifyThreadAckOnlyPostDisposition rejects an epistemic adverb casting doubt on the acknowledgment (self-critique, same pass as round 12, #2858)', () => {
+  // A fourth closed enumeration added proactively rather than waiting
+  // for a review round: epistemic adverbs cast doubt on whether the
+  // claimed fix genuinely happened at all -- neither a degree (hedge)
+  // nor an outright denial (negation). "This supposedly addresses the
+  // concern" reads as the acknowledgment itself questioning its own
+  // claim.
+  const thread = {
+    id: 'thread-epistemic-supposedly-addresses',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'EP-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'EP-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@user`, confirmed. This supposedly addresses the ' +
             'wording concern.\n\n🐇 ✓',
           createdAt: '2026-05-12T02:00:00Z',
           updatedAt: '2026-05-12T02:00:00Z',

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -1103,6 +1103,98 @@ test('classifyThreadAckOnlyPostDisposition rejects a hedged "partially addresses
   assert.equal(classification.ackOnlyPostDisposition, false);
 });
 
+test('classifyThreadAckOnlyPostDisposition rejects a same-sentence "addresses the X but reveals another Y" construction (Codex P1 round 3, #2858)', () => {
+  // Codex's round-3 finding: a plain lazy gap could still backtrack past
+  // an EARLIER "concern"/"finding" occurrence that failed the
+  // boilerplate-tail check, to match a LATER one that succeeds --
+  // "confirmed. This addresses the original concern but reveals another
+  // finding.\n\n🐇 ✓" has a genuinely new finding joined by "but" in the
+  // same sentence, yet the gap could stretch past the first "concern"
+  // (not followed by a period) to reach "finding." instead. The gap is
+  // now pinned to the FIRST "concern"/"finding" occurrence via a
+  // per-character negative lookahead, so this must still be rejected.
+  const thread = {
+    id: 'thread-addresses-but-reveals-another',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'BR-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'BR-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@kurone-kito`, confirmed. This addresses the original ' +
+            'concern but reveals another finding.\n\n🐇 ✓',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
+test('classifyThreadAckOnlyPostDisposition still recognizes a strong "Review thread resolved" closure even when unrelated boilerplate elsewhere contains hedge-shaped wording (Copilot round 3, #2858)', () => {
+  // Copilot's round-3 finding on the round-2 hedge-adverb fix: the guard
+  // originally tested the WHOLE body, so a genuinely strong closure
+  // ("Review thread resolved.") could be wrongly rejected if unrelated
+  // trailing boilerplate -- such as a Learnings-used block quoting a
+  // past PR's discussion -- happened to contain phrasing like "partially
+  // addresses the concern." The hedge-adverb guard is now a lookbehind
+  // scoped to only the weaker "addresses the ..." alternative, so it
+  // never reaches the two strong forms at all.
+  const thread = {
+    id: 'thread-strong-closure-with-unrelated-hedge-text',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'SH-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'SH-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@kurone-kito`, confirmed.\n\n✅ Review thread resolved.\n\n' +
+            '<details><summary>🧠 Learnings used</summary>\n' +
+            'Learning: a past reviewer noted that this pattern only ' +
+            'partially addresses the concern in an unrelated PR.\n' +
+            '</details>',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, true);
+});
+
 // Codex review findings on this PR (#2014), both verified against source
 // before accepting.
 

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -2233,6 +2233,146 @@ test('classifyThreadAckOnlyPostDisposition rejects an epistemic adverb casting d
   assert.equal(classification.ackOnlyPostDisposition, false);
 });
 
+test('classifyThreadAckOnlyPostDisposition rejects "perhaps" and "possibly" as missing epistemic qualifiers (Codex round 13, #2868)', () => {
+  // Codex's round-13 finding on PR #2868: the initial epistemic
+  // enumeration (added proactively alongside round 12) omitted the
+  // common qualifiers "perhaps"/"possibly"/"maybe"/"presumably". This is
+  // Codex's exact adversarial example plus one additional member from
+  // its own suggested list.
+  const opts = {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  };
+  const mkThread = (id, body) => ({
+    id,
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: `${id}-1`,
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: `${id}-2`,
+          author: { login: 'coderabbitai[bot]' },
+          body,
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  });
+
+  const perhaps = mkThread(
+    'thread-epistemic-perhaps',
+    '`@user`, confirmed. The fix perhaps addresses the security ' +
+      'concern.\n\n🐇 ✓',
+  );
+  const possibly = mkThread(
+    'thread-epistemic-possibly',
+    '`@user`, confirmed. The fix possibly addresses the security ' +
+      'concern.\n\n🐇 ✓',
+  );
+
+  assert.equal(
+    classifyThreadAckOnlyPostDisposition(perhaps, opts).ackOnlyPostDisposition,
+    false,
+  );
+  assert.equal(
+    classifyThreadAckOnlyPostDisposition(possibly, opts).ackOnlyPostDisposition,
+    false,
+  );
+});
+
+test('classifyThreadAckOnlyPostDisposition rejects a compact conjunction-joined finding within the token cap (Codex round 13, #2868)', () => {
+  // Codex's round-13 finding on PR #2868: the round-7 token cap alone
+  // does not close every conjunction-joined bypass -- a COMPACT
+  // construction fits within the `{0,3}` budget where round 7's
+  // original 5-token example did not. "This addresses the concern but
+  // raises concerns.\n\n🐇 ✓" consumes "concern", "but", "raises" as
+  // three modifier tokens (within budget) and reaches the second,
+  // plural "concerns" as the closure target. This is Codex's exact
+  // adversarial example.
+  const thread = {
+    id: 'thread-conjunction-compact-but-raises',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'CC-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'CC-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@user`, confirmed. This addresses the concern but ' +
+            'raises concerns.\n\n🐇 ✓',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
+test('classifyThreadAckOnlyPostDisposition rejects a 2-token conjunction bypass demonstrating no finite token cap alone closes this class (self-critique, same pass as round 13, #2858)', () => {
+  // Confirms the doc comment's own claim: tightening the token cap
+  // cannot close this bypass class in general, since an even shorter
+  // (2-token) variant exists. Only excluding coordinating conjunctions
+  // themselves closes it.
+  const thread = {
+    id: 'thread-conjunction-two-token-yet',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'CY-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'CY-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@user`, confirmed. This addresses the concern yet ' +
+            'concerns.\n\n🐇 ✓',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
 // Codex review findings on this PR (#2014), both verified against source
 // before accepting.
 

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -841,12 +841,19 @@ test('classifyThreadAckOnlyPostDisposition recognizes the "addresses the ... fin
   assert.equal(classification.ackOnlyPostDisposition, true);
 });
 
-test('classifyThreadAckOnlyPostDisposition rejects the "addresses the ... concern" shape when the closure phrase is more than 80 characters from a distant, unrelated "finding" mention (#2858)', () => {
-  // Locality guard: the third closure shape is bounded (`{0,80}`) so an
-  // incidental "finding"/"concern" mention deep in a reply's boilerplate
-  // (e.g. a Learnings-used block) does not retroactively turn an
-  // unrelated "addresses the" phrase into a false closure signal.
-  const farAway = 'x'.repeat(200);
+test('classifyThreadAckOnlyPostDisposition rejects the "addresses the ... concern" shape when "concern" sits more than 80 characters away, in the SAME sentence, immediately before genuine boilerplate (Copilot review, #2858)', () => {
+  // Locality guard: the third closure shape is bounded (`{0,80}`) so a
+  // "concern"/"finding" mention too far from "addresses the" does not
+  // create a false closure signal. Copilot review flagged the original
+  // version of this test: its fixture put "finding" in a different
+  // sentence with no boilerplate anywhere, so it failed for those two
+  // reasons regardless of the 80-char bound, never actually exercising
+  // it. This fixture keeps "concern" in the SAME sentence (no `.!?`
+  // between them, so the sentence-boundary guard does not fire) and adds
+  // genuine boilerplate immediately after it (so the boilerplate-tail
+  // guard does not fire either) -- the >80-character gap is the only
+  // remaining reason this must still be rejected.
+  const filler = 'x '.repeat(45); // 90 chars, no sentence-terminating punctuation
   const thread = {
     id: 'thread-addresses-far-from-concern',
     isResolved: true,
@@ -864,9 +871,7 @@ test('classifyThreadAckOnlyPostDisposition rejects the "addresses the ... concer
         {
           id: 'FA-2',
           author: { login: 'coderabbitai[bot]' },
-          body:
-            `\`@kurone-kito\`, confirmed. This addresses the retry path. ${farAway} ` +
-            'Unrelated closing remark about a finding elsewhere.',
+          body: `\`@kurone-kito\`, confirmed. This addresses the ${filler}concern.\n\n🐇 ✓`,
           createdAt: '2026-05-12T02:00:00Z',
           updatedAt: '2026-05-12T02:00:00Z',
         },

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -724,6 +724,252 @@ test('classifyThreadAckOnlyPostDisposition rejects a non-CodeRabbit bot reply th
   assert.equal(classification.ackOnlyPostDisposition, false);
 });
 
+// #2858: the "I couldn't resolve..." fallback closure shape (added in
+// #2649 alongside "✅ Review thread resolved.") had no positive regression
+// test of its own -- only a comment referenced it. Pin it directly.
+test('classifyThreadAckOnlyPostDisposition recognizes the "I couldn\'t resolve" fallback closure shape (#2649, regression added #2858)', () => {
+  const thread = {
+    id: 'thread-resolve-attempt-failed',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'RF-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'RF-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@kurone-kito`, confirmed. Thanks for the fix.\n\n' +
+            "I couldn't resolve this review thread on the repository platform. " +
+            'Please resolve it manually.\n\n' +
+            '<!-- This is an auto-generated reply by CodeRabbit -->',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, true);
+});
+
+// #2858: a third ack shape with no closure trailer at all -- observed
+// verbatim on kurone-kito/idd-skill#2853's review thread on the
+// issue-reference template link (fetched via GraphQL for byte-exact
+// fixtures, boilerplate included: the 🐇 sign-off, the "Learnings used"
+// details block, the AI-system disclaimer, and the auto-generated-reply
+// marker at the END of the body rather than the start). CodeRabbit
+// reports no thread-resolve attempt because the thread was already
+// resolved independently before it replied.
+test('classifyThreadAckOnlyPostDisposition recognizes the "addresses the ... concern" closure shape with a trailing sign-off (kurone-kito/idd-skill#2853, #2858)', () => {
+  const thread = {
+    id: 'thread-addresses-concern-with-signoff',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'AC-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'AC-2',
+          author: { login: 'coderabbitai[bot]' },
+          body: '`@kurone-kito`, confirmed. The repository-qualified reference addresses the template link-resolution concern.\n\n🐇 ✓\n\n---\n\n<details>\n<summary>🧠 Learnings used</summary>\n\n```\nLearnt from: kurone-kito\nRepo: kurone-kito/idd-skill PR: 1738\nFile: idd-template/docs/idd-design-rationale.md:137-139\nTimestamp: 2026-07-31T13:33:10.518Z\nLearning: In idd-template/docs/, markdown files (particularly idd-design-rationale.md) use structure-mode synchronization via audit/sync-manifest.json, which validates heading signatures only while allowing intentional prose differences. When documenting in template files, use fully qualified issue references (kurone-kito/idd-skill#<number>) to ensure links resolve correctly in adopter repositories. Source repository documentation (docs/) can use bare references (#<number>). Structure-mode validation ensures heading structures match across template and source versions while permitting different reference styles and prose content.\n```\n\n</details>\n\n_You are interacting with an AI system._\n\n<!-- This is an auto-generated reply by CodeRabbit -->',
+          createdAt: '2026-09-10T05:01:11Z',
+          updatedAt: '2026-09-10T05:01:11Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, true);
+});
+
+test('classifyThreadAckOnlyPostDisposition recognizes the "addresses the ... finding" closure shape with no sign-off at all (kurone-kito/idd-skill#2853, #2858)', () => {
+  const thread = {
+    id: 'thread-addresses-finding-no-signoff',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'AF-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'AF-2',
+          author: { login: 'coderabbitai[bot]' },
+          body: '`@kurone-kito`, confirmed. Commit `80c936a7` addresses the template issue-reference finding.\n\n---\n\n<details>\n<summary>🧠 Learnings used</summary>\n\n```\nLearnt from: kurone-kito\nRepo: kurone-kito/idd-skill PR: 1738\nFile: idd-template/docs/idd-design-rationale.md:137-139\nTimestamp: 2026-07-31T13:33:10.518Z\nLearning: In idd-template/docs/, markdown files (particularly idd-design-rationale.md) use structure-mode synchronization via audit/sync-manifest.json, which validates heading signatures only while allowing intentional prose differences. When documenting in template files, use fully qualified issue references (kurone-kito/idd-skill#<number>) to ensure links resolve correctly in adopter repositories. Source repository documentation (docs/) can use bare references (#<number>). Structure-mode validation ensures heading structures match across template and source versions while permitting different reference styles and prose content.\n```\n\n</details>\n\n_You are interacting with an AI system._\n\n<!-- This is an auto-generated reply by CodeRabbit -->',
+          createdAt: '2026-09-10T05:27:25Z',
+          updatedAt: '2026-09-10T05:27:25Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, true);
+});
+
+test('classifyThreadAckOnlyPostDisposition rejects the "addresses the ... concern" shape when the closure phrase is more than 80 characters from a distant, unrelated "finding" mention (#2858)', () => {
+  // Locality guard: the third closure shape is bounded (`{0,80}`) so an
+  // incidental "finding"/"concern" mention deep in a reply's boilerplate
+  // (e.g. a Learnings-used block) does not retroactively turn an
+  // unrelated "addresses the" phrase into a false closure signal.
+  const farAway = 'x'.repeat(200);
+  const thread = {
+    id: 'thread-addresses-far-from-concern',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'FA-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'FA-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            `\`@kurone-kito\`, confirmed. This addresses the retry path. ${farAway} ` +
+            'Unrelated closing remark about a finding elsewhere.',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
+test('classifyThreadAckOnlyPostDisposition rejects an "addresses the ... concern" opening that goes on to raise a new, unrelated concern in the same sentence span (#2858)', () => {
+  // AC3 (issue #2858): "A CodeRabbit reply that is *not* a pure
+  // acknowledgment (contains substantive new content) still does not
+  // match." The closure sentence must end in a period immediately
+  // followed by known CodeRabbit reply boilerplate (or end of body) --
+  // a genuinely new concern appended after a comma, rather than a
+  // period, never reaches that tail check, even though it is well
+  // within the 80-character locality bound the sibling test above
+  // exercises.
+  const thread = {
+    id: 'thread-addresses-concern-but-new-issue',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'CN-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'CN-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@kurone-kito`, confirmed. This partially addresses the ' +
+            'concern, but the retry path still dereferences null.',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
+test('classifyThreadAckOnlyPostDisposition rejects an "addresses the ... concern" opening followed by a genuinely new sentence, even with a period boundary (#2858)', () => {
+  // A stricter adversarial variant than the comma-joined case above: the
+  // closure sentence properly ends in a period, but is followed by a new
+  // sentence of ordinary prose ("However, ...") rather than CodeRabbit's
+  // own reply boilerplate. The tail anchor requires known boilerplate (or
+  // end of body) immediately after that period, so this still does not
+  // match -- pinning the doc comment's claim that the tail anchor closes
+  // this shape too, not only the comma-joined one.
+  const thread = {
+    id: 'thread-addresses-concern-new-sentence',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'CS-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'CS-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@kurone-kito`, confirmed. This addresses the retry-path ' +
+            'concern. However, the null-check issue in the fallback ' +
+            'branch is still unresolved.',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
 // Codex review findings on this PR (#2014), both verified against source
 // before accepting.
 

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -1209,7 +1209,10 @@ test('classifyThreadAckOnlyPostDisposition rejects an "addresses the ... concern
   // sentence between the opening and the closure was invisible. This is
   // Codex's exact adversarial example: an explicit "remains unresolved"
   // sentence sits between "confirmed." and the closure sentence that
-  // follows it.
+  // follows it. Originally caught by a terminator-count bound (two
+  // periods instead of one); round 5 replaced that with the positive
+  // lead-in whitelist below, which rejects this fixture too -- "However"
+  // is not one of the whitelisted lead-in shapes.
   const thread = {
     id: 'thread-addresses-concern-after-unresolved-sentence',
     isResolved: true,
@@ -1231,6 +1234,129 @@ test('classifyThreadAckOnlyPostDisposition rejects an "addresses the ... concern
             '`@user`, confirmed. However, the null-check remains ' +
             'unresolved. The documentation update addresses the ' +
             'wording concern.\n\n🐇 ✓',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
+test('classifyThreadAckOnlyPostDisposition rejects an unresolved clause joined to the closure with a semicolon instead of a second sentence terminator (Codex round 5, #2868)', () => {
+  // Codex's round-5 finding on PR #2868: the round-4 terminator-count
+  // bound (at most one `.`/`!`/`?` between opening and closure) is a
+  // NEGATIVE bound -- defined by what the gap must NOT contain -- and
+  // natural language can join an unresolved clause to the closure
+  // without a second terminator at all. A semicolon leaves the count at
+  // exactly one and would have passed round 4's guard. The positive
+  // lead-in whitelist rejects this outright: "The null-check remains
+  // unresolved" is not one of the whitelisted lead-in shapes.
+  const thread = {
+    id: 'thread-addresses-concern-after-semicolon-clause',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'SC-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'SC-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@user`, confirmed. The null-check remains unresolved; ' +
+            'this update addresses the wording concern.\n\n🐇 ✓',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
+test('classifyThreadAckOnlyPostDisposition rejects an unresolved clause joined to the closure with an em dash (regression guard, #2858)', () => {
+  // Same class as the semicolon case above, demonstrating the lead-in
+  // whitelist closes the general "unbounded joining punctuation" gap
+  // rather than just the one punctuation mark Codex happened to probe.
+  const thread = {
+    id: 'thread-addresses-concern-after-em-dash-clause',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'ED-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'ED-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@user`, confirmed. The null-check remains unresolved ' +
+            '— this update addresses the wording concern.\n\n🐇 ✓',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
+test('classifyThreadAckOnlyPostDisposition rejects an unresolved clause joined to the closure with a bare coordinating conjunction (regression guard, #2858)', () => {
+  // A third joining shape with no punctuation at all between the
+  // opening's period and the closure's lead-in -- confirms the
+  // whitelist fails closed on arbitrary lead-in text, not just on
+  // specific joining punctuation.
+  const thread = {
+    id: 'thread-addresses-concern-after-and-conjunction',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'AC5-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'AC5-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@user`, confirmed. Still broken and this addresses the ' +
+            'concern.\n\n🐇 ✓',
           createdAt: '2026-05-12T02:00:00Z',
           updatedAt: '2026-05-12T02:00:00Z',
         },

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -895,7 +895,12 @@ test('classifyThreadAckOnlyPostDisposition rejects an "addresses the ... concern
   // a genuinely new concern appended after a comma, rather than a
   // period, never reaches that tail check, even though it is well
   // within the 80-character locality bound the sibling test above
-  // exercises.
+  // exercises. CodeRabbit's round-4 review on PR #2868 found the
+  // original fixture used "partially addresses," so the hedge-adverb
+  // guard (guard 5) rejected it before ever reaching the tail check this
+  // test is meant to exercise -- the assertion held, but not for the
+  // stated reason. Dropped "partially" so the tail check (guard 3) is
+  // what actually rejects this fixture, matching the test's own claim.
   const thread = {
     id: 'thread-addresses-concern-but-new-issue',
     isResolved: true,
@@ -914,7 +919,7 @@ test('classifyThreadAckOnlyPostDisposition rejects an "addresses the ... concern
           id: 'CN-2',
           author: { login: 'coderabbitai[bot]' },
           body:
-            '`@kurone-kito`, confirmed. This partially addresses the ' +
+            '`@kurone-kito`, confirmed. This addresses the ' +
             'concern, but the retry path still dereferences null.',
           createdAt: '2026-05-12T02:00:00Z',
           updatedAt: '2026-05-12T02:00:00Z',
@@ -1193,6 +1198,137 @@ test('classifyThreadAckOnlyPostDisposition still recognizes a strong "Review thr
   });
 
   assert.equal(classification.ackOnlyPostDisposition, true);
+});
+
+test('classifyThreadAckOnlyPostDisposition rejects an "addresses the ... concern" closure separated from the opening by an intervening unresolved sentence (Codex round 4, #2858)', () => {
+  // Codex's round-4 finding on PR #2868: every guard on
+  // `CODERABBIT_ACK_ADDRESSES_CLOSURE_RE` narrows what counts as a
+  // closure WITHIN a matched span, but neither closure regex was ever
+  // anchored to where the opening ends -- `.test(body)` searches the
+  // WHOLE body, so a genuinely new, unresolved concern in its OWN
+  // sentence between the opening and the closure was invisible. This is
+  // Codex's exact adversarial example: an explicit "remains unresolved"
+  // sentence sits between "confirmed." and the closure sentence that
+  // follows it.
+  const thread = {
+    id: 'thread-addresses-concern-after-unresolved-sentence',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'AU-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'AU-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@user`, confirmed. However, the null-check remains ' +
+            'unresolved. The documentation update addresses the ' +
+            'wording concern.\n\n🐇 ✓',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
+test('classifyThreadAckOnlyPostDisposition rejects a same-sentence "addresses the X concerns but reveals a new finding" construction using plural nouns (CodeRabbit round 4, #2858)', () => {
+  // CodeRabbit's round-4 review on PR #2868: guard 4's per-character
+  // negative lookahead only recognized the SINGULAR "concern"/"finding",
+  // so a PLURAL first occurrence ("concerns") does not satisfy
+  // `\b(?:concern|finding)\b` (no word boundary between "concern" and
+  // its trailing "s") and the lookahead trivially succeeds there,
+  // letting the gap consume straight through the plural occurrence to
+  // reach a later singular one instead -- the same backtrack-past-the-
+  // first-occurrence class guard 4 already closed for singular nouns,
+  // reopened for plurals.
+  const thread = {
+    id: 'thread-addresses-plural-concerns-but-reveals-finding',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'PL-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'PL-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@kurone-kito`, confirmed. This addresses the original ' +
+            'concerns but reveals another finding.\n\n🐇 ✓',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
+test('classifyThreadAckOnlyPostDisposition rejects a hedged "partially  addresses" closure with a double space bypassing the hedge lookbehind (CodeRabbit round 4, #2858)', () => {
+  // CodeRabbit's round-4 review on PR #2868: the hedge lookbehind ended
+  // in a single `\s`, so two spaces between the hedge word and
+  // "addresses" fell outside its fixed one-character gap and bypassed
+  // the guard entirely. Widened to `\s+`.
+  const thread = {
+    id: 'thread-hedged-double-space-bypass',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'DS-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'DS-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@kurone-kito`, confirmed. This partially  addresses the ' +
+            'concern.\n\n🐇 ✓',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
 });
 
 // Codex review findings on this PR (#2014), both verified against source

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -1372,6 +1372,133 @@ test('classifyThreadAckOnlyPostDisposition rejects an unresolved clause joined t
   assert.equal(classification.ackOnlyPostDisposition, false);
 });
 
+test('classifyThreadAckOnlyPostDisposition rejects genuinely new feedback appended right after the "---" boilerplate marker (Codex round 6, #2868)', () => {
+  // Codex's round-6 finding on PR #2868: the boilerplate-tail alternation
+  // validated only the FIRST recognized token ("---", in this example)
+  // and accepted whatever followed it unexamined -- a prefix match, the
+  // same "validated a fragment, not the whole shape" bug rounds 4-5
+  // already closed on the opening side. This is Codex's exact
+  // adversarial example.
+  const thread = {
+    id: 'thread-addresses-concern-then-prose-after-rule',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'TT-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'TT-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@user`, confirmed. This addresses the wording ' +
+            'concern.\n\n---\n\nHowever, the null-check remains ' +
+            'unresolved.',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
+test('classifyThreadAckOnlyPostDisposition rejects genuinely new feedback appended right after the 🐇 sign-off with no separating boilerplate (regression guard, #2858)', () => {
+  // Same class as the "---" case above, for the sign-off marker
+  // specifically: the tail grammar must require the ENTIRE remainder to
+  // be one of the known trailing shapes, not just start with one.
+  const thread = {
+    id: 'thread-addresses-concern-then-prose-after-signoff',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'TS-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'TS-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@user`, confirmed. This addresses the wording concern.' +
+            '\n\n🐇 ✓ However, the null-check remains unresolved.',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
+test('classifyThreadAckOnlyPostDisposition rejects genuinely new feedback sandwiched between two "<details>" blocks (regression guard, #2858)', () => {
+  // The details-block sub-pattern uses a LAZY `[\s\S]*?` so it stops at
+  // the first "</details>" rather than the last -- confirms a second,
+  // unrelated details block later in the tail cannot be used to smuggle
+  // prose past the lazy match by making the whole tail look like "one
+  // details block" when it is actually two with substantive text between
+  // them.
+  const thread = {
+    id: 'thread-addresses-concern-then-prose-between-details',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'TD-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'TD-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@user`, confirmed. This addresses the wording ' +
+            'concern.\n\n---\n\n<details>\n<summary>foo</summary>\n' +
+            '</details>\n\nHowever, the null-check remains ' +
+            'unresolved.\n\n<details>\n<summary>bar</summary>\n' +
+            '</details>',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
 test('classifyThreadAckOnlyPostDisposition rejects a same-sentence "addresses the X concerns but reveals a new finding" construction using plural nouns (CodeRabbit round 4, #2858)', () => {
   // CodeRabbit's round-4 review on PR #2868: guard 4's per-character
   // negative lookahead only recognized the SINGULAR "concern"/"finding",

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -899,14 +899,16 @@ test('classifyThreadAckOnlyPostDisposition rejects an "addresses the ... concern
   // match." The closure sentence must end in a period immediately
   // followed by known CodeRabbit reply boilerplate (or end of body) --
   // a genuinely new concern appended after a comma, rather than a
-  // period, never reaches that tail check, even though it is well
-  // within the 80-character locality bound the sibling test above
-  // exercises. CodeRabbit's round-4 review on PR #2868 found the
-  // original fixture used "partially addresses," so the hedge-adverb
-  // guard (guard 5) rejected it before ever reaching the tail check this
-  // test is meant to exercise -- the assertion held, but not for the
-  // stated reason. Dropped "partially" so the tail check (guard 3) is
-  // what actually rejects this fixture, matching the test's own claim.
+  // period, never reaches that tail check, even though "concern" is
+  // well within the 3-modifier-token gap bound the sibling test above
+  // exercises (the comma itself also breaks the token chain outright,
+  // since round 7 restricted gap tokens to `[\w-]+`). CodeRabbit's
+  // round-4 review on PR #2868 found the original fixture used
+  // "partially addresses," so the hedge-adverb guard (guard 5) rejected
+  // it before ever reaching the tail check this test is meant to
+  // exercise -- the assertion held, but not for the stated reason.
+  // Dropped "partially" so the tail check (guard 3) is what actually
+  // rejects this fixture, matching the test's own claim.
   const thread = {
     id: 'thread-addresses-concern-but-new-issue',
     isResolved: true,

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -1057,6 +1057,47 @@ test('classifyThreadAckOnlyPostDisposition rejects a genuinely new concern in a 
   assert.equal(classification.ackOnlyPostDisposition, false);
 });
 
+test('classifyThreadAckOnlyPostDisposition rejects a hedged "partially addresses" closure sentence even with genuine trailing boilerplate (Codex P1 round 2, #2858)', () => {
+  // Codex's round-2 finding: the round-1 fixes (sentence-boundary gap,
+  // mandatory boilerplate tail) do not by themselves catch a hedge
+  // adverb inside the matched sentence -- "confirmed. This partially
+  // addresses the concern.\n\n🐇 ✓" has genuine boilerplate immediately
+  // following and never crosses a sentence boundary, so it still passed
+  // both round-1 guards. The hedge-adverb guard closes this specific,
+  // demonstrated case.
+  const thread = {
+    id: 'thread-hedged-with-boilerplate',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'HB-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'HB-2',
+          author: { login: 'coderabbitai[bot]' },
+          body: '`@kurone-kito`, confirmed. This partially addresses the concern.\n\n🐇 ✓',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
 // Codex review findings on this PR (#2014), both verified against source
 // before accepting.
 

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -1678,6 +1678,334 @@ test('classifyThreadAckOnlyPostDisposition rejects a hedged "partially  addresse
   assert.equal(classification.ackOnlyPostDisposition, false);
 });
 
+test('classifyThreadAckOnlyPostDisposition rejects a hedge adjective inside the lead-in noun phrase (self-critique, E2 pass, #2858)', () => {
+  // E2 critique pass on this PR found the hedge-word exclusion added to
+  // the internal "addresses the ... concern" gap never reached the
+  // LEAD-IN's own "the" plus 1-2 word slots, since that whitelist was a
+  // purely structural check. "The partial workaround addresses the
+  // wording concern" matched despite "partial" being exactly the
+  // hedged, non-committal shape the hedge guard exists to reject
+  // elsewhere. The first attempted fix reused only the existing
+  // degree-ADVERB enumeration and still let this through, since a
+  // lead-in noun phrase's modifier is grammatically an ADJECTIVE
+  // ("partial", "temporary") rather than an adverb ("partially") --
+  // caught empirically before this ever reached review.
+  const thread = {
+    id: 'thread-leadin-hedge-adjective',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'LH-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'LH-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@user`, confirmed. The partial workaround addresses ' +
+            'the wording concern.\n\n🐇 ✓',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
+test('classifyThreadAckOnlyPostDisposition rejects a second hedge adjective inside the lead-in noun phrase (self-critique, E2 pass, #2858)', () => {
+  // Same class as above with a second word from the adjective
+  // enumeration, confirming the fix is not overfit to "partial" alone.
+  const thread = {
+    id: 'thread-leadin-hedge-adjective-temporary',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'LT-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'LT-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@user`, confirmed. The temporary fix addresses the ' +
+            'wording concern.\n\n🐇 ✓',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
+test('classifyThreadAckOnlyPostDisposition safely rejects a first "addresses the ... concern" occurrence composed with a genuine second one (self-critique, E2 pass, #2858)', () => {
+  // `CODERABBIT_ACK_ADDRESSES_CLOSURE_RE` is not left-anchored, so a
+  // first "addresses the ... concern" occurrence that fails only the
+  // boilerplate-tail check does not abort the whole match -- the engine
+  // retries at a later "addresses" occurrence. This fixture confirms
+  // the composition stays safe: the gap from the opening to the SECOND
+  // occurrence spans an entire extra sentence ("The retry still
+  // fails."), which the lead-in whitelist (guard 6) rejects. This pins
+  // an interaction between two independently-motivated guards (the tail
+  // anchor and the lead-in whitelist) that was previously untested in
+  // combination.
+  const thread = {
+    id: 'thread-two-addresses-occurrences',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'TO-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'TO-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@user`, confirmed. This addresses the layout concern. ' +
+            'The retry still fails. Commit `abc1234` addresses the ' +
+            'wording concern.\n\n🐇 ✓',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
+test("classifyThreadAckOnlyPostDisposition recognizes the tail grammar's disclaimer-only branch with no sign-off or details block (self-critique, E2 pass, #2858)", () => {
+  // `CODERABBIT_ACK_CLOSURE_TAIL_SOURCE` is a 4-branch alternation; only
+  // the full-stack and details-first branches had a positive test before
+  // this. This pins the disclaimer-only entry point.
+  const thread = {
+    id: 'thread-tail-disclaimer-only',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'TDO-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'TDO-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@user`, confirmed. This addresses the wording ' +
+            'concern.\n\n_You are interacting with an AI system._',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, true);
+});
+
+test("classifyThreadAckOnlyPostDisposition recognizes the tail grammar's marker-only branch with no other boilerplate (self-critique, E2 pass, #2858)", () => {
+  // Pins the fourth and final tail-grammar entry point: the bare
+  // auto-generated-reply marker with nothing else following the closure.
+  const thread = {
+    id: 'thread-tail-marker-only',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'TMO-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'TMO-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@user`, confirmed. This addresses the wording ' +
+            'concern.\n\n<!-- This is an auto-generated reply by ' +
+            'CodeRabbit -->',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, true);
+});
+
+test('classifyThreadAckOnlyPostDisposition recognizes the lead-in whitelist\'s bare "that"/"it" pronoun branches (self-critique, E2 pass, #2858)', () => {
+  // Every existing fixture using "This" as the lead-in pronoun is a
+  // NEGATIVE test failing for an unrelated reason; "that" and "it"
+  // appeared in no fixture at all. Pins both positively in one test.
+  const thatThread = {
+    id: 'thread-leadin-that-pronoun',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'PT-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'PT-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@user`, confirmed. That addresses the wording ' +
+            'concern.\n\n🐇 ✓',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+  const itThread = {
+    id: 'thread-leadin-it-pronoun',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'PI-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'PI-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@user`, confirmed. It addresses the wording ' +
+            'concern.\n\n🐇 ✓',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const opts = {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  };
+  assert.equal(
+    classifyThreadAckOnlyPostDisposition(thatThread, opts)
+      .ackOnlyPostDisposition,
+    true,
+  );
+  assert.equal(
+    classifyThreadAckOnlyPostDisposition(itThread, opts).ackOnlyPostDisposition,
+    true,
+  );
+});
+
+test('classifyThreadAckOnlyPostDisposition safely rejects the "Thanks for the fix." opening combined with the third closure shape (self-critique, E2 pass, #2858)', () => {
+  // `CODERABBIT_ACK_OPENING_RE`'s own doc comment cites "Thanks for the
+  // fix." as a real observed opening. Paired with the third-form
+  // closure, this is rejected: the opening match stops right after
+  // "Thanks", so the rest of that same sentence (" for the fix.") lands
+  // inside the opening-to-closure gap and its leading whitespace breaks
+  // the lead-in whitelist's `^[.!]` anchor. This fails CLOSED (safe) --
+  // guard 6's own stated philosophy explicitly accepts rejecting an
+  // unobserved-but-legitimate combination -- but pins the current,
+  // intentional behavior so a future edit that changes it is a visible
+  // decision, not a silent one.
+  const thread = {
+    id: 'thread-thanks-for-fix-plus-third-form',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'TF-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'TF-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@user` Thanks for the fix. Commit `abc1234` addresses ' +
+            'the template concern.\n\n🐇 ✓',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
 // Codex review findings on this PR (#2014), both verified against source
 // before accepting.
 

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -988,9 +988,10 @@ test('classifyThreadAckOnlyPostDisposition rejects an "addresses the ... concern
   assert.equal(classification.ackOnlyPostDisposition, false);
 });
 
-// Codex review findings on this PR (#2858), both verified against source
-// before accepting: a legitimate structural gap, not the semantic
-// "new concern" phrasing this file already documents as out of scope.
+// Codex review findings on PR #2868 (fixing issue #2858), both verified
+// against source before accepting: a legitimate structural gap, not the
+// semantic "new concern" phrasing this file already documents as out of
+// scope.
 
 test('classifyThreadAckOnlyPostDisposition rejects a hedged closure sentence with no trailing boilerplate at all (Codex P1, #2858)', () => {
   // Codex's exact adversarial example: a single-sentence reply --


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

`isKnownAdvisoryAckTemplate` (`src/scripts/protocol-helpers.mts`)
recognized only two CodeRabbit reply-closure shapes: "✅ Review thread
resolved." and its "I couldn't resolve..." fallback. A third real shape
went unrecognized: when a review thread is already resolved
independently (e.g. by the IDD agent's own `resolve-review-thread.mjs`)
before CodeRabbit replies, CodeRabbit has no resolve-attempt of its own
to report and instead confirms in prose that something "addresses the
... concern/finding" (observed verbatim on this repository's own PR
#2853). The unrecognized shape forced a manual review-watermark refresh
instead of a clean ack-only disposition.

This PR adds that third closure shape as a new regex,
`CODERABBIT_ACK_ADDRESSES_CLOSURE_RE`, checked only after the two
existing strong closure forms fail. Thirteen rounds of adversarial
automated review (Codex, Copilot, and CodeRabbit) plus one independent
E2 critique pass on this PR progressively hardened it from an initial
`{0,80}`-character, loosely-bounded gap into a fully structural,
positive-shape grammar spanning the entire reply body:

- The opening (`^`-anchored) and the closure clause are linked by a
  positive whitelist of the lead-in shapes the real observed samples
  actually use (a bare pronoun, "the" plus a short noun phrase, or
  "commit" plus a hex SHA) — not a negative bound on what the gap must
  avoid, which proved probeable with a semicolon, an em dash, or a bare
  coordinating conjunction. No unrelated prose (a genuinely outstanding
  concern in its own sentence) can sit between the acknowledgment and
  the closure.
- The gap between "addresses the" and "concern"/"finding" is capped at
  3 space/hyphen-separated word tokens (matching both real observed
  samples' 2-token noun phrases, with one token of headroom) — this
  closes a coordinating-conjunction bypass ("addresses the X but leaves
  a Y concern") that an open-ended character-count bound could not.
- The trailing boilerplate is validated as a complete, fixed-order
  grammar through the end of the body (sign-off, `<details>`
  Learnings-used block, AI-system disclaimer, auto-generated-reply
  marker), not merely a prefix match that could let genuine new
  feedback follow one of the recognized markers unexamined.
- Every free word-token slot (the internal gap, the lead-in's noun
  phrase, and the position immediately before "addresses") is checked
  against four small, closed English *semantic* function-word
  enumerations: degree hedges (adverb and adjective forms —
  "partially", "temporary"), negation ("never", "not", "seldom", "in
  no way"), and epistemic adverbs that cast doubt on the claim itself
  ("supposedly", "allegedly"). Each closes a distinct semantic
  relationship to the acknowledgment; none of the four is folded into
  another, since each was independently demonstrated as a real bypass.
- A fifth, *grammatical* (not semantic) enumeration — English's seven
  coordinating conjunctions ("FANBOYS": for/and/nor/but/or/yet/so) —
  closes a compact bypass the token cap alone cannot: a construction
  like "addresses the concern but raises concerns" reaches a second,
  plural "concerns" within budget using only conjunction-joined
  filler. No finite cap size closes this in general (a 2-token variant
  of the same bypass exists), so this had to be a closed-class
  exclusion rather than a cap adjustment — but because it is a fact
  about English grammar rather than an open-ended vocabulary list, it
  does not reopen the "new concern" blocklist problem below.

An enumerated *open-ended* new-concern blocklist was considered and
rejected throughout: this file's own comments document that approach
as tried and reverted (natural language has unbounded ways to raise a
concern), so every guard above is either a small, closed, reviewable
enumeration or a structural anchor — never an attempt to semantically
parse arbitrary prose. A broader residual gap in that same spirit is
documented explicitly in code and raised as a design question on
issue #2858 (with a follow-up addendum after this loop concluded)
rather than chased with an open-ended list here: the four semantic
enumerations above were found one at a time across five review
rounds, each closing a genuinely different word class (hedge, hedge
adjective, negation, epistemic doubt) — the honest lesson is that the
*set* of such closed function-word classes occupying this slot is
itself open-ended, not just the originally-flagged contrastive
adjective (e.g. "addresses the **wrong** security concern"). The issue
comment lays out the fail-closed alternative (an exact-token
whitelist) as a one-commit follow-up if the maintainer wants zero
residual instead of this documented risk.

Regenerated `scripts/protocol-helpers.mjs` via `pnpm run build` from
the edited `.mts` source (never hand-edited).

## Linked issue

Closes #2858

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Two byte-exact regression tests use the real CodeRabbit reply bodies
fetched via GraphQL from PR #2853's review thread (full boilerplate
intact: the 🐇 sign-off, the Learnings-used details block, the
AI-system disclaimer, and — in one of the two — the auto-generated-reply
marker at the *end* of the body rather than the start, a variant the
existing marker-first test didn't cover).

The remaining ~40 new regression tests were each added to pin a
specific adversarial finding from the review-fix loop, roughly in the
order found: the pre-existing "I couldn't resolve..." fallback shape
(zero positive coverage before this change); the gap's locality bound
(now token-count, not character-count); a hedge-adverb bypass and its
scoping to only the weak closure form (so unrelated hedge-shaped text
elsewhere in a reply's boilerplate can never reject a strong closure);
a no-backtrack-past-the-first-occurrence guard for "concern"/"finding"
(subsumed into the token grammar by round 7); an opening-to-closure
lead-in whitelist (semicolon-, em-dash-, and bare-conjunction-joined
unresolved clauses all rejected); a full end-of-body tail grammar
(prose injected right after any of the four recognized boilerplate
markers is rejected, including a self-caught regression where a naive
lazy quantifier could backtrack past a first `</details>` close to a
second one, smuggling text sandwiched between them); the
coordinating-conjunction gap bypass; an independent E2 critique pass
(a fresh subagent review of the full diff) that found a hedge-adjective
bypass in the lead-in whitelist and confirmed several previously-safe
but untested guard interactions; negation words plus a proactively
added epistemic-adverb enumeration (widened twice, most recently for
"perhaps"/"possibly"/"presumably"); and a fifth, grammatical
coordinating-conjunction enumeration closing a compact "addresses the
concern but raises concerns" bypass that no cap-size adjustment alone
could close. Two findings were verified empirically and rejected as
factually incorrect rather than acted on: a claimed V8 lookbehind
`SyntaxError` on variable-length alternatives (ECMAScript has
supported these since ES2018, unlike Python's `re` module) and a
claimed multi-word-hedge-phrase bypass (the exclusion is a zero-width
lookahead, which can match a multi-word span without needing the
following token to consume it). One further commit, after the review
loop's findings were exhausted, fixed a CI-only `pnpm run typecheck`
failure (two implicit-`any` test-helper parameters) that `node --test`
and `pnpm run build:check` do not catch locally — a mechanical fix,
not a review finding.

The residual risk is stated explicitly in the updated code comments
rather than papered over, in two places: the `<details>` block's
interior is intentionally unvalidated opaque quoted text (a concern
hidden there rather than as sibling prose would still misclassify),
and the 3-token gap's open-ended-function-word-class gap above (of
which contrastive adjectives are the originally-flagged example). No
sampled reply has used either shape to hide substantive feedback. This
was raised as a design question on issue #2858, with a follow-up
addendum posted once the review loop concluded acknowledging that the
residual is broader than first scoped; see that issue's comments for
the options considered, including a one-commit fail-closed alternative
(exact-token whitelist) if the maintainer prefers zero residual.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed

`classifyThreadAckOnlyPostDisposition` feeds merge-readiness evidence
(whether a resolved thread's post-disposition activity counts as
blocking); this change narrows one input to that classification, so
the box above is checked for reviewer visibility even though the
change is a narrow, evidence-gated addition rather than a policy or
gate-structure change.

## Verification

- [x] `pnpm lint` (`npx biome check`, `npx dprint check "**/*.md"`,
      `npx markdownlint-cli2 "**/*.md"`, `npx cspell lint "**"`) — clean
- [x] `pnpm test` (`node --test tests/*.test.mts`) — full suite passing;
      `tests/protocol-helpers.test.mts` alone: 65/65 pass
- [x] `pnpm run typecheck` (`tsc -p tsconfig.json`) — clean
- [x] `node scripts/audit-docs.mjs --check` — passed
- [ ] `pnpm run docs:sync:check` (no docs/instructions changed; not
      applicable to this diff)
- [x] `node scripts/idd-doctor.mjs` — passed (pre-existing warnings
      unrelated to this change)
- [x] `pnpm run build:check` — no drift between `.mts` source and the
      committed `.mjs` mirror

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdQ5SPdFLaDGus5PNdBUhw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of CodeRabbit acknowledgment responses confirming that concerns or findings were addressed.
  * Reduced false positives by rejecting ambiguous, hedged, negated, incomplete, or improperly connected statements.
  * Added support for valid plural wording and approved acknowledgment formats with disclaimer or marker text.
  * Improved handling of repeated matches, punctuation variations, and additional response edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


