### PR TITLE
fix(triage-structural-evidence): mask HTML-attribute backticks and fix inherited-list HTML-block tracking

### DIFF
--- a/scripts/discover-shared-file-overlap.mjs
+++ b/scripts/discover-shared-file-overlap.mjs
@@ -17,6 +17,7 @@ import { resolve } from 'node:path';
 import { parseAutopilotSuitability } from './autopilot-suitability.mjs';
 import { parseCliArgs } from './cli-args.mjs';
 import { loadPolicyConfig } from './idd-config.mjs';
+import { findMarkdownCodeRanges } from './markdown-code.mjs';
 import { parseIsoDurationToMs } from './policy-helpers.mjs';
 import {
   resolveActiveClaim,
@@ -335,8 +336,28 @@ export function parseCandidateFileEntries(body) {
   const section = lines.slice(start, end);
   const sectionText = section.join('\n');
   const entries = [];
-  // Every backtick-quoted path in the section, regardless of line wrapping.
+  // Every backtick-quoted path in the section, regardless of line wrapping --
+  // but only a genuine inline-code-span match (#2865): a naive backtick pair
+  // can also fall inside an HTML tag's attribute value or a link's own
+  // title/destination (e.g. `<span title="`package.json`">not a
+  // candidate</span>`), which CommonMark renders as literal attribute/title
+  // text, never a code span (`gh api /markdown` confirms this). Reuse
+  // `markdown-code.mts`'s own exclusion (the same fix applied to
+  // `hasVerificationCommandSignal`'s command-span detection) by accepting a
+  // match only when it is fully contained in one of
+  // `findMarkdownCodeRanges`'s real code-span ranges -- containment, not
+  // exact-range equality, because adjacent real spans with no gap between
+  // them can merge into one wider range.
+  const codeRanges = findMarkdownCodeRanges(sectionText);
   for (const match of sectionText.matchAll(/`([^`]+)`/g)) {
+    const matchStart = match.index;
+    const matchEnd = matchStart + match[0].length;
+    const isGenuineCodeSpan = codeRanges.some(
+      (range) => matchStart >= range.start && matchEnd <= range.end,
+    );
+    if (!isGenuineCodeSpan) {
+      continue;
+    }
     const raw = match[1].trim();
     const normalized = normalizeContentionPath(raw);
     if (looksLikePath(normalized)) {

--- a/scripts/markdown-code.mjs
+++ b/scripts/markdown-code.mjs
@@ -112,6 +112,15 @@ export function stripMarkdownCodeRegions(text) {
       `${ticks}${inner.replace(/[^\r\n]/g, ' ')}${ticks}`,
   );
 }
+/**
+ * True when the character at `index` is escaped by an odd-length run of
+ * backslashes immediately before it. Despite the name, this counts
+ * backslashes only -- it never inspects `text[index]` itself -- so it is
+ * equally valid for a backtick (its original use), a link-text bracket, or
+ * an HTML tag's opening `<` (#2865): `\<span title="` and `\[test](` are
+ * both ordinary escaped-punctuation text per CommonMark, not the start of
+ * raw HTML or a real link.
+ */
 function isEscapedBacktick(text, index) {
   let backslashCount = 0;
   for (
@@ -1769,48 +1778,135 @@ function matchInlineHtmlTagEnd(text, start, end) {
 // span (#2865, Codex review PR #2840 round 27, databaseId 3977018342):
 // `[test](/url "`node --test`")` renders its title's backticks literally
 // too (`gh api /markdown` confirms `<a href="/url" title="`node
-// --test`">`), never a code span. A bare destination is a run of
-// non-whitespace, non-paren characters -- with one level of backslash-
-// escaped or balanced unescaped parens allowed, per spec (`gh api
-// /markdown` confirms `/wiki/Example_(disambiguation)` survives as a real
-// destination) -- or an angle-bracket-quoted form. The optional title is a
-// double-, single-, or paren-quoted string; unlike an HTML attribute value,
-// a title supports backslash-escaping so an escaped delimiter does not end
-// it early. Per spec the destination/title parenthesis must directly
-// follow the link text's own closing `]` with no intervening whitespace,
-// so the caller only tries this match when the preceding character is `]`
-// -- a link-shaped prefix that never reaches a valid destination/title/`)`
-// (e.g. `[note](which uses \`code\`)`) fails the whole anchored match and
-// falls through to ordinary text, leaving that backtick pair a genuine
-// code span (`gh api /markdown` confirms GitHub renders exactly that).
+// --test`">`), never a code span. The optional title is a double-,
+// single-, or paren-quoted string; unlike an HTML attribute value, a title
+// supports backslash-escaping so an escaped delimiter does not end it
+// early. The bare (non-angle-bracket) destination itself is scanned
+// manually by {@link scanBareLinkDestinationEnd} below, not matched by this
+// pattern, since CommonMark allows arbitrarily nested balanced parens
+// there (a fixed-depth regex alternative under-matched a real doubly-nested
+// destination -- Codex review round 1, databaseId 3978211245).
 const INLINE_LINK_TITLE_PATTERN =
   '(?:"(?:[^"\\\\]|\\\\.)*"|\'(?:[^\'\\\\]|\\\\.)*\'|\\((?:[^()\\\\]|\\\\.)*\\))';
-const INLINE_LINK_DESTINATION_PATTERN =
-  '(?:<[^<>\\r\\n]*>|(?:[^ \\t\\r\\n()\\\\]|\\\\.|\\([^()]*\\))*)';
-const INLINE_LINK_DEST_TITLE_PATTERN = new RegExp(
-  '^\\([ \\t\\r\\n]*' +
-    INLINE_LINK_DESTINATION_PATTERN +
-    `(?:[ \\t\\r\\n]+${INLINE_LINK_TITLE_PATTERN})?[ \\t\\r\\n]*\\)`,
+const INLINE_LINK_ANGLE_DESTINATION_PATTERN = /^<[^<>\r\n]*>/u;
+const INLINE_LINK_TITLE_AND_CLOSE_PATTERN = new RegExp(
+  `^(?:[ \\t\\r\\n]+${INLINE_LINK_TITLE_PATTERN})?[ \\t\\r\\n]*\\)`,
   'u',
 );
 /**
+ * The end offset of a bare (non-angle-bracket) link destination starting at
+ * `start`, honoring CommonMark's rule that parens are allowed there only
+ * when backslash-escaped or part of an arbitrarily-nested balanced pair
+ * (`gh api /markdown` confirms `/foo(a(b)c)` survives as a real
+ * destination with two nesting levels) -- manual scanning, rather than a
+ * fixed-depth regex alternative, generalizes to any nesting depth. Stops
+ * at the first whitespace or unbalanced (closing) `)`, which belongs to
+ * the enclosing link syntax, not the destination.
+ */
+function scanBareLinkDestinationEnd(text, start, end) {
+  let cursor = start;
+  let depth = 0;
+  while (cursor < end) {
+    const character = text[cursor];
+    if (character === '\\' && cursor + 1 < end) {
+      cursor += 2;
+      continue;
+    }
+    if (character === '(') {
+      depth += 1;
+      cursor += 1;
+      continue;
+    }
+    if (character === ')') {
+      if (depth === 0) {
+        break;
+      }
+      depth -= 1;
+      cursor += 1;
+      continue;
+    }
+    if (
+      character === ' ' ||
+      character === '\t' ||
+      character === '\r' ||
+      character === '\n'
+    ) {
+      break;
+    }
+    cursor += 1;
+  }
+  return cursor;
+}
+/**
+ * True when the nearest earlier unescaped `[` or `]` before
+ * `closeBracketIndex` -- bounded by the start of the current paragraph,
+ * since a link's own `[...]` text can never cross a blank line -- is a
+ * `[`, a plausible open link/image bracket for the `]` at
+ * `closeBracketIndex`. A bounded heuristic (nearest-bracket, not full
+ * CommonMark link-text balance/precedence parsing), but it resolves the
+ * two shapes Codex review round 1 (databaseId 3978211256) flagged: `gh api
+ * /markdown` confirms `foo](/url "`x`")` (no `[` at all) and
+ * `\[test](/url "`x`")` (the `[` itself escaped) both render their
+ * backticks as a genuine code span, never a link -- this must return
+ * `false` for both so {@link matchInlineLinkDestTitleEnd} never excludes
+ * them.
+ */
+function hasPlausibleLinkOpener(text, closeBracketIndex) {
+  let paragraphStart = 0;
+  for (const match of text.matchAll(/\r?\n[ \t]*\r?\n/gu)) {
+    const matchEnd = match.index + match[0].length;
+    if (matchEnd > closeBracketIndex) {
+      break;
+    }
+    paragraphStart = matchEnd;
+  }
+  for (
+    let cursor = closeBracketIndex - 1;
+    cursor >= paragraphStart;
+    cursor -= 1
+  ) {
+    const character = text[cursor];
+    if (
+      (character === '[' || character === ']') &&
+      !isEscapedBacktick(text, cursor)
+    ) {
+      return character === '[';
+    }
+  }
+  return false;
+}
+/**
  * The end offset of an inline link's `(destination "title")` span starting
  * at `start` (which must hold `(`), bounded to `[start, end)`, or `null`
- * when `start` is not immediately preceded by a link text's closing `]`,
- * no valid destination/title matches there, or the match would span a
- * blank line (see {@link matchInlineHtmlTagEnd}'s identical guard and
- * rationale).
+ * when `start` is not immediately preceded by a plausible open link/image
+ * bracket (see {@link hasPlausibleLinkOpener}), no valid destination/title
+ * matches there, or the match would span a blank line (see
+ * {@link matchInlineHtmlTagEnd}'s identical guard and rationale). A
+ * link-shaped prefix that never reaches a valid destination/title/`)`
+ * (e.g. `[note](which uses \`code\`)`) leaves the whole match unresolved
+ * and falls through to ordinary text, leaving that backtick pair a genuine
+ * code span (`gh api /markdown` confirms GitHub renders exactly that).
  */
 function matchInlineLinkDestTitleEnd(text, start, end) {
-  if (text[start - 1] !== ']') {
+  if (text[start - 1] !== ']' || !hasPlausibleLinkOpener(text, start - 1)) {
     return null;
   }
-  const remainder = text.slice(start, end);
-  const match = INLINE_LINK_DEST_TITLE_PATTERN.exec(remainder);
-  if (match === null) {
+  const leadingWhitespace = /^[ \t\r\n]*/u.exec(text.slice(start + 1, end));
+  let cursor = start + 1 + (leadingWhitespace?.[0].length ?? 0);
+  const angleMatch = INLINE_LINK_ANGLE_DESTINATION_PATTERN.exec(
+    text.slice(cursor, end),
+  );
+  cursor =
+    angleMatch !== null
+      ? cursor + angleMatch[0].length
+      : scanBareLinkDestinationEnd(text, cursor, end);
+  const rest = INLINE_LINK_TITLE_AND_CLOSE_PATTERN.exec(
+    text.slice(cursor, end),
+  );
+  if (rest === null) {
     return null;
   }
-  const matchEnd = start + match[0].length;
+  const matchEnd = cursor + rest[0].length;
   return hasBlankLine(text, start, matchEnd) ? null : matchEnd;
 }
 function findInlineCodeRanges(text, start, end) {
@@ -1820,14 +1916,19 @@ function findInlineCodeRanges(text, start, end) {
     // #2865: skip an inline HTML tag or a link's own destination/title span
     // entirely before ever considering a backtick inside it as a code-span
     // delimiter -- CommonMark's raw-HTML and link rules take precedence
-    // over the code-span rule there.
-    if (text[cursor] === '<') {
+    // over the code-span rule there. Codex review (round 1, databaseId
+    // 3978211270): an escaped `<` or `(` (`\<span title="`x`">`,
+    // `foo\(bar` `x` `)`) is ordinary text per CommonMark, never the start
+    // of raw HTML or a link's destination/title, so a backtick inside it
+    // stays a genuine code-span candidate -- skip the exclusion entirely
+    // when the opening character itself is escaped.
+    if (text[cursor] === '<' && !isEscapedBacktick(text, cursor)) {
       const tagEnd = matchInlineHtmlTagEnd(text, cursor, end);
       if (tagEnd !== null) {
         cursor = tagEnd;
         continue;
       }
-    } else if (text[cursor] === '(') {
+    } else if (text[cursor] === '(' && !isEscapedBacktick(text, cursor)) {
       const linkEnd = matchInlineLinkDestTitleEnd(text, cursor, end);
       if (linkEnd !== null) {
         cursor = linkEnd;

--- a/scripts/markdown-code.mjs
+++ b/scripts/markdown-code.mjs
@@ -1167,6 +1167,17 @@ export function findHtmlBlockRanges(text, fencedRanges = []) {
   // this `true` for exactly that reason.
   let noOpenParagraph = true;
   let fencedRangeIndex = 0;
+  // #2865: mirrors blankFencedCodeBlocks's/findFencedCodeRanges's own
+  // inherited-list-content-indent tracker (see
+  // {@link createListContentIndentTrackerState}) so a block opener line
+  // with no list marker of its own (a continuation line of an
+  // already-open list item, e.g. an indented `<pre>` two lines below a
+  // `- Example:` bullet) still inherits that list's content indent
+  // instead of always reading `null` -- see {@link
+  // isHtmlBlockContainerEnded}'s call sites below for why an unfixed
+  // `null` here let an unclosed block's forward scan run past the list's
+  // real end, masking later genuine content.
+  const listTracker = createListContentIndentTrackerState();
   while (lineStart <= text.length) {
     const newlineIndex = text.indexOf('\n', lineStart);
     const lineEnd =
@@ -1177,7 +1188,12 @@ export function findHtmlBlockRanges(text, fencedRanges = []) {
           : newlineIndex;
     const lineAfter = newlineIndex === -1 ? text.length : newlineIndex + 1;
     const line = text.slice(lineStart, lineEnd);
-    const isBlank = line.trim() === '';
+    // Content-based (blockquote-marker-stripped), matching
+    // blankFencedCodeBlocks's own `isBlank` derivation -- a lone `>` line
+    // (no content after the marker) is blank for list/blank-line-counting
+    // purposes even though the raw line itself is not whitespace-only.
+    const containerLine = parseContainerLine(line);
+    const isBlank = containerLine.content.trim() === '';
     while (
       fencedRangeIndex < fencedRanges.length &&
       lineStart >= (fencedRanges[fencedRangeIndex]?.end ?? text.length)
@@ -1194,6 +1210,9 @@ export function findHtmlBlockRanges(text, fencedRanges = []) {
       // review, PR #2840, round 16 -- corrects this round's own earlier
       // `false`): `gh api /markdown` confirms a type-7 tag right after a
       // closed fence, with no blank line between, still freely opens.
+      // The list-content-indent tracker is deliberately left untouched
+      // for opaque fence content, the same "frozen while inside a fence"
+      // choice blankFencedCodeBlocks itself makes for its own local fence.
       noOpenParagraph = true;
       lineStart = lineAfter;
       if (newlineIndex === -1) {
@@ -1201,6 +1220,16 @@ export function findHtmlBlockRanges(text, fencedRanges = []) {
       }
       continue;
     }
+    // Runs for every non-opaque line (blank or not) ahead of the
+    // per-branch dispatch below, so all four of that dispatch's own exits
+    // (raw-text/special/generic block open, and the plain fallthrough)
+    // see a tracker already advanced for *this* line -- reset (drop stale
+    // state) before reading, then adopt (record this line's own opener,
+    // if any) after, mirroring blankFencedCodeBlocks's identical
+    // ordering.
+    resetListContentIndentTrackerForLine(listTracker, containerLine, isBlank);
+    const trackedListContentIndent = listTracker.contentIndent;
+    adoptListContentIndentForLine(listTracker, containerLine);
     // Codex review, PR #2840 (round 20, widened round 22): does this
     // non-blank line, on its own, complete a one-line block that leaves
     // no paragraph open behind it -- an ATX heading or a thematic break
@@ -1233,7 +1262,7 @@ export function findHtmlBlockRanges(text, fencedRanges = []) {
     // comment for the masking bug this closes.
     let endsOwnBlock = false;
     if (!isBlank) {
-      const openerLine = parseContainerLine(line);
+      const openerLine = containerLine;
       const containerContent = openerLine.content;
       endsOwnBlock =
         (MARKDOWN_INDENTED_CODE_PRECEDER_PATTERN.test(containerContent) &&
@@ -1255,7 +1284,12 @@ export function findHtmlBlockRanges(text, fencedRanges = []) {
       // comment for why deriving it directly from this line (rather than
       // a cross-line tracker) is sufficient here.
       const openerContainerDepth = openerLine.containerDepth;
-      const openerListContentIndent = openerLine.listContentIndent;
+      // #2865: this opener line's own marker wins when present (no
+      // regression to the pre-fix behavior); otherwise inherit the
+      // tracker's carried indent from an earlier, still-open list item's
+      // own opener -- the continuation-line case this fix adds.
+      const openerListContentIndent =
+        openerLine.listContentIndent ?? trackedListContentIndent;
       const rawTag = rawTextOpenTag(content);
       const closeToken = specialHtmlBlockCloseToken(content);
       const opensGeneric =

--- a/scripts/markdown-code.mjs
+++ b/scripts/markdown-code.mjs
@@ -1805,6 +1805,14 @@ const INLINE_LINK_TITLE_AND_CLOSE_PATTERN = new RegExp(
  * CommonMark link destination or link-text length in practice.
  */
 const MAX_LINK_SCAN_LENGTH = 2000;
+// CommonMark §2.4: only an ASCII punctuation character may be
+// backslash-escaped; a backslash before anything else (including
+// whitespace) is a literal backslash, not an escape (Codex review, PR
+// #2869 round 3, databaseId 3978515897): `gh api /markdown` confirms
+// `[x](foo\ bar "`node --test`")` renders entirely as literal text with a
+// genuine code span for the backticks -- `\` before a space never escapes
+// it, so the space still ends the bare destination.
+const ASCII_PUNCTUATION_PATTERN = /[!-/:-@[-`{-~]/u;
 /**
  * The end offset of a bare (non-angle-bracket) link destination starting at
  * `start`, honoring CommonMark's rule that parens are allowed there only
@@ -1824,7 +1832,11 @@ function scanBareLinkDestinationEnd(text, start, end) {
   let depth = 0;
   while (cursor < bound) {
     const character = text[cursor];
-    if (character === '\\' && cursor + 1 < bound) {
+    if (
+      character === '\\' &&
+      cursor + 1 < bound &&
+      ASCII_PUNCTUATION_PATTERN.test(text[cursor + 1] ?? '')
+    ) {
       cursor += 2;
       continue;
     }
@@ -1862,7 +1874,21 @@ function scanBareLinkDestinationEnd(text, start, end) {
  * True when `closeBracketIndex` (which must hold `]`) is the properly
  * balanced close of an earlier unescaped `[` -- a plausible open link/image
  * bracket -- within the current paragraph (a link's own `[...]` text can
- * never cross a blank line) and within {@link MAX_LINK_SCAN_LENGTH}.
+ * never cross a blank line) and within {@link MAX_LINK_SCAN_LENGTH} of
+ * `closeBracketIndex` (the paragraph search itself is bounded to that same
+ * trailing window, not the whole document -- Codex review, PR #2869 round
+ * 3, databaseId 3978515904: an unbounded `matchAll` over the full text on
+ * every call reintroduced quadratic behavior even after the backward
+ * bracket scan itself was bounded). `codeRanges` -- the genuine code-span
+ * ranges `findInlineCodeRanges` has already found to the left of this
+ * point in the same call -- lets the scan skip over an already-closed code
+ * span as one opaque unit rather than reading a bracket inside it as real
+ * Markdown structure (Codex review, PR #2869 round 3, databaseId
+ * 3978515893): `gh api /markdown` confirms `` `[foo` ](/url "`x`") ``
+ * renders `` `[foo` `` as its own real code span and `` `x` `` as a
+ * second, separate one -- the `[` inside the first span must never count
+ * as a link opener for the `]` that follows it.
+ *
  * Tracks nested-bracket depth while scanning backward, rather than
  * accepting or rejecting on the nearest bracket alone (Codex review, PR
  * #2869 round 2, databaseId 3978373742): `gh api /markdown` confirms a
@@ -1873,24 +1899,25 @@ function scanBareLinkDestinationEnd(text, start, end) {
  * "`x`")` (the `[` itself escaped) both render their backticks as a
  * genuine code span, never a link, so this must return `false` for both.
  */
-function hasPlausibleLinkOpener(text, closeBracketIndex) {
-  let paragraphStart = 0;
-  for (const match of text.matchAll(/\r?\n[ \t]*\r?\n/gu)) {
-    const matchEnd = match.index + match[0].length;
-    if (matchEnd > closeBracketIndex) {
-      break;
-    }
-    paragraphStart = matchEnd;
+function hasPlausibleLinkOpener(text, closeBracketIndex, codeRanges) {
+  const searchFloor = Math.max(0, closeBracketIndex - MAX_LINK_SCAN_LENGTH);
+  const searchWindow = text.slice(searchFloor, closeBracketIndex);
+  let paragraphStart = searchFloor;
+  for (const match of searchWindow.matchAll(/\r?\n[ \t]*\r?\n/gu)) {
+    paragraphStart = searchFloor + match.index + match[0].length;
   }
-  const lowerBound = Math.max(
-    paragraphStart,
-    closeBracketIndex - MAX_LINK_SCAN_LENGTH,
-  );
+  let cursor = closeBracketIndex - 1;
   let depth = 0;
-  for (let cursor = closeBracketIndex - 1; cursor >= lowerBound; cursor -= 1) {
+  while (cursor >= paragraphStart) {
+    const enclosingCodeRange = getMarkdownCodeRange(text, cursor, codeRanges);
+    if (enclosingCodeRange !== null) {
+      cursor = enclosingCodeRange.start - 1;
+      continue;
+    }
     const character = text[cursor];
     if (character === ']' && !isEscapedBacktick(text, cursor)) {
       depth += 1;
+      cursor -= 1;
       continue;
     }
     if (character === '[' && !isEscapedBacktick(text, cursor)) {
@@ -1899,6 +1926,7 @@ function hasPlausibleLinkOpener(text, closeBracketIndex) {
       }
       depth -= 1;
     }
+    cursor -= 1;
   }
   return false;
 }
@@ -1913,9 +1941,13 @@ function hasPlausibleLinkOpener(text, closeBracketIndex) {
  * (e.g. `[note](which uses \`code\`)`) leaves the whole match unresolved
  * and falls through to ordinary text, leaving that backtick pair a genuine
  * code span (`gh api /markdown` confirms GitHub renders exactly that).
+ * `codeRanges` is forwarded to {@link hasPlausibleLinkOpener} unchanged.
  */
-function matchInlineLinkDestTitleEnd(text, start, end) {
-  if (text[start - 1] !== ']' || !hasPlausibleLinkOpener(text, start - 1)) {
+function matchInlineLinkDestTitleEnd(text, start, end, codeRanges) {
+  if (
+    text[start - 1] !== ']' ||
+    !hasPlausibleLinkOpener(text, start - 1, codeRanges)
+  ) {
     return null;
   }
   const leadingWhitespace = /^[ \t\r\n]*/u.exec(text.slice(start + 1, end));
@@ -1961,7 +1993,7 @@ function findInlineCodeRanges(text, start, end) {
         continue;
       }
     } else if (text[cursor] === '(' && !isEscapedBacktick(text, cursor)) {
-      const linkEnd = matchInlineLinkDestTitleEnd(text, cursor, end);
+      const linkEnd = matchInlineLinkDestTitleEnd(text, cursor, end, ranges);
       if (linkEnd !== null) {
         cursor = linkEnd;
         continue;

--- a/scripts/markdown-code.mjs
+++ b/scripts/markdown-code.mjs
@@ -1794,6 +1794,18 @@ const INLINE_LINK_TITLE_AND_CLOSE_PATTERN = new RegExp(
   'u',
 );
 /**
+ * Bound on how far {@link scanBareLinkDestinationEnd} and
+ * {@link hasPlausibleLinkOpener} scan before giving up, so a long run of
+ * unresolved link-like prefixes in untrusted issue-body text (adversarial
+ * or merely malformed, e.g. many `[x](` occurrences with no closing paren
+ * or whitespace) cannot make `findMarkdownCodeRanges` quadratic in body
+ * length (Codex review, PR #2869 round 2, databaseId 3978373746: ~2.7s for
+ * a single 64 KB instance without this bound, and discovery/triage
+ * processes untrusted issue bodies routinely). Far beyond any legitimate
+ * CommonMark link destination or link-text length in practice.
+ */
+const MAX_LINK_SCAN_LENGTH = 2000;
+/**
  * The end offset of a bare (non-angle-bracket) link destination starting at
  * `start`, honoring CommonMark's rule that parens are allowed there only
  * when backslash-escaped or part of an arbitrarily-nested balanced pair
@@ -1801,14 +1813,18 @@ const INLINE_LINK_TITLE_AND_CLOSE_PATTERN = new RegExp(
  * destination with two nesting levels) -- manual scanning, rather than a
  * fixed-depth regex alternative, generalizes to any nesting depth. Stops
  * at the first whitespace or unbalanced (closing) `)`, which belongs to
- * the enclosing link syntax, not the destination.
+ * the enclosing link syntax, not the destination. Returns `null` instead
+ * of a position when the scan reaches {@link MAX_LINK_SCAN_LENGTH} without
+ * finding either terminator -- the caller treats that the same as no valid
+ * destination.
  */
 function scanBareLinkDestinationEnd(text, start, end) {
+  const bound = Math.min(end, start + MAX_LINK_SCAN_LENGTH);
   let cursor = start;
   let depth = 0;
-  while (cursor < end) {
+  while (cursor < bound) {
     const character = text[cursor];
-    if (character === '\\' && cursor + 1 < end) {
+    if (character === '\\' && cursor + 1 < bound) {
       cursor += 2;
       continue;
     }
@@ -1819,7 +1835,7 @@ function scanBareLinkDestinationEnd(text, start, end) {
     }
     if (character === ')') {
       if (depth === 0) {
-        break;
+        return cursor;
       }
       depth -= 1;
       cursor += 1;
@@ -1831,25 +1847,31 @@ function scanBareLinkDestinationEnd(text, start, end) {
       character === '\r' ||
       character === '\n'
     ) {
-      break;
+      return cursor;
     }
     cursor += 1;
   }
-  return cursor;
+  // Reached the scan bound (the {@link MAX_LINK_SCAN_LENGTH} cap or the
+  // caller's own `end`) without finding a real terminator -- never a valid
+  // destination; the caller's own title/close match would fail on this
+  // position anyway, but returning `null` here makes that fail-closed
+  // outcome explicit rather than incidental.
+  return null;
 }
 /**
- * True when the nearest earlier unescaped `[` or `]` before
- * `closeBracketIndex` -- bounded by the start of the current paragraph,
- * since a link's own `[...]` text can never cross a blank line -- is a
- * `[`, a plausible open link/image bracket for the `]` at
- * `closeBracketIndex`. A bounded heuristic (nearest-bracket, not full
- * CommonMark link-text balance/precedence parsing), but it resolves the
- * two shapes Codex review round 1 (databaseId 3978211256) flagged: `gh api
- * /markdown` confirms `foo](/url "`x`")` (no `[` at all) and
- * `\[test](/url "`x`")` (the `[` itself escaped) both render their
- * backticks as a genuine code span, never a link -- this must return
- * `false` for both so {@link matchInlineLinkDestTitleEnd} never excludes
- * them.
+ * True when `closeBracketIndex` (which must hold `]`) is the properly
+ * balanced close of an earlier unescaped `[` -- a plausible open link/image
+ * bracket -- within the current paragraph (a link's own `[...]` text can
+ * never cross a blank line) and within {@link MAX_LINK_SCAN_LENGTH}.
+ * Tracks nested-bracket depth while scanning backward, rather than
+ * accepting or rejecting on the nearest bracket alone (Codex review, PR
+ * #2869 round 2, databaseId 3978373742): `gh api /markdown` confirms a
+ * nested label such as `[foo [bar] baz](/url "..)")` is a real link, whose
+ * inner `[bar]` must not be mistaken for -- or block reaching -- the real
+ * outer opener. Also still resolves round 1's two shapes (databaseId
+ * 3978211256): `foo](/url "`x`")` (no `[` at all) and `\[test](/url
+ * "`x`")` (the `[` itself escaped) both render their backticks as a
+ * genuine code span, never a link, so this must return `false` for both.
  */
 function hasPlausibleLinkOpener(text, closeBracketIndex) {
   let paragraphStart = 0;
@@ -1860,17 +1882,22 @@ function hasPlausibleLinkOpener(text, closeBracketIndex) {
     }
     paragraphStart = matchEnd;
   }
-  for (
-    let cursor = closeBracketIndex - 1;
-    cursor >= paragraphStart;
-    cursor -= 1
-  ) {
+  const lowerBound = Math.max(
+    paragraphStart,
+    closeBracketIndex - MAX_LINK_SCAN_LENGTH,
+  );
+  let depth = 0;
+  for (let cursor = closeBracketIndex - 1; cursor >= lowerBound; cursor -= 1) {
     const character = text[cursor];
-    if (
-      (character === '[' || character === ']') &&
-      !isEscapedBacktick(text, cursor)
-    ) {
-      return character === '[';
+    if (character === ']' && !isEscapedBacktick(text, cursor)) {
+      depth += 1;
+      continue;
+    }
+    if (character === '[' && !isEscapedBacktick(text, cursor)) {
+      if (depth === 0) {
+        return true;
+      }
+      depth -= 1;
     }
   }
   return false;
@@ -1896,10 +1923,15 @@ function matchInlineLinkDestTitleEnd(text, start, end) {
   const angleMatch = INLINE_LINK_ANGLE_DESTINATION_PATTERN.exec(
     text.slice(cursor, end),
   );
-  cursor =
-    angleMatch !== null
-      ? cursor + angleMatch[0].length
-      : scanBareLinkDestinationEnd(text, cursor, end);
+  if (angleMatch !== null) {
+    cursor += angleMatch[0].length;
+  } else {
+    const destinationEnd = scanBareLinkDestinationEnd(text, cursor, end);
+    if (destinationEnd === null) {
+      return null;
+    }
+    cursor = destinationEnd;
+  }
   const rest = INLINE_LINK_TITLE_AND_CLOSE_PATTERN.exec(
     text.slice(cursor, end),
   );

--- a/scripts/markdown-code.mjs
+++ b/scripts/markdown-code.mjs
@@ -1703,10 +1703,137 @@ function mergeMarkdownCodeRanges(ranges) {
   }
   return merged;
 }
+// CommonMark §6.6 raw-HTML inline tag grammar (open-tag and closing-tag
+// forms only -- the two shapes whose attribute values can hide a backtick
+// pair, #2865). An attribute value may be unquoted (a nonempty run of
+// characters excluding whitespace, quotes, `=`, `<`, `>`, and a backtick --
+// CommonMark's own grammar excludes the backtick there too, so
+// `<span title=`x`>` never matches as a tag at all, leaving `` `x` `` a
+// genuine code span), single-quoted, or double-quoted; a quoted value may
+// itself contain a backtick, which GitHub renders as literal attribute
+// text, never a code-span delimiter (`gh api /markdown` confirms
+// `<span title="`node --test`"></span>` keeps its backticks literal).
+// {@link findInlineCodeRanges} skips a matched tag entirely so an
+// attribute-embedded backtick pair is never read as a code-span
+// opener/closer.
+const INLINE_HTML_TAG_NAME_PATTERN = '[A-Za-z][A-Za-z0-9-]*';
+const INLINE_HTML_ATTRIBUTE_NAME_PATTERN = '[A-Za-z_:][A-Za-z0-9_.:-]*';
+const INLINE_HTML_ATTRIBUTE_VALUE_PATTERN =
+  '(?:[^ \\t\\r\\n"\'=<>`]+|\'[^\']*\'|"[^"]*")';
+const INLINE_HTML_ATTRIBUTE_PATTERN =
+  `[ \\t\\r\\n]+${INLINE_HTML_ATTRIBUTE_NAME_PATTERN}` +
+  `(?:[ \\t\\r\\n]*=[ \\t\\r\\n]*${INLINE_HTML_ATTRIBUTE_VALUE_PATTERN})?`;
+const INLINE_HTML_OPEN_TAG_PATTERN = new RegExp(
+  `^<${INLINE_HTML_TAG_NAME_PATTERN}(?:${INLINE_HTML_ATTRIBUTE_PATTERN})*[ \\t\\r\\n]*/?>`,
+  'u',
+);
+const INLINE_HTML_CLOSE_TAG_PATTERN = new RegExp(
+  `^</${INLINE_HTML_TAG_NAME_PATTERN}[ \\t\\r\\n]*>`,
+  'u',
+);
+/**
+ * The end offset of a CommonMark raw-HTML inline tag (open or closing form)
+ * starting at `start` (which must hold `<`), bounded to `[start, end)`, or
+ * `null` when no valid tag matches there -- an unterminated quoted
+ * attribute value, for example, fails both patterns and falls through to
+ * ordinary text, leaving any backtick inside it a normal code-span
+ * candidate.
+ *
+ * **Blank-line guard**: CommonMark parses block structure (including where
+ * a blank line ends a paragraph) before inline content, so no raw-HTML
+ * inline tag can ever span a blank line -- `gh api /markdown` confirms
+ * `<span title="a` / (blank) / `b">` renders as two separate literal-text
+ * paragraphs, never one tag. The character classes above allow a bare `\n`
+ * (a quoted value may wrap a soft line break) but cannot themselves refuse
+ * a *second* consecutive one, so a match that happens to reach a real
+ * closing quote/`>` on the far side of a blank line is rejected here via
+ * {@link hasBlankLine} -- the same post-match guard
+ * {@link findInlineCodeRanges}'s own closing-backtick search already
+ * applies for the identical reason.
+ */
+function matchInlineHtmlTagEnd(text, start, end) {
+  const remainder = text.slice(start, end);
+  const open = INLINE_HTML_OPEN_TAG_PATTERN.exec(remainder);
+  const matchLength =
+    open?.[0].length ??
+    INLINE_HTML_CLOSE_TAG_PATTERN.exec(remainder)?.[0].length ??
+    null;
+  if (matchLength === null) {
+    return null;
+  }
+  const matchEnd = start + matchLength;
+  return hasBlankLine(text, start, matchEnd) ? null : matchEnd;
+}
+// CommonMark §6.3 inline-link destination/title grammar, generalizing the
+// same attribute-value exclusion to a link's own `(destination "title")`
+// span (#2865, Codex review PR #2840 round 27, databaseId 3977018342):
+// `[test](/url "`node --test`")` renders its title's backticks literally
+// too (`gh api /markdown` confirms `<a href="/url" title="`node
+// --test`">`), never a code span. A bare destination is a run of
+// non-whitespace, non-paren characters -- with one level of backslash-
+// escaped or balanced unescaped parens allowed, per spec (`gh api
+// /markdown` confirms `/wiki/Example_(disambiguation)` survives as a real
+// destination) -- or an angle-bracket-quoted form. The optional title is a
+// double-, single-, or paren-quoted string; unlike an HTML attribute value,
+// a title supports backslash-escaping so an escaped delimiter does not end
+// it early. Per spec the destination/title parenthesis must directly
+// follow the link text's own closing `]` with no intervening whitespace,
+// so the caller only tries this match when the preceding character is `]`
+// -- a link-shaped prefix that never reaches a valid destination/title/`)`
+// (e.g. `[note](which uses \`code\`)`) fails the whole anchored match and
+// falls through to ordinary text, leaving that backtick pair a genuine
+// code span (`gh api /markdown` confirms GitHub renders exactly that).
+const INLINE_LINK_TITLE_PATTERN =
+  '(?:"(?:[^"\\\\]|\\\\.)*"|\'(?:[^\'\\\\]|\\\\.)*\'|\\((?:[^()\\\\]|\\\\.)*\\))';
+const INLINE_LINK_DESTINATION_PATTERN =
+  '(?:<[^<>\\r\\n]*>|(?:[^ \\t\\r\\n()\\\\]|\\\\.|\\([^()]*\\))*)';
+const INLINE_LINK_DEST_TITLE_PATTERN = new RegExp(
+  '^\\([ \\t\\r\\n]*' +
+    INLINE_LINK_DESTINATION_PATTERN +
+    `(?:[ \\t\\r\\n]+${INLINE_LINK_TITLE_PATTERN})?[ \\t\\r\\n]*\\)`,
+  'u',
+);
+/**
+ * The end offset of an inline link's `(destination "title")` span starting
+ * at `start` (which must hold `(`), bounded to `[start, end)`, or `null`
+ * when `start` is not immediately preceded by a link text's closing `]`,
+ * no valid destination/title matches there, or the match would span a
+ * blank line (see {@link matchInlineHtmlTagEnd}'s identical guard and
+ * rationale).
+ */
+function matchInlineLinkDestTitleEnd(text, start, end) {
+  if (text[start - 1] !== ']') {
+    return null;
+  }
+  const remainder = text.slice(start, end);
+  const match = INLINE_LINK_DEST_TITLE_PATTERN.exec(remainder);
+  if (match === null) {
+    return null;
+  }
+  const matchEnd = start + match[0].length;
+  return hasBlankLine(text, start, matchEnd) ? null : matchEnd;
+}
 function findInlineCodeRanges(text, start, end) {
   const ranges = [];
   let cursor = start;
   while (cursor < end) {
+    // #2865: skip an inline HTML tag or a link's own destination/title span
+    // entirely before ever considering a backtick inside it as a code-span
+    // delimiter -- CommonMark's raw-HTML and link rules take precedence
+    // over the code-span rule there.
+    if (text[cursor] === '<') {
+      const tagEnd = matchInlineHtmlTagEnd(text, cursor, end);
+      if (tagEnd !== null) {
+        cursor = tagEnd;
+        continue;
+      }
+    } else if (text[cursor] === '(') {
+      const linkEnd = matchInlineLinkDestTitleEnd(text, cursor, end);
+      if (linkEnd !== null) {
+        cursor = linkEnd;
+        continue;
+      }
+    }
     if (text[cursor] !== '`' || isEscapedBacktick(text, cursor)) {
       cursor += 1;
       continue;

--- a/src/scripts/discover-shared-file-overlap.mts
+++ b/src/scripts/discover-shared-file-overlap.mts
@@ -19,6 +19,7 @@ import { resolve } from 'node:path';
 import { parseAutopilotSuitability } from './autopilot-suitability.mts';
 import { parseCliArgs } from './cli-args.mts';
 import { loadPolicyConfig } from './idd-config.mts';
+import { findMarkdownCodeRanges } from './markdown-code.mts';
 import { parseIsoDurationToMs } from './policy-helpers.mts';
 import {
   resolveActiveClaim,
@@ -413,8 +414,28 @@ export function parseCandidateFileEntries(body: unknown): CandidateFileEntry[] {
   const sectionText = section.join('\n');
   const entries: CandidateFileEntry[] = [];
 
-  // Every backtick-quoted path in the section, regardless of line wrapping.
+  // Every backtick-quoted path in the section, regardless of line wrapping --
+  // but only a genuine inline-code-span match (#2865): a naive backtick pair
+  // can also fall inside an HTML tag's attribute value or a link's own
+  // title/destination (e.g. `<span title="`package.json`">not a
+  // candidate</span>`), which CommonMark renders as literal attribute/title
+  // text, never a code span (`gh api /markdown` confirms this). Reuse
+  // `markdown-code.mts`'s own exclusion (the same fix applied to
+  // `hasVerificationCommandSignal`'s command-span detection) by accepting a
+  // match only when it is fully contained in one of
+  // `findMarkdownCodeRanges`'s real code-span ranges -- containment, not
+  // exact-range equality, because adjacent real spans with no gap between
+  // them can merge into one wider range.
+  const codeRanges = findMarkdownCodeRanges(sectionText);
   for (const match of sectionText.matchAll(/`([^`]+)`/g)) {
+    const matchStart = match.index;
+    const matchEnd = matchStart + match[0].length;
+    const isGenuineCodeSpan = codeRanges.some(
+      (range) => matchStart >= range.start && matchEnd <= range.end,
+    );
+    if (!isGenuineCodeSpan) {
+      continue;
+    }
     const raw = match[1].trim();
     const normalized = normalizeContentionPath(raw);
     if (looksLikePath(normalized)) {

--- a/src/scripts/markdown-code.mts
+++ b/src/scripts/markdown-code.mts
@@ -1897,6 +1897,128 @@ function mergeMarkdownCodeRanges(
   return merged;
 }
 
+// CommonMark §6.6 raw-HTML inline tag grammar (open-tag and closing-tag
+// forms only -- the two shapes whose attribute values can hide a backtick
+// pair, #2865). An attribute value may be unquoted (a nonempty run of
+// characters excluding whitespace, quotes, `=`, `<`, `>`, and a backtick --
+// CommonMark's own grammar excludes the backtick there too, so
+// `<span title=`x`>` never matches as a tag at all, leaving `` `x` `` a
+// genuine code span), single-quoted, or double-quoted; a quoted value may
+// itself contain a backtick, which GitHub renders as literal attribute
+// text, never a code-span delimiter (`gh api /markdown` confirms
+// `<span title="`node --test`"></span>` keeps its backticks literal).
+// {@link findInlineCodeRanges} skips a matched tag entirely so an
+// attribute-embedded backtick pair is never read as a code-span
+// opener/closer.
+const INLINE_HTML_TAG_NAME_PATTERN = '[A-Za-z][A-Za-z0-9-]*';
+const INLINE_HTML_ATTRIBUTE_NAME_PATTERN = '[A-Za-z_:][A-Za-z0-9_.:-]*';
+const INLINE_HTML_ATTRIBUTE_VALUE_PATTERN =
+  '(?:[^ \\t\\r\\n"\'=<>`]+|\'[^\']*\'|"[^"]*")';
+const INLINE_HTML_ATTRIBUTE_PATTERN =
+  `[ \\t\\r\\n]+${INLINE_HTML_ATTRIBUTE_NAME_PATTERN}` +
+  `(?:[ \\t\\r\\n]*=[ \\t\\r\\n]*${INLINE_HTML_ATTRIBUTE_VALUE_PATTERN})?`;
+const INLINE_HTML_OPEN_TAG_PATTERN = new RegExp(
+  `^<${INLINE_HTML_TAG_NAME_PATTERN}(?:${INLINE_HTML_ATTRIBUTE_PATTERN})*[ \\t\\r\\n]*/?>`,
+  'u',
+);
+const INLINE_HTML_CLOSE_TAG_PATTERN = new RegExp(
+  `^</${INLINE_HTML_TAG_NAME_PATTERN}[ \\t\\r\\n]*>`,
+  'u',
+);
+
+/**
+ * The end offset of a CommonMark raw-HTML inline tag (open or closing form)
+ * starting at `start` (which must hold `<`), bounded to `[start, end)`, or
+ * `null` when no valid tag matches there -- an unterminated quoted
+ * attribute value, for example, fails both patterns and falls through to
+ * ordinary text, leaving any backtick inside it a normal code-span
+ * candidate.
+ *
+ * **Blank-line guard**: CommonMark parses block structure (including where
+ * a blank line ends a paragraph) before inline content, so no raw-HTML
+ * inline tag can ever span a blank line -- `gh api /markdown` confirms
+ * `<span title="a` / (blank) / `b">` renders as two separate literal-text
+ * paragraphs, never one tag. The character classes above allow a bare `\n`
+ * (a quoted value may wrap a soft line break) but cannot themselves refuse
+ * a *second* consecutive one, so a match that happens to reach a real
+ * closing quote/`>` on the far side of a blank line is rejected here via
+ * {@link hasBlankLine} -- the same post-match guard
+ * {@link findInlineCodeRanges}'s own closing-backtick search already
+ * applies for the identical reason.
+ */
+function matchInlineHtmlTagEnd(
+  text: string,
+  start: number,
+  end: number,
+): number | null {
+  const remainder = text.slice(start, end);
+  const open = INLINE_HTML_OPEN_TAG_PATTERN.exec(remainder);
+  const matchLength =
+    open?.[0].length ??
+    INLINE_HTML_CLOSE_TAG_PATTERN.exec(remainder)?.[0].length ??
+    null;
+  if (matchLength === null) {
+    return null;
+  }
+  const matchEnd = start + matchLength;
+  return hasBlankLine(text, start, matchEnd) ? null : matchEnd;
+}
+
+// CommonMark §6.3 inline-link destination/title grammar, generalizing the
+// same attribute-value exclusion to a link's own `(destination "title")`
+// span (#2865, Codex review PR #2840 round 27, databaseId 3977018342):
+// `[test](/url "`node --test`")` renders its title's backticks literally
+// too (`gh api /markdown` confirms `<a href="/url" title="`node
+// --test`">`), never a code span. A bare destination is a run of
+// non-whitespace, non-paren characters -- with one level of backslash-
+// escaped or balanced unescaped parens allowed, per spec (`gh api
+// /markdown` confirms `/wiki/Example_(disambiguation)` survives as a real
+// destination) -- or an angle-bracket-quoted form. The optional title is a
+// double-, single-, or paren-quoted string; unlike an HTML attribute value,
+// a title supports backslash-escaping so an escaped delimiter does not end
+// it early. Per spec the destination/title parenthesis must directly
+// follow the link text's own closing `]` with no intervening whitespace,
+// so the caller only tries this match when the preceding character is `]`
+// -- a link-shaped prefix that never reaches a valid destination/title/`)`
+// (e.g. `[note](which uses \`code\`)`) fails the whole anchored match and
+// falls through to ordinary text, leaving that backtick pair a genuine
+// code span (`gh api /markdown` confirms GitHub renders exactly that).
+const INLINE_LINK_TITLE_PATTERN =
+  '(?:"(?:[^"\\\\]|\\\\.)*"|\'(?:[^\'\\\\]|\\\\.)*\'|\\((?:[^()\\\\]|\\\\.)*\\))';
+const INLINE_LINK_DESTINATION_PATTERN =
+  '(?:<[^<>\\r\\n]*>|(?:[^ \\t\\r\\n()\\\\]|\\\\.|\\([^()]*\\))*)';
+const INLINE_LINK_DEST_TITLE_PATTERN = new RegExp(
+  '^\\([ \\t\\r\\n]*' +
+    INLINE_LINK_DESTINATION_PATTERN +
+    `(?:[ \\t\\r\\n]+${INLINE_LINK_TITLE_PATTERN})?[ \\t\\r\\n]*\\)`,
+  'u',
+);
+
+/**
+ * The end offset of an inline link's `(destination "title")` span starting
+ * at `start` (which must hold `(`), bounded to `[start, end)`, or `null`
+ * when `start` is not immediately preceded by a link text's closing `]`,
+ * no valid destination/title matches there, or the match would span a
+ * blank line (see {@link matchInlineHtmlTagEnd}'s identical guard and
+ * rationale).
+ */
+function matchInlineLinkDestTitleEnd(
+  text: string,
+  start: number,
+  end: number,
+): number | null {
+  if (text[start - 1] !== ']') {
+    return null;
+  }
+  const remainder = text.slice(start, end);
+  const match = INLINE_LINK_DEST_TITLE_PATTERN.exec(remainder);
+  if (match === null) {
+    return null;
+  }
+  const matchEnd = start + match[0].length;
+  return hasBlankLine(text, start, matchEnd) ? null : matchEnd;
+}
+
 function findInlineCodeRanges(
   text: string,
   start: number,
@@ -1906,6 +2028,23 @@ function findInlineCodeRanges(
   let cursor = start;
 
   while (cursor < end) {
+    // #2865: skip an inline HTML tag or a link's own destination/title span
+    // entirely before ever considering a backtick inside it as a code-span
+    // delimiter -- CommonMark's raw-HTML and link rules take precedence
+    // over the code-span rule there.
+    if (text[cursor] === '<') {
+      const tagEnd = matchInlineHtmlTagEnd(text, cursor, end);
+      if (tagEnd !== null) {
+        cursor = tagEnd;
+        continue;
+      }
+    } else if (text[cursor] === '(') {
+      const linkEnd = matchInlineLinkDestTitleEnd(text, cursor, end);
+      if (linkEnd !== null) {
+        cursor = linkEnd;
+        continue;
+      }
+    }
     if (text[cursor] !== '`' || isEscapedBacktick(text, cursor)) {
       cursor += 1;
       continue;

--- a/src/scripts/markdown-code.mts
+++ b/src/scripts/markdown-code.mts
@@ -123,6 +123,15 @@ export function stripMarkdownCodeRegions(text: string): string {
 
 export type MarkdownCodeRange = { start: number; end: number };
 
+/**
+ * True when the character at `index` is escaped by an odd-length run of
+ * backslashes immediately before it. Despite the name, this counts
+ * backslashes only -- it never inspects `text[index]` itself -- so it is
+ * equally valid for a backtick (its original use), a link-text bracket, or
+ * an HTML tag's opening `<` (#2865): `\<span title="` and `\[test](` are
+ * both ordinary escaped-punctuation text per CommonMark, not the start of
+ * raw HTML or a real link.
+ */
 function isEscapedBacktick(text: string, index: number): boolean {
   let backslashCount = 0;
   for (
@@ -1969,53 +1978,149 @@ function matchInlineHtmlTagEnd(
 // span (#2865, Codex review PR #2840 round 27, databaseId 3977018342):
 // `[test](/url "`node --test`")` renders its title's backticks literally
 // too (`gh api /markdown` confirms `<a href="/url" title="`node
-// --test`">`), never a code span. A bare destination is a run of
-// non-whitespace, non-paren characters -- with one level of backslash-
-// escaped or balanced unescaped parens allowed, per spec (`gh api
-// /markdown` confirms `/wiki/Example_(disambiguation)` survives as a real
-// destination) -- or an angle-bracket-quoted form. The optional title is a
-// double-, single-, or paren-quoted string; unlike an HTML attribute value,
-// a title supports backslash-escaping so an escaped delimiter does not end
-// it early. Per spec the destination/title parenthesis must directly
-// follow the link text's own closing `]` with no intervening whitespace,
-// so the caller only tries this match when the preceding character is `]`
-// -- a link-shaped prefix that never reaches a valid destination/title/`)`
-// (e.g. `[note](which uses \`code\`)`) fails the whole anchored match and
-// falls through to ordinary text, leaving that backtick pair a genuine
-// code span (`gh api /markdown` confirms GitHub renders exactly that).
+// --test`">`), never a code span. The optional title is a double-,
+// single-, or paren-quoted string; unlike an HTML attribute value, a title
+// supports backslash-escaping so an escaped delimiter does not end it
+// early. The bare (non-angle-bracket) destination itself is scanned
+// manually by {@link scanBareLinkDestinationEnd} below, not matched by this
+// pattern, since CommonMark allows arbitrarily nested balanced parens
+// there (a fixed-depth regex alternative under-matched a real doubly-nested
+// destination -- Codex review round 1, databaseId 3978211245).
 const INLINE_LINK_TITLE_PATTERN =
   '(?:"(?:[^"\\\\]|\\\\.)*"|\'(?:[^\'\\\\]|\\\\.)*\'|\\((?:[^()\\\\]|\\\\.)*\\))';
-const INLINE_LINK_DESTINATION_PATTERN =
-  '(?:<[^<>\\r\\n]*>|(?:[^ \\t\\r\\n()\\\\]|\\\\.|\\([^()]*\\))*)';
-const INLINE_LINK_DEST_TITLE_PATTERN = new RegExp(
-  '^\\([ \\t\\r\\n]*' +
-    INLINE_LINK_DESTINATION_PATTERN +
-    `(?:[ \\t\\r\\n]+${INLINE_LINK_TITLE_PATTERN})?[ \\t\\r\\n]*\\)`,
+const INLINE_LINK_ANGLE_DESTINATION_PATTERN = /^<[^<>\r\n]*>/u;
+const INLINE_LINK_TITLE_AND_CLOSE_PATTERN = new RegExp(
+  `^(?:[ \\t\\r\\n]+${INLINE_LINK_TITLE_PATTERN})?[ \\t\\r\\n]*\\)`,
   'u',
 );
 
 /**
+ * The end offset of a bare (non-angle-bracket) link destination starting at
+ * `start`, honoring CommonMark's rule that parens are allowed there only
+ * when backslash-escaped or part of an arbitrarily-nested balanced pair
+ * (`gh api /markdown` confirms `/foo(a(b)c)` survives as a real
+ * destination with two nesting levels) -- manual scanning, rather than a
+ * fixed-depth regex alternative, generalizes to any nesting depth. Stops
+ * at the first whitespace or unbalanced (closing) `)`, which belongs to
+ * the enclosing link syntax, not the destination.
+ */
+function scanBareLinkDestinationEnd(
+  text: string,
+  start: number,
+  end: number,
+): number {
+  let cursor = start;
+  let depth = 0;
+  while (cursor < end) {
+    const character = text[cursor];
+    if (character === '\\' && cursor + 1 < end) {
+      cursor += 2;
+      continue;
+    }
+    if (character === '(') {
+      depth += 1;
+      cursor += 1;
+      continue;
+    }
+    if (character === ')') {
+      if (depth === 0) {
+        break;
+      }
+      depth -= 1;
+      cursor += 1;
+      continue;
+    }
+    if (
+      character === ' ' ||
+      character === '\t' ||
+      character === '\r' ||
+      character === '\n'
+    ) {
+      break;
+    }
+    cursor += 1;
+  }
+  return cursor;
+}
+
+/**
+ * True when the nearest earlier unescaped `[` or `]` before
+ * `closeBracketIndex` -- bounded by the start of the current paragraph,
+ * since a link's own `[...]` text can never cross a blank line -- is a
+ * `[`, a plausible open link/image bracket for the `]` at
+ * `closeBracketIndex`. A bounded heuristic (nearest-bracket, not full
+ * CommonMark link-text balance/precedence parsing), but it resolves the
+ * two shapes Codex review round 1 (databaseId 3978211256) flagged: `gh api
+ * /markdown` confirms `foo](/url "`x`")` (no `[` at all) and
+ * `\[test](/url "`x`")` (the `[` itself escaped) both render their
+ * backticks as a genuine code span, never a link -- this must return
+ * `false` for both so {@link matchInlineLinkDestTitleEnd} never excludes
+ * them.
+ */
+function hasPlausibleLinkOpener(
+  text: string,
+  closeBracketIndex: number,
+): boolean {
+  let paragraphStart = 0;
+  for (const match of text.matchAll(/\r?\n[ \t]*\r?\n/gu)) {
+    const matchEnd = match.index + match[0].length;
+    if (matchEnd > closeBracketIndex) {
+      break;
+    }
+    paragraphStart = matchEnd;
+  }
+  for (
+    let cursor = closeBracketIndex - 1;
+    cursor >= paragraphStart;
+    cursor -= 1
+  ) {
+    const character = text[cursor];
+    if (
+      (character === '[' || character === ']') &&
+      !isEscapedBacktick(text, cursor)
+    ) {
+      return character === '[';
+    }
+  }
+  return false;
+}
+
+/**
  * The end offset of an inline link's `(destination "title")` span starting
  * at `start` (which must hold `(`), bounded to `[start, end)`, or `null`
- * when `start` is not immediately preceded by a link text's closing `]`,
- * no valid destination/title matches there, or the match would span a
- * blank line (see {@link matchInlineHtmlTagEnd}'s identical guard and
- * rationale).
+ * when `start` is not immediately preceded by a plausible open link/image
+ * bracket (see {@link hasPlausibleLinkOpener}), no valid destination/title
+ * matches there, or the match would span a blank line (see
+ * {@link matchInlineHtmlTagEnd}'s identical guard and rationale). A
+ * link-shaped prefix that never reaches a valid destination/title/`)`
+ * (e.g. `[note](which uses \`code\`)`) leaves the whole match unresolved
+ * and falls through to ordinary text, leaving that backtick pair a genuine
+ * code span (`gh api /markdown` confirms GitHub renders exactly that).
  */
 function matchInlineLinkDestTitleEnd(
   text: string,
   start: number,
   end: number,
 ): number | null {
-  if (text[start - 1] !== ']') {
+  if (text[start - 1] !== ']' || !hasPlausibleLinkOpener(text, start - 1)) {
     return null;
   }
-  const remainder = text.slice(start, end);
-  const match = INLINE_LINK_DEST_TITLE_PATTERN.exec(remainder);
-  if (match === null) {
+  const leadingWhitespace = /^[ \t\r\n]*/u.exec(text.slice(start + 1, end));
+  let cursor = start + 1 + (leadingWhitespace?.[0].length ?? 0);
+  const angleMatch = INLINE_LINK_ANGLE_DESTINATION_PATTERN.exec(
+    text.slice(cursor, end),
+  );
+  cursor =
+    angleMatch !== null
+      ? cursor + angleMatch[0].length
+      : scanBareLinkDestinationEnd(text, cursor, end);
+  const rest = INLINE_LINK_TITLE_AND_CLOSE_PATTERN.exec(
+    text.slice(cursor, end),
+  );
+  if (rest === null) {
     return null;
   }
-  const matchEnd = start + match[0].length;
+  const matchEnd = cursor + rest[0].length;
   return hasBlankLine(text, start, matchEnd) ? null : matchEnd;
 }
 
@@ -2031,14 +2136,19 @@ function findInlineCodeRanges(
     // #2865: skip an inline HTML tag or a link's own destination/title span
     // entirely before ever considering a backtick inside it as a code-span
     // delimiter -- CommonMark's raw-HTML and link rules take precedence
-    // over the code-span rule there.
-    if (text[cursor] === '<') {
+    // over the code-span rule there. Codex review (round 1, databaseId
+    // 3978211270): an escaped `<` or `(` (`\<span title="`x`">`,
+    // `foo\(bar` `x` `)`) is ordinary text per CommonMark, never the start
+    // of raw HTML or a link's destination/title, so a backtick inside it
+    // stays a genuine code-span candidate -- skip the exclusion entirely
+    // when the opening character itself is escaped.
+    if (text[cursor] === '<' && !isEscapedBacktick(text, cursor)) {
       const tagEnd = matchInlineHtmlTagEnd(text, cursor, end);
       if (tagEnd !== null) {
         cursor = tagEnd;
         continue;
       }
-    } else if (text[cursor] === '(') {
+    } else if (text[cursor] === '(' && !isEscapedBacktick(text, cursor)) {
       const linkEnd = matchInlineLinkDestTitleEnd(text, cursor, end);
       if (linkEnd !== null) {
         cursor = linkEnd;

--- a/src/scripts/markdown-code.mts
+++ b/src/scripts/markdown-code.mts
@@ -2007,6 +2007,15 @@ const INLINE_LINK_TITLE_AND_CLOSE_PATTERN = new RegExp(
  */
 const MAX_LINK_SCAN_LENGTH = 2000;
 
+// CommonMark §2.4: only an ASCII punctuation character may be
+// backslash-escaped; a backslash before anything else (including
+// whitespace) is a literal backslash, not an escape (Codex review, PR
+// #2869 round 3, databaseId 3978515897): `gh api /markdown` confirms
+// `[x](foo\ bar "`node --test`")` renders entirely as literal text with a
+// genuine code span for the backticks -- `\` before a space never escapes
+// it, so the space still ends the bare destination.
+const ASCII_PUNCTUATION_PATTERN = /[!-/:-@[-`{-~]/u;
+
 /**
  * The end offset of a bare (non-angle-bracket) link destination starting at
  * `start`, honoring CommonMark's rule that parens are allowed there only
@@ -2030,7 +2039,11 @@ function scanBareLinkDestinationEnd(
   let depth = 0;
   while (cursor < bound) {
     const character = text[cursor];
-    if (character === '\\' && cursor + 1 < bound) {
+    if (
+      character === '\\' &&
+      cursor + 1 < bound &&
+      ASCII_PUNCTUATION_PATTERN.test(text[cursor + 1] ?? '')
+    ) {
       cursor += 2;
       continue;
     }
@@ -2069,7 +2082,21 @@ function scanBareLinkDestinationEnd(
  * True when `closeBracketIndex` (which must hold `]`) is the properly
  * balanced close of an earlier unescaped `[` -- a plausible open link/image
  * bracket -- within the current paragraph (a link's own `[...]` text can
- * never cross a blank line) and within {@link MAX_LINK_SCAN_LENGTH}.
+ * never cross a blank line) and within {@link MAX_LINK_SCAN_LENGTH} of
+ * `closeBracketIndex` (the paragraph search itself is bounded to that same
+ * trailing window, not the whole document -- Codex review, PR #2869 round
+ * 3, databaseId 3978515904: an unbounded `matchAll` over the full text on
+ * every call reintroduced quadratic behavior even after the backward
+ * bracket scan itself was bounded). `codeRanges` -- the genuine code-span
+ * ranges `findInlineCodeRanges` has already found to the left of this
+ * point in the same call -- lets the scan skip over an already-closed code
+ * span as one opaque unit rather than reading a bracket inside it as real
+ * Markdown structure (Codex review, PR #2869 round 3, databaseId
+ * 3978515893): `gh api /markdown` confirms `` `[foo` ](/url "`x`") ``
+ * renders `` `[foo` `` as its own real code span and `` `x` `` as a
+ * second, separate one -- the `[` inside the first span must never count
+ * as a link opener for the `]` that follows it.
+ *
  * Tracks nested-bracket depth while scanning backward, rather than
  * accepting or rejecting on the nearest bracket alone (Codex review, PR
  * #2869 round 2, databaseId 3978373742): `gh api /markdown` confirms a
@@ -2083,24 +2110,26 @@ function scanBareLinkDestinationEnd(
 function hasPlausibleLinkOpener(
   text: string,
   closeBracketIndex: number,
+  codeRanges: readonly MarkdownCodeRange[],
 ): boolean {
-  let paragraphStart = 0;
-  for (const match of text.matchAll(/\r?\n[ \t]*\r?\n/gu)) {
-    const matchEnd = match.index + match[0].length;
-    if (matchEnd > closeBracketIndex) {
-      break;
-    }
-    paragraphStart = matchEnd;
+  const searchFloor = Math.max(0, closeBracketIndex - MAX_LINK_SCAN_LENGTH);
+  const searchWindow = text.slice(searchFloor, closeBracketIndex);
+  let paragraphStart = searchFloor;
+  for (const match of searchWindow.matchAll(/\r?\n[ \t]*\r?\n/gu)) {
+    paragraphStart = searchFloor + match.index + match[0].length;
   }
-  const lowerBound = Math.max(
-    paragraphStart,
-    closeBracketIndex - MAX_LINK_SCAN_LENGTH,
-  );
+  let cursor = closeBracketIndex - 1;
   let depth = 0;
-  for (let cursor = closeBracketIndex - 1; cursor >= lowerBound; cursor -= 1) {
+  while (cursor >= paragraphStart) {
+    const enclosingCodeRange = getMarkdownCodeRange(text, cursor, codeRanges);
+    if (enclosingCodeRange !== null) {
+      cursor = enclosingCodeRange.start - 1;
+      continue;
+    }
     const character = text[cursor];
     if (character === ']' && !isEscapedBacktick(text, cursor)) {
       depth += 1;
+      cursor -= 1;
       continue;
     }
     if (character === '[' && !isEscapedBacktick(text, cursor)) {
@@ -2109,6 +2138,7 @@ function hasPlausibleLinkOpener(
       }
       depth -= 1;
     }
+    cursor -= 1;
   }
   return false;
 }
@@ -2124,13 +2154,18 @@ function hasPlausibleLinkOpener(
  * (e.g. `[note](which uses \`code\`)`) leaves the whole match unresolved
  * and falls through to ordinary text, leaving that backtick pair a genuine
  * code span (`gh api /markdown` confirms GitHub renders exactly that).
+ * `codeRanges` is forwarded to {@link hasPlausibleLinkOpener} unchanged.
  */
 function matchInlineLinkDestTitleEnd(
   text: string,
   start: number,
   end: number,
+  codeRanges: readonly MarkdownCodeRange[],
 ): number | null {
-  if (text[start - 1] !== ']' || !hasPlausibleLinkOpener(text, start - 1)) {
+  if (
+    text[start - 1] !== ']' ||
+    !hasPlausibleLinkOpener(text, start - 1, codeRanges)
+  ) {
     return null;
   }
   const leadingWhitespace = /^[ \t\r\n]*/u.exec(text.slice(start + 1, end));
@@ -2182,7 +2217,7 @@ function findInlineCodeRanges(
         continue;
       }
     } else if (text[cursor] === '(' && !isEscapedBacktick(text, cursor)) {
-      const linkEnd = matchInlineLinkDestTitleEnd(text, cursor, end);
+      const linkEnd = matchInlineLinkDestTitleEnd(text, cursor, end, ranges);
       if (linkEnd !== null) {
         cursor = linkEnd;
         continue;
@@ -2250,7 +2285,7 @@ export function findMarkdownCodeRanges(text: string): MarkdownCodeRange[] {
 export function getMarkdownCodeRange(
   text: string,
   position: number,
-  ranges: MarkdownCodeRange[] = findMarkdownCodeRanges(text),
+  ranges: readonly MarkdownCodeRange[] = findMarkdownCodeRanges(text),
 ): MarkdownCodeRange | null {
   if (!Number.isInteger(position) || position < 0 || position >= text.length) {
     return null;

--- a/src/scripts/markdown-code.mts
+++ b/src/scripts/markdown-code.mts
@@ -1327,6 +1327,17 @@ export function findHtmlBlockRanges(
   // this `true` for exactly that reason.
   let noOpenParagraph = true;
   let fencedRangeIndex = 0;
+  // #2865: mirrors blankFencedCodeBlocks's/findFencedCodeRanges's own
+  // inherited-list-content-indent tracker (see
+  // {@link createListContentIndentTrackerState}) so a block opener line
+  // with no list marker of its own (a continuation line of an
+  // already-open list item, e.g. an indented `<pre>` two lines below a
+  // `- Example:` bullet) still inherits that list's content indent
+  // instead of always reading `null` -- see {@link
+  // isHtmlBlockContainerEnded}'s call sites below for why an unfixed
+  // `null` here let an unclosed block's forward scan run past the list's
+  // real end, masking later genuine content.
+  const listTracker = createListContentIndentTrackerState();
 
   while (lineStart <= text.length) {
     const newlineIndex = text.indexOf('\n', lineStart);
@@ -1338,7 +1349,12 @@ export function findHtmlBlockRanges(
           : newlineIndex;
     const lineAfter = newlineIndex === -1 ? text.length : newlineIndex + 1;
     const line = text.slice(lineStart, lineEnd);
-    const isBlank = line.trim() === '';
+    // Content-based (blockquote-marker-stripped), matching
+    // blankFencedCodeBlocks's own `isBlank` derivation -- a lone `>` line
+    // (no content after the marker) is blank for list/blank-line-counting
+    // purposes even though the raw line itself is not whitespace-only.
+    const containerLine = parseContainerLine(line);
+    const isBlank = containerLine.content.trim() === '';
 
     while (
       fencedRangeIndex < fencedRanges.length &&
@@ -1356,6 +1372,9 @@ export function findHtmlBlockRanges(
       // review, PR #2840, round 16 -- corrects this round's own earlier
       // `false`): `gh api /markdown` confirms a type-7 tag right after a
       // closed fence, with no blank line between, still freely opens.
+      // The list-content-indent tracker is deliberately left untouched
+      // for opaque fence content, the same "frozen while inside a fence"
+      // choice blankFencedCodeBlocks itself makes for its own local fence.
       noOpenParagraph = true;
       lineStart = lineAfter;
       if (newlineIndex === -1) {
@@ -1363,6 +1382,17 @@ export function findHtmlBlockRanges(
       }
       continue;
     }
+
+    // Runs for every non-opaque line (blank or not) ahead of the
+    // per-branch dispatch below, so all four of that dispatch's own exits
+    // (raw-text/special/generic block open, and the plain fallthrough)
+    // see a tracker already advanced for *this* line -- reset (drop stale
+    // state) before reading, then adopt (record this line's own opener,
+    // if any) after, mirroring blankFencedCodeBlocks's identical
+    // ordering.
+    resetListContentIndentTrackerForLine(listTracker, containerLine, isBlank);
+    const trackedListContentIndent = listTracker.contentIndent;
+    adoptListContentIndentForLine(listTracker, containerLine);
 
     // Codex review, PR #2840 (round 20, widened round 22): does this
     // non-blank line, on its own, complete a one-line block that leaves
@@ -1396,7 +1426,7 @@ export function findHtmlBlockRanges(
     // comment for the masking bug this closes.
     let endsOwnBlock = false;
     if (!isBlank) {
-      const openerLine = parseContainerLine(line);
+      const openerLine = containerLine;
       const containerContent = openerLine.content;
       endsOwnBlock =
         (MARKDOWN_INDENTED_CODE_PRECEDER_PATTERN.test(containerContent) &&
@@ -1418,7 +1448,12 @@ export function findHtmlBlockRanges(
       // comment for why deriving it directly from this line (rather than
       // a cross-line tracker) is sufficient here.
       const openerContainerDepth = openerLine.containerDepth;
-      const openerListContentIndent = openerLine.listContentIndent;
+      // #2865: this opener line's own marker wins when present (no
+      // regression to the pre-fix behavior); otherwise inherit the
+      // tracker's carried indent from an earlier, still-open list item's
+      // own opener -- the continuation-line case this fix adds.
+      const openerListContentIndent =
+        openerLine.listContentIndent ?? trackedListContentIndent;
       const rawTag = rawTextOpenTag(content);
       const closeToken = specialHtmlBlockCloseToken(content);
       const opensGeneric =

--- a/src/scripts/markdown-code.mts
+++ b/src/scripts/markdown-code.mts
@@ -1995,6 +1995,19 @@ const INLINE_LINK_TITLE_AND_CLOSE_PATTERN = new RegExp(
 );
 
 /**
+ * Bound on how far {@link scanBareLinkDestinationEnd} and
+ * {@link hasPlausibleLinkOpener} scan before giving up, so a long run of
+ * unresolved link-like prefixes in untrusted issue-body text (adversarial
+ * or merely malformed, e.g. many `[x](` occurrences with no closing paren
+ * or whitespace) cannot make `findMarkdownCodeRanges` quadratic in body
+ * length (Codex review, PR #2869 round 2, databaseId 3978373746: ~2.7s for
+ * a single 64 KB instance without this bound, and discovery/triage
+ * processes untrusted issue bodies routinely). Far beyond any legitimate
+ * CommonMark link destination or link-text length in practice.
+ */
+const MAX_LINK_SCAN_LENGTH = 2000;
+
+/**
  * The end offset of a bare (non-angle-bracket) link destination starting at
  * `start`, honoring CommonMark's rule that parens are allowed there only
  * when backslash-escaped or part of an arbitrarily-nested balanced pair
@@ -2002,18 +2015,22 @@ const INLINE_LINK_TITLE_AND_CLOSE_PATTERN = new RegExp(
  * destination with two nesting levels) -- manual scanning, rather than a
  * fixed-depth regex alternative, generalizes to any nesting depth. Stops
  * at the first whitespace or unbalanced (closing) `)`, which belongs to
- * the enclosing link syntax, not the destination.
+ * the enclosing link syntax, not the destination. Returns `null` instead
+ * of a position when the scan reaches {@link MAX_LINK_SCAN_LENGTH} without
+ * finding either terminator -- the caller treats that the same as no valid
+ * destination.
  */
 function scanBareLinkDestinationEnd(
   text: string,
   start: number,
   end: number,
-): number {
+): number | null {
+  const bound = Math.min(end, start + MAX_LINK_SCAN_LENGTH);
   let cursor = start;
   let depth = 0;
-  while (cursor < end) {
+  while (cursor < bound) {
     const character = text[cursor];
-    if (character === '\\' && cursor + 1 < end) {
+    if (character === '\\' && cursor + 1 < bound) {
       cursor += 2;
       continue;
     }
@@ -2024,7 +2041,7 @@ function scanBareLinkDestinationEnd(
     }
     if (character === ')') {
       if (depth === 0) {
-        break;
+        return cursor;
       }
       depth -= 1;
       cursor += 1;
@@ -2036,26 +2053,32 @@ function scanBareLinkDestinationEnd(
       character === '\r' ||
       character === '\n'
     ) {
-      break;
+      return cursor;
     }
     cursor += 1;
   }
-  return cursor;
+  // Reached the scan bound (the {@link MAX_LINK_SCAN_LENGTH} cap or the
+  // caller's own `end`) without finding a real terminator -- never a valid
+  // destination; the caller's own title/close match would fail on this
+  // position anyway, but returning `null` here makes that fail-closed
+  // outcome explicit rather than incidental.
+  return null;
 }
 
 /**
- * True when the nearest earlier unescaped `[` or `]` before
- * `closeBracketIndex` -- bounded by the start of the current paragraph,
- * since a link's own `[...]` text can never cross a blank line -- is a
- * `[`, a plausible open link/image bracket for the `]` at
- * `closeBracketIndex`. A bounded heuristic (nearest-bracket, not full
- * CommonMark link-text balance/precedence parsing), but it resolves the
- * two shapes Codex review round 1 (databaseId 3978211256) flagged: `gh api
- * /markdown` confirms `foo](/url "`x`")` (no `[` at all) and
- * `\[test](/url "`x`")` (the `[` itself escaped) both render their
- * backticks as a genuine code span, never a link -- this must return
- * `false` for both so {@link matchInlineLinkDestTitleEnd} never excludes
- * them.
+ * True when `closeBracketIndex` (which must hold `]`) is the properly
+ * balanced close of an earlier unescaped `[` -- a plausible open link/image
+ * bracket -- within the current paragraph (a link's own `[...]` text can
+ * never cross a blank line) and within {@link MAX_LINK_SCAN_LENGTH}.
+ * Tracks nested-bracket depth while scanning backward, rather than
+ * accepting or rejecting on the nearest bracket alone (Codex review, PR
+ * #2869 round 2, databaseId 3978373742): `gh api /markdown` confirms a
+ * nested label such as `[foo [bar] baz](/url "..)")` is a real link, whose
+ * inner `[bar]` must not be mistaken for -- or block reaching -- the real
+ * outer opener. Also still resolves round 1's two shapes (databaseId
+ * 3978211256): `foo](/url "`x`")` (no `[` at all) and `\[test](/url
+ * "`x`")` (the `[` itself escaped) both render their backticks as a
+ * genuine code span, never a link, so this must return `false` for both.
  */
 function hasPlausibleLinkOpener(
   text: string,
@@ -2069,17 +2092,22 @@ function hasPlausibleLinkOpener(
     }
     paragraphStart = matchEnd;
   }
-  for (
-    let cursor = closeBracketIndex - 1;
-    cursor >= paragraphStart;
-    cursor -= 1
-  ) {
+  const lowerBound = Math.max(
+    paragraphStart,
+    closeBracketIndex - MAX_LINK_SCAN_LENGTH,
+  );
+  let depth = 0;
+  for (let cursor = closeBracketIndex - 1; cursor >= lowerBound; cursor -= 1) {
     const character = text[cursor];
-    if (
-      (character === '[' || character === ']') &&
-      !isEscapedBacktick(text, cursor)
-    ) {
-      return character === '[';
+    if (character === ']' && !isEscapedBacktick(text, cursor)) {
+      depth += 1;
+      continue;
+    }
+    if (character === '[' && !isEscapedBacktick(text, cursor)) {
+      if (depth === 0) {
+        return true;
+      }
+      depth -= 1;
     }
   }
   return false;
@@ -2110,10 +2138,15 @@ function matchInlineLinkDestTitleEnd(
   const angleMatch = INLINE_LINK_ANGLE_DESTINATION_PATTERN.exec(
     text.slice(cursor, end),
   );
-  cursor =
-    angleMatch !== null
-      ? cursor + angleMatch[0].length
-      : scanBareLinkDestinationEnd(text, cursor, end);
+  if (angleMatch !== null) {
+    cursor += angleMatch[0].length;
+  } else {
+    const destinationEnd = scanBareLinkDestinationEnd(text, cursor, end);
+    if (destinationEnd === null) {
+      return null;
+    }
+    cursor = destinationEnd;
+  }
   const rest = INLINE_LINK_TITLE_AND_CLOSE_PATTERN.exec(
     text.slice(cursor, end),
   );

--- a/tests/discover-shared-file-overlap.test.mts
+++ b/tests/discover-shared-file-overlap.test.mts
@@ -444,6 +444,25 @@ test('parseCandidateFileEntries still de-dupes an exact repeated raw spelling', 
   ]);
 });
 
+test('parseCandidateFileEntries excludes an HTML-attribute-embedded backtick path (#2865)', () => {
+  // `gh api /markdown` confirms `<span title="`package.json`">not a
+  // candidate</span>` keeps its backticks literal inside the attribute
+  // value -- never a rendered code span, so `package.json` here is not a
+  // real candidate file, even though a naive backtick-pair scan would
+  // extract it as one.
+  const body =
+    '## Candidate files\n\n<span title="`package.json`">not a candidate</span>\n';
+  assert.deepEqual(parseCandidateFileEntries(body), []);
+});
+
+test('parseCandidateFileEntries still extracts a real candidate path alongside an HTML-attribute-embedded backtick (#2865)', () => {
+  const body =
+    '## Candidate files\n\n- `src/scripts/foo.mts`\n<span title="`package.json`">not a candidate</span>\n';
+  assert.deepEqual(parseCandidateFileEntries(body), [
+    { raw: 'src/scripts/foo.mts', normalized: 'src/scripts/foo.mts' },
+  ]);
+});
+
 test('parseCandidateFiles applies its own normalized-key dedup on top of parseCandidateFileEntries (Codex review, PR #2840 round 9)', () => {
   // parseCandidateFileEntries now keeps every distinct raw spelling
   // (including two that share a normalized key), so parseCandidateFiles

--- a/tests/markdown-code.test.mts
+++ b/tests/markdown-code.test.mts
@@ -1265,3 +1265,46 @@ test('findHtmlBlockRanges stops an unclosed raw-text block at an inherited list-
   assert.equal(masked.includes('Acceptance criteria'), true);
   assert.equal(masked.includes('[ ] one'), true);
 });
+
+// --- #2865 review-fix (Codex review, round 1): four correctness gaps in
+// the round-4 matchers above, each verified against `gh api /markdown`.
+
+test('findMarkdownCodeRanges: a link destination with two levels of nested balanced parens still masks the title backticks (databaseId 3978211245)', () => {
+  // `gh api /markdown` confirms `/foo(a(b)c)` survives as a real
+  // destination (`<a href="/foo(a(b)c)" title="`node --test`">`) --
+  // the fixed-depth regex this replaced under-matched here, wrongly
+  // restoring the title's backticks as a real code span.
+  const body = 'See [test](/foo(a(b)c) "`node --test`") for details.\n';
+  assert.deepEqual(findMarkdownCodeRanges(body), []);
+});
+
+test('findMarkdownCodeRanges: a bare `]` with no link opener leaves its backtick pair a real span (databaseId 3978211256)', () => {
+  // `gh api /markdown` confirms `foo](/url "`node --test`")` renders
+  // `foo](/url "` as literal text and `` `node --test` `` as a genuine
+  // code span -- never a link, since no `[` precedes the `]` at all.
+  const body = 'foo](/url "`node --test`")\n';
+  const ranges = findMarkdownCodeRanges(body);
+  assert.equal(ranges.length, 1);
+  assert.equal(body.slice(ranges[0].start, ranges[0].end), '`node --test`');
+});
+
+test('findMarkdownCodeRanges: an escaped `[` before `]` leaves its backtick pair a real span (databaseId 3978211256)', () => {
+  // `gh api /markdown` confirms `\[test](/url "`node --test`")` renders
+  // the escaped bracket as literal `[test](/url "` text, with a genuine
+  // code span for the backticks -- the escaped `[` is not a real link
+  // opener.
+  const body = '\\[test](/url "`node --test`")\n';
+  const ranges = findMarkdownCodeRanges(body);
+  assert.equal(ranges.length, 1);
+  assert.equal(body.slice(ranges[0].start, ranges[0].end), '`node --test`');
+});
+
+test('findMarkdownCodeRanges: an escaped `<` leaves its backtick pair a real span (databaseId 3978211270)', () => {
+  // `gh api /markdown` confirms `\<span title="`node --test`">` renders
+  // the escaped angle bracket as literal `&lt;span title="` text, with a
+  // genuine code span for the backticks -- never raw HTML.
+  const body = '\\<span title="`node --test`">\n';
+  const ranges = findMarkdownCodeRanges(body);
+  assert.equal(ranges.length, 1);
+  assert.equal(body.slice(ranges[0].start, ranges[0].end), '`node --test`');
+});

--- a/tests/markdown-code.test.mts
+++ b/tests/markdown-code.test.mts
@@ -1337,3 +1337,48 @@ test('findMarkdownCodeRanges: many unresolved link-like prefixes stay linear, no
     `expected a bounded scan to stay well under 2s, took ${elapsedMs}ms`,
   );
 });
+
+// --- #2865 review-fix (Codex review, round 3): a bracket inside an
+// earlier code span, an invalid (non-punctuation) escape in a bare
+// destination, and a still-unbounded paragraph search.
+
+test('findMarkdownCodeRanges: a bracket inside an earlier code span is not a link opener (databaseId 3978515893)', () => {
+  // `gh api /markdown` confirms `` `[foo` ](/url "`node --test`") `` is
+  // TWO separate real code spans (`` `[foo` `` and `` `node --test` ``)
+  // with plain text between them -- the `[` inside the first span is
+  // literal code content, not a real Markdown bracket, so it must never
+  // count as a link opener for the `]` that follows.
+  const body = '`[foo` ](/url "`node --test`")\n';
+  const ranges = findMarkdownCodeRanges(body);
+  assert.equal(ranges.length, 2);
+  assert.equal(body.slice(ranges[0].start, ranges[0].end), '`[foo`');
+  assert.equal(body.slice(ranges[1].start, ranges[1].end), '`node --test`');
+});
+
+test('findMarkdownCodeRanges: a backslash before a non-punctuation character in a bare destination is literal (databaseId 3978515897)', () => {
+  // `gh api /markdown` confirms `[x](foo\ bar "`node --test`")` renders
+  // entirely as literal text with a genuine code span for the backticks
+  // -- CommonMark only allows backslash-escaping ASCII punctuation, so
+  // `\` before a space is a literal backslash and the space still ends
+  // the bare destination, breaking this out of link syntax entirely.
+  const body = '[x](foo\\ bar "`node --test`")\n';
+  const ranges = findMarkdownCodeRanges(body);
+  assert.equal(ranges.length, 1);
+  assert.equal(body.slice(ranges[0].start, ranges[0].end), '`node --test`');
+});
+
+test('findMarkdownCodeRanges: many unresolved link-like prefixes stay linear even with the paragraph-boundary search (databaseId 3978515904)', () => {
+  // Same pathological shape as the round-2 performance test above, but
+  // specifically exercising that hasPlausibleLinkOpener's own
+  // paragraph-start search is bounded to the trailing scan window, not
+  // the whole document, on every one of the 20000 calls this makes.
+  const body = '[x]('.repeat(20000);
+  const start = Date.now();
+  const ranges = findMarkdownCodeRanges(body);
+  const elapsedMs = Date.now() - start;
+  assert.deepEqual(ranges, []);
+  assert.ok(
+    elapsedMs < 2000,
+    `expected a bounded scan to stay well under 2s, took ${elapsedMs}ms`,
+  );
+});

--- a/tests/markdown-code.test.mts
+++ b/tests/markdown-code.test.mts
@@ -1170,3 +1170,33 @@ test('findHtmlBlockRanges returns [] for a body with no HTML blocks', () => {
   const body = '## Acceptance criteria\n\n- [ ] one\n- [ ] two\n';
   assert.deepEqual(findHtmlBlockRanges(body), []);
 });
+
+// --- #2865: inherit an HTML block's list content indent on a
+// continuation-line opener (no marker of its own).
+
+test('findHtmlBlockRanges stops an unclosed raw-text block at an inherited list-item container end with no marker on the opener line itself (#2865)', () => {
+  // Same failure class as the existing round-15 `- <pre>` test above, but
+  // the `<pre>` opener line itself carries no list marker -- it is a
+  // continuation line of the `- Example:` item two lines above, separated
+  // only by one blank line (still within the list's own content zone).
+  // `gh api /markdown` confirms the rendered `<pre>` stays scoped inside
+  // the list item (`<li><p>Example:</p><pre>still open</pre></li>`) and
+  // the heading below renders as real structure, never swallowed.
+  const body = [
+    '- Example:',
+    '',
+    '  <pre>',
+    '  still open',
+    '',
+    '## Acceptance criteria',
+    '',
+    '- [ ] one',
+    '- [ ] two',
+  ].join('\n');
+  const ranges = findHtmlBlockRanges(body);
+  assert.equal(ranges.length, 1);
+  const masked = maskMarkdownCodeRegionsPreservingPositions(body, ranges);
+  assert.equal(masked.includes('still open'), false);
+  assert.equal(masked.includes('Acceptance criteria'), true);
+  assert.equal(masked.includes('[ ] one'), true);
+});

--- a/tests/markdown-code.test.mts
+++ b/tests/markdown-code.test.mts
@@ -1308,3 +1308,32 @@ test('findMarkdownCodeRanges: an escaped `<` leaves its backtick pair a real spa
   assert.equal(ranges.length, 1);
   assert.equal(body.slice(ranges[0].start, ranges[0].end), '`node --test`');
 });
+
+// --- #2865 review-fix (Codex review, round 2): balanced-bracket link
+// opener and a bounded scan against quadratic behavior on malformed input.
+
+test('findMarkdownCodeRanges: a nested balanced-bracket link label still masks the title backticks (databaseId 3978373742)', () => {
+  // `gh api /markdown` confirms `[foo [bar] baz](/url "`node --test`")` is
+  // a real link (nested balanced brackets are valid link-text content) --
+  // the nearest-bracket heuristic this replaces wrongly rejected the real
+  // outer `[` because it hit the inner `]` first.
+  const body = '[foo [bar] baz](/url "`node --test`")\n';
+  assert.deepEqual(findMarkdownCodeRanges(body), []);
+});
+
+test('findMarkdownCodeRanges: many unresolved link-like prefixes stay linear, not quadratic (databaseId 3978373746)', () => {
+  // A pathological run of `[x](` with no closing paren or whitespace
+  // anywhere -- each occurrence previously invoked an unbounded forward
+  // scan over the entire remaining text. 20000 repetitions (80 KB) must
+  // complete well within a normal test timeout; a quadratic regression
+  // here would make this hang or take seconds, not milliseconds.
+  const body = '[x]('.repeat(20000);
+  const start = Date.now();
+  const ranges = findMarkdownCodeRanges(body);
+  const elapsedMs = Date.now() - start;
+  assert.deepEqual(ranges, []);
+  assert.ok(
+    elapsedMs < 2000,
+    `expected a bounded scan to stay well under 2s, took ${elapsedMs}ms`,
+  );
+});

--- a/tests/markdown-code.test.mts
+++ b/tests/markdown-code.test.mts
@@ -1171,8 +1171,73 @@ test('findHtmlBlockRanges returns [] for a body with no HTML blocks', () => {
   assert.deepEqual(findHtmlBlockRanges(body), []);
 });
 
-// --- #2865: inherit an HTML block's list content indent on a
-// continuation-line opener (no marker of its own).
+// --- #2865: mask HTML-attribute and inline-link-title/destination backticks,
+// and inherit an HTML block's list content indent on a continuation-line
+// opener. All shapes below verified against `gh api /markdown` (mode: gfm)
+// before implementation.
+
+test('findMarkdownCodeRanges: an HTML-attribute-embedded backtick command is not a real code span (#2865)', () => {
+  // `gh api /markdown` confirms `<span title="`node --test`"></span>`
+  // keeps its backticks literal inside the attribute value -- CommonMark's
+  // raw-HTML inline rule takes precedence over the code-span rule there.
+  const body =
+    '## Acceptance criteria\n\n<span title="`node --test`"></span>\n';
+  assert.deepEqual(findMarkdownCodeRanges(body), []);
+});
+
+test('findMarkdownCodeRanges: an inline-link title/destination-embedded backtick is not a real code span (#2865)', () => {
+  // `gh api /markdown` confirms `[test](/url "`node --test`")` renders as
+  // `<a href="/url" title="`node --test`">test</a>`, backticks literal.
+  const body = 'See [test](/url "`node --test`") for details.\n';
+  assert.deepEqual(findMarkdownCodeRanges(body), []);
+});
+
+test('findMarkdownCodeRanges: an inline-link destination with a balanced nested paren still masks the title backticks (#2865)', () => {
+  // `gh api /markdown` confirms `/wiki/Example_(disambiguation)` survives
+  // as a real destination (CommonMark allows one balanced, unescaped
+  // paren pair in a bare destination), with the title's backticks still
+  // literal: `<a href="/wiki/Example_(disambiguation)" title="`node
+  // --test`">`.
+  const body =
+    'See [wiki](/wiki/Example_(disambiguation) "`node --test`") page.\n';
+  assert.deepEqual(findMarkdownCodeRanges(body), []);
+});
+
+test('findMarkdownCodeRanges: a real code span right next to an excluded HTML tag is still found (control, #2865)', () => {
+  // `gh api /markdown` confirms `` `real` `` renders as a genuine
+  // `<code>` span immediately followed by the (backtick-literal) `<span>`
+  // tag -- the new exclusion must not swallow adjacent real content.
+  const body = 'Prefix `real` <span title="`fake`"></span> suffix.\n';
+  const ranges = findMarkdownCodeRanges(body);
+  assert.equal(ranges.length, 1);
+  assert.equal(body.slice(ranges[0].start, ranges[0].end), '`real`');
+});
+
+test('findMarkdownCodeRanges: a link-shaped prefix that never reaches a valid title/close fails closed, leaving its backtick pair a real span (#2865)', () => {
+  // `gh api /markdown` confirms `[note](which uses `code`)` renders
+  // `[note](which uses` as literal text, a real `<code>` span for
+  // `` `code` ``, then a literal `)` -- never a link at all, since the
+  // text after the destination never resolves to a valid title or a
+  // direct closing `)`.
+  const body = '[note](which uses `code`)\n';
+  const ranges = findMarkdownCodeRanges(body);
+  assert.equal(ranges.length, 1);
+  assert.equal(body.slice(ranges[0].start, ranges[0].end), '`code`');
+});
+
+test('findMarkdownCodeRanges: an HTML tag match never spans a blank line, so a backtick pair on the far side stays a real span (#2865)', () => {
+  // `gh api /markdown` confirms `<span title="` / (blank) / `` `node
+  // --test`"> `` never forms one tag (CommonMark parses block structure,
+  // including where a blank line ends a paragraph, before inline
+  // content) -- it renders as two literal-text paragraphs, the second of
+  // which contains a genuine `<code>` span. Without the blank-line guard,
+  // the tag-matching regex's own quoted-value character class would
+  // otherwise happily span the blank line and swallow this real span.
+  const body = '<span title="\n\n`node --test`">\n';
+  const ranges = findMarkdownCodeRanges(body);
+  assert.equal(ranges.length, 1);
+  assert.equal(body.slice(ranges[0].start, ranges[0].end), '`node --test`');
+});
 
 test('findHtmlBlockRanges stops an unclosed raw-text block at an inherited list-item container end with no marker on the opener line itself (#2865)', () => {
   // Same failure class as the existing round-15 `- <pre>` test above, but

--- a/tests/triage-structural-evidence.test.mts
+++ b/tests/triage-structural-evidence.test.mts
@@ -76,6 +76,16 @@ test('hasVerificationCommandSignal: false on an unrelated code span in AC', () =
   assert.equal(hasVerificationCommandSignal(body), false);
 });
 
+test('hasVerificationCommandSignal: false on an HTML-attribute-embedded backtick command (#2865)', () => {
+  // `gh api /markdown` confirms `<span title="`node --test`"></span>`
+  // keeps its backticks literal inside the attribute value -- CommonMark's
+  // raw-HTML inline rule takes precedence over the code-span rule there,
+  // so this is never a real code span GitHub renders as verification
+  // evidence.
+  const body = `## Acceptance criteria\n\n<span title="\`node --test\`"></span>\n`;
+  assert.equal(hasVerificationCommandSignal(body), false);
+});
+
 test('hasVerificationCommandSignal: a command in a LATER section does not count', () => {
   const body = `## Acceptance criteria\n\n- [ ] Only one thing\n\n## Candidate files\n\n- \`node --test tests/foo.test.mts\`\n`;
   assert.equal(hasVerificationCommandSignal(body), false);


### PR DESCRIPTION
## Summary

Fixes the three deferred structural-evidence masking gaps from PR
#2840's review, plus one additional confirmed instance the issue
author posted as a follow-up comment (same category, same function):

1. **HTML-attribute-embedded backtick command spans** —
   `findMarkdownCodeRanges` treated a backtick pair inside an HTML
   tag's attribute value (e.g. `<span title="`node --test`"></span>`)
   as a genuine inline code span, even though CommonMark's raw-HTML
   inline rule renders those backticks as literal attribute text. This
   let a fake verification-command signal demote a genuine
   `hasVerificationCommandSignal` failure to a warning.
2. **HTML-attribute-embedded backtick candidate-file paths** — the
   same masking gap let `parseCandidateFileEntries` extract a bogus
   candidate-file path from an HTML tag's attribute value.
3. **Inherited list container not tracked for HTML blocks** —
   `findHtmlBlockRanges` only read `openerLine.listContentIndent` from
   the *current* line's own list marker, so an unclosed HTML block
   opened on a list item's continuation line (no marker of its own)
   could mask a later, genuine `## Acceptance criteria` or
   `## Candidate files` section all the way through EOF.
4. **Inline-link title/destination backticks** (confirmed follow-up
   comment on the issue, same category as #1) — the same masking gap
   for a link's own `(destination "title")` span, e.g.
   `[test](/url "`node --test`")`.

The "probable sibling" flagged in a second follow-up comment
(`findIndentedCodeRanges`'s `previousLineBlockBoundary` handling) is
explicitly marked "not verified yet" by the issue author and lives in
a different mechanism (Setext-ambiguity tracking) — left out of scope
here; worth a separate issue if confirmed later.

Every masking shape addressed here (including new control/edge cases
found during an independent critique pass — a blank-line guard for the
new matchers, and a balanced-nested-paren destination case) was
verified against `gh api /markdown` (`mode: gfm`) before being written
into a test, per this repository's established review discipline.

## Changes

- `src/scripts/markdown-code.mts`: `findHtmlBlockRanges` now inherits
  an active list's content indent via the existing
  `ListContentIndentTrackerState` tracker when the opener line carries
  no marker of its own (gap 3). `findInlineCodeRanges` now skips a
  matched CommonMark inline HTML tag or inline-link
  destination/title span before ever considering a backtick inside it
  a code-span delimiter, with a blank-line guard since neither
  construct can legitimately span one (gaps 1 and 4).
- `src/scripts/discover-shared-file-overlap.mts`:
  `parseCandidateFileEntries` now accepts a backtick-pair match only
  when it is fully contained in a genuine `findMarkdownCodeRanges`
  code-span range (gap 2).
- Tests added to `tests/markdown-code.test.mts`,
  `tests/triage-structural-evidence.test.mts`, and
  `tests/discover-shared-file-overlap.test.mts` for all four gaps plus
  control/edge cases (a real code span adjacent to an excluded
  construct, a link-shaped prefix that fails closed, and the
  blank-line guard).

## Test plan

- [x] `node --test tests/*.test.mts` (5850 tests, full suite)
- [x] `pnpm run typecheck`
- [x] `pnpm run build:check`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `node scripts/idd-doctor.mjs` (only pre-existing, unrelated
      warnings)
- [x] `node scripts/token-cost-report.mjs --check`
- [x] Every new masking shape verified against `gh api /markdown`
      before implementation

## Known limitations

A few narrower masking shapes surfaced during review and were
deliberately left unfixed because the failure direction is
fail-closed (a real code span or candidate path gets hidden, which
only makes structural evidence *weaker* — never fabricates fake
evidence the way this issue's original bug did):

- A nested list's content indent is tracked with a single-value
  `ListContentIndentTrackerState`, not a stack, so a doubly-nested
  list transition can still mis-track `findHtmlBlockRanges`'s opener
  indent in principle (flagged in review, not independently
  reproduced).
- An escaped closing bracket immediately before a `(destination
  "title")`, e.g. `` [foo\](/url "`node --test`") ``, is still
  accepted as a link opener by `hasPlausibleLinkOpener`, wrongly
  excluding the genuine trailing code span.
- CommonMark's link-activation/nesting-deactivation rule isn't
  tracked, so a completed inner link like `` [foo [bar](baz)](/url
  "`node --test`") `` doesn't deactivate the outer bracket, again
  wrongly excluding the genuine trailing code span.

A correct fix for the last two requires CommonMark's own
bracket-activation/delimiter-stack tracking — effectively a link
parser — which is out of scope for this issue's HTML-attribute and
link-title backtick shapes. Worth a follow-up issue if a real
false-negative surfaces from one of these in practice.

Closes #2865

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EycqtGKuWjJMpw2tUav3Tn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown parsing to correctly distinguish code spans from backticks in HTML attributes, links, destinations, and titles.
  * Improved handling of escaped punctuation, nested links, list indentation, blockquotes, and malformed link-like content.
  * Prevented command-like text inside HTML attributes from being treated as verification evidence.
  * Improved candidate path detection to exclude backticks in non-code Markdown contexts.

* **Tests**
  * Added regression coverage for Markdown boundaries, HTML masking, nested links, escaped delimiters, and performance with unresolved links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
