### PR TITLE
fix(audit-code-span-wrap): flag hyphen-wrapped prose compounds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,8 +68,7 @@ the reasoning behind this layout.
   script also flags this failure mode outside code spans, in prose
   Markdown text: a hyphenated compound word (e.g. "transport-layer")
   must never wrap right after the hyphen inside `**bold**` / `*italic*`
-  emphasis, for the same corrupting-space reason (idd-skill issue
-  `#2876`).
+  emphasis, for the same corrupting-space reason (issue `#2876`).
 - **Bare issue/PR reference wrapping**: a bare `#NNN` reference must
   never be the first token of a paragraph, list item, or wrapped
   continuation line in prose Markdown — `dprint fmt`'s automatic

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,12 @@ the reasoning behind this layout.
   wrap-point character is a hand-added artifact rather than part of
   the real value, delete it instead of just relocating the break.
   Enforced by `node scripts/audit-code-span-wrap.mjs`
-  (repository-local; not distributed to `idd-template/`).
+  (repository-local; not distributed to `idd-template/`). The same
+  script also flags this failure mode outside code spans, in prose
+  Markdown text: a hyphenated compound word (e.g. "transport-layer")
+  must never wrap right after the hyphen inside `**bold**` / `*italic*`
+  emphasis, for the same corrupting-space reason (idd-skill issue
+  `#2876`).
 - **Bare issue/PR reference wrapping**: a bare `#NNN` reference must
   never be the first token of a paragraph, list item, or wrapped
   continuation line in prose Markdown — `dprint fmt`'s automatic

--- a/scripts/audit-code-span-wrap.mjs
+++ b/scripts/audit-code-span-wrap.mjs
@@ -8,7 +8,10 @@
 // Repository-local authoring guardrail (idd-skill issue #1677): fails when
 // a Markdown file contains an inline code span whose line break falls
 // mid-token (see code-span-wrap.mts for the exact rule and rationale).
-// This is dogfood-only tooling -- the lint configuration is not part of
+// Also fails on the prose counterpart (idd-skill issue #2876): a
+// hyphenated compound word whose line break falls immediately after the
+// hyphen inside `**bold**` / `*italic*` emphasis text. This is
+// dogfood-only tooling -- the lint configuration is not part of
 // the distributed idd-template/ (see docs/typescript-sources.md and this
 // script's registration in tests/helper-runtime-manifest.test.mts's
 // DOGFOOD_ONLY_CONCRETE_TOOLS set).
@@ -23,7 +26,10 @@
 // bare-node boundary.
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
-import { findCorruptingCodeSpanWraps } from './code-span-wrap.mjs';
+import {
+  findCorruptingCodeSpanWraps,
+  findCorruptingProseWraps,
+} from './code-span-wrap.mjs';
 
 const ROOT = process.cwd();
 const MARKDOWNLINT_CONFIG_PATH = '.markdownlint-cli2.yaml';
