### PR TITLE
feat(claim): persist generated claim tokens on disk

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -578,7 +578,8 @@ for the full algorithm.
 
 A same-machine fast path complementing the cross-machine claim check
 above. Acquire once the B1 worktree exists (before the first mutation;
-also re-run `--record-tokens` there), then re-run alongside every later
+also re-run `--record-tokens` there (with `--nonce`)), then re-run
+alongside every later
 pre-mutation check:
 `node scripts/claim-lock.mjs --acquire --worktree <path> --agent-id
 {agent-id} --claim-id {claim-id}`.

--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -278,8 +278,9 @@ incomplete/current authoring hold blocks; only exact anchor/set/session
 `release-complete` allows a completed generation.
 Route directly to already-claimed/Discover fallback (A0-T stops), never A5(c).
 
-Post the claim comment using the exact format and posting mechanics
-already defined in
+First record `{agent-id}`/`{claim-id}` via `--record-tokens`; then post
+the claim comment using the exact format and posting mechanics already
+defined in
 [Claim format](idd-overview-core.instructions.md#claim-format) — do not
 re-derive them here. `emit-marker` (`--type claimed-by`, emit-only) also
 renders the body without posting.
@@ -316,9 +317,10 @@ verification_ below); never skip it for any activation path:
 _{agent-id}: claim activation nonce — IDD automation marker. Do not edit._
 ```
 
-`{nonce}` is fresh; record it with `{agent-id}` / `{claim-id}`. For multiple
-trusted markers sharing a claim, the lexicographically earliest nonce wins;
-no marker means no comparison. With helper runtime, post it using
+`{nonce}` is fresh; record it via `--record-tokens` before posting. For
+multiple trusted markers sharing a claim, the lexicographically earliest
+nonce wins; no marker means no comparison. With helper runtime, post it
+using
 `post-idd-marker --type activation-nonce --target issue <number> --apply`
 with the four fields defined in `docs/idd-helper-scripts.md`.
 
@@ -575,8 +577,9 @@ for the full algorithm.
 ### Worktree-local lock file (same-machine collision)
 
 A same-machine fast path complementing the cross-machine claim check
-above. Acquire once the B1 worktree exists (before the first mutation),
-then re-run alongside every later pre-mutation check:
+above. Acquire once the B1 worktree exists (before the first mutation;
+also re-run `--record-tokens` there), then re-run alongside every later
+pre-mutation check:
 `node scripts/claim-lock.mjs --acquire --worktree <path> --agent-id
 {agent-id} --claim-id {claim-id}`.
 
@@ -594,10 +597,9 @@ session's leftover lock resolves the same way. See
 `docs/idd-helper-scripts.md`'s Worktree-local claim lock entry for
 mechanical detail.
 
-**Generated-tokens record.** Write `{agent-id}` / `{claim-id}` (then the
-nonce) via `--record-tokens` before posting each marker; re-check with
-`--read-tokens` alongside `--acquire` before trusting a recalled
-`{claim-id}`. See `docs/idd-helper-scripts.md`.
+**Generated-tokens record.** Re-check with `--read-tokens` alongside
+`--acquire` before trusting a recalled `{claim-id}`. See
+`docs/idd-helper-scripts.md`.
 
 Then continue to `idd-work.instructions.md`.
 

--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -594,6 +594,11 @@ session's leftover lock resolves the same way. See
 `docs/idd-helper-scripts.md`'s Worktree-local claim lock entry for
 mechanical detail.
 
+**Generated-tokens record.** Write `{agent-id}` / `{claim-id}` (then the
+nonce) via `--record-tokens` before posting each marker; re-check with
+`--read-tokens` alongside `--acquire` before trusting a recalled
+`{claim-id}`. See `docs/idd-helper-scripts.md`.
+
 Then continue to `idd-work.instructions.md`.
 
 ## Claim-state parsing

--- a/.github/instructions/idd-overview-appendix.instructions.md
+++ b/.github/instructions/idd-overview-appendix.instructions.md
@@ -110,16 +110,14 @@ Merge Wrapper; never permanently rewrite signing config. `--no-gpg-sign`
 on `git commit`/`git merge` is the last resort.
 
 Record material progress, decisions, and hold reasons as issue or PR
-comments as they happen. That includes a non-default signing outcome
-(including a `--no-gpg-sign` fallback). This ensures that any agent
-resuming without session context can understand the current state and
-continue correctly. Do not rely on session memory alone for
-information that another agent may need.
+comments as they happen -- including any non-default signing outcome
+(e.g. `--no-gpg-sign`) -- so a resuming agent needs no session memory
+to continue correctly.
 
 Operational restore markers (`review-watermark` and `review-baseline`)
 must include the current `{claim-id}` and must never be restored across
 a claim change. A takeover starts a new restore scope. These markers
-must also be authored by a trusted marker actor and include a visible
+must be authored by a trusted marker actor with a visible
 human-readable note (see `idd-review-snapshot.instructions.md`).
 
 ## Review item classes

--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -58,9 +58,8 @@ but never create new hidden-only claim comments.
   session-record checks. Generate a fresh value on every fresh claim or
   stale takeover. Reuse the same `{claim-id}` only for heartbeats of
   that already-verified claim. Reading an existing `{claim-id}` from
-  issue comments does not by itself prove ownership; the current
-  session must have recorded that token before the
-  revalidation step.
+  issue comments does not prove ownership; the current session must
+  have recorded that token on disk first (`idd-claim.instructions.md`).
 - `{prior-claim-id}` is `none` for a fresh claim on an unclaimed issue.
   For a stale-claim takeover, set it to the currently active claim's
   `{claim-id}`.

--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -208,6 +208,9 @@ When in scope, run:
    helper-free fallback in `idd-work.instructions.md`, which uses the
    same `idd-claim.lock` namespace. A `collision` is fail-closed: stop
    unless the active claim revalidation authorizes an explicit takeover.
+   Also confirm `--read-tokens` finds this `{claim-id}` recorded
+   (`idd-claim.instructions.md`); absent or malformed fails closed the
+   same way.
 
 **Recovery if a commit already landed on the wrong branch.** If this gate
 or `idd-doctor` finds a commit on the wrong branch, cherry-pick it onto

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -167,11 +167,17 @@ tools" above), acquire the
 immediately after the worktree exists, **before Step 3** —
 `install-deps` itself writes into the worktree and runs lifecycle
 hooks, so acquiring the lock any later leaves that install unprotected.
+Also re-run `--record-tokens` for this worktree's own copy of the
+[generated-tokens record](idd-claim.instructions.md#worktree-local-lock-file-same-machine-collision)
+at the same point — the A5 copy lives in the primary worktree's admin
+directory, not this one, so the later Claim revalidation gate's
+`--read-tokens` check has nothing to find here until this step runs it.
 
 WorkTrunk's pre-start hook runs before the create command returns. If it
 installs dependencies, its **first** command must acquire the lock for
-the new worktree with the current `{agent-id}` / `{claim-id}`, then run
-the install — acquiring the lock afterward is too late. Under
+the new worktree with the current `{agent-id}` / `{claim-id}` and
+re-run `--record-tokens`, then run the install — doing either afterward
+is too late. Under
 `package-manager`, the new worktree's `idd:claim-lock` bin may not exist
 yet: invoke a pre-install-available helper from the primary worktree
 with the new path as `--worktree`, or use the helper-free fallback

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -167,7 +167,10 @@ tools" above), acquire the
 immediately after the worktree exists, **before Step 3** —
 `install-deps` itself writes into the worktree and runs lifecycle
 hooks, so acquiring the lock any later leaves that install unprotected.
-Also re-run `--record-tokens` for this worktree's own copy of the
+Also re-run `--record-tokens` (with the same `{nonce}` the A5 write
+used — `--record-tokens` overwrites rather than merges, so omitting it
+here drops the nonce from this worktree's own copy) for this
+worktree's own copy of the
 [generated-tokens record](idd-claim.instructions.md#worktree-local-lock-file-same-machine-collision)
 at the same point — the A5 copy lives in the primary worktree's admin
 directory, not this one, so the later Claim revalidation gate's
@@ -176,8 +179,8 @@ directory, not this one, so the later Claim revalidation gate's
 WorkTrunk's pre-start hook runs before the create command returns. If it
 installs dependencies, its **first** command must acquire the lock for
 the new worktree with the current `{agent-id}` / `{claim-id}` and
-re-run `--record-tokens`, then run the install — doing either afterward
-is too late. Under
+re-run `--record-tokens` (with the same `{nonce}` the A5 write used),
+then run the install — doing either afterward is too late. Under
 `package-manager`, the new worktree's `idd:claim-lock` bin may not exist
 yet: invoke a pre-install-available helper from the primary worktree
 with the new path as `--worktree`, or use the helper-free fallback

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1746,12 +1746,13 @@ Interpretation rules:
   Codex P1 -- the mandatory `--read-tokens` check in the Claim
   revalidation gate has no helper-free path without this): resolve the
   same filename for the queried `{claim-id}`, using the same sanitize-
-  then-truncate rule as the write side. Missing file, unparseable JSON,
-  or a parsed `claimId` field that disagrees with the queried
-  `{claim-id}` are all `present: false`/`malformed` -- treat every one
-  of them as absent and fail closed, mirroring the CLI's own
-  `readGeneratedClaimTokens` behavior above; only a well-formed record
-  whose `claimId` field matches is `present: true`.
+  then-truncate rule as the write side, then reproduce the same three
+  outcomes as the CLI's own `--read-tokens` above: a missing file is
+  `present: false`; a file that exists but is unparseable JSON, or whose
+  parsed `claimId` field disagrees with the queried `{claim-id}`, is
+  `present: true, malformed: true`; only a well-formed record whose
+  `claimId` field matches is plain `present: true`. Treat `malformed`
+  the same as absent for the ownership check -- fail closed on both.
 
 ### Clone-scoped lock
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1658,6 +1658,72 @@ Interpretation rules:
   namespace, so a helper-runtime session and an instructions-only
   session see the same lock.
 
+### Worktree-local generated-tokens record
+
+- A sibling artifact to the worktree-local claim lock above, in the same
+  admin directory, answering a narrower question (#2719): not "does
+  anyone else hold this worktree" but "did _this_ session actually
+  generate the `{agent-id}`/`{claim-id}` it is about to trust, on disk,
+  independent of possibly-compacted conversation memory." Referenced by
+  the "Generated-tokens record" paragraph in
+  [`idd-claim.instructions.md`'s Worktree-local lock file section](../.github/instructions/idd-claim.instructions.md#worktree-local-lock-file-same-machine-collision).
+- Source repo / vendored-node commands:
+  `node scripts/claim-lock.mjs --record-tokens --worktree <path>
+  --agent-id <id> --claim-id <id> [--nonce <nonce>]`
+  and `node scripts/claim-lock.mjs --read-tokens --worktree <path>
+  --claim-id <id>`
+- Package-manager / ephemeral-npx command: use the same profile-selected
+  `idd:claim-lock` command as the lock above; the literal invocations are:
+
+  ```sh
+  npx --yes --package <helper-package-spec> \
+    idd-claim-lock --record-tokens --worktree <path> --agent-id <id> \
+    --claim-id <id> [--nonce <nonce>]
+
+  npx --yes --package <helper-package-spec> \
+    idd-claim-lock --read-tokens --worktree <path> --claim-id <id>
+  ```
+
+- **When to call `--record-tokens`**: once at A5 claim time, right after
+  generating `{agent-id}`/`{claim-id}`, before posting the `claimed-by`
+  marker (the B1 worktree does not exist yet, so `<path>` is then the
+  _primary_ worktree); again with `--nonce` right before posting the
+  activation-nonce marker; again at B1 once the sibling worktree exists,
+  mirroring the lock's own `--acquire` step. Keyed by `--claim-id` (a
+  content-hash-suffixed, sanitized filename), so two sessions generating
+  two different claim-ids never collide even while sharing the primary
+  worktree's admin directory. No collision or `--takeover` concept: this
+  is per-claim-id evidence, not a mutual-exclusion primitive, so
+  re-invoking for the same `--claim-id` is always a safe, idempotent
+  overwrite. Exits `0` unless a filesystem error occurs.
+- **When to call `--read-tokens`**: alongside every later `--acquire`
+  re-run, before trusting a `{claim-id}` recalled only from context.
+  Reports `{ path, present, malformed?, record? }` read-only, mirroring
+  `--check`'s own shape: `present: true` with `record` means a
+  well-formed record for exactly this `--claim-id` exists; `present:
+  true, malformed: true` means a file exists at the resolved path but
+  cannot be trusted as this claim-id's record (corrupt content, or an
+  internal `claimId` field that disagrees with the path it was found
+  at); `present: false` means this claim-id was never recorded. Treat
+  `malformed` the same as absent for an ownership check — never trust a
+  claim-id this record does not affirmatively confirm.
+- No explicit release verb, no cleanup across takeovers: like the lock
+  file, the record lives inside the worktree's own private git-admin
+  directory, so `git worktree remove` at F4 deletes it together with the
+  worktree. The _primary_-worktree copy written at A5 (before the B1
+  worktree exists) is not cleaned up by that removal — an accepted
+  residual, since giving this record cross-worktree, pre-acquisition
+  visibility is explicitly out of scope (see the lock file's own
+  cross-worktree-visibility note above).
+- **`instructions-only` helper-free fallback** (no helper runtime
+  available): resolve the private admin directory the same way as the
+  lock file above, then atomically create-or-replace an
+  `idd-generated-tokens-<sanitized-claim-id>-<8-hex-char sha256
+  prefix>.json` file there, writing `{ agentId, claimId, nonce?,
+  recordedAt }`. No exclusive-create semantics needed (unlike the lock):
+  a plain atomic replace is correct since this is idempotent evidence,
+  not a mutual-exclusion primitive.
+
 ### Clone-scoped lock
 
 - Source repo / vendored-node commands:

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1688,14 +1688,22 @@ Interpretation rules:
   generating `{agent-id}`/`{claim-id}`, before posting the `claimed-by`
   marker (the B1 worktree does not exist yet, so `<path>` is then the
   _primary_ worktree); again with `--nonce` right before posting the
-  activation-nonce marker; again at B1 once the sibling worktree exists,
-  mirroring the lock's own `--acquire` step. Keyed by `--claim-id` (a
-  content-hash-suffixed, sanitized filename), so two sessions generating
-  two different claim-ids never collide even while sharing the primary
-  worktree's admin directory. No collision or `--takeover` concept: this
-  is per-claim-id evidence, not a mutual-exclusion primitive, so
-  re-invoking for the same `--claim-id` is always a safe, idempotent
-  overwrite. Exits `0` unless a filesystem error occurs.
+  activation-nonce marker; a third time at B1 once the sibling worktree
+  exists, mirroring the lock's own `--acquire` step. Keyed by
+  `--claim-id` (a content-hash-suffixed, sanitized filename), so two
+  sessions generating two different claim-ids resolve to different paths
+  (an astronomically unlikely, not provably impossible, chance of
+  collision from the truncated hash suffix) even while sharing the
+  primary worktree's admin directory. No collision or `--takeover`
+  concept: this is per-claim-id evidence, not a mutual-exclusion
+  primitive, so re-invoking for the same `--claim-id` is always a safe,
+  idempotent overwrite. Exits `0` unless a filesystem error occurs.
+  **Scope**: a `--read-tokens` hit against the **shared primary**
+  worktree path is bootstrap evidence only, not proof of current-session
+  ownership by itself — see `claim-lock.mts`'s own "Scope of the
+  ownership proof" header comment (#2879 review). Always resolve
+  `--read-tokens`/`--acquire` against the caller's own current cwd, never
+  an explicit different worktree's path.
 - **When to call `--read-tokens`**: alongside every later `--acquire`
   re-run, before trusting a `{claim-id}` recalled only from context.
   Reports `{ path, present, malformed?, record? }` read-only, mirroring

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1745,7 +1745,12 @@ Interpretation rules:
   `<sanitized-claim-id>`: non-`[A-Za-z0-9._-]` characters replaced with
   `_`, then truncated to 64 characters, so a long claim-id can't push
   the filename past the filesystem's `NAME_MAX` -- #2879 review, Codex
-  P1. Write `{ agentId, claimId, nonce?, recordedAt }`. No
+  P1. `<8-hex-char sha256 prefix>`: the first 8 hex characters of the
+  SHA-256 digest of the **original, pre-sanitize, pre-truncate**
+  `{claim-id}`, UTF-8-encoded -- not the sanitized or truncated form,
+  so a fallback and the CLI (or two fallback implementations) agree on
+  the same path for the same claim-id (#2879 review, Codex P2). Write
+  `{ agentId, claimId, nonce?, recordedAt }`. No
   exclusive-create semantics needed (unlike the lock): a plain atomic
   replace is correct since this is idempotent evidence, not a
   mutual-exclusion primitive.

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1732,16 +1732,23 @@ Interpretation rules:
   profile, see
   [Helper Runtime Profile](customization.md#helper-runtime-profile) —
   so this path is the common case, not an edge case): resolve the
-  private admin
-  directory the same way as the lock file above, then atomically
-  create-or-replace an `idd-generated-tokens-<sanitized-claim-id>-<8-hex
-  -char sha256 prefix>.json` file there (`<sanitized-claim-id>`:
-  non-`[A-Za-z0-9._-]` characters replaced with `_`, then truncated to
-  64 characters, so a long claim-id can't push the filename past the
-  filesystem's `NAME_MAX` -- #2879 review, Codex P1), writing
-  `{ agentId, claimId, nonce?, recordedAt }`. No exclusive-create
-  semantics needed (unlike the lock): a plain atomic replace is correct
-  since this is idempotent evidence, not a mutual-exclusion primitive.
+  private admin directory the same way as the lock file above, then
+  atomically create-or-replace a file there matching this pattern
+  (kept in a fenced block, not a prose code span, so a Markdown
+  reflow can't break the filename across a line -- #2879 review,
+  Codex P1):
+
+  ```text
+  idd-generated-tokens-<sanitized-claim-id>-<8-hex-char sha256 prefix>.json
+  ```
+
+  `<sanitized-claim-id>`: non-`[A-Za-z0-9._-]` characters replaced with
+  `_`, then truncated to 64 characters, so a long claim-id can't push
+  the filename past the filesystem's `NAME_MAX` -- #2879 review, Codex
+  P1. Write `{ agentId, claimId, nonce?, recordedAt }`. No
+  exclusive-create semantics needed (unlike the lock): a plain atomic
+  replace is correct since this is idempotent evidence, not a
+  mutual-exclusion primitive.
 - **`instructions-only` helper-free fallback, read side** (#2879 review,
   Codex P1 -- the mandatory `--read-tokens` check in the Claim
   revalidation gate has no helper-free path without this): resolve the

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1727,9 +1727,12 @@ Interpretation rules:
   available): resolve the private admin directory the same way as the
   lock file above, then atomically create-or-replace an
   `idd-generated-tokens-<sanitized-claim-id>-<8-hex-char sha256
