### PR TITLE
docs(idd-ci): broaden Wake-up discipline's scope sentence

### DIFF
--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -329,7 +329,11 @@ This advisory, tool-agnostic note keeps the **wait itself cheap**: the
 dominant cost is each re-invocation's context re-read (worse past the
 prompt-cache TTL), not the idle time. It applies to a session pushing a
 commit and waiting on CI or bot review outside a formal IDD claim too
-(issue `#2464`) — nothing below depends on being mid-phase.
+(issue `#2464`) — nothing below depends on being mid-phase. The same
+discipline covers any long-running foreground command a phase
+requires — CI polling, bot/advisory review waits, and local
+build/test/lint runs alike (see the local-command guidance below,
+issue `#2798`).
 
 **Portability**: under supervisor/worker topologies, a background
 wait's completion notification often reaches only the supervisor, so

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -324,7 +324,11 @@ This advisory, tool-agnostic note keeps the **wait itself cheap**: the
 dominant cost is each re-invocation's context re-read (worse past the
 prompt-cache TTL), not the idle time. It applies to a session pushing a
 commit and waiting on CI or bot review outside a formal IDD claim too
-(issue `#2464`) — nothing below depends on being mid-phase.
+(issue `#2464`) — nothing below depends on being mid-phase. The same
+discipline covers any long-running foreground command a phase
+requires — CI polling, bot/advisory review waits, and local
+build/test/lint runs alike (see the local-command guidance below,
+issue `#2798`).
 
 **Portability**: under supervisor/worker topologies, a background
 wait's completion notification often reaches only the supervisor, so


### PR DESCRIPTION
# Summary

The Wake-up discipline section's opening prose scoped itself only to a
session waiting on CI or bot review outside a formal IDD claim, even
though the section's own local-command guidance (added by issue #2798)
already covers a local build/test/lint wait too. A reader who skims
only the opening sentence could miss that the local-command guidance a
few paragraphs below is in scope.

Appends a new sentence to the opening paragraph naming any
long-running foreground command a phase requires -- CI polling,
bot/advisory review waits, and local build/test/lint runs alike -- as
in scope, without touching the existing issue-#2464-scoped sentence
or the issue-#2798 local-command guidance itself. Edits the canonical
source `idd-template/.github/instructions/idd-ci.instructions.md`
and regenerates the mirrored `.github/instructions/idd-ci.instructions.md`
via `node scripts/sync-docs.mjs --apply`.

Kept as a separate sentence rather than folded into the existing
"pushing a commit ... outside a claim" clause: an earlier B2-phase
critique pass on the plan flagged that folding it in would tie the
new local-wait scope to that clause's post-push, outside-a-claim
framing, while the actual issue-#2798 failure mode (a worker stalling
on a local run) is typically mid-phase and pre-push.

## Linked issue

Closes #2844

## Follow-up issues (if any)

- [ ] `idd-template/ONBOARDING.md`'s Step 5 boilerplate (the snippet
      operators paste into an adopting repo's own entry file) restates
      the same narrower "CI or bot review" enumeration and will read
      as non-exhaustive after this change. It is not in this issue's
      `## Candidate files` and stays correct (not wrong) even if
      non-exhaustive, so it is deliberately left unchanged here --
      noted as a documentation-completeness fast-follow candidate
      rather than filed as a separate issue for a single-line nit.

## Background / rationale (if material)

A C1 self-review pass confirmed the change satisfies all three of the
issue's acceptance criteria, stays within the two mirrored
`idd-ci.instructions.md` files, and does not duplicate or contradict
the unchanged `#2798` local-command bullet a few paragraphs below.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CK2SHn8Bir6VHrXrMVMdn3