@@ -102,7 +108,12 @@ export function globToRegExp(pattern) {
 function readText(file) {
   return readFileSync(`${ROOT}/${file}`, 'utf8');
 }
-/** Scan every non-ignored Markdown file for corrupting code-span wraps. */
+/**
+ * Scan every non-ignored Markdown file for corrupting mid-token line
+ * breaks: inline code spans ({@link findCorruptingCodeSpanWraps}) and, per
+ * idd-skill issue #2876, hyphenated compound words inside `**`/`*`
+ * emphasis-marked prose text ({@link findCorruptingProseWraps}).
+ */
 export function auditCodeSpanWraps() {
   const ignorePatterns = parseMarkdownlintIgnores(
     readText(MARKDOWNLINT_CONFIG_PATH),
@@ -120,9 +131,10 @@ export function auditCodeSpanWraps() {
       unreadableFiles.push(file);
       continue;
     }
-    const violations = findCorruptingCodeSpanWraps(text);
-    if (violations.length > 0) {
-      results.push({ file, violations });
+    const codeSpanViolations = findCorruptingCodeSpanWraps(text);
+    const proseViolations = findCorruptingProseWraps(text);
+    if (codeSpanViolations.length > 0 || proseViolations.length > 0) {
+      results.push({ file, codeSpanViolations, proseViolations });
     }
   }
   return { results, unreadableFiles };
@@ -143,13 +155,16 @@ if (import.meta.main) {
   }
   if (results.length > 0) {
     failed = true;
-    console.error(
-      'audit-code-span-wrap: mid-token inline code span line break(s) found:',
-    );
-    for (const { file, violations } of results) {
-      for (const violation of violations) {
+    console.error('audit-code-span-wrap: mid-token line break(s) found:');
+    for (const { file, codeSpanViolations, proseViolations } of results) {
+      for (const violation of codeSpanViolations) {
         console.error(
-          `- ${file}:${violation.line}  ...${violation.before}|${violation.after}...`,
+          `- ${file}:${violation.line}  ...${violation.before}|${violation.after}... (code span)`,
+        );
+      }
+      for (const violation of proseViolations) {
+        console.error(
+          `- ${file}:${violation.line}  ...${violation.before}|${violation.after}... (prose emphasis)`,
         );
       }
     }

--- a/scripts/audit-code-span-wrap.mjs
+++ b/scripts/audit-code-span-wrap.mjs
@@ -181,5 +181,7 @@ if (import.meta.main) {
   if (failed) {
     process.exit(1);
   }
-  console.log('audit-code-span-wrap: no mid-token code span wraps found.');
+  console.log(
+    'audit-code-span-wrap: no mid-token line breaks found (code spans or prose emphasis).',
+  );
 }

--- a/scripts/code-span-wrap.mjs
+++ b/scripts/code-span-wrap.mjs
@@ -114,25 +114,63 @@ export function findCorruptingCodeSpanWraps(text) {
 //
 // EMPHASIS_SPAN_PATTERN mirrors INLINE_CODE_SPAN_PATTERN's own technique --
 // a backreference-counted delimiter run (`\1`) whose inner content may
-// cross a single line break but never a blank line -- with two extra
-// guards approximating CommonMark's emphasis flanking rules well enough to
-// avoid misreading a `*`/`-`/`+` bullet-list marker as an emphasis opener:
-// the opening run must not be immediately followed by whitespace (a bullet
+// cross any number of line breaks, same as INLINE_CODE_SPAN_PATTERN, as
+// long as none of them is a blank line -- with two extra guards
+// approximating CommonMark's emphasis flanking rules well enough to avoid
+// misreading a `*`/`-`/`+` bullet-list marker as an emphasis opener: the
+// opening run must not be immediately followed by whitespace (a bullet
 // marker always is, e.g. `* item`), and the closing run must be
 // immediately preceded by non-whitespace (rules out closing on a stray
 // later `*`/`**` separated from the emphasized text by a space). This is a
 // heuristic, not a full CommonMark emphasis parser -- deliberately, to keep
 // this dogfood-only check simple and low-risk; see
 // findCorruptingProseWraps's own corpus-validated scope below.
+//
+// Known limitations (PR #2880 review, Codex), accepted as residual scope
+// rather than fixed here -- each is a missed detection (false negative),
+// never a false positive that could wrongly block a clean PR, and a human/
+// Copilot review remains the backstop that caught this issue's own
+// incident in the first place:
+// - An escaped delimiter (`\*`) immediately before a wrapped compound is
+//   read as a real closing marker, ending the match early and missing the
+//   wrap after it (e.g. `*note \*literal well-\nknown*`).
+// - A blockquote `>` container prefix on a wrapped continuation line is
+//   not stripped before the neighbor check, so a wrap inside a
+//   blockquoted emphasis span (e.g. `> **well-\n> known**`) is missed.
+// - The neighbor test below is ASCII-only ({@link TOKEN_CONTINUING} is
+//   shared with {@link findCorruptingCodeSpanWraps}, which this issue does
+//   not change), so a non-ASCII letter adjacent to the hyphen (e.g.
+//   `**café-\nstyle**`) is not recognized as continuing the compound.
 const EMPHASIS_SPAN_PATTERN =
   /(\*{1,2})(?!\s)((?:(?!\1)[^\r\n]|\r?\n(?![ \t]*\r?\n))+?)(?<=\S)\1/g;
+// idd-skill issue #2876 (PR #2880 review, Codex): an HTML comment can
+// legitimately quote example Markdown -- including a multi-line
+// `**bold**` hyphen wrap used to illustrate this very rule -- that
+// CommonMark never renders as real emphasis at all. stripMarkdownCodeRegions
+// deliberately does NOT mask HTML comments (some operational markers are
+// HTML comments), so mask them here, scoped to this prose scan only:
+// blank each `<!-- ... -->` region's content (preserving line/column
+// structure, same style as blankFencedCodeBlocks) before matching
+// emphasis spans. Simple `indexOf`-based closing, matching this
+// repository's other HTML-comment handling (e.g. resolved-decision.mts's
+// findHtmlCommentRanges) -- not a full HTML parser.
+const HTML_COMMENT_PATTERN = /<!--[\s\S]*?(?:-->|$)/g;
+function blankHtmlComments(text) {
+  return text.replace(HTML_COMMENT_PATTERN, (match) =>
+    match.replace(/[^\r\n]/g, ' '),
+  );
+}
 /**
  * Find `**`/`*` emphasis spans in prose Markdown text (outside fenced code
- * blocks and inline code spans) whose line break falls immediately after a
- * hyphen joining a token on each side (reusing the same
- * {@link TOKEN_CONTINUING} neighbor test as
+ * blocks, inline code spans, and HTML comments) whose line break falls
+ * immediately after a hyphen joining a token on each side (reusing the
+ * same {@link TOKEN_CONTINUING} neighbor test as
  * {@link findCorruptingCodeSpanWraps}) -- the prose counterpart of that
- * function. Returns one violation per corrupting break, in document order.
+ * function. A hyphen at the very start of an emphasis span's content does
+ * not qualify: with nothing before it, there is no left-side token to
+ * join, so it is not a corrupted compound word (PR #2880 review,
+ * Copilot). Returns one violation per corrupting break, in document
+ * order.
  */
 export function findCorruptingProseWraps(text) {
   const normalized = text.replace(/\r\n?/g, '\n');
@@ -141,8 +179,9 @@ export function findCorruptingProseWraps(text) {
   // preserving line/column structure -- so code content already covered by
   // findCorruptingCodeSpanWraps is never double-flagged here, and this scan
   // never mistakes a code span's own emphasis-looking characters for real
-  // prose emphasis.
-  const scanned = stripMarkdownCodeRegions(normalized);
+  // prose emphasis. blankHtmlComments does the same for HTML comment
+  // content, which is never real Markdown structure either.
+  const scanned = blankHtmlComments(stripMarkdownCodeRegions(normalized));
   const violations = [];
   for (const match of scanned.matchAll(EMPHASIS_SPAN_PATTERN)) {
     const marker = match[1];
@@ -164,7 +203,8 @@ export function findCorruptingProseWraps(text) {
       const nextChar = inner[afterIndex];
       if (
         prevChar === '-' &&
-        (prevPrevChar === undefined || TOKEN_CONTINUING.test(prevPrevChar)) &&
+        prevPrevChar !== undefined &&
+        TOKEN_CONTINUING.test(prevPrevChar) &&
         nextChar !== undefined &&
         TOKEN_CONTINUING.test(nextChar)
       ) {

--- a/scripts/code-span-wrap.mjs
+++ b/scripts/code-span-wrap.mjs
@@ -37,6 +37,8 @@
 // this repository's corpus.
 import {
   blankFencedCodeBlocks,
+  findFencedCodeRanges,
+  findHtmlBlockRanges,
   findMarkdownCodeRanges,
   INLINE_CODE_SPAN_PATTERN,
   maskMarkdownCodeRegionsPreservingPositions,
@@ -132,9 +134,14 @@ export function findCorruptingCodeSpanWraps(text) {
 // never a false positive that could wrongly block a clean PR, and a human/
 // Copilot review remains the backstop that caught this issue's own
 // incident in the first place:
-// - An escaped delimiter (`\*`) immediately before a wrapped compound is
-//   read as a real closing marker, ending the match early and missing the
-//   wrap after it (e.g. `*note \*literal well-\nknown*`).
+// - An escaped delimiter (`\*`) immediately before a wrapped compound,
+//   INSIDE an already-open span, is read as a real closing marker, ending
+//   the match early and missing the wrap after it (e.g.
+//   `*note \*literal well-\nknown*`). The negative lookbehind below only
+//   stops a leading escaped delimiter from wrongly OPENING a span in the
+//   first place (the opposite-direction, false-positive-causing case) --
+//   it does not give `(?!\1)` the same escape awareness for a closer
+//   found mid-span.
 // - A blockquote `>` container prefix on a wrapped continuation line is
 //   not stripped before the neighbor check, so a wrap inside a
 //   blockquoted emphasis span (e.g. `> **well-\n> known**`) is missed.
@@ -142,8 +149,18 @@ export function findCorruptingCodeSpanWraps(text) {
 //   shared with {@link findCorruptingCodeSpanWraps}, which this issue does
 //   not change), so a non-ASCII letter adjacent to the hyphen (e.g.
 //   `**café-\nstyle**`) is not recognized as continuing the compound.
+//
+// The leading `(?<!\\)` (PR #2880 review, Codex) stops an escaped
+// delimiter (e.g. `\*well-\nknown*`) from opening a span at all: CommonMark
+// never treats an escaped `*` as a real emphasis delimiter, so the
+// asterisks and the text after them are literal, not emphasis, and must
+// not be scanned as if they were (a false positive that could reject a
+// literal-example PR). Single-backslash heuristic, matching this
+// repository's existing style for the same "good enough" escape check
+// (e.g. resolved-decision.mts's isEscapedBacktick) -- does not attempt
+// full backslash-run parity for a doubly-escaped `\\*`.
 const EMPHASIS_SPAN_PATTERN =
-  /(\*{1,2})(?!\s)((?:(?!\1)[^\r\n]|\r?\n(?![ \t]*\r?\n))+?)(?<=\S)\1/g;
+  /(?<!\\)(\*{1,2})(?!\s)((?:(?!\1)[^\r\n]|\r?\n(?![ \t]*\r?\n))+?)(?<=\S)\1/g;
 // idd-skill issue #2876 (PR #2880 review, Codex): an HTML comment can
 // legitimately quote example Markdown -- including a multi-line
 // `**bold**` hyphen wrap used to illustrate this very rule -- that
@@ -202,15 +219,16 @@ function blankAsteriskThematicBreaks(text) {
 }
 /**
  * Find `**`/`*` emphasis spans in prose Markdown text (outside fenced,
- * indented, and inline code, HTML comments, and asterisk thematic-break
- * lines) whose line break falls immediately after a hyphen joining a
- * token on each side (reusing the same {@link TOKEN_CONTINUING} neighbor
- * test as {@link findCorruptingCodeSpanWraps}) -- the prose counterpart
- * of that function. A hyphen at the very start of an emphasis span's
- * content does not qualify: with nothing before it, there is no
- * left-side token to join, so it is not a corrupted compound word (PR
- * #2880 review, Copilot). Returns one violation per corrupting break, in
- * document order.
+ * indented, and inline code, raw HTML blocks, HTML comments, and
+ * asterisk thematic-break lines) whose line break falls immediately
+ * after a hyphen joining a token on each side (reusing the same
+ * {@link TOKEN_CONTINUING} neighbor test as
+ * {@link findCorruptingCodeSpanWraps}) -- the prose counterpart of that
+ * function. A hyphen at the very start of an emphasis span's content
+ * does not qualify: with nothing before it, there is no left-side token
+ * to join, so it is not a corrupted compound word (PR #2880 review,
+ * Copilot). Returns one violation per corrupting break, in document
+ * order.
  */
 export function findCorruptingProseWraps(text) {
   const normalized = text.replace(/\r\n?/g, '\n');
@@ -219,15 +237,22 @@ export function findCorruptingProseWraps(text) {
   // fenced, indented, and inline (findMarkdownCodeRanges /
   // maskMarkdownCodeRegionsPreservingPositions cover all three, unlike
   // stripMarkdownCodeRegions's fenced-plus-inline-only scope; #2880
-  // review, Codex) -- so code content already covered by
-  // findCorruptingCodeSpanWraps is never double-flagged here and this
-  // scan never mistakes a code region's own emphasis-looking characters
-  // for real prose emphasis. Both preserve line/column structure. Then
-  // blank asterisk thematic-break lines, which are never real emphasis.
+  // review, Codex) plus raw HTML blocks (e.g. `<pre>...</pre>`, whose
+  // contents CommonMark renders literally, never as emphasis; same
+  // review round) -- so code/HTML-block content already covered
+  // elsewhere is never double-flagged here and this scan never mistakes
+  // such a region's own emphasis-looking characters for real prose
+  // emphasis. All three preserve line/column structure. Then blank
+  // asterisk thematic-break lines, which are never real emphasis.
   const withoutComments = blankHtmlComments(normalized);
+  const fencedRanges = findFencedCodeRanges(withoutComments);
+  const codeAndHtmlBlockRanges = [
+    ...findMarkdownCodeRanges(withoutComments),
+    ...findHtmlBlockRanges(withoutComments, fencedRanges),
+  ];
   const withoutCode = maskMarkdownCodeRegionsPreservingPositions(
     withoutComments,
-    findMarkdownCodeRanges(withoutComments),
+    codeAndHtmlBlockRanges,
   );
   const scanned = blankAsteriskThematicBreaks(withoutCode);
   const violations = [];

--- a/scripts/code-span-wrap.mjs
+++ b/scripts/code-span-wrap.mjs
@@ -38,6 +38,7 @@
 import {
   blankFencedCodeBlocks,
   INLINE_CODE_SPAN_PATTERN,
+  stripMarkdownCodeRegions,
 } from './markdown-code.mjs';
 
 const MID_TOKEN_CONTINUATION = /[-_/.]/;
@@ -77,6 +78,92 @@ export function findCorruptingCodeSpanWraps(text) {
       if (
         prevChar !== undefined &&
         MID_TOKEN_CONTINUATION.test(prevChar) &&
+        (prevPrevChar === undefined || TOKEN_CONTINUING.test(prevPrevChar)) &&
+        nextChar !== undefined &&
+        TOKEN_CONTINUING.test(nextChar)
+      ) {
+        const breakOffset = innerStart + breakIndex;
+        const line = scanned.slice(0, breakOffset).split('\n').length;
+        violations.push({
+          line,
+          before: inner.slice(
+            Math.max(0, breakIndex - CONTEXT_CHARS),
+            breakIndex,
+          ),
+          after: inner.slice(afterIndex, afterIndex + CONTEXT_CHARS),
+        });
+      }
+      cursor = breakIndex + 1;
+    }
+  }
+  return violations;
+}
+// idd-skill issue #2876: the corrupting-line-wrap failure mode above is not
+// unique to backtick-delimited code spans -- the same "CommonMark renders
+// the break as a single space, silently corrupting a hyphenated compound
+// word" problem occurs when a manual hard-wrap splits a compound right
+// after the hyphen inside `**bold**` / `*italic*` emphasis text (observed
+// live in this repository, 2026-09-10, PR #2875 closing issue #2806:
+// "**infrastructure/transport-layer failure**" hard-wrapped as
+// "transport-\n  layer", which `dprint fmt`, `markdownlint-cli2`, and this
+// script's own code-span check all missed -- only a Copilot review caught
+// it). Scoped to the hyphen case only (not underscore/slash/dot, which stay
+// code-span-only): underscore is itself an emphasis delimiter, and
+// slash/dot mid-token splits are a code/path concern this prose check does
+// not attempt to generalize to.
+//
+// EMPHASIS_SPAN_PATTERN mirrors INLINE_CODE_SPAN_PATTERN's own technique --
+// a backreference-counted delimiter run (`\1`) whose inner content may
+// cross a single line break but never a blank line -- with two extra
+// guards approximating CommonMark's emphasis flanking rules well enough to
+// avoid misreading a `*`/`-`/`+` bullet-list marker as an emphasis opener:
+// the opening run must not be immediately followed by whitespace (a bullet
+// marker always is, e.g. `* item`), and the closing run must be
+// immediately preceded by non-whitespace (rules out closing on a stray
+// later `*`/`**` separated from the emphasized text by a space). This is a
+// heuristic, not a full CommonMark emphasis parser -- deliberately, to keep
+// this dogfood-only check simple and low-risk; see
+// findCorruptingProseWraps's own corpus-validated scope below.
+const EMPHASIS_SPAN_PATTERN =
+  /(\*{1,2})(?!\s)((?:(?!\1)[^\r\n]|\r?\n(?![ \t]*\r?\n))+?)(?<=\S)\1/g;
+/**
+ * Find `**`/`*` emphasis spans in prose Markdown text (outside fenced code
+ * blocks and inline code spans) whose line break falls immediately after a
+ * hyphen joining a token on each side (reusing the same
+ * {@link TOKEN_CONTINUING} neighbor test as
+ * {@link findCorruptingCodeSpanWraps}) -- the prose counterpart of that
+ * function. Returns one violation per corrupting break, in document order.
+ */
+export function findCorruptingProseWraps(text) {
+  const normalized = text.replace(/\r\n?/g, '\n');
+  // stripMarkdownCodeRegions blanks fenced-block lines and masks inline
+  // code span interiors (backticks kept, content replaced with spaces),
+  // preserving line/column structure -- so code content already covered by
+  // findCorruptingCodeSpanWraps is never double-flagged here, and this scan
+  // never mistakes a code span's own emphasis-looking characters for real
+  // prose emphasis.
+  const scanned = stripMarkdownCodeRegions(normalized);
+  const violations = [];
+  for (const match of scanned.matchAll(EMPHASIS_SPAN_PATTERN)) {
+    const marker = match[1];
+    const inner = match[2];
+    const matchStart = match.index ?? 0;
+    const innerStart = matchStart + marker.length;
+    let cursor = 0;
+    for (;;) {
+      const breakIndex = inner.indexOf('\n', cursor);
+      if (breakIndex === -1) {
+        break;
+      }
+      const prevChar = inner[breakIndex - 1];
+      const prevPrevChar = inner[breakIndex - 2];
+      let afterIndex = breakIndex + 1;
+      while (inner[afterIndex] === ' ' || inner[afterIndex] === '\t') {
+        afterIndex += 1;
+      }
+      const nextChar = inner[afterIndex];
+      if (
+        prevChar === '-' &&
         (prevPrevChar === undefined || TOKEN_CONTINUING.test(prevPrevChar)) &&
         nextChar !== undefined &&
         TOKEN_CONTINUING.test(nextChar)

--- a/scripts/code-span-wrap.mjs
+++ b/scripts/code-span-wrap.mjs
@@ -37,8 +37,9 @@
 // this repository's corpus.
 import {
   blankFencedCodeBlocks,
+  findMarkdownCodeRanges,
   INLINE_CODE_SPAN_PATTERN,
-  stripMarkdownCodeRegions,
+  maskMarkdownCodeRegionsPreservingPositions,
 } from './markdown-code.mjs';
 
 const MID_TOKEN_CONTINUATION = /[-_/.]/;
@@ -146,42 +147,89 @@ const EMPHASIS_SPAN_PATTERN =
 // idd-skill issue #2876 (PR #2880 review, Codex): an HTML comment can
 // legitimately quote example Markdown -- including a multi-line
 // `**bold**` hyphen wrap used to illustrate this very rule -- that
-// CommonMark never renders as real emphasis at all. stripMarkdownCodeRegions
-// deliberately does NOT mask HTML comments (some operational markers are
-// HTML comments), so mask them here, scoped to this prose scan only:
-// blank each `<!-- ... -->` region's content (preserving line/column
-// structure, same style as blankFencedCodeBlocks) before matching
-// emphasis spans. Simple `indexOf`-based closing, matching this
-// repository's other HTML-comment handling (e.g. resolved-decision.mts's
-// findHtmlCommentRanges) -- not a full HTML parser.
+// CommonMark never renders as real emphasis at all. findMarkdownCodeRanges/
+// stripMarkdownCodeRegions deliberately do NOT mask HTML comments (some
+// operational markers are HTML comments), so mask them here, scoped to
+// this prose scan only, and BEFORE code-region detection runs (a second
+// review round, Codex): otherwise a stray backtick inside a comment can
+// pair with a later real backtick outside it into one bogus code span
+// that blanks real intervening prose. Blank each `<!-- ... -->` region's
+// content (preserving line/column structure, same style as
+// blankFencedCodeBlocks), using a Private Use Area filler character
+// rather than a literal space: a same-line, mid-line comment (e.g.
+// `<!-- note --> **word-\nwrap**`) blanked to plain spaces left several
+// leading space columns before the real `**word-` content that follows
+// on the same line -- enough to misread that remainder as a 4+-space
+// indented code block once findMarkdownCodeRanges below started
+// covering indented code too, silently masking the real prose it was
+// supposed to scan (round-3 regression caught by this file's own
+// regression tests, not a live review finding). The filler character is
+// never whitespace (so it cannot manufacture indentation), never
+// alphanumeric or one of `-_/.` (so it can never satisfy
+// {@link TOKEN_CONTINUING}), and never a Markdown structural character
+// (` ` ` ~ * _ = # > + digit), so it is inert to every check in
+// markdown-code.mts and to this file's own matching alike. Regex-based
+// closing (not the `indexOf`-based scan resolved-decision.mts's
+// findHtmlCommentRanges uses for the same "mask an HTML comment" need)
+// -- not a full HTML parser either way.
 const HTML_COMMENT_PATTERN = /<!--[\s\S]*?(?:-->|$)/g;
+const HTML_COMMENT_MASK_CHAR = '';
 function blankHtmlComments(text) {
   return text.replace(HTML_COMMENT_PATTERN, (match) =>
-    match.replace(/[^\r\n]/g, ' '),
+    match.replace(/[^\r\n]/g, HTML_COMMENT_MASK_CHAR),
   );
 }
+// idd-skill issue #2876 (PR #2880 review, CodeRabbit): a standalone
+// thematic-break line of 3+ `*` characters (optionally interior-spaced,
+// e.g. `***` or `* * *`) is never emphasis -- CommonMark resolves it as
+// its own block, never as an opening or closing delimiter run -- but
+// EMPHASIS_SPAN_PATTERN's plain `\*{1,2}` match does not know that, so
+// prose genuinely between two such lines (e.g. `***\nwell-\nknown\n***`)
+// could otherwise be misread as one emphasis span. Blank the asterisks on
+// a matching line (mirrors this repo's own unexported
+// MARKDOWN_THEMATIC_BREAK_PATTERN test in markdown-code.mts, narrowed to
+// the `*` marker this scan cares about) before matching emphasis.
+const ASTERISK_THEMATIC_BREAK_LINE_PATTERN = /^ {0,3}\*(?:[ \t]*\*){2,}[ \t]*$/;
+function blankAsteriskThematicBreaks(text) {
+  return text
+    .split('\n')
+    .map((line) =>
+      ASTERISK_THEMATIC_BREAK_LINE_PATTERN.test(line)
+        ? line.replace(/\S/g, ' ')
+        : line,
+    )
+    .join('\n');
+}
 /**
- * Find `**`/`*` emphasis spans in prose Markdown text (outside fenced code
- * blocks, inline code spans, and HTML comments) whose line break falls
- * immediately after a hyphen joining a token on each side (reusing the
- * same {@link TOKEN_CONTINUING} neighbor test as
- * {@link findCorruptingCodeSpanWraps}) -- the prose counterpart of that
- * function. A hyphen at the very start of an emphasis span's content does
- * not qualify: with nothing before it, there is no left-side token to
- * join, so it is not a corrupted compound word (PR #2880 review,
- * Copilot). Returns one violation per corrupting break, in document
- * order.
+ * Find `**`/`*` emphasis spans in prose Markdown text (outside fenced,
+ * indented, and inline code, HTML comments, and asterisk thematic-break
+ * lines) whose line break falls immediately after a hyphen joining a
+ * token on each side (reusing the same {@link TOKEN_CONTINUING} neighbor
+ * test as {@link findCorruptingCodeSpanWraps}) -- the prose counterpart
+ * of that function. A hyphen at the very start of an emphasis span's
+ * content does not qualify: with nothing before it, there is no
+ * left-side token to join, so it is not a corrupted compound word (PR
+ * #2880 review, Copilot). Returns one violation per corrupting break, in
+ * document order.
  */
 export function findCorruptingProseWraps(text) {
   const normalized = text.replace(/\r\n?/g, '\n');
-  // stripMarkdownCodeRegions blanks fenced-block lines and masks inline
-  // code span interiors (backticks kept, content replaced with spaces),
-  // preserving line/column structure -- so code content already covered by
-  // findCorruptingCodeSpanWraps is never double-flagged here, and this scan
-  // never mistakes a code span's own emphasis-looking characters for real
-  // prose emphasis. blankHtmlComments does the same for HTML comment
-  // content, which is never real Markdown structure either.
-  const scanned = blankHtmlComments(stripMarkdownCodeRegions(normalized));
+  // Order matters: blank HTML comments first (see the comment above
+  // HTML_COMMENT_PATTERN for why), then mask every code region --
+  // fenced, indented, and inline (findMarkdownCodeRanges /
+  // maskMarkdownCodeRegionsPreservingPositions cover all three, unlike
+  // stripMarkdownCodeRegions's fenced-plus-inline-only scope; #2880
+  // review, Codex) -- so code content already covered by
+  // findCorruptingCodeSpanWraps is never double-flagged here and this
+  // scan never mistakes a code region's own emphasis-looking characters
+  // for real prose emphasis. Both preserve line/column structure. Then
+  // blank asterisk thematic-break lines, which are never real emphasis.
+  const withoutComments = blankHtmlComments(normalized);
+  const withoutCode = maskMarkdownCodeRegionsPreservingPositions(
+    withoutComments,
+    findMarkdownCodeRanges(withoutComments),
+  );
+  const scanned = blankAsteriskThematicBreaks(withoutCode);
   const violations = [];
   for (const match of scanned.matchAll(EMPHASIS_SPAN_PATTERN)) {
     const marker = match[1];

--- a/scripts/code-span-wrap.mjs
+++ b/scripts/code-span-wrap.mjs
@@ -190,7 +190,7 @@ const EMPHASIS_SPAN_PATTERN =
 // findHtmlCommentRanges uses for the same "mask an HTML comment" need)
 // -- not a full HTML parser either way.
 const HTML_COMMENT_PATTERN = /<!--[\s\S]*?(?:-->|$)/g;
-const HTML_COMMENT_MASK_CHAR = '';
+const HTML_COMMENT_MASK_CHAR = '\uE000';
 function blankHtmlComments(text) {
   return text.replace(HTML_COMMENT_PATTERN, (match) =>
     match.replace(/[^\r\n]/g, HTML_COMMENT_MASK_CHAR),

--- a/src/scripts/audit-code-span-wrap.mts
+++ b/src/scripts/audit-code-span-wrap.mts
@@ -8,7 +8,10 @@
 // Repository-local authoring guardrail (idd-skill issue #1677): fails when
 // a Markdown file contains an inline code span whose line break falls
 // mid-token (see code-span-wrap.mts for the exact rule and rationale).
-// This is dogfood-only tooling -- the lint configuration is not part of
+// Also fails on the prose counterpart (idd-skill issue #2876): a
+// hyphenated compound word whose line break falls immediately after the
+// hyphen inside `**bold**` / `*italic*` emphasis text. This is
+// dogfood-only tooling -- the lint configuration is not part of
 // the distributed idd-template/ (see docs/typescript-sources.md and this
 // script's registration in tests/helper-runtime-manifest.test.mts's
 // DOGFOOD_ONLY_CONCRETE_TOOLS set).
@@ -28,6 +31,7 @@ import { readFileSync } from 'node:fs';
 import {
   type CodeSpanWrapViolation,
   findCorruptingCodeSpanWraps,
+  findCorruptingProseWraps,
 } from './code-span-wrap.mts';
 
 const ROOT = process.cwd();
@@ -115,7 +119,8 @@ function readText(file: string): string {
 
 interface FileViolations {
   file: string;
-  violations: CodeSpanWrapViolation[];
+  codeSpanViolations: CodeSpanWrapViolation[];
+  proseViolations: CodeSpanWrapViolation[];
 }
 
 export interface AuditCodeSpanWrapsResult {
@@ -130,7 +135,12 @@ export interface AuditCodeSpanWrapsResult {
   unreadableFiles: string[];
 }
 
-/** Scan every non-ignored Markdown file for corrupting code-span wraps. */
+/**
+ * Scan every non-ignored Markdown file for corrupting mid-token line
+ * breaks: inline code spans ({@link findCorruptingCodeSpanWraps}) and, per
+ * idd-skill issue #2876, hyphenated compound words inside `**`/`*`
+ * emphasis-marked prose text ({@link findCorruptingProseWraps}).
+ */
 export function auditCodeSpanWraps(): AuditCodeSpanWrapsResult {
   const ignorePatterns = parseMarkdownlintIgnores(
     readText(MARKDOWNLINT_CONFIG_PATH),
@@ -149,9 +159,10 @@ export function auditCodeSpanWraps(): AuditCodeSpanWrapsResult {
       unreadableFiles.push(file);
       continue;
     }
-    const violations = findCorruptingCodeSpanWraps(text);
-    if (violations.length > 0) {
-      results.push({ file, violations });
+    const codeSpanViolations = findCorruptingCodeSpanWraps(text);
+    const proseViolations = findCorruptingProseWraps(text);
+    if (codeSpanViolations.length > 0 || proseViolations.length > 0) {
+      results.push({ file, codeSpanViolations, proseViolations });
     }
   }
   return { results, unreadableFiles };
@@ -175,13 +186,16 @@ if (import.meta.main) {
 
   if (results.length > 0) {
     failed = true;
-    console.error(
-      'audit-code-span-wrap: mid-token inline code span line break(s) found:',
-    );
-    for (const { file, violations } of results) {
-      for (const violation of violations) {
+    console.error('audit-code-span-wrap: mid-token line break(s) found:');
+    for (const { file, codeSpanViolations, proseViolations } of results) {
+      for (const violation of codeSpanViolations) {
         console.error(
-          `- ${file}:${violation.line}  ...${violation.before}|${violation.after}...`,
+          `- ${file}:${violation.line}  ...${violation.before}|${violation.after}... (code span)`,
+        );
+      }
+      for (const violation of proseViolations) {
+        console.error(
+          `- ${file}:${violation.line}  ...${violation.before}|${violation.after}... (prose emphasis)`,
         );
       }
     }

--- a/src/scripts/audit-code-span-wrap.mts
+++ b/src/scripts/audit-code-span-wrap.mts
@@ -213,5 +213,7 @@ if (import.meta.main) {
   if (failed) {
     process.exit(1);
   }
-  console.log('audit-code-span-wrap: no mid-token code span wraps found.');
+  console.log(
+    'audit-code-span-wrap: no mid-token line breaks found (code spans or prose emphasis).',
+  );
 }

--- a/src/scripts/code-span-wrap.mts
+++ b/src/scripts/code-span-wrap.mts
@@ -207,7 +207,7 @@ const EMPHASIS_SPAN_PATTERN =
 // findHtmlCommentRanges uses for the same "mask an HTML comment" need)
 // -- not a full HTML parser either way.
 const HTML_COMMENT_PATTERN = /<!--[\s\S]*?(?:-->|$)/g;
-const HTML_COMMENT_MASK_CHAR = '';
+const HTML_COMMENT_MASK_CHAR = '\uE000';
 
 function blankHtmlComments(text: string): string {
   return text.replace(HTML_COMMENT_PATTERN, (match) =>

--- a/src/scripts/code-span-wrap.mts
+++ b/src/scripts/code-span-wrap.mts
@@ -130,26 +130,66 @@ export function findCorruptingCodeSpanWraps(
 //
 // EMPHASIS_SPAN_PATTERN mirrors INLINE_CODE_SPAN_PATTERN's own technique --
 // a backreference-counted delimiter run (`\1`) whose inner content may
-// cross a single line break but never a blank line -- with two extra
-// guards approximating CommonMark's emphasis flanking rules well enough to
-// avoid misreading a `*`/`-`/`+` bullet-list marker as an emphasis opener:
-// the opening run must not be immediately followed by whitespace (a bullet
+// cross any number of line breaks, same as INLINE_CODE_SPAN_PATTERN, as
+// long as none of them is a blank line -- with two extra guards
+// approximating CommonMark's emphasis flanking rules well enough to avoid
+// misreading a `*`/`-`/`+` bullet-list marker as an emphasis opener: the
+// opening run must not be immediately followed by whitespace (a bullet
 // marker always is, e.g. `* item`), and the closing run must be
 // immediately preceded by non-whitespace (rules out closing on a stray
 // later `*`/`**` separated from the emphasized text by a space). This is a
 // heuristic, not a full CommonMark emphasis parser -- deliberately, to keep
 // this dogfood-only check simple and low-risk; see
 // findCorruptingProseWraps's own corpus-validated scope below.
+//
+// Known limitations (PR #2880 review, Codex), accepted as residual scope
+// rather than fixed here -- each is a missed detection (false negative),
+// never a false positive that could wrongly block a clean PR, and a human/
+// Copilot review remains the backstop that caught this issue's own
+// incident in the first place:
+// - An escaped delimiter (`\*`) immediately before a wrapped compound is
+//   read as a real closing marker, ending the match early and missing the
+//   wrap after it (e.g. `*note \*literal well-\nknown*`).
+// - A blockquote `>` container prefix on a wrapped continuation line is
+//   not stripped before the neighbor check, so a wrap inside a
+//   blockquoted emphasis span (e.g. `> **well-\n> known**`) is missed.
+// - The neighbor test below is ASCII-only ({@link TOKEN_CONTINUING} is
+//   shared with {@link findCorruptingCodeSpanWraps}, which this issue does
+//   not change), so a non-ASCII letter adjacent to the hyphen (e.g.
+//   `**café-\nstyle**`) is not recognized as continuing the compound.
 const EMPHASIS_SPAN_PATTERN =
   /(\*{1,2})(?!\s)((?:(?!\1)[^\r\n]|\r?\n(?![ \t]*\r?\n))+?)(?<=\S)\1/g;
 
+// idd-skill issue #2876 (PR #2880 review, Codex): an HTML comment can
+// legitimately quote example Markdown -- including a multi-line
+// `**bold**` hyphen wrap used to illustrate this very rule -- that
+// CommonMark never renders as real emphasis at all. stripMarkdownCodeRegions
+// deliberately does NOT mask HTML comments (some operational markers are
+// HTML comments), so mask them here, scoped to this prose scan only:
+// blank each `<!-- ... -->` region's content (preserving line/column
+// structure, same style as blankFencedCodeBlocks) before matching
+// emphasis spans. Simple `indexOf`-based closing, matching this
+// repository's other HTML-comment handling (e.g. resolved-decision.mts's
+// findHtmlCommentRanges) -- not a full HTML parser.
+const HTML_COMMENT_PATTERN = /<!--[\s\S]*?(?:-->|$)/g;
+
+function blankHtmlComments(text: string): string {
+  return text.replace(HTML_COMMENT_PATTERN, (match) =>
+    match.replace(/[^\r\n]/g, ' '),
+  );
+}
+
 /**
  * Find `**`/`*` emphasis spans in prose Markdown text (outside fenced code
- * blocks and inline code spans) whose line break falls immediately after a
- * hyphen joining a token on each side (reusing the same
- * {@link TOKEN_CONTINUING} neighbor test as
+ * blocks, inline code spans, and HTML comments) whose line break falls
+ * immediately after a hyphen joining a token on each side (reusing the
+ * same {@link TOKEN_CONTINUING} neighbor test as
  * {@link findCorruptingCodeSpanWraps}) -- the prose counterpart of that
- * function. Returns one violation per corrupting break, in document order.
+ * function. A hyphen at the very start of an emphasis span's content does
+ * not qualify: with nothing before it, there is no left-side token to
+ * join, so it is not a corrupted compound word (PR #2880 review,
+ * Copilot). Returns one violation per corrupting break, in document
+ * order.
  */
 export function findCorruptingProseWraps(
   text: string,
@@ -160,8 +200,9 @@ export function findCorruptingProseWraps(
   // preserving line/column structure -- so code content already covered by
   // findCorruptingCodeSpanWraps is never double-flagged here, and this scan
   // never mistakes a code span's own emphasis-looking characters for real
-  // prose emphasis.
-  const scanned = stripMarkdownCodeRegions(normalized);
+  // prose emphasis. blankHtmlComments does the same for HTML comment
+  // content, which is never real Markdown structure either.
+  const scanned = blankHtmlComments(stripMarkdownCodeRegions(normalized));
   const violations: CodeSpanWrapViolation[] = [];
 
   for (const match of scanned.matchAll(EMPHASIS_SPAN_PATTERN)) {
@@ -184,7 +225,8 @@ export function findCorruptingProseWraps(
       const nextChar = inner[afterIndex];
       if (
         prevChar === '-' &&
-        (prevPrevChar === undefined || TOKEN_CONTINUING.test(prevPrevChar)) &&
+        prevPrevChar !== undefined &&
+        TOKEN_CONTINUING.test(prevPrevChar) &&
         nextChar !== undefined &&
         TOKEN_CONTINUING.test(nextChar)
       ) {

--- a/src/scripts/code-span-wrap.mts
+++ b/src/scripts/code-span-wrap.mts
@@ -39,6 +39,7 @@
 import {
   blankFencedCodeBlocks,
   INLINE_CODE_SPAN_PATTERN,
+  stripMarkdownCodeRegions,
 } from './markdown-code.mts';
 
 export interface CodeSpanWrapViolation {
@@ -91,6 +92,98 @@ export function findCorruptingCodeSpanWraps(
       if (
         prevChar !== undefined &&
         MID_TOKEN_CONTINUATION.test(prevChar) &&
+        (prevPrevChar === undefined || TOKEN_CONTINUING.test(prevPrevChar)) &&
+        nextChar !== undefined &&
+        TOKEN_CONTINUING.test(nextChar)
+      ) {
+        const breakOffset = innerStart + breakIndex;
+        const line = scanned.slice(0, breakOffset).split('\n').length;
+        violations.push({
+          line,
+          before: inner.slice(
+            Math.max(0, breakIndex - CONTEXT_CHARS),
+            breakIndex,
+          ),
+          after: inner.slice(afterIndex, afterIndex + CONTEXT_CHARS),
+        });
+      }
+      cursor = breakIndex + 1;
+    }
+  }
+
+  return violations;
+}
+
+// idd-skill issue #2876: the corrupting-line-wrap failure mode above is not
+// unique to backtick-delimited code spans -- the same "CommonMark renders
+// the break as a single space, silently corrupting a hyphenated compound
+// word" problem occurs when a manual hard-wrap splits a compound right
+// after the hyphen inside `**bold**` / `*italic*` emphasis text (observed
+// live in this repository, 2026-09-10, PR #2875 closing issue #2806:
+// "**infrastructure/transport-layer failure**" hard-wrapped as
+// "transport-\n  layer", which `dprint fmt`, `markdownlint-cli2`, and this
+// script's own code-span check all missed -- only a Copilot review caught
+// it). Scoped to the hyphen case only (not underscore/slash/dot, which stay
+// code-span-only): underscore is itself an emphasis delimiter, and
+// slash/dot mid-token splits are a code/path concern this prose check does
+// not attempt to generalize to.
+//
+// EMPHASIS_SPAN_PATTERN mirrors INLINE_CODE_SPAN_PATTERN's own technique --
+// a backreference-counted delimiter run (`\1`) whose inner content may
+// cross a single line break but never a blank line -- with two extra
+// guards approximating CommonMark's emphasis flanking rules well enough to
+// avoid misreading a `*`/`-`/`+` bullet-list marker as an emphasis opener:
+// the opening run must not be immediately followed by whitespace (a bullet
+// marker always is, e.g. `* item`), and the closing run must be
+// immediately preceded by non-whitespace (rules out closing on a stray
+// later `*`/`**` separated from the emphasized text by a space). This is a
+// heuristic, not a full CommonMark emphasis parser -- deliberately, to keep
+// this dogfood-only check simple and low-risk; see
+// findCorruptingProseWraps's own corpus-validated scope below.
+const EMPHASIS_SPAN_PATTERN =
+  /(\*{1,2})(?!\s)((?:(?!\1)[^\r\n]|\r?\n(?![ \t]*\r?\n))+?)(?<=\S)\1/g;
+
+/**
+ * Find `**`/`*` emphasis spans in prose Markdown text (outside fenced code
+ * blocks and inline code spans) whose line break falls immediately after a
+ * hyphen joining a token on each side (reusing the same
+ * {@link TOKEN_CONTINUING} neighbor test as
+ * {@link findCorruptingCodeSpanWraps}) -- the prose counterpart of that
+ * function. Returns one violation per corrupting break, in document order.
+ */
+export function findCorruptingProseWraps(
+  text: string,
+): CodeSpanWrapViolation[] {
+  const normalized = text.replace(/\r\n?/g, '\n');
+  // stripMarkdownCodeRegions blanks fenced-block lines and masks inline
+  // code span interiors (backticks kept, content replaced with spaces),
+  // preserving line/column structure -- so code content already covered by
+  // findCorruptingCodeSpanWraps is never double-flagged here, and this scan
+  // never mistakes a code span's own emphasis-looking characters for real
+  // prose emphasis.
+  const scanned = stripMarkdownCodeRegions(normalized);
+  const violations: CodeSpanWrapViolation[] = [];
+
+  for (const match of scanned.matchAll(EMPHASIS_SPAN_PATTERN)) {
+    const marker = match[1];
+    const inner = match[2];
+    const matchStart = match.index ?? 0;
+    const innerStart = matchStart + marker.length;
+    let cursor = 0;
+    for (;;) {
+      const breakIndex = inner.indexOf('\n', cursor);
+      if (breakIndex === -1) {
+        break;
+      }
+      const prevChar = inner[breakIndex - 1];
+      const prevPrevChar = inner[breakIndex - 2];
+      let afterIndex = breakIndex + 1;
+      while (inner[afterIndex] === ' ' || inner[afterIndex] === '\t') {
+        afterIndex += 1;
+      }
+      const nextChar = inner[afterIndex];
+      if (
+        prevChar === '-' &&
         (prevPrevChar === undefined || TOKEN_CONTINUING.test(prevPrevChar)) &&
         nextChar !== undefined &&
         TOKEN_CONTINUING.test(nextChar)

--- a/src/scripts/code-span-wrap.mts
+++ b/src/scripts/code-span-wrap.mts
@@ -38,8 +38,9 @@
 
 import {
   blankFencedCodeBlocks,
+  findMarkdownCodeRanges,
   INLINE_CODE_SPAN_PATTERN,
-  stripMarkdownCodeRegions,
+  maskMarkdownCodeRegionsPreservingPositions,
 } from './markdown-code.mts';
 
 export interface CodeSpanWrapViolation {
@@ -163,46 +164,95 @@ const EMPHASIS_SPAN_PATTERN =
 // idd-skill issue #2876 (PR #2880 review, Codex): an HTML comment can
 // legitimately quote example Markdown -- including a multi-line
 // `**bold**` hyphen wrap used to illustrate this very rule -- that
-// CommonMark never renders as real emphasis at all. stripMarkdownCodeRegions
-// deliberately does NOT mask HTML comments (some operational markers are
-// HTML comments), so mask them here, scoped to this prose scan only:
-// blank each `<!-- ... -->` region's content (preserving line/column
-// structure, same style as blankFencedCodeBlocks) before matching
-// emphasis spans. Simple `indexOf`-based closing, matching this
-// repository's other HTML-comment handling (e.g. resolved-decision.mts's
-// findHtmlCommentRanges) -- not a full HTML parser.
+// CommonMark never renders as real emphasis at all. findMarkdownCodeRanges/
+// stripMarkdownCodeRegions deliberately do NOT mask HTML comments (some
+// operational markers are HTML comments), so mask them here, scoped to
+// this prose scan only, and BEFORE code-region detection runs (a second
+// review round, Codex): otherwise a stray backtick inside a comment can
+// pair with a later real backtick outside it into one bogus code span
+// that blanks real intervening prose. Blank each `<!-- ... -->` region's
+// content (preserving line/column structure, same style as
+// blankFencedCodeBlocks), using a Private Use Area filler character
+// rather than a literal space: a same-line, mid-line comment (e.g.
+// `<!-- note --> **word-\nwrap**`) blanked to plain spaces left several
+// leading space columns before the real `**word-` content that follows
+// on the same line -- enough to misread that remainder as a 4+-space
+// indented code block once findMarkdownCodeRanges below started
+// covering indented code too, silently masking the real prose it was
+// supposed to scan (round-3 regression caught by this file's own
+// regression tests, not a live review finding). The filler character is
+// never whitespace (so it cannot manufacture indentation), never
+// alphanumeric or one of `-_/.` (so it can never satisfy
+// {@link TOKEN_CONTINUING}), and never a Markdown structural character
+// (` ` ` ~ * _ = # > + digit), so it is inert to every check in
+// markdown-code.mts and to this file's own matching alike. Regex-based
+// closing (not the `indexOf`-based scan resolved-decision.mts's
+// findHtmlCommentRanges uses for the same "mask an HTML comment" need)
+// -- not a full HTML parser either way.
 const HTML_COMMENT_PATTERN = /<!--[\s\S]*?(?:-->|$)/g;
+const HTML_COMMENT_MASK_CHAR = '';
 
 function blankHtmlComments(text: string): string {
   return text.replace(HTML_COMMENT_PATTERN, (match) =>
-    match.replace(/[^\r\n]/g, ' '),
+    match.replace(/[^\r\n]/g, HTML_COMMENT_MASK_CHAR),
   );
 }
 
+// idd-skill issue #2876 (PR #2880 review, CodeRabbit): a standalone
+// thematic-break line of 3+ `*` characters (optionally interior-spaced,
+// e.g. `***` or `* * *`) is never emphasis -- CommonMark resolves it as
+// its own block, never as an opening or closing delimiter run -- but
+// EMPHASIS_SPAN_PATTERN's plain `\*{1,2}` match does not know that, so
+// prose genuinely between two such lines (e.g. `***\nwell-\nknown\n***`)
+// could otherwise be misread as one emphasis span. Blank the asterisks on
+// a matching line (mirrors this repo's own unexported
+// MARKDOWN_THEMATIC_BREAK_PATTERN test in markdown-code.mts, narrowed to
+// the `*` marker this scan cares about) before matching emphasis.
+const ASTERISK_THEMATIC_BREAK_LINE_PATTERN = /^ {0,3}\*(?:[ \t]*\*){2,}[ \t]*$/;
+
+function blankAsteriskThematicBreaks(text: string): string {
+  return text
+    .split('\n')
+    .map((line) =>
+      ASTERISK_THEMATIC_BREAK_LINE_PATTERN.test(line)
+        ? line.replace(/\S/g, ' ')
+        : line,
+    )
+    .join('\n');
+}
+
 /**
- * Find `**`/`*` emphasis spans in prose Markdown text (outside fenced code
- * blocks, inline code spans, and HTML comments) whose line break falls
- * immediately after a hyphen joining a token on each side (reusing the
- * same {@link TOKEN_CONTINUING} neighbor test as
- * {@link findCorruptingCodeSpanWraps}) -- the prose counterpart of that
- * function. A hyphen at the very start of an emphasis span's content does
- * not qualify: with nothing before it, there is no left-side token to
- * join, so it is not a corrupted compound word (PR #2880 review,
- * Copilot). Returns one violation per corrupting break, in document
- * order.
+ * Find `**`/`*` emphasis spans in prose Markdown text (outside fenced,
+ * indented, and inline code, HTML comments, and asterisk thematic-break
+ * lines) whose line break falls immediately after a hyphen joining a
+ * token on each side (reusing the same {@link TOKEN_CONTINUING} neighbor
+ * test as {@link findCorruptingCodeSpanWraps}) -- the prose counterpart
+ * of that function. A hyphen at the very start of an emphasis span's
+ * content does not qualify: with nothing before it, there is no
+ * left-side token to join, so it is not a corrupted compound word (PR
+ * #2880 review, Copilot). Returns one violation per corrupting break, in
+ * document order.
  */
 export function findCorruptingProseWraps(
   text: string,
 ): CodeSpanWrapViolation[] {
   const normalized = text.replace(/\r\n?/g, '\n');
-  // stripMarkdownCodeRegions blanks fenced-block lines and masks inline
-  // code span interiors (backticks kept, content replaced with spaces),
-  // preserving line/column structure -- so code content already covered by
-  // findCorruptingCodeSpanWraps is never double-flagged here, and this scan
-  // never mistakes a code span's own emphasis-looking characters for real
-  // prose emphasis. blankHtmlComments does the same for HTML comment
-  // content, which is never real Markdown structure either.
-  const scanned = blankHtmlComments(stripMarkdownCodeRegions(normalized));
+  // Order matters: blank HTML comments first (see the comment above
+  // HTML_COMMENT_PATTERN for why), then mask every code region --
+  // fenced, indented, and inline (findMarkdownCodeRanges /
+  // maskMarkdownCodeRegionsPreservingPositions cover all three, unlike
+  // stripMarkdownCodeRegions's fenced-plus-inline-only scope; #2880
+  // review, Codex) -- so code content already covered by
+  // findCorruptingCodeSpanWraps is never double-flagged here and this
+  // scan never mistakes a code region's own emphasis-looking characters
+  // for real prose emphasis. Both preserve line/column structure. Then
+  // blank asterisk thematic-break lines, which are never real emphasis.
+  const withoutComments = blankHtmlComments(normalized);
+  const withoutCode = maskMarkdownCodeRegionsPreservingPositions(
+    withoutComments,
+    findMarkdownCodeRanges(withoutComments),
+  );
+  const scanned = blankAsteriskThematicBreaks(withoutCode);
   const violations: CodeSpanWrapViolation[] = [];
 
   for (const match of scanned.matchAll(EMPHASIS_SPAN_PATTERN)) {

--- a/src/scripts/code-span-wrap.mts
+++ b/src/scripts/code-span-wrap.mts
@@ -38,6 +38,8 @@
 
 import {
   blankFencedCodeBlocks,
+  findFencedCodeRanges,
+  findHtmlBlockRanges,
   findMarkdownCodeRanges,
   INLINE_CODE_SPAN_PATTERN,
   maskMarkdownCodeRegionsPreservingPositions,
@@ -148,9 +150,14 @@ export function findCorruptingCodeSpanWraps(
 // never a false positive that could wrongly block a clean PR, and a human/
 // Copilot review remains the backstop that caught this issue's own
 // incident in the first place:
-// - An escaped delimiter (`\*`) immediately before a wrapped compound is
-//   read as a real closing marker, ending the match early and missing the
-//   wrap after it (e.g. `*note \*literal well-\nknown*`).
+// - An escaped delimiter (`\*`) immediately before a wrapped compound,
+//   INSIDE an already-open span, is read as a real closing marker, ending
+//   the match early and missing the wrap after it (e.g.
+//   `*note \*literal well-\nknown*`). The negative lookbehind below only
+//   stops a leading escaped delimiter from wrongly OPENING a span in the
+//   first place (the opposite-direction, false-positive-causing case) --
+//   it does not give `(?!\1)` the same escape awareness for a closer
+//   found mid-span.
 // - A blockquote `>` container prefix on a wrapped continuation line is
 //   not stripped before the neighbor check, so a wrap inside a
 //   blockquoted emphasis span (e.g. `> **well-\n> known**`) is missed.
@@ -158,8 +165,18 @@ export function findCorruptingCodeSpanWraps(
 //   shared with {@link findCorruptingCodeSpanWraps}, which this issue does
 //   not change), so a non-ASCII letter adjacent to the hyphen (e.g.
 //   `**café-\nstyle**`) is not recognized as continuing the compound.
+//
+// The leading `(?<!\\)` (PR #2880 review, Codex) stops an escaped
+// delimiter (e.g. `\*well-\nknown*`) from opening a span at all: CommonMark
+// never treats an escaped `*` as a real emphasis delimiter, so the
+// asterisks and the text after them are literal, not emphasis, and must
+// not be scanned as if they were (a false positive that could reject a
+// literal-example PR). Single-backslash heuristic, matching this
+// repository's existing style for the same "good enough" escape check
+// (e.g. resolved-decision.mts's isEscapedBacktick) -- does not attempt
+// full backslash-run parity for a doubly-escaped `\\*`.
 const EMPHASIS_SPAN_PATTERN =
-  /(\*{1,2})(?!\s)((?:(?!\1)[^\r\n]|\r?\n(?![ \t]*\r?\n))+?)(?<=\S)\1/g;
+  /(?<!\\)(\*{1,2})(?!\s)((?:(?!\1)[^\r\n]|\r?\n(?![ \t]*\r?\n))+?)(?<=\S)\1/g;
 
 // idd-skill issue #2876 (PR #2880 review, Codex): an HTML comment can
 // legitimately quote example Markdown -- including a multi-line
@@ -223,15 +240,16 @@ function blankAsteriskThematicBreaks(text: string): string {
 
 /**
  * Find `**`/`*` emphasis spans in prose Markdown text (outside fenced,
- * indented, and inline code, HTML comments, and asterisk thematic-break
- * lines) whose line break falls immediately after a hyphen joining a
- * token on each side (reusing the same {@link TOKEN_CONTINUING} neighbor
- * test as {@link findCorruptingCodeSpanWraps}) -- the prose counterpart
- * of that function. A hyphen at the very start of an emphasis span's
- * content does not qualify: with nothing before it, there is no
- * left-side token to join, so it is not a corrupted compound word (PR
- * #2880 review, Copilot). Returns one violation per corrupting break, in
- * document order.
+ * indented, and inline code, raw HTML blocks, HTML comments, and
+ * asterisk thematic-break lines) whose line break falls immediately
+ * after a hyphen joining a token on each side (reusing the same
+ * {@link TOKEN_CONTINUING} neighbor test as
+ * {@link findCorruptingCodeSpanWraps}) -- the prose counterpart of that
+ * function. A hyphen at the very start of an emphasis span's content
+ * does not qualify: with nothing before it, there is no left-side token
+ * to join, so it is not a corrupted compound word (PR #2880 review,
+ * Copilot). Returns one violation per corrupting break, in document
+ * order.
  */
 export function findCorruptingProseWraps(
   text: string,
@@ -242,15 +260,22 @@ export function findCorruptingProseWraps(
   // fenced, indented, and inline (findMarkdownCodeRanges /
   // maskMarkdownCodeRegionsPreservingPositions cover all three, unlike
   // stripMarkdownCodeRegions's fenced-plus-inline-only scope; #2880
-  // review, Codex) -- so code content already covered by
-  // findCorruptingCodeSpanWraps is never double-flagged here and this
-  // scan never mistakes a code region's own emphasis-looking characters
-  // for real prose emphasis. Both preserve line/column structure. Then
-  // blank asterisk thematic-break lines, which are never real emphasis.
+  // review, Codex) plus raw HTML blocks (e.g. `<pre>...</pre>`, whose
+  // contents CommonMark renders literally, never as emphasis; same
+  // review round) -- so code/HTML-block content already covered
+  // elsewhere is never double-flagged here and this scan never mistakes
+  // such a region's own emphasis-looking characters for real prose
+  // emphasis. All three preserve line/column structure. Then blank
+  // asterisk thematic-break lines, which are never real emphasis.
   const withoutComments = blankHtmlComments(normalized);
+  const fencedRanges = findFencedCodeRanges(withoutComments);
+  const codeAndHtmlBlockRanges = [
+    ...findMarkdownCodeRanges(withoutComments),
+    ...findHtmlBlockRanges(withoutComments, fencedRanges),
+  ];
   const withoutCode = maskMarkdownCodeRegionsPreservingPositions(
     withoutComments,
-    findMarkdownCodeRanges(withoutComments),
+    codeAndHtmlBlockRanges,
   );
   const scanned = blankAsteriskThematicBreaks(withoutCode);
   const violations: CodeSpanWrapViolation[] = [];

--- a/tests/code-span-wrap.test.mts
+++ b/tests/code-span-wrap.test.mts
@@ -233,11 +233,11 @@ test('findCorruptingProseWraps: does not flag emphasis text preceding an untermi
   assert.equal(violations.length, 1);
 });
 
-test('findCorruptingProseWraps: a single fixture file with no emphasis markup reports no violations', () => {
-  // This checks one specific fixture, not a full repository corpus scan
-  // -- that end-to-end check lives in
-  // audit-code-span-wrap.test.mts's auditCodeSpanWraps() regression
-  // (PR #2880 review, Copilot).
+test('findCorruptingProseWraps: a real fixture file with emphasis markup has no corrupting hyphen wraps', () => {
+  // This checks one specific fixture (which does contain `**bold**`
+  // emphasis, e.g. its "**Example**:" line -- PR #2880 review, Copilot),
+  // not a full repository corpus scan; that end-to-end check lives in
+  // audit-code-span-wrap.test.mts's auditCodeSpanWraps() regression.
   const text = readFileSync(
     join(
       REPO_ROOT,

--- a/tests/code-span-wrap.test.mts
+++ b/tests/code-span-wrap.test.mts
@@ -196,11 +196,48 @@ test('findCorruptingProseWraps: does not flag when the hyphen sits right before 
   assert.deepEqual(findCorruptingProseWraps('**foo-\n**bar'), []);
 });
 
-test('findCorruptingProseWraps: real-corpus regression finds no violations on this repository’s own tracked Markdown files', () => {
-  // Direct counterpart of code-span-wrap's own real-corpus regression
-  // above, and of audit-code-span-wrap.test.mts's end-to-end
-  // auditCodeSpanWraps() check -- confirms acceptance criterion 3 (no new
-  // false positives) at the function level too.
+test('findCorruptingProseWraps: does not flag a hyphen at the very start of an emphasis span (no left-side token)', () => {
+  // PR #2880 review (Copilot): a hyphen with nothing before it in the
+  // span (prevPrevChar undefined) is not a compound-word join -- e.g. a
+  // hyphen/flag-style prefix like "*-flag*", not "well-known".
+  assert.deepEqual(findCorruptingProseWraps('*-\nflag* text'), []);
+  assert.deepEqual(findCorruptingProseWraps('**-\nflag** text'), []);
+});
+
+test('findCorruptingProseWraps: does not flag a multi-line emphasis example quoted inside an HTML comment', () => {
+  // PR #2880 review (Codex): CommonMark never renders HTML comment
+  // content as emphasis, so an example quoted inside one (this rule's
+  // own kind of illustrative comment) must not be flagged.
+  assert.deepEqual(
+    findCorruptingProseWraps('<!-- example: **well-\nknown** -->'),
+    [],
+  );
+});
+
+test('findCorruptingProseWraps: still flags a real violation outside an unrelated HTML comment', () => {
+  // Regression guard: masking HTML comments must not also mask real
+  // prose that merely sits near one.
+  const violations = findCorruptingProseWraps(
+    '<!-- note --> **transport-\nlayer** failure',
+  );
+  assert.equal(violations.length, 1);
+});
+
+test('findCorruptingProseWraps: does not flag emphasis text preceding an unterminated HTML comment', () => {
+  // An unterminated `<!--` masks through end of text (mirrors
+  // resolved-decision.mts's own findHtmlCommentRanges close-scan), so a
+  // real violation entirely before it must still be found.
+  const violations = findCorruptingProseWraps(
+    '**transport-\nlayer** failure <!-- unterminated',
+  );
+  assert.equal(violations.length, 1);
+});
+
+test('findCorruptingProseWraps: a single fixture file with no emphasis markup reports no violations', () => {
+  // This checks one specific fixture, not a full repository corpus scan
+  // -- that end-to-end check lives in
+  // audit-code-span-wrap.test.mts's auditCodeSpanWraps() regression
+  // (PR #2880 review, Copilot).
   const text = readFileSync(
     join(
       REPO_ROOT,

--- a/tests/code-span-wrap.test.mts
+++ b/tests/code-span-wrap.test.mts
@@ -274,6 +274,34 @@ test('findCorruptingProseWraps: an HTML comment with a stray backtick does not s
   assert.equal(violations.length, 1);
 });
 
+test('findCorruptingProseWraps: does not flag literal emphasis markers inside a raw HTML block', () => {
+  // PR #2880 review (Codex): CommonMark renders a raw HTML block's
+  // contents literally, never as emphasis, so a wrapped `*...*` example
+  // inside e.g. `<pre>` must not be scanned as prose.
+  assert.deepEqual(
+    findCorruptingProseWraps(
+      ['<pre>', '*well-', 'known*', '</pre>'].join('\n'),
+    ),
+    [],
+  );
+});
+
+test('findCorruptingProseWraps: does not flag emphasis starting right after an escaped delimiter', () => {
+  // PR #2880 review (Codex): CommonMark never treats an escaped `*` as a
+  // real emphasis opener, so the asterisks and text after it are literal,
+  // not emphasis, and must not be scanned as if they were.
+  assert.deepEqual(findCorruptingProseWraps('\\*well-\nknown* text'), []);
+});
+
+test('findCorruptingProseWraps: still flags a real violation elsewhere when an earlier escaped delimiter is present', () => {
+  // Regression guard: ignoring an escaped opener must not also blank a
+  // later, genuine emphasis span.
+  const violations = findCorruptingProseWraps(
+    '\\*literal* then **transport-\nlayer** failure',
+  );
+  assert.equal(violations.length, 1);
+});
+
 test('findCorruptingProseWraps: a real fixture file with emphasis markup has no corrupting hyphen wraps', () => {
   // This checks one specific fixture (which does contain `**bold**`
   // emphasis, e.g. its "**Example**:" line -- PR #2880 review, Copilot),

--- a/tests/code-span-wrap.test.mts
+++ b/tests/code-span-wrap.test.mts
@@ -223,12 +223,53 @@ test('findCorruptingProseWraps: still flags a real violation outside an unrelate
   assert.equal(violations.length, 1);
 });
 
-test('findCorruptingProseWraps: does not flag emphasis text preceding an unterminated HTML comment', () => {
+test('findCorruptingProseWraps: still flags a real violation preceding an unterminated HTML comment', () => {
   // An unterminated `<!--` masks through end of text (mirrors
   // resolved-decision.mts's own findHtmlCommentRanges close-scan), so a
   // real violation entirely before it must still be found.
   const violations = findCorruptingProseWraps(
     '**transport-\nlayer** failure <!-- unterminated',
+  );
+  assert.equal(violations.length, 1);
+});
+
+test('findCorruptingProseWraps: does not flag an indented code block containing literal emphasis markers', () => {
+  // PR #2880 review (Codex): a 4-space-indented code block renders
+  // literally, preserving its own line break, so it must not be scanned
+  // as prose emphasis.
+  const body = [
+    'before text',
+    '',
+    '    **well-',
+    '    known**',
+    '',
+    'after',
+  ].join('\n');
+  assert.deepEqual(findCorruptingProseWraps(body), []);
+});
+
+test('findCorruptingProseWraps: does not flag prose between two asterisk thematic-break lines', () => {
+  // PR #2880 review (CodeRabbit): a standalone `***` line is a thematic
+  // break, never an emphasis delimiter, so the prose between two of them
+  // must not be misread as one emphasis span.
+  const violations = findCorruptingProseWraps('***\nwell-\nknown\n***');
+  assert.deepEqual(violations, []);
+});
+
+test('findCorruptingProseWraps: still flags a real violation inside a genuine emphasis span next to a thematic break', () => {
+  // Regression guard: blanking thematic-break lines must not also blank
+  // a real, separate emphasis span elsewhere in the document.
+  const body = ['***', '', 'a **transport-', 'layer** failure'].join('\n');
+  const violations = findCorruptingProseWraps(body);
+  assert.equal(violations.length, 1);
+});
+
+test('findCorruptingProseWraps: an HTML comment with a stray backtick does not swallow real prose into a bogus code span', () => {
+  // PR #2880 review (Codex): comments must be masked before code-region
+  // detection runs, or a lone backtick inside one can pair with a later
+  // real backtick and blank the real prose between them.
+  const violations = findCorruptingProseWraps(
+    '<!-- ` --> **well-\nknown** `text`',
   );
   assert.equal(violations.length, 1);
 });

--- a/tests/code-span-wrap.test.mts
+++ b/tests/code-span-wrap.test.mts
@@ -4,7 +4,10 @@ import { join } from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
-import { findCorruptingCodeSpanWraps } from '../src/scripts/code-span-wrap.mts';
+import {
+  findCorruptingCodeSpanWraps,
+  findCorruptingProseWraps,
+} from '../src/scripts/code-span-wrap.mts';
 
 const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
 
@@ -140,4 +143,70 @@ test('real-corpus regression: a known word-boundary multi-line span is not flagg
     'utf8',
   );
   assert.deepEqual(findCorruptingCodeSpanWraps(text), []);
+});
+
+// idd-skill issue #2876: findCorruptingProseWraps flags a hyphenated
+// compound word wrapped right after the hyphen inside `**`/`*` emphasis
+// text, outside code spans.
+
+test('findCorruptingProseWraps: flags this issue’s own incident (bold emphasis, hyphen mid-token wrap)', () => {
+  // Reproduces PR #2875's incident: "**infrastructure/transport-layer
+  // failure**" hard-wrapped as "transport-\n  layer" inside bold emphasis.
+  const violations = findCorruptingProseWraps(
+    'a **infrastructure/transport-\n  layer failure** occurred',
+  );
+  assert.equal(violations.length, 1);
+  assert.deepEqual(violations[0], {
+    line: 1,
+    before: 'structure/transport-',
+    after: 'layer failure',
+  });
+});
+
+test('findCorruptingProseWraps: flags a hyphen mid-token wrap inside single-* italic emphasis', () => {
+  const violations = findCorruptingProseWraps('*well-\nknown* term');
+  assert.equal(violations.length, 1);
+  assert.deepEqual(violations[0], { line: 1, before: 'well-', after: 'known' });
+});
+
+test('findCorruptingProseWraps: does not flag a word-boundary wrap inside bold emphasis', () => {
+  assert.deepEqual(findCorruptingProseWraps('**foo bar\nbaz** text'), []);
+});
+
+test('findCorruptingProseWraps: does not misread a bullet-list `*` marker as an emphasis opener', () => {
+  assert.deepEqual(findCorruptingProseWraps('* item-\nfoo\n* other'), []);
+});
+
+test('findCorruptingProseWraps: does not flag a hyphen mid-token wrap inside a code span', () => {
+  // Code-span wraps stay findCorruptingCodeSpanWraps's own concern; this
+  // function must not double-flag them.
+  assert.deepEqual(findCorruptingProseWraps('`foo-\nbar` plain text'), []);
+});
+
+test('findCorruptingProseWraps: does not flag prose text with no emphasis markers at all', () => {
+  assert.deepEqual(
+    findCorruptingProseWraps('plain transport-\nlayer text, no emphasis'),
+    [],
+  );
+});
+
+test('findCorruptingProseWraps: does not flag when the hyphen sits right before the closing delimiter', () => {
+  // Nothing continues the "token" after the hyphen but the closing `**`
+  // itself, so this is not a corrupted compound word.
+  assert.deepEqual(findCorruptingProseWraps('**foo-\n**bar'), []);
+});
+
+test('findCorruptingProseWraps: real-corpus regression finds no violations on this repository’s own tracked Markdown files', () => {
+  // Direct counterpart of code-span-wrap's own real-corpus regression
+  // above, and of audit-code-span-wrap.test.mts's end-to-end
+  // auditCodeSpanWraps() check -- confirms acceptance criterion 3 (no new
+  // false positives) at the function level too.
+  const text = readFileSync(
+    join(
+      REPO_ROOT,
+      '.claude/skills/issue-authoring/references/draft-patterns.md',
+    ),
+    'utf8',
+  );
+  assert.deepEqual(findCorruptingProseWraps(text), []);
 });


### PR DESCRIPTION
# Summary

Extends `scripts/audit-code-span-wrap.mjs` to also flag a hyphenated
compound word whose line break falls immediately after the hyphen inside
`**bold**` / `*italic*` emphasis text — the same corrupting-line-wrap
failure mode the script already caught for backtick-delimited inline
code spans, now also caught in ordinary prose.

- `src/scripts/code-span-wrap.mts`: adds `findCorruptingProseWraps`
  alongside the existing `findCorruptingCodeSpanWraps`. It masks fenced
  code blocks and inline code span interiors (`stripMarkdownCodeRegions`)
  so code content stays that function's own concern, then scans
  `**`/`*` emphasis spans for a hyphen immediately followed by a line
  break between two token characters, reusing the existing
  `TOKEN_CONTINUING` neighbor rule. Scope stays hyphen-only, matching
  the observed incident (underscore/slash/dot mid-token splits remain
  code-span-only, since underscore is itself an emphasis delimiter and
  slash/dot are a code/path concern).
- `src/scripts/audit-code-span-wrap.mts`: runs both checks per file and
  reports each kind distinctly (`(code span)` / `(prose emphasis)`).
- `AGENTS.md`: documents the broadened scope in the existing "Inline
  code span wrapping" rule.
- `tests/code-span-wrap.test.mts`: adds regression coverage, including
  a fixture reproducing this issue's own incident, non-flagging
  controls (word-boundary wrap, bullet-list `*` marker, code-span
  hyphen wrap not double-counted), and a real-corpus check confirming
  no new false positives against this repository's own tracked
  Markdown files.

`scripts/*.mjs` are regenerated from the `.mts` sources via
`pnpm run build` and committed, per `docs/typescript-sources.md`.

## Linked issue

Closes #2876

## Follow-up issues (if any)

`findCorruptingProseWraps` is a deliberately heuristic regex scan, not
a full CommonMark emphasis parser (documented in-file). Two Codex
findings during review identified genuine gaps against the full
CommonMark spec; both are rejected as accepted residual limitations
rather than fixed here, since closing them would require reimplementing
CommonMark's stack-based inline delimiter resolution and/or its block
parser, well beyond this issue's declared heuristic scope. Both are
false positives only, on contrived shapes with zero occurrences in this
repository's own corpus (confirmed by this PR's real-corpus regression
test):

- [ ] Right-flanking rule incompleteness: a closing delimiter preceded
  by punctuation and followed directly by an alphanumeric character
  (e.g. `*well-\nknown.*suffix`) cannot close emphasis per CommonMark,
  but this heuristic's closer guard only checks for a preceding
  non-whitespace character.
- [ ] Block-boundary crossing: an unmatched opener in one block (e.g.
  an ATX heading) and an unmatched closer in the next are still joined
  across the boundary, even though CommonMark inline emphasis cannot
  cross block boundaries.

## Background / rationale (if material)

Concrete incident (2026-09-10, PR #2875 closing #2806): a manual edit
hard-wrapped the bold term "**infrastructure/transport-layer failure**"
right after the hyphen ("transport-\n  layer"). CommonMark/GFM renders a
soft line break inside a paragraph as a single space, so this rendered
as "transport- layer" — a stray space corrupting the term. `dprint fmt`,
`markdownlint-cli2`, and the existing `audit-code-span-wrap.mjs` all
passed cleanly on the corrupted text; only a Copilot review caught it.
This PR closes that detection gap for the `**`/`*` emphasis case named
in the issue's acceptance criteria.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`npx biome check`, `npx dprint check`, `npx markdownlint-cli2` — all clean; 8 pre-existing warnings in unrelated files, unchanged from `main`)
- [x] `pnpm test` (`node --test tests/*.test.mts` — 5935 passed, 0 failed)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passed; only pre-existing, unrelated warnings)
- [x] `pnpm run build:check`
- [x] `node scripts/token-cost-report.mjs --check`

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdQ5SPdFLaDGus5PNdBUhw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Markdown quality checks now detect hyphenated compound words incorrectly split across bold or italic text.
  * Reports distinguish between inline-code wrapping issues and emphasized-prose wrapping issues, with clearer violation details.

* **Documentation**
  * Updated code-formatting guidance with examples of hyphenated compound-word wrapping and related audit checks.

* **Tests**
  * Expanded coverage for valid and invalid wrapping patterns, including comments, lists, code, and emphasis edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
