### PR TITLE
feat(claim-lite): mirror generated-tokens check to lite profile

### DIFF
--- a/.github/instructions/lite/idd-claim-lite.instructions.md
+++ b/.github/instructions/lite/idd-claim-lite.instructions.md
@@ -289,7 +289,10 @@ differently for step 5:
    inheritable match → use the name pre-check (e) computed.
 2. **`{claim-id}`**: generate a fresh opaque token — **except**
    forced-handoff adopt-verbatim, which reuses the marker's
-   `newClaimId` instead. Record it (`--record-tokens`) before step 4.
+   `newClaimId` instead. Record it with the profile-selected
+   `claim-lock` helper's `--record-tokens` mode (`--worktree <path>
+   --agent-id <id> --claim-id <id>`; resolve the exact command from
+   `docs/idd-helper-scripts.md`) before step 4.
 3. **`{prior-claim-id}` / `supersedes:`**: `none` for a fresh claim or
    legacy migration; the active claim's `{claim-id}` for a stale
    takeover. Not applicable to forced-handoff (step 4 is skipped
@@ -324,8 +327,9 @@ differently for step 5:
 
 5. **Every fresh activation** (fresh claim, takeover, legacy migration,
    or forced-handoff adopt-verbatim) also posts an activation-nonce —
-   never for a plain heartbeat. Record it (`--record-tokens --nonce
-   <nonce>`) first:
+   never for a plain heartbeat. Record it with the same
+   `--record-tokens` invocation as step 2 plus `--nonce <nonce>`
+   (primary worktree) first:
 
    ```sh
    node scripts/post-idd-marker.mjs --type activation-nonce \

--- a/.github/instructions/lite/idd-claim-lite.instructions.md
+++ b/.github/instructions/lite/idd-claim-lite.instructions.md
@@ -128,10 +128,12 @@ Pass `--nonce` when this session already recorded one for that
 `{claim-id}` (true after forced-handoff step 5) so a session that lost
 the nonce tie-break cannot pass as `already_owned`; omit it otherwise.
 
