### PR TITLE
feat(idd-work): verify example field names before implementation

### DIFF
--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -340,10 +340,10 @@ On no conflict, continue with the plan below.
 
 ### B2.2 — Example field-name verification
 
-When the issue's "Proposed change" or "Acceptance criteria" cites a
-schema field, config key, or similar token as an example, verify it
-exists in that location before planning; fix or drop it if not
-(2026-09-10, `#2806`).
+When the issue's "Proposed change" or "Acceptance criteria" cites an
+existing schema field, config key, or token as an example (not one it
+adds), verify it exists; fix or drop it if not, hold if unclear
+(`#2806`).
 
 Draft an implementation plan and post it as an issue comment, then run
 a critique pass for correctness and concreteness (see

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -342,7 +342,7 @@ On no conflict, continue with the plan below.
 
 When the issue's "Proposed change" or "Acceptance criteria" cites an
 existing schema field, config key, or token as an example (not one it
-adds), verify it exists; fix or drop it if not, hold if unclear
+adds), verify it exists as cited; fix or drop if not, hold if unclear
 (`#2806`).
 
 Draft an implementation plan and post it as an issue comment, then run

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -338,6 +338,13 @@ silent edit. Resume planning only after the addendum is recorded.
 
 On no conflict, continue with the plan below.
 
+### B2.2 — Example field-name verification
+
+When the issue's "Proposed change" or "Acceptance criteria" cites a
+schema field, config key, or similar token as an example, verify it
+exists in that location before planning; fix or drop it if not
+(2026-09-10, `#2806`).
+
 Draft an implementation plan and post it as an issue comment, then run
 a critique pass for correctness and concreteness (see
 `idd-overview-appendix.instructions.md` for per-agent implementation),

--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -580,9 +580,9 @@ decision-transcription, and the fabricated field appeared in an
 illustrative example, not a rationale claim, so nothing in the written
 instructions caught it during that issue's own implementation, PR
 `#2875`; a Codex review caught it instead, after the text had already
-shipped once. A maintainer hearing on 2026-09-10 added this narrow,
-adjacent check rather than broadening B2.1's own condition (issue
-`#2878`).
+shipped once. A maintainer hearing recorded on issue `#2878` added
+this narrow, adjacent check rather than broadening B2.1's own
+condition.
 
 ### B3 — De-duplication refactor: check for behavior parity, not just body equivalence
 

--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -580,7 +580,7 @@ decision-transcription, and the fabricated field appeared in an
 illustrative example, not a rationale claim, so nothing in the written
 instructions caught it during that issue's own implementation, PR
 `#2875`; a Codex review caught it instead, after the text had already
-shipped once. A maintainer hearing on 2026-09-11 added this narrow,
+shipped once. A maintainer hearing on 2026-09-10 added this narrow,
 adjacent check rather than broadening B2.1's own condition (issue
 `#2878`).
 

--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -569,6 +569,21 @@ instructions prompted that judgment call, and a documentation-only PR
 has no test suite to catch a silently transcribed false premise later
 (#1390).
 
+### B2.2 — Example field-name verification
+
+Issue `#2806`'s own "Proposed change" section cited an illustrative
+gate field, `claimValid: false`, that did not exist anywhere in
+`schemas/pre-merge-readiness.schema.json` — the real fields are
+`claim.matchesExpectedClaim` / `claim.claimLost`. B2.1 did not apply
+because that issue was an ordinary bugfix issue, not
+decision-transcription, and the fabricated field appeared in an
+illustrative example, not a rationale claim, so nothing in the written
+instructions caught it during that issue's own implementation, PR
+`#2875`; a Codex review caught it instead, after the text had already
+shipped once. A maintainer hearing on 2026-09-11 added this narrow,
+adjacent check rather than broadening B2.1's own condition (issue
+`#2878`).
+
 ### B3 — De-duplication refactor: check for behavior parity, not just body equivalence
 
 Closes a real regression class hit during #1208's `gh-exec.mts`

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -335,10 +335,10 @@ On no conflict, continue with the plan below.
 
 ### B2.2 — Example field-name verification
 
