### PR TITLE
fix(idd-merge): avoid the idd-cleanup-evidence duplicate-comment race

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -350,13 +350,15 @@ Before any mutating action in F3, apply the
    node scripts/audit-pr-cleanup.mjs --pr <pr-number> --dry-run --format table
    ```
 
-   **Workflow-run pre-post check (#2846)**: before this rule (here and
-   below), check this PR's `post-merge-cleanup.yml` run, waiting
-   (bounded) for it to finish if still in flight — see
-   `docs/idd-comment-minimization.md`'s Workflow-run ownership check.
-   Its posting step's conclusion exactly `success`: skip the agent's
-   own post entirely — that run owns it. Otherwise (no run found, or
-   any other conclusion): continue to the rule below unchanged.
+   **Workflow-run pre-post check (#2846)**: immediately before actually
+   posting below (fresh each time, not cached from here — a run's
+   status can change during dry-run/apply), check this PR's
+   `post-merge-cleanup.yml` run, waiting (bounded) for it to finish if
+   still in flight — see `docs/idd-comment-minimization.md`'s
+   Workflow-run ownership check. Its posting step's conclusion exactly
+   `success`: skip the agent's own post entirely — that run owns it.
+   Otherwise (no run found, or any other conclusion): continue to the
+   rule below unchanged.
 
    **Duplicate-success-record skip rule**: before posting any evidence
    comment below, skip it if the PR already carries a

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -351,11 +351,12 @@ Before any mutating action in F3, apply the
    ```
 
    **Workflow-run pre-post check (#2846)**: before this rule (here and
-   below), check this PR's `post-merge-cleanup.yml` run — see
+   below), check this PR's `post-merge-cleanup.yml` run, waiting
+   (bounded) for it to finish if still in flight — see
    `docs/idd-comment-minimization.md`'s Workflow-run ownership check.
-   In flight, or completed with its posting step's conclusion exactly
-   `success`: skip the agent's own post entirely — that run owns it.
-   Otherwise continue to the rule below unchanged.
+   Its posting step's conclusion exactly `success`: skip the agent's
+   own post entirely — that run owns it. Otherwise (no run found, or
+   any other conclusion): continue to the rule below unchanged.
 
    **Duplicate-success-record skip rule**: before posting any evidence
    comment below, skip it if the PR already carries a

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -350,15 +350,14 @@ Before any mutating action in F3, apply the
    node scripts/audit-pr-cleanup.mjs --pr <pr-number> --dry-run --format table
    ```
 
-   **Workflow-run pre-post check (#2846)**: immediately before actually
+   **In-flight cleanup-run wait (#2846)**: immediately before actually
    posting below (fresh each time, not cached from here — a run's
-   status can change during dry-run/apply), check this PR's
-   `post-merge-cleanup.yml` run, waiting (bounded) for it to finish if
-   still in flight — see `docs/idd-comment-minimization.md`'s
-   Workflow-run ownership check. Its posting step's conclusion exactly
-   `success`: skip the agent's own post entirely — that run owns it.
-   Otherwise (no run found, or any other conclusion): continue to the
-   rule below unchanged.
+   status can change during dry-run/apply), check whether this PR's
+   `post-merge-cleanup.yml` run is still in flight, waiting (bounded)
+   for it to finish if so — see `docs/idd-comment-minimization.md`'s
+   In-flight cleanup-run wait. Either way, continue to the rule below
+   unchanged: it reads whatever that run may have posted and decides
+   ownership from the marker's own recorded status.
 
    **Duplicate-success-record skip rule**: before posting any evidence
    comment below, skip it if the PR already carries a

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -350,6 +350,13 @@ Before any mutating action in F3, apply the
    node scripts/audit-pr-cleanup.mjs --pr <pr-number> --dry-run --format table
    ```
 
+   **Workflow-run pre-post check (#2846)**: before this rule (here and
+   below), check this PR's `post-merge-cleanup.yml` run — see
+   `docs/idd-comment-minimization.md`'s Workflow-run ownership check.
+   In flight, or completed with its posting step's conclusion exactly
+   `success`: skip the agent's own post entirely — that run owns it.
+   Otherwise continue to the rule below unchanged.
+
    **Duplicate-success-record skip rule**: before posting any evidence
    comment below, skip it if the PR already carries a
    `<!-- idd-cleanup-evidence:` comment recording a successful outcome

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -301,18 +301,37 @@ gh pr checks <pr-number> --json workflow,bucket,link,startedAt --jq \
    | if length == 0 then empty
      elif any(.bucket == "pending") then (map(select(.bucket == "pending")) | .[0])
      else max_by(.startedAt) end
