### PR TITLE
fix(issue-authoring): make hide-on-supersede marker minimization actually run

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -1642,6 +1642,23 @@ only approval boundary.
   `matchCanonicalAuthoringMarkerFamily` unchanged) every byte-exact
   canonical match that is not the newest **trusted-actor** match for its
   family, exactly as the opportunistic per-post step above does.
+  **Fetch that paginated log via GraphQL, never a plain REST
+  issue-comments fetch, and skip an already-minimized candidate before
+  submitting it** (#2896 review, Codex): a GraphQL `issueComments` /
+  `comments` query can select `isMinimized` on each node directly,
+  while REST's issue-comments endpoint never carries that field at
+  all, so a REST-fetched snapshot cannot distinguish a comment this
+  sweep already cleared from one it never touched. Use that field to
+  exclude any candidate already `isMinimized: true` **before** it ever
+  reaches the minimize helper's `--subject-ids`, not only when
+  auditing the result afterward. Without this, every historical
+  byte-exact canonical comment on a long-lived shared journal (one can
+  accumulate hundreds over time) gets resubmitted to
+  `minimize-superseded-markers.mjs` on every single sweep invocation
+  across every target, and that helper probes each subject ID serially
+  with no overall deadline -- a degraded GitHub API can then consume
+  its per-call timeout once per historical comment and stall release
+  for many minutes despite the attempted-not-blocking framing below.
   Determine "newest" only among candidates from a trusted marker actor
   (#2896 review, Codex), never from every structural match
   indiscriminately -- an untrusted actor's byte-exact canonical comment
@@ -1775,9 +1792,16 @@ only approval boundary.
   cleared), and counts exactly the same as a fresh `"applied"` for this
   update: both mean the comment is minimized now, regardless of which
   attempt did it. Missing either status keeps that comment's snapshot
-  entry wrongly `isMinimized: false`. Re-fetching the paginated log fresh
-  is an acceptable alternative to this snapshot update, not merely a
+  entry wrongly `isMinimized: false`. Re-fetching the paginated log
+  fresh **via GraphQL** (matching the sweep's own fetch above) is an
+  acceptable alternative to this snapshot update, not merely a
   fallback -- either one produces the same accurate post-sweep state.
+  A REST re-fetch is not a valid alternative here (#2896 review,
+  Codex): REST's issue-comments endpoint never carries `isMinimized`
+  at all, so a REST re-fetch is exactly as blind to minimization state
+  as the stale pre-mutation snapshot this paragraph exists to correct
+  -- it produces a different but equally wrong snapshot, not an
+  accurate one.
   Skipping both and auditing the unmodified pre-mutation snapshot reports
   every comment the sweep (or a prior one) already minimized as
   still-outstanding backlog, making even a fully successful, fully

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -1790,6 +1790,23 @@ only approval boundary.
   instead of silent, the same kind of gap that went unnoticed for weeks
   in the original per-post-only instruction this section replaces
   (measured effectiveness cited above).
+
+  **When the backlog check itself cannot run, record that fact through a
+  runtime-independent path (#2896 review, Codex).** The check depends on
+  the same paginated comment snapshot and the same helper runtime
+  (Node.js) as the sweep it audits, so the one scenario this whole
+  mechanism exists to catch -- the sweep silently skipped because the
+  helper runtime is unavailable (`instructions-only` profile, or Node.js
+  absent), or because the paginated comment fetch itself failed -- is
+  exactly the scenario in which the mechanical count also cannot run,
+  leaving no signal at all if nothing else is done. When either the
+  sweep or the audit could not run for this reason, still post an
+  explicit plain-text note through a path that needs no helper runtime
+  (a `gh`/HTTP comment on the target, or the session's own live status
+  digest) -- for example "hide-on-supersede sweep skipped this cycle:
+  helper runtime unavailable" -- naming the reason. This never blocks
+  release either; it only ensures a fully-silent skip never happens even
+  in the one failure mode the mechanical signal cannot itself cover.
 - **Narrow auto-release exception (review-fix-loop-cutoff).** A
   follow-up issue whose body carried the exact marker
   `<!-- idd-skill-authoring-defer-source: review-fix-loop-cutoff -->` at

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -1743,11 +1743,22 @@ only approval boundary.
   snapshot. Before running the check, update the just-fetched snapshot's
   `isMinimized` field to `true` for every candidate the minimize
   helper's own report (`minimize-superseded-markers.mjs`'s `items[]`,
-  keyed by subject id) lists with `status: "applied"` -- or re-fetch the
-  paginated log fresh -- before auditing; running the check against the
-  unmodified pre-mutation snapshot reports every comment the sweep just
-  minimized as still-outstanding backlog, making even a fully successful
-  sweep look like it failed. A nonzero count after this update means the
+  keyed by subject id) lists with **either** `status: "applied"` **or**
+  `status: "skipped", reason: "already-minimized"` -- the latter fires
+  whenever the fetched snapshot's own `isMinimized` was already stale or
+  absent for a comment GitHub already considers minimized (for example
+  one an earlier sweep or the opportunistic per-post step already
+  cleared), and counts exactly the same as a fresh `"applied"` for this
+  update: both mean the comment is minimized now, regardless of which
+  attempt did it. Missing either status keeps that comment's snapshot
+  entry wrongly `isMinimized: false`. Re-fetching the paginated log fresh
+  is an acceptable alternative to this snapshot update, not merely a
+  fallback -- either one produces the same accurate post-sweep state.
+  Skipping both and auditing the unmodified pre-mutation snapshot reports
+  every comment the sweep (or a prior one) already minimized as
+  still-outstanding backlog, making even a fully successful, fully
+  idempotent sweep look like it failed. A nonzero count after this update
+  means the
   sweep attempt genuinely did not fully clear the backlog it was
   supposed to (a partial permission failure or a genuine defect) --
   record it, but never block release on it; this is the mechanical

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -1513,8 +1513,18 @@ only approval boundary.
   applies to `acquire`, `bootstrap`, `resume`, `release`,
   `release-guard`, or `release-complete` markers; only a `heartbeat`
   append may be skipped.
-- **Hide superseded owner/publication-intent markers.** Once a fresh
-  `authoring-owner` marker (any `mode`, including the first,
+- **Hide superseded owner/publication-intent markers.** Opportunistic:
+  see the mandatory Stage 2 sweep below for the mechanism this contract
+  actually relies on. Measured 2026-09-11 across 22 issues published
+  after this per-post step first shipped (#2750/#2821): of 95
+  expected-hideable `authoring-owner`/`authoring-publication-intent`
+  comments, only 3 (about 3%) were actually minimized (#2896). Following
+  this step in the moment is correct and still worth doing when
+  convenient -- every comment it hides is one the Stage 2 sweep below
+  does not have to -- but it is not something this contract can depend
+  on by itself: a step invoked 3-9+ times per issue, buried mid-protocol
+  with no mechanical enforcement, is too easy to skip under load. Once a
+  fresh `authoring-owner` marker (any `mode`, including the first,
   generation-opening `acquire`/`bootstrap`) or `authoring-publication-intent`
   record (any `state`) has been posted and its own POST and re-fetch/verify
   above have both succeeded -- never before, and never interleaved with
@@ -1567,8 +1577,11 @@ only approval boundary.
   `review-watermark`, `advisory-wait`; see `docs/idd-comment-minimization.md`).
   Do not add `authoring-owner`, `authoring-publication-intent`, or
   `authoring-publication` to `OPERATIONAL_MARKERS`, and do not fold this
-  step into the F4 driver: it is a separate, earlier-lifecycle,
-  hide-at-post-time behavior.
+  step or the Stage 2 sweep below into the F4 driver: minimization for
+  this marker family stays a separate, earlier-lifecycle behavior owned
+  by the issue-authoring protocol itself, not the post-merge cleanup
+  driver -- whether triggered opportunistically here or mandatorily at
+  Stage 2 release.
 - **Conflict check before every edit.** Immediately before each body or
   roadmap relationship update, re-fetch both the target and the set anchor
   (the same fresh snapshot serves both roles when the target is the anchor).
@@ -1618,6 +1631,28 @@ only approval boundary.
   exception below. Keep the set anchor held until every other
   target's label removal is verified, and remove the anchor label last. For
   every target, first re-fetch owner comments during release-marker preflight.
+  **Mandatory release-time hide-on-supersede sweep (#2896).** At this same
+  point -- before the reuse-or-append decision below, so a retried or
+  resumed release (which reuses an existing `release` marker and never
+  appends a new one) still runs the sweep every time this preflight step
+  is reached -- paginate the full owner-marker log this re-fetch just
+  retrieved, plus the publication-intent log for the journal named in
+  this session's own records, and minimize (classifier `OUTDATED`, via
+  the existing `minimize-superseded-markers.mjs`, reusing
+  `matchCanonicalAuthoringMarkerFamily` unchanged) every byte-exact
+  canonical match that is not the newest for its family, exactly as the
+  opportunistic per-post step above does. Attempt this once per target
+  here, and once more on the anchor immediately before the
+  release-complete preflight below; this is the sweep the contract
+  depends on, but "mandatory" means **attempted**, not
+  blocking -- a failed attempt (permission error, an unreadable comment
+  list, or an unavailable helper runtime) skips silently and never stops
+  release, matching the opportunistic step's own best-effort framing.
+  `audit-authored-issue.mjs`'s `authoring-marker-minimization-backlog`
+  check, given the same paginated comment data, reports the count of
+  eligible-but-not-yet-minimized markers mechanically, so a skipped or
+  failed sweep attempt becomes a visible, countable signal instead of
+  silence.
   If a valid current-owner/set `mode=release` marker already exists, reuse the
   earliest matching GitHub comment ID; otherwise append one with `supersedes`
   equal to the current owner token, re-fetch to verify it, and record its
@@ -1642,7 +1677,12 @@ only approval boundary.
   target at a time and re-fetch each result. After the final anchor label
   removal is verified, re-fetch every target and verify its current release
   marker, absent label, and expected body snapshot; any drift leaves the set
-  open and prevents completion. Then reuse the earliest
+  open and prevents completion. Immediately before the release-complete
+  reuse-or-append decision below, repeat the same mandatory sweep once
+  more on the anchor's own owner-marker log and the journal's
+  publication-intent log -- idempotent with every earlier target's own
+  sweep above, since a comment either was already minimized or was not
+  yet the newest for its family either way. Then reuse the earliest
   valid current-owner/set/session `mode=release-complete`
   marker on the anchor, or append one and record its returned comment ID.
   Re-fetch that ID and the anchor's paginated owner-marker log with bounded

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -1752,7 +1752,7 @@ only approval boundary.
   (#2896 review, Codex): the paginated GitHub REST/GraphQL response
   this section already fetches exposes a comment's author nested as
   `user.login` (REST) or `author.login` (GraphQL), never as a flat
-  `author` string -- write each entry's `--comments-file`/
+  `author` string -- write each entry's `--comments-file` /
   `--journal-comments-file` JSON with `author` set to that nested
   login, not passed through unmapped. Skipping this normalization does
   not error: every comment silently loses its author, the trust filter

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -1647,12 +1647,11 @@ only approval boundary.
   depends on, but "mandatory" means **attempted**, not
   blocking -- a failed attempt (permission error, an unreadable comment
   list, or an unavailable helper runtime) skips silently and never stops
-  release, matching the opportunistic step's own best-effort framing.
-  `audit-authored-issue.mjs`'s `authoring-marker-minimization-backlog`
-  check, given the same paginated comment data, reports the count of
-  eligible-but-not-yet-minimized markers mechanically, so a skipped or
-  failed sweep attempt becomes a visible, countable signal instead of
-  silence.
+  release, matching the opportunistic step's own best-effort framing. See
+  the **Closing sweep** bullet below for the third sweep point this
+  preflight sweep alone does not cover, and for the explicit
+  `authoring-marker-minimization-backlog` invocation that makes each
+  sweep attempt's outcome a visible, countable signal instead of silence.
   If a valid current-owner/set `mode=release` marker already exists, reuse the
   earliest matching GitHub comment ID; otherwise append one with `supersedes`
   equal to the current owner token, re-fetch to verify it, and record its
@@ -1708,6 +1707,41 @@ only approval boundary.
   record a set-level recovery hold and never claim a partial release. Release
   is a human action; nothing in this bundle auto-releases a held issue set,
   except the narrow, marker-scoped exception immediately below.
+- **Closing sweep (after Stage 2 closes, #2896 review, Codex).** The two
+  sweep points above run _before_ Stage 2's own later marker appends for
+  the same generation -- the per-target `release` marker, the
+  pre-label-removal heartbeat each target receives immediately before
+  its own label removal, and (on the anchor) `release-guard` and
+  `release-complete` itself. None of those markers exist yet when their
+  target's preflight sweep runs, so the preflight sweep(s) alone can
+  never clear them, and a target's Stage 2 for a given generation runs
+  only once -- there is no future preflight sweep that would ever
+  revisit them. Once the set-level release actually closes (the
+  successful-close branch immediately above: the trusted
+  `release-complete` marker is found and every label is confirmed
+  absent), attempt the mandatory sweep one more time: paginate every
+  target's now-final owner-marker log (the anchor's included this time,
+  not just its own) and the journal's publication-intent log, and
+  minimize every byte-exact canonical match that is not the newest for
+  its family, exactly as the preflight sweeps above do. Same
+  attempted-not-blocking framing: a failed attempt here does not reopen
+  the set or roll back the close already recorded above.
+
+  **Make every sweep attempt's outcome visible.** Immediately after each
+  of the three sweep attempts in this section (per-target preflight,
+  anchor-before-release-complete, and this closing sweep), run
+  `audit-authored-issue.mjs`'s `authoring-marker-minimization-backlog`
+  check against the same paginated owner-marker/journal data just
+  fetched for that sweep (`--comments-file`/`--journal-comments-file`,
+  or `auditAuthoredIssue()` directly) and note its reported count. A
+  nonzero count immediately after a sweep attempt means that attempt did
+  not fully clear the backlog it was supposed to (a partial permission
+  failure, an untrusted-authored candidate the sweep correctly declined
+  to touch, or a genuine defect) -- record it, but never block release
+  on it; this is the mechanical signal that makes a skipped or
+  partially-failed sweep attempt visible instead of silent, the way
+  #2750/#2821's original per-post-only instruction's gap went unnoticed
+  for weeks.
 - **Narrow auto-release exception (review-fix-loop-cutoff).** A
   follow-up issue whose body carried the exact marker
   `<!-- idd-skill-authoring-defer-source: review-fix-loop-cutoff -->` at

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -1659,6 +1659,16 @@ only approval boundary.
   with no overall deadline -- a degraded GitHub API can then consume
   its per-call timeout once per historical comment and stall release
   for many minutes despite the attempted-not-blocking framing below.
+  **Also pass `--deadline-ms`** (#2896 review, Codex, round 8) to
+  every `minimize-superseded-markers.mjs` invocation this sweep makes
+  -- for example `--deadline-ms 300000` (five minutes) -- as a second,
+  independent bound: the `isMinimized` pre-filter above only skips
+  already-cleared candidates cheaply, but a first-ever sweep of a
+  large backlog can still submit many genuinely-not-yet-minimized
+  candidates that each cost a real GitHub API round-trip, and without
+  `--deadline-ms` each one can individually consume the helper's own
+  per-call timeout with no overall cap.
+
   Determine "newest" only among candidates from a trusted marker actor
   (#2896 review, Codex), never from every structural match
   indiscriminately -- an untrusted actor's byte-exact canonical comment

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -1731,17 +1731,30 @@ only approval boundary.
   of the three sweep attempts in this section (per-target preflight,
   anchor-before-release-complete, and this closing sweep), run
   `audit-authored-issue.mjs`'s `authoring-marker-minimization-backlog`
-  check against the same paginated owner-marker/journal data just
-  fetched for that sweep (`--comments-file`/`--journal-comments-file`,
-  or `auditAuthoredIssue()` directly) and note its reported count. A
-  nonzero count immediately after a sweep attempt means that attempt did
-  not fully clear the backlog it was supposed to (a partial permission
-  failure, an untrusted-authored candidate the sweep correctly declined
-  to touch, or a genuine defect) -- record it, but never block release
-  on it; this is the mechanical signal that makes a skipped or
-  partially-failed sweep attempt visible instead of silent, the way
-  #2750/#2821's original per-post-only instruction's gap went unnoticed
-  for weeks.
+  check and note its reported count -- always with `--trusted-marker-logins`
+  (or the equivalent `trustedMarkerActors` option on `auditAuthoredIssue()`)
+  set to the same trusted actors the sweep itself used, so the check's
+  own eligibility rule matches what the sweep could actually clear;
+  omitting it makes the count overstate the real backlog by including
+  untrusted-authored matches the sweep was never going to touch.
+  **Feed it the sweep's own post-mutation result, never the
+  pre-mutation snapshot the sweep read.** The minimize helper mutates
+  GitHub directly; it never updates an in-memory or on-disk comment
+  snapshot. Before running the check, update the just-fetched snapshot's
+  `isMinimized` field to `true` for every candidate the minimize
+  helper's own report (`minimize-superseded-markers.mjs`'s `items[]`,
+  keyed by subject id) lists with `status: "applied"` -- or re-fetch the
+  paginated log fresh -- before auditing; running the check against the
+  unmodified pre-mutation snapshot reports every comment the sweep just
+  minimized as still-outstanding backlog, making even a fully successful
+  sweep look like it failed. A nonzero count after this update means the
+  sweep attempt genuinely did not fully clear the backlog it was
+  supposed to (a partial permission failure or a genuine defect) --
+  record it, but never block release on it; this is the mechanical
+  signal that makes a skipped or partially-failed sweep attempt visible
+  instead of silent, the same kind of gap that went unnoticed for weeks
+  in the original per-post-only instruction this section replaces
+  (measured effectiveness cited above).
 - **Narrow auto-release exception (review-fix-loop-cutoff).** A
   follow-up issue whose body carried the exact marker
   `<!-- idd-skill-authoring-defer-source: review-fix-loop-cutoff -->` at

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -1640,8 +1640,19 @@ only approval boundary.
   this session's own records, and minimize (classifier `OUTDATED`, via
   the existing `minimize-superseded-markers.mjs`, reusing
   `matchCanonicalAuthoringMarkerFamily` unchanged) every byte-exact
-  canonical match that is not the newest for its family, exactly as the
-  opportunistic per-post step above does. Attempt this once per target
+  canonical match that is not the newest **trusted-actor** match for its
+  family, exactly as the opportunistic per-post step above does.
+  Determine "newest" only among candidates from a trusted marker actor
+  (#2896 review, Codex), never from every structural match
+  indiscriminately -- an untrusted actor's byte-exact canonical comment
+  posted after the real newest trusted one must never be treated as the
+  thing to keep visible: `minimize-superseded-markers.mjs` itself
+  refuses to minimize any comment outside `--trusted-marker-logins`
+  regardless of this selection, so naively treating the untrusted
+  comment as newest would instead select the legitimate trusted marker
+  for minimization -- exactly backwards. This mirrors
+  `checkAuthoringMarkerMinimizationBacklog`'s own audit-side fix; keep
+  the two in sync. Attempt this once per target
   here, and once more on the anchor immediately before the
   release-complete preflight below; this is the sweep the contract
   depends on, but "mandatory" means **attempted**, not
@@ -1737,6 +1748,19 @@ only approval boundary.
   own eligibility rule matches what the sweep could actually clear;
   omitting it makes the count overstate the real backlog by including
   untrusted-authored matches the sweep was never going to touch.
+  **Normalize the author field before writing the comments-file JSON**
+  (#2896 review, Codex): the paginated GitHub REST/GraphQL response
+  this section already fetches exposes a comment's author nested as
+  `user.login` (REST) or `author.login` (GraphQL), never as a flat
+  `author` string -- write each entry's `--comments-file`/
+  `--journal-comments-file` JSON with `author` set to that nested
+  login, not passed through unmapped. Skipping this normalization does
+  not error: every comment silently loses its author, the trust filter
+  above then excludes every candidate as unknown-author, and the count
+  falsely reports zero backlog even when the sweep was skipped or
+  failed entirely -- the opposite failure mode from omitting
+  `--trusted-marker-logins` (that overstates; this understates to
+  nothing).
   **Feed it the sweep's own post-mutation result, never the
   pre-mutation snapshot the sweep read.** The minimize helper mutates
   GitHub directly; it never updates an in-memory or on-disk comment

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -1215,8 +1215,18 @@ retrieved, plus the publication-intent log for the journal named in this
 session's own records, and minimize (classifier `OUTDATED`, via the
 existing `minimize-superseded-markers.mjs`, reusing
 `matchCanonicalAuthoringMarkerFamily` unchanged) every byte-exact
-canonical match that is not the newest for its family, exactly as the
-opportunistic per-post step above does. Attempt this once per target
+canonical match that is not the newest **trusted-actor** match for its
+family, exactly as the opportunistic per-post step above does. Determine
+"newest" only among candidates from a trusted marker actor (#2896
+review, Codex), never from every structural match indiscriminately --
+an untrusted actor's byte-exact canonical comment posted after the real
+newest trusted one must never be treated as the thing to keep visible:
+`minimize-superseded-markers.mjs` itself refuses to minimize any comment
+outside `--trusted-marker-logins` regardless of this selection, so
+naively treating the untrusted comment as newest would instead select
+the legitimate trusted marker for minimization -- exactly backwards.
+This mirrors `checkAuthoringMarkerMinimizationBacklog`'s own audit-side
+fix; keep the two in sync. Attempt this once per target
 here, and once more on the anchor immediately before the release-complete
 preflight below; this is the sweep the contract depends on, but
 "mandatory" means **attempted**, not blocking -- a failed attempt
@@ -1319,6 +1329,19 @@ set to the same trusted actors the sweep itself used, so the check's own
 eligibility rule matches what the sweep could actually clear; omitting
 it makes the count overstate the real backlog by including
 untrusted-authored matches the sweep was never going to touch.
+
+**Normalize the author field before writing the comments-file JSON**
+(#2896 review, Codex): the paginated GitHub REST/GraphQL response this
+section already fetches exposes a comment's author nested as
+`user.login` (REST) or `author.login` (GraphQL), never as a flat
+`author` string -- write each entry's `--comments-file`/
+`--journal-comments-file` JSON with `author` set to that nested login,
+not passed through unmapped. Skipping this normalization does not
+error: every comment silently loses its author, the trust filter above
+then excludes every candidate as unknown-author, and the count falsely
+reports zero backlog even when the sweep was skipped or failed entirely
+-- the opposite failure mode from omitting `--trusted-marker-logins`
+(that overstates; this understates to nothing).
 
 **Feed it the sweep's own post-mutation result, never the pre-mutation
 snapshot the sweep read.** The minimize helper mutates GitHub directly;

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -1069,7 +1069,17 @@ that list, a changed body digest, or the marker cannot be found conclusively
 `acquire`, `bootstrap`, `resume`, `release`, `release-guard`, or
 `release-complete` markers; only a `heartbeat` append may be skipped.
 
-**Hide superseded owner/publication-intent markers.** Once a fresh
+**Hide superseded owner/publication-intent markers.** Opportunistic: see
+the mandatory Stage 2 sweep below for the mechanism this contract
+actually relies on. Measured 2026-09-11 across 22 issues published
+after this per-post step first shipped (#2750/#2821): of 95
+expected-hideable `authoring-owner`/`authoring-publication-intent`
+comments, only 3 (about 3%) were actually minimized (#2896). Following
+this step in the moment is correct and still worth doing when
+convenient -- every comment it hides is one the Stage 2 sweep below does
+not have to -- but it is not something this contract can depend on by
+itself: a step invoked 3-9+ times per issue, buried mid-protocol with no
+mechanical enforcement, is too easy to skip under load. Once a fresh
 `authoring-owner` marker (any `mode`, including the first, generation-opening
 `acquire`/`bootstrap`) or `authoring-publication-intent` record (any `state`)
 has been posted and its own POST and re-fetch/verify above have both
@@ -1122,8 +1132,11 @@ nothing to minimize -- and every marker family already covered by the
 post-merge F4 cleanup driver (for example `claimed-by`, `review-watermark`,
 `advisory-wait`; see `docs/idd-comment-minimization.md`). Do not add
 `authoring-owner`, `authoring-publication-intent`, or `authoring-publication`
-to `OPERATIONAL_MARKERS`, and do not fold this step into the F4 driver: it
-is a separate, earlier-lifecycle, hide-at-post-time behavior.
+to `OPERATIONAL_MARKERS`, and do not fold this step or the Stage 2 sweep
+below into the F4 driver: minimization for this marker family stays a
+separate, earlier-lifecycle behavior owned by the issue-authoring
+protocol itself, not the post-merge cleanup driver -- whether triggered
+opportunistically here or mandatorily at Stage 2 release.
 
 Immediately before every body or roadmap relationship update, re-fetch both
 the target and the set anchor (the same fresh snapshot serves both roles when
@@ -1191,7 +1204,32 @@ release from the authoring hold (see the
 below for the one marker-scoped exception to this precondition). Keep the
 set anchor held until every other
 target's label removal is verified, and remove the anchor label last. First
-re-fetch owner comments during release-marker preflight. If a valid
+re-fetch owner comments during release-marker preflight.
+
+**Mandatory release-time hide-on-supersede sweep (#2896).** At this same
+point -- before the reuse-or-append decision below, so a retried or
+resumed release (which reuses an existing `release` marker and never
+appends a new one) still runs the sweep every time this preflight step
+is reached -- paginate the full owner-marker log this re-fetch just
+retrieved, plus the publication-intent log for the journal named in this
+session's own records, and minimize (classifier `OUTDATED`, via the
+existing `minimize-superseded-markers.mjs`, reusing
+`matchCanonicalAuthoringMarkerFamily` unchanged) every byte-exact
+canonical match that is not the newest for its family, exactly as the
+opportunistic per-post step above does. Attempt this once per target
+here, and once more on the anchor immediately before the release-complete
+preflight below; this is the sweep the contract depends on, but
+"mandatory" means **attempted**, not blocking -- a failed attempt
+(permission error, an unreadable comment list, or an unavailable helper
+runtime) skips silently and never stops release, matching the
+opportunistic step's own best-effort framing.
+`src/scripts/audit-authored-issue.mts`'s
+`authoring-marker-minimization-backlog` check, given the same paginated
+comment data, reports the count of eligible-but-not-yet-minimized markers
+mechanically, so a skipped or failed sweep attempt becomes a visible,
+countable signal instead of silence.
+
+If a valid
 current-owner/set `mode=release` marker already exists, reuse the earliest
 matching GitHub comment ID; otherwise append one with `supersedes` equal to
 the current owner token, re-fetch to verify it, and record its comment ID.
@@ -1215,8 +1253,13 @@ non-anchor
 labels one target at a time and re-fetch each result. After the
 final anchor label removal is verified, re-fetch every target and verify its
 current release marker, absent label, and expected body snapshot; any drift
-leaves the set open and prevents completion. Then reuse or append the
-anchor-only
+leaves the set open and prevents completion. Immediately before the
+release-complete reuse-or-append decision below, repeat the same
+mandatory sweep once more on the anchor's own owner-marker log and the
+journal's publication-intent log -- idempotent with every earlier
+target's own sweep above, since a comment either was already minimized
+or was not yet the newest for its family either way. Then reuse or
+append the anchor-only
 `mode=release-complete` marker and record its comment ID. Reconcile that ID
 and the paginated anchor log with bounded retries; a successful POST or
 verification timeout is inconclusive. If the trusted marker is found, keep

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -1313,16 +1313,30 @@ the set or roll back the close already recorded above.
 of the three sweep attempts in this section (per-target preflight,
 anchor-before-release-complete, and this closing sweep), run
 `audit-authored-issue.mjs`'s `authoring-marker-minimization-backlog`
-check against the same paginated owner-marker/journal data just fetched
-for that sweep (`--comments-file`/`--journal-comments-file`, or
-`auditAuthoredIssue()` directly) and note its reported count. A nonzero
-count immediately after a sweep attempt means that attempt did not fully
-clear the backlog it was supposed to (a partial permission failure, an
-untrusted-authored candidate the sweep correctly declined to touch, or a
-genuine defect) -- record it, but never block release on it; this is the
-mechanical signal that makes a skipped or partially-failed sweep attempt
-visible instead of silent, the way #2750/#2821's original
-per-post-only instruction's gap went unnoticed for weeks.
+check and note its reported count -- always with `--trusted-marker-logins`
+(or the equivalent `trustedMarkerActors` option on `auditAuthoredIssue()`)
+set to the same trusted actors the sweep itself used, so the check's own
+eligibility rule matches what the sweep could actually clear; omitting
+it makes the count overstate the real backlog by including
+untrusted-authored matches the sweep was never going to touch.
+
+**Feed it the sweep's own post-mutation result, never the pre-mutation
+snapshot the sweep read.** The minimize helper mutates GitHub directly;
+it never updates an in-memory or on-disk comment snapshot. Before
+running the check, update the just-fetched snapshot's `isMinimized`
+field to `true` for every candidate the minimize helper's own report
+(`minimize-superseded-markers.mjs`'s `items[]`, keyed by subject id)
+lists with `status: "applied"` -- or re-fetch the paginated log fresh --
+before auditing; running the check against the unmodified pre-mutation
+snapshot reports every comment the sweep just minimized as still-
+outstanding backlog, making even a fully successful sweep look like it
+failed. A nonzero count after this update means the sweep attempt
+genuinely did not fully clear the backlog it was supposed to (a partial
+permission failure or a genuine defect) -- record it, but never block
+release on it; this is the mechanical signal that makes a skipped or
+partially-failed sweep attempt visible instead of silent, the same kind
+of gap that went unnoticed for weeks in the original per-post-only
+instruction this section replaces (measured effectiveness cited above).
 
 ### Narrow auto-release exception (review-fix-loop-cutoff)
 

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -1334,7 +1334,7 @@ untrusted-authored matches the sweep was never going to touch.
 (#2896 review, Codex): the paginated GitHub REST/GraphQL response this
 section already fetches exposes a comment's author nested as
 `user.login` (REST) or `author.login` (GraphQL), never as a flat
-`author` string -- write each entry's `--comments-file`/
+`author` string -- write each entry's `--comments-file` /
 `--journal-comments-file` JSON with `author` set to that nested login,
 not passed through unmapped. Skipping this normalization does not
 error: every comment silently loses its author, the trust filter above

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -1222,12 +1222,12 @@ preflight below; this is the sweep the contract depends on, but
 "mandatory" means **attempted**, not blocking -- a failed attempt
 (permission error, an unreadable comment list, or an unavailable helper
 runtime) skips silently and never stops release, matching the
-opportunistic step's own best-effort framing.
-`src/scripts/audit-authored-issue.mts`'s
-`authoring-marker-minimization-backlog` check, given the same paginated
-comment data, reports the count of eligible-but-not-yet-minimized markers
-mechanically, so a skipped or failed sweep attempt becomes a visible,
-countable signal instead of silence.
+opportunistic step's own best-effort framing. See the
+[Closing sweep](#closing-sweep-after-stage-2-closes-2896-review-codex)
+section below for the third sweep point this preflight sweep alone does
+not cover, and for the explicit `authoring-marker-minimization-backlog`
+invocation that makes each sweep attempt's outcome a visible, countable
+signal instead of silence.
 
 If a valid
 current-owner/set `mode=release` marker already exists, reuse the earliest
@@ -1288,6 +1288,41 @@ authorizes IDD execution for the released issues. Do it only as part
 of that explicit release request, or the narrow auto-release exception
 below; nothing else removes the label or starts Discover, Claim, and
 Work on its own.
+
+### Closing sweep (after Stage 2 closes, #2896 review, Codex)
+
+The two sweep points above run _before_ Stage 2's own later marker
+appends for the same generation -- the per-target `release` marker, the
+pre-label-removal heartbeat each target receives immediately before its
+own label removal, and (on the anchor) `release-guard` and
+`release-complete` itself. None of those markers exist yet when their
+target's preflight sweep runs, so the preflight sweep(s) alone can never
+clear them, and a target's Stage 2 for a given generation runs only
+once -- there is no future preflight sweep that would ever revisit them.
+Once the set-level release actually closes (the successful-close branch
+above: the trusted `release-complete` marker is found and every label is
+confirmed absent), attempt the mandatory sweep one more time: paginate
+every target's now-final owner-marker log (the anchor's included this
+time, not just its own) and the journal's publication-intent log, and
+minimize every byte-exact canonical match that is not the newest for its
+family, exactly as the preflight sweeps above do. Same
+attempted-not-blocking framing: a failed attempt here does not reopen
+the set or roll back the close already recorded above.
+
+**Make every sweep attempt's outcome visible.** Immediately after each
+of the three sweep attempts in this section (per-target preflight,
+anchor-before-release-complete, and this closing sweep), run
+`audit-authored-issue.mjs`'s `authoring-marker-minimization-backlog`
+check against the same paginated owner-marker/journal data just fetched
+for that sweep (`--comments-file`/`--journal-comments-file`, or
+`auditAuthoredIssue()` directly) and note its reported count. A nonzero
+count immediately after a sweep attempt means that attempt did not fully
+clear the backlog it was supposed to (a partial permission failure, an
+untrusted-authored candidate the sweep correctly declined to touch, or a
+genuine defect) -- record it, but never block release on it; this is the
+mechanical signal that makes a skipped or partially-failed sweep attempt
+visible instead of silent, the way #2750/#2821's original
+per-post-only instruction's gap went unnoticed for weeks.
 
 ### Narrow auto-release exception (review-fix-loop-cutoff)
 

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -1371,6 +1371,23 @@ partially-failed sweep attempt visible instead of silent, the same kind
 of gap that went unnoticed for weeks in the original per-post-only
 instruction this section replaces (measured effectiveness cited above).
 
+**When the backlog check itself cannot run, record that fact through a
+runtime-independent path (#2896 review, Codex).** The check depends on
+the same paginated comment snapshot and the same helper runtime
+(Node.js) as the sweep it audits, so the one scenario this whole
+mechanism exists to catch -- the sweep silently skipped because the
+helper runtime is unavailable (`instructions-only` profile, or Node.js
+absent), or because the paginated comment fetch itself failed -- is
+exactly the scenario in which the mechanical count also cannot run,
+leaving no signal at all if nothing else is done. When either the sweep
+or the audit could not run for this reason, still post an explicit
+plain-text note through a path that needs no helper runtime (a
+`gh`/HTTP comment on the target, or the session's own live status
+digest) -- for example "hide-on-supersede sweep skipped this cycle:
+helper runtime unavailable" -- naming the reason. This never blocks
+release either; it only ensures a fully-silent skip never happens even
+in the one failure mode the mechanical signal cannot itself cover.
+
 ### Narrow auto-release exception (review-fix-loop-cutoff)
 
 A follow-up issue whose body carried the exact marker

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -1216,7 +1216,27 @@ session's own records, and minimize (classifier `OUTDATED`, via the
 existing `minimize-superseded-markers.mjs`, reusing
 `matchCanonicalAuthoringMarkerFamily` unchanged) every byte-exact
 canonical match that is not the newest **trusted-actor** match for its
-family, exactly as the opportunistic per-post step above does. Determine
+family, exactly as the opportunistic per-post step above does.
+
+**Fetch that paginated log via GraphQL, never a plain REST
+issue-comments fetch, and skip an already-minimized candidate before
+submitting it** (#2896 review, Codex): a GraphQL `issueComments` /
+`comments` query can select `isMinimized` on each node directly, while
+REST's issue-comments endpoint never carries that field at all, so a
+REST-fetched snapshot cannot distinguish a comment this sweep already
+cleared from one it never touched. Use that field to exclude any
+candidate already `isMinimized: true` **before** it ever reaches the
+minimize helper's `--subject-ids`, not only when auditing the result
+afterward. Without this, every historical byte-exact canonical comment
+on a long-lived shared journal (one can accumulate hundreds over time)
+gets resubmitted to `minimize-superseded-markers.mjs` on every single
+sweep invocation across every target, and that helper probes each
+subject ID serially with no overall deadline -- a degraded GitHub API
+can then consume its per-call timeout once per historical comment and
+stall release for many minutes despite the attempted-not-blocking
+framing below.
+
+Determine
 "newest" only among candidates from a trusted marker actor (#2896
 review, Codex), never from every structural match indiscriminately --
 an untrusted actor's byte-exact canonical comment posted after the real
@@ -1357,9 +1377,15 @@ the opportunistic per-post step already cleared), and counts exactly the
 same as a fresh `"applied"` for this update: both mean the comment is
 minimized now, regardless of which attempt did it. Missing either status
 keeps that comment's snapshot entry wrongly `isMinimized: false`.
-Re-fetching the paginated log fresh is an acceptable alternative to this
-snapshot update, not merely a fallback -- either one produces the same
-accurate post-sweep state. Skipping both and auditing the unmodified
+Re-fetching the paginated log fresh **via GraphQL** (matching the
+sweep's own fetch above) is an acceptable alternative to this snapshot
+update, not merely a fallback -- either one produces the same accurate
+post-sweep state. A REST re-fetch is not a valid alternative here
+(#2896 review, Codex): REST's issue-comments endpoint never carries
+`isMinimized` at all, so a REST re-fetch is exactly as blind to
+minimization state as the stale pre-mutation snapshot this paragraph
+exists to correct -- it produces a different but equally wrong
+snapshot, not an accurate one. Skipping both and auditing the unmodified
 pre-mutation snapshot reports every comment the sweep (or a prior one)
 already minimized as still-outstanding backlog, making even a fully
 successful, fully idempotent sweep look like it failed. A nonzero count

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -1236,6 +1236,16 @@ can then consume its per-call timeout once per historical comment and
 stall release for many minutes despite the attempted-not-blocking
 framing below.
 
+**Also pass `--deadline-ms`** (#2896 review, Codex, round 8) to every
+`minimize-superseded-markers.mjs` invocation this sweep makes -- for
+example `--deadline-ms 300000` (five minutes) -- as a second,
+independent bound: the `isMinimized` pre-filter above only skips
+already-cleared candidates cheaply, but a first-ever sweep of a large
+backlog can still submit many genuinely-not-yet-minimized candidates
+that each cost a real GitHub API round-trip, and without
+`--deadline-ms` each one can individually consume the helper's own
+per-call timeout with no overall cap.
+
 Determine
 "newest" only among candidates from a trusted marker actor (#2896
 review, Codex), never from every structural match indiscriminately --

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -1326,12 +1326,22 @@ it never updates an in-memory or on-disk comment snapshot. Before
 running the check, update the just-fetched snapshot's `isMinimized`
 field to `true` for every candidate the minimize helper's own report
 (`minimize-superseded-markers.mjs`'s `items[]`, keyed by subject id)
-lists with `status: "applied"` -- or re-fetch the paginated log fresh --
-before auditing; running the check against the unmodified pre-mutation
-snapshot reports every comment the sweep just minimized as still-
-outstanding backlog, making even a fully successful sweep look like it
-failed. A nonzero count after this update means the sweep attempt
-genuinely did not fully clear the backlog it was supposed to (a partial
+lists with **either** `status: "applied"` **or** `status: "skipped",
+reason: "already-minimized"` -- the latter fires whenever the fetched
+snapshot's own `isMinimized` was already stale or absent for a comment
+GitHub already considers minimized (for example one an earlier sweep or
+the opportunistic per-post step already cleared), and counts exactly the
+same as a fresh `"applied"` for this update: both mean the comment is
+minimized now, regardless of which attempt did it. Missing either status
+keeps that comment's snapshot entry wrongly `isMinimized: false`.
+Re-fetching the paginated log fresh is an acceptable alternative to this
+snapshot update, not merely a fallback -- either one produces the same
+accurate post-sweep state. Skipping both and auditing the unmodified
+pre-mutation snapshot reports every comment the sweep (or a prior one)
+already minimized as still-outstanding backlog, making even a fully
+successful, fully idempotent sweep look like it failed. A nonzero count
+after this update means the sweep attempt genuinely did not fully clear
+the backlog it was supposed to (a partial
 permission failure or a genuine defect) -- record it, but never block
 release on it; this is the mechanical signal that makes a skipped or
 partially-failed sweep attempt visible instead of silent, the same kind

--- a/idd-template/scripts/minimize-superseded-markers.mjs
+++ b/idd-template/scripts/minimize-superseded-markers.mjs
@@ -137,6 +137,7 @@ if (import.meta.main) {
     trustedSet,
     apply: args.apply,
     allowUntrusted: args.allowUntrusted,
+    deadlineMs: args.deadlineMs,
   });
   report.trustedMarkerActors = [...trustedSet].sort();
   report.trustedMarkerActorsSource = trustedMarkerActorsSource;
@@ -634,6 +635,7 @@ function parseMinimizeArgs(argv) {
       // the genuinely-absent case.
       'trusted-marker-logins': { type: 'string', default: '' },
       format: { type: 'string', default: 'json' },
+      'deadline-ms': { type: 'string' },
     },
     strict: true,
   });
@@ -646,6 +648,34 @@ function parseMinimizeArgs(argv) {
       throw new Error(`--${flag} requires a value`);
     }
   }
+  // --deadline-ms is optional (undefined keeps runMinimize's pre-existing
+  // unbounded behavior) but, when given, must be a non-negative integer --
+  // this file stays self-contained (see the module header comment on
+  // loadIddConfig) so it cannot reuse cli-args.mts's canonical-integer
+  // helper; the same rejection shape as the flags above (a bare "requires
+  // a value"-style error, not a silent NaN) is reproduced by hand here.
+  // `0` is deliberately accepted, not just `>= 1`: runMinimize() gives it a
+  // specific, well-defined meaning of its own (the budget reads exhausted
+  // immediately at every checkpoint except the very first candidate's own
+  // probe, which still falls back to the un-throttled default timeout --
+  // see runMinimize's own deadlineMs doc comment and its "review round 2"
+  // test) -- a real degenerate-but-legitimate input, not an off-by-one
+  // edge case to reject. `^(?:0|[1-9]\d*)$` accepts exactly "0" or a
+  // non-zero-leading positive integer -- the same no-leading-zero idiom
+  // REST_SHAPED_SUBJECT_ID_PATTERN above already uses -- so "00"/"007" are
+  // still rejected as malformed rather than silently parsed.
+  let deadlineMs;
+  if (values['deadline-ms'] !== undefined) {
+    if (
+      values['deadline-ms'] === '' ||
+      !/^(?:0|[1-9]\d*)$/.test(values['deadline-ms'])
+    ) {
+      throw new Error(
+        '--deadline-ms must be a non-negative integer (milliseconds)',
+      );
+    }
+    deadlineMs = Number.parseInt(values['deadline-ms'], 10);
+  }
   return {
     subjectIds: (values['subject-ids'] ?? '')
       .split(',')
@@ -657,10 +687,11 @@ function parseMinimizeArgs(argv) {
     allowUntrusted: values['allow-untrusted'] ?? false,
     format: values.format ?? 'json',
     help: values.help ?? false,
+    deadlineMs,
   };
 }
 function printUsage() {
-  console.log(`Usage: minimize-superseded-markers --subject-ids <id1,id2,...> [--classifier OUTDATED|RESOLVED] [--trusted-marker-logins login1,login2] [--allow-untrusted] [--apply] [--format json|table]
+  console.log(`Usage: minimize-superseded-markers --subject-ids <id1,id2,...> [--classifier OUTDATED|RESOLVED] [--trusted-marker-logins login1,login2] [--allow-untrusted] [--apply] [--format json|table] [--deadline-ms <milliseconds>]
 
 The trusted-author gate is mandatory by default: supply trusted logins
 via --trusted-marker-logins, IDD_TRUSTED_MARKER_ACTORS, or the
@@ -674,5 +705,13 @@ verified the subject IDs are operationally safe to hide.
 IC_kwDOSWpaqs8AAAABIk9VAg), not REST numeric IDs (e.g. 4870591746).
 Convert a REST ID to its node ID first, using the command for the
 subject type:
-${NODE_ID_CONVERSION_COMMANDS}`);
+${NODE_ID_CONVERSION_COMMANDS}
+
+--deadline-ms bounds the whole pass to an overall wall-clock budget
+(non-negative integer milliseconds); omit it to keep the default unbounded
+behavior. Without it, a degraded GitHub API can stall the whole
+invocation for up to ~60s per candidate (a probe call plus an apply
+call, each capped at 30s) with no overall cap -- pass it for any
+invocation over a large or untrusted-source candidate list, such as a
+release-time sweep over a long-lived shared journal's full history.`);
 }

--- a/idd-template/scripts/minimize-superseded-markers.mjs
+++ b/idd-template/scripts/minimize-superseded-markers.mjs
@@ -652,24 +652,30 @@ function parseMinimizeArgs(argv) {
   // unbounded behavior) but, when given, must be a non-negative integer --
   // this file stays self-contained (see the module header comment on
   // loadIddConfig) so it cannot reuse cli-args.mts's canonical-integer
-  // helper; the same rejection shape as the flags above (a bare "requires
-  // a value"-style error, not a silent NaN) is reproduced by hand here.
-  // `0` is deliberately accepted, not just `>= 1`: runMinimize() gives it a
-  // specific, well-defined meaning of its own (the budget reads exhausted
-  // immediately at every checkpoint except the very first candidate's own
-  // probe, which still falls back to the un-throttled default timeout --
-  // see runMinimize's own deadlineMs doc comment and its "review round 2"
-  // test) -- a real degenerate-but-legitimate input, not an off-by-one
-  // edge case to reject. `^(?:0|[1-9]\d*)$` accepts exactly "0" or a
-  // non-zero-leading positive integer -- the same no-leading-zero idiom
-  // REST_SHAPED_SUBJECT_ID_PATTERN above already uses -- so "00"/"007" are
-  // still rejected as malformed rather than silently parsed.
+  // helper. `0` is deliberately accepted, not just `>= 1`: runMinimize()
+  // gives it a specific, well-defined meaning of its own (the budget
+  // reads exhausted immediately at every checkpoint except the very
+  // first candidate's own probe, which still falls back to the
+  // un-throttled default timeout -- see runMinimize's own deadlineMs doc
+  // comment and its "review round 2" test) -- a real
+  // degenerate-but-legitimate input, not an off-by-one edge case to
+  // reject. `^(?:0|[1-9]\d*)$` accepts exactly "0" or a non-zero-leading
+  // positive integer -- the same no-leading-zero idiom
+  // REST_SHAPED_SUBJECT_ID_PATTERN above already uses -- so "00"/"007"
+  // are still rejected as malformed rather than silently parsed.
   let deadlineMs;
   if (values['deadline-ms'] !== undefined) {
-    if (
-      values['deadline-ms'] === '' ||
-      !/^(?:0|[1-9]\d*)$/.test(values['deadline-ms'])
-    ) {
+    // An explicit empty value (--deadline-ms='' or --deadline-ms=) gets
+    // its own branch, reproducing the exact "requires a value" shape the
+    // other flags above use (#2896 review, Copilot, round 9): folding it
+    // into the malformed-value branch below would report "must be a
+    // non-negative integer" for an input that is not malformed so much
+    // as simply absent, an inconsistent and less actionable message for
+    // that specific case.
+    if (values['deadline-ms'] === '') {
+      throw new Error('--deadline-ms requires a value');
+    }
+    if (!/^(?:0|[1-9]\d*)$/.test(values['deadline-ms'])) {
       throw new Error(
         '--deadline-ms must be a non-negative integer (milliseconds)',
       );

--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -13,11 +13,15 @@
 // the roadmap shape's `## Tracks` checkbox lines actually resolving to a
 // child issue reference, the roadmap-id/blocked-by dependency-marker
 // rules, visible/hidden line agreement for the suitability and effort
-// footers, and an advisory warning-severity check that flags an issue/PR
+// footers, an advisory warning-severity check that flags an issue/PR
 // reference used near coordination language (e.g. "before", "once",
 // "requires") with no corresponding Blocked-by/Depends-on/task-list
-// dependency encoding. The advisory check never fails the report or
-// changes the exit code — see checkProseOnlyDependency.
+// dependency encoding (see checkProseOnlyDependency), and (given
+// pre-fetched comment data) a mechanical count of eligible,
+// not-yet-minimized superseded authoring-owner / authoring-publication-intent
+// marker comments (see checkAuthoringMarkerMinimizationBacklog, #2896).
+// Every advisory/count-only check always reports `result: 'pass'` and
+// never changes the exit code.
 //
 // All marker value parsing is delegated to the existing
 // autopilot-suitability.mts / effort.mts / marker-regex.mts /
@@ -47,6 +51,7 @@ import {
 } from './idd-config.mjs';
 import { stripMarkdownCodeRegions } from './markdown-code.mjs';
 import {
+  matchCanonicalAuthoringMarkerFamily,
   parseAuthoringOwnerComment,
   parseAuthoringPublicationComment,
   parseAuthoringPublicationIntentComment,
@@ -357,10 +362,13 @@ if (import.meta.main) {
  * Audit a drafted issue body against the issue-authoring contract's
  * structural expectations for the declared shape. Every check runs
  * independently (no short-circuit), so one report surfaces every problem
- * at once instead of stopping at the first failure. One check
- * (`prose-dependency`) is advisory-only: it always reports `result:
- * 'pass'` and only ever adds a `severity: 'warning'` marker plus detail,
- * so it never affects `passed` or the caller's exit code.
+ * at once instead of stopping at the first failure. Three checks
+ * (`prose-dependency`, `roadmap-tracks-parse`, and
+ * `authoring-marker-minimization-backlog`) are advisory-only: each
+ * always reports `result: 'pass'` and only ever adds a `severity:
+ * 'warning'` marker plus detail on the specific condition it flags, so
+ * none of the three ever affects `passed` or the caller's exit code. See
+ * {@link AuditFinding.severity}.
  */
 export function auditAuthoredIssue(body, options) {
   const rawText = typeof body === 'string' ? body : String(body ?? '');
@@ -429,6 +437,7 @@ export function auditAuthoredIssue(body, options) {
     checkEffortVisibleLineAgreement(text, markerPrefix),
     checkProseOnlyDependency(text, normalizeCurrentRepo(options.currentRepo)),
     checkAuthoringOwnerMarkerTrail(text, markerPrefix, labels, options),
+    checkAuthoringMarkerMinimizationBacklog(markerPrefix, options),
     checkUpstreamCandidateMarkerLabel(
       text,
       markerPrefix,
@@ -1376,6 +1385,148 @@ function checkAuthoringOwnerMarkerTrail(text, markerPrefix, labels, options) {
     'owner-marker, publication-token line, and journal publication-intent record are all present and well-formed',
   );
 }
+/**
+ * Counts how many entries in `comments` are byte-exact canonical
+ * renderings of `family` (#2896) and are not the single newest such match
+ * -- mirroring the "skip the just-posted comment itself" rule the
+ * hide-on-supersede sweep (`skills/issue-authoring/references/
+ * contract.md`'s "Authoring hold and release" section) already applies.
+ * "Newest" is the last matching entry in array order: callers are
+ * expected to supply comments in GitHub's deterministic
+ * `created_at`-then-id order. This is the first **order-dependent**
+ * comment-aware check in this file -- unlike
+ * {@link checkAuthoringOwnerMarkerTrail}, which uses order-independent
+ * `.some()`/`.every()` scans, this function's result changes if the input
+ * order changes. `AuthoringCommentInput.createdAt` is accepted but never
+ * consulted here to verify or sort by ascending order; a caller that
+ * supplies comments out of order gets a silently wrong count, not a
+ * detected error.
+ *
+ * `family` is matched against the RAW `comment.body` (never
+ * `stripMarkdownCodeRegions`-masked): unlike the structural checks above,
+ * this count exists to mirror exactly what the live hide-on-supersede
+ * sweep would find on the real, unmodified comment body -- a body this
+ * function would treat as canonical only by first stripping content out
+ * of it is not actually byte-exact against what
+ * `matchCanonicalAuthoringMarkerFamily` would see live.
+ *
+ * A match whose `isMinimized` is already `true` is excluded from the
+ * count -- it is not backlog, it is already handled. Returns `0` when
+ * `comments` is `undefined` (the caller, {@link
+ * checkAuthoringMarkerMinimizationBacklog}, reports that family as "not
+ * checked" rather than treating this `0` as a confirmed zero) or when
+ * fewer than two matches exist (nothing can be "superseded" without a
+ * later match to supersede it).
+ */
+function countEligibleSupersededMarkers(comments, markerPrefix, family) {
+  if (comments === undefined) {
+    return 0;
+  }
+  const matchIndexes = [];
+  comments.forEach((comment, index) => {
+    if (
+      matchCanonicalAuthoringMarkerFamily(comment.body, markerPrefix) === family
+    ) {
+      matchIndexes.push(index);
+    }
+  });
+  if (matchIndexes.length < 2) {
+    return 0;
+  }
+  const newestIndex = matchIndexes[matchIndexes.length - 1];
+  let count = 0;
+  for (const index of matchIndexes) {
+    if (index === newestIndex || comments[index].isMinimized === true) {
+      continue;
+    }
+    count += 1;
+  }
+  return count;
+}
+/**
+ * Reports how many `authoring-owner` (from {@link AuditOptions.comments})
+ * and `authoring-publication-intent` (from
+ * {@link AuditOptions.journalComments}) comments are eligible for the
+ * hide-on-supersede sweep but not yet minimized (#2896). This is the
+ * mechanical observability signal the issue-authoring contract's release-
+ * time sweep depends on to make a compliance gap visible instead of
+ * silent, the way #2750/#2821's original per-post-only instruction's gap
+ * went unnoticed for weeks (measured 2026-09-11: 3 of 95 expected-
+ * hideable comments across 22 sampled issues, about 3%).
+ *
+ * Always reports `result: 'pass'` -- a nonzero backlog is surfaced as a
+ * `severity: 'warning'` finding, never a hard failure: the same body can
+ * be re-audited at any point in an issue's lifecycle (not only
+ * immediately after the Stage 2 sweep runs), and the journal issue's own
+ * backlog accumulates across every authoring set that shares it, so a
+ * strict fail here would block an unrelated publish on backlog this
+ * session did not create. Not applicable (as a whole) when the caller
+ * supplies neither `comments` nor `journalComments` -- unlike
+ * `authoring-owner-marker-trail`, this check is never gated on the
+ * authoring label: the backlog it counts exists (or does not) regardless
+ * of whether the audited body currently carries that label.
+ *
+ * **Per-family "not checked" vs "checked, zero found" (#2896 review).**
+ * `comments` and `journalComments` are independently optional: a caller
+ * may supply only one. The `detail` text always names both families and
+ * distinguishes an omitted family ("not checked") from one that was
+ * supplied and found to have zero backlog ("0") -- collapsing the two
+ * into a bare `0` would misreport "never actually counted" as "counted,
+ * found none", which is exactly the kind of silent gap this check exists
+ * to surface. `total` (and therefore whether this finding carries
+ * `severity: 'warning'`) sums only the families actually checked; an
+ * omitted family never contributes a phantom `0` to that sum.
+ */
+function checkAuthoringMarkerMinimizationBacklog(markerPrefix, options) {
+  const id = 'authoring-marker-minimization-backlog';
+  const name =
+    'Eligible, not-yet-minimized superseded authoring-owner / authoring-publication-intent marker count';
+  const ownerChecked = options.comments !== undefined;
+  const intentChecked = options.journalComments !== undefined;
+  if (!ownerChecked && !intentChecked) {
+    return pass(
+      id,
+      name,
+      'not applicable: neither comments nor journalComments were supplied to this check',
+    );
+  }
+  const ownerBacklog = ownerChecked
+    ? countEligibleSupersededMarkers(
+        options.comments,
+        markerPrefix,
+        'authoring-owner',
+      )
+    : null;
+  const publicationIntentBacklog = intentChecked
+    ? countEligibleSupersededMarkers(
+        options.journalComments,
+        markerPrefix,
+        'authoring-publication-intent',
+      )
+    : null;
+  const total = (ownerBacklog ?? 0) + (publicationIntentBacklog ?? 0);
+  const ownerPart = ownerChecked
+    ? `authoring-owner: ${ownerBacklog}`
+    : 'authoring-owner: not checked (comments not supplied)';
+  const intentPart = intentChecked
+    ? `authoring-publication-intent: ${publicationIntentBacklog}`
+    : 'authoring-publication-intent: not checked (journalComments not supplied)';
+  const breakdown = `${ownerPart}, ${intentPart}`;
+  if (total === 0) {
+    return pass(
+      id,
+      name,
+      `no eligible, not-yet-minimized superseded marker comments found among the checked families (${breakdown})`,
+    );
+  }
+  return {
+    id,
+    name,
+    result: 'pass',
+    severity: 'warning',
+    detail: `${total} eligible, not-yet-minimized superseded marker comment(s) found among the checked families (${breakdown}) -- run the Stage 2 release-time hide-on-supersede sweep to clear the backlog`,
+  };
+}
 // An empty or whitespace-only currentRepo (reachable via an explicit
 // `--current-repo ''`, or an environment where `$GITHUB_REPOSITORY`
 // resolves to an empty string) must be treated the same as it being
@@ -1912,10 +2063,10 @@ function fail(id, name, detail) {
 }
 /**
  * Read and JSON-parse a comments file (an array of
- * `{body, author?, createdAt?}` objects) the same uncaught-throw-on-
- * malformed-input way `--body-file` already behaves: a missing file or
- * invalid JSON propagates as an unhandled exception rather than a new
- * soft-degrade path this file does not otherwise have.
+ * `{body, author?, createdAt?, isMinimized?}` objects) the same
+ * uncaught-throw-on-malformed-input way `--body-file` already behaves: a
+ * missing file or invalid JSON propagates as an unhandled exception
+ * rather than a new soft-degrade path this file does not otherwise have.
  */
 function readCommentsFile(path) {
   const raw = readFileSync(resolve(process.cwd(), path), 'utf8');
@@ -1933,6 +2084,9 @@ function readCommentsFile(path) {
       ...(typeof record.author === 'string' ? { author: record.author } : {}),
       ...(typeof record.createdAt === 'string'
         ? { createdAt: record.createdAt }
+        : {}),
+      ...(typeof record.isMinimized === 'boolean'
+        ? { isMinimized: record.isMinimized }
         : {}),
     };
   });
@@ -1964,9 +2118,20 @@ function main() {
   ) {
     fail_('--expect-bucket must be needs-decision or blocked-by-human');
   }
-  if (args.journalCommentsFile && !args.newIssue) {
-    fail_('--journal-comments-file requires --new-issue');
-  }
+  // #2896 review: --journal-comments-file no longer requires --new-issue.
+  // It used to (the only consumer was the new-issue publication-intent
+  // cross-check), but authoring-marker-minimization-backlog also reads
+  // journalComments unconditionally, and that check's whole point is to
+  // run at Stage 2 release on an already-published (never new) issue --
+  // requiring --new-issue here made the CLI unable to reach the exact
+  // invocation shape the issue-authoring contract's release-time sweep
+  // documents. Dropping this gate does not change
+  // authoring-owner-marker-trail's own behavior: it already no-ops the
+  // journal cross-check whenever --new-issue is absent (`options.newIssue
+  // !== true` returns early before journalComments is ever read), so
+  // journalComments passed without --new-issue is simply unused by that
+  // check, exactly as before.
+  //
   // Supplying journal data with no --comments-file would silently produce
   // a misleading pass: the owner-marker check (a prerequisite for even
   // reaching the journal cross-check) reports "not applicable" without
@@ -2163,11 +2328,15 @@ section headings for the declared shape, the roadmap-id/blocked-by
 dependency-marker rules, visible/hidden suitability+effort line
 agreement, and an advisory (warning-severity only) check that flags an
 issue/PR reference used near coordination language with no corresponding
-dependency marker, and (when --comments-file is supplied) the
+dependency marker, (when --comments-file is supplied) the
 authoring-owner-marker-trail check that verifies an authoring-labeled
-issue carries the owner-marker/publication-token trail. Exits 0 when
-every check passes, 1 when any check fails, 2 on a usage error; the
-advisory check never affects the exit code.
+issue carries the owner-marker/publication-token trail, and (when
+--comments-file and/or --journal-comments-file is supplied) the
+authoring-marker-minimization-backlog check that counts eligible,
+not-yet-minimized superseded authoring-owner / authoring-publication-intent
+marker comments. Exits 0 when every check passes, 1 when any check fails,
+2 on a usage error; the advisory check and
+authoring-marker-minimization-backlog never affect the exit code.
 
 Options:
   --shape <orphan|roadmap|child>   declared issue shape (required)
@@ -2198,13 +2367,24 @@ Options:
                                     target match (requires --current-repo or
                                     $GITHUB_REPOSITORY to be resolvable)
   --comments-file <path>           JSON array of this issue's pre-fetched comments
-                                    ({body, author?, createdAt?}); enables
-                                    authoring-owner-marker-trail (network-free: this
-                                    module never fetches comments itself)
+                                    ({body, author?, createdAt?, isMinimized?});
+                                    enables authoring-owner-marker-trail and the
+                                    authoring-owner half of
+                                    authoring-marker-minimization-backlog
+                                    (network-free: this module never fetches
+                                    comments itself; isMinimized defaults to
+                                    "not minimized" when omitted)
   --journal-comments-file <path>   JSON array of the journal issue's pre-fetched
-                                    comments, for the new-issue publication-intent
-                                    cross-check (requires --new-issue and
-                                    --comments-file)
+                                    comments (same shape as --comments-file);
+                                    requires --comments-file. Feeds the
+                                    authoring-publication-intent half of
+                                    authoring-marker-minimization-backlog on its
+                                    own (usable without --new-issue -- for
+                                    example, at Stage 2 release on an
+                                    already-published issue), and additionally
+                                    feeds the new-issue publication-intent
+                                    cross-check when --new-issue and --issue
+                                    are also given
   --new-issue                      this issue was just created in this invocation
                                     (not an edit); requires the leading
                                     authoring-publication body line, and (when

--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -58,6 +58,7 @@ import {
 } from './marker-helpers.mjs';
 import { createMarkerRegex, escapeRegex } from './marker-regex.mjs';
 import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mjs';
+import { resolveTrustedMarkerActors } from './protocol-helpers.mjs';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
 // Shared "skip" detail for every ready-shape-only check when
@@ -314,6 +315,7 @@ const AUDIT_AUTHORED_ISSUE_FLAG_SPEC = {
   '--comments-file': { type: 'string' },
   '--journal-comments-file': { type: 'string' },
   '--new-issue': { type: 'boolean', default: false },
+  '--trusted-marker-logins': { type: 'string' },
   '--format': { type: 'string', default: 'json' },
 };
 // Declared here (alongside the flag spec above), not next to
@@ -1411,14 +1413,30 @@ function checkAuthoringOwnerMarkerTrail(text, markerPrefix, labels, options) {
  * `matchCanonicalAuthoringMarkerFamily` would see live.
  *
  * A match whose `isMinimized` is already `true` is excluded from the
- * count -- it is not backlog, it is already handled. Returns `0` when
- * `comments` is `undefined` (the caller, {@link
- * checkAuthoringMarkerMinimizationBacklog}, reports that family as "not
- * checked" rather than treating this `0` as a confirmed zero) or when
- * fewer than two matches exist (nothing can be "superseded" without a
- * later match to supersede it).
+ * count -- it is not backlog, it is already handled. When
+ * `trustedActors` is provided (#2896 review, Codex), a match whose
+ * `comment.author` is missing or not a case-insensitive member of that
+ * set is also excluded from the count: `minimize-superseded-markers.mts`
+ * and the documented sweep both require a trusted marker actor
+ * regardless of body match, so an untrusted-author match is never
+ * actually clearable and must not inflate this "eligible" count. This
+ * filter applies only to eligibility, never to which match is
+ * "newest" -- the newest determination stays purely structural (see
+ * above) so an untrusted-author comment can still correctly supersede
+ * an earlier trusted one. `trustedActors` left `undefined` disables this
+ * filter entirely (backward-compatible: every match counts regardless
+ * of author). Returns `0` when `comments` is `undefined` (the caller,
+ * {@link checkAuthoringMarkerMinimizationBacklog}, reports that family
+ * as "not checked" rather than treating this `0` as a confirmed zero) or
+ * when fewer than two matches exist (nothing can be "superseded" without
+ * a later match to supersede it).
  */
-function countEligibleSupersededMarkers(comments, markerPrefix, family) {
+function countEligibleSupersededMarkers(
+  comments,
+  markerPrefix,
+  family,
+  trustedActors,
+) {
   if (comments === undefined) {
     return 0;
   }
@@ -1438,6 +1456,15 @@ function countEligibleSupersededMarkers(comments, markerPrefix, family) {
   for (const index of matchIndexes) {
     if (index === newestIndex || comments[index].isMinimized === true) {
       continue;
+    }
+    if (trustedActors !== undefined) {
+      const author = comments[index].author;
+      if (
+        typeof author !== 'string' ||
+        !trustedActors.has(author.toLowerCase())
+      ) {
+        continue;
+      }
     }
     count += 1;
   }
@@ -1490,11 +1517,18 @@ function checkAuthoringMarkerMinimizationBacklog(markerPrefix, options) {
       'not applicable: neither comments nor journalComments were supplied to this check',
     );
   }
+  const trustedActors =
+    options.trustedMarkerActors === undefined
+      ? undefined
+      : new Set(
+          options.trustedMarkerActors.map((actor) => actor.toLowerCase()),
+        );
   const ownerBacklog = ownerChecked
     ? countEligibleSupersededMarkers(
         options.comments,
         markerPrefix,
         'authoring-owner',
+        trustedActors,
       )
     : null;
   const publicationIntentBacklog = intentChecked
@@ -1502,6 +1536,7 @@ function checkAuthoringMarkerMinimizationBacklog(markerPrefix, options) {
         options.journalComments,
         markerPrefix,
         'authoring-publication-intent',
+        trustedActors,
       )
     : null;
   const total = (ownerBacklog ?? 0) + (publicationIntentBacklog ?? 0);
@@ -1511,7 +1546,11 @@ function checkAuthoringMarkerMinimizationBacklog(markerPrefix, options) {
   const intentPart = intentChecked
     ? `authoring-publication-intent: ${publicationIntentBacklog}`
     : 'authoring-publication-intent: not checked (journalComments not supplied)';
-  const breakdown = `${ownerPart}, ${intentPart}`;
+  const trustNote =
+    trustedActors === undefined
+      ? ' [not author-trust-filtered: pass trustedMarkerActors for an accurate count]'
+      : '';
+  const breakdown = `${ownerPart}, ${intentPart}${trustNote}`;
   if (total === 0) {
     return pass(
       id,
@@ -2171,6 +2210,16 @@ function main() {
   }
   const policy = loadPolicy(args.configPath);
   const markerPrefix = args.markerPrefix ?? policy.markerPrefix;
+  // Same flag/env/config precedence every other resolveTrustedMarkerActors
+  // caller in this codebase uses (#2896 review, Codex): an empty
+  // resolution (no flag/env/config trusted actors configured) leaves
+  // authoring-marker-minimization-backlog's trust filter disabled, the
+  // same as omitting --trusted-marker-logins entirely.
+  const { actors: trustedMarkerActors } = resolveTrustedMarkerActors({
+    flagValue: args.trustedMarkerLogins ?? '',
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
+    config: policy.rawConfig,
+  });
   const report = auditAuthoredIssue(bodyText, {
     shape: args.shape,
     markerPrefix,
@@ -2190,6 +2239,12 @@ function main() {
       : undefined,
     newIssue: args.newIssue,
     upstreamEscalationEnabled: policy.upstreamEscalationEnabled,
+    // An empty resolution (no flag/env/config trusted actors found) is
+    // "trust unknown," not "no one is trusted" -- pass `undefined` so
+    // authoring-marker-minimization-backlog's trust filter stays
+    // disabled (permissive) rather than zeroing out every count.
+    trustedMarkerActors:
+      trustedMarkerActors.length > 0 ? trustedMarkerActors : undefined,
   });
   writeReport(report, args.format);
   process.exit(report.passed ? 0 : 1);
@@ -2249,6 +2304,7 @@ function loadPolicy(configPath) {
       needsDecisionLabelName: POLICY_DEFAULTS.labels.needsDecisionLabelName,
       authoringLabelName: POLICY_DEFAULTS.issueAuthoring.authoringLabelName,
       upstreamEscalationEnabled: false,
+      rawConfig: null,
     };
   }
   return {
@@ -2260,6 +2316,7 @@ function loadPolicy(configPath) {
     authoringLabelName:
       normalizePolicyConfig(config).issueAuthoring.authoringLabelName,
     upstreamEscalationEnabled: isUpstreamEscalationEnabled(config),
+    rawConfig: config,
   };
 }
 function writeReport(report, format) {
@@ -2314,6 +2371,7 @@ function parseArgs(argv) {
     commentsFile: values['comments-file'],
     journalCommentsFile: values['journal-comments-file'],
     newIssue: values['new-issue'],
+    trustedMarkerLogins: values['trusted-marker-logins'],
     format,
   };
 }
@@ -2390,8 +2448,20 @@ Options:
                                     authoring-publication body line, and (when
                                     --comments-file is also given) requires
                                     --journal-comments-file and --issue too
+  --trusted-marker-logins <csv>    comma-separated trusted GitHub actor logins
+                                    (flag > $IDD_TRUSTED_MARKER_ACTORS >
+                                    .github/idd/config.json's trustedMarkerActors);
+                                    filters authoring-marker-minimization-backlog's
+                                    count to comments from a trusted actor, matching
+                                    minimize-superseded-markers.mjs's own trust gate.
+                                    Omitted or empty leaves that count unfiltered
+                                    (every check above this one is unaffected)
   --format <json|table>            output format (default: json)
   --help                           show this help
+
+Environment:
+  IDD_TRUSTED_MARKER_ACTORS        comma-separated trusted actor logins, used when
+                                    --trusted-marker-logins is not given (see above)
 `);
 }
 function fail_(message) {

--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -1412,24 +1412,34 @@ function checkAuthoringOwnerMarkerTrail(text, markerPrefix, labels, options) {
  * of it is not actually byte-exact against what
  * `matchCanonicalAuthoringMarkerFamily` would see live.
  *
- * A match whose `isMinimized` is already `true` is excluded from the
- * count -- it is not backlog, it is already handled. When
- * `trustedActors` is provided (#2896 review, Codex), a match whose
+ * When `trustedActors` is provided (#2896 review, Codex), a match whose
  * `comment.author` is missing or not a case-insensitive member of that
- * set is also excluded from the count: `minimize-superseded-markers.mts`
- * and the documented sweep both require a trusted marker actor
- * regardless of body match, so an untrusted-author match is never
- * actually clearable and must not inflate this "eligible" count. This
- * filter applies only to eligibility, never to which match is
- * "newest" -- the newest determination stays purely structural (see
- * above) so an untrusted-author comment can still correctly supersede
- * an earlier trusted one. `trustedActors` left `undefined` disables this
- * filter entirely (backward-compatible: every match counts regardless
- * of author). Returns `0` when `comments` is `undefined` (the caller,
- * {@link checkAuthoringMarkerMinimizationBacklog}, reports that family
- * as "not checked" rather than treating this `0` as a confirmed zero) or
- * when fewer than two matches exist (nothing can be "superseded" without
- * a later match to supersede it).
+ * set is excluded from the candidate set **before** "newest" is
+ * selected, not only from the eligible count: the contract states
+ * "syntax alone never grants ownership" (see [Per-target
+ * ownership](../../skills/issue-authoring/references/contract.md)), so
+ * an untrusted-author body -- even a byte-exact canonical one -- is
+ * never treated as a real marker for either purpose. An earlier
+ * revision filtered trust only for eligibility, which let a trailing
+ * untrusted-author match steal "newest" status from the legitimate
+ * trusted marker just before it, wrongly reporting that trusted marker
+ * as superseded backlog (round 2 of review, Codex: the fix for the
+ * `minimize-superseded-markers.mts`/documented-sweep trust
+ * requirement -- round 1 -- did not go far enough). `trustedActors` left
+ * `undefined` disables this filter entirely (backward-compatible: every
+ * byte-exact match counts as a candidate regardless of author, matching
+ * pre-#2896-review behavior).
+ *
+ * A candidate match whose `isMinimized` is already `true` is excluded
+ * from the eligible count -- it is not backlog, it is already handled
+ * (this exclusion is unaffected by trust filtering: it applies to
+ * whichever candidate set survives the trust filter above). Returns `0`
+ * when `comments` is `undefined` (the caller, {@link
+ * checkAuthoringMarkerMinimizationBacklog}, reports that family as "not
+ * checked" rather than treating this `0` as a confirmed zero) or when
+ * fewer than two (trust-filtered, when applicable) candidates exist
+ * (nothing can be "superseded" without a later candidate to supersede
+ * it).
  */
 function countEligibleSupersededMarkers(
   comments,
@@ -1443,10 +1453,23 @@ function countEligibleSupersededMarkers(
   const matchIndexes = [];
   comments.forEach((comment, index) => {
     if (
-      matchCanonicalAuthoringMarkerFamily(comment.body, markerPrefix) === family
+      matchCanonicalAuthoringMarkerFamily(comment.body, markerPrefix) !== family
     ) {
-      matchIndexes.push(index);
+      return;
     }
+    if (trustedActors !== undefined) {
+      const author = comment.author;
+      if (
+        typeof author !== 'string' ||
+        !trustedActors.has(author.toLowerCase())
+      ) {
+        // Not a real candidate at all when a trust set is supplied:
+        // never counted, and never eligible to be selected as "newest"
+        // either -- syntax alone never grants ownership.
+        return;
+      }
+    }
+    matchIndexes.push(index);
   });
   if (matchIndexes.length < 2) {
     return 0;
@@ -1456,15 +1479,6 @@ function countEligibleSupersededMarkers(
   for (const index of matchIndexes) {
     if (index === newestIndex || comments[index].isMinimized === true) {
       continue;
-    }
-    if (trustedActors !== undefined) {
-      const author = comments[index].author;
-      if (
-        typeof author !== 'string' ||
-        !trustedActors.has(author.toLowerCase())
-      ) {
-        continue;
-      }
     }
     count += 1;
   }

--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -2185,14 +2185,17 @@ function main() {
   // journalComments passed without --new-issue is simply unused by that
   // check, exactly as before.
   //
-  // Supplying journal data with no --comments-file would silently produce
-  // a misleading pass: the owner-marker check (a prerequisite for even
-  // reaching the journal cross-check) reports "not applicable" without
-  // --comments-file, so the journal data would never actually be consulted
-  // (#2628 review, Copilot).
-  if (args.journalCommentsFile && !args.commentsFile) {
-    fail_('--journal-comments-file requires --comments-file');
-  }
+  // #2896 review (round 3, Codex): --journal-comments-file also no longer
+  // requires --comments-file. It used to (#2628 review, Copilot): without
+  // --comments-file, authoring-owner-marker-trail's journal cross-check
+  // was unreachable, so journal data alone would go unconsulted by that
+  // ONE check -- but that check already reports "not applicable" (never a
+  // false compliant pass) whenever --comments-file is absent, with or
+  // without this gate, and authoring-marker-minimization-backlog's own
+  // publication-intent half now consults journalComments completely on
+  // its own. Requiring --comments-file here made the CLI advertise
+  // "--comments-file and/or --journal-comments-file" in its own --help
+  // text while actually rejecting the journal-only half of that "or".
   // Without this, a new-issue check with real owner-marker evidence but no
   // journal data would report "not applicable" for the journal half and
   // still exit 0 -- a misleading success for the AC's combined
@@ -2447,16 +2450,17 @@ Options:
                                     comments itself; isMinimized defaults to
                                     "not minimized" when omitted)
   --journal-comments-file <path>   JSON array of the journal issue's pre-fetched
-                                    comments (same shape as --comments-file);
-                                    requires --comments-file. Feeds the
-                                    authoring-publication-intent half of
-                                    authoring-marker-minimization-backlog on its
-                                    own (usable without --new-issue -- for
-                                    example, at Stage 2 release on an
-                                    already-published issue), and additionally
-                                    feeds the new-issue publication-intent
-                                    cross-check when --new-issue and --issue
-                                    are also given
+                                    comments (same shape as --comments-file).
+                                    Feeds the authoring-publication-intent half
+                                    of authoring-marker-minimization-backlog on
+                                    its own -- usable standalone, without
+                                    --comments-file or --new-issue (for example,
+                                    to audit only the shared journal's backlog at
+                                    Stage 2 release on an already-published
+                                    issue) -- and additionally feeds the
+                                    new-issue publication-intent cross-check
+                                    when --comments-file, --new-issue, and
+                                    --issue are also given
   --new-issue                      this issue was just created in this invocation
                                     (not an edit); requires the leading
                                     authoring-publication body line, and (when

--- a/scripts/minimize-superseded-markers.mjs
+++ b/scripts/minimize-superseded-markers.mjs
@@ -137,6 +137,7 @@ if (import.meta.main) {
     trustedSet,
     apply: args.apply,
     allowUntrusted: args.allowUntrusted,
+    deadlineMs: args.deadlineMs,
   });
   report.trustedMarkerActors = [...trustedSet].sort();
   report.trustedMarkerActorsSource = trustedMarkerActorsSource;
@@ -634,6 +635,7 @@ function parseMinimizeArgs(argv) {
       // the genuinely-absent case.
       'trusted-marker-logins': { type: 'string', default: '' },
       format: { type: 'string', default: 'json' },
+      'deadline-ms': { type: 'string' },
     },
     strict: true,
   });
@@ -646,6 +648,34 @@ function parseMinimizeArgs(argv) {
       throw new Error(`--${flag} requires a value`);
     }
   }
+  // --deadline-ms is optional (undefined keeps runMinimize's pre-existing
+  // unbounded behavior) but, when given, must be a non-negative integer --
+  // this file stays self-contained (see the module header comment on
+  // loadIddConfig) so it cannot reuse cli-args.mts's canonical-integer
+  // helper; the same rejection shape as the flags above (a bare "requires
+  // a value"-style error, not a silent NaN) is reproduced by hand here.
+  // `0` is deliberately accepted, not just `>= 1`: runMinimize() gives it a
+  // specific, well-defined meaning of its own (the budget reads exhausted
+  // immediately at every checkpoint except the very first candidate's own
+  // probe, which still falls back to the un-throttled default timeout --
+  // see runMinimize's own deadlineMs doc comment and its "review round 2"
+  // test) -- a real degenerate-but-legitimate input, not an off-by-one
+  // edge case to reject. `^(?:0|[1-9]\d*)$` accepts exactly "0" or a
+  // non-zero-leading positive integer -- the same no-leading-zero idiom
+  // REST_SHAPED_SUBJECT_ID_PATTERN above already uses -- so "00"/"007" are
+  // still rejected as malformed rather than silently parsed.
+  let deadlineMs;
+  if (values['deadline-ms'] !== undefined) {
+    if (
+      values['deadline-ms'] === '' ||
+      !/^(?:0|[1-9]\d*)$/.test(values['deadline-ms'])
+    ) {
+      throw new Error(
+        '--deadline-ms must be a non-negative integer (milliseconds)',
+      );
+    }
+    deadlineMs = Number.parseInt(values['deadline-ms'], 10);
+  }
   return {
     subjectIds: (values['subject-ids'] ?? '')
       .split(',')
@@ -657,10 +687,11 @@ function parseMinimizeArgs(argv) {
     allowUntrusted: values['allow-untrusted'] ?? false,
     format: values.format ?? 'json',
     help: values.help ?? false,
+    deadlineMs,
   };
 }
 function printUsage() {
-  console.log(`Usage: minimize-superseded-markers --subject-ids <id1,id2,...> [--classifier OUTDATED|RESOLVED] [--trusted-marker-logins login1,login2] [--allow-untrusted] [--apply] [--format json|table]
+  console.log(`Usage: minimize-superseded-markers --subject-ids <id1,id2,...> [--classifier OUTDATED|RESOLVED] [--trusted-marker-logins login1,login2] [--allow-untrusted] [--apply] [--format json|table] [--deadline-ms <milliseconds>]
 
 The trusted-author gate is mandatory by default: supply trusted logins
 via --trusted-marker-logins, IDD_TRUSTED_MARKER_ACTORS, or the
@@ -674,5 +705,13 @@ verified the subject IDs are operationally safe to hide.
 IC_kwDOSWpaqs8AAAABIk9VAg), not REST numeric IDs (e.g. 4870591746).
 Convert a REST ID to its node ID first, using the command for the
 subject type:
-${NODE_ID_CONVERSION_COMMANDS}`);
+${NODE_ID_CONVERSION_COMMANDS}
+
+--deadline-ms bounds the whole pass to an overall wall-clock budget
+(non-negative integer milliseconds); omit it to keep the default unbounded
+behavior. Without it, a degraded GitHub API can stall the whole
+invocation for up to ~60s per candidate (a probe call plus an apply
+call, each capped at 30s) with no overall cap -- pass it for any
+invocation over a large or untrusted-source candidate list, such as a
+release-time sweep over a long-lived shared journal's full history.`);
 }

--- a/scripts/minimize-superseded-markers.mjs
+++ b/scripts/minimize-superseded-markers.mjs
@@ -652,24 +652,30 @@ function parseMinimizeArgs(argv) {
   // unbounded behavior) but, when given, must be a non-negative integer --
   // this file stays self-contained (see the module header comment on
   // loadIddConfig) so it cannot reuse cli-args.mts's canonical-integer
-  // helper; the same rejection shape as the flags above (a bare "requires
-  // a value"-style error, not a silent NaN) is reproduced by hand here.
-  // `0` is deliberately accepted, not just `>= 1`: runMinimize() gives it a
-  // specific, well-defined meaning of its own (the budget reads exhausted
-  // immediately at every checkpoint except the very first candidate's own
-  // probe, which still falls back to the un-throttled default timeout --
-  // see runMinimize's own deadlineMs doc comment and its "review round 2"
-  // test) -- a real degenerate-but-legitimate input, not an off-by-one
-  // edge case to reject. `^(?:0|[1-9]\d*)$` accepts exactly "0" or a
-  // non-zero-leading positive integer -- the same no-leading-zero idiom
-  // REST_SHAPED_SUBJECT_ID_PATTERN above already uses -- so "00"/"007" are
-  // still rejected as malformed rather than silently parsed.
+  // helper. `0` is deliberately accepted, not just `>= 1`: runMinimize()
+  // gives it a specific, well-defined meaning of its own (the budget
+  // reads exhausted immediately at every checkpoint except the very
+  // first candidate's own probe, which still falls back to the
+  // un-throttled default timeout -- see runMinimize's own deadlineMs doc
+  // comment and its "review round 2" test) -- a real
+  // degenerate-but-legitimate input, not an off-by-one edge case to
+  // reject. `^(?:0|[1-9]\d*)$` accepts exactly "0" or a non-zero-leading
+  // positive integer -- the same no-leading-zero idiom
+  // REST_SHAPED_SUBJECT_ID_PATTERN above already uses -- so "00"/"007"
+  // are still rejected as malformed rather than silently parsed.
   let deadlineMs;
   if (values['deadline-ms'] !== undefined) {
-    if (
-      values['deadline-ms'] === '' ||
-      !/^(?:0|[1-9]\d*)$/.test(values['deadline-ms'])
-    ) {
+    // An explicit empty value (--deadline-ms='' or --deadline-ms=) gets
+    // its own branch, reproducing the exact "requires a value" shape the
+    // other flags above use (#2896 review, Copilot, round 9): folding it
+    // into the malformed-value branch below would report "must be a
+    // non-negative integer" for an input that is not malformed so much
+    // as simply absent, an inconsistent and less actionable message for
+    // that specific case.
+    if (values['deadline-ms'] === '') {
+      throw new Error('--deadline-ms requires a value');
+    }
+    if (!/^(?:0|[1-9]\d*)$/.test(values['deadline-ms'])) {
       throw new Error(
         '--deadline-ms must be a non-negative integer (milliseconds)',
       );

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -1642,6 +1642,23 @@ only approval boundary.
   `matchCanonicalAuthoringMarkerFamily` unchanged) every byte-exact
   canonical match that is not the newest **trusted-actor** match for its
   family, exactly as the opportunistic per-post step above does.
+  **Fetch that paginated log via GraphQL, never a plain REST
+  issue-comments fetch, and skip an already-minimized candidate before
+  submitting it** (#2896 review, Codex): a GraphQL `issueComments` /
+  `comments` query can select `isMinimized` on each node directly,
+  while REST's issue-comments endpoint never carries that field at
+  all, so a REST-fetched snapshot cannot distinguish a comment this
+  sweep already cleared from one it never touched. Use that field to
+  exclude any candidate already `isMinimized: true` **before** it ever
+  reaches the minimize helper's `--subject-ids`, not only when
+  auditing the result afterward. Without this, every historical
+  byte-exact canonical comment on a long-lived shared journal (one can
+  accumulate hundreds over time) gets resubmitted to
+  `minimize-superseded-markers.mjs` on every single sweep invocation
+  across every target, and that helper probes each subject ID serially
+  with no overall deadline -- a degraded GitHub API can then consume
+  its per-call timeout once per historical comment and stall release
+  for many minutes despite the attempted-not-blocking framing below.
   Determine "newest" only among candidates from a trusted marker actor
   (#2896 review, Codex), never from every structural match
   indiscriminately -- an untrusted actor's byte-exact canonical comment
@@ -1775,9 +1792,16 @@ only approval boundary.
   cleared), and counts exactly the same as a fresh `"applied"` for this
   update: both mean the comment is minimized now, regardless of which
   attempt did it. Missing either status keeps that comment's snapshot
-  entry wrongly `isMinimized: false`. Re-fetching the paginated log fresh
-  is an acceptable alternative to this snapshot update, not merely a
+  entry wrongly `isMinimized: false`. Re-fetching the paginated log
+  fresh **via GraphQL** (matching the sweep's own fetch above) is an
+  acceptable alternative to this snapshot update, not merely a
   fallback -- either one produces the same accurate post-sweep state.
+  A REST re-fetch is not a valid alternative here (#2896 review,
+  Codex): REST's issue-comments endpoint never carries `isMinimized`
+  at all, so a REST re-fetch is exactly as blind to minimization state
+  as the stale pre-mutation snapshot this paragraph exists to correct
+  -- it produces a different but equally wrong snapshot, not an
+  accurate one.
   Skipping both and auditing the unmodified pre-mutation snapshot reports
   every comment the sweep (or a prior one) already minimized as
   still-outstanding backlog, making even a fully successful, fully

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -1790,6 +1790,23 @@ only approval boundary.
   instead of silent, the same kind of gap that went unnoticed for weeks
   in the original per-post-only instruction this section replaces
   (measured effectiveness cited above).
+
+  **When the backlog check itself cannot run, record that fact through a
+  runtime-independent path (#2896 review, Codex).** The check depends on
+  the same paginated comment snapshot and the same helper runtime
+  (Node.js) as the sweep it audits, so the one scenario this whole
+  mechanism exists to catch -- the sweep silently skipped because the
+  helper runtime is unavailable (`instructions-only` profile, or Node.js
+  absent), or because the paginated comment fetch itself failed -- is
+  exactly the scenario in which the mechanical count also cannot run,
+  leaving no signal at all if nothing else is done. When either the
+  sweep or the audit could not run for this reason, still post an
+  explicit plain-text note through a path that needs no helper runtime
+  (a `gh`/HTTP comment on the target, or the session's own live status
+  digest) -- for example "hide-on-supersede sweep skipped this cycle:
+  helper runtime unavailable" -- naming the reason. This never blocks
+  release either; it only ensures a fully-silent skip never happens even
+  in the one failure mode the mechanical signal cannot itself cover.
 - **Narrow auto-release exception (review-fix-loop-cutoff).** A
   follow-up issue whose body carried the exact marker
   `<!-- idd-skill-authoring-defer-source: review-fix-loop-cutoff -->` at

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -1743,11 +1743,22 @@ only approval boundary.
   snapshot. Before running the check, update the just-fetched snapshot's
   `isMinimized` field to `true` for every candidate the minimize
   helper's own report (`minimize-superseded-markers.mjs`'s `items[]`,
-  keyed by subject id) lists with `status: "applied"` -- or re-fetch the
-  paginated log fresh -- before auditing; running the check against the
-  unmodified pre-mutation snapshot reports every comment the sweep just
-  minimized as still-outstanding backlog, making even a fully successful
-  sweep look like it failed. A nonzero count after this update means the
+  keyed by subject id) lists with **either** `status: "applied"` **or**
+  `status: "skipped", reason: "already-minimized"` -- the latter fires
+  whenever the fetched snapshot's own `isMinimized` was already stale or
+  absent for a comment GitHub already considers minimized (for example
+  one an earlier sweep or the opportunistic per-post step already
+  cleared), and counts exactly the same as a fresh `"applied"` for this
+  update: both mean the comment is minimized now, regardless of which
+  attempt did it. Missing either status keeps that comment's snapshot
+  entry wrongly `isMinimized: false`. Re-fetching the paginated log fresh
+  is an acceptable alternative to this snapshot update, not merely a
+  fallback -- either one produces the same accurate post-sweep state.
+  Skipping both and auditing the unmodified pre-mutation snapshot reports
+  every comment the sweep (or a prior one) already minimized as
+  still-outstanding backlog, making even a fully successful, fully
+  idempotent sweep look like it failed. A nonzero count after this update
+  means the
   sweep attempt genuinely did not fully clear the backlog it was
   supposed to (a partial permission failure or a genuine defect) --
   record it, but never block release on it; this is the mechanical

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -1513,8 +1513,18 @@ only approval boundary.
   applies to `acquire`, `bootstrap`, `resume`, `release`,
   `release-guard`, or `release-complete` markers; only a `heartbeat`
   append may be skipped.
-- **Hide superseded owner/publication-intent markers.** Once a fresh
-  `authoring-owner` marker (any `mode`, including the first,
+- **Hide superseded owner/publication-intent markers.** Opportunistic:
+  see the mandatory Stage 2 sweep below for the mechanism this contract
+  actually relies on. Measured 2026-09-11 across 22 issues published
+  after this per-post step first shipped (#2750/#2821): of 95
+  expected-hideable `authoring-owner`/`authoring-publication-intent`
+  comments, only 3 (about 3%) were actually minimized (#2896). Following
+  this step in the moment is correct and still worth doing when
+  convenient -- every comment it hides is one the Stage 2 sweep below
+  does not have to -- but it is not something this contract can depend
+  on by itself: a step invoked 3-9+ times per issue, buried mid-protocol
+  with no mechanical enforcement, is too easy to skip under load. Once a
+  fresh `authoring-owner` marker (any `mode`, including the first,
   generation-opening `acquire`/`bootstrap`) or `authoring-publication-intent`
   record (any `state`) has been posted and its own POST and re-fetch/verify
   above have both succeeded -- never before, and never interleaved with
@@ -1567,8 +1577,11 @@ only approval boundary.
   `review-watermark`, `advisory-wait`; see `docs/idd-comment-minimization.md`).
   Do not add `authoring-owner`, `authoring-publication-intent`, or
   `authoring-publication` to `OPERATIONAL_MARKERS`, and do not fold this
-  step into the F4 driver: it is a separate, earlier-lifecycle,
-  hide-at-post-time behavior.
+  step or the Stage 2 sweep below into the F4 driver: minimization for
+  this marker family stays a separate, earlier-lifecycle behavior owned
+  by the issue-authoring protocol itself, not the post-merge cleanup
+  driver -- whether triggered opportunistically here or mandatorily at
+  Stage 2 release.
 - **Conflict check before every edit.** Immediately before each body or
   roadmap relationship update, re-fetch both the target and the set anchor
   (the same fresh snapshot serves both roles when the target is the anchor).
@@ -1618,6 +1631,28 @@ only approval boundary.
   exception below. Keep the set anchor held until every other
   target's label removal is verified, and remove the anchor label last. For
   every target, first re-fetch owner comments during release-marker preflight.
+  **Mandatory release-time hide-on-supersede sweep (#2896).** At this same
+  point -- before the reuse-or-append decision below, so a retried or
+  resumed release (which reuses an existing `release` marker and never
+  appends a new one) still runs the sweep every time this preflight step
+  is reached -- paginate the full owner-marker log this re-fetch just
+  retrieved, plus the publication-intent log for the journal named in
+  this session's own records, and minimize (classifier `OUTDATED`, via
+  the existing `minimize-superseded-markers.mjs`, reusing
+  `matchCanonicalAuthoringMarkerFamily` unchanged) every byte-exact
+  canonical match that is not the newest for its family, exactly as the
+  opportunistic per-post step above does. Attempt this once per target
+  here, and once more on the anchor immediately before the
+  release-complete preflight below; this is the sweep the contract
+  depends on, but "mandatory" means **attempted**, not
+  blocking -- a failed attempt (permission error, an unreadable comment
+  list, or an unavailable helper runtime) skips silently and never stops
+  release, matching the opportunistic step's own best-effort framing.
+  `audit-authored-issue.mjs`'s `authoring-marker-minimization-backlog`
+  check, given the same paginated comment data, reports the count of
+  eligible-but-not-yet-minimized markers mechanically, so a skipped or
+  failed sweep attempt becomes a visible, countable signal instead of
+  silence.
   If a valid current-owner/set `mode=release` marker already exists, reuse the
   earliest matching GitHub comment ID; otherwise append one with `supersedes`
   equal to the current owner token, re-fetch to verify it, and record its
@@ -1642,7 +1677,12 @@ only approval boundary.
   target at a time and re-fetch each result. After the final anchor label
   removal is verified, re-fetch every target and verify its current release
   marker, absent label, and expected body snapshot; any drift leaves the set
-  open and prevents completion. Then reuse the earliest
+  open and prevents completion. Immediately before the release-complete
+  reuse-or-append decision below, repeat the same mandatory sweep once
+  more on the anchor's own owner-marker log and the journal's
+  publication-intent log -- idempotent with every earlier target's own
+  sweep above, since a comment either was already minimized or was not
+  yet the newest for its family either way. Then reuse the earliest
   valid current-owner/set/session `mode=release-complete`
   marker on the anchor, or append one and record its returned comment ID.
   Re-fetch that ID and the anchor's paginated owner-marker log with bounded

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -1752,7 +1752,7 @@ only approval boundary.
   (#2896 review, Codex): the paginated GitHub REST/GraphQL response
   this section already fetches exposes a comment's author nested as
   `user.login` (REST) or `author.login` (GraphQL), never as a flat
-  `author` string -- write each entry's `--comments-file`/
+  `author` string -- write each entry's `--comments-file` /
   `--journal-comments-file` JSON with `author` set to that nested
   login, not passed through unmapped. Skipping this normalization does
   not error: every comment silently loses its author, the trust filter

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -1647,12 +1647,11 @@ only approval boundary.
   depends on, but "mandatory" means **attempted**, not
   blocking -- a failed attempt (permission error, an unreadable comment
   list, or an unavailable helper runtime) skips silently and never stops
-  release, matching the opportunistic step's own best-effort framing.
-  `audit-authored-issue.mjs`'s `authoring-marker-minimization-backlog`
-  check, given the same paginated comment data, reports the count of
-  eligible-but-not-yet-minimized markers mechanically, so a skipped or
-  failed sweep attempt becomes a visible, countable signal instead of
-  silence.
+  release, matching the opportunistic step's own best-effort framing. See
+  the **Closing sweep** bullet below for the third sweep point this
+  preflight sweep alone does not cover, and for the explicit
+  `authoring-marker-minimization-backlog` invocation that makes each
+  sweep attempt's outcome a visible, countable signal instead of silence.
   If a valid current-owner/set `mode=release` marker already exists, reuse the
   earliest matching GitHub comment ID; otherwise append one with `supersedes`
   equal to the current owner token, re-fetch to verify it, and record its
@@ -1708,6 +1707,41 @@ only approval boundary.
   record a set-level recovery hold and never claim a partial release. Release
   is a human action; nothing in this bundle auto-releases a held issue set,
   except the narrow, marker-scoped exception immediately below.
+- **Closing sweep (after Stage 2 closes, #2896 review, Codex).** The two
+  sweep points above run _before_ Stage 2's own later marker appends for
+  the same generation -- the per-target `release` marker, the
+  pre-label-removal heartbeat each target receives immediately before
+  its own label removal, and (on the anchor) `release-guard` and
+  `release-complete` itself. None of those markers exist yet when their
+  target's preflight sweep runs, so the preflight sweep(s) alone can
+  never clear them, and a target's Stage 2 for a given generation runs
+  only once -- there is no future preflight sweep that would ever
+  revisit them. Once the set-level release actually closes (the
+  successful-close branch immediately above: the trusted
+  `release-complete` marker is found and every label is confirmed
+  absent), attempt the mandatory sweep one more time: paginate every
+  target's now-final owner-marker log (the anchor's included this time,
+  not just its own) and the journal's publication-intent log, and
+  minimize every byte-exact canonical match that is not the newest for
+  its family, exactly as the preflight sweeps above do. Same
+  attempted-not-blocking framing: a failed attempt here does not reopen
+  the set or roll back the close already recorded above.
+
+  **Make every sweep attempt's outcome visible.** Immediately after each
+  of the three sweep attempts in this section (per-target preflight,
+  anchor-before-release-complete, and this closing sweep), run
+  `audit-authored-issue.mjs`'s `authoring-marker-minimization-backlog`
+  check against the same paginated owner-marker/journal data just
+  fetched for that sweep (`--comments-file`/`--journal-comments-file`,
+  or `auditAuthoredIssue()` directly) and note its reported count. A
+  nonzero count immediately after a sweep attempt means that attempt did
+  not fully clear the backlog it was supposed to (a partial permission
+  failure, an untrusted-authored candidate the sweep correctly declined
+  to touch, or a genuine defect) -- record it, but never block release
+  on it; this is the mechanical signal that makes a skipped or
+  partially-failed sweep attempt visible instead of silent, the way
+  #2750/#2821's original per-post-only instruction's gap went unnoticed
+  for weeks.
 - **Narrow auto-release exception (review-fix-loop-cutoff).** A
   follow-up issue whose body carried the exact marker
   `<!-- idd-skill-authoring-defer-source: review-fix-loop-cutoff -->` at

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -1659,6 +1659,16 @@ only approval boundary.
   with no overall deadline -- a degraded GitHub API can then consume
   its per-call timeout once per historical comment and stall release
   for many minutes despite the attempted-not-blocking framing below.
+  **Also pass `--deadline-ms`** (#2896 review, Codex, round 8) to
+  every `minimize-superseded-markers.mjs` invocation this sweep makes
+  -- for example `--deadline-ms 300000` (five minutes) -- as a second,
+  independent bound: the `isMinimized` pre-filter above only skips
+  already-cleared candidates cheaply, but a first-ever sweep of a
+  large backlog can still submit many genuinely-not-yet-minimized
+  candidates that each cost a real GitHub API round-trip, and without
+  `--deadline-ms` each one can individually consume the helper's own
+  per-call timeout with no overall cap.
+
   Determine "newest" only among candidates from a trusted marker actor
   (#2896 review, Codex), never from every structural match
   indiscriminately -- an untrusted actor's byte-exact canonical comment

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -1731,17 +1731,30 @@ only approval boundary.
   of the three sweep attempts in this section (per-target preflight,
   anchor-before-release-complete, and this closing sweep), run
   `audit-authored-issue.mjs`'s `authoring-marker-minimization-backlog`
-  check against the same paginated owner-marker/journal data just
-  fetched for that sweep (`--comments-file`/`--journal-comments-file`,
-  or `auditAuthoredIssue()` directly) and note its reported count. A
-  nonzero count immediately after a sweep attempt means that attempt did
-  not fully clear the backlog it was supposed to (a partial permission
-  failure, an untrusted-authored candidate the sweep correctly declined
-  to touch, or a genuine defect) -- record it, but never block release
-  on it; this is the mechanical signal that makes a skipped or
-  partially-failed sweep attempt visible instead of silent, the way
-  #2750/#2821's original per-post-only instruction's gap went unnoticed
-  for weeks.
+  check and note its reported count -- always with `--trusted-marker-logins`
+  (or the equivalent `trustedMarkerActors` option on `auditAuthoredIssue()`)
+  set to the same trusted actors the sweep itself used, so the check's
+  own eligibility rule matches what the sweep could actually clear;
+  omitting it makes the count overstate the real backlog by including
+  untrusted-authored matches the sweep was never going to touch.
+  **Feed it the sweep's own post-mutation result, never the
+  pre-mutation snapshot the sweep read.** The minimize helper mutates
+  GitHub directly; it never updates an in-memory or on-disk comment
+  snapshot. Before running the check, update the just-fetched snapshot's
+  `isMinimized` field to `true` for every candidate the minimize
+  helper's own report (`minimize-superseded-markers.mjs`'s `items[]`,
+  keyed by subject id) lists with `status: "applied"` -- or re-fetch the
+  paginated log fresh -- before auditing; running the check against the
+  unmodified pre-mutation snapshot reports every comment the sweep just
+  minimized as still-outstanding backlog, making even a fully successful
+  sweep look like it failed. A nonzero count after this update means the
+  sweep attempt genuinely did not fully clear the backlog it was
+  supposed to (a partial permission failure or a genuine defect) --
+  record it, but never block release on it; this is the mechanical
+  signal that makes a skipped or partially-failed sweep attempt visible
+  instead of silent, the same kind of gap that went unnoticed for weeks
+  in the original per-post-only instruction this section replaces
+  (measured effectiveness cited above).
 - **Narrow auto-release exception (review-fix-loop-cutoff).** A
   follow-up issue whose body carried the exact marker
   `<!-- idd-skill-authoring-defer-source: review-fix-loop-cutoff -->` at

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -1640,8 +1640,19 @@ only approval boundary.
   this session's own records, and minimize (classifier `OUTDATED`, via
   the existing `minimize-superseded-markers.mjs`, reusing
   `matchCanonicalAuthoringMarkerFamily` unchanged) every byte-exact
-  canonical match that is not the newest for its family, exactly as the
-  opportunistic per-post step above does. Attempt this once per target
+  canonical match that is not the newest **trusted-actor** match for its
+  family, exactly as the opportunistic per-post step above does.
+  Determine "newest" only among candidates from a trusted marker actor
+  (#2896 review, Codex), never from every structural match
+  indiscriminately -- an untrusted actor's byte-exact canonical comment
+  posted after the real newest trusted one must never be treated as the
+  thing to keep visible: `minimize-superseded-markers.mjs` itself
+  refuses to minimize any comment outside `--trusted-marker-logins`
+  regardless of this selection, so naively treating the untrusted
+  comment as newest would instead select the legitimate trusted marker
+  for minimization -- exactly backwards. This mirrors
+  `checkAuthoringMarkerMinimizationBacklog`'s own audit-side fix; keep
+  the two in sync. Attempt this once per target
   here, and once more on the anchor immediately before the
   release-complete preflight below; this is the sweep the contract
   depends on, but "mandatory" means **attempted**, not
@@ -1737,6 +1748,19 @@ only approval boundary.
   own eligibility rule matches what the sweep could actually clear;
   omitting it makes the count overstate the real backlog by including
   untrusted-authored matches the sweep was never going to touch.
+  **Normalize the author field before writing the comments-file JSON**
+  (#2896 review, Codex): the paginated GitHub REST/GraphQL response
+  this section already fetches exposes a comment's author nested as
+  `user.login` (REST) or `author.login` (GraphQL), never as a flat
+  `author` string -- write each entry's `--comments-file`/
+  `--journal-comments-file` JSON with `author` set to that nested
+  login, not passed through unmapped. Skipping this normalization does
+  not error: every comment silently loses its author, the trust filter
+  above then excludes every candidate as unknown-author, and the count
+  falsely reports zero backlog even when the sweep was skipped or
+  failed entirely -- the opposite failure mode from omitting
+  `--trusted-marker-logins` (that overstates; this understates to
+  nothing).
   **Feed it the sweep's own post-mutation result, never the
   pre-mutation snapshot the sweep read.** The minimize helper mutates
   GitHub directly; it never updates an in-memory or on-disk comment

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -2603,14 +2603,17 @@ function main(): void {
   // journalComments passed without --new-issue is simply unused by that
   // check, exactly as before.
   //
-  // Supplying journal data with no --comments-file would silently produce
-  // a misleading pass: the owner-marker check (a prerequisite for even
-  // reaching the journal cross-check) reports "not applicable" without
-  // --comments-file, so the journal data would never actually be consulted
-  // (#2628 review, Copilot).
-  if (args.journalCommentsFile && !args.commentsFile) {
-    fail_('--journal-comments-file requires --comments-file');
-  }
+  // #2896 review (round 3, Codex): --journal-comments-file also no longer
+  // requires --comments-file. It used to (#2628 review, Copilot): without
+  // --comments-file, authoring-owner-marker-trail's journal cross-check
+  // was unreachable, so journal data alone would go unconsulted by that
+  // ONE check -- but that check already reports "not applicable" (never a
+  // false compliant pass) whenever --comments-file is absent, with or
+  // without this gate, and authoring-marker-minimization-backlog's own
+  // publication-intent half now consults journalComments completely on
+  // its own. Requiring --comments-file here made the CLI advertise
+  // "--comments-file and/or --journal-comments-file" in its own --help
+  // text while actually rejecting the journal-only half of that "or".
   // Without this, a new-issue check with real owner-marker evidence but no
   // journal data would report "not applicable" for the journal half and
   // still exit 0 -- a misleading success for the AC's combined
@@ -2894,16 +2897,17 @@ Options:
                                     comments itself; isMinimized defaults to
                                     "not minimized" when omitted)
   --journal-comments-file <path>   JSON array of the journal issue's pre-fetched
-                                    comments (same shape as --comments-file);
-                                    requires --comments-file. Feeds the
-                                    authoring-publication-intent half of
-                                    authoring-marker-minimization-backlog on its
-                                    own (usable without --new-issue -- for
-                                    example, at Stage 2 release on an
-                                    already-published issue), and additionally
-                                    feeds the new-issue publication-intent
-                                    cross-check when --new-issue and --issue
-                                    are also given
+                                    comments (same shape as --comments-file).
+                                    Feeds the authoring-publication-intent half
+                                    of authoring-marker-minimization-backlog on
+                                    its own -- usable standalone, without
+                                    --comments-file or --new-issue (for example,
+                                    to audit only the shared journal's backlog at
+                                    Stage 2 release on an already-published
+                                    issue) -- and additionally feeds the
+                                    new-issue publication-intent cross-check
+                                    when --comments-file, --new-issue, and
+                                    --issue are also given
   --new-issue                      this issue was just created in this invocation
                                     (not an edit); requires the leading
                                     authoring-publication body line, and (when

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -13,11 +13,15 @@
 // the roadmap shape's `## Tracks` checkbox lines actually resolving to a
 // child issue reference, the roadmap-id/blocked-by dependency-marker
 // rules, visible/hidden line agreement for the suitability and effort
-// footers, and an advisory warning-severity check that flags an issue/PR
+// footers, an advisory warning-severity check that flags an issue/PR
 // reference used near coordination language (e.g. "before", "once",
 // "requires") with no corresponding Blocked-by/Depends-on/task-list
-// dependency encoding. The advisory check never fails the report or
-// changes the exit code — see checkProseOnlyDependency.
+// dependency encoding (see checkProseOnlyDependency), and (given
+// pre-fetched comment data) a mechanical count of eligible,
+// not-yet-minimized superseded authoring-owner / authoring-publication-intent
+// marker comments (see checkAuthoringMarkerMinimizationBacklog, #2896).
+// Every advisory/count-only check always reports `result: 'pass'` and
+// never changes the exit code.
 //
 // All marker value parsing is delegated to the existing
 // autopilot-suitability.mts / effort.mts / marker-regex.mts /
@@ -54,6 +58,7 @@ import type {
   ParsedAuthoringPublicationMarker,
 } from './marker-helpers.mts';
 import {
+  matchCanonicalAuthoringMarkerFamily,
   parseAuthoringOwnerComment,
   parseAuthoringPublicationComment,
   parseAuthoringPublicationIntentComment,
@@ -128,13 +133,17 @@ export interface AuditFinding {
   result: 'pass' | 'fail';
   detail: string;
   /**
-   * Present only on the advisory `prose-dependency` check when it flags a
-   * possible unencoded dependency. Deliberately separate from `result`
-   * (which stays `'pass'` for this check in every case): an advisory
-   * finding must never flip {@link AuditReport.passed} to `false` or change
-   * the CLI exit code, and keeping it a distinct optional field makes that
-   * true by construction instead of relying on a special case in the
-   * `passed` aggregation below.
+   * Present on an advisory finding that stays `result: 'pass'` but still
+   * has something worth surfacing: `prose-dependency` (an unencoded
+   * dependency), `roadmap-tracks-parse` (an unresolved `## Tracks`
+   * checkbox line, #2765), and `authoring-marker-minimization-backlog` (a
+   * nonzero not-yet-minimized marker count, #2896). Deliberately separate
+   * from `result` (which stays `'pass'` for every one of these checks in
+   * every case): an advisory finding must never flip
+   * {@link AuditReport.passed} to `false` or change the CLI exit code, and
+   * keeping it a distinct optional field makes that true by construction
+   * instead of relying on a special case in the `passed` aggregation
+   * below.
    */
   severity?: 'warning';
 }
@@ -270,13 +279,25 @@ export interface AuditOptions {
 }
 
 /** One pre-fetched comment, as supplied to {@link AuditOptions.comments} and
- * {@link AuditOptions.journalComments}. Only `body` is inspected today;
- * `author`/`createdAt` are accepted for forward compatibility with a future
- * trust/recency check but currently unused. */
+ * {@link AuditOptions.journalComments}. `body` is inspected by every
+ * comment-aware check; `isMinimized` is inspected only by
+ * `authoring-marker-minimization-backlog` (#2896); `author`/`createdAt` are
+ * accepted for forward compatibility with a future trust/recency check but
+ * currently unused. */
 export interface AuthoringCommentInput {
   body: string;
   author?: string;
   createdAt?: string;
+  /**
+   * Whether GitHub already reports this comment as minimized (the same
+   * `isMinimized` field the GraphQL `node(id:)` probe in
+   * `minimize-superseded-markers.mts` reads). Omitted or `false` is treated
+   * as "not minimized" -- the fail-closed default for an observability
+   * count: a caller that does not know a comment's minimization state must
+   * not silently undercount the backlog `authoring-marker-minimization-
+   * backlog` reports.
+   */
+  isMinimized?: boolean;
 }
 
 interface HeadingRequirement {
@@ -568,10 +589,13 @@ if (import.meta.main) {
  * Audit a drafted issue body against the issue-authoring contract's
  * structural expectations for the declared shape. Every check runs
  * independently (no short-circuit), so one report surfaces every problem
- * at once instead of stopping at the first failure. One check
- * (`prose-dependency`) is advisory-only: it always reports `result:
- * 'pass'` and only ever adds a `severity: 'warning'` marker plus detail,
- * so it never affects `passed` or the caller's exit code.
+ * at once instead of stopping at the first failure. Three checks
+ * (`prose-dependency`, `roadmap-tracks-parse`, and
+ * `authoring-marker-minimization-backlog`) are advisory-only: each
+ * always reports `result: 'pass'` and only ever adds a `severity:
+ * 'warning'` marker plus detail on the specific condition it flags, so
+ * none of the three ever affects `passed` or the caller's exit code. See
+ * {@link AuditFinding.severity}.
  */
 export function auditAuthoredIssue(
   body: unknown,
@@ -645,6 +669,7 @@ export function auditAuthoredIssue(
     checkEffortVisibleLineAgreement(text, markerPrefix),
     checkProseOnlyDependency(text, normalizeCurrentRepo(options.currentRepo)),
     checkAuthoringOwnerMarkerTrail(text, markerPrefix, labels, options),
+    checkAuthoringMarkerMinimizationBacklog(markerPrefix, options),
     checkUpstreamCandidateMarkerLabel(
       text,
       markerPrefix,
@@ -1667,6 +1692,157 @@ function checkAuthoringOwnerMarkerTrail(
   );
 }
 
+/**
+ * Counts how many entries in `comments` are byte-exact canonical
+ * renderings of `family` (#2896) and are not the single newest such match
+ * -- mirroring the "skip the just-posted comment itself" rule the
+ * hide-on-supersede sweep (`skills/issue-authoring/references/
+ * contract.md`'s "Authoring hold and release" section) already applies.
+ * "Newest" is the last matching entry in array order: callers are
+ * expected to supply comments in GitHub's deterministic
+ * `created_at`-then-id order. This is the first **order-dependent**
+ * comment-aware check in this file -- unlike
+ * {@link checkAuthoringOwnerMarkerTrail}, which uses order-independent
+ * `.some()`/`.every()` scans, this function's result changes if the input
+ * order changes. `AuthoringCommentInput.createdAt` is accepted but never
+ * consulted here to verify or sort by ascending order; a caller that
+ * supplies comments out of order gets a silently wrong count, not a
+ * detected error.
+ *
+ * `family` is matched against the RAW `comment.body` (never
+ * `stripMarkdownCodeRegions`-masked): unlike the structural checks above,
+ * this count exists to mirror exactly what the live hide-on-supersede
+ * sweep would find on the real, unmodified comment body -- a body this
+ * function would treat as canonical only by first stripping content out
+ * of it is not actually byte-exact against what
+ * `matchCanonicalAuthoringMarkerFamily` would see live.
+ *
+ * A match whose `isMinimized` is already `true` is excluded from the
+ * count -- it is not backlog, it is already handled. Returns `0` when
+ * `comments` is `undefined` (the caller, {@link
+ * checkAuthoringMarkerMinimizationBacklog}, reports that family as "not
+ * checked" rather than treating this `0` as a confirmed zero) or when
+ * fewer than two matches exist (nothing can be "superseded" without a
+ * later match to supersede it).
+ */
+function countEligibleSupersededMarkers(
+  comments: readonly AuthoringCommentInput[] | undefined,
+  markerPrefix: string,
+  family: 'authoring-owner' | 'authoring-publication-intent',
+): number {
+  if (comments === undefined) {
+    return 0;
+  }
+  const matchIndexes: number[] = [];
+  comments.forEach((comment, index) => {
+    if (
+      matchCanonicalAuthoringMarkerFamily(comment.body, markerPrefix) === family
+    ) {
+      matchIndexes.push(index);
+    }
+  });
+  if (matchIndexes.length < 2) {
+    return 0;
+  }
+  const newestIndex = matchIndexes[matchIndexes.length - 1];
+  let count = 0;
+  for (const index of matchIndexes) {
+    if (index === newestIndex || comments[index].isMinimized === true) {
+      continue;
+    }
+    count += 1;
+  }
+  return count;
+}
+
+/**
+ * Reports how many `authoring-owner` (from {@link AuditOptions.comments})
+ * and `authoring-publication-intent` (from
+ * {@link AuditOptions.journalComments}) comments are eligible for the
+ * hide-on-supersede sweep but not yet minimized (#2896). This is the
+ * mechanical observability signal the issue-authoring contract's release-
+ * time sweep depends on to make a compliance gap visible instead of
+ * silent, the way #2750/#2821's original per-post-only instruction's gap
+ * went unnoticed for weeks (measured 2026-09-11: 3 of 95 expected-
+ * hideable comments across 22 sampled issues, about 3%).
+ *
+ * Always reports `result: 'pass'` -- a nonzero backlog is surfaced as a
+ * `severity: 'warning'` finding, never a hard failure: the same body can
+ * be re-audited at any point in an issue's lifecycle (not only
+ * immediately after the Stage 2 sweep runs), and the journal issue's own
+ * backlog accumulates across every authoring set that shares it, so a
+ * strict fail here would block an unrelated publish on backlog this
+ * session did not create. Not applicable (as a whole) when the caller
+ * supplies neither `comments` nor `journalComments` -- unlike
+ * `authoring-owner-marker-trail`, this check is never gated on the
+ * authoring label: the backlog it counts exists (or does not) regardless
+ * of whether the audited body currently carries that label.
+ *
+ * **Per-family "not checked" vs "checked, zero found" (#2896 review).**
+ * `comments` and `journalComments` are independently optional: a caller
+ * may supply only one. The `detail` text always names both families and
+ * distinguishes an omitted family ("not checked") from one that was
+ * supplied and found to have zero backlog ("0") -- collapsing the two
+ * into a bare `0` would misreport "never actually counted" as "counted,
+ * found none", which is exactly the kind of silent gap this check exists
+ * to surface. `total` (and therefore whether this finding carries
+ * `severity: 'warning'`) sums only the families actually checked; an
+ * omitted family never contributes a phantom `0` to that sum.
+ */
+function checkAuthoringMarkerMinimizationBacklog(
+  markerPrefix: string,
+  options: AuditOptions,
+): AuditFinding {
+  const id = 'authoring-marker-minimization-backlog';
+  const name =
+    'Eligible, not-yet-minimized superseded authoring-owner / authoring-publication-intent marker count';
+  const ownerChecked = options.comments !== undefined;
+  const intentChecked = options.journalComments !== undefined;
+  if (!ownerChecked && !intentChecked) {
+    return pass(
+      id,
+      name,
+      'not applicable: neither comments nor journalComments were supplied to this check',
+    );
+  }
+  const ownerBacklog = ownerChecked
+    ? countEligibleSupersededMarkers(
+        options.comments,
+        markerPrefix,
+        'authoring-owner',
+      )
+    : null;
+  const publicationIntentBacklog = intentChecked
+    ? countEligibleSupersededMarkers(
+        options.journalComments,
+        markerPrefix,
+        'authoring-publication-intent',
+      )
+    : null;
+  const total = (ownerBacklog ?? 0) + (publicationIntentBacklog ?? 0);
+  const ownerPart = ownerChecked
+    ? `authoring-owner: ${ownerBacklog}`
+    : 'authoring-owner: not checked (comments not supplied)';
+  const intentPart = intentChecked
+    ? `authoring-publication-intent: ${publicationIntentBacklog}`
+    : 'authoring-publication-intent: not checked (journalComments not supplied)';
+  const breakdown = `${ownerPart}, ${intentPart}`;
+  if (total === 0) {
+    return pass(
+      id,
+      name,
+      `no eligible, not-yet-minimized superseded marker comments found among the checked families (${breakdown})`,
+    );
+  }
+  return {
+    id,
+    name,
+    result: 'pass',
+    severity: 'warning',
+    detail: `${total} eligible, not-yet-minimized superseded marker comment(s) found among the checked families (${breakdown}) -- run the Stage 2 release-time hide-on-supersede sweep to clear the backlog`,
+  };
+}
+
 // An empty or whitespace-only currentRepo (reachable via an explicit
 // `--current-repo ''`, or an environment where `$GITHUB_REPOSITORY`
 // resolves to an empty string) must be treated the same as it being
@@ -2275,10 +2451,10 @@ interface CliArgs {
 
 /**
  * Read and JSON-parse a comments file (an array of
- * `{body, author?, createdAt?}` objects) the same uncaught-throw-on-
- * malformed-input way `--body-file` already behaves: a missing file or
- * invalid JSON propagates as an unhandled exception rather than a new
- * soft-degrade path this file does not otherwise have.
+ * `{body, author?, createdAt?, isMinimized?}` objects) the same
+ * uncaught-throw-on-malformed-input way `--body-file` already behaves: a
+ * missing file or invalid JSON propagates as an unhandled exception
+ * rather than a new soft-degrade path this file does not otherwise have.
  */
 function readCommentsFile(path: string): AuthoringCommentInput[] {
   const raw = readFileSync(resolve(process.cwd(), path), 'utf8');
@@ -2291,6 +2467,7 @@ function readCommentsFile(path: string): AuthoringCommentInput[] {
       body?: unknown;
       author?: unknown;
       createdAt?: unknown;
+      isMinimized?: unknown;
     };
     if (typeof record?.body !== 'string') {
       throw new Error(`${path}[${index}] is missing a string "body" field`);
@@ -2300,6 +2477,9 @@ function readCommentsFile(path: string): AuthoringCommentInput[] {
       ...(typeof record.author === 'string' ? { author: record.author } : {}),
       ...(typeof record.createdAt === 'string'
         ? { createdAt: record.createdAt }
+        : {}),
+      ...(typeof record.isMinimized === 'boolean'
+        ? { isMinimized: record.isMinimized }
         : {}),
     };
   });
@@ -2336,9 +2516,20 @@ function main(): void {
   ) {
     fail_('--expect-bucket must be needs-decision or blocked-by-human');
   }
-  if (args.journalCommentsFile && !args.newIssue) {
-    fail_('--journal-comments-file requires --new-issue');
-  }
+  // #2896 review: --journal-comments-file no longer requires --new-issue.
+  // It used to (the only consumer was the new-issue publication-intent
+  // cross-check), but authoring-marker-minimization-backlog also reads
+  // journalComments unconditionally, and that check's whole point is to
+  // run at Stage 2 release on an already-published (never new) issue --
+  // requiring --new-issue here made the CLI unable to reach the exact
+  // invocation shape the issue-authoring contract's release-time sweep
+  // documents. Dropping this gate does not change
+  // authoring-owner-marker-trail's own behavior: it already no-ops the
+  // journal cross-check whenever --new-issue is absent (`options.newIssue
+  // !== true` returns early before journalComments is ever read), so
+  // journalComments passed without --new-issue is simply unused by that
+  // check, exactly as before.
+  //
   // Supplying journal data with no --comments-file would silently produce
   // a misleading pass: the owner-marker check (a prerequisite for even
   // reaching the journal cross-check) reports "not applicable" without
@@ -2556,11 +2747,15 @@ section headings for the declared shape, the roadmap-id/blocked-by
 dependency-marker rules, visible/hidden suitability+effort line
 agreement, and an advisory (warning-severity only) check that flags an
 issue/PR reference used near coordination language with no corresponding
-dependency marker, and (when --comments-file is supplied) the
+dependency marker, (when --comments-file is supplied) the
 authoring-owner-marker-trail check that verifies an authoring-labeled
-issue carries the owner-marker/publication-token trail. Exits 0 when
-every check passes, 1 when any check fails, 2 on a usage error; the
-advisory check never affects the exit code.
+issue carries the owner-marker/publication-token trail, and (when
+--comments-file and/or --journal-comments-file is supplied) the
+authoring-marker-minimization-backlog check that counts eligible,
+not-yet-minimized superseded authoring-owner / authoring-publication-intent
+marker comments. Exits 0 when every check passes, 1 when any check fails,
+2 on a usage error; the advisory check and
+authoring-marker-minimization-backlog never affect the exit code.
 
 Options:
   --shape <orphan|roadmap|child>   declared issue shape (required)
@@ -2591,13 +2786,24 @@ Options:
                                     target match (requires --current-repo or
                                     $GITHUB_REPOSITORY to be resolvable)
   --comments-file <path>           JSON array of this issue's pre-fetched comments
-                                    ({body, author?, createdAt?}); enables
-                                    authoring-owner-marker-trail (network-free: this
-                                    module never fetches comments itself)
+                                    ({body, author?, createdAt?, isMinimized?});
+                                    enables authoring-owner-marker-trail and the
+                                    authoring-owner half of
+                                    authoring-marker-minimization-backlog
+                                    (network-free: this module never fetches
+                                    comments itself; isMinimized defaults to
+                                    "not minimized" when omitted)
   --journal-comments-file <path>   JSON array of the journal issue's pre-fetched
-                                    comments, for the new-issue publication-intent
-                                    cross-check (requires --new-issue and
-                                    --comments-file)
+                                    comments (same shape as --comments-file);
+                                    requires --comments-file. Feeds the
+                                    authoring-publication-intent half of
+                                    authoring-marker-minimization-backlog on its
+                                    own (usable without --new-issue -- for
+                                    example, at Stage 2 release on an
+                                    already-published issue), and additionally
+                                    feeds the new-issue publication-intent
+                                    cross-check when --new-issue and --issue
+                                    are also given
   --new-issue                      this issue was just created in this invocation
                                     (not an edit); requires the leading
                                     authoring-publication body line, and (when

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -65,6 +65,7 @@ import {
 } from './marker-helpers.mts';
 import { createMarkerRegex, escapeRegex } from './marker-regex.mts';
 import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mts';
+import { resolveTrustedMarkerActors } from './protocol-helpers.mts';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
 
@@ -276,6 +277,24 @@ export interface AuditOptions {
    * this one) omits it and gets the pre-#2703 no-op behavior.
    */
   upstreamEscalationEnabled?: boolean;
+  /**
+   * Trusted marker actor logins (case-insensitive), used only by
+   * `authoring-marker-minimization-backlog` to filter its count to
+   * comments the live hide-on-supersede sweep could actually clear
+   * (#2896 review, Codex): `minimize-superseded-markers.mts` and the
+   * documented sweep both reject a comment from an actor outside this
+   * set regardless of how byte-exact its body is, so counting an
+   * untrusted-author match as "eligible" would overstate what the sweep
+   * can clear. When omitted, this check does not filter by author at
+   * all -- every check in this module stays network-free and has no
+   * independent way to resolve a trust policy on its own, so an omitted
+   * value is treated as "trust unknown, do not filter" rather than "no
+   * one is trusted" (which would instead silently zero out the count).
+   * `main()` resolves this the same flag/env/config way every other
+   * `resolveTrustedMarkerActors` caller in this codebase does; a direct
+   * (non-CLI) caller that wants an accurate count should supply it.
+   */
+  trustedMarkerActors?: readonly string[];
 }
 
 /** One pre-fetched comment, as supplied to {@link AuditOptions.comments} and
@@ -293,9 +312,9 @@ export interface AuthoringCommentInput {
    * `isMinimized` field the GraphQL `node(id:)` probe in
    * `minimize-superseded-markers.mts` reads). Omitted or `false` is treated
    * as "not minimized" -- the fail-closed default for an observability
-   * count: a caller that does not know a comment's minimization state must
-   * not silently undercount the backlog `authoring-marker-minimization-
-   * backlog` reports.
+   * count: a caller that does not know a comment's minimization state
+   * must not silently undercount the backlog
+   * `authoring-marker-minimization-backlog` reports.
    */
   isMinimized?: boolean;
 }
@@ -538,6 +557,7 @@ const AUDIT_AUTHORED_ISSUE_FLAG_SPEC = {
   '--comments-file': { type: 'string' },
   '--journal-comments-file': { type: 'string' },
   '--new-issue': { type: 'boolean', default: false },
+  '--trusted-marker-logins': { type: 'string' },
   '--format': { type: 'string', default: 'json' },
 } as const;
 
@@ -1718,17 +1738,29 @@ function checkAuthoringOwnerMarkerTrail(
  * `matchCanonicalAuthoringMarkerFamily` would see live.
  *
  * A match whose `isMinimized` is already `true` is excluded from the
- * count -- it is not backlog, it is already handled. Returns `0` when
- * `comments` is `undefined` (the caller, {@link
- * checkAuthoringMarkerMinimizationBacklog}, reports that family as "not
- * checked" rather than treating this `0` as a confirmed zero) or when
- * fewer than two matches exist (nothing can be "superseded" without a
- * later match to supersede it).
+ * count -- it is not backlog, it is already handled. When
+ * `trustedActors` is provided (#2896 review, Codex), a match whose
+ * `comment.author` is missing or not a case-insensitive member of that
+ * set is also excluded from the count: `minimize-superseded-markers.mts`
+ * and the documented sweep both require a trusted marker actor
+ * regardless of body match, so an untrusted-author match is never
+ * actually clearable and must not inflate this "eligible" count. This
+ * filter applies only to eligibility, never to which match is
+ * "newest" -- the newest determination stays purely structural (see
+ * above) so an untrusted-author comment can still correctly supersede
+ * an earlier trusted one. `trustedActors` left `undefined` disables this
+ * filter entirely (backward-compatible: every match counts regardless
+ * of author). Returns `0` when `comments` is `undefined` (the caller,
+ * {@link checkAuthoringMarkerMinimizationBacklog}, reports that family
+ * as "not checked" rather than treating this `0` as a confirmed zero) or
+ * when fewer than two matches exist (nothing can be "superseded" without
+ * a later match to supersede it).
  */
 function countEligibleSupersededMarkers(
   comments: readonly AuthoringCommentInput[] | undefined,
   markerPrefix: string,
   family: 'authoring-owner' | 'authoring-publication-intent',
+  trustedActors: ReadonlySet<string> | undefined,
 ): number {
   if (comments === undefined) {
     return 0;
@@ -1749,6 +1781,15 @@ function countEligibleSupersededMarkers(
   for (const index of matchIndexes) {
     if (index === newestIndex || comments[index].isMinimized === true) {
       continue;
+    }
+    if (trustedActors !== undefined) {
+      const author = comments[index].author;
+      if (
+        typeof author !== 'string' ||
+        !trustedActors.has(author.toLowerCase())
+      ) {
+        continue;
+      }
     }
     count += 1;
   }
@@ -1805,11 +1846,18 @@ function checkAuthoringMarkerMinimizationBacklog(
       'not applicable: neither comments nor journalComments were supplied to this check',
     );
   }
+  const trustedActors =
+    options.trustedMarkerActors === undefined
+      ? undefined
+      : new Set(
+          options.trustedMarkerActors.map((actor) => actor.toLowerCase()),
+        );
   const ownerBacklog = ownerChecked
     ? countEligibleSupersededMarkers(
         options.comments,
         markerPrefix,
         'authoring-owner',
+        trustedActors,
       )
     : null;
   const publicationIntentBacklog = intentChecked
@@ -1817,6 +1865,7 @@ function checkAuthoringMarkerMinimizationBacklog(
         options.journalComments,
         markerPrefix,
         'authoring-publication-intent',
+        trustedActors,
       )
     : null;
   const total = (ownerBacklog ?? 0) + (publicationIntentBacklog ?? 0);
@@ -1826,7 +1875,11 @@ function checkAuthoringMarkerMinimizationBacklog(
   const intentPart = intentChecked
     ? `authoring-publication-intent: ${publicationIntentBacklog}`
     : 'authoring-publication-intent: not checked (journalComments not supplied)';
-  const breakdown = `${ownerPart}, ${intentPart}`;
+  const trustNote =
+    trustedActors === undefined
+      ? ' [not author-trust-filtered: pass trustedMarkerActors for an accurate count]'
+      : '';
+  const breakdown = `${ownerPart}, ${intentPart}${trustNote}`;
   if (total === 0) {
     return pass(
       id,
@@ -2447,6 +2500,7 @@ interface CliArgs {
   commentsFile?: string;
   journalCommentsFile?: string;
   newIssue: boolean;
+  trustedMarkerLogins?: string;
 }
 
 /**
@@ -2571,6 +2625,16 @@ function main(): void {
 
   const policy = loadPolicy(args.configPath);
   const markerPrefix = args.markerPrefix ?? policy.markerPrefix;
+  // Same flag/env/config precedence every other resolveTrustedMarkerActors
+  // caller in this codebase uses (#2896 review, Codex): an empty
+  // resolution (no flag/env/config trusted actors configured) leaves
+  // authoring-marker-minimization-backlog's trust filter disabled, the
+  // same as omitting --trusted-marker-logins entirely.
+  const { actors: trustedMarkerActors } = resolveTrustedMarkerActors({
+    flagValue: args.trustedMarkerLogins ?? '',
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
+    config: policy.rawConfig,
+  });
 
   const report = auditAuthoredIssue(bodyText, {
     shape: args.shape as IssueShape,
@@ -2593,6 +2657,12 @@ function main(): void {
       : undefined,
     newIssue: args.newIssue,
     upstreamEscalationEnabled: policy.upstreamEscalationEnabled,
+    // An empty resolution (no flag/env/config trusted actors found) is
+    // "trust unknown," not "no one is trusted" -- pass `undefined` so
+    // authoring-marker-minimization-backlog's trust filter stays
+    // disabled (permissive) rather than zeroing out every count.
+    trustedMarkerActors:
+      trustedMarkerActors.length > 0 ? trustedMarkerActors : undefined,
   });
 
   writeReport(report, args.format);
@@ -2621,6 +2691,14 @@ function loadPolicy(configPath?: string): {
   needsDecisionLabelName: string;
   authoringLabelName: string;
   upstreamEscalationEnabled: boolean;
+  /**
+   * The raw loaded config object (or `null` when absent/unreadable),
+   * threaded through so `main()` can resolve `trustedMarkerActors` via
+   * the shared `resolveTrustedMarkerActors` flag/env/config ladder
+   * without this function needing its own opinion about that resolution
+   * order (#2896 review, Codex).
+   */
+  rawConfig: { trustedMarkerActors?: unknown } | null;
 } {
   // Default path: reuse the shared loadIddConfig() (idd-config.mts) rather
   // than a second "readFileSync + JSON.parse, null on error" copy of the
@@ -2661,6 +2739,7 @@ function loadPolicy(configPath?: string): {
       needsDecisionLabelName: POLICY_DEFAULTS.labels.needsDecisionLabelName,
       authoringLabelName: POLICY_DEFAULTS.issueAuthoring.authoringLabelName,
       upstreamEscalationEnabled: false,
+      rawConfig: null,
     };
   }
   return {
@@ -2674,6 +2753,7 @@ function loadPolicy(configPath?: string): {
     authoringLabelName:
       normalizePolicyConfig(config).issueAuthoring.authoringLabelName,
     upstreamEscalationEnabled: isUpstreamEscalationEnabled(config),
+    rawConfig: config as { trustedMarkerActors?: unknown },
   };
 }
 
@@ -2732,6 +2812,7 @@ function parseArgs(argv: string[]): CliArgs {
     commentsFile: values['comments-file'] as string | undefined,
     journalCommentsFile: values['journal-comments-file'] as string | undefined,
     newIssue: values['new-issue'] as boolean,
+    trustedMarkerLogins: values['trusted-marker-logins'] as string | undefined,
     format,
   };
 }
@@ -2809,8 +2890,20 @@ Options:
                                     authoring-publication body line, and (when
                                     --comments-file is also given) requires
                                     --journal-comments-file and --issue too
+  --trusted-marker-logins <csv>    comma-separated trusted GitHub actor logins
+                                    (flag > $IDD_TRUSTED_MARKER_ACTORS >
+                                    .github/idd/config.json's trustedMarkerActors);
+                                    filters authoring-marker-minimization-backlog's
+                                    count to comments from a trusted actor, matching
+                                    minimize-superseded-markers.mjs's own trust gate.
+                                    Omitted or empty leaves that count unfiltered
+                                    (every check above this one is unaffected)
   --format <json|table>            output format (default: json)
   --help                           show this help
+
+Environment:
+  IDD_TRUSTED_MARKER_ACTORS        comma-separated trusted actor logins, used when
+                                    --trusted-marker-logins is not given (see above)
 `);
 }
 

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -300,9 +300,14 @@ export interface AuditOptions {
 /** One pre-fetched comment, as supplied to {@link AuditOptions.comments} and
  * {@link AuditOptions.journalComments}. `body` is inspected by every
  * comment-aware check; `isMinimized` is inspected only by
- * `authoring-marker-minimization-backlog` (#2896); `author`/`createdAt` are
- * accepted for forward compatibility with a future trust/recency check but
- * currently unused. */
+ * `authoring-marker-minimization-backlog` (#2896); `author` is inspected
+ * by that same check only when {@link AuditOptions.trustedMarkerActors}
+ * is supplied (#2896 review, Copilot: omitting `author` on a comment
+ * from an unknown/untrusted actor is not safe when an accurate
+ * trust-filtered count is wanted -- see
+ * {@link countEligibleSupersededMarkers}'s own doc comment); `createdAt`
+ * remains accepted for forward compatibility with a future recency check
+ * but is currently unused everywhere. */
 export interface AuthoringCommentInput {
   body: string;
   author?: string;
@@ -1737,24 +1742,34 @@ function checkAuthoringOwnerMarkerTrail(
  * of it is not actually byte-exact against what
  * `matchCanonicalAuthoringMarkerFamily` would see live.
  *
- * A match whose `isMinimized` is already `true` is excluded from the
- * count -- it is not backlog, it is already handled. When
- * `trustedActors` is provided (#2896 review, Codex), a match whose
+ * When `trustedActors` is provided (#2896 review, Codex), a match whose
  * `comment.author` is missing or not a case-insensitive member of that
- * set is also excluded from the count: `minimize-superseded-markers.mts`
- * and the documented sweep both require a trusted marker actor
- * regardless of body match, so an untrusted-author match is never
- * actually clearable and must not inflate this "eligible" count. This
- * filter applies only to eligibility, never to which match is
- * "newest" -- the newest determination stays purely structural (see
- * above) so an untrusted-author comment can still correctly supersede
- * an earlier trusted one. `trustedActors` left `undefined` disables this
- * filter entirely (backward-compatible: every match counts regardless
- * of author). Returns `0` when `comments` is `undefined` (the caller,
- * {@link checkAuthoringMarkerMinimizationBacklog}, reports that family
- * as "not checked" rather than treating this `0` as a confirmed zero) or
- * when fewer than two matches exist (nothing can be "superseded" without
- * a later match to supersede it).
+ * set is excluded from the candidate set **before** "newest" is
+ * selected, not only from the eligible count: the contract states
+ * "syntax alone never grants ownership" (see [Per-target
+ * ownership](../../skills/issue-authoring/references/contract.md)), so
+ * an untrusted-author body -- even a byte-exact canonical one -- is
+ * never treated as a real marker for either purpose. An earlier
+ * revision filtered trust only for eligibility, which let a trailing
+ * untrusted-author match steal "newest" status from the legitimate
+ * trusted marker just before it, wrongly reporting that trusted marker
+ * as superseded backlog (round 2 of review, Codex: the fix for the
+ * `minimize-superseded-markers.mts`/documented-sweep trust
+ * requirement -- round 1 -- did not go far enough). `trustedActors` left
+ * `undefined` disables this filter entirely (backward-compatible: every
+ * byte-exact match counts as a candidate regardless of author, matching
+ * pre-#2896-review behavior).
+ *
+ * A candidate match whose `isMinimized` is already `true` is excluded
+ * from the eligible count -- it is not backlog, it is already handled
+ * (this exclusion is unaffected by trust filtering: it applies to
+ * whichever candidate set survives the trust filter above). Returns `0`
+ * when `comments` is `undefined` (the caller, {@link
+ * checkAuthoringMarkerMinimizationBacklog}, reports that family as "not
+ * checked" rather than treating this `0` as a confirmed zero) or when
+ * fewer than two (trust-filtered, when applicable) candidates exist
+ * (nothing can be "superseded" without a later candidate to supersede
+ * it).
  */
 function countEligibleSupersededMarkers(
   comments: readonly AuthoringCommentInput[] | undefined,
@@ -1768,10 +1783,23 @@ function countEligibleSupersededMarkers(
   const matchIndexes: number[] = [];
   comments.forEach((comment, index) => {
     if (
-      matchCanonicalAuthoringMarkerFamily(comment.body, markerPrefix) === family
+      matchCanonicalAuthoringMarkerFamily(comment.body, markerPrefix) !== family
     ) {
-      matchIndexes.push(index);
+      return;
     }
+    if (trustedActors !== undefined) {
+      const author = comment.author;
+      if (
+        typeof author !== 'string' ||
+        !trustedActors.has(author.toLowerCase())
+      ) {
+        // Not a real candidate at all when a trust set is supplied:
+        // never counted, and never eligible to be selected as "newest"
+        // either -- syntax alone never grants ownership.
+        return;
+      }
+    }
+    matchIndexes.push(index);
   });
   if (matchIndexes.length < 2) {
     return 0;
@@ -1781,15 +1809,6 @@ function countEligibleSupersededMarkers(
   for (const index of matchIndexes) {
     if (index === newestIndex || comments[index].isMinimized === true) {
       continue;
-    }
-    if (trustedActors !== undefined) {
-      const author = comments[index].author;
-      if (
-        typeof author !== 'string' ||
-        !trustedActors.has(author.toLowerCase())
-      ) {
-        continue;
-      }
     }
     count += 1;
   }

--- a/src/scripts/minimize-superseded-markers.mts
+++ b/src/scripts/minimize-superseded-markers.mts
@@ -154,6 +154,25 @@ interface MinimizeArgs {
   allowUntrusted: boolean;
   format: string;
   help: boolean;
+  /**
+   * Optional overall wall-clock budget in milliseconds for the whole
+   * pass, threaded straight into {@link runMinimize}'s own `deadlineMs`
+   * parameter (#2896 review, Codex, round 8). Previously exercised only
+   * by non-CLI callers (`post-idd-marker.mts`'s hide-at-post-time step,
+   * #2754) -- the CLI entry point itself always omitted it, so a caller
+   * invoking this file as a subprocess (the only path available to the
+   * issue-authoring contract's own sweep instructions, which cannot
+   * import `runMinimize` directly) had no way to bound a sweep with a
+   * large candidate list: `runMinimize` probes subject IDs serially,
+   * each candidate costing up to `GH_TIMEOUT_MS` (30s) twice (probe +
+   * apply) with no deadline, so a degraded GitHub API could stall a
+   * single sweep attempt for a very long time on a large
+   * first-ever-swept backlog, undercutting the
+   * attempted-not-blocking contract that same sweep is documented
+   * under. `undefined` (the flag omitted) keeps the pre-existing
+   * unbounded behavior.
+   */
+  deadlineMs?: number;
 }
 
 if (import.meta.main) {
@@ -209,6 +228,7 @@ if (import.meta.main) {
     trustedSet,
     apply: args.apply,
     allowUntrusted: args.allowUntrusted,
+    deadlineMs: args.deadlineMs,
   });
   report.trustedMarkerActors = [...trustedSet].sort();
   report.trustedMarkerActorsSource = trustedMarkerActorsSource;
@@ -810,6 +830,7 @@ function parseMinimizeArgs(argv: string[]): MinimizeArgs {
       // the genuinely-absent case.
       'trusted-marker-logins': { type: 'string', default: '' },
       format: { type: 'string', default: 'json' },
+      'deadline-ms': { type: 'string' },
     },
     strict: true,
   });
@@ -824,6 +845,35 @@ function parseMinimizeArgs(argv: string[]): MinimizeArgs {
     }
   }
 
+  // --deadline-ms is optional (undefined keeps runMinimize's pre-existing
+  // unbounded behavior) but, when given, must be a non-negative integer --
+  // this file stays self-contained (see the module header comment on
+  // loadIddConfig) so it cannot reuse cli-args.mts's canonical-integer
+  // helper; the same rejection shape as the flags above (a bare "requires
+  // a value"-style error, not a silent NaN) is reproduced by hand here.
+  // `0` is deliberately accepted, not just `>= 1`: runMinimize() gives it a
+  // specific, well-defined meaning of its own (the budget reads exhausted
+  // immediately at every checkpoint except the very first candidate's own
+  // probe, which still falls back to the un-throttled default timeout --
+  // see runMinimize's own deadlineMs doc comment and its "review round 2"
+  // test) -- a real degenerate-but-legitimate input, not an off-by-one
+  // edge case to reject. `^(?:0|[1-9]\d*)$` accepts exactly "0" or a
+  // non-zero-leading positive integer -- the same no-leading-zero idiom
+  // REST_SHAPED_SUBJECT_ID_PATTERN above already uses -- so "00"/"007" are
+  // still rejected as malformed rather than silently parsed.
+  let deadlineMs: number | undefined;
+  if (values['deadline-ms'] !== undefined) {
+    if (
+      values['deadline-ms'] === '' ||
+      !/^(?:0|[1-9]\d*)$/.test(values['deadline-ms'])
+    ) {
+      throw new Error(
+        '--deadline-ms must be a non-negative integer (milliseconds)',
+      );
+    }
+    deadlineMs = Number.parseInt(values['deadline-ms'], 10);
+  }
+
   return {
     subjectIds: (values['subject-ids'] ?? '')
       .split(',')
@@ -835,12 +885,13 @@ function parseMinimizeArgs(argv: string[]): MinimizeArgs {
     allowUntrusted: values['allow-untrusted'] ?? false,
     format: values.format ?? 'json',
     help: values.help ?? false,
+    deadlineMs,
   };
 }
 
 function printUsage(): void {
   console.log(
-    `Usage: minimize-superseded-markers --subject-ids <id1,id2,...> [--classifier OUTDATED|RESOLVED] [--trusted-marker-logins login1,login2] [--allow-untrusted] [--apply] [--format json|table]
+    `Usage: minimize-superseded-markers --subject-ids <id1,id2,...> [--classifier OUTDATED|RESOLVED] [--trusted-marker-logins login1,login2] [--allow-untrusted] [--apply] [--format json|table] [--deadline-ms <milliseconds>]
 
 The trusted-author gate is mandatory by default: supply trusted logins
 via --trusted-marker-logins, IDD_TRUSTED_MARKER_ACTORS, or the
@@ -854,6 +905,14 @@ verified the subject IDs are operationally safe to hide.
 IC_kwDOSWpaqs8AAAABIk9VAg), not REST numeric IDs (e.g. 4870591746).
 Convert a REST ID to its node ID first, using the command for the
 subject type:
-${NODE_ID_CONVERSION_COMMANDS}`,
+${NODE_ID_CONVERSION_COMMANDS}
+
+--deadline-ms bounds the whole pass to an overall wall-clock budget
+(non-negative integer milliseconds); omit it to keep the default unbounded
+behavior. Without it, a degraded GitHub API can stall the whole
+invocation for up to ~60s per candidate (a probe call plus an apply
+call, each capped at 30s) with no overall cap -- pass it for any
+invocation over a large or untrusted-source candidate list, such as a
+release-time sweep over a long-lived shared journal's full history.`,
   );
 }

--- a/src/scripts/minimize-superseded-markers.mts
+++ b/src/scripts/minimize-superseded-markers.mts
@@ -849,24 +849,30 @@ function parseMinimizeArgs(argv: string[]): MinimizeArgs {
   // unbounded behavior) but, when given, must be a non-negative integer --
   // this file stays self-contained (see the module header comment on
   // loadIddConfig) so it cannot reuse cli-args.mts's canonical-integer
-  // helper; the same rejection shape as the flags above (a bare "requires
-  // a value"-style error, not a silent NaN) is reproduced by hand here.
-  // `0` is deliberately accepted, not just `>= 1`: runMinimize() gives it a
-  // specific, well-defined meaning of its own (the budget reads exhausted
-  // immediately at every checkpoint except the very first candidate's own
-  // probe, which still falls back to the un-throttled default timeout --
-  // see runMinimize's own deadlineMs doc comment and its "review round 2"
-  // test) -- a real degenerate-but-legitimate input, not an off-by-one
-  // edge case to reject. `^(?:0|[1-9]\d*)$` accepts exactly "0" or a
-  // non-zero-leading positive integer -- the same no-leading-zero idiom
-  // REST_SHAPED_SUBJECT_ID_PATTERN above already uses -- so "00"/"007" are
-  // still rejected as malformed rather than silently parsed.
+  // helper. `0` is deliberately accepted, not just `>= 1`: runMinimize()
+  // gives it a specific, well-defined meaning of its own (the budget
+  // reads exhausted immediately at every checkpoint except the very
+  // first candidate's own probe, which still falls back to the
+  // un-throttled default timeout -- see runMinimize's own deadlineMs doc
+  // comment and its "review round 2" test) -- a real
+  // degenerate-but-legitimate input, not an off-by-one edge case to
+  // reject. `^(?:0|[1-9]\d*)$` accepts exactly "0" or a non-zero-leading
+  // positive integer -- the same no-leading-zero idiom
+  // REST_SHAPED_SUBJECT_ID_PATTERN above already uses -- so "00"/"007"
+  // are still rejected as malformed rather than silently parsed.
   let deadlineMs: number | undefined;
   if (values['deadline-ms'] !== undefined) {
-    if (
-      values['deadline-ms'] === '' ||
-      !/^(?:0|[1-9]\d*)$/.test(values['deadline-ms'])
-    ) {
+    // An explicit empty value (--deadline-ms='' or --deadline-ms=) gets
+    // its own branch, reproducing the exact "requires a value" shape the
+    // other flags above use (#2896 review, Copilot, round 9): folding it
+    // into the malformed-value branch below would report "must be a
+    // non-negative integer" for an input that is not malformed so much
+    // as simply absent, an inconsistent and less actionable message for
+    // that specific case.
+    if (values['deadline-ms'] === '') {
+      throw new Error('--deadline-ms requires a value');
+    }
+    if (!/^(?:0|[1-9]\d*)$/.test(values['deadline-ms'])) {
       throw new Error(
         '--deadline-ms must be a non-negative integer (milliseconds)',
       );

--- a/tests/audit-authored-issue.test.mts
+++ b/tests/audit-authored-issue.test.mts
@@ -2972,6 +2972,119 @@ test('authoring-marker-minimization-backlog never fails the report, even with a 
   assert.equal(report.passed, true);
 });
 
+test('authoring-marker-minimization-backlog without trustedMarkerActors counts every byte-exact match regardless of author (backward compatible)', () => {
+  const report = auditAuthoredIssue(orphanBody(), {
+    shape: 'orphan',
+    comments: [
+      {
+        body: canonicalOwnerMarkerBody({ mode: 'acquire' }),
+        author: 'some-untrusted-user',
+      },
+      { body: canonicalOwnerMarkerBody({ mode: 'release' }) },
+    ],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-marker-minimization-backlog',
+  );
+  assert.match(finding?.detail ?? '', /authoring-owner: 1/);
+  assert.match(finding?.detail ?? '', /not author-trust-filtered/);
+});
+
+test('authoring-marker-minimization-backlog with trustedMarkerActors excludes an untrusted-author match from the count (#2896 review, Codex)', () => {
+  const report = auditAuthoredIssue(orphanBody(), {
+    shape: 'orphan',
+    trustedMarkerActors: ['kurone-kito'],
+    comments: [
+      {
+        body: canonicalOwnerMarkerBody({ mode: 'acquire' }),
+        author: 'some-untrusted-user',
+      },
+      {
+        body: canonicalOwnerMarkerBody({ mode: 'release' }),
+        author: 'kurone-kito',
+      },
+    ],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-marker-minimization-backlog',
+  );
+  // The untrusted-author 'acquire' match is superseded but is never
+  // actually clearable by the live sweep -- it must not count as
+  // eligible, and the detail text must not repeat the "unfiltered"
+  // caveat once trustedMarkerActors is actually supplied.
+  assert.match(finding?.detail ?? '', /authoring-owner: 0\b/);
+  assert.doesNotMatch(finding?.detail ?? '', /not author-trust-filtered/);
+});
+
+test('authoring-marker-minimization-backlog with trustedMarkerActors counts a trusted-author match (case-insensitive)', () => {
+  const report = auditAuthoredIssue(orphanBody(), {
+    shape: 'orphan',
+    trustedMarkerActors: ['Kurone-Kito'],
+    comments: [
+      {
+        body: canonicalOwnerMarkerBody({ mode: 'acquire' }),
+        author: 'kurone-kito',
+      },
+      {
+        body: canonicalOwnerMarkerBody({ mode: 'release' }),
+        author: 'KURONE-KITO',
+      },
+    ],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-marker-minimization-backlog',
+  );
+  assert.match(finding?.detail ?? '', /authoring-owner: 1/);
+});
+
+test('authoring-marker-minimization-backlog with trustedMarkerActors excludes a match with no author at all', () => {
+  const report = auditAuthoredIssue(orphanBody(), {
+    shape: 'orphan',
+    trustedMarkerActors: ['kurone-kito'],
+    comments: [
+      // No `author` field -- unknown authorship must not be treated as
+      // trusted merely because a trust set was supplied.
+      { body: canonicalOwnerMarkerBody({ mode: 'acquire' }) },
+      {
+        body: canonicalOwnerMarkerBody({ mode: 'release' }),
+        author: 'kurone-kito',
+      },
+    ],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-marker-minimization-backlog',
+  );
+  assert.match(finding?.detail ?? '', /authoring-owner: 0\b/);
+});
+
+test('authoring-marker-minimization-backlog trust filtering never changes which match is "newest"', () => {
+  // The 'release' marker (untrusted author) is still correctly excluded
+  // as "newest" -- structural newest-selection never consults trust --
+  // rather than being wrongly treated as a NEW eligible candidate simply
+  // because its own author fails the trust check. The earlier 'acquire'
+  // marker (trusted author) is genuinely superseded backlog and still
+  // counts as eligible on its own merits, regardless of who posted the
+  // newer marker that supersedes it.
+  const report = auditAuthoredIssue(orphanBody(), {
+    shape: 'orphan',
+    trustedMarkerActors: ['kurone-kito'],
+    comments: [
+      {
+        body: canonicalOwnerMarkerBody({ mode: 'acquire' }),
+        author: 'kurone-kito',
+      },
+      {
+        body: canonicalOwnerMarkerBody({ mode: 'release' }),
+        author: 'some-untrusted-user',
+      },
+    ],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-marker-minimization-backlog',
+  );
+  assert.match(finding?.detail ?? '', /authoring-owner: 1/);
+});
+
 // --- upstream-candidate-marker-label: bidirectional pairing (#2700/#2703) ---
 
 function withUpstreamCandidateMarker(body: string): string {

--- a/tests/audit-authored-issue.test.mts
+++ b/tests/audit-authored-issue.test.mts
@@ -3057,14 +3057,15 @@ test('authoring-marker-minimization-backlog with trustedMarkerActors excludes a 
   assert.match(finding?.detail ?? '', /authoring-owner: 0\b/);
 });
 
-test('authoring-marker-minimization-backlog trust filtering never changes which match is "newest"', () => {
-  // The 'release' marker (untrusted author) is still correctly excluded
-  // as "newest" -- structural newest-selection never consults trust --
-  // rather than being wrongly treated as a NEW eligible candidate simply
-  // because its own author fails the trust check. The earlier 'acquire'
-  // marker (trusted author) is genuinely superseded backlog and still
-  // counts as eligible on its own merits, regardless of who posted the
-  // newer marker that supersedes it.
+test('authoring-marker-minimization-backlog excludes an untrusted-author match from newest-selection, not only from the count (#2896 round 2 review, Codex)', () => {
+  // The trailing 'release' marker has an UNTRUSTED author. A naive design
+  // that only filters trust for the eligible count (not for candidate
+  // selection) would let this untrusted match "steal" newest status,
+  // wrongly making the legitimate trusted 'acquire' marker before it read
+  // as superseded backlog -- exactly backwards, since "syntax alone never
+  // grants ownership" (contract.md). The untrusted match must be excluded
+  // from the candidate set entirely: with only one real (trusted)
+  // candidate left, nothing is superseded and the count stays 0.
   const report = auditAuthoredIssue(orphanBody(), {
     shape: 'orphan',
     trustedMarkerActors: ['kurone-kito'],
@@ -3076,6 +3077,36 @@ test('authoring-marker-minimization-backlog trust filtering never changes which 
       {
         body: canonicalOwnerMarkerBody({ mode: 'release' }),
         author: 'some-untrusted-user',
+      },
+    ],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-marker-minimization-backlog',
+  );
+  assert.match(finding?.detail ?? '', /authoring-owner: 0\b/);
+  assert.equal(finding?.severity, undefined);
+});
+
+test('authoring-marker-minimization-backlog: an untrusted match sandwiched between two trusted matches never becomes "newest" and is skipped as a candidate', () => {
+  // Three candidates: trusted 'acquire', untrusted 'heartbeat', trusted
+  // 'release'. The untrusted middle one must never count as either the
+  // eligible backlog or the newest -- the two trusted candidates
+  // ('acquire' superseded by 'release') are the only real pair here.
+  const report = auditAuthoredIssue(orphanBody(), {
+    shape: 'orphan',
+    trustedMarkerActors: ['kurone-kito'],
+    comments: [
+      {
+        body: canonicalOwnerMarkerBody({ mode: 'acquire' }),
+        author: 'kurone-kito',
+      },
+      {
+        body: canonicalOwnerMarkerBody({ mode: 'heartbeat' }),
+        author: 'some-untrusted-user',
+      },
+      {
+        body: canonicalOwnerMarkerBody({ mode: 'release' }),
+        author: 'kurone-kito',
       },
     ],
   });

--- a/tests/audit-authored-issue.test.mts
+++ b/tests/audit-authored-issue.test.mts
@@ -2,6 +2,10 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import { auditAuthoredIssue } from '../src/scripts/audit-authored-issue.mts';
+import {
+  renderAuthoringOwnerMarker,
+  renderAuthoringPublicationIntentMarker,
+} from '../src/scripts/marker-helpers.mts';
 
 function suitabilityFooter(score: number): string {
   return `---\n\n_Autopilot suitability: ${score} / 5 -- higher is more autopilot-suitable;\nbelow the configured floor is human-oriented._\n\n<!-- idd-skill-autopilot-suitability: ${score} -->`;
@@ -2712,6 +2716,260 @@ test('authoring-owner-marker-trail rejects issue=none at state=member even when 
     (entry) => entry.id === 'authoring-owner-marker-trail',
   );
   assert.equal(finding?.result, 'fail');
+});
+
+// --- authoring-marker-minimization-backlog (#2896) ---
+
+function canonicalOwnerMarkerBody({
+  target = 'kurone-kito/idd-skill#9001',
+  mode = 'acquire',
+}: {
+  target?: string;
+  mode?:
+    | 'acquire'
+    | 'resume'
+    | 'bootstrap'
+    | 'heartbeat'
+    | 'release'
+    | 'release-guard'
+    | 'release-complete';
+} = {}): string {
+  return renderAuthoringOwnerMarker({
+    markerPrefix: 'idd-skill',
+    target,
+    anchor: target,
+    mode,
+    owner: 'owner-tok1',
+    set: 'set-xyz789',
+    session: 'sess-1',
+    bodySha256: TEST_BODY_SHA256,
+    snapshotSha256: 'none',
+    supersedes: 'none',
+  });
+}
+
+function canonicalPublicationIntentBody({
+  target = 'target-abc123',
+  state = 'member',
+}: {
+  target?: string;
+  state?: 'pending' | 'member' | 'cleanup' | 'abandoned';
+} = {}): string {
+  return renderAuthoringPublicationIntentMarker({
+    markerPrefix: 'idd-skill',
+    target,
+    anchor: 'kurone-kito/idd-skill#9001',
+    set: 'set-xyz789',
+    session: 'sess-1',
+    token: 'pub-token1',
+    journal: 'kurone-kito/idd-skill#9001',
+    issue: 'kurone-kito/idd-skill#9001',
+    actor: 'kurone-kito',
+    state,
+  });
+}
+
+test('authoring-marker-minimization-backlog is not applicable when neither comments nor journalComments are supplied', () => {
+  const report = auditAuthoredIssue(orphanBody(), { shape: 'orphan' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-marker-minimization-backlog',
+  );
+  assert.equal(finding?.result, 'pass');
+  assert.equal(finding?.severity, undefined);
+  assert.match(finding?.detail ?? '', /not applicable/);
+});
+
+test('authoring-marker-minimization-backlog reports zero when only one canonical owner marker exists (nothing superseded yet)', () => {
+  const report = auditAuthoredIssue(orphanBody(), {
+    shape: 'orphan',
+    comments: [{ body: canonicalOwnerMarkerBody() }],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-marker-minimization-backlog',
+  );
+  assert.equal(finding?.result, 'pass');
+  assert.equal(finding?.severity, undefined);
+  assert.match(finding?.detail ?? '', /authoring-owner: 0/);
+});
+
+test('authoring-marker-minimization-backlog counts every canonical owner marker except the newest (last in array order)', () => {
+  const report = auditAuthoredIssue(orphanBody(), {
+    shape: 'orphan',
+    comments: [
+      { body: canonicalOwnerMarkerBody({ mode: 'acquire' }) },
+      { body: canonicalOwnerMarkerBody({ mode: 'heartbeat' }) },
+      { body: canonicalOwnerMarkerBody({ mode: 'release' }) },
+    ],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-marker-minimization-backlog',
+  );
+  assert.equal(finding?.result, 'pass');
+  assert.equal(finding?.severity, 'warning');
+  assert.match(finding?.detail ?? '', /authoring-owner: 2/);
+});
+
+test('authoring-marker-minimization-backlog excludes a comment already reported isMinimized', () => {
+  const report = auditAuthoredIssue(orphanBody(), {
+    shape: 'orphan',
+    comments: [
+      {
+        body: canonicalOwnerMarkerBody({ mode: 'acquire' }),
+        isMinimized: true,
+      },
+      { body: canonicalOwnerMarkerBody({ mode: 'heartbeat' }) },
+      { body: canonicalOwnerMarkerBody({ mode: 'release' }) },
+    ],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-marker-minimization-backlog',
+  );
+  assert.match(finding?.detail ?? '', /authoring-owner: 1/);
+});
+
+test('authoring-marker-minimization-backlog ignores a non-byte-exact match (blank-line separator variant), matching the live sweep', () => {
+  const canonical = canonicalOwnerMarkerBody({ mode: 'acquire' });
+  const blankLineVariant = canonical.replace(
+    '\n_Issue-authoring',
+    '\n\n_Issue-authoring',
+  );
+  assert.notEqual(blankLineVariant, canonical);
+  const report = auditAuthoredIssue(orphanBody(), {
+    shape: 'orphan',
+    comments: [
+      { body: blankLineVariant },
+      { body: canonicalOwnerMarkerBody({ mode: 'release' }) },
+    ],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-marker-minimization-backlog',
+  );
+  assert.match(finding?.detail ?? '', /authoring-owner: 0/);
+});
+
+test('authoring-marker-minimization-backlog counts the authoring-publication-intent family from journalComments independently', () => {
+  const report = auditAuthoredIssue(orphanBody(), {
+    shape: 'orphan',
+    journalComments: [
+      { body: canonicalPublicationIntentBody({ state: 'pending' }) },
+      { body: canonicalPublicationIntentBody({ state: 'member' }) },
+    ],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-marker-minimization-backlog',
+  );
+  assert.equal(finding?.severity, 'warning');
+  assert.match(finding?.detail ?? '', /authoring-publication-intent: 1/);
+  // The owner half was never supplied (no `comments` option) -- it must
+  // report as "not checked", never as a confirmed "0" (#2896 review):
+  // collapsing the two would misreport "never counted" as "counted,
+  // found none".
+  assert.match(finding?.detail ?? '', /authoring-owner: not checked/);
+});
+
+test('authoring-marker-minimization-backlog distinguishes "not checked" from "checked, zero found" for the omitted family', () => {
+  const report = auditAuthoredIssue(orphanBody(), {
+    shape: 'orphan',
+    comments: [{ body: canonicalOwnerMarkerBody() }],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-marker-minimization-backlog',
+  );
+  // Only one canonical owner marker -- nothing superseded -- so the total
+  // stays 0 and this finding carries no warning severity, but the
+  // never-supplied journalComments half must still read "not checked",
+  // never a bare "0".
+  assert.equal(finding?.severity, undefined);
+  assert.match(finding?.detail ?? '', /authoring-owner: 0\b/);
+  assert.match(
+    finding?.detail ?? '',
+    /authoring-publication-intent: not checked/,
+  );
+});
+
+test('authoring-marker-minimization-backlog treats an empty comments array as checked (zero found), not "not applicable"', () => {
+  const report = auditAuthoredIssue(orphanBody(), {
+    shape: 'orphan',
+    comments: [],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-marker-minimization-backlog',
+  );
+  assert.equal(finding?.result, 'pass');
+  assert.doesNotMatch(finding?.detail ?? '', /not applicable/);
+  assert.match(finding?.detail ?? '', /authoring-owner: 0\b/);
+});
+
+test('authoring-marker-minimization-backlog computes "newest" independently per family in a mixed-family comments array', () => {
+  // Both families appear in the SAME comments array (an unrealistic but
+  // worth-covering shape): the owner family's "newest" must be its own
+  // last owner-family match, not simply the array's last element overall
+  // (which here is a publication-intent match).
+  const report = auditAuthoredIssue(orphanBody(), {
+    shape: 'orphan',
+    comments: [
+      { body: canonicalOwnerMarkerBody({ mode: 'acquire' }) },
+      { body: canonicalOwnerMarkerBody({ mode: 'release' }) },
+      { body: canonicalPublicationIntentBody({ state: 'member' }) },
+    ],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-marker-minimization-backlog',
+  );
+  // The 'acquire' owner marker is superseded by the later 'release' one
+  // even though a later, different-family comment follows it.
+  assert.match(finding?.detail ?? '', /authoring-owner: 1/);
+});
+
+test('authoring-marker-minimization-backlog excludes a non-canonical variant even when it is the last array entry', () => {
+  const blankLineVariant = canonicalOwnerMarkerBody({
+    mode: 'release',
+  }).replace('\n_Issue-authoring', '\n\n_Issue-authoring');
+  const report = auditAuthoredIssue(orphanBody(), {
+    shape: 'orphan',
+    comments: [
+      { body: canonicalOwnerMarkerBody({ mode: 'acquire' }) },
+      // Last in array order, but not a byte-exact canonical match, so it
+      // must not become the "newest" match -- there is then only one
+      // real canonical match ('acquire'), so nothing is superseded.
+      { body: blankLineVariant },
+    ],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-marker-minimization-backlog',
+  );
+  assert.match(finding?.detail ?? '', /authoring-owner: 0\b/);
+});
+
+test('authoring-marker-minimization-backlog is not gated on the authoring label', () => {
+  const report = auditAuthoredIssue(orphanBody(), {
+    shape: 'orphan',
+    labels: [],
+    comments: [
+      { body: canonicalOwnerMarkerBody({ mode: 'acquire' }) },
+      { body: canonicalOwnerMarkerBody({ mode: 'release' }) },
+    ],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-marker-minimization-backlog',
+  );
+  assert.equal(finding?.severity, 'warning');
+  assert.match(finding?.detail ?? '', /authoring-owner: 1/);
+});
+
+test('authoring-marker-minimization-backlog never fails the report, even with a nonzero backlog', () => {
+  const report = auditAuthoredIssue(orphanBody(), {
+    shape: 'orphan',
+    comments: [
+      { body: canonicalOwnerMarkerBody({ mode: 'acquire' }) },
+      { body: canonicalOwnerMarkerBody({ mode: 'release' }) },
+    ],
+  });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'authoring-marker-minimization-backlog',
+  );
+  assert.equal(finding?.result, 'pass');
+  assert.equal(report.passed, true);
 });
 
 // --- upstream-candidate-marker-label: bidirectional pairing (#2700/#2703) ---

--- a/tests/minimize-superseded-markers.test.mts
+++ b/tests/minimize-superseded-markers.test.mts
@@ -737,3 +737,217 @@ process.exit(1);
 // invoke this same runMinimize call site with deadlineMs:
 // HIDE_STEP_DEADLINE_MS (45s, never exhausted in-test) and assert the
 // mutation actually ran via readMutatedSubjectIds.
+
+// --- --deadline-ms CLI flag (#2896 review, Codex, round 8) ---
+//
+// The CLI entry point previously always called runMinimize() without a
+// deadlineMs, so a subprocess caller (the only invocation path available
+// to the issue-authoring contract's own sweep instructions, which cannot
+// import runMinimize directly) had no way to bound a sweep over a large
+// candidate list. These tests cover the new --deadline-ms flag's
+// parse-time validation and its actual end-to-end wiring into
+// runMinimize's own deadline enforcement.
+
+test('a non-numeric --deadline-ms is rejected at parse time', () => {
+  const script = join(
+    dirname(fileURLToPath(import.meta.url)),
+    '..',
+    'scripts',
+    'minimize-superseded-markers.mjs',
+  );
+  const result = spawnSync(
+    process.execPath,
+    [
+      script,
+      '--subject-ids',
+      'IC_a',
+      '--allow-untrusted',
+      '--deadline-ms',
+      'notanumber',
+    ],
+    { encoding: 'utf8' },
+  );
+
+  assert.equal(result.status, 2);
+  assert.equal(result.stdout, '');
+  assert.equal(
+    result.stderr.trim(),
+    'error: --deadline-ms must be a non-negative integer (milliseconds)',
+  );
+});
+
+test('--deadline-ms 0 is accepted, not rejected (a deliberate, well-defined degenerate value)', () => {
+  // 0 is not an edge case to reject: runMinimize() gives it a specific
+  // meaning of its own (see the "actually bounding the pass end-to-end"
+  // test below, and runMinimize's own review-round-2 test) -- the budget
+  // reads exhausted at every checkpoint except the first candidate's own
+  // probe. Parse-time validation must accept it, matching that contract.
+  const restore = withProbeOnlyGhStub();
+  try {
+    const script = join(
+      dirname(fileURLToPath(import.meta.url)),
+      '..',
+      'scripts',
+      'minimize-superseded-markers.mjs',
+    );
+    const result = spawnSync(
+      process.execPath,
+      [
+        script,
+        '--subject-ids',
+        'IC_a',
+        '--allow-untrusted',
+        '--deadline-ms',
+        '0',
+        '--format',
+        'json',
+      ],
+      { encoding: 'utf8' },
+    );
+    assert.notEqual(result.status, 2);
+    const report = JSON.parse(result.stdout);
+    assert.equal(report.counts.deadlineSkipped, 0);
+  } finally {
+    restore();
+  }
+});
+
+test('a negative --deadline-ms is rejected', () => {
+  const script = join(
+    dirname(fileURLToPath(import.meta.url)),
+    '..',
+    'scripts',
+    'minimize-superseded-markers.mjs',
+  );
+  // The `=`-joined form, not a separate `--deadline-ms -5` pair: a
+  // dash-shaped bare value after a string flag is ambiguous to parseArgs
+  // itself (it could be the next flag), so it throws its own "argument
+  // is ambiguous" error before this file's own validation ever runs --
+  // matching this file's own documented parseArgs-migration deltas. The
+  // `=` form is parseArgs' own escape hatch and reaches this file's
+  // --deadline-ms validation as intended.
+  const result = spawnSync(
+    process.execPath,
+    [script, '--subject-ids', 'IC_a', '--allow-untrusted', '--deadline-ms=-5'],
+    { encoding: 'utf8' },
+  );
+
+  assert.equal(result.status, 2);
+  assert.equal(
+    result.stderr.trim(),
+    'error: --deadline-ms must be a non-negative integer (milliseconds)',
+  );
+});
+
+test('a leading-zero --deadline-ms (e.g. "007") is rejected as malformed', () => {
+  const script = join(
+    dirname(fileURLToPath(import.meta.url)),
+    '..',
+    'scripts',
+    'minimize-superseded-markers.mjs',
+  );
+  const result = spawnSync(
+    process.execPath,
+    [
+      script,
+      '--subject-ids',
+      'IC_a',
+      '--allow-untrusted',
+      '--deadline-ms',
+      '007',
+    ],
+    { encoding: 'utf8' },
+  );
+
+  assert.equal(result.status, 2);
+  assert.equal(
+    result.stderr.trim(),
+    'error: --deadline-ms must be a non-negative integer (milliseconds)',
+  );
+});
+
+test('an omitted --deadline-ms keeps the pre-existing unbounded behavior (no rejection, no deadline-skipped items)', () => {
+  const restore = withProbeOnlyGhStub();
+  try {
+    const script = join(
+      dirname(fileURLToPath(import.meta.url)),
+      '..',
+      'scripts',
+      'minimize-superseded-markers.mjs',
+    );
+    const result = spawnSync(
+      process.execPath,
+      [
+        script,
+        '--subject-ids',
+        'IC_a',
+        '--allow-untrusted',
+        '--format',
+        'json',
+      ],
+      { encoding: 'utf8' },
+    );
+    assert.equal(result.status, 0);
+    const report = JSON.parse(result.stdout);
+    assert.equal(report.counts.deadlineSkipped, 0);
+    assert.equal(report.counts.eligible, 1);
+  } finally {
+    restore();
+  }
+});
+
+test('--deadline-ms is threaded through the CLI into runMinimize, actually bounding the pass end-to-end', () => {
+  // deadlineMs: 0 means the budget reads exhausted the instant any
+  // wall-clock time has passed -- true by the time the first (real,
+  // subprocess-spawning) probe call returns, proving this flag reaches
+  // runMinimize's own deadline enforcement, not merely that it parses.
+  // 0 is deliberately used rather than a small positive value: it is the
+  // one value for which the FIRST candidate's own probe still gets the
+  // un-throttled default timeout (falls back to `undefined` rather than a
+  // near-zero timeoutMs that would itself kill the real subprocess call),
+  // so the probe genuinely completes and the deadline is only caught at
+  // the pre-apply checkpoint -- exactly mirroring runMinimize's own
+  // review-round-2 test. withProbeOnlyGhStub fails loudly on any mutation
+  // call, so a bug that let this candidate through the deadline check
+  // would surface as a hard subprocess failure here, not a
+  // silently-wrong report.
+  const restore = withProbeOnlyGhStub();
+  try {
+    const script = join(
+      dirname(fileURLToPath(import.meta.url)),
+      '..',
+      'scripts',
+      'minimize-superseded-markers.mjs',
+    );
+    const result = spawnSync(
+      process.execPath,
+      [
+        script,
+        '--subject-ids',
+        'IC_a',
+        '--allow-untrusted',
+        '--apply',
+        '--deadline-ms',
+        '0',
+        '--format',
+        'json',
+      ],
+      { encoding: 'utf8' },
+    );
+    const report = JSON.parse(result.stdout);
+    assert.deepEqual(
+      report.items.map(
+        (item: { subjectId: string; status: string; reason?: string }) => ({
+          subjectId: item.subjectId,
+          status: item.status,
+          reason: item.reason,
+        }),
+      ),
+      [{ subjectId: 'IC_a', status: 'skipped', reason: 'deadline-exceeded' }],
+    );
+    assert.equal(report.counts.deadlineSkipped, 1);
+    assert.equal(report.counts.applied, 0);
+  } finally {
+    restore();
+  }
+});

--- a/tests/minimize-superseded-markers.test.mts
+++ b/tests/minimize-superseded-markers.test.mts
@@ -776,6 +776,24 @@ test('a non-numeric --deadline-ms is rejected at parse time', () => {
   );
 });
 
+test('an explicit empty --deadline-ms value is rejected with the same "requires a value" shape as the other flags (#2896 review, Copilot, round 9)', () => {
+  const script = join(
+    dirname(fileURLToPath(import.meta.url)),
+    '..',
+    'scripts',
+    'minimize-superseded-markers.mjs',
+  );
+  const result = spawnSync(
+    process.execPath,
+    [script, '--subject-ids', 'IC_a', '--allow-untrusted', '--deadline-ms='],
+    { encoding: 'utf8' },
+  );
+
+  assert.equal(result.status, 2);
+  assert.equal(result.stdout, '');
+  assert.equal(result.stderr.trim(), 'error: --deadline-ms requires a value');
+});
+
 test('--deadline-ms 0 is accepted, not rejected (a deliberate, well-defined degenerate value)', () => {
   // 0 is not an edge case to reject: runMinimize() gives it a specific
   // meaning of its own (see the "actually bounding the pass end-to-end"


### PR DESCRIPTION
# Summary

Issue #2896 measured that the per-post "hide superseded owner/
publication-intent markers" instruction added by #2750/#2821 only
actually fires about 3% of the time in practice (3 of 95
expected-hideable comments across 22 sampled issues), because it is a
compliance-dependent step invoked 3-9+ times per issue with no
mechanical enforcement and no signal when it is skipped.

This PR replaces reliance on that per-post step with a single mandatory
sweep at the one lifecycle point every authoring session reliably
reaches once per target: Stage 2 release's release-marker preflight,
before the reuse-or-append decision for each target's `release` marker
(so a resumed release, which reuses an existing marker and never
appends, still runs the sweep every time preflight is reached), and
again on the anchor before the release-complete decision. The per-post
step stays documented as correct, opportunistic behavior.

It also adds a mechanical observability signal:
`audit-authored-issue.mjs` gains a new `authoring-marker-minimization-
backlog` check that counts, from caller-supplied comment data,
byte-exact canonical `authoring-owner` / `authoring-publication-intent`
markers that are not the newest for their family and are not already
minimized -- always a `pass` with `severity: 'warning'` when nonzero,
never gating the linter's exit code.

## Linked issue

Closes #2896

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

An independent C1 critique pass on this branch's diff found a genuine
correctness gap in the first draft of the mechanical check: when a
caller supplied only one of `comments`/`journalComments`, the other
family's count reported a bare `0`, indistinguishable from "checked,
found none" -- exactly the kind of silent gap the check exists to
surface. The same review also found the CLI's `--journal-comments-file
requires --new-issue` gate made the check unreachable through the
packaged CLI at the Stage 2 lifecycle point this PR's own contract.md
change documents (Stage 2 audits an *already-published*, never-new
issue). Both are fixed here: the check's `detail` text now distinguishes
"not checked" from "checked, zero found" per family, and the CLI gate
that made `--journal-comments-file` require `--new-issue` was removed
(it does not affect `authoring-owner-marker-trail`'s own behavior, which
already no-ops its journal cross-check whenever `--new-issue` is
absent).

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDJpTELrY2SnjHW9m5Aw7i