-| Top-level `state` / `action` | Meaning                                                           |
-| ---------------------------- | ----------------------------------------------------------------- |
-| `already_owned` / `keep`     | Confirmed — see the two cases below                               |
-| anything else                | Not yours — forced-handoff: Stop-and-ask; else fall through below |
+<!-- dprint-ignore-start -->
+| Top-level `state` / `action` | Meaning |
+| --- | --- |
+| `already_owned` / `keep` | Confirmed — see the two cases below |
+| anything else | Not yours — forced-handoff: Stop-and-ask; else fall through below |
+<!-- dprint-ignore-end -->
 
 `already_owned`/`keep` splits in two: if `--nonce` was passed above
 (resume/heartbeat continuation), skip to Claim verification (or
@@ -149,11 +151,13 @@ write:
 node scripts/resume-claim-routing.mjs --issue <N> --fresh-claim-gate
 ```
 
-| Helper `fresh_claim_gate.verdict` | Action                                |
-| --------------------------------- | ------------------------------------- |
-| `claimable`                       | Proceed to Claim execution (fresh)    |
-| `stale-reclaimable`               | Proceed to Claim execution (takeover) |
-| `already-claimed`                 | **STOP** — live competitor or race    |
+<!-- dprint-ignore-start -->
+| Helper `fresh_claim_gate.verdict` | Action |
+| --- | --- |
+| `claimable` | Proceed to Claim execution (fresh) |
+| `stale-reclaimable` | Proceed to Claim execution (takeover) |
+| `already-claimed` | **STOP** — live competitor or race |
+<!-- dprint-ignore-end -->
 
 Written fallback (`instructions-only` profile only — per the Helper
 runtime contract above, any other profile stops-and-asks on a
@@ -246,12 +250,14 @@ gh api "repos/{owner}/{repo}/git/matching-refs/heads/issue/<N>-" \
   --jq '.[].ref | sub("^refs/heads/"; "")'
 ```
 
-| Match found?                                                           | Action                                                          |
-| ---------------------------------------------------------------------- | --------------------------------------------------------------- |
-| No local or remote match                                               | Proceed to claim posting                                        |
-| Match corresponds to an inheritable claim (per (d) above)              | Proceed — expected branch                                       |
-| Match does not correspond, but an active non-stale claim references it | **STOP** — concurrent session                                   |
-| Match does not correspond, and no active claim references it           | **STOP** — hold note, possible orphaned branch; operator review |
+<!-- dprint-ignore-start -->
+| Match found? | Action |
+| --- | --- |
+| No local or remote match | Proceed to claim posting |
+| Match corresponds to an inheritable claim (per (d) above) | Proceed — expected branch |
+| Match does not correspond, but an active non-stale claim references it | **STOP** — concurrent session |
+| Match does not correspond, and no active claim references it | **STOP** — hold note, possible orphaned branch; operator review |
+<!-- dprint-ignore-end -->
 
 No remote branch with the computed name may already exist unless it is
 inheritable per the table above.

--- a/.github/instructions/lite/idd-claim-lite.instructions.md
+++ b/.github/instructions/lite/idd-claim-lite.instructions.md
@@ -27,7 +27,9 @@ collapses to a single outcome here: **STOP and report; do not claim**.
 2. **When the repository is `instructions-only`** (no helper runtime
    shipped): skip the helper commands and use the written tables only.
    That is the sole path where the tables below are the primary
-   control surface.
+   control surface. The generated-tokens `--record-tokens`/
+   `--read-tokens` ownership check has no written-table equivalent
+   under this profile; skip it.
 
 Every `node scripts/<name>.mjs` command below is the **source-repo /
 vendored-node** invocation form. Under `package-manager` /

--- a/.github/instructions/lite/idd-claim-lite.instructions.md
+++ b/.github/instructions/lite/idd-claim-lite.instructions.md
@@ -427,9 +427,9 @@ node scripts/claim-lock.mjs --acquire --worktree <path> \
   --agent-id <agent-id> --claim-id <claim-id>
 ```
 
-Also confirm `--read-tokens` finds `{claim-id}` recorded before
-trusting it; absent or malformed → stop. See
-`docs/idd-helper-scripts.md`.
+Then, separately, run `--read-tokens --worktree <path> --claim-id
+<id>` and require `present: true` with no `malformed`; otherwise
+stop. See `docs/idd-helper-scripts.md`.
 
 A matching `{claim-id}` re-acquires as a read-only check. A different
 `{claim-id}` is always a collision — re-run pre-check (c) (`--claim-id`

--- a/.github/instructions/lite/idd-claim-lite.instructions.md
+++ b/.github/instructions/lite/idd-claim-lite.instructions.md
@@ -27,9 +27,8 @@ collapses to a single outcome here: **STOP and report; do not claim**.
 2. **When the repository is `instructions-only`** (no helper runtime
    shipped): skip the helper commands and use the written tables only.
    That is the sole path where the tables below are the primary
-   control surface. The generated-tokens `--record-tokens`/
-   `--read-tokens` ownership check has no written-table equivalent
-   under this profile; skip it.
+   control surface. The `--record-tokens`/`--read-tokens` check
+   instead uses `docs/idd-helper-scripts.md`'s helper-free fallback.
 
 Every `node scripts/<name>.mjs` command below is the **source-repo /
 vendored-node** invocation form. Under `package-manager` /

--- a/.github/instructions/lite/idd-claim-lite.instructions.md
+++ b/.github/instructions/lite/idd-claim-lite.instructions.md
@@ -289,7 +289,7 @@ differently for step 5:
    inheritable match → use the name pre-check (e) computed.
 2. **`{claim-id}`**: generate a fresh opaque token — **except**
    forced-handoff adopt-verbatim, which reuses the marker's
-   `newClaimId` instead.
+   `newClaimId` instead. Record it (`--record-tokens`) before step 4.
 3. **`{prior-claim-id}` / `supersedes:`**: `none` for a fresh claim or
    legacy migration; the active claim's `{claim-id}` for a stale
    takeover. Not applicable to forced-handoff (step 4 is skipped
@@ -324,7 +324,8 @@ differently for step 5:
 
 5. **Every fresh activation** (fresh claim, takeover, legacy migration,
    or forced-handoff adopt-verbatim) also posts an activation-nonce —
-   never for a plain heartbeat:
+   never for a plain heartbeat. Record it (`--record-tokens --nonce
+   <nonce>`) first:
 
    ```sh
    node scripts/post-idd-marker.mjs --type activation-nonce \
@@ -425,6 +426,10 @@ Once the B1 worktree exists, before every mutation:
 node scripts/claim-lock.mjs --acquire --worktree <path> \
   --agent-id <agent-id> --claim-id <claim-id>
 ```
+
+Also confirm `--read-tokens` finds `{claim-id}` recorded before
+trusting it; absent or malformed → stop. See
+`docs/idd-helper-scripts.md`.
 
 A matching `{claim-id}` re-acquires as a read-only check. A different
 `{claim-id}` is always a collision — re-run pre-check (c) (`--claim-id`

--- a/.github/instructions/lite/idd-merge-handoff-lite.instructions.md
+++ b/.github/instructions/lite/idd-merge-handoff-lite.instructions.md
@@ -39,8 +39,9 @@ Before posting the handoff comment, confirm all of the following:
    the package-manager-profile `idd:claim-lock` command with the same
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
-   fail-closed: stop rather than proceed. Also confirm `--read-tokens`
-   finds this `{claim-id}` recorded; absent or malformed → stop.
+   fail-closed: stop rather than proceed. Then, separately, run
+   `--read-tokens --worktree <path> --claim-id <id>` and require
+   `present: true` with no `malformed`; otherwise stop.
 4. If any check fails, stop.
 
 ## F2.5 — Draft and post the handoff comment

--- a/.github/instructions/lite/idd-merge-handoff-lite.instructions.md
+++ b/.github/instructions/lite/idd-merge-handoff-lite.instructions.md
@@ -39,7 +39,8 @@ Before posting the handoff comment, confirm all of the following:
    the package-manager-profile `idd:claim-lock` command with the same
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
-   fail-closed: stop rather than proceed.
+   fail-closed: stop rather than proceed. Also confirm `--read-tokens`
+   finds this `{claim-id}` recorded; absent or malformed → stop.
 4. If any check fails, stop.
 
 ## F2.5 — Draft and post the handoff comment

--- a/.github/instructions/lite/idd-merge-handoff-lite.instructions.md
+++ b/.github/instructions/lite/idd-merge-handoff-lite.instructions.md
@@ -40,8 +40,8 @@ Before posting the handoff comment, confirm all of the following:
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
-   `--read-tokens --worktree <path> --claim-id <id>` and require
-   `present: true` with no `malformed`; otherwise stop.
+   `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
+   and require `present: true` with no `malformed`; otherwise stop.
 4. If any check fails, stop.
 
 ## F2.5 — Draft and post the handoff comment

--- a/.github/instructions/lite/idd-pr-submit-lite.instructions.md
+++ b/.github/instructions/lite/idd-pr-submit-lite.instructions.md
@@ -84,8 +84,9 @@ following:
    the package-manager-profile `idd:claim-lock` command with the same
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
-   fail-closed: stop rather than proceed. Also confirm `--read-tokens`
-   finds this `{claim-id}` recorded; absent or malformed → stop.
+   fail-closed: stop rather than proceed. Then, separately, run
+   `--read-tokens --worktree <path> --claim-id <id>` and require
+   `present: true` with no `malformed`; otherwise stop.
 6. If any check fails, stop.
 
 ## D1 — Sync main before first push

--- a/.github/instructions/lite/idd-pr-submit-lite.instructions.md
+++ b/.github/instructions/lite/idd-pr-submit-lite.instructions.md
@@ -84,7 +84,8 @@ following:
    the package-manager-profile `idd:claim-lock` command with the same
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
-   fail-closed: stop rather than proceed.
+   fail-closed: stop rather than proceed. Also confirm `--read-tokens`
+   finds this `{claim-id}` recorded; absent or malformed → stop.
 6. If any check fails, stop.
 
 ## D1 — Sync main before first push

--- a/.github/instructions/lite/idd-pr-submit-lite.instructions.md
+++ b/.github/instructions/lite/idd-pr-submit-lite.instructions.md
@@ -85,8 +85,8 @@ following:
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
-   `--read-tokens --worktree <path> --claim-id <id>` and require
-   `present: true` with no `malformed`; otherwise stop.
+   `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
+   and require `present: true` with no `malformed`; otherwise stop.
 6. If any check fails, stop.
 
 ## D1 — Sync main before first push

--- a/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -86,8 +86,8 @@ other GitHub side effect, confirm all of the following:
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
-   `--read-tokens --worktree <path> --claim-id <id>` and require
-   `present: true` with no `malformed`; otherwise stop.
+   `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
+   and require `present: true` with no `malformed`; otherwise stop.
 6. If any check fails, stop.
 
 ## E9 — Fix accepted issues

--- a/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -85,8 +85,9 @@ other GitHub side effect, confirm all of the following:
    the package-manager-profile `idd:claim-lock` command with the same
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
-   fail-closed: stop rather than proceed. Also confirm `--read-tokens`
-   finds this `{claim-id}` recorded; absent or malformed → stop.
+   fail-closed: stop rather than proceed. Then, separately, run
+   `--read-tokens --worktree <path> --claim-id <id>` and require
+   `present: true` with no `malformed`; otherwise stop.
 6. If any check fails, stop.
 
 ## E9 — Fix accepted issues

--- a/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -85,7 +85,8 @@ other GitHub side effect, confirm all of the following:
    the package-manager-profile `idd:claim-lock` command with the same
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
-   fail-closed: stop rather than proceed.
+   fail-closed: stop rather than proceed. Also confirm `--read-tokens`
+   finds this `{claim-id}` recorded; absent or malformed → stop.
 6. If any check fails, stop.
 
 ## E9 — Fix accepted issues

--- a/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
@@ -60,7 +60,8 @@ GitHub side effect, confirm all of the following:
    the package-manager-profile `idd:claim-lock` command with the same
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
-   fail-closed: stop rather than proceed.
+   fail-closed: stop rather than proceed. Also confirm `--read-tokens`
+   finds this `{claim-id}` recorded; absent or malformed → stop.
 6. If any check fails, stop.
 
 ## E1 — Fetch review items into ReviewItems_snapshot

--- a/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
@@ -61,8 +61,8 @@ GitHub side effect, confirm all of the following:
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
-   `--read-tokens --worktree <path> --claim-id <id>` and require
-   `present: true` with no `malformed`; otherwise stop.
+   `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
+   and require `present: true` with no `malformed`; otherwise stop.
 6. If any check fails, stop.
 
 ## E1 — Fetch review items into ReviewItems_snapshot

--- a/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
@@ -60,8 +60,9 @@ GitHub side effect, confirm all of the following:
    the package-manager-profile `idd:claim-lock` command with the same
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
-   fail-closed: stop rather than proceed. Also confirm `--read-tokens`
-   finds this `{claim-id}` recorded; absent or malformed → stop.
+   fail-closed: stop rather than proceed. Then, separately, run
+   `--read-tokens --worktree <path> --claim-id <id>` and require
+   `present: true` with no `malformed`; otherwise stop.
 6. If any check fails, stop.
 
 ## E1 — Fetch review items into ReviewItems_snapshot

--- a/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/.github/instructions/lite/idd-work-lite.instructions.md
@@ -55,8 +55,8 @@ request, or other GitHub side effect, confirm all of the following:
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
-   `--read-tokens --worktree <path> --claim-id <id>` and require
-   `present: true` with no `malformed`; otherwise stop.
+   `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
+   and require `present: true` with no `malformed`; otherwise stop.
 6. If any check fails, stop.
 
 ## B1 — Create worktree

--- a/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/.github/instructions/lite/idd-work-lite.instructions.md
@@ -54,8 +54,9 @@ request, or other GitHub side effect, confirm all of the following:
    the package-manager-profile `idd:claim-lock` command with the same
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
-   fail-closed: stop rather than proceed. Also confirm `--read-tokens`
-   finds this `{claim-id}` recorded; absent or malformed → stop.
+   fail-closed: stop rather than proceed. Then, separately, run
+   `--read-tokens --worktree <path> --claim-id <id>` and require
+   `present: true` with no `malformed`; otherwise stop.
 6. If any check fails, stop.
 
 ## B1 — Create worktree

--- a/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/.github/instructions/lite/idd-work-lite.instructions.md
@@ -108,11 +108,12 @@ worktree removal) behind the
     narrower than the global `-y`/`--yes` flag, which would also skip
     approval for any other command WorkTrunk runs on that call.
 18. Do not use `wt new`.