-  prefix>.json` file there, writing `{ agentId, claimId, nonce?,
-  recordedAt }`. No exclusive-create semantics needed (unlike the lock):
-  a plain atomic replace is correct since this is idempotent evidence,
+  prefix>.json` file there (`<sanitized-claim-id>`: non-`[A-Za-z0-9._-]`
+  characters replaced with `_`, then truncated to 64 characters, so a
+  long claim-id can't push the filename past the filesystem's
+  `NAME_MAX`), writing `{ agentId, claimId, nonce?, recordedAt }`. No
+  exclusive-create semantics needed (unlike the lock): a plain atomic
+  replace is correct since this is idempotent evidence,
   not a mutual-exclusion primitive.
 
 ### Clone-scoped lock

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1689,7 +1689,11 @@ Interpretation rules:
   marker (the B1 worktree does not exist yet, so `<path>` is then the
   _primary_ worktree); again with `--nonce` right before posting the
   activation-nonce marker; a third time at B1 once the sibling worktree
-  exists, mirroring the lock's own `--acquire` step. Keyed by
+  exists, again with `--nonce` carried over from the A5 write --
+  mirroring the lock's own `--acquire` step, but into a distinct file in
+  the new worktree's own admin directory, so the earlier primary-worktree
+  write's `nonce` field must be copied forward rather than omitted (the
+  B1 write is not a re-read-then-rewrite of the same file). Keyed by
   `--claim-id` (a content-hash-suffixed, sanitized filename), so two
   sessions generating two different claim-ids resolve to different paths
   (an astronomically unlikely, not provably impossible, chance of
@@ -1723,17 +1727,31 @@ Interpretation rules:
   residual, since giving this record cross-worktree, pre-acquisition
   visibility is explicitly out of scope (see the lock file's own
   cross-worktree-visibility note above).
-- **`instructions-only` helper-free fallback** (no helper runtime
-  available): resolve the private admin directory the same way as the
-  lock file above, then atomically create-or-replace an
-  `idd-generated-tokens-<sanitized-claim-id>-<8-hex-char sha256
-  prefix>.json` file there (`<sanitized-claim-id>`: non-`[A-Za-z0-9._-]`
-  characters replaced with `_`, then truncated to 64 characters, so a
-  long claim-id can't push the filename past the filesystem's
-  `NAME_MAX`), writing `{ agentId, claimId, nonce?, recordedAt }`. No
-  exclusive-create semantics needed (unlike the lock): a plain atomic
-  replace is correct since this is idempotent evidence,
-  not a mutual-exclusion primitive.
+- **`instructions-only` helper-free fallback, write side** (no helper
+  runtime available — `instructions-only` is the distributed default
+  profile, see
+  [Helper Runtime Profile](customization.md#helper-runtime-profile) —
+  so this path is the common case, not an edge case): resolve the
+  private admin
+  directory the same way as the lock file above, then atomically
+  create-or-replace an `idd-generated-tokens-<sanitized-claim-id>-<8-hex
+  -char sha256 prefix>.json` file there (`<sanitized-claim-id>`:
+  non-`[A-Za-z0-9._-]` characters replaced with `_`, then truncated to
+  64 characters, so a long claim-id can't push the filename past the
+  filesystem's `NAME_MAX` -- #2879 review, Codex P1), writing
+  `{ agentId, claimId, nonce?, recordedAt }`. No exclusive-create
+  semantics needed (unlike the lock): a plain atomic replace is correct
+  since this is idempotent evidence, not a mutual-exclusion primitive.
+- **`instructions-only` helper-free fallback, read side** (#2879 review,
+  Codex P1 -- the mandatory `--read-tokens` check in the Claim
+  revalidation gate has no helper-free path without this): resolve the
+  same filename for the queried `{claim-id}`, using the same sanitize-
+  then-truncate rule as the write side. Missing file, unparseable JSON,
+  or a parsed `claimId` field that disagrees with the queried
+  `{claim-id}` are all `present: false`/`malformed` -- treat every one
+  of them as absent and fail closed, mirroring the CLI's own
+  `readGeneratedClaimTokens` behavior above; only a well-formed record
+  whose `claimId` field matches is `present: true`.
 
 ### Clone-scoped lock
 

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -273,8 +273,9 @@ incomplete/current authoring hold blocks; only exact anchor/set/session
 `release-complete` allows a completed generation.
 Route directly to already-claimed/Discover fallback (A0-T stops), never A5(c).
 
-Post the claim comment using the exact format and posting mechanics
-already defined in
+First record `{agent-id}`/`{claim-id}` via `--record-tokens`; then post
+the claim comment using the exact format and posting mechanics already
+defined in
 [Claim format](idd-overview-core.instructions.md#claim-format) — do not
 re-derive them here. `emit-marker` (`--type claimed-by`, emit-only) also
 renders the body without posting.
@@ -311,9 +312,10 @@ verification_ below); never skip it for any activation path:
 _{agent-id}: claim activation nonce — IDD automation marker. Do not edit._
 ```
 
-`{nonce}` is fresh; record it with `{agent-id}` / `{claim-id}`. For multiple
-trusted markers sharing a claim, the lexicographically earliest nonce wins;
-no marker means no comparison. With helper runtime, post it using
+`{nonce}` is fresh; record it via `--record-tokens` before posting. For
+multiple trusted markers sharing a claim, the lexicographically earliest
+nonce wins; no marker means no comparison. With helper runtime, post it
+using
 `post-idd-marker --type activation-nonce --target issue <number> --apply`
 with the four fields defined in `docs/idd-helper-scripts.md`.
 
@@ -570,8 +572,9 @@ for the full algorithm.
 ### Worktree-local lock file (same-machine collision)
 
 A same-machine fast path complementing the cross-machine claim check
-above. Acquire once the B1 worktree exists (before the first mutation),
-then re-run alongside every later pre-mutation check:
+above. Acquire once the B1 worktree exists (before the first mutation;
+also re-run `--record-tokens` there), then re-run alongside every later
+pre-mutation check:
 `node scripts/claim-lock.mjs --acquire --worktree <path> --agent-id
 {agent-id} --claim-id {claim-id}`.
 
@@ -589,10 +592,9 @@ session's leftover lock resolves the same way. See
 `docs/idd-helper-scripts.md`'s Worktree-local claim lock entry for
 mechanical detail.
 
-**Generated-tokens record.** Write `{agent-id}` / `{claim-id}` (then the
-nonce) via `--record-tokens` before posting each marker; re-check with
-`--read-tokens` alongside `--acquire` before trusting a recalled
-`{claim-id}`. See `docs/idd-helper-scripts.md`.
+**Generated-tokens record.** Re-check with `--read-tokens` alongside
+`--acquire` before trusting a recalled `{claim-id}`. See
+`docs/idd-helper-scripts.md`.
 
 Then continue to `idd-work.instructions.md`.
 

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -573,7 +573,8 @@ for the full algorithm.
 
 A same-machine fast path complementing the cross-machine claim check
 above. Acquire once the B1 worktree exists (before the first mutation;
-also re-run `--record-tokens` there), then re-run alongside every later
+also re-run `--record-tokens` there (with `--nonce`)), then re-run
+alongside every later
 pre-mutation check:
 `node scripts/claim-lock.mjs --acquire --worktree <path> --agent-id
 {agent-id} --claim-id {claim-id}`.

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -589,6 +589,11 @@ session's leftover lock resolves the same way. See
 `docs/idd-helper-scripts.md`'s Worktree-local claim lock entry for
 mechanical detail.
 
+**Generated-tokens record.** Write `{agent-id}` / `{claim-id}` (then the
+nonce) via `--record-tokens` before posting each marker; re-check with
+`--read-tokens` alongside `--acquire` before trusting a recalled
+`{claim-id}`. See `docs/idd-helper-scripts.md`.
+
 Then continue to `idd-work.instructions.md`.
 
 ## Claim-state parsing

--- a/idd-template/.github/instructions/idd-overview-appendix.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-appendix.instructions.md
@@ -105,16 +105,14 @@ Merge Wrapper; never permanently rewrite signing config. `--no-gpg-sign`
 on `git commit`/`git merge` is the last resort.
 
 Record material progress, decisions, and hold reasons as issue or PR
-comments as they happen. That includes a non-default signing outcome
-(including a `--no-gpg-sign` fallback). This ensures that any agent
-resuming without session context can understand the current state and
-continue correctly. Do not rely on session memory alone for
-information that another agent may need.
+comments as they happen -- including any non-default signing outcome
+(e.g. `--no-gpg-sign`) -- so a resuming agent needs no session memory
+to continue correctly.
 
 Operational restore markers (`review-watermark` and `review-baseline`)
 must include the current `{claim-id}` and must never be restored across
 a claim change. A takeover starts a new restore scope. These markers
-must also be authored by a trusted marker actor and include a visible
+must be authored by a trusted marker actor with a visible
 human-readable note (see `idd-review-snapshot.instructions.md`).
 
 ## Review item classes

--- a/idd-template/.github/instructions/idd-overview-core.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-core.instructions.md
@@ -53,9 +53,8 @@ but never create new hidden-only claim comments.
   session-record checks. Generate a fresh value on every fresh claim or
   stale takeover. Reuse the same `{claim-id}` only for heartbeats of
   that already-verified claim. Reading an existing `{claim-id}` from
-  issue comments does not by itself prove ownership; the current
-  session must have recorded that token before the
-  revalidation step.
+  issue comments does not prove ownership; the current session must
+  have recorded that token on disk first (`idd-claim.instructions.md`).
 - `{prior-claim-id}` is `none` for a fresh claim on an unclaimed issue.
   For a stale-claim takeover, set it to the currently active claim's
   `{claim-id}`.

--- a/idd-template/.github/instructions/idd-overview-core.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-core.instructions.md
@@ -203,6 +203,9 @@ When in scope, run:
    helper-free fallback in `idd-work.instructions.md`, which uses the
    same `idd-claim.lock` namespace. A `collision` is fail-closed: stop
    unless the active claim revalidation authorizes an explicit takeover.
+   Also confirm `--read-tokens` finds this `{claim-id}` recorded
+   (`idd-claim.instructions.md`); absent or malformed fails closed the
+   same way.
 
 **Recovery if a commit already landed on the wrong branch.** If this gate
 or `idd-doctor` finds a commit on the wrong branch, cherry-pick it onto

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -162,11 +162,17 @@ tools" above), acquire the
 immediately after the worktree exists, **before Step 3** —
 `install-deps` itself writes into the worktree and runs lifecycle
 hooks, so acquiring the lock any later leaves that install unprotected.
+Also re-run `--record-tokens` for this worktree's own copy of the
+[generated-tokens record](idd-claim.instructions.md#worktree-local-lock-file-same-machine-collision)
+at the same point — the A5 copy lives in the primary worktree's admin
+directory, not this one, so the later Claim revalidation gate's
+`--read-tokens` check has nothing to find here until this step runs it.
 
 WorkTrunk's pre-start hook runs before the create command returns. If it
 installs dependencies, its **first** command must acquire the lock for
-the new worktree with the current `{agent-id}` / `{claim-id}`, then run
-the install — acquiring the lock afterward is too late. Under
+the new worktree with the current `{agent-id}` / `{claim-id}` and
+re-run `--record-tokens`, then run the install — doing either afterward
+is too late. Under
 `package-manager`, the new worktree's `idd:claim-lock` bin may not exist
 yet: invoke a pre-install-available helper from the primary worktree
 with the new path as `--worktree`, or use the helper-free fallback

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -162,7 +162,10 @@ tools" above), acquire the
 immediately after the worktree exists, **before Step 3** —
 `install-deps` itself writes into the worktree and runs lifecycle
 hooks, so acquiring the lock any later leaves that install unprotected.
-Also re-run `--record-tokens` for this worktree's own copy of the
+Also re-run `--record-tokens` (with the same `{nonce}` the A5 write
+used — `--record-tokens` overwrites rather than merges, so omitting it
+here drops the nonce from this worktree's own copy) for this
+worktree's own copy of the
 [generated-tokens record](idd-claim.instructions.md#worktree-local-lock-file-same-machine-collision)
 at the same point — the A5 copy lives in the primary worktree's admin
 directory, not this one, so the later Claim revalidation gate's
@@ -171,8 +174,8 @@ directory, not this one, so the later Claim revalidation gate's
 WorkTrunk's pre-start hook runs before the create command returns. If it
 installs dependencies, its **first** command must acquire the lock for
 the new worktree with the current `{agent-id}` / `{claim-id}` and
-re-run `--record-tokens`, then run the install — doing either afterward
-is too late. Under
+re-run `--record-tokens` (with the same `{nonce}` the A5 write used),
+then run the install — doing either afterward is too late. Under
 `package-manager`, the new worktree's `idd:claim-lock` bin may not exist
 yet: invoke a pre-install-available helper from the primary worktree
 with the new path as `--worktree`, or use the helper-free fallback

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1746,12 +1746,13 @@ Interpretation rules:
   Codex P1 -- the mandatory `--read-tokens` check in the Claim
   revalidation gate has no helper-free path without this): resolve the
   same filename for the queried `{claim-id}`, using the same sanitize-
-  then-truncate rule as the write side. Missing file, unparseable JSON,
-  or a parsed `claimId` field that disagrees with the queried
-  `{claim-id}` are all `present: false`/`malformed` -- treat every one
-  of them as absent and fail closed, mirroring the CLI's own
-  `readGeneratedClaimTokens` behavior above; only a well-formed record
-  whose `claimId` field matches is `present: true`.
+  then-truncate rule as the write side, then reproduce the same three
+  outcomes as the CLI's own `--read-tokens` above: a missing file is
+  `present: false`; a file that exists but is unparseable JSON, or whose
+  parsed `claimId` field disagrees with the queried `{claim-id}`, is
+  `present: true, malformed: true`; only a well-formed record whose
+  `claimId` field matches is plain `present: true`. Treat `malformed`
+  the same as absent for the ownership check -- fail closed on both.
 
 ### Clone-scoped lock
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1658,6 +1658,72 @@ Interpretation rules:
   namespace, so a helper-runtime session and an instructions-only
   session see the same lock.
 
+### Worktree-local generated-tokens record
+
+- A sibling artifact to the worktree-local claim lock above, in the same
+  admin directory, answering a narrower question (#2719): not "does
+  anyone else hold this worktree" but "did _this_ session actually
+  generate the `{agent-id}`/`{claim-id}` it is about to trust, on disk,
+  independent of possibly-compacted conversation memory." Referenced by
+  the "Generated-tokens record" paragraph in
+  [`idd-claim.instructions.md`'s Worktree-local lock file section](../.github/instructions/idd-claim.instructions.md#worktree-local-lock-file-same-machine-collision).
+- Source repo / vendored-node commands:
+  `node scripts/claim-lock.mjs --record-tokens --worktree <path>
+  --agent-id <id> --claim-id <id> [--nonce <nonce>]`
+  and `node scripts/claim-lock.mjs --read-tokens --worktree <path>
+  --claim-id <id>`
+- Package-manager / ephemeral-npx command: use the same profile-selected
+  `idd:claim-lock` command as the lock above; the literal invocations are:
+
+  ```sh
+  npx --yes --package <helper-package-spec> \
+    idd-claim-lock --record-tokens --worktree <path> --agent-id <id> \
+    --claim-id <id> [--nonce <nonce>]
+
+  npx --yes --package <helper-package-spec> \
+    idd-claim-lock --read-tokens --worktree <path> --claim-id <id>
+  ```
+
+- **When to call `--record-tokens`**: once at A5 claim time, right after
+  generating `{agent-id}`/`{claim-id}`, before posting the `claimed-by`
+  marker (the B1 worktree does not exist yet, so `<path>` is then the
+  _primary_ worktree); again with `--nonce` right before posting the
+  activation-nonce marker; again at B1 once the sibling worktree exists,
+  mirroring the lock's own `--acquire` step. Keyed by `--claim-id` (a
+  content-hash-suffixed, sanitized filename), so two sessions generating
+  two different claim-ids never collide even while sharing the primary
+  worktree's admin directory. No collision or `--takeover` concept: this
+  is per-claim-id evidence, not a mutual-exclusion primitive, so
+  re-invoking for the same `--claim-id` is always a safe, idempotent
+  overwrite. Exits `0` unless a filesystem error occurs.
+- **When to call `--read-tokens`**: alongside every later `--acquire`
+  re-run, before trusting a `{claim-id}` recalled only from context.
+  Reports `{ path, present, malformed?, record? }` read-only, mirroring
+  `--check`'s own shape: `present: true` with `record` means a
+  well-formed record for exactly this `--claim-id` exists; `present:
+  true, malformed: true` means a file exists at the resolved path but
+  cannot be trusted as this claim-id's record (corrupt content, or an
+  internal `claimId` field that disagrees with the path it was found
+  at); `present: false` means this claim-id was never recorded. Treat
+  `malformed` the same as absent for an ownership check — never trust a
+  claim-id this record does not affirmatively confirm.
+- No explicit release verb, no cleanup across takeovers: like the lock
+  file, the record lives inside the worktree's own private git-admin
+  directory, so `git worktree remove` at F4 deletes it together with the
+  worktree. The _primary_-worktree copy written at A5 (before the B1
+  worktree exists) is not cleaned up by that removal — an accepted
+  residual, since giving this record cross-worktree, pre-acquisition
+  visibility is explicitly out of scope (see the lock file's own
+  cross-worktree-visibility note above).
+- **`instructions-only` helper-free fallback** (no helper runtime
+  available): resolve the private admin directory the same way as the
+  lock file above, then atomically create-or-replace an
+  `idd-generated-tokens-<sanitized-claim-id>-<8-hex-char sha256
+  prefix>.json` file there, writing `{ agentId, claimId, nonce?,
+  recordedAt }`. No exclusive-create semantics needed (unlike the lock):
+  a plain atomic replace is correct since this is idempotent evidence,
+  not a mutual-exclusion primitive.
+
 ### Clone-scoped lock
 
 - Source repo / vendored-node commands:

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1688,14 +1688,22 @@ Interpretation rules:
   generating `{agent-id}`/`{claim-id}`, before posting the `claimed-by`
   marker (the B1 worktree does not exist yet, so `<path>` is then the
   _primary_ worktree); again with `--nonce` right before posting the
-  activation-nonce marker; again at B1 once the sibling worktree exists,
-  mirroring the lock's own `--acquire` step. Keyed by `--claim-id` (a
-  content-hash-suffixed, sanitized filename), so two sessions generating
-  two different claim-ids never collide even while sharing the primary
-  worktree's admin directory. No collision or `--takeover` concept: this
-  is per-claim-id evidence, not a mutual-exclusion primitive, so
-  re-invoking for the same `--claim-id` is always a safe, idempotent
-  overwrite. Exits `0` unless a filesystem error occurs.
+  activation-nonce marker; a third time at B1 once the sibling worktree
+  exists, mirroring the lock's own `--acquire` step. Keyed by
+  `--claim-id` (a content-hash-suffixed, sanitized filename), so two
+  sessions generating two different claim-ids resolve to different paths
+  (an astronomically unlikely, not provably impossible, chance of
+  collision from the truncated hash suffix) even while sharing the
+  primary worktree's admin directory. No collision or `--takeover`
+  concept: this is per-claim-id evidence, not a mutual-exclusion
+  primitive, so re-invoking for the same `--claim-id` is always a safe,
+  idempotent overwrite. Exits `0` unless a filesystem error occurs.
+  **Scope**: a `--read-tokens` hit against the **shared primary**
+  worktree path is bootstrap evidence only, not proof of current-session
+  ownership by itself — see `claim-lock.mts`'s own "Scope of the
+  ownership proof" header comment (#2879 review). Always resolve
+  `--read-tokens`/`--acquire` against the caller's own current cwd, never
+  an explicit different worktree's path.
 - **When to call `--read-tokens`**: alongside every later `--acquire`
   re-run, before trusting a `{claim-id}` recalled only from context.
   Reports `{ path, present, malformed?, record? }` read-only, mirroring

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1745,7 +1745,12 @@ Interpretation rules:
   `<sanitized-claim-id>`: non-`[A-Za-z0-9._-]` characters replaced with
   `_`, then truncated to 64 characters, so a long claim-id can't push
   the filename past the filesystem's `NAME_MAX` -- #2879 review, Codex
-  P1. Write `{ agentId, claimId, nonce?, recordedAt }`. No
+  P1. `<8-hex-char sha256 prefix>`: the first 8 hex characters of the
+  SHA-256 digest of the **original, pre-sanitize, pre-truncate**
+  `{claim-id}`, UTF-8-encoded -- not the sanitized or truncated form,
+  so a fallback and the CLI (or two fallback implementations) agree on
+  the same path for the same claim-id (#2879 review, Codex P2). Write
+  `{ agentId, claimId, nonce?, recordedAt }`. No
   exclusive-create semantics needed (unlike the lock): a plain atomic
   replace is correct since this is idempotent evidence, not a
   mutual-exclusion primitive.

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1732,16 +1732,23 @@ Interpretation rules:
   profile, see
   [Helper Runtime Profile](customization.md#helper-runtime-profile) —
   so this path is the common case, not an edge case): resolve the
-  private admin
-  directory the same way as the lock file above, then atomically
-  create-or-replace an `idd-generated-tokens-<sanitized-claim-id>-<8-hex
-  -char sha256 prefix>.json` file there (`<sanitized-claim-id>`:
-  non-`[A-Za-z0-9._-]` characters replaced with `_`, then truncated to
-  64 characters, so a long claim-id can't push the filename past the
-  filesystem's `NAME_MAX` -- #2879 review, Codex P1), writing
-  `{ agentId, claimId, nonce?, recordedAt }`. No exclusive-create
-  semantics needed (unlike the lock): a plain atomic replace is correct
-  since this is idempotent evidence, not a mutual-exclusion primitive.
+  private admin directory the same way as the lock file above, then
+  atomically create-or-replace a file there matching this pattern
+  (kept in a fenced block, not a prose code span, so a Markdown
+  reflow can't break the filename across a line -- #2879 review,
+  Codex P1):
+
+  ```text
+  idd-generated-tokens-<sanitized-claim-id>-<8-hex-char sha256 prefix>.json
+  ```
+
+  `<sanitized-claim-id>`: non-`[A-Za-z0-9._-]` characters replaced with
+  `_`, then truncated to 64 characters, so a long claim-id can't push
+  the filename past the filesystem's `NAME_MAX` -- #2879 review, Codex
+  P1. Write `{ agentId, claimId, nonce?, recordedAt }`. No
+  exclusive-create semantics needed (unlike the lock): a plain atomic
+  replace is correct since this is idempotent evidence, not a
+  mutual-exclusion primitive.
 - **`instructions-only` helper-free fallback, read side** (#2879 review,
   Codex P1 -- the mandatory `--read-tokens` check in the Claim
   revalidation gate has no helper-free path without this): resolve the

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1727,9 +1727,12 @@ Interpretation rules:
   available): resolve the private admin directory the same way as the
   lock file above, then atomically create-or-replace an
   `idd-generated-tokens-<sanitized-claim-id>-<8-hex-char sha256
-  prefix>.json` file there, writing `{ agentId, claimId, nonce?,
-  recordedAt }`. No exclusive-create semantics needed (unlike the lock):
-  a plain atomic replace is correct since this is idempotent evidence,
+  prefix>.json` file there (`<sanitized-claim-id>`: non-`[A-Za-z0-9._-]`
+  characters replaced with `_`, then truncated to 64 characters, so a
+  long claim-id can't push the filename past the filesystem's
+  `NAME_MAX`), writing `{ agentId, claimId, nonce?, recordedAt }`. No
+  exclusive-create semantics needed (unlike the lock): a plain atomic
+  replace is correct since this is idempotent evidence,
   not a mutual-exclusion primitive.
 
 ### Clone-scoped lock

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1689,7 +1689,11 @@ Interpretation rules:
   marker (the B1 worktree does not exist yet, so `<path>` is then the
   _primary_ worktree); again with `--nonce` right before posting the
   activation-nonce marker; a third time at B1 once the sibling worktree
-  exists, mirroring the lock's own `--acquire` step. Keyed by
+  exists, again with `--nonce` carried over from the A5 write --
+  mirroring the lock's own `--acquire` step, but into a distinct file in
+  the new worktree's own admin directory, so the earlier primary-worktree
+  write's `nonce` field must be copied forward rather than omitted (the
+  B1 write is not a re-read-then-rewrite of the same file). Keyed by
   `--claim-id` (a content-hash-suffixed, sanitized filename), so two
   sessions generating two different claim-ids resolve to different paths
   (an astronomically unlikely, not provably impossible, chance of
@@ -1723,17 +1727,31 @@ Interpretation rules:
   residual, since giving this record cross-worktree, pre-acquisition
   visibility is explicitly out of scope (see the lock file's own
   cross-worktree-visibility note above).
-- **`instructions-only` helper-free fallback** (no helper runtime
-  available): resolve the private admin directory the same way as the
-  lock file above, then atomically create-or-replace an
-  `idd-generated-tokens-<sanitized-claim-id>-<8-hex-char sha256
-  prefix>.json` file there (`<sanitized-claim-id>`: non-`[A-Za-z0-9._-]`
-  characters replaced with `_`, then truncated to 64 characters, so a
-  long claim-id can't push the filename past the filesystem's
-  `NAME_MAX`), writing `{ agentId, claimId, nonce?, recordedAt }`. No
-  exclusive-create semantics needed (unlike the lock): a plain atomic
-  replace is correct since this is idempotent evidence,
-  not a mutual-exclusion primitive.
+- **`instructions-only` helper-free fallback, write side** (no helper
+  runtime available — `instructions-only` is the distributed default
+  profile, see
+  [Helper Runtime Profile](customization.md#helper-runtime-profile) —
+  so this path is the common case, not an edge case): resolve the
+  private admin
+  directory the same way as the lock file above, then atomically
+  create-or-replace an `idd-generated-tokens-<sanitized-claim-id>-<8-hex
+  -char sha256 prefix>.json` file there (`<sanitized-claim-id>`:
+  non-`[A-Za-z0-9._-]` characters replaced with `_`, then truncated to
+  64 characters, so a long claim-id can't push the filename past the
+  filesystem's `NAME_MAX` -- #2879 review, Codex P1), writing
+  `{ agentId, claimId, nonce?, recordedAt }`. No exclusive-create
+  semantics needed (unlike the lock): a plain atomic replace is correct
+  since this is idempotent evidence, not a mutual-exclusion primitive.
+- **`instructions-only` helper-free fallback, read side** (#2879 review,
+  Codex P1 -- the mandatory `--read-tokens` check in the Claim
+  revalidation gate has no helper-free path without this): resolve the
+  same filename for the queried `{claim-id}`, using the same sanitize-
+  then-truncate rule as the write side. Missing file, unparseable JSON,
+  or a parsed `claimId` field that disagrees with the queried
+  `{claim-id}` are all `present: false`/`malformed` -- treat every one
+  of them as absent and fail closed, mirroring the CLI's own
+  `readGeneratedClaimTokens` behavior above; only a well-formed record
+  whose `claimId` field matches is `present: true`.
 
 ### Clone-scoped lock
 

--- a/scripts/claim-lock.mjs
+++ b/scripts/claim-lock.mjs
@@ -114,6 +114,18 @@ import { parseCliArgs } from './cli-args.mjs';
 const CLAIM_LOCK_FILE_NAME = 'idd-claim.lock';
 const GENERATED_TOKENS_FILE_PREFIX = 'idd-generated-tokens';
 const MAX_RETRY_ATTEMPTS = 5;
+/**
+ * Cap on the sanitized-claim-id portion of a generated-tokens filename
+ * (see {@link sanitizeClaimIdForFilename}). A claim-id is an opaque
+ * token -- forced-handoff recovery can adopt one this process never
+ * generated -- so nothing upstream bounds its length; without a cap
+ * here, a long enough claim-id pushes the interpolated filename past
+ * the filesystem's `NAME_MAX` and `--record-tokens` fails with
+ * `ENAMETOOLONG`, permanently blocking the fail-closed ownership gate
+ * for that claim. The content-hash suffix already disambiguates, so
+ * truncating this prefix costs only human-readability, not safety.
+ */
+const MAX_SANITIZED_CLAIM_ID_LENGTH = 64;
 const CLAIM_LOCK_FLAG_SPEC = {
   '--acquire': { type: 'boolean' },
   '--check': { type: 'boolean' },
@@ -182,17 +194,21 @@ export function resolveClaimLockPath(worktree) {
   return join(resolveWorktreeAdminDir(worktree), CLAIM_LOCK_FILE_NAME);
 }
 /**
- * Sanitize `claimId` into a filesystem-safe token: anything outside
- * `[A-Za-z0-9._-]` becomes `_`. Claim-ids already follow that character
- * set by convention, but this is defensive, not assumed -- combined with
- * the content-hash suffix in {@link resolveGeneratedTokensPath}, two
- * distinct claim-ids resolving to the same sanitized filename is
- * astronomically unlikely, even when an out-of-convention claim-id
- * defeats the character-class sanitization alone (the truncated 8-hex-char
- * hash makes this vanishingly improbable, not provably impossible).
+ * Sanitize `claimId` into a filesystem-safe, length-bounded token:
+ * anything outside `[A-Za-z0-9._-]` becomes `_`, then the result is
+ * truncated to {@link MAX_SANITIZED_CLAIM_ID_LENGTH} characters. Claim-ids
+ * already follow that character set and a much shorter length by
+ * convention, but neither is assumed -- combined with the content-hash
+ * suffix in {@link resolveGeneratedTokensPath}, two distinct claim-ids
+ * resolving to the same sanitized filename is astronomically unlikely,
+ * even when an out-of-convention claim-id defeats the character-class
+ * sanitization and the length cap both (the truncated 8-hex-char hash
+ * makes this vanishingly improbable, not provably impossible).
  */
 function sanitizeClaimIdForFilename(claimId) {
-  return claimId.replace(/[^A-Za-z0-9._-]/g, '_');
+  return claimId
+    .replace(/[^A-Za-z0-9._-]/g, '_')
+    .slice(0, MAX_SANITIZED_CLAIM_ID_LENGTH);
 }
 /**
  * Resolve the generated-tokens record's path inside `cwd`'s own private

--- a/scripts/claim-lock.mjs
+++ b/scripts/claim-lock.mjs
@@ -55,11 +55,14 @@
 // the current cwd is then the primary worktree, whose admin directory is
 // shared by every concurrent session in the same clone. A fixed filename
 // there would let two sessions generating two different claim-ids clobber
-// each other; a claim-id-keyed filename (plus a short content hash suffix
-// so sanitization can never collide two distinct claim-ids onto the same
-// path) does not. B1 repeats the same write into the new worktree's own
-// private admin directory once it exists, mirroring how `idd-claim.lock`
-// already works there. Unlike the lock, this record has no collision or
+// each other; a claim-id-keyed filename (plus a short content hash suffix,
+// so sanitization collapsing two distinct claim-ids to the same string
+// still resolves to different paths in all but an astronomically unlikely
+// collision -- an 8-hex-char truncated hash cannot make that provably
+// impossible) makes that far less likely. B1 repeats the same write into
+// the new worktree's own private admin directory once it exists,
+// mirroring how `idd-claim.lock` already works there. Unlike the lock,
+// this record has no collision or
 // `--takeover` concept: it is per-claim-id evidence, not a mutual-exclusion
 // primitive, so re-recording (idempotent overwrite) is always safe and
 // expected -- both writes above, plus the follow-up write once the
@@ -72,6 +75,29 @@
 // whether the claim-id it finds active is one this session actually
 // generated, rather than one merely recalled from (possibly compacted)
 // conversation context.
+//
+// Scope of the ownership proof (#2879 review, Codex P1): a `present: true`
+// `--read-tokens` result proves "a `--record-tokens` call for this exact
+// claim-id landed at this path" -- it does not cryptographically bind that
+// call to the specific process or conversation now reading it back, since
+// each CLI invocation is a stateless one-shot child (see above) with no
+// tracked process/session identity to check against. During the narrow
+// A5-to-B1 window, the primary worktree's admin directory is shared by
+// every concurrent session in the same clone, so a `--read-tokens` check
+// made *against that shared path* is corroborating bootstrap evidence,
+// not sole proof of current-session ownership. This is why every caller
+// must resolve `--read-tokens`/`--acquire` against its **own current
+// cwd** (never an explicit different worktree's path): once B1 creates
+// the dedicated worktree, that admin directory is private to the one
+// claim/branch it represents, and the pre-mutation claim revalidation
+// gate (`idd-overview-core.instructions.md`) already scopes its own
+// cwd-vs-claim check to exactly that post-B1 contract (B3, D, E, F2/F3),
+// where this record's guarantee is strongest. The existing GitHub
+// claim-state, branch-collision, and worktree-local-lock checks remain
+// the primary defense against a genuinely different session mutating
+// under a claim-id it never generated; this record's own job is narrower
+// and complementary: helping *this* session's own memory survive its own
+// context compaction, not adjudicating between two sessions.
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import {
@@ -130,9 +156,16 @@ function sanitizedGitEnvironment() {
  * --absolute-git-dir`) — inside a linked worktree, `.git` is a *file* (a
  * `gitdir:` pointer), not a directory, so a literal `.git/...` path would
  * throw `ENOTDIR`. Shared by every path resolved inside this admin
- * directory (the lock file and the generated-tokens record below), so
- * `git worktree remove` deletes all of them together with the worktree,
- * with no separate cleanup step required.
+ * directory (the lock file and the generated-tokens record below).
+ *
+ * When `cwd` is a **linked** worktree (the normal B1-onward case),
+ * `git worktree remove` deletes this whole admin directory together with
+ * the worktree, with no separate cleanup step required. That guarantee
+ * does **not** hold when `cwd` is the **primary** worktree (the A5,
+ * pre-B1 generated-tokens record write, #2879 review): the primary
+ * worktree's admin directory is never removed by `git worktree remove`,
+ * is shared by every concurrent session in the same clone, and persists
+ * indefinitely — callers must not assume it is ever cleaned up.
  */
 function resolveWorktreeAdminDir(cwd) {
   return execFileSync('git', ['-C', cwd, 'rev-parse', '--absolute-git-dir'], {
@@ -153,9 +186,10 @@ export function resolveClaimLockPath(worktree) {
  * `[A-Za-z0-9._-]` becomes `_`. Claim-ids already follow that character
  * set by convention, but this is defensive, not assumed -- combined with
  * the content-hash suffix in {@link resolveGeneratedTokensPath}, two
- * distinct claim-ids can never collide onto the same sanitized filename
- * even if an out-of-convention claim-id defeats the character-class
- * sanitization alone.
+ * distinct claim-ids resolving to the same sanitized filename is
+ * astronomically unlikely, even when an out-of-convention claim-id
+ * defeats the character-class sanitization alone (the truncated 8-hex-char
+ * hash makes this vanishingly improbable, not provably impossible).
  */
 function sanitizeClaimIdForFilename(claimId) {
   return claimId.replace(/[^A-Za-z0-9._-]/g, '_');
@@ -168,11 +202,18 @@ function sanitizeClaimIdForFilename(claimId) {
  * before the B1 worktree exists, so `cwd` is then the *primary*
  * worktree — its admin directory is shared by every concurrent session
  * in the same clone. A claim-id-keyed filename means two sessions
- * generating two different claim-ids never collide on the same path,
- * even while they momentarily share that admin directory; once B1
- * creates the sibling worktree, its own private admin directory is
- * unique per worktree anyway (matching `idd-claim.lock`'s existing
- * guarantee), so the same scheme still works there unchanged.
+ * generating two different claim-ids resolve to different paths (in all
+ * but an astronomically unlikely hash-suffix collision, see
+ * {@link sanitizeClaimIdForFilename}), even while they momentarily share
+ * that admin directory; once B1 creates the sibling worktree, its own
+ * private admin directory is unique per worktree anyway (matching
+ * `idd-claim.lock`'s existing guarantee), so the same scheme still works
+ * there unchanged. A `present: true` result from a `--read-tokens` check
+ * against this **shared primary** path is bootstrap evidence only, not
+ * proof of current-session ownership by itself — see the header comment's
+ * "Generated-tokens record" note and {@link resolveWorktreeAdminDir} for
+ * why a caller must always resolve against its **own** current cwd, never
+ * an explicit different worktree's path.
  */
 export function resolveGeneratedTokensPath(cwd, claimId) {
   const sanitized = sanitizeClaimIdForFilename(claimId);
@@ -231,13 +272,21 @@ function renderLockBody(agentId, claimId) {
  * directory as `path` (a cross-filesystem rename is not atomic), then
  * renamed into place. POSIX `rename` onto an existing regular file is
  * atomic, but Windows does not replace an existing destination, so a regular
- * file must be removed before retrying the rename on that platform. A
- * directory target is handled the same way for malformed-lock recovery.
- * The `finally` cleans up the temp file if `renameSync` throws, so a failed
+ * file must be removed before retrying the rename on that platform. The
+ * `finally` cleans up the temp file if `renameSync` throws, so a failed
  * replace never leaks it. Shared by the lock file's authorized-takeover
  * path and the generated-tokens record's always-idempotent write.
+ *
+ * A directory at `path` is replaced (recursively removed, then the temp
+ * file renamed in) **only** when `options.replaceDirectory` is `true` —
+ * the authorized-takeover recovery path for a malformed lock directory.
+ * Every other caller (including the generated-tokens record's plain
+ * idempotent write) must never silently delete an unrelated directory
+ * that happens to occupy the resolved path; that case throws instead,
+ * surfacing it as a genuine error for the caller to investigate (#2879
+ * review).
  */
-function atomicReplaceFile(path, body) {
+function atomicReplaceFile(path, body, options = {}) {
   const tmpPath = `${path}.tmp-${process.pid}-${Math.random().toString(36).slice(2)}`;
   writeFileSync(tmpPath, body, { flag: 'wx' });
   try {
@@ -263,6 +312,9 @@ function atomicReplaceFile(path, body) {
         renameSync(tmpPath, path);
         return;
       }
+      if (!options.replaceDirectory) {
+        throw error;
+      }
       rmSync(path, { recursive: true, force: true });
       renameSync(tmpPath, path);
     }
@@ -280,11 +332,15 @@ function atomicReplaceFile(path, body) {
 }
 /**
  * Replace `path` with a freshly-rendered lock body. Only reached from an
- * authorized `--takeover` (see {@link acquireClaimLock}); see
- * {@link atomicReplaceFile} for the write mechanics.
+ * authorized `--takeover` (see {@link acquireClaimLock}), which is also
+ * the malformed-lock-directory recovery path, so directory replacement is
+ * intentionally enabled here; see {@link atomicReplaceFile} for the write
+ * mechanics.
  */
 function overwriteLockAtomically(path, agentId, claimId) {
-  atomicReplaceFile(path, renderLockBody(agentId, claimId));
+  atomicReplaceFile(path, renderLockBody(agentId, claimId), {
+    replaceDirectory: true,
+  });
 }
 /**
  * Acquire (or idempotently re-acquire) the worktree-local claim lock.

--- a/scripts/claim-lock.mjs
+++ b/scripts/claim-lock.mjs
@@ -44,7 +44,36 @@
 // lock) is the real authority there: GitHub claim parsing is deterministic,
 // so only one concurrent takeover's claim-id can actually be the active one,
 // regardless of what this local lock file happens to contain.
+//
+// Generated-tokens record (#2719): a second, sibling on-disk artifact in
+// the same admin directory, answering a narrower question than the lock
+// above -- not "does anyone else hold this worktree" but "did *this*
+// session actually generate the agent-id/claim-id it is about to trust,
+// on disk, independent of (possibly compacted) conversation memory."
+// Keyed by claim-id rather than a single fixed filename because the
+// *first* write happens at A5 claim time, before the B1 worktree exists --
+// the current cwd is then the primary worktree, whose admin directory is
+// shared by every concurrent session in the same clone. A fixed filename
+// there would let two sessions generating two different claim-ids clobber
+// each other; a claim-id-keyed filename (plus a short content hash suffix
+// so sanitization can never collide two distinct claim-ids onto the same
+// path) does not. B1 repeats the same write into the new worktree's own
+// private admin directory once it exists, mirroring how `idd-claim.lock`
+// already works there. Unlike the lock, this record has no collision or
+// `--takeover` concept: it is per-claim-id evidence, not a mutual-exclusion
+// primitive, so re-recording (idempotent overwrite) is always safe and
+// expected -- both writes above, plus the follow-up write once the
+// activation-nonce is minted, target the same path for a given cwd.
+//
+// This record does not itself replace GitHub claim state as authority.
+// The GitHub claim-id parse (`idd-overview-core.instructions.md`'s Claim
+// revalidation gate) always stays authoritative for *whether* a claim is
+// active; this record answers a narrower question that gate alone cannot:
+// whether the claim-id it finds active is one this session actually
+// generated, rather than one merely recalled from (possibly compacted)
+// conversation context.
 import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import {
   readFileSync,
   renameSync,
@@ -57,13 +86,17 @@ import { join } from 'node:path';
 import { parseCliArgs } from './cli-args.mjs';
 
 const CLAIM_LOCK_FILE_NAME = 'idd-claim.lock';
+const GENERATED_TOKENS_FILE_PREFIX = 'idd-generated-tokens';
 const MAX_RETRY_ATTEMPTS = 5;
 const CLAIM_LOCK_FLAG_SPEC = {
   '--acquire': { type: 'boolean' },
   '--check': { type: 'boolean' },
+  '--record-tokens': { type: 'boolean' },
+  '--read-tokens': { type: 'boolean' },
   '--worktree': { type: 'string' },
   '--agent-id': { type: 'string' },
   '--claim-id': { type: 'string' },
+  '--nonce': { type: 'string' },
   '--takeover': { type: 'boolean' },
   '--help': { type: 'boolean', short: 'h' },
 };
@@ -93,21 +126,64 @@ function sanitizedGitEnvironment() {
   return env;
 }
 /**
+ * Resolve `cwd`'s own private git-admin directory (`git rev-parse
+ * --absolute-git-dir`) — inside a linked worktree, `.git` is a *file* (a
+ * `gitdir:` pointer), not a directory, so a literal `.git/...` path would
+ * throw `ENOTDIR`. Shared by every path resolved inside this admin
+ * directory (the lock file and the generated-tokens record below), so
+ * `git worktree remove` deletes all of them together with the worktree,
+ * with no separate cleanup step required.
+ */
+function resolveWorktreeAdminDir(cwd) {
+  return execFileSync('git', ['-C', cwd, 'rev-parse', '--absolute-git-dir'], {
+    encoding: 'utf8',
+    env: sanitizedGitEnvironment(),
+  }).trim();
+}
+/**
  * Resolve the lock file's path inside `worktree`'s own private git-admin
- * directory (`git rev-parse --absolute-git-dir`), never a literal
- * `.git/idd-claim.lock` — inside a linked worktree, `.git` is a *file*
- * (a `gitdir:` pointer), not a directory, so that literal path would throw
- * `ENOTDIR`. Using the worktree's own admin dir also means `git worktree
- * remove` deletes the lock together with the worktree, with no separate
- * cleanup step required.
+ * directory, never a literal `.git/idd-claim.lock` (see
+ * {@link resolveWorktreeAdminDir}).
  */
 export function resolveClaimLockPath(worktree) {
-  const gitDir = execFileSync(
-    'git',
-    ['-C', worktree, 'rev-parse', '--absolute-git-dir'],
-    { encoding: 'utf8', env: sanitizedGitEnvironment() },
-  ).trim();
-  return join(gitDir, CLAIM_LOCK_FILE_NAME);
+  return join(resolveWorktreeAdminDir(worktree), CLAIM_LOCK_FILE_NAME);
+}
+/**
+ * Sanitize `claimId` into a filesystem-safe token: anything outside
+ * `[A-Za-z0-9._-]` becomes `_`. Claim-ids already follow that character
+ * set by convention, but this is defensive, not assumed -- combined with
+ * the content-hash suffix in {@link resolveGeneratedTokensPath}, two
+ * distinct claim-ids can never collide onto the same sanitized filename
+ * even if an out-of-convention claim-id defeats the character-class
+ * sanitization alone.
+ */
+function sanitizeClaimIdForFilename(claimId) {
+  return claimId.replace(/[^A-Za-z0-9._-]/g, '_');
+}
+/**
+ * Resolve the generated-tokens record's path inside `cwd`'s own private
+ * git-admin directory, sibling to `idd-claim.lock` (see
+ * {@link resolveWorktreeAdminDir}). Keyed by `claimId` rather than a
+ * single fixed filename: the first write happens at A5 claim time,
+ * before the B1 worktree exists, so `cwd` is then the *primary*
+ * worktree — its admin directory is shared by every concurrent session
+ * in the same clone. A claim-id-keyed filename means two sessions
+ * generating two different claim-ids never collide on the same path,
+ * even while they momentarily share that admin directory; once B1
+ * creates the sibling worktree, its own private admin directory is
+ * unique per worktree anyway (matching `idd-claim.lock`'s existing
+ * guarantee), so the same scheme still works there unchanged.
+ */
+export function resolveGeneratedTokensPath(cwd, claimId) {
+  const sanitized = sanitizeClaimIdForFilename(claimId);
+  const contentHash = createHash('sha256')
+    .update(claimId, 'utf8')
+    .digest('hex')
+    .slice(0, 8);
+  return join(
+    resolveWorktreeAdminDir(cwd),
+    `${GENERATED_TOKENS_FILE_PREFIX}-${sanitized}-${contentHash}.json`,
+  );
 }
 function isClaimLockBody(value) {
   return (
@@ -151,18 +227,19 @@ function renderLockBody(agentId, claimId) {
   return JSON.stringify(body);
 }
 /**
- * Replace `path` with a freshly-rendered lock body. The temp file is written
- * in the same directory as `path` (a cross-filesystem rename is not atomic),
- * then renamed into place. POSIX `rename` onto an existing regular file is
+ * Replace `path` with `body`. The temp file is written in the same
+ * directory as `path` (a cross-filesystem rename is not atomic), then
+ * renamed into place. POSIX `rename` onto an existing regular file is
  * atomic, but Windows does not replace an existing destination, so a regular
  * file must be removed before retrying the rename on that platform. A
  * directory target is handled the same way for malformed-lock recovery.
  * The `finally` cleans up the temp file if `renameSync` throws, so a failed
- * replace never leaks it.
+ * replace never leaks it. Shared by the lock file's authorized-takeover
+ * path and the generated-tokens record's always-idempotent write.
  */
-function overwriteLockAtomically(path, agentId, claimId) {
+function atomicReplaceFile(path, body) {
   const tmpPath = `${path}.tmp-${process.pid}-${Math.random().toString(36).slice(2)}`;
-  writeFileSync(tmpPath, renderLockBody(agentId, claimId), { flag: 'wx' });
+  writeFileSync(tmpPath, body, { flag: 'wx' });
   try {
     try {
       renameSync(tmpPath, path);
@@ -200,6 +277,14 @@ function overwriteLockAtomically(path, agentId, claimId) {
       // ignore
     }
   }
+}
+/**
+ * Replace `path` with a freshly-rendered lock body. Only reached from an
+ * authorized `--takeover` (see {@link acquireClaimLock}); see
+ * {@link atomicReplaceFile} for the write mechanics.
+ */
+function overwriteLockAtomically(path, agentId, claimId) {
+  atomicReplaceFile(path, renderLockBody(agentId, claimId));
 }
 /**
  * Acquire (or idempotently re-acquire) the worktree-local claim lock.
@@ -295,17 +380,93 @@ export function checkClaimLock(worktree) {
   }
   return { path, present: true, holder: read.lock };
 }
+function isGeneratedTokensBody(value) {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate = value;
+  return (
+    typeof candidate.agentId === 'string' &&
+    typeof candidate.claimId === 'string' &&
+    typeof candidate.recordedAt === 'string' &&
+    (candidate.nonce === undefined || typeof candidate.nonce === 'string')
+  );
+}
+/**
+ * Read-only inspection of the generated-tokens record for `claimId` at
+ * `cwd`'s own private git-admin directory. Never creates, mutates, or
+ * deletes anything.
+ */
+export function readGeneratedClaimTokens(cwd, claimId) {
+  const path = resolveGeneratedTokensPath(cwd, claimId);
+  let raw;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return { status: 'absent', path };
+    }
+    // Any other read failure means the path cannot be trusted as absent or
+    // valid (EACCES/EPERM, EISDIR, a transient filesystem error). Fail
+    // closed as malformed, matching {@link readLock}'s own convention.
+    return { status: 'malformed', path };
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { status: 'malformed', path };
+  }
+  if (!isGeneratedTokensBody(parsed) || parsed.claimId !== claimId) {
+    // The claim-id check defends against a would-be hash-suffix collision
+    // or manual tampering, not just a missing/corrupt file: a record whose
+    // own recorded claim-id disagrees with the one this path was resolved
+    // for is never trustworthy evidence for that claim-id.
+    return { status: 'malformed', path };
+  }
+  return { status: 'present', path, record: parsed };
+}
+/**
+ * Write (create or idempotently replace) the generated-tokens record for
+ * `claimId` at `cwd`'s own private git-admin directory. Unlike the lock
+ * file, this has no collision/`--takeover` concept: the record is
+ * per-claim-id evidence, not a mutual-exclusion primitive, so re-invoking
+ * (once in the primary worktree at A5 claim time with `{agentId,
+ * claimId}`, again with `{agentId, claimId, nonce}` right before the
+ * activation-nonce marker posts, and again in the new sibling worktree at
+ * B1) is always a safe, expected, idempotent overwrite of the same path.
+ */
+export function recordGeneratedClaimTokens(cwd, fields) {
+  const path = resolveGeneratedTokensPath(cwd, fields.claimId);
+  const body = {
+    agentId: fields.agentId,
+    claimId: fields.claimId,
+    ...(fields.nonce === undefined ? {} : { nonce: fields.nonce }),
+    recordedAt: new Date().toISOString(),
+  };
+  atomicReplaceFile(path, JSON.stringify(body));
+  return { path };
+}
 function parseArgs(argv) {
   const { values, help } = parseCliArgs(argv, CLAIM_LOCK_FLAG_SPEC);
   return {
     acquire: Boolean(values.acquire),
     check: Boolean(values.check),
+    recordTokens: Boolean(values['record-tokens']),
+    readTokens: Boolean(values['read-tokens']),
     worktree: typeof values.worktree === 'string' ? values.worktree : null,
     agentId: typeof values['agent-id'] === 'string' ? values['agent-id'] : null,
     claimId: typeof values['claim-id'] === 'string' ? values['claim-id'] : null,
+    nonce: typeof values.nonce === 'string' ? values.nonce : null,
     takeover: Boolean(values.takeover),
     help,
   };
+}
+/** Exactly one of the four mode flags, for the `runCli` mode-selection error. */
+function selectedModeCount(args) {
+  return [args.acquire, args.check, args.recordTokens, args.readTokens].filter(
+    Boolean,
+  ).length;
 }
 function runCli() {
   const args = parseArgs(process.argv.slice(2));
@@ -313,14 +474,45 @@ function runCli() {
     printHelp();
     process.exit(0);
   }
-  if (args.acquire === args.check) {
-    throw new Error('exactly one of --acquire or --check is required');
+  if (selectedModeCount(args) !== 1) {
+    throw new Error(
+      'exactly one of --acquire, --check, --record-tokens, or --read-tokens is required',
+    );
   }
   if (args.worktree === null) {
     throw new Error('--worktree is required');
   }
   if (args.check) {
     process.stdout.write(`${JSON.stringify(checkClaimLock(args.worktree))}\n`);
+    return;
+  }
+  if (args.readTokens) {
+    if (args.claimId === null) {
+      throw new Error('--claim-id is required for --read-tokens');
+    }
+    const read = readGeneratedClaimTokens(args.worktree, args.claimId);
+    const outcome =
+      read.status === 'present'
+        ? { path: read.path, present: true, record: read.record }
+        : read.status === 'malformed'
+          ? { path: read.path, present: true, malformed: true }
+          : { path: read.path, present: false };
+    process.stdout.write(`${JSON.stringify(outcome)}\n`);
+    return;
+  }
+  if (args.recordTokens) {
+    if (args.agentId === null) {
+      throw new Error('--agent-id is required for --record-tokens');
+    }
+    if (args.claimId === null) {
+      throw new Error('--claim-id is required for --record-tokens');
+    }
+    const outcome = recordGeneratedClaimTokens(args.worktree, {
+      agentId: args.agentId,
+      claimId: args.claimId,
+      ...(args.nonce === null ? {} : { nonce: args.nonce }),
+    });
+    process.stdout.write(`${JSON.stringify(outcome)}\n`);
     return;
   }
   if (args.agentId === null) {
@@ -344,6 +536,8 @@ function printHelp() {
   process.stdout.write(`Usage:
   node scripts/claim-lock.mjs --acquire --worktree <path> --agent-id <id> --claim-id <id> [--takeover]
   node scripts/claim-lock.mjs --check --worktree <path>
+  node scripts/claim-lock.mjs --record-tokens --worktree <path> --agent-id <id> --claim-id <id> [--nonce <nonce>]
+  node scripts/claim-lock.mjs --read-tokens --worktree <path> --claim-id <id>
 
 Worktree-local lock file: a same-machine fast path that complements the
 cross-machine activation-nonce claim check. Resolves the lock file inside
@@ -367,5 +561,26 @@ and an authorized takeover.
 --check is read-only: it reports the current lock state without creating,
 mutating, or deleting anything. \`malformed: true\` means a lock file
 exists but could not be parsed as a well-formed lock body.
+
+--record-tokens writes (creating or idempotently replacing) the
+generated-tokens record (#2719) for --claim-id at <path>'s own private
+git-admin directory -- a sibling artifact to the lock file above, keyed by
+claim-id so it is safe to call before the B1 worktree exists (<path> is
+then the primary worktree, whose admin directory is shared by every
+concurrent session in the same clone). Call it once right after
+generating --agent-id/--claim-id, before posting the \`claimed-by\`
+marker, and again with --nonce right before posting the activation-nonce
+marker. Unlike --acquire, this has no collision concept: re-invoking is
+always a safe, expected overwrite.
+
+--read-tokens is read-only: it reports whether --claim-id was actually
+recorded on disk by this mechanism, distinguishing \`present\` (a
+well-formed record whose own claim-id matches) from \`malformed\` (a
+file exists at the resolved path but cannot be trusted as that claim-id's
+record) from neither field set, meaning absent -- this claim-id was never
+recorded (or was recorded under a different claim-id, which resolves to a
+different path). Both \`malformed\` and absent must be treated the same
+way by a caller checking ownership: never trust a claim-id this record
+does not affirmatively confirm.
 `);
 }

--- a/scripts/claim-lock.mjs
+++ b/scripts/claim-lock.mjs
@@ -122,7 +122,8 @@ const MAX_RETRY_ATTEMPTS = 5;
  * here, a long enough claim-id pushes the interpolated filename past
  * the filesystem's `NAME_MAX` and `--record-tokens` fails with
  * `ENAMETOOLONG`, permanently blocking the fail-closed ownership gate
- * for that claim. The content-hash suffix already disambiguates, so
+ * for that claim (#2879 review, Codex P1). The content-hash suffix
+ * already disambiguates, so
  * truncating this prefix costs only human-readability, not safety.
  */
 const MAX_SANITIZED_CLAIM_ID_LENGTH = 64;

--- a/src/scripts/claim-lock.mts
+++ b/src/scripts/claim-lock.mts
@@ -127,6 +127,18 @@ interface ClaimLockBody {
 const CLAIM_LOCK_FILE_NAME = 'idd-claim.lock';
 const GENERATED_TOKENS_FILE_PREFIX = 'idd-generated-tokens';
 const MAX_RETRY_ATTEMPTS = 5;
+/**
+ * Cap on the sanitized-claim-id portion of a generated-tokens filename
+ * (see {@link sanitizeClaimIdForFilename}). A claim-id is an opaque
+ * token -- forced-handoff recovery can adopt one this process never
+ * generated -- so nothing upstream bounds its length; without a cap
+ * here, a long enough claim-id pushes the interpolated filename past
+ * the filesystem's `NAME_MAX` and `--record-tokens` fails with
+ * `ENAMETOOLONG`, permanently blocking the fail-closed ownership gate
+ * for that claim. The content-hash suffix already disambiguates, so
+ * truncating this prefix costs only human-readability, not safety.
+ */
+const MAX_SANITIZED_CLAIM_ID_LENGTH = 64;
 
 const CLAIM_LOCK_FLAG_SPEC = {
   '--acquire': { type: 'boolean' },
@@ -201,17 +213,21 @@ export function resolveClaimLockPath(worktree: string): string {
 }
 
 /**
- * Sanitize `claimId` into a filesystem-safe token: anything outside
- * `[A-Za-z0-9._-]` becomes `_`. Claim-ids already follow that character
- * set by convention, but this is defensive, not assumed -- combined with
- * the content-hash suffix in {@link resolveGeneratedTokensPath}, two
- * distinct claim-ids resolving to the same sanitized filename is
- * astronomically unlikely, even when an out-of-convention claim-id
- * defeats the character-class sanitization alone (the truncated 8-hex-char
- * hash makes this vanishingly improbable, not provably impossible).
+ * Sanitize `claimId` into a filesystem-safe, length-bounded token:
+ * anything outside `[A-Za-z0-9._-]` becomes `_`, then the result is
+ * truncated to {@link MAX_SANITIZED_CLAIM_ID_LENGTH} characters. Claim-ids
+ * already follow that character set and a much shorter length by
+ * convention, but neither is assumed -- combined with the content-hash
+ * suffix in {@link resolveGeneratedTokensPath}, two distinct claim-ids
+ * resolving to the same sanitized filename is astronomically unlikely,
+ * even when an out-of-convention claim-id defeats the character-class
+ * sanitization and the length cap both (the truncated 8-hex-char hash
+ * makes this vanishingly improbable, not provably impossible).
  */
 function sanitizeClaimIdForFilename(claimId: string): string {
-  return claimId.replace(/[^A-Za-z0-9._-]/g, '_');
+  return claimId
+    .replace(/[^A-Za-z0-9._-]/g, '_')
+    .slice(0, MAX_SANITIZED_CLAIM_ID_LENGTH);
 }
 
 /**

--- a/src/scripts/claim-lock.mts
+++ b/src/scripts/claim-lock.mts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 // idd-generated-from: src/scripts/claim-lock.mts
 //
 // The scripts/claim-lock.mjs copy is generated from the .mts source
@@ -44,8 +45,37 @@
 // lock) is the real authority there: GitHub claim parsing is deterministic,
 // so only one concurrent takeover's claim-id can actually be the active one,
 // regardless of what this local lock file happens to contain.
+//
+// Generated-tokens record (#2719): a second, sibling on-disk artifact in
+// the same admin directory, answering a narrower question than the lock
+// above -- not "does anyone else hold this worktree" but "did *this*
+// session actually generate the agent-id/claim-id it is about to trust,
+// on disk, independent of (possibly compacted) conversation memory."
+// Keyed by claim-id rather than a single fixed filename because the
+// *first* write happens at A5 claim time, before the B1 worktree exists --
+// the current cwd is then the primary worktree, whose admin directory is
+// shared by every concurrent session in the same clone. A fixed filename
+// there would let two sessions generating two different claim-ids clobber
+// each other; a claim-id-keyed filename (plus a short content hash suffix
+// so sanitization can never collide two distinct claim-ids onto the same
+// path) does not. B1 repeats the same write into the new worktree's own
+// private admin directory once it exists, mirroring how `idd-claim.lock`
+// already works there. Unlike the lock, this record has no collision or
+// `--takeover` concept: it is per-claim-id evidence, not a mutual-exclusion
+// primitive, so re-recording (idempotent overwrite) is always safe and
+// expected -- both writes above, plus the follow-up write once the
+// activation-nonce is minted, target the same path for a given cwd.
+//
+// This record does not itself replace GitHub claim state as authority.
+// The GitHub claim-id parse (`idd-overview-core.instructions.md`'s Claim
+// revalidation gate) always stays authoritative for *whether* a claim is
+// active; this record answers a narrower question that gate alone cannot:
+// whether the claim-id it finds active is one this session actually
+// generated, rather than one merely recalled from (possibly compacted)
+// conversation context.
 
 import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import {
   readFileSync,
   renameSync,
@@ -69,14 +99,18 @@ interface ClaimLockBody {
 }
 
 const CLAIM_LOCK_FILE_NAME = 'idd-claim.lock';
+const GENERATED_TOKENS_FILE_PREFIX = 'idd-generated-tokens';
 const MAX_RETRY_ATTEMPTS = 5;
 
 const CLAIM_LOCK_FLAG_SPEC = {
   '--acquire': { type: 'boolean' },
   '--check': { type: 'boolean' },
+  '--record-tokens': { type: 'boolean' },
+  '--read-tokens': { type: 'boolean' },
   '--worktree': { type: 'string' },
   '--agent-id': { type: 'string' },
   '--claim-id': { type: 'string' },
+  '--nonce': { type: 'string' },
   '--takeover': { type: 'boolean' },
   '--help': { type: 'boolean', short: 'h' },
 } as const;
@@ -109,21 +143,70 @@ function sanitizedGitEnvironment(): NodeJS.ProcessEnv {
 }
 
 /**
+ * Resolve `cwd`'s own private git-admin directory (`git rev-parse
+ * --absolute-git-dir`) — inside a linked worktree, `.git` is a *file* (a
+ * `gitdir:` pointer), not a directory, so a literal `.git/...` path would
+ * throw `ENOTDIR`. Shared by every path resolved inside this admin
+ * directory (the lock file and the generated-tokens record below), so
+ * `git worktree remove` deletes all of them together with the worktree,
+ * with no separate cleanup step required.
+ */
+function resolveWorktreeAdminDir(cwd: string): string {
+  return execFileSync('git', ['-C', cwd, 'rev-parse', '--absolute-git-dir'], {
+    encoding: 'utf8',
+    env: sanitizedGitEnvironment(),
+  }).trim();
+}
+
+/**
  * Resolve the lock file's path inside `worktree`'s own private git-admin
- * directory (`git rev-parse --absolute-git-dir`), never a literal
- * `.git/idd-claim.lock` — inside a linked worktree, `.git` is a *file*
- * (a `gitdir:` pointer), not a directory, so that literal path would throw
- * `ENOTDIR`. Using the worktree's own admin dir also means `git worktree
- * remove` deletes the lock together with the worktree, with no separate
- * cleanup step required.
+ * directory, never a literal `.git/idd-claim.lock` (see
+ * {@link resolveWorktreeAdminDir}).
  */
 export function resolveClaimLockPath(worktree: string): string {
-  const gitDir = execFileSync(
-    'git',
-    ['-C', worktree, 'rev-parse', '--absolute-git-dir'],
-    { encoding: 'utf8', env: sanitizedGitEnvironment() },
-  ).trim();
-  return join(gitDir, CLAIM_LOCK_FILE_NAME);
+  return join(resolveWorktreeAdminDir(worktree), CLAIM_LOCK_FILE_NAME);
+}
+
+/**
+ * Sanitize `claimId` into a filesystem-safe token: anything outside
+ * `[A-Za-z0-9._-]` becomes `_`. Claim-ids already follow that character
+ * set by convention, but this is defensive, not assumed -- combined with
+ * the content-hash suffix in {@link resolveGeneratedTokensPath}, two
+ * distinct claim-ids can never collide onto the same sanitized filename
+ * even if an out-of-convention claim-id defeats the character-class
+ * sanitization alone.
+ */
+function sanitizeClaimIdForFilename(claimId: string): string {
+  return claimId.replace(/[^A-Za-z0-9._-]/g, '_');
+}
+
+/**
+ * Resolve the generated-tokens record's path inside `cwd`'s own private
+ * git-admin directory, sibling to `idd-claim.lock` (see
+ * {@link resolveWorktreeAdminDir}). Keyed by `claimId` rather than a
+ * single fixed filename: the first write happens at A5 claim time,
+ * before the B1 worktree exists, so `cwd` is then the *primary*
+ * worktree — its admin directory is shared by every concurrent session
+ * in the same clone. A claim-id-keyed filename means two sessions
+ * generating two different claim-ids never collide on the same path,
+ * even while they momentarily share that admin directory; once B1
+ * creates the sibling worktree, its own private admin directory is
+ * unique per worktree anyway (matching `idd-claim.lock`'s existing
+ * guarantee), so the same scheme still works there unchanged.
+ */
+export function resolveGeneratedTokensPath(
+  cwd: string,
+  claimId: string,
+): string {
+  const sanitized = sanitizeClaimIdForFilename(claimId);
+  const contentHash = createHash('sha256')
+    .update(claimId, 'utf8')
+    .digest('hex')
+    .slice(0, 8);
+  return join(
+    resolveWorktreeAdminDir(cwd),
+    `${GENERATED_TOKENS_FILE_PREFIX}-${sanitized}-${contentHash}.json`,
+  );
 }
 
 /**
@@ -185,22 +268,19 @@ function renderLockBody(agentId: string, claimId: string): string {
 }
 
 /**
- * Replace `path` with a freshly-rendered lock body. The temp file is written
- * in the same directory as `path` (a cross-filesystem rename is not atomic),
- * then renamed into place. POSIX `rename` onto an existing regular file is
+ * Replace `path` with `body`. The temp file is written in the same
+ * directory as `path` (a cross-filesystem rename is not atomic), then
+ * renamed into place. POSIX `rename` onto an existing regular file is
  * atomic, but Windows does not replace an existing destination, so a regular
  * file must be removed before retrying the rename on that platform. A
  * directory target is handled the same way for malformed-lock recovery.
  * The `finally` cleans up the temp file if `renameSync` throws, so a failed
- * replace never leaks it.
+ * replace never leaks it. Shared by the lock file's authorized-takeover
+ * path and the generated-tokens record's always-idempotent write.
  */
-function overwriteLockAtomically(
-  path: string,
-  agentId: string,
-  claimId: string,
-): void {
+function atomicReplaceFile(path: string, body: string): void {
   const tmpPath = `${path}.tmp-${process.pid}-${Math.random().toString(36).slice(2)}`;
-  writeFileSync(tmpPath, renderLockBody(agentId, claimId), { flag: 'wx' });
+  writeFileSync(tmpPath, body, { flag: 'wx' });
   try {
     try {
       renameSync(tmpPath, path);
@@ -238,6 +318,19 @@ function overwriteLockAtomically(
       // ignore
     }
   }
+}
+
+/**
+ * Replace `path` with a freshly-rendered lock body. Only reached from an
+ * authorized `--takeover` (see {@link acquireClaimLock}); see
+ * {@link atomicReplaceFile} for the write mechanics.
+ */
+function overwriteLockAtomically(
+  path: string,
+  agentId: string,
+  claimId: string,
+): void {
+  atomicReplaceFile(path, renderLockBody(agentId, claimId));
 }
 
 /** Outcome shape returned by {@link acquireClaimLock}. */
@@ -363,12 +456,121 @@ export function checkClaimLock(worktree: string): CheckLockOutcome {
   return { path, present: true, holder: read.lock };
 }
 
+/**
+ * Shape of the JSON generated-tokens record written to disk (#2719).
+ * `recordedAt` is audit-only, mirroring {@link ClaimLockBody}'s
+ * `acquiredAt` -- no code path here reads it back to make a decision.
+ */
+interface GeneratedTokensBody {
+  agentId: string;
+  claimId: string;
+  nonce?: string;
+  recordedAt: string;
+}
+
+function isGeneratedTokensBody(value: unknown): value is GeneratedTokensBody {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.agentId === 'string' &&
+    typeof candidate.claimId === 'string' &&
+    typeof candidate.recordedAt === 'string' &&
+    (candidate.nonce === undefined || typeof candidate.nonce === 'string')
+  );
+}
+
+/**
+ * A read of the generated-tokens path resolves to exactly one of: absent
+ * (never recorded, or recorded for a different claim-id -- a different
+ * claim-id resolves to a different path by construction, see
+ * {@link resolveGeneratedTokensPath}), malformed (a file exists at the
+ * resolved path but is not a well-formed record for that exact claim-id --
+ * corrupted write, truncated crash, foreign content, or its own internal
+ * `claimId` field disagrees with the path it was found at), or a valid
+ * parsed body. Callers must never treat `malformed` the same as `absent`:
+ * a record that cannot be trusted must never be read as "this claim-id was
+ * never recorded" -- that would silently defeat the ownership check this
+ * record exists to support.
+ */
+export type GeneratedTokensReadResult =
+  | { status: 'absent'; path: string }
+  | { status: 'malformed'; path: string }
+  | { status: 'present'; path: string; record: GeneratedTokensBody };
+
+/**
+ * Read-only inspection of the generated-tokens record for `claimId` at
+ * `cwd`'s own private git-admin directory. Never creates, mutates, or
+ * deletes anything.
+ */
+export function readGeneratedClaimTokens(
+  cwd: string,
+  claimId: string,
+): GeneratedTokensReadResult {
+  const path = resolveGeneratedTokensPath(cwd, claimId);
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { status: 'absent', path };
+    }
+    // Any other read failure means the path cannot be trusted as absent or
+    // valid (EACCES/EPERM, EISDIR, a transient filesystem error). Fail
+    // closed as malformed, matching {@link readLock}'s own convention.
+    return { status: 'malformed', path };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { status: 'malformed', path };
+  }
+  if (!isGeneratedTokensBody(parsed) || parsed.claimId !== claimId) {
+    // The claim-id check defends against a would-be hash-suffix collision
+    // or manual tampering, not just a missing/corrupt file: a record whose
+    // own recorded claim-id disagrees with the one this path was resolved
+    // for is never trustworthy evidence for that claim-id.
+    return { status: 'malformed', path };
+  }
+  return { status: 'present', path, record: parsed };
+}
+
+/**
+ * Write (create or idempotently replace) the generated-tokens record for
+ * `claimId` at `cwd`'s own private git-admin directory. Unlike the lock
+ * file, this has no collision/`--takeover` concept: the record is
+ * per-claim-id evidence, not a mutual-exclusion primitive, so re-invoking
+ * (once in the primary worktree at A5 claim time with `{agentId,
+ * claimId}`, again with `{agentId, claimId, nonce}` right before the
+ * activation-nonce marker posts, and again in the new sibling worktree at
+ * B1) is always a safe, expected, idempotent overwrite of the same path.
+ */
+export function recordGeneratedClaimTokens(
+  cwd: string,
+  fields: { agentId: string; claimId: string; nonce?: string },
+): { path: string } {
+  const path = resolveGeneratedTokensPath(cwd, fields.claimId);
+  const body: GeneratedTokensBody = {
+    agentId: fields.agentId,
+    claimId: fields.claimId,
+    ...(fields.nonce === undefined ? {} : { nonce: fields.nonce }),
+    recordedAt: new Date().toISOString(),
+  };
+  atomicReplaceFile(path, JSON.stringify(body));
+  return { path };
+}
+
 interface ParsedArgs {
   acquire: boolean;
   check: boolean;
+  recordTokens: boolean;
+  readTokens: boolean;
   worktree: string | null;
   agentId: string | null;
   claimId: string | null;
+  nonce: string | null;
   takeover: boolean;
   help: boolean;
 }
@@ -378,6 +580,8 @@ function parseArgs(argv: string[]): ParsedArgs {
   return {
     acquire: Boolean(values.acquire),
     check: Boolean(values.check),
+    recordTokens: Boolean(values['record-tokens']),
+    readTokens: Boolean(values['read-tokens']),
     worktree: typeof values.worktree === 'string' ? values.worktree : null,
     agentId:
       typeof values['agent-id'] === 'string'
@@ -387,9 +591,17 @@ function parseArgs(argv: string[]): ParsedArgs {
       typeof values['claim-id'] === 'string'
         ? (values['claim-id'] as string)
         : null,
+    nonce: typeof values.nonce === 'string' ? values.nonce : null,
     takeover: Boolean(values.takeover),
     help,
   };
+}
+
+/** Exactly one of the four mode flags, for the `runCli` mode-selection error. */
+function selectedModeCount(args: ParsedArgs): number {
+  return [args.acquire, args.check, args.recordTokens, args.readTokens].filter(
+    Boolean,
+  ).length;
 }
 
 function runCli(): void {
@@ -398,8 +610,10 @@ function runCli(): void {
     printHelp();
     process.exit(0);
   }
-  if (args.acquire === args.check) {
-    throw new Error('exactly one of --acquire or --check is required');
+  if (selectedModeCount(args) !== 1) {
+    throw new Error(
+      'exactly one of --acquire, --check, --record-tokens, or --read-tokens is required',
+    );
   }
   if (args.worktree === null) {
     throw new Error('--worktree is required');
@@ -407,6 +621,37 @@ function runCli(): void {
 
   if (args.check) {
     process.stdout.write(`${JSON.stringify(checkClaimLock(args.worktree))}\n`);
+    return;
+  }
+
+  if (args.readTokens) {
+    if (args.claimId === null) {
+      throw new Error('--claim-id is required for --read-tokens');
+    }
+    const read = readGeneratedClaimTokens(args.worktree, args.claimId);
+    const outcome =
+      read.status === 'present'
+        ? { path: read.path, present: true, record: read.record }
+        : read.status === 'malformed'
+          ? { path: read.path, present: true, malformed: true }
+          : { path: read.path, present: false };
+    process.stdout.write(`${JSON.stringify(outcome)}\n`);
+    return;
+  }
+
+  if (args.recordTokens) {
+    if (args.agentId === null) {
+      throw new Error('--agent-id is required for --record-tokens');
+    }
+    if (args.claimId === null) {
+      throw new Error('--claim-id is required for --record-tokens');
+    }
+    const outcome = recordGeneratedClaimTokens(args.worktree, {
+      agentId: args.agentId,
+      claimId: args.claimId,
+      ...(args.nonce === null ? {} : { nonce: args.nonce }),
+    });
+    process.stdout.write(`${JSON.stringify(outcome)}\n`);
     return;
   }
 
@@ -432,6 +677,8 @@ function printHelp(): void {
   process.stdout.write(`Usage:
   node scripts/claim-lock.mjs --acquire --worktree <path> --agent-id <id> --claim-id <id> [--takeover]
   node scripts/claim-lock.mjs --check --worktree <path>
+  node scripts/claim-lock.mjs --record-tokens --worktree <path> --agent-id <id> --claim-id <id> [--nonce <nonce>]
+  node scripts/claim-lock.mjs --read-tokens --worktree <path> --claim-id <id>
 
 Worktree-local lock file: a same-machine fast path that complements the
 cross-machine activation-nonce claim check. Resolves the lock file inside
@@ -455,5 +702,26 @@ and an authorized takeover.
 --check is read-only: it reports the current lock state without creating,
 mutating, or deleting anything. \`malformed: true\` means a lock file
 exists but could not be parsed as a well-formed lock body.
+
+--record-tokens writes (creating or idempotently replacing) the
+generated-tokens record (#2719) for --claim-id at <path>'s own private
+git-admin directory -- a sibling artifact to the lock file above, keyed by
+claim-id so it is safe to call before the B1 worktree exists (<path> is
+then the primary worktree, whose admin directory is shared by every
+concurrent session in the same clone). Call it once right after
+generating --agent-id/--claim-id, before posting the \`claimed-by\`
+marker, and again with --nonce right before posting the activation-nonce
+marker. Unlike --acquire, this has no collision concept: re-invoking is
+always a safe, expected overwrite.
+
+--read-tokens is read-only: it reports whether --claim-id was actually
+recorded on disk by this mechanism, distinguishing \`present\` (a
+well-formed record whose own claim-id matches) from \`malformed\` (a
+file exists at the resolved path but cannot be trusted as that claim-id's
+record) from neither field set, meaning absent -- this claim-id was never
+recorded (or was recorded under a different claim-id, which resolves to a
+different path). Both \`malformed\` and absent must be treated the same
+way by a caller checking ownership: never trust a claim-id this record
+does not affirmatively confirm.
 `);
 }

--- a/src/scripts/claim-lock.mts
+++ b/src/scripts/claim-lock.mts
@@ -135,7 +135,8 @@ const MAX_RETRY_ATTEMPTS = 5;
  * here, a long enough claim-id pushes the interpolated filename past
  * the filesystem's `NAME_MAX` and `--record-tokens` fails with
  * `ENAMETOOLONG`, permanently blocking the fail-closed ownership gate
- * for that claim. The content-hash suffix already disambiguates, so
+ * for that claim (#2879 review, Codex P1). The content-hash suffix
+ * already disambiguates, so
  * truncating this prefix costs only human-readability, not safety.
  */
 const MAX_SANITIZED_CLAIM_ID_LENGTH = 64;

--- a/src/scripts/claim-lock.mts
+++ b/src/scripts/claim-lock.mts
@@ -56,11 +56,14 @@
 // the current cwd is then the primary worktree, whose admin directory is
 // shared by every concurrent session in the same clone. A fixed filename
 // there would let two sessions generating two different claim-ids clobber
-// each other; a claim-id-keyed filename (plus a short content hash suffix
-// so sanitization can never collide two distinct claim-ids onto the same
-// path) does not. B1 repeats the same write into the new worktree's own
-// private admin directory once it exists, mirroring how `idd-claim.lock`
-// already works there. Unlike the lock, this record has no collision or
+// each other; a claim-id-keyed filename (plus a short content hash suffix,
+// so sanitization collapsing two distinct claim-ids to the same string
+// still resolves to different paths in all but an astronomically unlikely
+// collision -- an 8-hex-char truncated hash cannot make that provably
+// impossible) makes that far less likely. B1 repeats the same write into
+// the new worktree's own private admin directory once it exists,
+// mirroring how `idd-claim.lock` already works there. Unlike the lock,
+// this record has no collision or
 // `--takeover` concept: it is per-claim-id evidence, not a mutual-exclusion
 // primitive, so re-recording (idempotent overwrite) is always safe and
 // expected -- both writes above, plus the follow-up write once the
@@ -73,6 +76,29 @@
 // whether the claim-id it finds active is one this session actually
 // generated, rather than one merely recalled from (possibly compacted)
 // conversation context.
+//
+// Scope of the ownership proof (#2879 review, Codex P1): a `present: true`
+// `--read-tokens` result proves "a `--record-tokens` call for this exact
+// claim-id landed at this path" -- it does not cryptographically bind that
+// call to the specific process or conversation now reading it back, since
+// each CLI invocation is a stateless one-shot child (see above) with no
+// tracked process/session identity to check against. During the narrow
+// A5-to-B1 window, the primary worktree's admin directory is shared by
+// every concurrent session in the same clone, so a `--read-tokens` check
+// made *against that shared path* is corroborating bootstrap evidence,
+// not sole proof of current-session ownership. This is why every caller
+// must resolve `--read-tokens`/`--acquire` against its **own current
+// cwd** (never an explicit different worktree's path): once B1 creates
+// the dedicated worktree, that admin directory is private to the one
+// claim/branch it represents, and the pre-mutation claim revalidation
+// gate (`idd-overview-core.instructions.md`) already scopes its own
+// cwd-vs-claim check to exactly that post-B1 contract (B3, D, E, F2/F3),
+// where this record's guarantee is strongest. The existing GitHub
+// claim-state, branch-collision, and worktree-local-lock checks remain
+// the primary defense against a genuinely different session mutating
+// under a claim-id it never generated; this record's own job is narrower
+// and complementary: helping *this* session's own memory survive its own
+// context compaction, not adjudicating between two sessions.
 
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
@@ -147,9 +173,16 @@ function sanitizedGitEnvironment(): NodeJS.ProcessEnv {
  * --absolute-git-dir`) — inside a linked worktree, `.git` is a *file* (a
  * `gitdir:` pointer), not a directory, so a literal `.git/...` path would
  * throw `ENOTDIR`. Shared by every path resolved inside this admin
- * directory (the lock file and the generated-tokens record below), so
- * `git worktree remove` deletes all of them together with the worktree,
- * with no separate cleanup step required.
+ * directory (the lock file and the generated-tokens record below).
+ *
+ * When `cwd` is a **linked** worktree (the normal B1-onward case),
+ * `git worktree remove` deletes this whole admin directory together with
+ * the worktree, with no separate cleanup step required. That guarantee
+ * does **not** hold when `cwd` is the **primary** worktree (the A5,
+ * pre-B1 generated-tokens record write, #2879 review): the primary
+ * worktree's admin directory is never removed by `git worktree remove`,
+ * is shared by every concurrent session in the same clone, and persists
+ * indefinitely — callers must not assume it is ever cleaned up.
  */
 function resolveWorktreeAdminDir(cwd: string): string {
   return execFileSync('git', ['-C', cwd, 'rev-parse', '--absolute-git-dir'], {
@@ -172,9 +205,10 @@ export function resolveClaimLockPath(worktree: string): string {
  * `[A-Za-z0-9._-]` becomes `_`. Claim-ids already follow that character
  * set by convention, but this is defensive, not assumed -- combined with
  * the content-hash suffix in {@link resolveGeneratedTokensPath}, two
- * distinct claim-ids can never collide onto the same sanitized filename
- * even if an out-of-convention claim-id defeats the character-class
- * sanitization alone.
+ * distinct claim-ids resolving to the same sanitized filename is
+ * astronomically unlikely, even when an out-of-convention claim-id
+ * defeats the character-class sanitization alone (the truncated 8-hex-char
+ * hash makes this vanishingly improbable, not provably impossible).
  */
 function sanitizeClaimIdForFilename(claimId: string): string {
   return claimId.replace(/[^A-Za-z0-9._-]/g, '_');
@@ -188,11 +222,18 @@ function sanitizeClaimIdForFilename(claimId: string): string {
  * before the B1 worktree exists, so `cwd` is then the *primary*
  * worktree — its admin directory is shared by every concurrent session
  * in the same clone. A claim-id-keyed filename means two sessions
- * generating two different claim-ids never collide on the same path,
- * even while they momentarily share that admin directory; once B1
- * creates the sibling worktree, its own private admin directory is
- * unique per worktree anyway (matching `idd-claim.lock`'s existing
- * guarantee), so the same scheme still works there unchanged.
+ * generating two different claim-ids resolve to different paths (in all
+ * but an astronomically unlikely hash-suffix collision, see
+ * {@link sanitizeClaimIdForFilename}), even while they momentarily share
+ * that admin directory; once B1 creates the sibling worktree, its own
+ * private admin directory is unique per worktree anyway (matching
+ * `idd-claim.lock`'s existing guarantee), so the same scheme still works
+ * there unchanged. A `present: true` result from a `--read-tokens` check
+ * against this **shared primary** path is bootstrap evidence only, not
+ * proof of current-session ownership by itself — see the header comment's
+ * "Generated-tokens record" note and {@link resolveWorktreeAdminDir} for
+ * why a caller must always resolve against its **own** current cwd, never
+ * an explicit different worktree's path.
  */
 export function resolveGeneratedTokensPath(
   cwd: string,
@@ -272,13 +313,25 @@ function renderLockBody(agentId: string, claimId: string): string {
  * directory as `path` (a cross-filesystem rename is not atomic), then
  * renamed into place. POSIX `rename` onto an existing regular file is
  * atomic, but Windows does not replace an existing destination, so a regular
- * file must be removed before retrying the rename on that platform. A
- * directory target is handled the same way for malformed-lock recovery.
- * The `finally` cleans up the temp file if `renameSync` throws, so a failed
+ * file must be removed before retrying the rename on that platform. The
+ * `finally` cleans up the temp file if `renameSync` throws, so a failed
  * replace never leaks it. Shared by the lock file's authorized-takeover
  * path and the generated-tokens record's always-idempotent write.
+ *
+ * A directory at `path` is replaced (recursively removed, then the temp
+ * file renamed in) **only** when `options.replaceDirectory` is `true` —
+ * the authorized-takeover recovery path for a malformed lock directory.
+ * Every other caller (including the generated-tokens record's plain
+ * idempotent write) must never silently delete an unrelated directory
+ * that happens to occupy the resolved path; that case throws instead,
+ * surfacing it as a genuine error for the caller to investigate (#2879
+ * review).
  */
-function atomicReplaceFile(path: string, body: string): void {
+function atomicReplaceFile(
+  path: string,
+  body: string,
+  options: { replaceDirectory?: boolean } = {},
+): void {
   const tmpPath = `${path}.tmp-${process.pid}-${Math.random().toString(36).slice(2)}`;
   writeFileSync(tmpPath, body, { flag: 'wx' });
   try {
@@ -304,6 +357,9 @@ function atomicReplaceFile(path: string, body: string): void {
         renameSync(tmpPath, path);
         return;
       }
+      if (!options.replaceDirectory) {
+        throw error;
+      }
       rmSync(path, { recursive: true, force: true });
       renameSync(tmpPath, path);
     }
@@ -322,15 +378,19 @@ function atomicReplaceFile(path: string, body: string): void {
 
 /**
  * Replace `path` with a freshly-rendered lock body. Only reached from an
- * authorized `--takeover` (see {@link acquireClaimLock}); see
- * {@link atomicReplaceFile} for the write mechanics.
+ * authorized `--takeover` (see {@link acquireClaimLock}), which is also
+ * the malformed-lock-directory recovery path, so directory replacement is
+ * intentionally enabled here; see {@link atomicReplaceFile} for the write
+ * mechanics.
  */
 function overwriteLockAtomically(
   path: string,
   agentId: string,
   claimId: string,
 ): void {
-  atomicReplaceFile(path, renderLockBody(agentId, claimId));
+  atomicReplaceFile(path, renderLockBody(agentId, claimId), {
+    replaceDirectory: true,
+  });
 }
 
 /** Outcome shape returned by {@link acquireClaimLock}. */
@@ -489,10 +549,13 @@ function isGeneratedTokensBody(value: unknown): value is GeneratedTokensBody {
  * resolved path but is not a well-formed record for that exact claim-id --
  * corrupted write, truncated crash, foreign content, or its own internal
  * `claimId` field disagrees with the path it was found at), or a valid
- * parsed body. Callers must never treat `malformed` the same as `absent`:
- * a record that cannot be trusted must never be read as "this claim-id was
- * never recorded" -- that would silently defeat the ownership check this
- * record exists to support.
+ * parsed body. Callers must never silently *report* `malformed` as if it
+ * were `absent` -- a record that cannot be trusted is a diagnostically
+ * distinct state ("something is here but unreadable") from "this claim-id
+ * was never recorded", and collapsing the two loses that signal. For the
+ * ownership *decision* itself both statuses converge to the same fail-closed
+ * outcome (not owned): a caller checking ownership must never trust a
+ * claim-id this record does not affirmatively confirm as `present`.
  */
 export type GeneratedTokensReadResult =
   | { status: 'absent'; path: string }

--- a/tests/claim-lock.test.mts
+++ b/tests/claim-lock.test.mts
@@ -606,6 +606,90 @@ test('generated-tokens: re-recording the same claim-id idempotently overwrites (
   }
 });
 
+test('generated-tokens: recording never deletes a pre-existing directory at the resolved path (regression, #2879 review)', () => {
+  const fixture = setupLinkedWorktree();
+  try {
+    const path = resolveGeneratedTokensPath(fixture.worktree, 'claim-a');
+    mkdirSync(path, { recursive: true });
+    writeFileSync(join(path, 'unrelated-file.txt'), 'do not delete me');
+
+    assert.throws(() =>
+      recordGeneratedClaimTokens(fixture.worktree, {
+        agentId: 'agent-a',
+        claimId: 'claim-a',
+      }),
+    );
+
+    // The pre-existing directory and its contents must survive untouched —
+    // unlike the lock file's authorized-takeover path, plain token
+    // recording must never silently delete a directory that happens to
+    // occupy the resolved path.
+    assert.equal(statSync(path).isDirectory(), true);
+    assert.equal(
+      readFileSync(join(path, 'unrelated-file.txt'), 'utf8'),
+      'do not delete me',
+    );
+  } finally {
+    teardown(fixture);
+  }
+});
+
+test('generated-tokens: primary-worktree admin dir is shared across concurrent "sessions" -- two different claim-ids do not clobber each other there', () => {
+  // Exercises the actual A5 pre-B1 scenario the claim-id keying scheme
+  // exists for (#2879 review): before the B1 worktree exists, `cwd` for
+  // this write is the *primary* worktree, whose admin directory every
+  // concurrent session in the clone shares. Uses `fixture.primary`
+  // directly, unlike every other case in this file (which exercises the
+  // dedicated linked-worktree path).
+  const fixture = setupLinkedWorktree();
+  try {
+    recordGeneratedClaimTokens(fixture.primary, {
+      agentId: 'agent-a',
+      claimId: 'claim-a',
+    });
+    recordGeneratedClaimTokens(fixture.primary, {
+      agentId: 'agent-b',
+      claimId: 'claim-b',
+    });
+
+    const readA = readGeneratedClaimTokens(fixture.primary, 'claim-a');
+    const readB = readGeneratedClaimTokens(fixture.primary, 'claim-b');
+    assert.equal(readA.status === 'present' && readA.record.agentId, 'agent-a');
+    assert.equal(readB.status === 'present' && readB.record.agentId, 'agent-b');
+  } finally {
+    teardown(fixture);
+  }
+});
+
+test('generated-tokens: documented limitation -- a --read-tokens hit against the shared primary path is not proof a *different* caller generated it (#2879 review, Codex P1)', () => {
+  // This is the documented boundary, not a bug: `readGeneratedClaimTokens`
+  // has no process/session identity to check, so any caller resolving the
+  // *same* cwd sees the *same* record. The mitigation is procedural (every
+  // caller must resolve `--read-tokens` against its own current cwd, never
+  // an explicit different worktree's path -- see the "Scope of the
+  // ownership proof" header comment) and by the existing GitHub
+  // claim-state / branch-collision / worktree-local-lock defenses, not a
+  // guarantee this function itself can provide. This test documents that
+  // boundary so it cannot silently regress into an unnoticed assumption.
+  const fixture = setupLinkedWorktree();
+  try {
+    // "Session A" records its own claim-id in the shared primary dir.
+    recordGeneratedClaimTokens(fixture.primary, {
+      agentId: 'agent-a',
+      claimId: 'claim-a',
+    });
+
+    // "Session B" merely recalls that same claim-id (for example, having
+    // read it off a GitHub claimed-by comment) and checks it against the
+    // *same shared primary path* -- `readGeneratedClaimTokens` has no way
+    // to distinguish this from session A's own genuine self-check.
+    const sessionBRead = readGeneratedClaimTokens(fixture.primary, 'claim-a');
+    assert.equal(sessionBRead.status, 'present');
+  } finally {
+    teardown(fixture);
+  }
+});
+
 test('generated-tokens: two claim-ids that sanitize to the same string still resolve to different paths', () => {
   const fixture = setupLinkedWorktree();
   try {

--- a/tests/claim-lock.test.mts
+++ b/tests/claim-lock.test.mts
@@ -19,7 +19,10 @@ import { promisify } from 'node:util';
 import {
   acquireClaimLock,
   checkClaimLock,
+  readGeneratedClaimTokens,
+  recordGeneratedClaimTokens,
   resolveClaimLockPath,
+  resolveGeneratedTokensPath,
 } from '../src/scripts/claim-lock.mts';
 
 const execFileAsync = promisify(execFile);
@@ -495,6 +498,212 @@ test('acquire: N concurrent forced-takeovers never corrupt the lock — every wr
       winningClaimIds.includes(finalBody.claimId),
       `expected the final lock to record exactly one of the racing claim-ids, got: ${JSON.stringify(finalBody)}`,
     );
+  } finally {
+    teardown(fixture);
+  }
+});
+
+// Generated-tokens record tests (#2719).
+
+test('generated-tokens: record/read round trip reports the recorded fields', () => {
+  const fixture = setupLinkedWorktree();
+  try {
+    const written = recordGeneratedClaimTokens(fixture.worktree, {
+      agentId: 'agent-a',
+      claimId: 'claim-a',
+      nonce: 'nonce-a',
+    });
+    assert.equal(
+      basename(written.path).startsWith('idd-generated-tokens-'),
+      true,
+    );
+
+    const read = readGeneratedClaimTokens(fixture.worktree, 'claim-a');
+    assert.equal(read.status, 'present');
+    assert.equal(read.status === 'present' && read.record.agentId, 'agent-a');
+    assert.equal(read.status === 'present' && read.record.claimId, 'claim-a');
+    assert.equal(read.status === 'present' && read.record.nonce, 'nonce-a');
+    assert.equal(read.path, written.path);
+  } finally {
+    teardown(fixture);
+  }
+});
+
+test('generated-tokens: a never-recorded claim-id reads absent, never treated as owned', () => {
+  const fixture = setupLinkedWorktree();
+  try {
+    recordGeneratedClaimTokens(fixture.worktree, {
+      agentId: 'agent-a',
+      claimId: 'claim-a',
+    });
+
+    const read = readGeneratedClaimTokens(fixture.worktree, 'claim-b');
+    assert.equal(read.status, 'absent');
+  } finally {
+    teardown(fixture);
+  }
+});
+
+test('generated-tokens: a malformed record file reads malformed, never silently absent', () => {
+  const fixture = setupLinkedWorktree();
+  try {
+    const path = resolveGeneratedTokensPath(fixture.worktree, 'claim-a');
+    mkdirSync(join(path, '..'), { recursive: true });
+    writeFileSync(path, 'not json at all {{{');
+
+    const read = readGeneratedClaimTokens(fixture.worktree, 'claim-a');
+    assert.equal(read.status, 'malformed');
+  } finally {
+    teardown(fixture);
+  }
+});
+
+test('generated-tokens: a record whose internal claim-id disagrees with the requested one reads malformed', () => {
+  const fixture = setupLinkedWorktree();
+  try {
+    // Simulate a tampered/collided file: written for "claim-a" but its own
+    // internal claimId field names a different claim entirely.
+    recordGeneratedClaimTokens(fixture.worktree, {
+      agentId: 'agent-a',
+      claimId: 'claim-a',
+    });
+    const path = resolveGeneratedTokensPath(fixture.worktree, 'claim-a');
+    writeFileSync(
+      path,
+      JSON.stringify({
+        agentId: 'agent-a',
+        claimId: 'claim-other',
+        recordedAt: new Date().toISOString(),
+      }),
+    );
+
+    const read = readGeneratedClaimTokens(fixture.worktree, 'claim-a');
+    assert.equal(read.status, 'malformed');
+  } finally {
+    teardown(fixture);
+  }
+});
+
+test('generated-tokens: re-recording the same claim-id idempotently overwrites (e.g. to add a nonce)', () => {
+  const fixture = setupLinkedWorktree();
+  try {
+    recordGeneratedClaimTokens(fixture.worktree, {
+      agentId: 'agent-a',
+      claimId: 'claim-a',
+    });
+    const first = readGeneratedClaimTokens(fixture.worktree, 'claim-a');
+    assert.equal(first.status === 'present' && first.record.nonce, undefined);
+
+    recordGeneratedClaimTokens(fixture.worktree, {
+      agentId: 'agent-a',
+      claimId: 'claim-a',
+      nonce: 'nonce-a',
+    });
+    const second = readGeneratedClaimTokens(fixture.worktree, 'claim-a');
+    assert.equal(second.status === 'present' && second.record.nonce, 'nonce-a');
+  } finally {
+    teardown(fixture);
+  }
+});
+
+test('generated-tokens: two claim-ids that sanitize to the same string still resolve to different paths', () => {
+  const fixture = setupLinkedWorktree();
+  try {
+    // Both sanitize to "claim_a" under the [A-Za-z0-9._-] allowlist, but the
+    // content-hash suffix keeps their resolved paths distinct.
+    const pathA = resolveGeneratedTokensPath(fixture.worktree, 'claim:a');
+    const pathB = resolveGeneratedTokensPath(fixture.worktree, 'claim/a');
+    assert.notEqual(pathA, pathB);
+
+    recordGeneratedClaimTokens(fixture.worktree, {
+      agentId: 'agent-a',
+      claimId: 'claim:a',
+    });
+    // The differently-punctuated claim-id was never recorded, and must not
+    // resolve to the same on-disk evidence as "claim:a" above.
+    const read = readGeneratedClaimTokens(fixture.worktree, 'claim/a');
+    assert.equal(read.status, 'absent');
+  } finally {
+    teardown(fixture);
+  }
+});
+
+test('generated-tokens: resolveGeneratedTokensPath resolves inside the linked worktree private git-dir, sibling to the lock file', () => {
+  const fixture = setupLinkedWorktree();
+  try {
+    const lockPath = resolveClaimLockPath(fixture.worktree);
+    const tokensPath = resolveGeneratedTokensPath(fixture.worktree, 'claim-a');
+    assert.equal(join(tokensPath, '..'), join(lockPath, '..'));
+    assert.ok(
+      tokensPath.split(sep).includes('worktrees'),
+      `expected the linked worktree's private admin dir, got: ${tokensPath}`,
+    );
+  } finally {
+    teardown(fixture);
+  }
+});
+
+test('CLI: --record-tokens then --read-tokens round trip via the compiled CLI', async () => {
+  const fixture = setupLinkedWorktree();
+  try {
+    const recordResult = await execFileAsync(process.execPath, [
+      CLI_PATH,
+      '--record-tokens',
+      '--worktree',
+      fixture.worktree,
+      '--agent-id',
+      'agent-a',
+      '--claim-id',
+      'claim-a',
+      '--nonce',
+      'nonce-a',
+    ]);
+    const recordOutcome = JSON.parse(recordResult.stdout);
+    assert.equal(typeof recordOutcome.path, 'string');
+
+    const readResult = await execFileAsync(process.execPath, [
+      CLI_PATH,
+      '--read-tokens',
+      '--worktree',
+      fixture.worktree,
+      '--claim-id',
+      'claim-a',
+    ]);
+    const readOutcome = JSON.parse(readResult.stdout);
+    assert.equal(readOutcome.present, true);
+    assert.equal(readOutcome.record.agentId, 'agent-a');
+    assert.equal(readOutcome.record.claimId, 'claim-a');
+    assert.equal(readOutcome.record.nonce, 'nonce-a');
+
+    // A different claim-id was never recorded.
+    const readOtherResult = await execFileAsync(process.execPath, [
+      CLI_PATH,
+      '--read-tokens',
+      '--worktree',
+      fixture.worktree,
+      '--claim-id',
+      'claim-b',
+    ]);
+    const readOtherOutcome = JSON.parse(readOtherResult.stdout);
+    assert.equal(readOtherOutcome.present, false);
+
+    // A corrupt record at the resolved path reads malformed, not absent.
+    const malformedPath = resolveGeneratedTokensPath(
+      fixture.worktree,
+      'claim-c',
+    );
+    writeFileSync(malformedPath, 'not json at all {{{');
+    const readMalformedResult = await execFileAsync(process.execPath, [
+      CLI_PATH,
+      '--read-tokens',
+      '--worktree',
+      fixture.worktree,
+      '--claim-id',
+      'claim-c',
+    ]);
+    const readMalformedOutcome = JSON.parse(readMalformedResult.stdout);
+    assert.equal(readMalformedOutcome.present, true);
+    assert.equal(readMalformedOutcome.malformed, true);
   } finally {
     teardown(fixture);
   }

--- a/tests/claim-lock.test.mts
+++ b/tests/claim-lock.test.mts
@@ -712,6 +712,35 @@ test('generated-tokens: two claim-ids that sanitize to the same string still res
   }
 });
 
+test('generated-tokens: a very long claim-id does not push the filename past NAME_MAX', () => {
+  const fixture = setupLinkedWorktree();
+  try {
+    // Claim-ids are opaque tokens -- forced-handoff recovery can adopt one
+    // this process never generated -- so nothing upstream bounds their
+    // length. Without truncating the sanitized prefix, this filename would
+    // exceed most filesystems' 255-byte NAME_MAX and `--record-tokens`
+    // would fail with ENAMETOOLONG, permanently blocking the fail-closed
+    // ownership gate for that claim.
+    const longClaimId = `claude-idd-thin-c1b296-20260910T130055Z-${'a'.repeat(300)}`;
+    const path = resolveGeneratedTokensPath(fixture.worktree, longClaimId);
+    assert.ok(
+      Buffer.byteLength(basename(path), 'utf8') <= 255,
+      `expected the filename to stay under NAME_MAX, got ${Buffer.byteLength(basename(path), 'utf8')} bytes: ${basename(
+        path,
+      )}`,
+    );
+
+    recordGeneratedClaimTokens(fixture.worktree, {
+      agentId: 'agent-a',
+      claimId: longClaimId,
+    });
+    const read = readGeneratedClaimTokens(fixture.worktree, longClaimId);
+    assert.equal(read.status, 'present');
+  } finally {
+    teardown(fixture);
+  }
+});
+
 test('generated-tokens: resolveGeneratedTokensPath resolves inside the linked worktree private git-dir, sibling to the lock file', () => {
   const fixture = setupLinkedWorktree();
   try {


### PR DESCRIPTION
# Summary

Ownership proof for an active `{claim-id}` currently depends on an
agent's live conversational recollection of having generated it —
context compaction can condense or drop that memory, and two prior
incidents saw exactly that: independent sessions treating an
identical agent-id/claim-id/activation-nonce triple as their own,
and a delegated worker editing a different session's worktree after
a compaction event.

This adds a worktree-local, on-disk "generated-tokens" record
(`claim-lock.mts`, sibling to the existing `idd-claim.lock`) and
wires it into the claim protocol so a session can prove — from disk,
not recollection — that it actually generated the `{agent-id}` /
`{claim-id}` / nonce it is about to trust.

## Linked issue

Closes #2719

## Follow-up issues (if any)

Filed during this PR's review cycle, each scoped out for the reasons
given in its own body:

- [ ] #2883 — extend the generated-tokens ownership check to the lite
      profile (`idd-claim-lite.instructions.md` and the lite
      work/PR-submit/review/merge guards never picked it up)
- [ ] #2884 — a backfill/migration route for a claim whose B1
      worktree predates this feature, so the new fail-closed gate
      doesn't stop a legitimately-owned claim with no token record
- [ ] #2886 — extend the token-ownership `--read-tokens` check (and
      the pre-existing worktree-local lock, which has the identical
      gap) to B2 and C5 mutations, not just B3/D/E/F2/F3

## Background / rationale (if material)

**What changed, mechanically:**

- **`src/scripts/claim-lock.mts`** (+ regenerated `scripts/claim-lock.mjs`):
  new `--record-tokens` / `--read-tokens` CLI modes alongside the
  existing `--acquire` / `--check` pair.
  - `resolveGeneratedTokensPath(cwd, claimId)`: resolves a
    claim-id-keyed path (sanitized claim-id + an 8-hex-char sha256
    suffix) inside the same private git-admin directory the lock file
    already uses. Keyed by claim-id — not a fixed filename — because
    the *first* write happens at A5 claim time, before the B1 worktree
    exists: `cwd` is then the primary worktree, whose admin directory
    is shared by every concurrent session in the same clone. The hash
    suffix guarantees two distinct claim-ids can never collide onto
    the same file even if the character-class sanitization alone
    would map them to the same string.
  - `recordGeneratedClaimTokens(cwd, {agentId, claimId, nonce?})`:
    atomic create-or-replace write. No collision/`--takeover` concept
    (unlike the lock) — this is per-claim-id evidence, not a
    mutual-exclusion primitive, so re-invoking is always a safe,
    idempotent overwrite.
  - `readGeneratedClaimTokens(cwd, claimId)`: returns `absent` /
    `malformed` / `present`, mirroring the existing lock's `readLock`
    convention. `malformed` covers both a corrupt file and a
    well-formed file whose own internal `claimId` field disagrees
    with the path it was resolved at (defends against a would-be
    collision or tampering) — never silently read as `absent`.
  - `resolveClaimLockPath` is now a thin wrapper over a shared
    `resolveWorktreeAdminDir(cwd)`, extracted so both the lock and the
    new record resolve the admin directory identically.
- **`idd-overview-core.instructions.md`** (canonical
  `idd-template/` source; mirror regenerated): the `{claim-id}`
  definition now says ownership requires the token to be recorded
  **on disk**, pointing at `idd-claim.instructions.md` for the
  mechanism. Net **-11 bytes** on the touched sentence (tightened
  "does not by itself prove ownership" → "does not prove
  ownership"), verified against `bundle-core`'s 97.97%/98% ceiling —
  genuinely no headroom for a net addition, so the edit had to
  shrink, not just insert.
- **`idd-claim.instructions.md`** (canonical source; mirror
  regenerated): new "Generated-tokens record" paragraph in the
  Worktree-local lock file section — when to write (`--record-tokens`,
  right after generating `{agent-id}`/`{claim-id}` and before posting
  `claimed-by`; again with `--nonce` right before posting the
  activation-nonce marker) and when to re-check (`--read-tokens`,
  alongside every `--acquire` re-run, before trusting a recalled
  `{claim-id}`).
- **`docs/idd-helper-scripts.md`** (canonical source; mirror
  regenerated): new "Worktree-local generated-tokens record" section
  documenting the two flags, the CLI contract, and the
  `instructions-only` helper-free fallback (mandatory per this repo's
  own rule for a helper step with no skip/fallback wording).
- **`tests/claim-lock.test.mts`**: 8 new cases (record/read round
  trip; never-recorded claim-id → `absent`; malformed file →
  `malformed`, not `absent`; a record whose internal `claimId`
  disagrees with the requested one → `malformed`; idempotent
  re-record adding a nonce; two claim-ids that sanitize to the same
  string still resolve to different paths; a path-resolution sibling
  check; and a CLI-level round trip covering `present`/`absent`/
  `malformed`). All offline (`node --test`), no network calls.

**Headroom note (why the issue's own text needed a second look):**
the issue's "Dependency partially resolved" note asserted `#2789`
already restored `bundle-core` headroom for the
`idd-overview-core.instructions.md` edit. A first pass took a
hand-rolled byte estimate at face value and (wrongly) concluded the
edit didn't fit, proposing to defer it via a follow-up issue. A
critique pass caught that this was applying the issue's own
`bundle-discovery-phase` escape-hatch sentence to a different bundle
by analogy, against the issue's own stated premise. Re-measuring with
the actual `audit-docs.mjs`/`sync-docs.mjs` pipeline (not the hand
estimate) showed the issue's premise was right: the edit fits once
the touched sentence itself is tightened — verified end-to-end
(`node scripts/sync-docs.mjs --apply --force`, `dprint fmt`, `node
scripts/audit-docs.mjs --check` passes: `bundle-core` 97.97%,
`bundle-discovery-phase` 97.74%, both under the 98% ceiling, no
per-file `instruction-size-budgets` violation). No follow-up issue
was needed.

**Test-coverage scope for both acceptance criteria:**

- **AC1** ("a generated claim-id is present on disk in the worktree
  before the `claimed-by` marker is posted"): the write/read
  mechanism is unit-tested; the ordering itself ("before posting") is
  an instruction-level contract (`idd-claim.instructions.md`'s new
  paragraph) that no offline test can assert across a live GitHub
  POST.
- **AC2** ("a session whose on-disk record does not contain the
  active claim-id does not treat that claim as owned"): the *read
  side* is fully covered — `absent` for a never-recorded claim-id,
  `malformed` for a record whose internal `claimId` disagrees. The
  *act-on-that-verdict* side is the same instruction-level contract as
  AC1 (the claim revalidation gate reading `--read-tokens` before
  trusting a recalled claim-id).

**Accepted residual (out of scope, per the issue's own scope line):**
the primary-worktree copy of the record, written at A5 before the B1
worktree exists, is never cleaned up by `git worktree remove` (that
only removes the sibling worktree's own copy, mirroring how
`idd-claim.lock` already works). Giving this record cross-worktree,
pre-acquisition visibility to garbage-collect it is explicitly out of
this issue's scope ("Extending `claim-lock.mts`'s pre-acquisition
cross-worktree visibility is out of this issue's scope").

**Review-fix rounds (added after the initial implementation above):**

- Rejected directory targets during `--record-tokens` instead of
  silently deleting a pre-existing directory at the resolved path
  (CodeRabbit) — `atomicReplaceFile` gained an opt-in
  `replaceDirectory` flag, defaulting off; only the lock's own
  authorized-takeover path still passes it.
- Documented the generated-tokens record's actual scope: a
  `present: true` read against the **shared primary** worktree path
  is bootstrap evidence, not sole proof of current-session ownership
  (Codex, independently confirmed by this PR's own critique pass) —
  full session-binding isn't achievable without persisting a secret
  in the same shared, world-readable file an adversarial read could
  already reach.
- Made the Claim revalidation gate's own cwd-vs-claim step actually
  invoke `--read-tokens` and fail closed on an absent/malformed
  record, closing a gap where a session that only learned the public
  claim-id could still pass the gate with no token record at all
  (Codex).
- Moved the `--record-tokens` directive to before each marker POST
  (claim-id at claim-comment time, nonce at activation-nonce time)
  instead of after, and added the missing B1 re-record step (with the
  nonce carried forward) to `idd-work.instructions.md`, which no
  instruction file had ever implemented despite the docs already
  describing it (Codex, ×2).
- Bounded the sanitized-claim-id filename segment to 64 characters so
  an unusually long claim-id (e.g. from forced-handoff recovery)
  can't push the filename past the filesystem's `NAME_MAX` (Codex).
- Defined the `instructions-only` read-side fallback for
  `--read-tokens` (only the write side existed), fixed a
  dprint-reflow line break that split the documented filename token
  mid-word, and specified exactly which bytes the fallback's
  content-hash prefix is computed over (Codex ×3, Copilot ×1 for a
  read-side output-shape mismatch against the documented CLI
  contract).

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed — changes the
      claim-ownership verification mechanism (adds an on-disk
      ownership-proof check consulted by the claim revalidation gate);
      no credential or merge-execution logic changed.

## Verification

- [x] `pnpm lint` (`npx biome check`, `npx dprint check "**/*.md"`,
      `npx markdownlint-cli2 "**/*.md"`) — clean
- [x] `pnpm test` (`node --test tests/*.test.mts`) — 5902/5902 pass
      (final HEAD, after the review-fix rounds above)
- [x] `node scripts/audit-docs.mjs --check` — passes
- [x] `pnpm run docs:sync:check` (`node scripts/sync-docs.mjs`, no
      drift after `--apply --force`)
- [x] `node scripts/idd-doctor.mjs` — clean (3 pre-existing,
      unrelated warnings: missing adopter profile files, no active
      commit hook in this environment, release-tag drift)
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run build:check` — clean, no drift
- [x] `npx cspell lint "**" --no-progress` — clean
- [x] `node scripts/audit-code-span-wrap.mjs` — clean
- [x] `node scripts/token-cost-report.mjs --check` — no drift

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed — no merge-execution behavior
      changed; the claim-ownership check this PR adds is consulted by
      the existing claim revalidation gate, not a new merge gate
- [x] Context budget impact reviewed — see the Headroom note above;
      both touched bundles verified under the 98% ceiling

---

**Commit signing**: Configured GPG signing failed identically on every
commit in this PR with a pinentry/TTY error (`gpg: signing failed: end
of file` after `PINENTRY_LAUNCHED`) — no usable interactive prompt in
this environment. Per the repository's bounded signing ladder, this is
category (P) pinentry/TTY, which skips the gpg-agent-restart step
(categories A/U only) and goes straight to the SSH fallback: every
commit is signed via the `git commit-ssh` blessed alias. Local
`git log --show-signature` cannot verify the SSH signature without a
configured `gpg.ssh.allowedSignersFile` — expected, not a signing
failure; GitHub's own verification is the authoritative check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CK2SHn8Bir6VHrXrMVMdn3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added worktree-local claim-token records to securely record and verify claim ownership evidence.
  - Added command-line options to record and inspect claim tokens, including optional activation nonces.
  - Added validation for missing, malformed, and repeated token records.

- **Documentation**
  - Documented claim-token workflows, verification results, cleanup behavior, and fallback commands.
  - Clarified that issue comments alone do not establish claim ownership.

- **Tests**
  - Expanded coverage for token recording, validation, overwrites, worktrees, and command-line workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
