### PR TITLE
fix(idd-pre-merge): retry once on transient helper 5xx

### DIFF
--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -141,11 +141,14 @@ turns an operator-visible failure into a silent stall.
   [`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#stable-helper-evidence-outputs)
   to collect this evidence (the fields listed at that anchor). Helpers
   remain read-only evidence collectors. Distinguish two failure shapes
-  before deciding whether to retry. On an **infrastructure/transport-
-  layer failure** — the invocation itself fails with no well-formed
-  gate result at all (a bare network/transport error, or a non-2xx
-  HTTP status with no substantive JSON body), **or returns well-formed
-  JSON whose sole content is a collection/transport-failure placeholder
+  before deciding whether to retry. On an
+  **infrastructure/transport failure** — the invocation itself fails
+  with no well-formed gate result at all (a bare network/transport
+  error such as a connection failure, timeout, or DNS failure, or a
+  retryable `5xx`/`429` HTTP status with no substantive JSON body —
+  never a non-retryable `4xx` such as `401`/`403`/`404`, which is
+  code-/auth-caused, not transient), **or returns well-formed JSON
+  whose sole content is a collection/transport-failure placeholder
   rather than a real gate criterion** (for example a non-empty
   `blockers` array whose only entry describes the collection failure
   itself, not any actual merge-readiness criterion) — retry the
@@ -156,10 +159,10 @@ turns an operator-visible failure into a silent stall.
   path below unchanged — a single bounded attempt, not a loop. A
   **substantive non-passing gate result** — the helper ran to
   completion and returned well-formed JSON with real gate fields backed
-  by an actual merge-readiness criterion (for example `claimValid:
-  false`), not a collection-failure placeholder — is never retried;
-  continue trusting it at face value, unchanged from today. For every
-  other case —
+  by an actual merge-readiness criterion (for example
+  `claim.matchesExpectedClaim: false`), not a collection-failure
+  placeholder — is never retried; continue trusting it at face value,
+  unchanged from today. For every other case —
   output is invalid JSON, required sections are missing, or live GitHub
   state disagrees with it — discard helper output and fetch the
   activity universe snapshot (same scope as E1 Step 1) plus current CI

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -140,12 +140,27 @@ turns an operator-visible failure into a silent stall.
   helper reference in
   [`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#stable-helper-evidence-outputs)
   to collect this evidence (the fields listed at that anchor). Helpers
-  remain read-only evidence collectors: if execution fails, output is
-  invalid JSON, required sections are missing, or live GitHub state
-  disagrees with it, discard helper output and fetch the activity
-  universe snapshot (same scope as E1 Step 1) plus current CI state for
-  the HEAD SHA directly — the instruction rules remain canonical. Return
-  to E1 if **any** of the following is true:
+  remain read-only evidence collectors. Distinguish two failure shapes
+  before deciding whether to retry: an **infrastructure/transport-layer
+  failure** — the invocation itself fails with no well-formed gate
+  result at all (a bare network/transport error, or a non-2xx HTTP
+  status with no substantive JSON body) — retries the identical
+  invocation once, mirroring the CI-wait algorithm's own infra-vs-code
+  retry distinction (`ciWait.rerunPolicy`,
+  `idd-ci.instructions.md`) rather than inventing a new pattern; if the
+  retry fails the same way, fall back to the discard-and-fetch-directly
+  path below unchanged — a single bounded attempt, not a loop. A
+  **substantive non-passing gate result** — the helper ran to
+  completion and returned well-formed JSON with real gate fields (for
+  example `claimValid: false` backed by an actual criterion, not a
+  collection-failure placeholder) — is never retried; continue trusting
+  it at face value, unchanged from today. For every other case —
+  output is invalid JSON, required sections are missing, or live GitHub
+  state disagrees with it — discard helper output and fetch the
+  activity universe snapshot (same scope as E1 Step 1) plus current CI
+  state for the HEAD SHA directly, unchanged and without retry — the
+  instruction rules remain canonical. Return to E1 if **any** of the
+  following is true:
   - The current PR HEAD SHA differs from the stored `{head-SHA}` (a new
     push after E1's snapshot, even if the watermark posted later).
   - The stored value is `none` and the live snapshot is non-empty

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -144,17 +144,22 @@ turns an operator-visible failure into a silent stall.
   before deciding whether to retry. On an **infrastructure/transport-
   layer failure** — the invocation itself fails with no well-formed
   gate result at all (a bare network/transport error, or a non-2xx
-  HTTP status with no substantive JSON body) — retry the identical
-  invocation once, mirroring the CI-wait algorithm's own infra-vs-code
-  retry distinction (`ciWait.rerunPolicy`,
+  HTTP status with no substantive JSON body), **or returns well-formed
+  JSON whose sole content is a collection/transport-failure placeholder
+  rather than a real gate criterion** (for example a non-empty
+  `blockers` array whose only entry describes the collection failure
+  itself, not any actual merge-readiness criterion) — retry the
+  identical invocation once, mirroring the CI-wait algorithm's own
+  infra-vs-code retry distinction (`ciWait.rerunPolicy`,
   `idd-ci.instructions.md`) rather than inventing a new pattern; if the
   retry fails the same way, fall back to the discard-and-fetch-directly
   path below unchanged — a single bounded attempt, not a loop. A
   **substantive non-passing gate result** — the helper ran to
-  completion and returned well-formed JSON with real gate fields (for
-  example `claimValid: false` backed by an actual criterion, not a
-  collection-failure placeholder) — is never retried; continue trusting
-  it at face value, unchanged from today. For every other case —
+  completion and returned well-formed JSON with real gate fields backed
+  by an actual merge-readiness criterion (for example `claimValid:
+  false`), not a collection-failure placeholder — is never retried;
+  continue trusting it at face value, unchanged from today. For every
+  other case —
   output is invalid JSON, required sections are missing, or live GitHub
   state disagrees with it — discard helper output and fetch the
   activity universe snapshot (same scope as E1 Step 1) plus current CI

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -141,10 +141,10 @@ turns an operator-visible failure into a silent stall.
   [`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#stable-helper-evidence-outputs)
   to collect this evidence (the fields listed at that anchor). Helpers
   remain read-only evidence collectors. Distinguish two failure shapes
-  before deciding whether to retry: an **infrastructure/transport-layer
-  failure** — the invocation itself fails with no well-formed gate
-  result at all (a bare network/transport error, or a non-2xx HTTP
-  status with no substantive JSON body) — retries the identical
+  before deciding whether to retry. On an **infrastructure/transport-
+  layer failure** — the invocation itself fails with no well-formed
+  gate result at all (a bare network/transport error, or a non-2xx
+  HTTP status with no substantive JSON body) — retry the identical
   invocation once, mirroring the CI-wait algorithm's own infra-vs-code
   retry distinction (`ciWait.rerunPolicy`,
   `idd-ci.instructions.md`) rather than inventing a new pattern; if the

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -139,17 +139,22 @@ turns an operator-visible failure into a silent stall.
   before deciding whether to retry. On an **infrastructure/transport-
   layer failure** — the invocation itself fails with no well-formed
   gate result at all (a bare network/transport error, or a non-2xx
-  HTTP status with no substantive JSON body) — retry the identical
-  invocation once, mirroring the CI-wait algorithm's own infra-vs-code
-  retry distinction (`ciWait.rerunPolicy`,
+  HTTP status with no substantive JSON body), **or returns well-formed
+  JSON whose sole content is a collection/transport-failure placeholder
+  rather than a real gate criterion** (for example a non-empty
+  `blockers` array whose only entry describes the collection failure
+  itself, not any actual merge-readiness criterion) — retry the
+  identical invocation once, mirroring the CI-wait algorithm's own
+  infra-vs-code retry distinction (`ciWait.rerunPolicy`,
   `idd-ci.instructions.md`) rather than inventing a new pattern; if the
   retry fails the same way, fall back to the discard-and-fetch-directly
   path below unchanged — a single bounded attempt, not a loop. A
   **substantive non-passing gate result** — the helper ran to
-  completion and returned well-formed JSON with real gate fields (for
-  example `claimValid: false` backed by an actual criterion, not a
-  collection-failure placeholder) — is never retried; continue trusting
-  it at face value, unchanged from today. For every other case —
+  completion and returned well-formed JSON with real gate fields backed
+  by an actual merge-readiness criterion (for example `claimValid:
+  false`), not a collection-failure placeholder — is never retried;
+  continue trusting it at face value, unchanged from today. For every
+  other case —
   output is invalid JSON, required sections are missing, or live GitHub
   state disagrees with it — discard helper output and fetch the
   activity universe snapshot (same scope as E1 Step 1) plus current CI

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -136,10 +136,10 @@ turns an operator-visible failure into a silent stall.
   [`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#stable-helper-evidence-outputs)
   to collect this evidence (the fields listed at that anchor). Helpers
   remain read-only evidence collectors. Distinguish two failure shapes
-  before deciding whether to retry: an **infrastructure/transport-layer
-  failure** — the invocation itself fails with no well-formed gate
-  result at all (a bare network/transport error, or a non-2xx HTTP
-  status with no substantive JSON body) — retries the identical
+  before deciding whether to retry. On an **infrastructure/transport-
+  layer failure** — the invocation itself fails with no well-formed
+  gate result at all (a bare network/transport error, or a non-2xx
+  HTTP status with no substantive JSON body) — retry the identical
   invocation once, mirroring the CI-wait algorithm's own infra-vs-code
   retry distinction (`ciWait.rerunPolicy`,
   `idd-ci.instructions.md`) rather than inventing a new pattern; if the

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -135,12 +135,27 @@ turns an operator-visible failure into a silent stall.
   helper reference in
   [`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#stable-helper-evidence-outputs)
   to collect this evidence (the fields listed at that anchor). Helpers
-  remain read-only evidence collectors: if execution fails, output is
-  invalid JSON, required sections are missing, or live GitHub state
-  disagrees with it, discard helper output and fetch the activity
-  universe snapshot (same scope as E1 Step 1) plus current CI state for
-  the HEAD SHA directly — the instruction rules remain canonical. Return
-  to E1 if **any** of the following is true:
+  remain read-only evidence collectors. Distinguish two failure shapes
+  before deciding whether to retry: an **infrastructure/transport-layer
+  failure** — the invocation itself fails with no well-formed gate
+  result at all (a bare network/transport error, or a non-2xx HTTP
+  status with no substantive JSON body) — retries the identical
+  invocation once, mirroring the CI-wait algorithm's own infra-vs-code
+  retry distinction (`ciWait.rerunPolicy`,
+  `idd-ci.instructions.md`) rather than inventing a new pattern; if the
+  retry fails the same way, fall back to the discard-and-fetch-directly
+  path below unchanged — a single bounded attempt, not a loop. A
+  **substantive non-passing gate result** — the helper ran to
+  completion and returned well-formed JSON with real gate fields (for
+  example `claimValid: false` backed by an actual criterion, not a
+  collection-failure placeholder) — is never retried; continue trusting
+  it at face value, unchanged from today. For every other case —
+  output is invalid JSON, required sections are missing, or live GitHub
+  state disagrees with it — discard helper output and fetch the
+  activity universe snapshot (same scope as E1 Step 1) plus current CI
+  state for the HEAD SHA directly, unchanged and without retry — the
+  instruction rules remain canonical. Return to E1 if **any** of the
+  following is true:
   - The current PR HEAD SHA differs from the stored `{head-SHA}` (a new
     push after E1's snapshot, even if the watermark posted later).
   - The stored value is `none` and the live snapshot is non-empty

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -136,11 +136,14 @@ turns an operator-visible failure into a silent stall.
   [`docs/idd-helper-scripts.md`](../../docs/idd-helper-scripts.md#stable-helper-evidence-outputs)
   to collect this evidence (the fields listed at that anchor). Helpers
   remain read-only evidence collectors. Distinguish two failure shapes
-  before deciding whether to retry. On an **infrastructure/transport-
-  layer failure** — the invocation itself fails with no well-formed
-  gate result at all (a bare network/transport error, or a non-2xx
-  HTTP status with no substantive JSON body), **or returns well-formed
-  JSON whose sole content is a collection/transport-failure placeholder
+  before deciding whether to retry. On an
+  **infrastructure/transport failure** — the invocation itself fails
+  with no well-formed gate result at all (a bare network/transport
+  error such as a connection failure, timeout, or DNS failure, or a
+  retryable `5xx`/`429` HTTP status with no substantive JSON body —
+  never a non-retryable `4xx` such as `401`/`403`/`404`, which is
+  code-/auth-caused, not transient), **or returns well-formed JSON
+  whose sole content is a collection/transport-failure placeholder
   rather than a real gate criterion** (for example a non-empty
   `blockers` array whose only entry describes the collection failure
   itself, not any actual merge-readiness criterion) — retry the
@@ -151,10 +154,10 @@ turns an operator-visible failure into a silent stall.
   path below unchanged — a single bounded attempt, not a loop. A
   **substantive non-passing gate result** — the helper ran to
   completion and returned well-formed JSON with real gate fields backed
-  by an actual merge-readiness criterion (for example `claimValid:
-  false`), not a collection-failure placeholder — is never retried;
-  continue trusting it at face value, unchanged from today. For every
-  other case —
+  by an actual merge-readiness criterion (for example
+  `claim.matchesExpectedClaim: false`), not a collection-failure
+  placeholder — is never retried; continue trusting it at face value,
+  unchanged from today. For every other case —
   output is invalid JSON, required sections are missing, or live GitHub
   state disagrees with it — discard helper output and fetch the
   activity universe snapshot (same scope as E1 Step 1) plus current CI


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

`idd-pre-merge.instructions.md`'s F1 merge-gate helper fallback treated
every helper execution failure identically: a bare transport-layer 5xx
with no well-formed result was discarded and re-fetched directly, the
same as a helper that ran fine but returned a substantive non-passing
gate result. A field incident hit exactly the first case: a
merge-readiness dry-run helper call failed once with a bare, transient
`gh: HTTP 503`, and the session had to make an ad hoc retry judgment
call (retry once; it then succeeded) with no stated rule covering the
ambiguity.

**Maintainer decision** (hearing, 2026-09-10, recorded on the issue):
implement the narrow retry-once rule now. Despite the single-occurrence
evidence base, the fix mirrors an already-established pattern elsewhere
in this same workflow (the CI-wait algorithm's `ciWait.rerunPolicy`
infra-vs-code retry distinction), so its cost and risk are both low.

## What changed

Split the existing "if execution fails … discard helper output and
fetch … directly" trigger into two distinguished failure shapes in
`idd-pre-merge.instructions.md`'s F1 review-currency helper-fallback
paragraph:

1. **Infrastructure/transport-layer failure** — no well-formed gate
   result at all (a bare network/transport error, or a non-2xx HTTP
   status with no substantive JSON body): retry the identical helper
   invocation once — a single bounded attempt, not a loop — mirroring
   `ciWait.rerunPolicy` rather than inventing a new pattern. If the
   retry fails the same way, fall back to the existing
   discard-and-fetch-directly path unchanged.
2. **Substantive non-passing gate result** — the helper ran to
   completion and returned well-formed JSON with real gate fields
   (e.g. `claimValid: false` backed by an actual criterion, not a
   collection-failure placeholder): never retried, unchanged from
   today.

Every other existing trigger (invalid JSON, missing required sections,
live-state disagreement) keeps its current discard-and-fetch-directly
behavior unchanged, with no retry.

**Files** (issue's own candidate list):

- `idd-template/.github/instructions/idd-pre-merge.instructions.md`
  (canonical) — the edit itself.
- `.github/instructions/idd-pre-merge.instructions.md` — generated
  mirror (`mode: exact`), regenerated via `node scripts/sync-docs.mjs
  --apply`.

No code, schema, or runtime behavior change — instructions-text only.

**Review round 1** (Copilot). One real finding, posted on both files:
the infra-failure definition excluded a collection-failure placeholder
from the "never retry" bucket without ever placing it in the "retry"
bucket — leaving #2806's own field-evidence case (well-formed JSON
whose sole content describes the collection failure itself, e.g. a
bare `gh: HTTP 503`) undefined by either branch. Fixed by extending the
infrastructure/transport-layer failure definition to explicitly cover
that case. (The review also flagged a "retries" → "retry" grammar slip
already caught and fixed in a prior commit during a retroactive C1
self-review, disclosed in a separate PR comment.)

**Review round 2** (Copilot + Codex, 3 findings, all accepted).
Copilot (x2, canonical + mirror): the bold term
"infrastructure/transport-layer failure" was hard-wrapped right after
the hyphen, which CommonMark renders as a stray space
("transport- layer") — fixed by dropping "-layer" entirely rather than
fighting the next reformat at the same boundary. Codex (P2): the
"non-2xx HTTP status" condition classified persistent, non-transient
client errors (401/403/404) as retryable infrastructure, which would
have repeated unauthorized/malformed requests instead of failing to
the existing fallback, and drifted from the issue's own "transient
5xx" scope — narrowed to `5xx`/`429` and genuine network-level
failures only. Codex (P2): the example gate field `claimValid: false`
does not exist in `schemas/pre-merge-readiness.schema.json` — it was
inherited verbatim from the issue's own field-evidence example without
checking it against the real schema — swapped in the actual
`claim.matchesExpectedClaim` field.

**Sibling call sites considered, not touched.** Two other files carry
near-identical "helpers are read-only evidence collectors; discard on
failure" boilerplate for their own helper calls:
`idd-merge.instructions.md` (F3) and `idd-review-snapshot.instructions.md`
(E1). Declined to touch either here: each phase owns a complete,
self-contained fallback for its own helper invocation, so an agent
running E1 (no retry) → F1 (retry once, after this change) → F3 (no
retry) hits no contradiction — no phase's text tells an agent to do the
opposite of what another phase's text requires for the same invocation.
The issue's own scope is explicitly narrow ("a single occurrence, not
independently reproduced" / "implement the narrow retry-once rule now")
and its Candidate files list names only this file and its mirror. See
the design-question follow-up below for the broader question.

**Citation exemption checked**: `docs/idd-design-rationale.md`'s "Cite
the observed incident" convention exempts `.github/instructions/` files
(and their `idd-template/` canonical sources) from the citation
requirement, even for a brand-new passage naming a failure mode, to
protect bundle byte budgets already near their ceiling — so no issue
citation was added to the instructions text itself; this issue's own
body remains the durable record.

## Linked issue

Closes #2806

## Follow-up issues (if any)

- [ ] Design question, not resolved here since it requires a
      repository-owner decision: should the same infra-vs-code
      retry-once distinction be rolled out uniformly to
      `idd-merge.instructions.md` (F3) and
      `idd-review-snapshot.instructions.md` (E1), which call the same
      class of helper and currently retry neither? This issue scoped
      the fix narrowly to the one call site with an observed incident;
      a uniform rollout is a separate, broader decision.

## Background / rationale (if material)

Maintainer decision recorded on `#2806`'s own body (hearing,
2026-09-10), from the same triage session that produced the
`#2795`/`#2796`-`#2806` gist-retrospective batch.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed

`idd-pre-merge.instructions.md` governs F1 merge-gate evidence
collection, so this changes how the merge gate handles a transient
helper failure (adds a single bounded retry before falling back to the
existing direct-fetch path) — flagged even though no credential/schema
surface changed.

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

Also ran `node scripts/audit-code-span-wrap.mjs`, `npx dprint check`,
`npx markdownlint-cli2`, `npx cspell lint`, `node
scripts/token-cost-report.mjs --check`, and `pnpm run build:check` —
all green. `node --test tests/*.test.mts`: 5890/5890 passing.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDJpTELrY2SnjHW9m5Aw7i