-19. If WorkTrunk uses a pre-start install hook, its first command must acquire
-    the worktree lock and re-run `--record-tokens --nonce <nonce>` (same
-    value as the A5 write; omitting `--nonce` drops it, since the helper
-    overwrites rather than merges) for this worktree's own copy, before it
-    installs anything.
+19. If WorkTrunk uses a pre-start install hook, its first command must
+    acquire the worktree lock, then — as a separate call — run
+    `--record-tokens --worktree <this-worktree-path> --agent-id <id>
+    --claim-id <id> --nonce <nonce>` (same nonce value as the A5 write;
+    omitting `--nonce` drops it, since the helper overwrites rather than
+    merges) for this worktree's own copy, before it installs anything.
 20. If the hook cannot acquire the lock or record tokens, create the
     worktree without the hook.
 21. If WorkTrunk is unavailable, use
@@ -127,11 +128,12 @@ worktree removal) behind the
     exists (rare), treat it as a fresh claim while preserving the inherited
     branch name.
 26. For manual `git worktree add` or WorkTrunk without a hook, acquire the
-    worktree lock with the profile-selected `claim-lock` helper and re-run
-    `--record-tokens --nonce <nonce>` (same value as the A5 write; omitting
-    `--nonce` drops it, since the helper overwrites rather than merges) for
-    this worktree's own copy, immediately after creation and before any
-    install or other mutation.
+    worktree lock with the profile-selected `claim-lock` helper, then — as
+    a separate call — run `--record-tokens --worktree <this-worktree-path>
+    --agent-id <id> --claim-id <id> --nonce <nonce>` (same nonce value as
+    the A5 write; omitting `--nonce` drops it, since the helper overwrites
+    rather than merges) for this worktree's own copy, immediately after
+    creation and before any install or other mutation.
 27. Run `install-deps` on the manual/no-hook path.
 28. Verify the primary worktree's HEAD is still on `main`.
 29. Verify `git worktree list` shows the new path.