-   | [.bucket, (.link | sub(".*/runs/"; "") | sub("/job/.*"; ""))] | @tsv'
+   | [.bucket, (.link | capture("/runs/(?<id>[0-9]+)").id)] | @tsv'
 ```
+
+The `id` capture stops at the first non-digit character, so it stays
+correct whether the `link` continues with a `/job/<job-id>` segment or
+a bare query string such as `?check_suite_focus=true` — the same
+tolerant boundary `parseRunIdFromUrl`
+(`src/scripts/rerun-advisory-convergence.mts`) already uses for this
+exact URL shape.
 
 - **No output, or the lookup itself fails** (old `gh`, no network, a
   GitHub Enterprise Server version without this data): no visible run
   for this PR. Continue to the duplicate-success-record skip rule
   unchanged.
-- **First field is `pending`**: the run is in flight. Skip the agent's
-  own evidence-comment post entirely — let that run own it. No need to
-  run step 2 below.
-- **Any other first field** (a completed run): run step 2 below with
-  the second field as `<run-id>`.
+- **First field is `pending`**: the run is in flight. Do **not** skip
+  on this alone — an in-flight run can still finish without ever
+  running its posting step (see the `instructions-only` case below),
+  which would leave neither side posting. Wait for it to finish first
+  (`gh run watch <run-id>`), bounded by the same
+  `ciWait.runningTimeout` (default `PT30M`, once started) /
+  `ciWait.generationTimeout` (default `PT10M`, while still queued)
+  windows `idd-ci.instructions.md`'s CI polling algorithm already
+  uses. Past that bound with the run still incomplete, treat it the
+  same as "no visible run" and continue to the duplicate-success-record
+  skip rule unchanged — a resulting duplicate comment is this check's
+  accepted fail-open default, the same one the other two "not found"
+  cases here already accept. Once the run finishes (immediately, or
+  after the wait above), evaluate it exactly like a completed run:
+  continue to step 2.
+- **Any other first field** (already completed): continue to step 2
+  with the second field as `<run-id>`.
 
 ```sh
 # 2. that run's posting-step conclusion

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -271,10 +271,13 @@ fresh evidence (preventive; no observed incident yet — #2043). The
 workflow's PR-keyed `concurrency` group only serializes workflow runs
 against each other; it does not gate the agent's local F4.
 
-**In-flight cleanup-run wait (#2846).** Before either side decides
-whether to post its own evidence comment (the duplicate-success-record
-rule above), also check whether this PR's own `post-merge-cleanup.yml`
-check run is still in flight — narrowing the residual race the
+**In-flight cleanup-run wait (#2846).** Before the agent's F4 step
+decides whether to post its own evidence comment (the
+duplicate-success-record rule above — only the agent can run this
+wait; the workflow itself cannot block on its own run without
+deadlocking), also check whether this PR's own
+`post-merge-cleanup.yml` check run is still in flight — narrowing the
+residual race the
 marker-comment check alone cannot fully close: a run that has started
 but not yet posted its comment leaves no marker for that rule to find,
 so without this earlier wait both sides can still post within the same
@@ -314,11 +317,14 @@ gh pr checks <pr-number> --json workflow,bucket --jq \
   any) and adjudicates on the marker's own recorded status, regardless
   of how the run itself concluded.
 - **`true`**: the run is in flight. Poll the same query at a reasonable
-  interval until it returns `false`, bounded by the same
-  `ciWait.runningTimeout` (default `PT30M`, once started) /
-  `ciWait.generationTimeout` (default `PT10M`, while still queued)
-  windows `idd-ci.instructions.md`'s CI polling algorithm already uses.
-  Past that bound with the run still in flight, treat it the same as
+  interval until it returns `false`, bounded by
+  `ciWait.generationTimeout` (default `PT10M`) measured from this
+  first `true` observation. A single bound suffices here — unlike the
+  longer-running checks `idd-ci.instructions.md`'s own polling
+  algorithm bounds with the queued/running split, this workflow's job
+  completes in roughly 15 seconds, so distinguishing a merely queued
+  run from an actually running one buys nothing at that scale. Past
+  that bound with the run still in flight, treat it the same as
   "not in flight" and continue to the duplicate-success-record skip
   rule unchanged — a resulting duplicate comment is this check's
   accepted fail-open default, the same one the "not in flight" case

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -279,9 +279,9 @@ finished doing so — closing the residual race the marker-comment check
 alone cannot: a run that has started but not yet posted its comment
 leaves no marker for that rule to find, so without this earlier check
 both sides can still post within the same few-second window after
-merge (the observed incident: a live CodeRabbit review caught exactly
-this duplicate `idd-cleanup-evidence` comment on
-`kurone-kito/dotfiles#396`).
+merge (observed 2026-09-09 on `kurone-kito/dotfiles#396`: a live
+CodeRabbit review caught exactly this duplicate `idd-cleanup-evidence`
+comment on an adopter's PR).
 
 `gh pr checks` surfaces this `pull_request_target`-triggered run as a
 normal PR check even though it fires after merge — verified on PR
@@ -596,9 +596,13 @@ merge does not re-block the merge; it is an explicit record only.
 Post this comment to the PR after a successful or partial apply. The
 HTML comment token on the first line acts as a stable machine-readable
 marker so a resuming agent — or a concurrent `post-merge-cleanup`
-workflow run — can detect that evidence was already posted. Both the
-**agent-side** F4 step and the `post-merge-cleanup` workflow key on the
-prior **success** record: **skip the post when the latest trusted
+workflow run — can detect that evidence was already posted. The
+[Workflow-run ownership check](#server-side-fallback-optional) above
+runs first, even earlier than this marker-based rule; reaching this
+rule at all already means that check found no run to defer to. Both
+the **agent-side** F4 step and the `post-merge-cleanup` workflow then
+key on the prior **success** record: **skip the post when the latest
+trusted
 `<!-- idd-cleanup-evidence:` comment records a successful outcome
 (`applied` / `clean`)**, so neither side stacks a duplicate success
 record — even when this run's own apply returned `applied` for residual

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -271,6 +271,82 @@ fresh evidence (preventive; no observed incident yet — #2043). The
 workflow's PR-keyed `concurrency` group only serializes workflow runs
 against each other; it does not gate the agent's local F4.
 
+**Workflow-run ownership check (#2846).** Before either side
+decides whether to post its own evidence comment (the
+duplicate-success-record rule above), also check whether this PR's own
+`post-merge-cleanup.yml` check run has already started posting or has
+finished doing so — closing the residual race the marker-comment check
+alone cannot: a run that has started but not yet posted its comment
+leaves no marker for that rule to find, so without this earlier check
+both sides can still post within the same few-second window after
+merge (the observed incident: a live CodeRabbit review caught exactly
+this duplicate `idd-cleanup-evidence` comment on
+`kurone-kito/dotfiles#396`).
+
+`gh pr checks` surfaces this `pull_request_target`-triggered run as a
+normal PR check even though it fires after merge — verified on PR
+`#2855`, 2026-09-10. Filter on whatever `name:` the adopter's own copy
+of the workflow actually declares; this repository's dogfooded copy
+and the template both currently say `Post-merge cleanup`. A
+`workflow_dispatch` rerun can add a second entry for the same
+workflow, so pick a single winning entry first: `pending` always wins
+outright (a still-running run always takes priority over an
+already-completed one); otherwise take the entry with the latest
+`startedAt`.
+
+```sh
+# 1. the winning entry's bucket and run id (from its own `link` URL)
+gh pr checks <pr-number> --json workflow,bucket,link,startedAt --jq \
+  'map(select(.workflow == "Post-merge cleanup"))
+   | if length == 0 then empty
+     elif any(.bucket == "pending") then (map(select(.bucket == "pending")) | .[0])
+     else max_by(.startedAt) end
+   | [.bucket, (.link | sub(".*/runs/"; "") | sub("/job/.*"; ""))] | @tsv'
+```
+
+- **No output, or the lookup itself fails** (old `gh`, no network, a
+  GitHub Enterprise Server version without this data): no visible run
+  for this PR. Continue to the duplicate-success-record skip rule
+  unchanged.
+- **First field is `pending`**: the run is in flight. Skip the agent's
+  own evidence-comment post entirely — let that run own it. No need to
+  run step 2 below.
+- **Any other first field** (a completed run): run step 2 below with
+  the second field as `<run-id>`.
+
+```sh
+# 2. that run's posting-step conclusion
+gh api "repos/{owner}/{repo}/actions/runs/<run-id>/jobs" --jq \
+  '.jobs[].steps[] | select(.name == "Post cleanup evidence comment") | .conclusion'
+```
+
+The posting step's own conclusion decides ownership for a completed
+run, not the check's overall `bucket` — two distinct failure modes
+would otherwise misclassify a run that never actually posted anything
+as one that did:
+
+- The template workflow skips its cleanup and evidence steps entirely
+  under an `instructions-only` (or ambiguous package-manager)
+  `helperRuntime.profile` — a job whose meaningful steps were all
+  skipped still reports a passing check.
+- The evidence-posting step itself runs under the default GitHub
+  Actions `bash -e`; its `COMMENTS_TSV=$(gh api --paginate ...)` read
+  is a plain assignment with no `set +e` guard, so a transient `gh
+  api` failure there (rate limit, network) aborts the step — and the
+  check run — before `gh pr comment` is ever reached.
+
+Only an exact `success` conclusion means the step actually ran to
+completion (whether it posted fresh evidence, or intentionally
+no-op'd because a success record already existed):
+
+- **`success`**: skip the agent's own post entirely — let that run own
+  it.
+- **Anything else** (`skipped`, `failure`, `cancelled`, no such step at
+  all — an older workflow copy, or an adopter's copy that renamed the
+  step, ...): that run did not reliably take ownership of posting.
+  Treat it the same as "no visible run" and continue to the
+  duplicate-success-record skip rule unchanged.
+
 ## GitHub mechanism
 
 GitHub GraphQL exposes `minimizeComment`:

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -311,6 +311,15 @@ tolerant boundary `parseRunIdFromUrl`
 (`src/scripts/rerun-advisory-convergence.mts`) already uses for this
 exact URL shape.
 
+- **A nonzero exit alone is not failure.** `gh pr checks` exits `8`
+  whenever _any_ check on the PR is still pending (its own documented
+  behavior — `gh pr checks --help`), even when this query's own
+  stdout is valid; a script that aborts under `set -e` on that exit
+  code, or that treats any nonzero status as "lookup failed", falls
+  through and skips the wait below entirely, leaving the race this
+  check exists to close. Capture and parse stdout regardless of exit
+  status; only _no parseable output at all_ counts as a lookup
+  failure.
 - **No output, or the lookup itself fails** (old `gh`, no network, a
   GitHub Enterprise Server version without this data): no visible run
   for this PR. Continue to the duplicate-success-record skip rule

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -271,45 +271,32 @@ fresh evidence (preventive; no observed incident yet — #2043). The
 workflow's PR-keyed `concurrency` group only serializes workflow runs
 against each other; it does not gate the agent's local F4.
 
-**Workflow-run ownership check (#2846).** Before either side
-decides whether to post its own evidence comment (the
-duplicate-success-record rule above), also check whether this PR's own
-`post-merge-cleanup.yml` check run has already started posting or has
-finished doing so — closing the residual race the marker-comment check
-alone cannot: a run that has started but not yet posted its comment
-leaves no marker for that rule to find, so without this earlier check
-both sides can still post within the same few-second window after
-merge (observed 2026-09-09 on `kurone-kito/dotfiles#396`: a live
-CodeRabbit review caught exactly this duplicate `idd-cleanup-evidence`
-comment on an adopter's PR).
+**In-flight cleanup-run wait (#2846).** Before either side decides
+whether to post its own evidence comment (the duplicate-success-record
+rule above), also check whether this PR's own `post-merge-cleanup.yml`
+check run is still in flight — narrowing the residual race the
+marker-comment check alone cannot fully close: a run that has started
+but not yet posted its comment leaves no marker for that rule to find,
+so without this earlier wait both sides can still post within the same
+few-second window after merge (observed 2026-09-09 on
+`kurone-kito/dotfiles#396`: a live CodeRabbit review caught exactly
+this duplicate `idd-cleanup-evidence` comment on an adopter's PR). This
+wait only narrows the window, it does not close it: GitHub registers
+the check run asynchronously after the triggering webhook fires, so a
+run that has not yet been created has no entry here to find yet; that
+residual sliver is an accepted fail-open gap, not something this check
+claims to close.
 
 `gh pr checks` surfaces this `pull_request_target`-triggered run as a
 normal PR check even though it fires after merge — verified on PR
 `#2855`, 2026-09-10. Filter on whatever `name:` the adopter's own copy
 of the workflow actually declares; this repository's dogfooded copy
-and the template both currently say `Post-merge cleanup`. A
-`workflow_dispatch` rerun can add a second entry for the same
-workflow, so pick a single winning entry first: `pending` always wins
-outright (a still-running run always takes priority over an
-already-completed one); otherwise take the entry with the latest
-`startedAt`.
+and the template both currently say `Post-merge cleanup`.
 
 ```sh
-# 1. the winning entry's bucket and run id (from its own `link` URL)
-gh pr checks <pr-number> --json workflow,bucket,link,startedAt --jq \
-  'map(select(.workflow == "Post-merge cleanup"))
-   | if length == 0 then empty
-     elif any(.bucket == "pending") then (map(select(.bucket == "pending")) | .[0])
-     else max_by(.startedAt) end
-   | [.bucket, (.link | capture("/runs/(?<id>[0-9]+)").id)] | @tsv'
+gh pr checks <pr-number> --json workflow,bucket --jq \
+  'map(select(.workflow == "Post-merge cleanup")) | any(.bucket == "pending")'
 ```
-
-The `id` capture stops at the first non-digit character, so it stays
-correct whether the `link` continues with a `/job/<job-id>` segment or
-a bare query string such as `?check_suite_focus=true` — the same
-tolerant boundary `parseRunIdFromUrl`
-(`src/scripts/rerun-advisory-convergence.mts`) already uses for this
-exact URL shape.
 
 - **A nonzero exit alone is not failure.** `gh pr checks` exits `8`
   whenever _any_ check on the PR is still pending (its own documented
@@ -317,63 +304,25 @@ exact URL shape.
   stdout is valid; a script that aborts under `set -e` on that exit
   code, or that treats any nonzero status as "lookup failed", falls
   through and skips the wait below entirely, leaving the race this
-  check exists to close. Capture and parse stdout regardless of exit
+  check exists to narrow. Capture and parse stdout regardless of exit
   status; only _no parseable output at all_ counts as a lookup
   failure.
-- **No output, or the lookup itself fails** (old `gh`, no network, a
-  GitHub Enterprise Server version without this data): no visible run
-  for this PR. Continue to the duplicate-success-record skip rule
-  unchanged.
-- **First field is `pending`**: the run is in flight. Do **not** skip
-  on this alone — an in-flight run can still finish without ever
-  running its posting step (see the `instructions-only` case below),
-  which would leave neither side posting. Wait for it to finish first
-  (`gh run watch <run-id>`), bounded by the same
+- **`false`, or no parseable output at all** (old `gh`, no network, a
+  GitHub Enterprise Server version without this data, or no run found
+  for this PR): not in flight. Continue to the duplicate-success-record
+  skip rule unchanged — it reads whatever that run may have posted (if
+  any) and adjudicates on the marker's own recorded status, regardless
+  of how the run itself concluded.
+- **`true`**: the run is in flight. Poll the same query at a reasonable
+  interval until it returns `false`, bounded by the same
   `ciWait.runningTimeout` (default `PT30M`, once started) /
   `ciWait.generationTimeout` (default `PT10M`, while still queued)
-  windows `idd-ci.instructions.md`'s CI polling algorithm already
-  uses. Past that bound with the run still incomplete, treat it the
-  same as "no visible run" and continue to the duplicate-success-record
-  skip rule unchanged — a resulting duplicate comment is this check's
-  accepted fail-open default, the same one the other two "not found"
-  cases here already accept. Once the run finishes (immediately, or
-  after the wait above), evaluate it exactly like a completed run:
-  continue to step 2.
-- **Any other first field** (already completed): continue to step 2
-  with the second field as `<run-id>`.
-
-```sh
-# 2. that run's posting-step conclusion
-gh api "repos/{owner}/{repo}/actions/runs/<run-id>/jobs" --jq \
-  '.jobs[].steps[] | select(.name == "Post cleanup evidence comment") | .conclusion'
-```
-
-The posting step's own conclusion decides ownership for a completed
-run, not the check's overall `bucket` — two distinct failure modes
-would otherwise misclassify a run that never actually posted anything
-as one that did:
-
-- The template workflow skips its cleanup and evidence steps entirely
-  under an `instructions-only` (or ambiguous package-manager)
-  `helperRuntime.profile` — a job whose meaningful steps were all
-  skipped still reports a passing check.
-- The evidence-posting step itself runs under the default GitHub
-  Actions `bash -e`; its `COMMENTS_TSV=$(gh api --paginate ...)` read
-  is a plain assignment with no `set +e` guard, so a transient `gh
-  api` failure there (rate limit, network) aborts the step — and the
-  check run — before `gh pr comment` is ever reached.
-
-Only an exact `success` conclusion means the step actually ran to
-completion (whether it posted fresh evidence, or intentionally
-no-op'd because a success record already existed):
-
-- **`success`**: skip the agent's own post entirely — let that run own
-  it.
-- **Anything else** (`skipped`, `failure`, `cancelled`, no such step at
-  all — an older workflow copy, or an adopter's copy that renamed the
-  step, ...): that run did not reliably take ownership of posting.
-  Treat it the same as "no visible run" and continue to the
-  duplicate-success-record skip rule unchanged.
+  windows `idd-ci.instructions.md`'s CI polling algorithm already uses.
+  Past that bound with the run still in flight, treat it the same as
+  "not in flight" and continue to the duplicate-success-record skip
+  rule unchanged — a resulting duplicate comment is this check's
+  accepted fail-open default, the same one the "not in flight" case
+  above already accepts.
 
 ## GitHub mechanism
 
@@ -606,9 +555,11 @@ Post this comment to the PR after a successful or partial apply. The
 HTML comment token on the first line acts as a stable machine-readable
 marker so a resuming agent — or a concurrent `post-merge-cleanup`
 workflow run — can detect that evidence was already posted. The
-[Workflow-run ownership check](#server-side-fallback-optional) above
-runs first, even earlier than this marker-based rule; reaching this
-rule at all already means that check found no run to defer to. Both
+[In-flight cleanup-run wait](#server-side-fallback-optional) above
+runs first, delaying only until any in-flight `post-merge-cleanup.yml`
+run finishes (or the wait bound elapses) — this marker-based rule is
+what actually adjudicates ownership once that run, if any, has had its
+chance to post. Both
 the **agent-side** F4 step and the `post-merge-cleanup` workflow then
 key on the prior **success** record: **skip the post when the latest
 trusted

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -345,13 +345,15 @@ Before any mutating action in F3, apply the
    node scripts/audit-pr-cleanup.mjs --pr <pr-number> --dry-run --format table
    ```
 
-   **Workflow-run pre-post check (#2846)**: before this rule (here and
-   below), check this PR's `post-merge-cleanup.yml` run, waiting
-   (bounded) for it to finish if still in flight — see
-   `docs/idd-comment-minimization.md`'s Workflow-run ownership check.
-   Its posting step's conclusion exactly `success`: skip the agent's
-   own post entirely — that run owns it. Otherwise (no run found, or
-   any other conclusion): continue to the rule below unchanged.
+   **Workflow-run pre-post check (#2846)**: immediately before actually
+   posting below (fresh each time, not cached from here — a run's
+   status can change during dry-run/apply), check this PR's
+   `post-merge-cleanup.yml` run, waiting (bounded) for it to finish if
+   still in flight — see `docs/idd-comment-minimization.md`'s
+   Workflow-run ownership check. Its posting step's conclusion exactly
+   `success`: skip the agent's own post entirely — that run owns it.
+   Otherwise (no run found, or any other conclusion): continue to the
+   rule below unchanged.
 
    **Duplicate-success-record skip rule**: before posting any evidence
    comment below, skip it if the PR already carries a

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -345,6 +345,13 @@ Before any mutating action in F3, apply the
    node scripts/audit-pr-cleanup.mjs --pr <pr-number> --dry-run --format table
    ```
 
+   **Workflow-run pre-post check (#2846)**: before this rule (here and
+   below), check this PR's `post-merge-cleanup.yml` run — see
+   `docs/idd-comment-minimization.md`'s Workflow-run ownership check.
+   In flight, or completed with its posting step's conclusion exactly
+   `success`: skip the agent's own post entirely — that run owns it.
+   Otherwise continue to the rule below unchanged.
+
    **Duplicate-success-record skip rule**: before posting any evidence
    comment below, skip it if the PR already carries a
    `<!-- idd-cleanup-evidence:` comment recording a successful outcome

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -346,11 +346,12 @@ Before any mutating action in F3, apply the
    ```
 
    **Workflow-run pre-post check (#2846)**: before this rule (here and
-   below), check this PR's `post-merge-cleanup.yml` run — see
+   below), check this PR's `post-merge-cleanup.yml` run, waiting
+   (bounded) for it to finish if still in flight — see
    `docs/idd-comment-minimization.md`'s Workflow-run ownership check.
-   In flight, or completed with its posting step's conclusion exactly
-   `success`: skip the agent's own post entirely — that run owns it.
-   Otherwise continue to the rule below unchanged.
+   Its posting step's conclusion exactly `success`: skip the agent's
+   own post entirely — that run owns it. Otherwise (no run found, or
+   any other conclusion): continue to the rule below unchanged.
 
    **Duplicate-success-record skip rule**: before posting any evidence
    comment below, skip it if the PR already carries a

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -345,15 +345,14 @@ Before any mutating action in F3, apply the
    node scripts/audit-pr-cleanup.mjs --pr <pr-number> --dry-run --format table
    ```
 
-   **Workflow-run pre-post check (#2846)**: immediately before actually
+   **In-flight cleanup-run wait (#2846)**: immediately before actually
    posting below (fresh each time, not cached from here — a run's
-   status can change during dry-run/apply), check this PR's
-   `post-merge-cleanup.yml` run, waiting (bounded) for it to finish if
-   still in flight — see `docs/idd-comment-minimization.md`'s
-   Workflow-run ownership check. Its posting step's conclusion exactly
-   `success`: skip the agent's own post entirely — that run owns it.
-   Otherwise (no run found, or any other conclusion): continue to the
-   rule below unchanged.
+   status can change during dry-run/apply), check whether this PR's
+   `post-merge-cleanup.yml` run is still in flight, waiting (bounded)
+   for it to finish if so — see `docs/idd-comment-minimization.md`'s
+   In-flight cleanup-run wait. Either way, continue to the rule below
+   unchanged: it reads whatever that run may have posted and decides
+   ownership from the marker's own recorded status.
 
    **Duplicate-success-record skip rule**: before posting any evidence
    comment below, skip it if the PR already carries a

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -301,18 +301,37 @@ gh pr checks <pr-number> --json workflow,bucket,link,startedAt --jq \
    | if length == 0 then empty
      elif any(.bucket == "pending") then (map(select(.bucket == "pending")) | .[0])
      else max_by(.startedAt) end
-   | [.bucket, (.link | sub(".*/runs/"; "") | sub("/job/.*"; ""))] | @tsv'
+   | [.bucket, (.link | capture("/runs/(?<id>[0-9]+)").id)] | @tsv'
 ```
+
+The `id` capture stops at the first non-digit character, so it stays
+correct whether the `link` continues with a `/job/<job-id>` segment or
+a bare query string such as `?check_suite_focus=true` — the same
+tolerant boundary `parseRunIdFromUrl`
+(`src/scripts/rerun-advisory-convergence.mts`) already uses for this
+exact URL shape.
 
 - **No output, or the lookup itself fails** (old `gh`, no network, a
   GitHub Enterprise Server version without this data): no visible run
   for this PR. Continue to the duplicate-success-record skip rule
   unchanged.
-- **First field is `pending`**: the run is in flight. Skip the agent's
-  own evidence-comment post entirely — let that run own it. No need to
-  run step 2 below.
-- **Any other first field** (a completed run): run step 2 below with
-  the second field as `<run-id>`.
+- **First field is `pending`**: the run is in flight. Do **not** skip
+  on this alone — an in-flight run can still finish without ever
+  running its posting step (see the `instructions-only` case below),
+  which would leave neither side posting. Wait for it to finish first
+  (`gh run watch <run-id>`), bounded by the same
+  `ciWait.runningTimeout` (default `PT30M`, once started) /
+  `ciWait.generationTimeout` (default `PT10M`, while still queued)
+  windows `idd-ci.instructions.md`'s CI polling algorithm already
+  uses. Past that bound with the run still incomplete, treat it the
+  same as "no visible run" and continue to the duplicate-success-record
+  skip rule unchanged — a resulting duplicate comment is this check's
+  accepted fail-open default, the same one the other two "not found"
+  cases here already accept. Once the run finishes (immediately, or
+  after the wait above), evaluate it exactly like a completed run:
+  continue to step 2.
+- **Any other first field** (already completed): continue to step 2
+  with the second field as `<run-id>`.
 
 ```sh
 # 2. that run's posting-step conclusion

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -271,10 +271,13 @@ fresh evidence (preventive; no observed incident yet — #2043). The
 workflow's PR-keyed `concurrency` group only serializes workflow runs
 against each other; it does not gate the agent's local F4.
 
-**In-flight cleanup-run wait (#2846).** Before either side decides
-whether to post its own evidence comment (the duplicate-success-record
-rule above), also check whether this PR's own `post-merge-cleanup.yml`
-check run is still in flight — narrowing the residual race the
+**In-flight cleanup-run wait (#2846).** Before the agent's F4 step
+decides whether to post its own evidence comment (the
+duplicate-success-record rule above — only the agent can run this
+wait; the workflow itself cannot block on its own run without
+deadlocking), also check whether this PR's own
+`post-merge-cleanup.yml` check run is still in flight — narrowing the
+residual race the
 marker-comment check alone cannot fully close: a run that has started
 but not yet posted its comment leaves no marker for that rule to find,
 so without this earlier wait both sides can still post within the same
@@ -314,11 +317,14 @@ gh pr checks <pr-number> --json workflow,bucket --jq \
   any) and adjudicates on the marker's own recorded status, regardless
   of how the run itself concluded.
 - **`true`**: the run is in flight. Poll the same query at a reasonable
-  interval until it returns `false`, bounded by the same
-  `ciWait.runningTimeout` (default `PT30M`, once started) /
-  `ciWait.generationTimeout` (default `PT10M`, while still queued)
-  windows `idd-ci.instructions.md`'s CI polling algorithm already uses.
-  Past that bound with the run still in flight, treat it the same as
+  interval until it returns `false`, bounded by
+  `ciWait.generationTimeout` (default `PT10M`) measured from this
+  first `true` observation. A single bound suffices here — unlike the
+  longer-running checks `idd-ci.instructions.md`'s own polling
+  algorithm bounds with the queued/running split, this workflow's job
+  completes in roughly 15 seconds, so distinguishing a merely queued
+  run from an actually running one buys nothing at that scale. Past
+  that bound with the run still in flight, treat it the same as
   "not in flight" and continue to the duplicate-success-record skip
   rule unchanged — a resulting duplicate comment is this check's
   accepted fail-open default, the same one the "not in flight" case

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -279,9 +279,9 @@ finished doing so — closing the residual race the marker-comment check
 alone cannot: a run that has started but not yet posted its comment
 leaves no marker for that rule to find, so without this earlier check
 both sides can still post within the same few-second window after
-merge (the observed incident: a live CodeRabbit review caught exactly
-this duplicate `idd-cleanup-evidence` comment on
-`kurone-kito/dotfiles#396`).
+merge (observed 2026-09-09 on `kurone-kito/dotfiles#396`: a live
+CodeRabbit review caught exactly this duplicate `idd-cleanup-evidence`
+comment on an adopter's PR).
 
 `gh pr checks` surfaces this `pull_request_target`-triggered run as a
 normal PR check even though it fires after merge — verified on PR
@@ -596,9 +596,13 @@ merge does not re-block the merge; it is an explicit record only.
 Post this comment to the PR after a successful or partial apply. The
 HTML comment token on the first line acts as a stable machine-readable
 marker so a resuming agent — or a concurrent `post-merge-cleanup`
-workflow run — can detect that evidence was already posted. Both the
-**agent-side** F4 step and the `post-merge-cleanup` workflow key on the
-prior **success** record: **skip the post when the latest trusted
+workflow run — can detect that evidence was already posted. The
+[Workflow-run ownership check](#server-side-fallback-optional) above
+runs first, even earlier than this marker-based rule; reaching this
+rule at all already means that check found no run to defer to. Both
+the **agent-side** F4 step and the `post-merge-cleanup` workflow then
+key on the prior **success** record: **skip the post when the latest
+trusted
 `<!-- idd-cleanup-evidence:` comment records a successful outcome
 (`applied` / `clean`)**, so neither side stacks a duplicate success
 record — even when this run's own apply returned `applied` for residual

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -271,6 +271,82 @@ fresh evidence (preventive; no observed incident yet — #2043). The
 workflow's PR-keyed `concurrency` group only serializes workflow runs
 against each other; it does not gate the agent's local F4.
 
+**Workflow-run ownership check (#2846).** Before either side
+decides whether to post its own evidence comment (the
+duplicate-success-record rule above), also check whether this PR's own
+`post-merge-cleanup.yml` check run has already started posting or has
+finished doing so — closing the residual race the marker-comment check
+alone cannot: a run that has started but not yet posted its comment
+leaves no marker for that rule to find, so without this earlier check
+both sides can still post within the same few-second window after
+merge (the observed incident: a live CodeRabbit review caught exactly
+this duplicate `idd-cleanup-evidence` comment on
+`kurone-kito/dotfiles#396`).
+
+`gh pr checks` surfaces this `pull_request_target`-triggered run as a
+normal PR check even though it fires after merge — verified on PR
+`#2855`, 2026-09-10. Filter on whatever `name:` the adopter's own copy
+of the workflow actually declares; this repository's dogfooded copy
+and the template both currently say `Post-merge cleanup`. A
+`workflow_dispatch` rerun can add a second entry for the same
+workflow, so pick a single winning entry first: `pending` always wins
+outright (a still-running run always takes priority over an
+already-completed one); otherwise take the entry with the latest
+`startedAt`.
+
+```sh
+# 1. the winning entry's bucket and run id (from its own `link` URL)
+gh pr checks <pr-number> --json workflow,bucket,link,startedAt --jq \
+  'map(select(.workflow == "Post-merge cleanup"))
+   | if length == 0 then empty
+     elif any(.bucket == "pending") then (map(select(.bucket == "pending")) | .[0])
+     else max_by(.startedAt) end
+   | [.bucket, (.link | sub(".*/runs/"; "") | sub("/job/.*"; ""))] | @tsv'
+```
+
+- **No output, or the lookup itself fails** (old `gh`, no network, a
+  GitHub Enterprise Server version without this data): no visible run
+  for this PR. Continue to the duplicate-success-record skip rule
+  unchanged.
+- **First field is `pending`**: the run is in flight. Skip the agent's
+  own evidence-comment post entirely — let that run own it. No need to
+  run step 2 below.
+- **Any other first field** (a completed run): run step 2 below with
+  the second field as `<run-id>`.
+
+```sh
+# 2. that run's posting-step conclusion
+gh api "repos/{owner}/{repo}/actions/runs/<run-id>/jobs" --jq \
+  '.jobs[].steps[] | select(.name == "Post cleanup evidence comment") | .conclusion'
+```
+
+The posting step's own conclusion decides ownership for a completed
+run, not the check's overall `bucket` — two distinct failure modes
+would otherwise misclassify a run that never actually posted anything
+as one that did:
+
+- The template workflow skips its cleanup and evidence steps entirely
+  under an `instructions-only` (or ambiguous package-manager)
+  `helperRuntime.profile` — a job whose meaningful steps were all
+  skipped still reports a passing check.
+- The evidence-posting step itself runs under the default GitHub
+  Actions `bash -e`; its `COMMENTS_TSV=$(gh api --paginate ...)` read
+  is a plain assignment with no `set +e` guard, so a transient `gh
+  api` failure there (rate limit, network) aborts the step — and the
+  check run — before `gh pr comment` is ever reached.
+
+Only an exact `success` conclusion means the step actually ran to
+completion (whether it posted fresh evidence, or intentionally
+no-op'd because a success record already existed):
+
+- **`success`**: skip the agent's own post entirely — let that run own
+  it.
+- **Anything else** (`skipped`, `failure`, `cancelled`, no such step at
+  all — an older workflow copy, or an adopter's copy that renamed the
+  step, ...): that run did not reliably take ownership of posting.
+  Treat it the same as "no visible run" and continue to the
+  duplicate-success-record skip rule unchanged.
+
 ## GitHub mechanism
 
 GitHub GraphQL exposes `minimizeComment`:

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -311,6 +311,15 @@ tolerant boundary `parseRunIdFromUrl`
 (`src/scripts/rerun-advisory-convergence.mts`) already uses for this
 exact URL shape.
 
+- **A nonzero exit alone is not failure.** `gh pr checks` exits `8`
+  whenever _any_ check on the PR is still pending (its own documented
+  behavior — `gh pr checks --help`), even when this query's own
+  stdout is valid; a script that aborts under `set -e` on that exit
+  code, or that treats any nonzero status as "lookup failed", falls
+  through and skips the wait below entirely, leaving the race this
+  check exists to close. Capture and parse stdout regardless of exit
+  status; only _no parseable output at all_ counts as a lookup
+  failure.
 - **No output, or the lookup itself fails** (old `gh`, no network, a
   GitHub Enterprise Server version without this data): no visible run
   for this PR. Continue to the duplicate-success-record skip rule

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -271,45 +271,32 @@ fresh evidence (preventive; no observed incident yet — #2043). The
 workflow's PR-keyed `concurrency` group only serializes workflow runs
 against each other; it does not gate the agent's local F4.
 
-**Workflow-run ownership check (#2846).** Before either side
-decides whether to post its own evidence comment (the
-duplicate-success-record rule above), also check whether this PR's own
-`post-merge-cleanup.yml` check run has already started posting or has
-finished doing so — closing the residual race the marker-comment check
-alone cannot: a run that has started but not yet posted its comment
-leaves no marker for that rule to find, so without this earlier check
-both sides can still post within the same few-second window after
-merge (observed 2026-09-09 on `kurone-kito/dotfiles#396`: a live
-CodeRabbit review caught exactly this duplicate `idd-cleanup-evidence`
-comment on an adopter's PR).
+**In-flight cleanup-run wait (#2846).** Before either side decides
+whether to post its own evidence comment (the duplicate-success-record
+rule above), also check whether this PR's own `post-merge-cleanup.yml`
+check run is still in flight — narrowing the residual race the
+marker-comment check alone cannot fully close: a run that has started
+but not yet posted its comment leaves no marker for that rule to find,
+so without this earlier wait both sides can still post within the same
+few-second window after merge (observed 2026-09-09 on
+`kurone-kito/dotfiles#396`: a live CodeRabbit review caught exactly
+this duplicate `idd-cleanup-evidence` comment on an adopter's PR). This
+wait only narrows the window, it does not close it: GitHub registers
+the check run asynchronously after the triggering webhook fires, so a
+run that has not yet been created has no entry here to find yet; that
+residual sliver is an accepted fail-open gap, not something this check
+claims to close.
 
 `gh pr checks` surfaces this `pull_request_target`-triggered run as a
 normal PR check even though it fires after merge — verified on PR
 `#2855`, 2026-09-10. Filter on whatever `name:` the adopter's own copy
 of the workflow actually declares; this repository's dogfooded copy
-and the template both currently say `Post-merge cleanup`. A
-`workflow_dispatch` rerun can add a second entry for the same
-workflow, so pick a single winning entry first: `pending` always wins
-outright (a still-running run always takes priority over an
-already-completed one); otherwise take the entry with the latest
-`startedAt`.
+and the template both currently say `Post-merge cleanup`.
 
 ```sh
-# 1. the winning entry's bucket and run id (from its own `link` URL)
-gh pr checks <pr-number> --json workflow,bucket,link,startedAt --jq \
-  'map(select(.workflow == "Post-merge cleanup"))
-   | if length == 0 then empty
-     elif any(.bucket == "pending") then (map(select(.bucket == "pending")) | .[0])
-     else max_by(.startedAt) end
-   | [.bucket, (.link | capture("/runs/(?<id>[0-9]+)").id)] | @tsv'
+gh pr checks <pr-number> --json workflow,bucket --jq \
+  'map(select(.workflow == "Post-merge cleanup")) | any(.bucket == "pending")'
 ```
-
-The `id` capture stops at the first non-digit character, so it stays
-correct whether the `link` continues with a `/job/<job-id>` segment or
-a bare query string such as `?check_suite_focus=true` — the same
-tolerant boundary `parseRunIdFromUrl`
-(`src/scripts/rerun-advisory-convergence.mts`) already uses for this
-exact URL shape.
 
 - **A nonzero exit alone is not failure.** `gh pr checks` exits `8`
   whenever _any_ check on the PR is still pending (its own documented
@@ -317,63 +304,25 @@ exact URL shape.
   stdout is valid; a script that aborts under `set -e` on that exit
   code, or that treats any nonzero status as "lookup failed", falls
   through and skips the wait below entirely, leaving the race this
-  check exists to close. Capture and parse stdout regardless of exit
+  check exists to narrow. Capture and parse stdout regardless of exit
   status; only _no parseable output at all_ counts as a lookup
   failure.
-- **No output, or the lookup itself fails** (old `gh`, no network, a
-  GitHub Enterprise Server version without this data): no visible run
-  for this PR. Continue to the duplicate-success-record skip rule
-  unchanged.
-- **First field is `pending`**: the run is in flight. Do **not** skip
-  on this alone — an in-flight run can still finish without ever
-  running its posting step (see the `instructions-only` case below),
-  which would leave neither side posting. Wait for it to finish first
-  (`gh run watch <run-id>`), bounded by the same
+- **`false`, or no parseable output at all** (old `gh`, no network, a
+  GitHub Enterprise Server version without this data, or no run found
+  for this PR): not in flight. Continue to the duplicate-success-record
+  skip rule unchanged — it reads whatever that run may have posted (if
+  any) and adjudicates on the marker's own recorded status, regardless
+  of how the run itself concluded.
+- **`true`**: the run is in flight. Poll the same query at a reasonable
+  interval until it returns `false`, bounded by the same
   `ciWait.runningTimeout` (default `PT30M`, once started) /
   `ciWait.generationTimeout` (default `PT10M`, while still queued)
-  windows `idd-ci.instructions.md`'s CI polling algorithm already
-  uses. Past that bound with the run still incomplete, treat it the
-  same as "no visible run" and continue to the duplicate-success-record
-  skip rule unchanged — a resulting duplicate comment is this check's
-  accepted fail-open default, the same one the other two "not found"
-  cases here already accept. Once the run finishes (immediately, or
-  after the wait above), evaluate it exactly like a completed run:
-  continue to step 2.
-- **Any other first field** (already completed): continue to step 2
-  with the second field as `<run-id>`.
-
-```sh
-# 2. that run's posting-step conclusion
-gh api "repos/{owner}/{repo}/actions/runs/<run-id>/jobs" --jq \
-  '.jobs[].steps[] | select(.name == "Post cleanup evidence comment") | .conclusion'
-```
-
-The posting step's own conclusion decides ownership for a completed
-run, not the check's overall `bucket` — two distinct failure modes
-would otherwise misclassify a run that never actually posted anything
-as one that did:
-
-- The template workflow skips its cleanup and evidence steps entirely
-  under an `instructions-only` (or ambiguous package-manager)
-  `helperRuntime.profile` — a job whose meaningful steps were all
-  skipped still reports a passing check.
-- The evidence-posting step itself runs under the default GitHub
-  Actions `bash -e`; its `COMMENTS_TSV=$(gh api --paginate ...)` read
-  is a plain assignment with no `set +e` guard, so a transient `gh
-  api` failure there (rate limit, network) aborts the step — and the
-  check run — before `gh pr comment` is ever reached.
-
-Only an exact `success` conclusion means the step actually ran to
-completion (whether it posted fresh evidence, or intentionally
-no-op'd because a success record already existed):
-
-- **`success`**: skip the agent's own post entirely — let that run own
-  it.
-- **Anything else** (`skipped`, `failure`, `cancelled`, no such step at
-  all — an older workflow copy, or an adopter's copy that renamed the
-  step, ...): that run did not reliably take ownership of posting.
-  Treat it the same as "no visible run" and continue to the
-  duplicate-success-record skip rule unchanged.
+  windows `idd-ci.instructions.md`'s CI polling algorithm already uses.
+  Past that bound with the run still in flight, treat it the same as
+  "not in flight" and continue to the duplicate-success-record skip
+  rule unchanged — a resulting duplicate comment is this check's
+  accepted fail-open default, the same one the "not in flight" case
+  above already accepts.
 
 ## GitHub mechanism
 
@@ -606,9 +555,11 @@ Post this comment to the PR after a successful or partial apply. The
 HTML comment token on the first line acts as a stable machine-readable
 marker so a resuming agent — or a concurrent `post-merge-cleanup`
 workflow run — can detect that evidence was already posted. The
-[Workflow-run ownership check](#server-side-fallback-optional) above
-runs first, even earlier than this marker-based rule; reaching this
-rule at all already means that check found no run to defer to. Both
+[In-flight cleanup-run wait](#server-side-fallback-optional) above
+runs first, delaying only until any in-flight `post-merge-cleanup.yml`
+run finishes (or the wait bound elapses) — this marker-based rule is
+what actually adjudicates ownership once that run, if any, has had its
+chance to post. Both
 the **agent-side** F4 step and the `post-merge-cleanup` workflow then
 key on the prior **success** record: **skip the post when the latest
 trusted


### PR DESCRIPTION
# Summary

F4's Duplicate-success-record skip rule only catches a duplicate
`idd-cleanup-evidence` comment *after* one side has already posted, by
reading for an existing evidence comment. Two independent
processes — the `post-merge-cleanup.yml` workflow and the agent's own
F4 step — can each reach that read-then-post sequence within the same
few-second window after merge and both post, since GitHub's
comment-creation API has no atomic compare-and-post primitive. This
adds an earlier, additional pre-post check to F4 step 3: before the
existing rule runs, the agent checks whether the PR's own
`post-merge-cleanup.yml` check run is still in flight (`pending`) and,
if so, waits for it to finish, bounded by `ciWait.generationTimeout`.
Either way — no run found, already completed, or the wait's bound
elapsed — the agent then always continues to the pre-existing
duplicate-success-record rule unchanged: that rule already decides
ownership correctly by reading whatever comment the run may have
posted and adjudicating on the *marker's own recorded status*, not on
the run's pass/fail conclusion.

The issue's own acceptance criteria describe skipping on "an
already-completed or in-flight" run. The completed-run half of that
was always covered by the pre-existing duplicate-success-record rule
itself, independently of this change — it already skips whenever a
trusted `applied`/`clean` marker is present, regardless of which side
posted it, and correctly does *not* skip on a passing check that
posted nothing (the `instructions-only`/ambiguous-package-manager
`helperRuntime.profile` case) or on a trusted marker recording
`failed`/`incomplete`. This PR only ever needed to add the in-flight
half, which is exactly what the wait above does. (An earlier revision
of this PR added a second lookup — the run's own job-step conclusion —
to try to determine ownership for a completed run more directly; review
found that check unsound (a `success` step conclusion does not imply a
success-shaped comment) and redundant (the duplicate-success-record
rule already makes the correct call from the marker itself), so it was
removed in favor of the simpler design described above.)

This wait narrows the race; it does not fully close it. GitHub
registers a `pull_request_target`-triggered check run asynchronously
after the merge webhook fires, so a run that has not yet been created
has no entry for this check to find — that residual sliver is an
accepted fail-open gap, the same kind the duplicate-success-record
rule's own "no run found" case already accepts.

## Linked issue

Closes #2846

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

- **Verified live** against this repository: `gh pr checks` surfaces
  the `pull_request_target`-triggered `post-merge-cleanup.yml` run as
  a normal PR check even though it fires after merge (confirmed on PR
  #2855).
- **Do not port `kurone-kito/dotfiles#397`'s** double-checked-locking
  pattern (the adopter's own workaround for the same observed
  incident) — this issue's Maintainer decision explicitly chose
  sequencing/ownership instead of that pattern.
- Edited only the `idd-template/` canonical sources (both files are
  `exact`-mode sync pairs per `audit/sync-manifest.json`) and
  regenerated the two `.github/`/`docs/` mirrors via
  `node scripts/sync-docs.mjs --apply`.
- The design was simplified across review rounds on this PR: dropped
  the run-id extraction, the `gh api .../actions/runs/<id>/jobs` job-step
  lookup, and the `gh run watch` wait (which does not support
  fine-grained PAT authentication) entirely, once review established
  that the ownership decision they existed to make was already made
  correctly by the pre-existing duplicate-success-record rule. Net
  effect versus the instructions-file paragraph's first version: fewer
  lines, not more.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`npx biome check`, `npx dprint check`,
      `npx markdownlint-cli2`)
- [x] `pnpm test` (`node --test tests/*.test.mts`; 5871/5871 passing —
      this is a docs/instructions-only change with no new runnable
      code path)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (`node scripts/audit-docs.mjs
      --check` also covers sync drift; `node scripts/sync-docs.mjs
      --apply` regenerated the two mirrors with no other file
      touched)
- [x] `node scripts/idd-doctor.mjs` (passed with 3 pre-existing,
      unrelated warnings)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (F4 cleanup evidence-posting only;
      never gates the merge itself)
- [x] Context budget impact reviewed (bundle byte budget checked
      before and after a `main` rebase that landed PR #2871's
      bundle-merge split mid-session; the final design also shrinks
      the instructions-file paragraph, easing rather than adding to
      that budget)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EycqtGKuWjJMpw2tUav3Tn
