### PR TITLE
update contribution guidelines to use discussions

### DIFF
--- a/.github/CONTRIBUTING.ja.md
+++ b/.github/CONTRIBUTING.ja.md
@@ -7,7 +7,7 @@ Language: [🇬🇧](./CONTRIBUTING.md) | **🇯🇵** | [🇨🇳](./CONTRIBUTI
 1. [行動規範](./CODE_OF_CONDUCT.ja.md)がありますので、
    プロジェクトとのやり取りのすべてに従ってください。
 2. このリポジトリに貢献する際には、変更を加える前に、このリポジトリの所有者と
-   [Issues](https://github.com/kurone-kito/idd-skill/issues)
+   [Discussions](https://github.com/kurone-kito/idd-skill/discussions)
    やその他の方法で変更したいことについて最初に話し合ってください。
 3. もしあなたのアイデアが**小さな修正で示せるのなら、
    [Pull request](https://github.com/kurone-kito/idd-skill/pulls)

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,8 +8,9 @@ Language: **🇬🇧** | [🇯🇵](./CONTRIBUTING.ja.md) | [🇨🇳](./CONTRIB
    follow it in all your interactions with the project.
 2. When contributing to this repository,
    please first discuss the change you wish to make via
-   [Issues](https://github.com/kurone-kito/idd-skill/issues) or any
-   other method with the owners of this repository before making a change.
+   [Discussions](https://github.com/kurone-kito/idd-skill/discussions) or
+   any other method with the owners of this repository before making a
+   change.
 3. If your idea can be shown **with a minor fix, please use directly the
    [pull request](https://github.com/kurone-kito/idd-skill/pulls)**.
 4. In this repository, discussion

--- a/.github/CONTRIBUTING.zh.md
+++ b/.github/CONTRIBUTING.zh.md
@@ -5,7 +5,9 @@ Language: [🇬🇧](./CONTRIBUTING.md) | [🇯🇵](./CONTRIBUTING.ja.md) | **�
 ---
 
 1. 请注意我们有[行为准则](./CODE_OF_CONDUCT.zh.md)，请在与项目的所有互动中遵循。
-2. 在为此存储库做出贡献时，请首先在进行更改之前与该存储库的所有者讨论您希望通过问题或任何其他方法进行的更改。
+2. 在为此存储库做出贡献时，请首先通过
+   [讨论](https://github.com/kurone-kito/idd-skill/discussions)
+   或任何其他方法与该存储库的所有者讨论您希望进行的更改，然后再进行更改。
 3. 如果您的想法可以通过**小修复显示，请直接使用[拉取请求](https://github.com/kurone-kito/idd-skill/pulls)**。
 4. 在此存储库中，建议**使用[英语或日语](https://translate.google.com/)进行**讨论。
 5. 本项目遵循


### PR DESCRIPTION
This pull request updates the contribution guidelines in all supported languages to recommend using GitHub Discussions instead of Issues when proposing changes. This ensures contributors are directed to the preferred communication channel before making changes.

**Contribution guideline updates:**

* Updated English contribution guide (`.github/CONTRIBUTING.md`) to recommend discussing proposed changes via GitHub Discussions rather than Issues.
* Updated Japanese contribution guide (`.github/CONTRIBUTING.ja.md`) to recommend using GitHub Discussions for change proposals.
* Updated Chinese contribution guide (`.github/CONTRIBUTING.zh.md`) to direct contributors to use GitHub Discussions when discussing proposed changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidance to direct proposed changes to GitHub Discussions before implementation.
  * Applied the updated guidance across English, Japanese, and Chinese documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->