--- a/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/.github/instructions/lite/idd-work-lite.instructions.md
@@ -54,7 +54,8 @@ request, or other GitHub side effect, confirm all of the following:
    the package-manager-profile `idd:claim-lock` command with the same
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
-   fail-closed: stop rather than proceed.
+   fail-closed: stop rather than proceed. Also confirm `--read-tokens`
+   finds this `{claim-id}` recorded; absent or malformed → stop.
 6. If any check fails, stop.
 
 ## B1 — Create worktree
@@ -107,8 +108,10 @@ worktree removal) behind the
     approval for any other command WorkTrunk runs on that call.
 18. Do not use `wt new`.
 19. If WorkTrunk uses a pre-start install hook, its first command must acquire
-    the worktree lock before it installs anything.
-20. If the hook cannot acquire the lock, create the worktree without the hook.
+    the worktree lock and re-run `--record-tokens` (same nonce as the A5
+    write) for this worktree's own copy, before it installs anything.
+20. If the hook cannot acquire the lock or record tokens, create the
+    worktree without the hook.
 21. If WorkTrunk is unavailable, use
     `git worktree add <path> -b <branch-name> origin/main` for a fresh claim.
 22. If WorkTrunk is unavailable and this is a takeover, use
@@ -121,8 +124,9 @@ worktree removal) behind the
     exists (rare), treat it as a fresh claim while preserving the inherited
     branch name.
 26. For manual `git worktree add` or WorkTrunk without a hook, acquire the
-    worktree lock with the profile-selected `claim-lock` helper immediately
-    after creation and before any install or other mutation.
+    worktree lock with the profile-selected `claim-lock` helper and re-run
+    `--record-tokens` (same nonce as the A5 write) for this worktree's own copy,
+    immediately after creation and before any install or other mutation.
 27. Run `install-deps` on the manual/no-hook path.
 28. Verify the primary worktree's HEAD is still on `main`.
 29. Verify `git worktree list` shows the new path.

--- a/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/.github/instructions/lite/idd-work-lite.instructions.md
@@ -109,8 +109,10 @@ worktree removal) behind the
     approval for any other command WorkTrunk runs on that call.
 18. Do not use `wt new`.
 19. If WorkTrunk uses a pre-start install hook, its first command must acquire
-    the worktree lock and re-run `--record-tokens` (same nonce as the A5
-    write) for this worktree's own copy, before it installs anything.
+    the worktree lock and re-run `--record-tokens --nonce <nonce>` (same
+    value as the A5 write; omitting `--nonce` drops it, since the helper
+    overwrites rather than merges) for this worktree's own copy, before it
+    installs anything.
 20. If the hook cannot acquire the lock or record tokens, create the
     worktree without the hook.
 21. If WorkTrunk is unavailable, use
@@ -126,8 +128,10 @@ worktree removal) behind the
     branch name.
 26. For manual `git worktree add` or WorkTrunk without a hook, acquire the
     worktree lock with the profile-selected `claim-lock` helper and re-run
-    `--record-tokens` (same nonce as the A5 write) for this worktree's own copy,
-    immediately after creation and before any install or other mutation.
+    `--record-tokens --nonce <nonce>` (same value as the A5 write; omitting
+    `--nonce` drops it, since the helper overwrites rather than merges) for
+    this worktree's own copy, immediately after creation and before any
+    install or other mutation.
 27. Run `install-deps` on the manual/no-hook path.
 28. Verify the primary worktree's HEAD is still on `main`.
 29. Verify `git worktree list` shows the new path.

--- a/idd-template/.github/instructions/lite/idd-claim-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-claim-lite.instructions.md
@@ -284,7 +284,10 @@ differently for step 5:
    inheritable match → use the name pre-check (e) computed.
 2. **`{claim-id}`**: generate a fresh opaque token — **except**
    forced-handoff adopt-verbatim, which reuses the marker's
-   `newClaimId` instead. Record it (`--record-tokens`) before step 4.
+   `newClaimId` instead. Record it with the profile-selected
+   `claim-lock` helper's `--record-tokens` mode (`--worktree <path>
+   --agent-id <id> --claim-id <id>`; resolve the exact command from
+   `docs/idd-helper-scripts.md`) before step 4.
 3. **`{prior-claim-id}` / `supersedes:`**: `none` for a fresh claim or
    legacy migration; the active claim's `{claim-id}` for a stale
    takeover. Not applicable to forced-handoff (step 4 is skipped
@@ -319,8 +322,9 @@ differently for step 5:
 
 5. **Every fresh activation** (fresh claim, takeover, legacy migration,
    or forced-handoff adopt-verbatim) also posts an activation-nonce —
-   never for a plain heartbeat. Record it (`--record-tokens --nonce
-   <nonce>`) first:
+   never for a plain heartbeat. Record it with the same
+   `--record-tokens` invocation as step 2 plus `--nonce <nonce>`
+   (primary worktree) first:
 
    ```sh
    node scripts/post-idd-marker.mjs --type activation-nonce \