-When the issue's "Proposed change" or "Acceptance criteria" cites a
-schema field, config key, or similar token as an example, verify it
-exists in that location before planning; fix or drop it if not
-(2026-09-10, `#2806`).
+When the issue's "Proposed change" or "Acceptance criteria" cites an
+existing schema field, config key, or token as an example (not one it
+adds), verify it exists; fix or drop it if not, hold if unclear
+(`#2806`).
 
 Draft an implementation plan and post it as an issue comment, then run
 a critique pass for correctness and concreteness (see

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -337,7 +337,7 @@ On no conflict, continue with the plan below.
 
 When the issue's "Proposed change" or "Acceptance criteria" cites an
 existing schema field, config key, or token as an example (not one it
-adds), verify it exists; fix or drop it if not, hold if unclear
+adds), verify it exists as cited; fix or drop if not, hold if unclear
 (`#2806`).
 
 Draft an implementation plan and post it as an issue comment, then run

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -333,6 +333,13 @@ silent edit. Resume planning only after the addendum is recorded.
 
 On no conflict, continue with the plan below.
 
+### B2.2 — Example field-name verification
+
+When the issue's "Proposed change" or "Acceptance criteria" cites a
+schema field, config key, or similar token as an example, verify it
+exists in that location before planning; fix or drop it if not
+(2026-09-10, `#2806`).
+
 Draft an implementation plan and post it as an issue comment, then run
 a critique pass for correctness and concreteness (see
 `idd-overview-appendix.instructions.md` for per-agent implementation),

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -569,6 +569,21 @@ instructions prompted that judgment call, and a documentation-only PR
 has no test suite to catch a silently transcribed false premise later
 (kurone-kito/idd-skill#1390).
 
+### B2.2 — Example field-name verification
+
+Issue kurone-kito/idd-skill#2806's own "Proposed change" section cited
+an illustrative gate field, `claimValid: false`, that did not exist
+anywhere in `schemas/pre-merge-readiness.schema.json` — the real
+fields are `claim.matchesExpectedClaim` / `claim.claimLost`. B2.1 did
+not apply because that issue was an ordinary bugfix issue, not
+decision-transcription, and the fabricated field appeared in an
+illustrative example, not a rationale claim, so nothing in the written
+instructions caught it during that issue's own implementation, PR
+kurone-kito/idd-skill#2875; a Codex review caught it instead, after
+the text had already shipped once. A maintainer hearing on 2026-09-11
+added this narrow, adjacent check rather than broadening B2.1's own
+condition (kurone-kito/idd-skill#2878).
+
 ### B3 — De-duplication refactor: check for behavior parity, not just body equivalence
 
 Closes a real regression class: consolidating a wrapper function used

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -580,9 +580,9 @@ decision-transcription, and the fabricated field appeared in an
 illustrative example, not a rationale claim, so nothing in the written
 instructions caught it during that issue's own implementation, PR
 kurone-kito/idd-skill#2875; a Codex review caught it instead, after
-the text had already shipped once. A maintainer hearing on 2026-09-10
-added this narrow, adjacent check rather than broadening B2.1's own
-condition (kurone-kito/idd-skill#2878).
+the text had already shipped once. A maintainer hearing recorded on
+kurone-kito/idd-skill#2878 added this narrow, adjacent check rather
+than broadening B2.1's own condition.
 
 ### B3 — De-duplication refactor: check for behavior parity, not just body equivalence
 

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -580,7 +580,7 @@ decision-transcription, and the fabricated field appeared in an
 illustrative example, not a rationale claim, so nothing in the written
 instructions caught it during that issue's own implementation, PR
 kurone-kito/idd-skill#2875; a Codex review caught it instead, after
-the text had already shipped once. A maintainer hearing on 2026-09-11
+the text had already shipped once. A maintainer hearing on 2026-09-10
 added this narrow, adjacent check rather than broadening B2.1's own
 condition (kurone-kito/idd-skill#2878).
 


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Adds a new "B2.2 — Example field-name verification" step to
`idd-work.instructions.md`, adjacent to but distinct from the existing
"B2.1 — Premise verification (decision-transcription issues)" step.
Before drafting a plan, when an issue's own "Proposed change" or
"Acceptance criteria" section cites an **existing** schema field,
config key, or similar token as an illustrative example — not one the
issue itself proposes adding — verify that token actually exists in
the cited location; fix or drop the example if it does not, and hold
for clarification if the token's intended status (existing vs. newly
proposed) is unclear.

The "not one it adds" / "hold if unclear" scoping was added during
review: an automated reviewer on this PR (Codex) correctly flagged
that the first-drafted wording would misfire on an issue that
legitimately proposes adding a new field or key, since a
newly-proposed identifier necessarily doesn't exist yet — the check
needs to catch only a fabricated reference to something claimed to
already exist, not a valid new-field proposal.

This closes a narrow gap the maintainer hearing recorded on the
tracked issue: `#2806`'s own "Proposed change" section cited an
illustrative gate field, `claimValid: false`, that does not exist
anywhere in `schemas/pre-merge-readiness.schema.json` (the real fields
are `claim.matchesExpectedClaim` / `claim.claimLost`). B2.1 did not
apply because `#2806` was an ordinary bugfix issue, not
decision-transcription, so nothing in the written instructions caught
the fabricated field during that issue's own implementation; a review
caught it instead, after the text had already shipped once.

- `idd-template/.github/instructions/idd-work.instructions.md`
  (canonical) — the new step.
- `.github/instructions/idd-work.instructions.md` (generated mirror,
  `concreted` mode) — regenerated via `sync-docs.mjs --apply`.
- `idd-template/docs/idd-design-rationale.md` /
  `docs/idd-design-rationale.md` (`structure`-mode pair, hand-edited
  both, matching heading text) — the rationale entry citing the
  incident, following the same fully-qualified-vs-bare issue-reference
  convention the existing B2.1 rationale entry already uses between
  the two files.

B2.1's own existing "both hold" condition and scope are left
unchanged. Unlike B2.1's own citation, the B2.2 step cites the
incident inline (`` (`#2806`) ``) instead of a `See
[rationale](...)` link — the link costs about a third of this step's
own byte budget under `bundle-work-phase`'s near-ceiling limit, so an
inline cite was the cheaper way to satisfy the issue's "documentation
cites #2806" acceptance criterion. The rationale entry itself still
exists in both `idd-design-rationale.md` files under the matching
phase heading, just without an inbound link from the instructions
file.

## Linked issue

Closes #2878

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Maintainer decision (hearing 2026-09-11, recorded on the issue):
single-occurrence evidence does not justify broadening B2.1's own
condition, given `idd-work.instructions.md`'s `bundle-work-phase`
byte budget was already near-ceiling; a narrow, adjacent check is
the scoped fix instead. `idd-work-lite.instructions.md` also carries
its own B2.1 step but is intentionally out of scope here — it is not
in the issue's "Candidate files" list, and the same cost-consciousness
argues against extending beyond what was asked.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed — `bundle-work-phase` sits at
      97.97% of its 30100-byte budget (banner excluded) after the
      review-driven scope narrowing above, confirmed via
      `node scripts/audit-docs.mjs --check` (hard ceiling is 98%). A
      concurrently merged sibling PR's own B1 addition landed on
      `main` during this branch's D1 rebase and consumed headroom
      first; both the original B2.2 wording and its later
      review-driven refinement were compressed to fit under the
      ceiling without touching that unrelated B1 text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDJpTELrY2SnjHW9m5Aw7i


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance requiring example schema fields, configuration keys, and tokens in proposals and acceptance criteria to be verified against canonical definitions.
  - Clarified that invalid references must be corrected or removed, while unclear cases should be placed on hold.
  - Documented the distinction between validating illustrative field names and transcribing established decisions.
  - Applied the updated guidance consistently across the primary documentation and its template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->