### PR TITLE
fix(idd-claim): drop stale snapshot-then-stop delegation default

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -515,18 +515,14 @@ see
 [docs/idd-design-rationale.md](../../docs/idd-design-rationale.md#context-inheriting-delegation-residual-risk)
 for the field evidence.
 
-**Restate the CI/advisory-wait topology-safety condition; use the
-snapshot-then-stop pattern.** Carry — verbatim or by reference — the
-topology-safety condition from [idd-ci.instructions.md's Wake-up
+**Restate the CI/advisory-wait topology-safety condition.** Carry —
+verbatim or by reference — the topology-safety condition from
+[idd-ci.instructions.md's Wake-up
 discipline](idd-ci.instructions.md#wake-up-discipline) (also in
 [docs/idd-workflow.md's Orchestrator fan-out
 variant](../../docs/idd-workflow.md#orchestrator-fan-out-variant));
 without it, a worker can stall indefinitely on an unconfirmed
-backgrounded wait (#2210). Default: the worker takes one non-blocking
-snapshot, reports it, stops if incomplete, never polls or waits on a
-notification. The orchestrator alone polls and resumes via a
-follow-up message (a fresh delegate re-inherits stale context and
-no-ops).
+backgrounded wait (#2210).
 
 ### Hide displaced claim chain on takeover
 

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -510,18 +510,14 @@ see
 [docs/idd-design-rationale.md](../../docs/idd-design-rationale.md#context-inheriting-delegation-residual-risk)
 for the field evidence.
 
-**Restate the CI/advisory-wait topology-safety condition; use the
-snapshot-then-stop pattern.** Carry — verbatim or by reference — the
-topology-safety condition from [idd-ci.instructions.md's Wake-up
+**Restate the CI/advisory-wait topology-safety condition.** Carry —
+verbatim or by reference — the topology-safety condition from
+[idd-ci.instructions.md's Wake-up
 discipline](idd-ci.instructions.md#wake-up-discipline) (also in
 [docs/idd-workflow.md's Orchestrator fan-out
 variant](../../docs/idd-workflow.md#orchestrator-fan-out-variant));
 without it, a worker can stall indefinitely on an unconfirmed
-backgrounded wait (#2210). Default: the worker takes one non-blocking
-snapshot, reports it, stops if incomplete, never polls or waits on a
-notification. The orchestrator alone polls and resumes via a
-follow-up message (a fresh delegate re-inherits stale context and
-no-ops).
+backgrounded wait (#2210).
 
 ### Hide displaced claim chain on takeover
 


### PR DESCRIPTION
# Summary

`idd-claim.instructions.md`'s "Orchestrator delegation" section told a
delegated worker to take one non-blocking snapshot and stop on an
incomplete backgrounded wait, handing control back to the
orchestrator. Issue #2720 (merged via PR #2881) established the
opposite rule elsewhere in the corpus: a delegated worker must wait
synchronously or arm a confirmed topology-safe wake, and must not end
its turn until that wait has a confirmed result. The two files
disagreed with no cross-reference reconciling them.

This drops the contradicting "Default: the worker takes one
non-blocking snapshot... no-ops)." sentences and trims the paragraph's
lead-in, relying on the paragraph's pre-existing citations to
`idd-ci.instructions.md`'s Wake-up discipline and
`docs/idd-workflow.md`'s Orchestrator fan-out variant section (this
repository's restatement-discipline convention, per
`skills/idd-spec-audit/SKILL.md` R5) instead of restating the
now-canonical rule a third time. `idd-claim.instructions.md` measured
only single-digit bytes of headroom under its 36,000-byte budget
before this edit, so a subtractive, no-new-prose fix was required, not
merely preferred. No other part of the "Orchestrator delegation"
section changes.

## Linked issue

Closes #2885

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

A repo-wide grep (`.github/`, `idd-template/`, `docs/`, `skills/`,
`tests/`) confirms the removed text was the only place in the corpus
stating or implying the stop-and-hand-back default; nothing else
needs updating.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`biome check`, `dprint check`, `markdownlint-cli2` —
      all pass; 8 pre-existing unrelated warnings in unchanged
      `scripts`/`src/scripts` files, not introduced by this diff)
- [x] `pnpm test` (`node --test tests/*.test.mts`, 5958/5958 passing)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (`sync-docs.mjs --apply` regenerated
      only the intended mirror; `git status` confirmed no drift)
- [x] `node scripts/idd-doctor.mjs`

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none — instructions-only change)
- [x] Context budget impact reviewed (`idd-claim.instructions.md`
      phase budget headroom went from ~9 bytes to ~292 bytes;
      `bundle-discovery-phase` headroom increased correspondingly)