--- a/idd-template/.github/instructions/lite/idd-claim-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-claim-lite.instructions.md
@@ -22,7 +22,9 @@ collapses to a single outcome here: **STOP and report; do not claim**.
 2. **When the repository is `instructions-only`** (no helper runtime
    shipped): skip the helper commands and use the written tables only.
    That is the sole path where the tables below are the primary
-   control surface.
+   control surface. The generated-tokens `--record-tokens`/
+   `--read-tokens` ownership check has no written-table equivalent
+   under this profile; skip it.
 
 Every `node scripts/<name>.mjs` command below is the **source-repo /
 vendored-node** invocation form. Under `package-manager` /

--- a/idd-template/.github/instructions/lite/idd-claim-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-claim-lite.instructions.md
@@ -284,7 +284,7 @@ differently for step 5:
    inheritable match → use the name pre-check (e) computed.
 2. **`{claim-id}`**: generate a fresh opaque token — **except**
    forced-handoff adopt-verbatim, which reuses the marker's
-   `newClaimId` instead.
+   `newClaimId` instead. Record it (`--record-tokens`) before step 4.
 3. **`{prior-claim-id}` / `supersedes:`**: `none` for a fresh claim or
    legacy migration; the active claim's `{claim-id}` for a stale
    takeover. Not applicable to forced-handoff (step 4 is skipped
@@ -319,7 +319,8 @@ differently for step 5:
 
 5. **Every fresh activation** (fresh claim, takeover, legacy migration,
    or forced-handoff adopt-verbatim) also posts an activation-nonce —
-   never for a plain heartbeat:
+   never for a plain heartbeat. Record it (`--record-tokens --nonce
+   <nonce>`) first:
 
    ```sh
    node scripts/post-idd-marker.mjs --type activation-nonce \
@@ -420,6 +421,10 @@ Once the B1 worktree exists, before every mutation:
 node scripts/claim-lock.mjs --acquire --worktree <path> \
   --agent-id <agent-id> --claim-id <claim-id>
 ```
+
+Also confirm `--read-tokens` finds `{claim-id}` recorded before
+trusting it; absent or malformed → stop. See
+`docs/idd-helper-scripts.md`.
 
 A matching `{claim-id}` re-acquires as a read-only check. A different
 `{claim-id}` is always a collision — re-run pre-check (c) (`--claim-id`

--- a/idd-template/.github/instructions/lite/idd-claim-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-claim-lite.instructions.md
@@ -22,9 +22,8 @@ collapses to a single outcome here: **STOP and report; do not claim**.
 2. **When the repository is `instructions-only`** (no helper runtime
    shipped): skip the helper commands and use the written tables only.
    That is the sole path where the tables below are the primary
-   control surface. The generated-tokens `--record-tokens`/
-   `--read-tokens` ownership check has no written-table equivalent
-   under this profile; skip it.
+   control surface. The `--record-tokens`/`--read-tokens` check
+   instead uses `docs/idd-helper-scripts.md`'s helper-free fallback.
 
 Every `node scripts/<name>.mjs` command below is the **source-repo /
 vendored-node** invocation form. Under `package-manager` /

--- a/idd-template/.github/instructions/lite/idd-claim-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-claim-lite.instructions.md
@@ -422,9 +422,9 @@ node scripts/claim-lock.mjs --acquire --worktree <path> \
   --agent-id <agent-id> --claim-id <claim-id>
 ```
 
-Also confirm `--read-tokens` finds `{claim-id}` recorded before
-trusting it; absent or malformed → stop. See
-`docs/idd-helper-scripts.md`.
+Then, separately, run `--read-tokens --worktree <path> --claim-id
+<id>` and require `present: true` with no `malformed`; otherwise
+stop. See `docs/idd-helper-scripts.md`.
 
 A matching `{claim-id}` re-acquires as a read-only check. A different
 `{claim-id}` is always a collision — re-run pre-check (c) (`--claim-id`

--- a/idd-template/.github/instructions/lite/idd-claim-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-claim-lite.instructions.md
@@ -123,10 +123,12 @@ Pass `--nonce` when this session already recorded one for that
 `{claim-id}` (true after forced-handoff step 5) so a session that lost
 the nonce tie-break cannot pass as `already_owned`; omit it otherwise.
 
-| Top-level `state` / `action` | Meaning                                                           |
-| ---------------------------- | ----------------------------------------------------------------- |
-| `already_owned` / `keep`     | Confirmed — see the two cases below                               |
-| anything else                | Not yours — forced-handoff: Stop-and-ask; else fall through below |
+<!-- dprint-ignore-start -->
+| Top-level `state` / `action` | Meaning |
+| --- | --- |
+| `already_owned` / `keep` | Confirmed — see the two cases below |
+| anything else | Not yours — forced-handoff: Stop-and-ask; else fall through below |
+<!-- dprint-ignore-end -->
 
 `already_owned`/`keep` splits in two: if `--nonce` was passed above
 (resume/heartbeat continuation), skip to Claim verification (or
@@ -144,11 +146,13 @@ write:
 node scripts/resume-claim-routing.mjs --issue <N> --fresh-claim-gate
 ```
 
-| Helper `fresh_claim_gate.verdict` | Action                                |
-| --------------------------------- | ------------------------------------- |
-| `claimable`                       | Proceed to Claim execution (fresh)    |
-| `stale-reclaimable`               | Proceed to Claim execution (takeover) |
-| `already-claimed`                 | **STOP** — live competitor or race    |
+<!-- dprint-ignore-start -->
+| Helper `fresh_claim_gate.verdict` | Action |
+| --- | --- |
+| `claimable` | Proceed to Claim execution (fresh) |
+| `stale-reclaimable` | Proceed to Claim execution (takeover) |
+| `already-claimed` | **STOP** — live competitor or race |
+<!-- dprint-ignore-end -->
 
 Written fallback (`instructions-only` profile only — per the Helper
 runtime contract above, any other profile stops-and-asks on a
@@ -241,12 +245,14 @@ gh api "repos/{owner}/{repo}/git/matching-refs/heads/issue/<N>-" \
   --jq '.[].ref | sub("^refs/heads/"; "")'
 ```
 
-| Match found?                                                           | Action                                                          |
-| ---------------------------------------------------------------------- | --------------------------------------------------------------- |
-| No local or remote match                                               | Proceed to claim posting                                        |
-| Match corresponds to an inheritable claim (per (d) above)              | Proceed — expected branch                                       |
-| Match does not correspond, but an active non-stale claim references it | **STOP** — concurrent session                                   |
-| Match does not correspond, and no active claim references it           | **STOP** — hold note, possible orphaned branch; operator review |
+<!-- dprint-ignore-start -->
+| Match found? | Action |
+| --- | --- |
+| No local or remote match | Proceed to claim posting |
+| Match corresponds to an inheritable claim (per (d) above) | Proceed — expected branch |
+| Match does not correspond, but an active non-stale claim references it | **STOP** — concurrent session |
+| Match does not correspond, and no active claim references it | **STOP** — hold note, possible orphaned branch; operator review |
+<!-- dprint-ignore-end -->
 
 No remote branch with the computed name may already exist unless it is
 inheritable per the table above.

--- a/idd-template/.github/instructions/lite/idd-merge-handoff-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-merge-handoff-lite.instructions.md
@@ -34,8 +34,9 @@ Before posting the handoff comment, confirm all of the following:
    the package-manager-profile `idd:claim-lock` command with the same
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
-   fail-closed: stop rather than proceed. Also confirm `--read-tokens`
-   finds this `{claim-id}` recorded; absent or malformed → stop.
+   fail-closed: stop rather than proceed. Then, separately, run
+   `--read-tokens --worktree <path> --claim-id <id>` and require
+   `present: true` with no `malformed`; otherwise stop.
 4. If any check fails, stop.
 
 ## F2.5 — Draft and post the handoff comment

--- a/idd-template/.github/instructions/lite/idd-merge-handoff-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-merge-handoff-lite.instructions.md
@@ -34,7 +34,8 @@ Before posting the handoff comment, confirm all of the following:
    the package-manager-profile `idd:claim-lock` command with the same
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
-   fail-closed: stop rather than proceed.
+   fail-closed: stop rather than proceed. Also confirm `--read-tokens`
+   finds this `{claim-id}` recorded; absent or malformed → stop.
 4. If any check fails, stop.
 
 ## F2.5 — Draft and post the handoff comment

--- a/idd-template/.github/instructions/lite/idd-merge-handoff-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-merge-handoff-lite.instructions.md
@@ -35,8 +35,8 @@ Before posting the handoff comment, confirm all of the following:
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
-   `--read-tokens --worktree <path> --claim-id <id>` and require
-   `present: true` with no `malformed`; otherwise stop.
+   `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
+   and require `present: true` with no `malformed`; otherwise stop.
 4. If any check fails, stop.
 
 ## F2.5 — Draft and post the handoff comment

--- a/idd-template/.github/instructions/lite/idd-pr-submit-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-pr-submit-lite.instructions.md
@@ -79,7 +79,8 @@ following:
    the package-manager-profile `idd:claim-lock` command with the same
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
-   fail-closed: stop rather than proceed.
+   fail-closed: stop rather than proceed. Also confirm `--read-tokens`
+   finds this `{claim-id}` recorded; absent or malformed → stop.
 6. If any check fails, stop.
 
 ## D1 — Sync main before first push

--- a/idd-template/.github/instructions/lite/idd-pr-submit-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-pr-submit-lite.instructions.md
@@ -80,8 +80,8 @@ following:
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
-   `--read-tokens --worktree <path> --claim-id <id>` and require
-   `present: true` with no `malformed`; otherwise stop.
+   `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
+   and require `present: true` with no `malformed`; otherwise stop.
 6. If any check fails, stop.
 
 ## D1 — Sync main before first push

--- a/idd-template/.github/instructions/lite/idd-pr-submit-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-pr-submit-lite.instructions.md
@@ -79,8 +79,9 @@ following:
    the package-manager-profile `idd:claim-lock` command with the same
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
-   fail-closed: stop rather than proceed. Also confirm `--read-tokens`
-   finds this `{claim-id}` recorded; absent or malformed → stop.
+   fail-closed: stop rather than proceed. Then, separately, run
+   `--read-tokens --worktree <path> --claim-id <id>` and require
+   `present: true` with no `malformed`; otherwise stop.
 6. If any check fails, stop.
 
 ## D1 — Sync main before first push

--- a/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -80,8 +80,9 @@ other GitHub side effect, confirm all of the following:
    the package-manager-profile `idd:claim-lock` command with the same
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
-   fail-closed: stop rather than proceed. Also confirm `--read-tokens`
-   finds this `{claim-id}` recorded; absent or malformed → stop.
+   fail-closed: stop rather than proceed. Then, separately, run
+   `--read-tokens --worktree <path> --claim-id <id>` and require
+   `present: true` with no `malformed`; otherwise stop.
 6. If any check fails, stop.
 
 ## E9 — Fix accepted issues

--- a/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -81,8 +81,8 @@ other GitHub side effect, confirm all of the following:
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
-   `--read-tokens --worktree <path> --claim-id <id>` and require
-   `present: true` with no `malformed`; otherwise stop.
+   `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
+   and require `present: true` with no `malformed`; otherwise stop.
 6. If any check fails, stop.
 
 ## E9 — Fix accepted issues

--- a/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -80,7 +80,8 @@ other GitHub side effect, confirm all of the following:
    the package-manager-profile `idd:claim-lock` command with the same
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
-   fail-closed: stop rather than proceed.
+   fail-closed: stop rather than proceed. Also confirm `--read-tokens`
+   finds this `{claim-id}` recorded; absent or malformed → stop.
 6. If any check fails, stop.
 
 ## E9 — Fix accepted issues

--- a/idd-template/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
@@ -55,8 +55,9 @@ GitHub side effect, confirm all of the following:
    the package-manager-profile `idd:claim-lock` command with the same
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
-   fail-closed: stop rather than proceed. Also confirm `--read-tokens`
-   finds this `{claim-id}` recorded; absent or malformed → stop.
+   fail-closed: stop rather than proceed. Then, separately, run
+   `--read-tokens --worktree <path> --claim-id <id>` and require
+   `present: true` with no `malformed`; otherwise stop.
 6. If any check fails, stop.
 
 ## E1 — Fetch review items into ReviewItems_snapshot

--- a/idd-template/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
@@ -56,8 +56,8 @@ GitHub side effect, confirm all of the following:
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
-   `--read-tokens --worktree <path> --claim-id <id>` and require
-   `present: true` with no `malformed`; otherwise stop.
+   `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
+   and require `present: true` with no `malformed`; otherwise stop.
 6. If any check fails, stop.
 
 ## E1 — Fetch review items into ReviewItems_snapshot

--- a/idd-template/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
@@ -55,7 +55,8 @@ GitHub side effect, confirm all of the following:
    the package-manager-profile `idd:claim-lock` command with the same
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
-   fail-closed: stop rather than proceed.
+   fail-closed: stop rather than proceed. Also confirm `--read-tokens`
+   finds this `{claim-id}` recorded; absent or malformed → stop.
 6. If any check fails, stop.
 
 ## E1 — Fetch review items into ReviewItems_snapshot

--- a/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
@@ -49,7 +49,8 @@ request, or other GitHub side effect, confirm all of the following:
    the package-manager-profile `idd:claim-lock` command with the same
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
-   fail-closed: stop rather than proceed.
+   fail-closed: stop rather than proceed. Also confirm `--read-tokens`
+   finds this `{claim-id}` recorded; absent or malformed → stop.
 6. If any check fails, stop.
 
 ## B1 — Create worktree
@@ -102,8 +103,10 @@ worktree removal) behind the
     approval for any other command WorkTrunk runs on that call.
 18. Do not use `wt new`.
 19. If WorkTrunk uses a pre-start install hook, its first command must acquire
-    the worktree lock before it installs anything.
-20. If the hook cannot acquire the lock, create the worktree without the hook.
+    the worktree lock and re-run `--record-tokens` (same nonce as the A5
+    write) for this worktree's own copy, before it installs anything.
+20. If the hook cannot acquire the lock or record tokens, create the
+    worktree without the hook.
 21. If WorkTrunk is unavailable, use
     `git worktree add <path> -b <branch-name> origin/main` for a fresh claim.
 22. If WorkTrunk is unavailable and this is a takeover, use
@@ -116,8 +119,9 @@ worktree removal) behind the
     exists (rare), treat it as a fresh claim while preserving the inherited
     branch name.
 26. For manual `git worktree add` or WorkTrunk without a hook, acquire the
-    worktree lock with the profile-selected `claim-lock` helper immediately
-    after creation and before any install or other mutation.
+    worktree lock with the profile-selected `claim-lock` helper and re-run
+    `--record-tokens` (same nonce as the A5 write) for this worktree's own copy,
+    immediately after creation and before any install or other mutation.
 27. Run `install-deps` on the manual/no-hook path.
 28. Verify the primary worktree's HEAD is still on `main`.
 29. Verify `git worktree list` shows the new path.

--- a/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
@@ -103,11 +103,12 @@ worktree removal) behind the
     narrower than the global `-y`/`--yes` flag, which would also skip
     approval for any other command WorkTrunk runs on that call.
 18. Do not use `wt new`.
-19. If WorkTrunk uses a pre-start install hook, its first command must acquire
-    the worktree lock and re-run `--record-tokens --nonce <nonce>` (same
-    value as the A5 write; omitting `--nonce` drops it, since the helper
-    overwrites rather than merges) for this worktree's own copy, before it
-    installs anything.
+19. If WorkTrunk uses a pre-start install hook, its first command must
+    acquire the worktree lock, then — as a separate call — run
+    `--record-tokens --worktree <this-worktree-path> --agent-id <id>
+    --claim-id <id> --nonce <nonce>` (same nonce value as the A5 write;
+    omitting `--nonce` drops it, since the helper overwrites rather than
+    merges) for this worktree's own copy, before it installs anything.
 20. If the hook cannot acquire the lock or record tokens, create the
     worktree without the hook.
 21. If WorkTrunk is unavailable, use
@@ -122,11 +123,12 @@ worktree removal) behind the
     exists (rare), treat it as a fresh claim while preserving the inherited
     branch name.
 26. For manual `git worktree add` or WorkTrunk without a hook, acquire the
-    worktree lock with the profile-selected `claim-lock` helper and re-run
-    `--record-tokens --nonce <nonce>` (same value as the A5 write; omitting
-    `--nonce` drops it, since the helper overwrites rather than merges) for
-    this worktree's own copy, immediately after creation and before any
-    install or other mutation.
+    worktree lock with the profile-selected `claim-lock` helper, then — as
+    a separate call — run `--record-tokens --worktree <this-worktree-path>
+    --agent-id <id> --claim-id <id> --nonce <nonce>` (same nonce value as
+    the A5 write; omitting `--nonce` drops it, since the helper overwrites
+    rather than merges) for this worktree's own copy, immediately after
+    creation and before any install or other mutation.
 27. Run `install-deps` on the manual/no-hook path.
 28. Verify the primary worktree's HEAD is still on `main`.
 29. Verify `git worktree list` shows the new path.

--- a/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
@@ -104,8 +104,10 @@ worktree removal) behind the
     approval for any other command WorkTrunk runs on that call.
 18. Do not use `wt new`.
 19. If WorkTrunk uses a pre-start install hook, its first command must acquire
-    the worktree lock and re-run `--record-tokens` (same nonce as the A5
-    write) for this worktree's own copy, before it installs anything.
+    the worktree lock and re-run `--record-tokens --nonce <nonce>` (same
+    value as the A5 write; omitting `--nonce` drops it, since the helper
+    overwrites rather than merges) for this worktree's own copy, before it
+    installs anything.
 20. If the hook cannot acquire the lock or record tokens, create the
     worktree without the hook.
 21. If WorkTrunk is unavailable, use
@@ -121,8 +123,10 @@ worktree removal) behind the
     branch name.
 26. For manual `git worktree add` or WorkTrunk without a hook, acquire the
     worktree lock with the profile-selected `claim-lock` helper and re-run
-    `--record-tokens` (same nonce as the A5 write) for this worktree's own copy,
-    immediately after creation and before any install or other mutation.
+    `--record-tokens --nonce <nonce>` (same value as the A5 write; omitting
+    `--nonce` drops it, since the helper overwrites rather than merges) for
+    this worktree's own copy, immediately after creation and before any
+    install or other mutation.
 27. Run `install-deps` on the manual/no-hook path.
 28. Verify the primary worktree's HEAD is still on `main`.
 29. Verify `git worktree list` shows the new path.

--- a/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
@@ -50,8 +50,8 @@ request, or other GitHub side effect, confirm all of the following:
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
-   `--read-tokens --worktree <path> --claim-id <id>` and require
-   `present: true` with no `malformed`; otherwise stop.
+   `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
+   and require `present: true` with no `malformed`; otherwise stop.
 6. If any check fails, stop.
 
 ## B1 — Create worktree

--- a/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
@@ -49,8 +49,9 @@ request, or other GitHub side effect, confirm all of the following:
    the package-manager-profile `idd:claim-lock` command with the same
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
-   fail-closed: stop rather than proceed. Also confirm `--read-tokens`
-   finds this `{claim-id}` recorded; absent or malformed → stop.
+   fail-closed: stop rather than proceed. Then, separately, run
+   `--read-tokens --worktree <path> --claim-id <id>` and require
+   `present: true` with no `malformed`; otherwise stop.
 6. If any check fails, stop.
 
 ## B1 — Create worktree


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

#2719 added a fail-closed generated-tokens ownership check to the
Claim revalidation gate, but only wired it into the standard-profile
instructions. This PR mirrors the same mechanism into the lite
(weak/local-model) profile:

- `idd-claim-lite.instructions.md` now records the claim-id and nonce
  via `--record-tokens` before their respective marker posts, and its
  Worktree-local lock section confirms `--read-tokens` before trusting
  a recalled claim-id.
- `idd-work-lite.instructions.md`'s two worktree-creation paths
  (WorkTrunk pre-start hook and manual/no-hook) now also re-run
  `--record-tokens` for the new sibling worktree's own copy, since the
  A5-time record lives in the primary worktree's admin directory, not
  the sibling's.
- The remaining four lite guard files (`pr-submit-lite`,
  `review-fix-lite`, `review-snapshot-lite`, `merge-handoff-lite`,
  plus `work-lite` itself) each extend their existing `--acquire`
  pre-mutation step with the same `--read-tokens` confirmation.

Before this change, a lite-profile session bypassed the ownership
check entirely and trusted a recalled `{claim-id}` exactly as before
#2719.

## Linked issue

Closes #2883

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

`idd-claim-lite.instructions.md`'s byte-budget bundle was already at
97.65% of its configured ceiling before this change (`audit/sync-manifest.json`'s
`bundle-claim-lite`, 22,000-byte limit), close to the documented 98%
hard-fail threshold. The first commit in this PR (`style(claim-lite):
drop forced table padding in idd-claim-lite`) wraps this file's three
markdown tables in `dprint-ignore` to drop dprint's forced
column-alignment padding -- no visible content change, verified with
`git diff --word-diff` -- freeing enough headroom for the second
commit's actual check additions without exceeding the repository's
documented near-ceiling trim-over-raise policy
(`docs/policy-constants.md`'s "Bundle-budget growth" section). The
two commits are split per this repo's atomic-commit convention
(formatting changes separate from logic changes).

All edits land on the `idd-template/` canonical sources; the mirrored
`.github/instructions/lite/` copies are regenerated via
`node scripts/sync-docs.mjs --apply` (verified byte-identical to the
sources plus the standard generated-file banner).

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`npx biome check`, `npx dprint check`, `npx markdownlint-cli2` -- all clean on changed files)
- [x] `pnpm test` (`node --test tests/*.test.mts` -- 5958/5958 pass)
- [x] `node scripts/audit-docs.mjs --check` (passes; only pre-existing unrelated bundle-utilization notices)
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passes; only pre-existing unrelated warnings)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified claim, handoff, submission, review, and worktree procedures.
  * Added safeguards that verify active claim records and token data before changes proceed.
  * Worktree creation now records required activation information before installation or other modifications.
  * Missing or invalid claim records, token data, lock acquisition, or recording steps now stop the workflow safely.
  * Clarified forced handoff and fresh activation recording requirements.
  * Standardized formatting for decision tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->