### PR TITLE
feat(issue-authoring): add authoring-owner-provenance helper

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -1871,9 +1871,10 @@ only approval boundary.
   each removal for owner/set/anchor/session and the expected
   label/body snapshot -- so a body edit landing between an earlier
   check and the actual removal cannot silently bypass this
-  precondition. A dedicated helper/test to perform and verify this
-  comparison mechanically is tracked as a follow-up rather than
-  designed here. This
+  precondition. The `authoring-owner-provenance` helper (`node
+  scripts/authoring-owner-provenance.mjs --issue <number>`; see
+  `docs/idd-helper-scripts.md`) performs and verifies this comparison
+  mechanically (`#2891`). This
   exists because
   `idd-review-triage.instructions.md`'s round-count cutoff files this
   exact marker on a follow-up issue during unattended autonomous

--- a/.gitattributes
+++ b/.gitattributes
@@ -18,6 +18,7 @@ scripts/audit-docs.mjs linguist-generated=true
 scripts/audit-pr-cleanup-summary.mjs linguist-generated=true
 scripts/audit-pr-cleanup.mjs linguist-generated=true
 scripts/authoring-label-guard.mjs linguist-generated=true
+scripts/authoring-owner-provenance.mjs linguist-generated=true
 scripts/autopilot-suitability.mjs linguist-generated=true
 scripts/branch-conflict-state.mjs linguist-generated=true
 scripts/branch-name.mjs linguist-generated=true

--- a/bin/idd-authoring-owner-provenance.mjs
+++ b/bin/idd-authoring-owner-provenance.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-authoring-owner-provenance.mts
+//
+// The bin/idd-authoring-owner-provenance.mjs copy is generated from the .mts source named above
+// by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+import { runHelper } from './run-helper.mjs';
+
+runHelper('../scripts/authoring-owner-provenance.mjs');

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -267,21 +267,26 @@ in this preamble, since the fallback differs per helper.
   auto-release exception's provenance check
   (`skills/issue-authoring/references/contract.md`): computes the sha256
   of a live issue body's exact UTF-8 content and compares it against that
-  same issue's own trusted `mode=acquire` `authoring-owner` marker's
-  recorded `body-sha256`, reporting a machine-readable
+  same issue's own trusted winning ownership-generation `authoring-owner`
+  marker's recorded `body-sha256`, reporting a machine-readable
   `pass`/`mismatch`/`not-found` verdict — `not-found` is never treated as
   a pass. Read-only: never posts, labels, or mutates anything (referenced
   in
   [kurone-kito/idd-skill#2891](https://github.com/kurone-kito/idd-skill/issues/2891)).
-  Replays the target's own marker log to pick the acquire that won its
-  last generation (a same-generation race between two competing acquires
-  resolves to the earlier one — contract.md: choose the winner by
-  deterministic comment order — and a generation closes only on a
-  `mode=release-complete` that retains that generation's exact
-  owner/set/session/anchor), rather than always taking the globally-last
-  acquire comment (PR #2901 review, chatgpt-codex-connector: the earlier
-  form could authorize the auto-release exception against a losing
-  racer's edited-body digest, or against an unrelated stale completion).
+  Replays the target's own marker log to pick the `acquire`, `bootstrap`,
+  or `resume` marker that won its last generation — contract.md: "the
+  first valid acquisition, bootstrap, or resume marker by GitHub comment
+  order wins" — rather than always taking the globally-last `acquire`
+  comment or ignoring `bootstrap`/`resume` entirely (PR #2901 review,
+  chatgpt-codex-connector across three rounds: the earlier forms could
+  authorize the auto-release exception against a losing racer's
+  edited-body digest, against an unrelated or incomplete stale
+  completion, or displace a legitimate `bootstrap`/`resume` winner with a
+  later competing `acquire`). A generation closes only on a
+  `mode=release-complete` that is itself anchor-scoped
+  (`target === anchor`), carries a real snapshot digest (not the
+  release-guard sentinel `none`), and retains that generation's exact
+  owner/set/session/anchor while superseding that same owner token.
   `mode=release-complete` is anchor-only, so for a non-anchor child in a
   multi-target set this replay cannot see the child's true generation
   boundary and fails closed (`mismatch`, never a false `pass`) instead —

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -272,7 +272,19 @@ in this preamble, since the fallback differs per helper.
   `pass`/`mismatch`/`not-found` verdict — `not-found` is never treated as
   a pass. Read-only: never posts, labels, or mutates anything (referenced
   in
-  [kurone-kito/idd-skill#2891](https://github.com/kurone-kito/idd-skill/issues/2891))
+  [kurone-kito/idd-skill#2891](https://github.com/kurone-kito/idd-skill/issues/2891)).
+  Replays the target's own marker log to pick the acquire that won its
+  last generation (a same-generation race between two competing acquires
+  resolves to the earlier one, per contract.md's deterministic-comment-
+  order tie-break; a generation closes only on `mode=release-complete`),
+  rather than always taking the globally-last acquire comment (PR #2901
+  review, chatgpt-codex-connector: the earlier form could authorize the
+  auto-release exception against a losing racer's edited-body digest).
+  `mode=release-complete` is anchor-only, so for a non-anchor child in a
+  multi-target set this replay cannot see the child's true generation
+  boundary and fails closed (`mismatch`, never a false `pass`) instead —
+  an accepted limitation, since this helper's own single-target orphan
+  use case never hits it
 
 **Review & Merge Phase Helpers:**
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -263,6 +263,16 @@ in this preamble, since the fallback differs per helper.
   and it invokes the resolved hook, always exiting `0` regardless of
   the hook's own success or failure (referenced in
   [kurone-kito/idd-skill#2679](https://github.com/kurone-kito/idd-skill/issues/2679))
+- `scripts/authoring-owner-provenance.mjs` for the review-fix-loop-cutoff
+  auto-release exception's provenance check
+  (`skills/issue-authoring/references/contract.md`): computes the sha256
+  of a live issue body's exact UTF-8 content and compares it against that
+  same issue's own trusted `mode=acquire` `authoring-owner` marker's
+  recorded `body-sha256`, reporting a machine-readable
+  `pass`/`mismatch`/`not-found` verdict — `not-found` is never treated as
+  a pass. Read-only: never posts, labels, or mutates anything (referenced
+  in
+  [kurone-kito/idd-skill#2891](https://github.com/kurone-kito/idd-skill/issues/2891))
 
 **Review & Merge Phase Helpers:**
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -275,11 +275,13 @@ in this preamble, since the fallback differs per helper.
   [kurone-kito/idd-skill#2891](https://github.com/kurone-kito/idd-skill/issues/2891)).
   Replays the target's own marker log to pick the acquire that won its
   last generation (a same-generation race between two competing acquires
-  resolves to the earlier one, per contract.md's deterministic-comment-
-  order tie-break; a generation closes only on `mode=release-complete`),
-  rather than always taking the globally-last acquire comment (PR #2901
-  review, chatgpt-codex-connector: the earlier form could authorize the
-  auto-release exception against a losing racer's edited-body digest).
+  resolves to the earlier one — contract.md: choose the winner by
+  deterministic comment order — and a generation closes only on a
+  `mode=release-complete` that retains that generation's exact
+  owner/set/session/anchor), rather than always taking the globally-last
+  acquire comment (PR #2901 review, chatgpt-codex-connector: the earlier
+  form could authorize the auto-release exception against a losing
+  racer's edited-body digest, or against an unrelated stale completion).
   `mode=release-complete` is anchor-only, so for a non-anchor child in a
   multi-target set this replay cannot see the child's true generation
   boundary and fails closed (`mismatch`, never a false `pass`) instead —

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -267,33 +267,30 @@ in this preamble, since the fallback differs per helper.
   auto-release exception's provenance check
   (`skills/issue-authoring/references/contract.md`): computes the sha256
   of a live issue body's exact UTF-8 content and compares it against that
-  same issue's own trusted winning ownership-generation `authoring-owner`
-  marker's recorded `body-sha256`, reporting a machine-readable
+  same issue's own Stage 1 `mode=acquire` `authoring-owner` marker's
+  recorded `body-sha256`, reporting a machine-readable
   `pass`/`mismatch`/`not-found` verdict — `not-found` is never treated as
   a pass. Read-only: never posts, labels, or mutates anything (referenced
   in
   [kurone-kito/idd-skill#2891](https://github.com/kurone-kito/idd-skill/issues/2891)).
-  Replays the target's own marker log to pick the `acquire`, `bootstrap`,
-  or `resume` marker that won its last generation — contract.md: "the
-  first valid acquisition, bootstrap, or resume marker by GitHub comment
-  order wins" — rather than always taking the globally-last `acquire`
-  comment or ignoring `bootstrap`/`resume` entirely (PR #2901 review,
-  chatgpt-codex-connector across three rounds: the earlier forms could
+  Anchors on the target's own trusted marker log's _first_ marker in
+  comment order (`target` comparisons fold case, since GitHub owner/repo
+  names are case-insensitive — PR #2901 review, Copilot), which must
+  itself be `mode=acquire`: only that first marker is guaranteed to have
+  hashed the body as published, since a same-generation racer, a
+  `bootstrap`/`resume` recovery, or a legitimate re-acquisition after a
+  full release cycle all hash whatever body is live at their own posting
+  time, not the originally published one — comparing against any of
+  those instead of the Stage 1 acquire would make the check pass
+  trivially for a body edited before that later marker (PR #2901 review,
+  chatgpt-codex-connector across four rounds: earlier forms could
   authorize the auto-release exception against a losing racer's
-  edited-body digest, against an unrelated or incomplete stale
-  completion, or displace a legitimate `bootstrap`/`resume` winner with a
-  later competing `acquire`). A generation closes only on a
-  `mode=release-complete` that is itself anchor-scoped (its `target`
-  names the same issue as its own `anchor`), carries a real snapshot
-  digest (not the release-guard sentinel `none`), and retains that
-  generation's exact owner/set/session while naming the same `anchor`
-  and superseding that same owner token. `target`/`anchor` comparisons
-  fold case, since GitHub owner/repo names are case-insensitive (PR
-  #2901 review, Copilot). `mode=release-complete` is anchor-only, so for
-  a non-anchor child in a multi-target set this replay cannot see the
-  child's true generation boundary and fails closed (`mismatch`, never a
-  false `pass`) instead — an accepted limitation, since this helper's
-  own single-target orphan use case never hits it
+  edited-body digest, or against a later legitimate re-acquisition's
+  refreshed digest that silently absorbed an intervening edit). A target
+  whose trusted marker log opens with some other mode (`bootstrap`,
+  `resume`, `heartbeat`, `release`, ...) reports `not-found` rather than
+  accepting that non-acquire first marker's own digest, since every one
+  of those modes presupposes a prior acquire
 
 **Review & Merge Phase Helpers:**
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -296,13 +296,21 @@ in this preamble, since the fallback differs per helper.
   `--verbose` evidence) rather than accepting an invalid marker: its own
   `supersedes` field is `none` (contract.md requires this for `acquire`);
   its `body-sha256` is a real 64-hex digest, never the sentinel `none`;
-  its own `anchor` names the same issue as its own `target` (a mismatch
-  means the marker declares itself a multi-target set's non-anchor
-  child, out of scope for this single-target-orphan helper); and the
-  underlying comment's `updatedAt` equals its `createdAt` (contract.md:
-  owner comments are append-only and must not be edited, since an edited
-  comment could have had its `body-sha256` rewritten after the fact) (PR
-  #2901 review round 5, chatgpt-codex-connector and Copilot)
+  and its own `anchor` names the same issue as its own `target` (a
+  mismatch means the marker declares itself a multi-target set's
+  non-anchor child, out of scope for this single-target-orphan helper)
+  (PR #2901 review round 5, chatgpt-codex-connector and Copilot). Before
+  selecting a marker at all, also rejects the whole log if ANY trusted,
+  owner-marker-shaped comment was edited after posting (`updatedAt`
+  differs from `createdAt`) — not just the one that would otherwise be
+  selected, so editing the true Stage 1 acquire into something
+  unparseable or retargeting it cannot make it silently vanish and let a
+  later acquire win instead (contract.md: owner comments are append-only
+  and must not be edited or deleted). A trusted actor who deletes the
+  true Stage 1 acquire outright, rather than editing it, is an accepted
+  limitation instead: a deleted comment leaves no trace in any API
+  response this helper can read (PR #2901 review round 6,
+  chatgpt-codex-connector and Copilot)
 
 **Review & Merge Phase Helpers:**
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -273,43 +273,45 @@ in this preamble, since the fallback differs per helper.
   a pass. Read-only: never posts, labels, or mutates anything (referenced
   in
   [kurone-kito/idd-skill#2891](https://github.com/kurone-kito/idd-skill/issues/2891)).
-  Anchors on the target's own trusted marker log's _first_ marker in
-  comment order (`target` comparisons fold case, since GitHub owner/repo
-  names are case-insensitive — PR #2901 review, Copilot), which must
-  itself be `mode=acquire`: only that first marker is guaranteed to have
-  hashed the body as published, since a same-generation racer, a
-  `bootstrap`/`resume` recovery, or a legitimate re-acquisition after a
-  full release cycle all hash whatever body is live at their own posting
-  time, not the originally published one — comparing against any of
-  those instead of the Stage 1 acquire would make the check pass
+  Anchors on the target's own trusted, owner-marker-shaped comments
+  (every one still containing the case-insensitive
+  `<marker-prefix>-authoring-owner:` token, whether or not it parses),
+  taken in deterministic comment order. If ANY of those comments was
+  edited after posting (`updatedAt` differs from `createdAt`), the whole
+  log is rejected up front, before a first candidate is even chosen — an
+  editor cannot make the true Stage 1 acquire vanish from consideration
+  by editing it into something unparseable or retargeting it, letting a
+  later acquire silently win instead (PR #2901 review round 6, Copilot;
+  contract.md: owner comments are append-only). Past that check, the
+  _first_ candidate in comment order is scrutinized whatever its shape —
+  not merely the first one that happens to parse and match this target —
+  and must itself parse, name this issue as its target, and be a valid
+  Stage 1 `mode=acquire` marker, or this reports `not-found` rather than
+  silently skipping it for a later, validly-parsing marker (PR #2901
+  review round 7, Copilot). "Valid" means every condition contract.md
+  attaches to a genuine acquire: `mode=acquire` itself (every other mode
+  — `bootstrap`, `resume`, `heartbeat`, `release`, ... — presupposes a
+  prior acquire, so a well-formed history never opens with one);
+  `supersedes=none` (contract.md requires this specifically for
+  `acquire`); a real 64-hex `body-sha256`, never the sentinel `none`; and
+  its own `anchor` names the same issue as its own `target` (a mismatch
+  means the marker declares itself a multi-target set's non-anchor
+  child, out of scope for this single-target-orphan helper) (PR #2901
+  review round 5, chatgpt-codex-connector and Copilot). Only it, not any
+  later marker, is guaranteed to have hashed the body as published: a
+  same-generation racer, a `bootstrap`/`resume` recovery, or a legitimate
+  re-acquisition after a full release cycle all hash whatever body is
+  live at their own posting time, not the originally published one —
+  comparing against any of those instead would make the check pass
   trivially for a body edited before that later marker (PR #2901 review,
-  chatgpt-codex-connector across four rounds: earlier forms could
-  authorize the auto-release exception against a losing racer's
-  edited-body digest, or against a later legitimate re-acquisition's
-  refreshed digest that silently absorbed an intervening edit). A target
-  whose trusted marker log opens with some other mode (`bootstrap`,
-  `resume`, `heartbeat`, `release`, ...) reports `not-found` rather than
-  accepting that non-acquire first marker's own digest, since every one
-  of those modes presupposes a prior acquire. Also validates every other
-  condition contract.md attaches to a genuine Stage 1 acquire, failing
-  closed to `not-found` (with the specific reason surfaced in
-  `--verbose` evidence) rather than accepting an invalid marker: its own
-  `supersedes` field is `none` (contract.md requires this for `acquire`);
-  its `body-sha256` is a real 64-hex digest, never the sentinel `none`;
-  and its own `anchor` names the same issue as its own `target` (a
-  mismatch means the marker declares itself a multi-target set's
-  non-anchor child, out of scope for this single-target-orphan helper)
-  (PR #2901 review round 5, chatgpt-codex-connector and Copilot). Before
-  selecting a marker at all, also rejects the whole log if ANY trusted,
-  owner-marker-shaped comment was edited after posting (`updatedAt`
-  differs from `createdAt`) — not just the one that would otherwise be
-  selected, so editing the true Stage 1 acquire into something
-  unparseable or retargeting it cannot make it silently vanish and let a
-  later acquire win instead (contract.md: owner comments are append-only
-  and must not be edited or deleted). A trusted actor who deletes the
-  true Stage 1 acquire outright, rather than editing it, is an accepted
-  limitation instead: a deleted comment leaves no trace in any API
-  response this helper can read (PR #2901 review round 6,
+  chatgpt-codex-connector across four rounds). `target` comparisons fold
+  case, since GitHub owner/repo names are case-insensitive. Two accepted
+  limitations, both fail-closed (never a false `pass`): a marker whose
+  own `anchor` differs from its own `target` (a multi-target set's
+  non-anchor child, out of scope here); and tampering with the true
+  Stage 1 acquire that leaves no authoring-owner token at all — deleting
+  it outright, or editing it into ordinary prose — which cannot be
+  detected by a live comment-log reader (PR #2901 review rounds 5-7,
   chatgpt-codex-connector and Copilot)
 
 **Review & Merge Phase Helpers:**

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -290,7 +290,19 @@ in this preamble, since the fallback differs per helper.
   whose trusted marker log opens with some other mode (`bootstrap`,
   `resume`, `heartbeat`, `release`, ...) reports `not-found` rather than
   accepting that non-acquire first marker's own digest, since every one
-  of those modes presupposes a prior acquire
+  of those modes presupposes a prior acquire. Also validates every other
+  condition contract.md attaches to a genuine Stage 1 acquire, failing
+  closed to `not-found` (with the specific reason surfaced in
+  `--verbose` evidence) rather than accepting an invalid marker: its own
+  `supersedes` field is `none` (contract.md requires this for `acquire`);
+  its `body-sha256` is a real 64-hex digest, never the sentinel `none`;
+  its own `anchor` names the same issue as its own `target` (a mismatch
+  means the marker declares itself a multi-target set's non-anchor
+  child, out of scope for this single-target-orphan helper); and the
+  underlying comment's `updatedAt` equals its `createdAt` (contract.md:
+  owner comments are append-only and must not be edited, since an edited
+  comment could have had its `body-sha256` rewritten after the fact) (PR
+  #2901 review round 5, chatgpt-codex-connector and Copilot)
 
 **Review & Merge Phase Helpers:**
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -283,15 +283,17 @@ in this preamble, since the fallback differs per helper.
   edited-body digest, against an unrelated or incomplete stale
   completion, or displace a legitimate `bootstrap`/`resume` winner with a
   later competing `acquire`). A generation closes only on a
-  `mode=release-complete` that is itself anchor-scoped
-  (`target === anchor`), carries a real snapshot digest (not the
-  release-guard sentinel `none`), and retains that generation's exact
-  owner/set/session/anchor while superseding that same owner token.
-  `mode=release-complete` is anchor-only, so for a non-anchor child in a
-  multi-target set this replay cannot see the child's true generation
-  boundary and fails closed (`mismatch`, never a false `pass`) instead —
-  an accepted limitation, since this helper's own single-target orphan
-  use case never hits it
+  `mode=release-complete` that is itself anchor-scoped (its `target`
+  names the same issue as its own `anchor`), carries a real snapshot
+  digest (not the release-guard sentinel `none`), and retains that
+  generation's exact owner/set/session while naming the same `anchor`
+  and superseding that same owner token. `target`/`anchor` comparisons
+  fold case, since GitHub owner/repo names are case-insensitive (PR
+  #2901 review, Copilot). `mode=release-complete` is anchor-only, so for
+  a non-anchor child in a multi-target set this replay cannot see the
+  child's true generation boundary and fails closed (`mismatch`, never a
+  false `pass`) instead — an accepted limitation, since this helper's
+  own single-target orphan use case never hits it
 
 **Review & Merge Phase Helpers:**
 

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -1463,9 +1463,10 @@ once earlier in the sequence — matching this section's existing
 discipline of re-verifying immediately before each removal for
 owner/set/anchor/session and the expected label/body snapshot — so a
 body edit landing between an earlier check and the actual removal
-cannot silently bypass this precondition. A dedicated helper/test to
-perform and verify this comparison mechanically is tracked as a
-follow-up rather than designed here.
+cannot silently bypass this precondition. The `authoring-owner-provenance`
+helper (`node scripts/authoring-owner-provenance.mjs --issue <number>`;
+see `docs/idd-helper-scripts.md`) performs and verifies this comparison
+mechanically (`#2891`).
 
 **Roadmap-anchor scope (accepted limitation, `#2877`).** The "never a
 roadmap anchor" exclusion above is permanent, not a gap awaiting a fix:

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -267,21 +267,26 @@ in this preamble, since the fallback differs per helper.
   auto-release exception's provenance check
   (`skills/issue-authoring/references/contract.md`): computes the sha256
   of a live issue body's exact UTF-8 content and compares it against that
-  same issue's own trusted `mode=acquire` `authoring-owner` marker's
-  recorded `body-sha256`, reporting a machine-readable
+  same issue's own trusted winning ownership-generation `authoring-owner`
+  marker's recorded `body-sha256`, reporting a machine-readable
   `pass`/`mismatch`/`not-found` verdict — `not-found` is never treated as
   a pass. Read-only: never posts, labels, or mutates anything (referenced
   in
   [kurone-kito/idd-skill#2891](https://github.com/kurone-kito/idd-skill/issues/2891)).
-  Replays the target's own marker log to pick the acquire that won its
-  last generation (a same-generation race between two competing acquires
-  resolves to the earlier one — contract.md: choose the winner by
-  deterministic comment order — and a generation closes only on a
-  `mode=release-complete` that retains that generation's exact
-  owner/set/session/anchor), rather than always taking the globally-last
-  acquire comment (PR #2901 review, chatgpt-codex-connector: the earlier
-  form could authorize the auto-release exception against a losing
-  racer's edited-body digest, or against an unrelated stale completion).
+  Replays the target's own marker log to pick the `acquire`, `bootstrap`,
+  or `resume` marker that won its last generation — contract.md: "the
+  first valid acquisition, bootstrap, or resume marker by GitHub comment
+  order wins" — rather than always taking the globally-last `acquire`
+  comment or ignoring `bootstrap`/`resume` entirely (PR #2901 review,
+  chatgpt-codex-connector across three rounds: the earlier forms could
+  authorize the auto-release exception against a losing racer's
+  edited-body digest, against an unrelated or incomplete stale
+  completion, or displace a legitimate `bootstrap`/`resume` winner with a
+  later competing `acquire`). A generation closes only on a
+  `mode=release-complete` that is itself anchor-scoped
+  (`target === anchor`), carries a real snapshot digest (not the
+  release-guard sentinel `none`), and retains that generation's exact
+  owner/set/session/anchor while superseding that same owner token.
   `mode=release-complete` is anchor-only, so for a non-anchor child in a
   multi-target set this replay cannot see the child's true generation
   boundary and fails closed (`mismatch`, never a false `pass`) instead —

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -272,7 +272,19 @@ in this preamble, since the fallback differs per helper.
   `pass`/`mismatch`/`not-found` verdict — `not-found` is never treated as
   a pass. Read-only: never posts, labels, or mutates anything (referenced
   in
-  [kurone-kito/idd-skill#2891](https://github.com/kurone-kito/idd-skill/issues/2891))
+  [kurone-kito/idd-skill#2891](https://github.com/kurone-kito/idd-skill/issues/2891)).
+  Replays the target's own marker log to pick the acquire that won its
+  last generation (a same-generation race between two competing acquires
+  resolves to the earlier one, per contract.md's deterministic-comment-
+  order tie-break; a generation closes only on `mode=release-complete`),
+  rather than always taking the globally-last acquire comment (PR #2901
+  review, chatgpt-codex-connector: the earlier form could authorize the
+  auto-release exception against a losing racer's edited-body digest).
+  `mode=release-complete` is anchor-only, so for a non-anchor child in a
+  multi-target set this replay cannot see the child's true generation
+  boundary and fails closed (`mismatch`, never a false `pass`) instead —
+  an accepted limitation, since this helper's own single-target orphan
+  use case never hits it
 
 **Review & Merge Phase Helpers:**
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -263,6 +263,16 @@ in this preamble, since the fallback differs per helper.
   and it invokes the resolved hook, always exiting `0` regardless of
   the hook's own success or failure (referenced in
   [kurone-kito/idd-skill#2679](https://github.com/kurone-kito/idd-skill/issues/2679))
+- `scripts/authoring-owner-provenance.mjs` for the review-fix-loop-cutoff
+  auto-release exception's provenance check
+  (`skills/issue-authoring/references/contract.md`): computes the sha256
+  of a live issue body's exact UTF-8 content and compares it against that
+  same issue's own trusted `mode=acquire` `authoring-owner` marker's
+  recorded `body-sha256`, reporting a machine-readable
+  `pass`/`mismatch`/`not-found` verdict — `not-found` is never treated as
+  a pass. Read-only: never posts, labels, or mutates anything (referenced
+  in
+  [kurone-kito/idd-skill#2891](https://github.com/kurone-kito/idd-skill/issues/2891))
 
 **Review & Merge Phase Helpers:**
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -275,11 +275,13 @@ in this preamble, since the fallback differs per helper.
   [kurone-kito/idd-skill#2891](https://github.com/kurone-kito/idd-skill/issues/2891)).
   Replays the target's own marker log to pick the acquire that won its
   last generation (a same-generation race between two competing acquires
-  resolves to the earlier one, per contract.md's deterministic-comment-
-  order tie-break; a generation closes only on `mode=release-complete`),
-  rather than always taking the globally-last acquire comment (PR #2901
-  review, chatgpt-codex-connector: the earlier form could authorize the
-  auto-release exception against a losing racer's edited-body digest).
+  resolves to the earlier one — contract.md: choose the winner by
+  deterministic comment order — and a generation closes only on a
+  `mode=release-complete` that retains that generation's exact
+  owner/set/session/anchor), rather than always taking the globally-last
+  acquire comment (PR #2901 review, chatgpt-codex-connector: the earlier
+  form could authorize the auto-release exception against a losing
+  racer's edited-body digest, or against an unrelated stale completion).
   `mode=release-complete` is anchor-only, so for a non-anchor child in a
   multi-target set this replay cannot see the child's true generation
   boundary and fails closed (`mismatch`, never a false `pass`) instead —

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -267,33 +267,30 @@ in this preamble, since the fallback differs per helper.
   auto-release exception's provenance check
   (`skills/issue-authoring/references/contract.md`): computes the sha256
   of a live issue body's exact UTF-8 content and compares it against that
-  same issue's own trusted winning ownership-generation `authoring-owner`
-  marker's recorded `body-sha256`, reporting a machine-readable
+  same issue's own Stage 1 `mode=acquire` `authoring-owner` marker's
+  recorded `body-sha256`, reporting a machine-readable
   `pass`/`mismatch`/`not-found` verdict — `not-found` is never treated as
   a pass. Read-only: never posts, labels, or mutates anything (referenced
   in
   [kurone-kito/idd-skill#2891](https://github.com/kurone-kito/idd-skill/issues/2891)).
-  Replays the target's own marker log to pick the `acquire`, `bootstrap`,
-  or `resume` marker that won its last generation — contract.md: "the
-  first valid acquisition, bootstrap, or resume marker by GitHub comment
-  order wins" — rather than always taking the globally-last `acquire`
-  comment or ignoring `bootstrap`/`resume` entirely (PR #2901 review,
-  chatgpt-codex-connector across three rounds: the earlier forms could
+  Anchors on the target's own trusted marker log's _first_ marker in
+  comment order (`target` comparisons fold case, since GitHub owner/repo
+  names are case-insensitive — PR #2901 review, Copilot), which must
+  itself be `mode=acquire`: only that first marker is guaranteed to have
+  hashed the body as published, since a same-generation racer, a
+  `bootstrap`/`resume` recovery, or a legitimate re-acquisition after a
+  full release cycle all hash whatever body is live at their own posting
+  time, not the originally published one — comparing against any of
+  those instead of the Stage 1 acquire would make the check pass
+  trivially for a body edited before that later marker (PR #2901 review,
+  chatgpt-codex-connector across four rounds: earlier forms could
   authorize the auto-release exception against a losing racer's
-  edited-body digest, against an unrelated or incomplete stale
-  completion, or displace a legitimate `bootstrap`/`resume` winner with a
-  later competing `acquire`). A generation closes only on a
-  `mode=release-complete` that is itself anchor-scoped (its `target`
-  names the same issue as its own `anchor`), carries a real snapshot
-  digest (not the release-guard sentinel `none`), and retains that
-  generation's exact owner/set/session while naming the same `anchor`
-  and superseding that same owner token. `target`/`anchor` comparisons
-  fold case, since GitHub owner/repo names are case-insensitive (PR
-  #2901 review, Copilot). `mode=release-complete` is anchor-only, so for
-  a non-anchor child in a multi-target set this replay cannot see the
-  child's true generation boundary and fails closed (`mismatch`, never a
-  false `pass`) instead — an accepted limitation, since this helper's
-  own single-target orphan use case never hits it
+  edited-body digest, or against a later legitimate re-acquisition's
+  refreshed digest that silently absorbed an intervening edit). A target
+  whose trusted marker log opens with some other mode (`bootstrap`,
+  `resume`, `heartbeat`, `release`, ...) reports `not-found` rather than
+  accepting that non-acquire first marker's own digest, since every one
+  of those modes presupposes a prior acquire
 
 **Review & Merge Phase Helpers:**
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -296,13 +296,21 @@ in this preamble, since the fallback differs per helper.
   `--verbose` evidence) rather than accepting an invalid marker: its own
   `supersedes` field is `none` (contract.md requires this for `acquire`);
   its `body-sha256` is a real 64-hex digest, never the sentinel `none`;
-  its own `anchor` names the same issue as its own `target` (a mismatch
-  means the marker declares itself a multi-target set's non-anchor
-  child, out of scope for this single-target-orphan helper); and the
-  underlying comment's `updatedAt` equals its `createdAt` (contract.md:
-  owner comments are append-only and must not be edited, since an edited
-  comment could have had its `body-sha256` rewritten after the fact) (PR
-  #2901 review round 5, chatgpt-codex-connector and Copilot)
+  and its own `anchor` names the same issue as its own `target` (a
+  mismatch means the marker declares itself a multi-target set's
+  non-anchor child, out of scope for this single-target-orphan helper)
+  (PR #2901 review round 5, chatgpt-codex-connector and Copilot). Before
+  selecting a marker at all, also rejects the whole log if ANY trusted,
+  owner-marker-shaped comment was edited after posting (`updatedAt`
+  differs from `createdAt`) — not just the one that would otherwise be
+  selected, so editing the true Stage 1 acquire into something
+  unparseable or retargeting it cannot make it silently vanish and let a
+  later acquire win instead (contract.md: owner comments are append-only
+  and must not be edited or deleted). A trusted actor who deletes the
+  true Stage 1 acquire outright, rather than editing it, is an accepted
+  limitation instead: a deleted comment leaves no trace in any API
+  response this helper can read (PR #2901 review round 6,
+  chatgpt-codex-connector and Copilot)
 
 **Review & Merge Phase Helpers:**
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -273,43 +273,45 @@ in this preamble, since the fallback differs per helper.
   a pass. Read-only: never posts, labels, or mutates anything (referenced
   in
   [kurone-kito/idd-skill#2891](https://github.com/kurone-kito/idd-skill/issues/2891)).
-  Anchors on the target's own trusted marker log's _first_ marker in
-  comment order (`target` comparisons fold case, since GitHub owner/repo
-  names are case-insensitive — PR #2901 review, Copilot), which must
-  itself be `mode=acquire`: only that first marker is guaranteed to have
-  hashed the body as published, since a same-generation racer, a
-  `bootstrap`/`resume` recovery, or a legitimate re-acquisition after a
-  full release cycle all hash whatever body is live at their own posting
-  time, not the originally published one — comparing against any of
-  those instead of the Stage 1 acquire would make the check pass
+  Anchors on the target's own trusted, owner-marker-shaped comments
+  (every one still containing the case-insensitive
+  `<marker-prefix>-authoring-owner:` token, whether or not it parses),
+  taken in deterministic comment order. If ANY of those comments was
+  edited after posting (`updatedAt` differs from `createdAt`), the whole
+  log is rejected up front, before a first candidate is even chosen — an
+  editor cannot make the true Stage 1 acquire vanish from consideration
+  by editing it into something unparseable or retargeting it, letting a
+  later acquire silently win instead (PR #2901 review round 6, Copilot;
+  contract.md: owner comments are append-only). Past that check, the
+  _first_ candidate in comment order is scrutinized whatever its shape —
+  not merely the first one that happens to parse and match this target —
+  and must itself parse, name this issue as its target, and be a valid
+  Stage 1 `mode=acquire` marker, or this reports `not-found` rather than
+  silently skipping it for a later, validly-parsing marker (PR #2901
+  review round 7, Copilot). "Valid" means every condition contract.md
+  attaches to a genuine acquire: `mode=acquire` itself (every other mode
+  — `bootstrap`, `resume`, `heartbeat`, `release`, ... — presupposes a
+  prior acquire, so a well-formed history never opens with one);
+  `supersedes=none` (contract.md requires this specifically for
+  `acquire`); a real 64-hex `body-sha256`, never the sentinel `none`; and
+  its own `anchor` names the same issue as its own `target` (a mismatch
+  means the marker declares itself a multi-target set's non-anchor
+  child, out of scope for this single-target-orphan helper) (PR #2901
+  review round 5, chatgpt-codex-connector and Copilot). Only it, not any
+  later marker, is guaranteed to have hashed the body as published: a
+  same-generation racer, a `bootstrap`/`resume` recovery, or a legitimate
+  re-acquisition after a full release cycle all hash whatever body is
+  live at their own posting time, not the originally published one —
+  comparing against any of those instead would make the check pass
   trivially for a body edited before that later marker (PR #2901 review,
-  chatgpt-codex-connector across four rounds: earlier forms could
-  authorize the auto-release exception against a losing racer's
-  edited-body digest, or against a later legitimate re-acquisition's
-  refreshed digest that silently absorbed an intervening edit). A target
-  whose trusted marker log opens with some other mode (`bootstrap`,
-  `resume`, `heartbeat`, `release`, ...) reports `not-found` rather than
-  accepting that non-acquire first marker's own digest, since every one
-  of those modes presupposes a prior acquire. Also validates every other
-  condition contract.md attaches to a genuine Stage 1 acquire, failing
-  closed to `not-found` (with the specific reason surfaced in
-  `--verbose` evidence) rather than accepting an invalid marker: its own
-  `supersedes` field is `none` (contract.md requires this for `acquire`);
-  its `body-sha256` is a real 64-hex digest, never the sentinel `none`;
-  and its own `anchor` names the same issue as its own `target` (a
-  mismatch means the marker declares itself a multi-target set's
-  non-anchor child, out of scope for this single-target-orphan helper)
-  (PR #2901 review round 5, chatgpt-codex-connector and Copilot). Before
-  selecting a marker at all, also rejects the whole log if ANY trusted,
-  owner-marker-shaped comment was edited after posting (`updatedAt`
-  differs from `createdAt`) — not just the one that would otherwise be
-  selected, so editing the true Stage 1 acquire into something
-  unparseable or retargeting it cannot make it silently vanish and let a
-  later acquire win instead (contract.md: owner comments are append-only
-  and must not be edited or deleted). A trusted actor who deletes the
-  true Stage 1 acquire outright, rather than editing it, is an accepted
-  limitation instead: a deleted comment leaves no trace in any API
-  response this helper can read (PR #2901 review round 6,
+  chatgpt-codex-connector across four rounds). `target` comparisons fold
+  case, since GitHub owner/repo names are case-insensitive. Two accepted
+  limitations, both fail-closed (never a false `pass`): a marker whose
+  own `anchor` differs from its own `target` (a multi-target set's
+  non-anchor child, out of scope here); and tampering with the true
+  Stage 1 acquire that leaves no authoring-owner token at all — deleting
+  it outright, or editing it into ordinary prose — which cannot be
+  detected by a live comment-log reader (PR #2901 review rounds 5-7,
   chatgpt-codex-connector and Copilot)
 
 **Review & Merge Phase Helpers:**

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -290,7 +290,19 @@ in this preamble, since the fallback differs per helper.
   whose trusted marker log opens with some other mode (`bootstrap`,
   `resume`, `heartbeat`, `release`, ...) reports `not-found` rather than
   accepting that non-acquire first marker's own digest, since every one
-  of those modes presupposes a prior acquire
+  of those modes presupposes a prior acquire. Also validates every other
+  condition contract.md attaches to a genuine Stage 1 acquire, failing
+  closed to `not-found` (with the specific reason surfaced in
+  `--verbose` evidence) rather than accepting an invalid marker: its own
+  `supersedes` field is `none` (contract.md requires this for `acquire`);
+  its `body-sha256` is a real 64-hex digest, never the sentinel `none`;
+  its own `anchor` names the same issue as its own `target` (a mismatch
+  means the marker declares itself a multi-target set's non-anchor
+  child, out of scope for this single-target-orphan helper); and the
+  underlying comment's `updatedAt` equals its `createdAt` (contract.md:
+  owner comments are append-only and must not be edited, since an edited
+  comment could have had its `body-sha256` rewritten after the fact) (PR
+  #2901 review round 5, chatgpt-codex-connector and Copilot)
 
 **Review & Merge Phase Helpers:**
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -283,15 +283,17 @@ in this preamble, since the fallback differs per helper.
   edited-body digest, against an unrelated or incomplete stale
   completion, or displace a legitimate `bootstrap`/`resume` winner with a
   later competing `acquire`). A generation closes only on a
-  `mode=release-complete` that is itself anchor-scoped
-  (`target === anchor`), carries a real snapshot digest (not the
-  release-guard sentinel `none`), and retains that generation's exact
-  owner/set/session/anchor while superseding that same owner token.
-  `mode=release-complete` is anchor-only, so for a non-anchor child in a
-  multi-target set this replay cannot see the child's true generation
-  boundary and fails closed (`mismatch`, never a false `pass`) instead —
-  an accepted limitation, since this helper's own single-target orphan
-  use case never hits it
+  `mode=release-complete` that is itself anchor-scoped (its `target`
+  names the same issue as its own `anchor`), carries a real snapshot
+  digest (not the release-guard sentinel `none`), and retains that
+  generation's exact owner/set/session while naming the same `anchor`
+  and superseding that same owner token. `target`/`anchor` comparisons
+  fold case, since GitHub owner/repo names are case-insensitive (PR
+  #2901 review, Copilot). `mode=release-complete` is anchor-only, so for
+  a non-anchor child in a multi-target set this replay cannot see the
+  child's true generation boundary and fails closed (`mismatch`, never a
+  false `pass`) instead — an accepted limitation, since this helper's
+  own single-target orphan use case never hits it
 
 **Review & Merge Phase Helpers:**
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "idd-advisory-wait-state": "./bin/idd-advisory-wait-state.mjs",
     "idd-audit-authored-issue": "./bin/idd-audit-authored-issue.mjs",
     "idd-audit-pr-cleanup": "./bin/idd-audit-pr-cleanup.mjs",
+    "idd-authoring-owner-provenance": "./bin/idd-authoring-owner-provenance.mjs",
     "idd-branch-conflict-state": "./bin/idd-branch-conflict-state.mjs",
     "idd-branch-name": "./bin/idd-branch-name.mjs",
     "idd-ci-wait-policy": "./bin/idd-ci-wait-policy.mjs",

--- a/scripts/authoring-owner-provenance.mjs
+++ b/scripts/authoring-owner-provenance.mjs
@@ -41,13 +41,17 @@
 // defects: (1) a marker whose own `anchor` differs from its own `target`
 // declares itself a multi-target set's non-anchor child, out of scope
 // for this single-target-orphan helper (kurone-kito/idd-skill#2901
-// review, Copilot round 5). (2) a trusted actor who *deletes* the true
-// Stage 1 acquire comment outright (rather than editing it) leaves no
-// trace in any API response this helper can read -- detectable tampering
-// (an edit) fails closed (`findStageOneAcquire`'s pre-pass), but
-// undetectable tampering (a deletion) cannot be caught by a live
-// comment-log reader at all (kurone-kito/idd-skill#2901 review round 6,
-// chatgpt-codex-connector). contract.md's own remedy for that case is a
+// review, Copilot round 5). (2) tampering with the true Stage 1 acquire
+// comment that leaves no `<marker-prefix>-authoring-owner:` trace at
+// all -- deleting it outright, or editing it into ordinary prose that
+// no longer contains the token -- cannot be detected by a live
+// comment-log reader: a deleted comment is absent from every API
+// response, and a fully rewritten one is indistinguishable from a
+// comment that was always unrelated (kurone-kito/idd-skill#2901 review
+// rounds 6-7, chatgpt-codex-connector). Detectable tampering -- an edit
+// that leaves the token recognizable, even if it breaks parsing or
+// changes the target -- does fail closed (`findStageOneAcquire`'s
+// pre-pass). contract.md's remedy for the undetectable case is a
 // durable record the *authoring session itself* persists in its hold
 // state, not an artifact this read-only helper can independently fetch;
 // kurone-kito/idd-skill#2891's acceptance criteria scope this helper to
@@ -138,19 +142,26 @@ function invalidStageOneAcquireReason(event, target) {
   return null;
 }
 /**
- * True when `comment.body` looks like it once was (or currently attempts
- * to be) an `authoring-owner` marker -- either it still opens with the
- * canonical `<!--` HTML-comment-first byte, or it at least still contains
- * the `<marker-prefix>-authoring-owner:` token somewhere (an edit that
- * broke the opener but left the token recognizable). Used only to decide
- * whether an *edited* comment is suspicious enough to fail closed, not to
- * parse it -- a comment failing this check is confidently unrelated to
- * ownership (kurone-kito/idd-skill#2901 review, Copilot round 6).
+ * True when `comment.body` still contains the `<marker-prefix>
+ * -authoring-owner:` token somewhere, case-insensitively (matching
+ * `parseAuthoringOwnerComment`'s own case-insensitive marker regex --
+ * kurone-kito/idd-skill#2901 review, Copilot round 7: an edit that
+ * changed the token's casing while breaking its `<!--` opener must still
+ * be recognized). Deliberately narrower than "starts with `<!--`":
+ * every IDD marker family (claim, activation-nonce, watermark,
+ * review-baseline, ...) opens with that same byte, and a review-fix-
+ * loop-cutoff issue's own comment log routinely carries several of them
+ * before the owner acquire -- matching on the opener alone would treat
+ * every one of those as owner-marker-shaped and misfire whenever any of
+ * them was legitimately edited (kurone-kito/idd-skill#2901 review round
+ * 7). Used only to decide whether a comment is suspicious enough to
+ * scrutinize, not to parse it -- a comment failing this check carries no
+ * detectable trace of ever being an owner marker at all.
  */
 function looksLikeOwnerMarker(body, markerPrefix) {
-  return (
-    body.startsWith('<!--') || body.includes(`${markerPrefix}-authoring-owner:`)
-  );
+  return body
+    .toLowerCase()
+    .includes(`${markerPrefix.toLowerCase()}-authoring-owner:`);
 }
 /**
  * Find `target`'s own first trusted `authoring-owner` marker in
@@ -178,35 +189,57 @@ function looksLikeOwnerMarker(body, markerPrefix) {
  *   general "first valid marker by GitHub comment order wins" rule and
  *   this helper's own round-1/round-3 regression tests.
  *
- * Before selecting a first marker at all, a pre-pass rejects the whole
- * log if ANY trusted, owner-marker-shaped comment (`looksLikeOwnerMarker`)
- * was edited (`updatedAt !== createdAt`) -- not just the comment that
- * would otherwise be selected. An editor who edits the true Stage 1
- * acquire into something that no longer parses, or retargets it to a
- * different issue, would otherwise make it silently vanish from the
- * target-matching candidates below, letting a later (legitimate-looking)
- * acquire become `events[0]` unchallenged (kurone-kito/idd-skill#2901
- * review, Copilot round 6: the round-5 `updatedAt` check only inspected
- * the marker this function was about to select, which the edited marker
- * itself is no longer once tampering breaks its parse or its target).
- * This is deliberately over-broad in one direction: an edited `heartbeat`
- * (or any other owner-marker-shaped comment, for any target) also trips
- * it, even though only the eventual Stage 1 acquire matters semantically
- * -- accepted, since contract.md's append-only rule covers "owner
- * comments" generically, and failing closed on any detected edit is the
- * safe direction.
+ * The candidate pool is every trusted, owner-marker-shaped comment
+ * (`looksLikeOwnerMarker`) -- not just the ones that happen to parse and
+ * match `target` -- sorted into the same deterministic comment order,
+ * with the *first* one in that order scrutinized as the Stage 1
+ * candidate, whatever its shape:
  *
- * Undetectable tampering -- a trusted actor deleting the true Stage 1
- * acquire outright, rather than editing it -- is out of scope: a deleted
- * comment is absent from every API response, so no comment-log reader
- * can see it happened (kurone-kito/idd-skill#2901 review round 6,
- * chatgpt-codex-connector; accepted limitation, same footing as the
- * non-anchor-child limitation above -- see this file's header comment).
+ * - If ANY owner-marker-shaped comment in the whole pool was edited
+ *   (`updatedAt !== createdAt`), the whole log is rejected up front,
+ *   before a first candidate is even chosen -- not only when the edited
+ *   comment would otherwise have been selected. An editor who edits the
+ *   true Stage 1 acquire into something that still carries the marker
+ *   token but no longer parses, or retargets it to a different issue,
+ *   cannot make it silently drop out of consideration and let a later
+ *   (legitimate-looking) acquire win instead (kurone-kito/idd-skill#2901
+ *   review, Copilot round 6). This is deliberately over-broad in one
+ *   direction: an edited `heartbeat` (or any other owner-marker-shaped
+ *   comment, for any target) also trips it, even though only the
+ *   eventual Stage 1 acquire matters semantically -- accepted, since
+ *   contract.md's append-only rule covers "owner comments" generically
+ *   and failing closed on any detected edit is the safe direction.
+ * - The pool's first comment, once past the edit check, must itself
+ *   parse as an `authoring-owner` marker and name `target` -- an
+ *   unedited-but-malformed first attempt (a genuine posting error, not
+ *   tampering) is rejected rather than silently skipped in favor of a
+ *   later, validly-parsing marker, matching "the target's own
+ *   `mode=acquire` owner marker" read literally: the log's first
+ *   candidate either is that marker or the log is unusable, never a
+ *   later marker standing in for it (kurone-kito/idd-skill#2901 review
+ *   round 7, Copilot: the earlier form filtered the pool down to
+ *   parsing, target-matching comments *before* taking the first one,
+ *   so a first comment that failed either check simply vanished from
+ *   consideration instead of blocking selection).
+ * - Once the first candidate parses and matches `target`, every other
+ *   Stage 1 validity condition still applies (see
+ *   `invalidStageOneAcquireReason`).
+ *
+ * Undetectable tampering is out of scope, on two related fronts,
+ * documented as accepted limitations in this file's header comment: a
+ * trusted actor who deletes the true Stage 1 acquire outright (rather
+ * than editing it), and one who edits it into ordinary prose that no
+ * longer contains the owner-marker token at all. Both leave no trace
+ * `looksLikeOwnerMarker` (or any comment-log reader) can detect --
+ * indistinguishable from a comment that was always unrelated
+ * (kurone-kito/idd-skill#2901 review round 6 and round 7,
+ * chatgpt-codex-connector).
  *
  * Returns `{ event: null, rejectReason }` (never a false `pass`) when
- * the log is rejected by the pre-pass or the first marker fails
- * validation, `{ event: null, rejectReason: null }` when no trusted
- * marker exists at all, or `{ event, rejectReason: null }` on success.
+ * the pool is rejected by the edit check or the first candidate fails
+ * parsing, target-matching, or validation; `{ event: null, rejectReason:
+ * null }` when the pool is empty; or `{ event, rejectReason: null }` on
+ * success.
  */
 function findStageOneAcquire(
   comments,
@@ -217,14 +250,19 @@ function findStageOneAcquire(
   const trusted = new Set(
     trustedMarkerLogins.map((login) => login.toLowerCase()),
   );
-  const trustedComments = comments.filter((comment) =>
-    trusted.has(String(comment.authorLogin ?? '').toLowerCase()),
-  );
-  for (const comment of trustedComments) {
-    if (
-      comment.updatedAt !== comment.createdAt &&
-      looksLikeOwnerMarker(comment.body, markerPrefix)
-    ) {
+  const shaped = comments
+    .filter((comment) =>
+      trusted.has(String(comment.authorLogin ?? '').toLowerCase()),
+    )
+    .filter((comment) => looksLikeOwnerMarker(comment.body, markerPrefix));
+  shaped.sort((a, b) => {
+    if (a.createdAt !== b.createdAt) {
+      return a.createdAt < b.createdAt ? -1 : 1;
+    }
+    return a.id - b.id;
+  });
+  for (const comment of shaped) {
+    if (comment.updatedAt !== comment.createdAt) {
       return {
         event: null,
         rejectReason:
@@ -234,29 +272,29 @@ function findStageOneAcquire(
       };
     }
   }
-  const events = [];
-  for (const comment of trustedComments) {
-    const parsed = parseAuthoringOwnerComment(comment.body, markerPrefix);
-    if (!parsed || !sameIssueRef(parsed.target, target)) {
-      continue;
-    }
-    events.push({ comment, parsed });
-  }
-  events.sort((a, b) => {
-    if (a.comment.createdAt !== b.comment.createdAt) {
-      return a.comment.createdAt < b.comment.createdAt ? -1 : 1;
-    }
-    return a.comment.id - b.comment.id;
-  });
-  const first = events[0];
+  const first = shaped[0];
   if (!first) {
     return { event: null, rejectReason: null };
   }
-  const rejectReason = invalidStageOneAcquireReason(first, target);
+  const parsed = parseAuthoringOwnerComment(first.body, markerPrefix);
+  if (!parsed) {
+    return {
+      event: null,
+      rejectReason: `trusted comment #${first.id} looks like an authoring-owner marker but does not parse as one`,
+    };
+  }
+  if (!sameIssueRef(parsed.target, target)) {
+    return {
+      event: null,
+      rejectReason: `trusted comment #${first.id}'s marker names a different target (${parsed.target})`,
+    };
+  }
+  const event = { comment: first, parsed };
+  const rejectReason = invalidStageOneAcquireReason(event, target);
   if (rejectReason) {
     return { event: null, rejectReason };
   }
-  return { event: first, rejectReason: null };
+  return { event, rejectReason: null };
 }
 /**
  * Compute the sha256 of `input.liveBody` (exact UTF-8 content, matching how
@@ -402,47 +440,53 @@ own Stage 1 mode=acquire authoring-owner marker's recorded body-sha256
 (kurone-kito/idd-skill#2891). Read-only: never posts, labels, or mutates
 anything. --owner and --repo must be given together or not at all.
 
-The comparison anchors on this issue's own trusted authoring-owner marker
-log's *first* marker, in deterministic comment order (createdAt, ties
-broken by comment id ascending) -- contract.md and this issue's own
-acceptance criteria both name "a named target's mode=acquire owner
-marker", singular, tied to Stage 1 publication. That first marker must
-itself be mode=acquire: only it is guaranteed to have hashed the body as
-published, since every later marker (a same-generation racer, a
-bootstrap/resume recovery, or a legitimate re-acquisition after a full
-release cycle) hashes whatever body is live at its own posting time, not
-the originally published one -- comparing against a later acquire would
-make this check pass trivially for a body edited before that later
-marker (kurone-kito/idd-skill#2901 review, chatgpt-codex-connector round
-4). target comparisons fold case, since GitHub owner/repo names are
-case-insensitive.
+The comparison anchors on this issue's own trusted, owner-marker-shaped
+comments -- every one still containing the case-insensitive
+"<marker-prefix>-authoring-owner:" token, whether or not it actually
+parses -- taken in deterministic comment order (createdAt, ties broken
+by comment id ascending). If ANY of those comments was edited after
+posting (its updatedAt differs from its createdAt), the whole log is
+rejected up front, before a first candidate is even chosen: an editor
+cannot make the true Stage 1 acquire vanish from consideration by
+editing it into something unparseable or retargeting it, letting a
+later acquire silently win instead (kurone-kito/idd-skill#2901 review
+round 6, Copilot). This is deliberately over-broad in one direction (an
+edited heartbeat, for example, also trips it) since contract.md's
+append-only rule covers owner comments generically.
 
-The first marker must also pass every validity condition contract.md
-attaches to a genuine Stage 1 acquire, or this reports not-found rather
-than accepting an invalid marker's own digest (kurone-kito/idd-skill#2901
-review round 5): mode=acquire itself (every other mode -- bootstrap,
-resume, heartbeat, release, ... -- presupposes a prior acquire, so a
-well-formed history never opens with one); supersedes=none (contract.md
-requires this specifically for acquire); a real 64-hex body-sha256, never
-the shape-valid sentinel "none"; and its own anchor names the same issue
-as its own target (a mismatch declares the marker a multi-target set's
+Past that check, the *first* candidate in comment order is scrutinized,
+whatever its shape -- not merely the first one that happens to parse and
+match this target. It must parse as an authoring-owner marker at all,
+name this issue as its own target, and itself be a valid Stage 1
+mode=acquire marker, or this reports not-found rather than silently
+skipping it in favor of a later, validly-parsing marker
+(kurone-kito/idd-skill#2901 review round 7, Copilot). "Valid" means
+every condition contract.md attaches to a genuine Stage 1 acquire:
+mode=acquire itself (every other mode -- bootstrap, resume, heartbeat,
+release, ... -- presupposes a prior acquire, so a well-formed history
+never opens with one); supersedes=none (contract.md requires this
+specifically for acquire); a real 64-hex body-sha256, never the
+shape-valid sentinel "none"; and its own anchor names the same issue as
+its own target (a mismatch declares the marker a multi-target set's
 non-anchor child, out of scope for this single-target-orphan helper).
---verbose surfaces which condition failed in the acquire_marker_found
-check's evidence.
+Only it, not any later marker, is guaranteed to have hashed the body as
+published: a same-generation racer, a bootstrap/resume recovery, or a
+legitimate re-acquisition after a full release cycle all hash whatever
+body is live at their own posting time, not the originally published
+one -- comparing against any of those instead would make this check
+pass trivially for a body edited before that later marker
+(kurone-kito/idd-skill#2901 review, chatgpt-codex-connector round 4).
+target comparisons fold case, since GitHub owner/repo names are
+case-insensitive. --verbose surfaces which condition failed in the
+acquire_marker_found check's evidence.
 
-Before selecting a marker at all, this also rejects the whole log (with
-not-found) if ANY trusted, owner-marker-shaped comment was edited after
-posting (its updatedAt differs from its createdAt) -- not just the one
-that would otherwise be selected, so an editor cannot make the true
-Stage 1 acquire vanish from consideration by editing it into something
-unparseable or retargeting it, letting a later acquire silently win
-instead (kurone-kito/idd-skill#2901 review round 6, Copilot). This is
-deliberately over-broad in one direction (an edited heartbeat, for
-example, also trips it) since contract.md's append-only rule covers
-owner comments generically. A trusted actor who deletes the true Stage 1
-acquire outright, rather than editing it, is an accepted limitation: a
-deleted comment leaves no trace in any API response this helper can read
-(kurone-kito/idd-skill#2901 review round 6, chatgpt-codex-connector).
+Two accepted limitations, both fail-closed (never a false pass): a
+marker whose own anchor differs from its own target (a multi-target
+set's non-anchor child, out of scope here); and tampering with the true
+Stage 1 acquire that leaves no authoring-owner token at all -- deleting
+it outright, or editing it into ordinary prose -- which cannot be
+detected by a live comment-log reader (kurone-kito/idd-skill#2901
+review rounds 5-7, chatgpt-codex-connector and Copilot).
 
 Output schema:
 {

--- a/scripts/authoring-owner-provenance.mjs
+++ b/scripts/authoring-owner-provenance.mjs
@@ -10,13 +10,21 @@
 // bullet, kurone-kito/idd-skill#2891): before honoring that exception, a
 // releasing session must recompute a target issue's current body-sha256
 // from a fresh read and compare it against that same target's own
-// winning `authoring-owner` ownership generation marker's recorded
-// `body-sha256` -- normally a `mode=acquire` marker, but a stale-hold
-// `bootstrap` or interrupted-set `resume` can legitimately win a
-// generation too (contract.md; see `findWinningAcquire`'s own doc
-// comment). That comparison previously relied entirely on a releasing
-// session's own manual judgment; this helper performs and verifies it
-// mechanically instead.
+// `mode=acquire` owner marker's recorded `body-sha256` -- specifically
+// the target's *first* trusted `mode=acquire` marker (the Stage 1
+// acquire), never a later one. contract.md is explicit that this digest
+// is "hashed from the fresh read taken immediately before that marker
+// was posted, so it already reflects the published body" -- that
+// property holds only for the very first acquire, since every acquire
+// (including a legitimate re-acquisition after a full release cycle)
+// hashes whatever body is live *at its own posting time*, not the
+// originally published one. Anchoring on "whichever generation currently
+// owns the target" instead of the first acquire would make the check
+// tautological for any edit landing before a later re-acquisition
+// (kurone-kito/idd-skill#2901 review, chatgpt-codex-connector round 4 --
+// see `findStageOneAcquire`'s own doc comment). That comparison
+// previously relied entirely on a releasing session's own manual
+// judgment; this helper performs and verifies it mechanically instead.
 //
 // Read-only evidence collector (docs/idd-helper-scripts.md's "Helper
 // contract classes"): it never posts comments, applies labels, or mutates
@@ -28,22 +36,6 @@
 // target issue (never on a different anchor issue), so the live body and
 // the marker to compare it against always come from the one `--issue`
 // argument.
-//
-// Generation-boundary caveat: `mode=release-complete` is anchor-only
-// (contract.md). For `target === anchor` -- the single-target hold shape
-// this helper is built for (a review-fix-loop-cutoff follow-up is always
-// orphan-shaped, never a set member) -- the target's own comment log
-// carries every generation boundary directly and the replay below is
-// exact. A non-anchor child in a multi-target set never carries its own
-// `release-complete`, so this helper (which reads only the named
-// `--issue`'s own log, never an anchor's) cannot see a child's true
-// generation boundary; every generation-opening marker (acquire,
-// bootstrap, or resume) on such a child reads as one still-open
-// generation. That is the fail-closed direction -- a
-// legitimately re-acquired child compares against the first
-// generation's digest and reports `mismatch`, never a false `pass` --
-// so it is an accepted limitation, not a defect. Fetching the anchor's
-// own log to resolve it is out of scope for kurone-kito/idd-skill#2891.
 import { createHash } from 'node:crypto';
 import { parseCliArgs } from './cli-args.mjs';
 import { loadPolicyConfig } from './idd-config.mjs';
@@ -73,41 +65,40 @@ function sameIssueRef(a, b) {
   return a.toLowerCase() === b.toLowerCase();
 }
 /**
- * Replay `target`'s own trusted `authoring-owner` marker log in
- * chronological order (ties broken by comment `id`, ascending — the
- * deterministic order contract.md's replay rule requires) and return the
- * generation-opening marker that won the log's last generation, or
- * `null` if none exists.
+ * Find `target`'s own first trusted `mode=acquire` `authoring-owner`
+ * marker in deterministic comment order (`createdAt`, ties broken by
+ * comment `id` ascending), or `null` if none exists.
  *
- * A generation opens at the first `acquire`, `bootstrap`, or `resume`
- * marker (`GENERATION_OPENER_MODES` below) when no generation is
- * currently open; contract.md: "the first valid acquisition, bootstrap,
- * or resume marker by GitHub comment order wins", so a second
- * generation-opening marker while a generation is already open is a
- * same-generation race — a losing racer or a duplicate — and never
- * overrides the winner. Whichever mode wins, its own `body-sha256` field
- * is the digest this comparison uses (kurone-kito/idd-skill#2901 review,
- * chatgpt-codex-connector round 3: the earlier form recognized only
- * `acquire` as a generation opener, so a legitimate `bootstrap`/`resume`
- * winner could be silently displaced by a later competing `acquire`).
+ * This is deliberately narrower than "whichever marker currently owns
+ * the target": contract.md's provenance-check clause and
+ * kurone-kito/idd-skill#2891's own acceptance criteria both name "a
+ * named target's `mode=acquire` owner marker" -- singular, tied to
+ * Stage 1 publication, not a general ownership-resolution query. Only
+ * the target's *first* trusted marker can carry that property, and only
+ * when that first marker is itself a `mode=acquire`:
  *
- * A generation closes only on a `mode=release-complete` that
- * `isValidReleaseComplete` (below) accepts as a genuine closure of the
- * currently open generation — a stale, malformed, or unrelated
- * completion never closes it (kurone-kito/idd-skill#2901 review,
- * chatgpt-codex-connector rounds 2-3: closing on any release-complete
- * for the target, unchecked, could let an unrelated or incomplete
- * completion evict a still-legitimate winner). `release` /
- * `release-guard` alone never close a generation either, since
- * contract.md allows a new acquisition to start "only once the anchor
- * completion is reconciled" — a generation-opening marker after
- * `release` but before `release-complete` is still a same-generation
- * race, not a fresh generation. See this file's header comment for the
- * anchor-only `release-complete` caveat this replay accepts for a
- * non-anchor child target.
+ * - A later `mode=acquire` (a legitimate re-acquisition after a full
+ *   release cycle) hashes whatever body is live at *its own* posting
+ *   time, not the originally published one -- comparing against it
+ *   would make this check pass trivially for a body edited between the
+ *   original acquire and the re-acquisition, defeating the point of the
+ *   check (kurone-kito/idd-skill#2901 review, chatgpt-codex-connector
+ *   round 4: the earlier "winning ownership generation" replay design
+ *   picked exactly this kind of later marker).
+ * - A same-generation race (two competing `mode=acquire` markers before
+ *   any release) still resolves to the first one, matching contract.md's
+ *   general "first valid marker by GitHub comment order wins" rule and
+ *   this helper's own round-1/round-3 regression tests.
+ * - If the target's first trusted marker is some other mode (`bootstrap`,
+ *   `resume`, `heartbeat`, `release`, ...), that is an anomaly: every
+ *   one of those modes presupposes a prior acquire, so a well-formed
+ *   history never opens with them. Reporting `not-found` (fail-closed)
+ *   for that case, rather than silently accepting a non-acquire first
+ *   marker's own digest, is the only defensible reading of "the
+ *   target's own `mode=acquire` owner marker" when no such marker heads
+ *   the log.
  */
-const GENERATION_OPENER_MODES = new Set(['acquire', 'bootstrap', 'resume']);
-function findWinningAcquire(
+function findStageOneAcquire(
   comments,
   target,
   markerPrefix,
@@ -133,87 +124,36 @@ function findWinningAcquire(
     }
     return a.comment.id - b.comment.id;
   });
-  let winner = null;
-  let generationOpen = false;
-  for (const event of events) {
-    if (GENERATION_OPENER_MODES.has(event.parsed.mode)) {
-      if (!generationOpen) {
-        winner = event;
-        generationOpen = true;
-      }
-      // else: same-generation race -- the first generation-opening
-      // marker (acquire, bootstrap, or resume) keeps ownership.
-    } else if (
-      event.parsed.mode === 'release-complete' &&
-      winner &&
-      isValidReleaseComplete(event.parsed, winner.parsed)
-    ) {
-      generationOpen = false;
-    }
+  const first = events[0];
+  if (!first || first.parsed.mode !== 'acquire') {
+    return null;
   }
-  return winner;
-}
-/**
- * True when `completion` (a `mode=release-complete` event) is a valid
- * closure of the generation `winner` opened. contract.md requires all of:
- * - **anchor-only** ("release-complete is valid only on the set
- *   anchor"): `completion.target` names the same issue as
- *   `completion.anchor` -- a release-complete recorded on a non-anchor
- *   child's own comment thread (this replay only ever reads the named
- *   target's own log, so `completion.target` is always this issue) can
- *   never legitimately close a generation here.
- * - **required snapshot digest** ("carries the required canonical set
- *   snapshot digest"): `completion.snapshotSha256 !== 'none'` --
- *   `'none'` is release-guard's own sentinel, not a valid completion.
- * - **retains the winning generation's identity** ("retains the
- *   anchor's current owner, set, anchor, and session, and sets
- *   supersedes to that owner token"): owner/set/session match `winner`'s
- *   exactly, `completion.anchor` names the same issue as `winner.anchor`,
- *   and `supersedes` equals `winner`'s own owner token.
- *
- * `target`/`anchor` comparisons fold case (`sameIssueRef`): GitHub
- * owner/repo names are case-insensitive, so a completion typed or quoted
- * with different capitalization than the winner's own `anchor` still
- * names the same issue (#2901 review, Copilot round 4).
- *
- * A release-complete failing any of these is stale, malformed, or for
- * an unrelated generation, and is ignored rather than closing the
- * current one (#2901 review, chatgpt-codex-connector rounds 2-3).
- */
-function isValidReleaseComplete(completion, winner) {
-  return (
-    sameIssueRef(completion.target, completion.anchor) &&
-    completion.snapshotSha256 !== 'none' &&
-    completion.owner === winner.owner &&
-    completion.set === winner.set &&
-    completion.session === winner.session &&
-    sameIssueRef(completion.anchor, winner.anchor) &&
-    completion.supersedes === winner.owner
-  );
+  return first;
 }
 /**
  * Compute the sha256 of `input.liveBody` (exact UTF-8 content, matching how
  * the `authoring-owner` marker's `body-sha256` field is documented to be
  * computed — contract.md's "Per-target ownership" section) and compare it
- * against `input.target`'s own trusted winning generation marker (see
- * `findWinningAcquire`).
+ * against `input.target`'s own first trusted `mode=acquire` marker (see
+ * `findStageOneAcquire`) -- the Stage 1 acquire, never a later
+ * re-acquisition.
  *
- * `verdict` is `not-found` when no generation marker won for
- * `input.target`; `pass`/`mismatch` otherwise based on exact digest
- * equality. This never fails open on ambiguity: a missing marker is
- * `not-found`, not `pass`.
+ * `verdict` is `not-found` when no trusted marker log for `input.target`
+ * opens with a `mode=acquire` marker; `pass`/`mismatch` otherwise based
+ * on exact digest equality. This never fails open on ambiguity: a
+ * missing or non-acquire-first marker is `not-found`, not `pass`.
  */
 export function evaluateAuthoringOwnerProvenance(input) {
   const computedBodySha256 = createHash('sha256')
     .update(input.liveBody, 'utf8')
     .digest('hex');
-  const winner = findWinningAcquire(
+  const acquire = findStageOneAcquire(
     input.comments ?? [],
     input.target,
     input.markerPrefix,
     input.trustedMarkerLogins ?? [],
   );
-  if (!winner) {
+  if (!acquire) {
     return {
       verdict: 'not-found',
       target: input.target,
@@ -222,21 +162,21 @@ export function evaluateAuthoringOwnerProvenance(input) {
       marker: null,
       checks: [
         {
-          id: 'generation_marker_found',
-          name: 'A trusted acquire/bootstrap/resume marker won a generation for target',
+          id: 'acquire_marker_found',
+          name: "Target's marker log opens with a trusted mode=acquire marker",
           result: 'fail',
-          evidence: `No trusted acquire/bootstrap/resume authoring-owner marker for target ${input.target} won an open generation in the replayed log.`,
+          evidence: `No trusted authoring-owner marker log for target ${input.target} opens with a mode=acquire marker.`,
         },
         {
           id: 'body_sha256_match',
-          name: "Live body sha256 matches the winning marker's recorded digest",
+          name: "Live body sha256 matches the Stage 1 acquire marker's recorded digest",
           result: 'fail',
-          evidence: 'No generation marker to compare against.',
+          evidence: 'No Stage 1 acquire marker to compare against.',
         },
       ],
     };
   }
-  const recordedBodySha256 = winner.parsed.bodySha256;
+  const recordedBodySha256 = acquire.parsed.bodySha256;
   const matches = recordedBodySha256 === computedBodySha256;
   return {
     verdict: matches ? 'pass' : 'mismatch',
@@ -244,24 +184,24 @@ export function evaluateAuthoringOwnerProvenance(input) {
     computedBodySha256,
     recordedBodySha256,
     marker: {
-      author: winner.comment.authorLogin,
-      createdAt: winner.comment.createdAt,
-      mode: winner.parsed.mode,
-      owner: winner.parsed.owner,
-      set: winner.parsed.set,
-      session: winner.parsed.session,
-      bodySha256: winner.parsed.bodySha256,
+      author: acquire.comment.authorLogin,
+      createdAt: acquire.comment.createdAt,
+      mode: acquire.parsed.mode,
+      owner: acquire.parsed.owner,
+      set: acquire.parsed.set,
+      session: acquire.parsed.session,
+      bodySha256: acquire.parsed.bodySha256,
     },
     checks: [
       {
-        id: 'generation_marker_found',
-        name: 'A trusted acquire/bootstrap/resume marker won a generation for target',
+        id: 'acquire_marker_found',
+        name: "Target's marker log opens with a trusted mode=acquire marker",
         result: 'pass',
-        evidence: `Winning mode=${winner.parsed.mode} marker posted by ${winner.comment.authorLogin} at ${winner.comment.createdAt} (owner=${winner.parsed.owner}).`,
+        evidence: `Stage 1 mode=acquire marker posted by ${acquire.comment.authorLogin} at ${acquire.comment.createdAt} (owner=${acquire.parsed.owner}).`,
       },
       {
         id: 'body_sha256_match',
-        name: "Live body sha256 matches the winning marker's recorded digest",
+        name: "Live body sha256 matches the Stage 1 acquire marker's recorded digest",
         result: matches ? 'pass' : 'fail',
         evidence: matches
           ? `computed ${computedBodySha256} matches recorded ${recordedBodySha256}.`
@@ -319,27 +259,27 @@ function printHelp() {
   node scripts/authoring-owner-provenance.mjs --issue <number> [--owner <owner> --repo <repo>] [--policy <path>] [--marker-prefix <prefix>] [--gh-token <token>] [--trusted-marker-logins <login1,login2>] [--verbose]
 
 Mechanically compares a live issue body's sha256 against that same issue's
-own trusted winning ownership-generation authoring-owner marker's recorded
-body-sha256 (kurone-kito/idd-skill#2891). Read-only: never posts, labels, or
-mutates anything. --owner and --repo must be given together or not at all.
+own Stage 1 mode=acquire authoring-owner marker's recorded body-sha256
+(kurone-kito/idd-skill#2891). Read-only: never posts, labels, or mutates
+anything. --owner and --repo must be given together or not at all.
 
-The comparison replays this issue's own authoring-owner marker log to find
-the acquire/bootstrap/resume marker that won its last generation (a
-same-generation race between two competing generation-opening markers
-resolves to the first one -- contract.md: choose the winner by
-deterministic comment order); a generation closes only on a
-mode=release-complete that retains that generation's exact
-owner/set/session, names the same anchor, supersedes that same owner
-token, is itself anchor-scoped (its target names the same issue as its
-own anchor), and carries a real snapshot digest (not the release-guard
-sentinel "none"). target/anchor comparisons fold case, since GitHub
-owner/repo names are case-insensitive. Caveat: release-complete is
-anchor-only, so for a non-anchor child target in a multi-target set this
-replay cannot see the child's true generation boundary and treats every
-generation-opening marker on it as one still-open generation -- fail-closed
-(mismatch, never a false pass), not a security gap; a review-fix-loop-cutoff
-follow-up (the case this helper exists for) is always a single-target
-orphan, never a set member.
+The comparison anchors on this issue's own trusted authoring-owner marker
+log's *first* marker, in deterministic comment order (createdAt, ties
+broken by comment id ascending) -- contract.md and this issue's own
+acceptance criteria both name "a named target's mode=acquire owner
+marker", singular, tied to Stage 1 publication. That first marker must
+itself be mode=acquire: only it is guaranteed to have hashed the body as
+published, since every later marker (a same-generation racer, a
+bootstrap/resume recovery, or a legitimate re-acquisition after a full
+release cycle) hashes whatever body is live at its own posting time, not
+the originally published one -- comparing against a later acquire would
+make this check pass trivially for a body edited before that later
+marker (kurone-kito/idd-skill#2901 review, chatgpt-codex-connector round
+4). target comparisons fold case, since GitHub owner/repo names are
+case-insensitive. If the target's first trusted marker is some other mode
+(bootstrap, resume, heartbeat, release, ...), that is an anomaly -- every
+one of those modes presupposes a prior acquire -- and reports not-found
+rather than accepting a non-acquire first marker's own digest.
 
 Output schema:
 {
@@ -349,21 +289,21 @@ Output schema:
   "verdict": "pass|mismatch|not-found",
   "computedBodySha256": "<64-hex>",
   "recordedBodySha256": "<64-hex-or-the-literal-string-none>|null",
-  "marker": {"author": "...", "createdAt": "...", "mode": "acquire|bootstrap|resume", "owner": "...", "set": "...", "session": "...", "bodySha256": "<64-hex-or-the-literal-string-none>"} | null,
-  "checks": [{"id":"generation_marker_found","name":"...","result":"pass|fail"}, {"id":"body_sha256_match","name":"...","result":"pass|fail"}]
+  "marker": {"author": "...", "createdAt": "...", "mode": "acquire", "owner": "...", "set": "...", "session": "...", "bodySha256": "<64-hex-or-the-literal-string-none>"} | null,
+  "checks": [{"id":"acquire_marker_found","name":"...","result":"pass|fail"}, {"id":"body_sha256_match","name":"...","result":"pass|fail"}]
 }
 
-"not-found" means no trusted acquire/bootstrap/resume authoring-owner
-marker won a generation for this issue's own target -- never treated as a
-pass. "mismatch" means the live body has changed since the winning
-marker's own snapshot, including when its body-sha256 is the
+"not-found" means this issue's own trusted authoring-owner marker log does
+not open with a mode=acquire marker for this target -- never treated as a
+pass. "mismatch" means the live body has changed since the Stage 1
+acquire marker's own snapshot, including when its body-sha256 is the
 malformed-but-shape-valid sentinel "none" -- it can never equal a real
 64-hex computed digest, so this stays fail-closed rather than silently
 passing.
 
 --verbose adds an "evidence" string to each checks[] entry (the computed
-and recorded digests, or the winning marker's author/timestamp); omitted by
-default to keep default output terse.
+and recorded digests, or the acquire marker's author/timestamp); omitted
+by default to keep default output terse.
 `);
 }
 function runCli() {

--- a/scripts/authoring-owner-provenance.mjs
+++ b/scripts/authoring-owner-provenance.mjs
@@ -65,17 +65,77 @@ function sameIssueRef(a, b) {
   return a.toLowerCase() === b.toLowerCase();
 }
 /**
- * Find `target`'s own first trusted `mode=acquire` `authoring-owner`
- * marker in deterministic comment order (`createdAt`, ties broken by
- * comment `id` ascending), or `null` if none exists.
+ * Matches a real 64-lowercase-hex sha256 digest, excluding the
+ * shape-valid-but-malformed sentinel `none` that a marker's own
+ * `body-sha256`/`snapshot-sha256` field can legitimately carry for other
+ * modes (`release-guard`'s `body-sha256=none`, for example) but never for
+ * a genuine Stage 1 `mode=acquire` marker, whose entire purpose is
+ * recording the published body's digest.
+ */
+const REAL_DIGEST_PATTERN = /^[0-9a-f]{64}$/;
+/**
+ * True when `event` is a genuine, unedited Stage 1 `mode=acquire` marker
+ * for `target` -- every condition contract.md attaches to a valid
+ * acquisition, checked explicitly rather than assumed:
+ *
+ * - `mode === 'acquire'`: every other mode (`bootstrap`, `resume`,
+ *   `heartbeat`, `release`, `release-complete`, ...) presupposes a prior
+ *   acquire, so a well-formed history never opens with one of them.
+ * - `supersedes === 'none'`: contract.md requires this for `acquire` (and
+ *   `bootstrap`) specifically -- only `resume` names a prior owner token
+ *   (kurone-kito/idd-skill#2901 review, chatgpt-codex-connector round 5).
+ * - `bodySha256` is a real 64-hex digest, never the shape-valid sentinel
+ *   `none` -- a Stage 1 acquire's whole purpose is recording the
+ *   published body's digest, so `none` here is malformed, not merely
+ *   unlucky.
+ * - the marker's own `anchor` names the same issue as `target`: per
+ *   contract.md, "the anchor's own marker uses its target as the
+ *   anchor" -- a marker with a different anchor is a multi-target set's
+ *   non-anchor child, out of scope for this helper's single-target
+ *   orphan design (kurone-kito/idd-skill#2891's own acceptance
+ *   criteria; kurone-kito/idd-skill#2901 review, Copilot round 5).
+ * - `comment.updatedAt === comment.createdAt`: contract.md requires
+ *   owner comments to be "append-only and must not be edited or
+ *   deleted" -- an edited comment could have had its `body-sha256`
+ *   silently rewritten to match a body modified after Stage 1, so this
+ *   fails closed instead of trusting an editable field
+ *   (kurone-kito/idd-skill#2901 review, chatgpt-codex-connector
+ *   round 5).
+ *
+ * Returns `null` when valid, or a short human-readable reason string
+ * when not (surfaced in the `acquire_marker_found` check's evidence).
+ */
+function invalidStageOneAcquireReason(event, target) {
+  const { parsed, comment } = event;
+  if (parsed.mode !== 'acquire') {
+    return `first trusted marker has mode=${parsed.mode}, not acquire`;
+  }
+  if (parsed.supersedes !== 'none') {
+    return `acquire marker has supersedes=${parsed.supersedes} (acquire requires none)`;
+  }
+  if (!REAL_DIGEST_PATTERN.test(parsed.bodySha256)) {
+    return `acquire marker's body-sha256 is not a real digest (got ${parsed.bodySha256})`;
+  }
+  if (!sameIssueRef(parsed.anchor, target)) {
+    return `acquire marker's anchor (${parsed.anchor}) differs from its target -- a multi-target set's non-anchor child is out of scope for this helper`;
+  }
+  if (comment.updatedAt !== comment.createdAt) {
+    return `acquire marker comment was edited after posting (createdAt=${comment.createdAt}, updatedAt=${comment.updatedAt}) -- owner comments must be append-only`;
+  }
+  return null;
+}
+/**
+ * Find `target`'s own first trusted `authoring-owner` marker in
+ * deterministic comment order (`createdAt`, ties broken by comment `id`
+ * ascending) and validate it as a genuine Stage 1 `mode=acquire` marker
+ * (see `invalidStageOneAcquireReason`).
  *
  * This is deliberately narrower than "whichever marker currently owns
  * the target": contract.md's provenance-check clause and
  * kurone-kito/idd-skill#2891's own acceptance criteria both name "a
  * named target's `mode=acquire` owner marker" -- singular, tied to
  * Stage 1 publication, not a general ownership-resolution query. Only
- * the target's *first* trusted marker can carry that property, and only
- * when that first marker is itself a `mode=acquire`:
+ * the target's *first* trusted marker can carry that property:
  *
  * - A later `mode=acquire` (a legitimate re-acquisition after a full
  *   release cycle) hashes whatever body is live at *its own* posting
@@ -89,14 +149,11 @@ function sameIssueRef(a, b) {
  *   any release) still resolves to the first one, matching contract.md's
  *   general "first valid marker by GitHub comment order wins" rule and
  *   this helper's own round-1/round-3 regression tests.
- * - If the target's first trusted marker is some other mode (`bootstrap`,
- *   `resume`, `heartbeat`, `release`, ...), that is an anomaly: every
- *   one of those modes presupposes a prior acquire, so a well-formed
- *   history never opens with them. Reporting `not-found` (fail-closed)
- *   for that case, rather than silently accepting a non-acquire first
- *   marker's own digest, is the only defensible reading of "the
- *   target's own `mode=acquire` owner marker" when no such marker heads
- *   the log.
+ *
+ * Returns `{ event: null, rejectReason }` (never a false `pass`) when
+ * the first marker exists but fails validation, `{ event: null,
+ * rejectReason: null }` when no trusted marker exists at all, or
+ * `{ event, rejectReason: null }` on success.
  */
 function findStageOneAcquire(
   comments,
@@ -125,10 +182,14 @@ function findStageOneAcquire(
     return a.comment.id - b.comment.id;
   });
   const first = events[0];
-  if (!first || first.parsed.mode !== 'acquire') {
-    return null;
+  if (!first) {
+    return { event: null, rejectReason: null };
   }
-  return first;
+  const rejectReason = invalidStageOneAcquireReason(first, target);
+  if (rejectReason) {
+    return { event: null, rejectReason };
+  }
+  return { event: first, rejectReason: null };
 }
 /**
  * Compute the sha256 of `input.liveBody` (exact UTF-8 content, matching how
@@ -147,7 +208,7 @@ export function evaluateAuthoringOwnerProvenance(input) {
   const computedBodySha256 = createHash('sha256')
     .update(input.liveBody, 'utf8')
     .digest('hex');
-  const acquire = findStageOneAcquire(
+  const { event: acquire, rejectReason } = findStageOneAcquire(
     input.comments ?? [],
     input.target,
     input.markerPrefix,
@@ -163,9 +224,11 @@ export function evaluateAuthoringOwnerProvenance(input) {
       checks: [
         {
           id: 'acquire_marker_found',
-          name: "Target's marker log opens with a trusted mode=acquire marker",
+          name: "Target's marker log opens with a valid trusted mode=acquire marker",
           result: 'fail',
-          evidence: `No trusted authoring-owner marker log for target ${input.target} opens with a mode=acquire marker.`,
+          evidence: rejectReason
+            ? `Target ${input.target}'s first trusted authoring-owner marker is not a valid Stage 1 acquire: ${rejectReason}.`
+            : `No trusted authoring-owner marker log for target ${input.target} opens with a mode=acquire marker.`,
         },
         {
           id: 'body_sha256_match',
@@ -195,9 +258,9 @@ export function evaluateAuthoringOwnerProvenance(input) {
     checks: [
       {
         id: 'acquire_marker_found',
-        name: "Target's marker log opens with a trusted mode=acquire marker",
+        name: "Target's marker log opens with a valid trusted mode=acquire marker",
         result: 'pass',
-        evidence: `Stage 1 mode=acquire marker posted by ${acquire.comment.authorLogin} at ${acquire.comment.createdAt} (owner=${acquire.parsed.owner}).`,
+        evidence: `Valid Stage 1 mode=acquire marker posted by ${acquire.comment.authorLogin} at ${acquire.comment.createdAt} (owner=${acquire.parsed.owner}).`,
       },
       {
         id: 'body_sha256_match',
@@ -242,8 +305,17 @@ function parseArgs(argv) {
       'authoring-owner-provenance: --owner and --repo must be provided together or not at all',
     );
   }
+  // `Number.parseInt` accepts trailing garbage ("2891junk" -> 2891), so a
+  // typo'd --issue would silently target the wrong issue instead of
+  // failing loudly (kurone-kito/idd-skill#2901 review, Copilot round 5).
+  // Require the whole token to be digits, matching
+  // suitability-close-execute.mts's own --issue parsing.
+  const issue =
+    issueToken !== undefined && /^\d+$/.test(issueToken)
+      ? Number(issueToken)
+      : null;
   return {
-    issue: issueToken === undefined ? null : Number.parseInt(issueToken, 10),
+    issue,
     owner,
     repo,
     policy: values.policy ?? '',
@@ -276,10 +348,23 @@ the originally published one -- comparing against a later acquire would
 make this check pass trivially for a body edited before that later
 marker (kurone-kito/idd-skill#2901 review, chatgpt-codex-connector round
 4). target comparisons fold case, since GitHub owner/repo names are
-case-insensitive. If the target's first trusted marker is some other mode
-(bootstrap, resume, heartbeat, release, ...), that is an anomaly -- every
-one of those modes presupposes a prior acquire -- and reports not-found
-rather than accepting a non-acquire first marker's own digest.
+case-insensitive.
+
+The first marker must also pass every validity condition contract.md
+attaches to a genuine Stage 1 acquire, or this reports not-found rather
+than accepting an invalid marker's own digest (kurone-kito/idd-skill#2901
+review round 5): mode=acquire itself (every other mode -- bootstrap,
+resume, heartbeat, release, ... -- presupposes a prior acquire, so a
+well-formed history never opens with one); supersedes=none (contract.md
+requires this specifically for acquire); a real 64-hex body-sha256, never
+the shape-valid sentinel "none"; its own anchor names the same issue as
+its own target (a mismatch declares the marker a multi-target set's
+non-anchor child, out of scope for this single-target-orphan helper); and
+the underlying comment's updatedAt equals its createdAt (contract.md:
+owner comments are append-only and must not be edited or deleted -- an
+edited comment could have had its body-sha256 rewritten after the fact).
+--verbose surfaces which condition failed in the acquire_marker_found
+check's evidence.
 
 Output schema:
 {
@@ -288,18 +373,15 @@ Output schema:
   "target": "owner/repo#2891",
   "verdict": "pass|mismatch|not-found",
   "computedBodySha256": "<64-hex>",
-  "recordedBodySha256": "<64-hex-or-the-literal-string-none>|null",
-  "marker": {"author": "...", "createdAt": "...", "mode": "acquire", "owner": "...", "set": "...", "session": "...", "bodySha256": "<64-hex-or-the-literal-string-none>"} | null,
+  "recordedBodySha256": "<64-hex>|null",
+  "marker": {"author": "...", "createdAt": "...", "mode": "acquire", "owner": "...", "set": "...", "session": "...", "bodySha256": "<64-hex>"} | null,
   "checks": [{"id":"acquire_marker_found","name":"...","result":"pass|fail"}, {"id":"body_sha256_match","name":"...","result":"pass|fail"}]
 }
 
 "not-found" means this issue's own trusted authoring-owner marker log does
-not open with a mode=acquire marker for this target -- never treated as a
-pass. "mismatch" means the live body has changed since the Stage 1
-acquire marker's own snapshot, including when its body-sha256 is the
-malformed-but-shape-valid sentinel "none" -- it can never equal a real
-64-hex computed digest, so this stays fail-closed rather than silently
-passing.
+not open with a valid mode=acquire marker for this target -- never
+treated as a pass. "mismatch" means a valid Stage 1 acquire marker exists
+but the live body has changed since its own snapshot.
 
 --verbose adds an "evidence" string to each checks[] entry (the computed
 and recorded digests, or the acquire marker's author/timestamp); omitted
@@ -325,16 +407,25 @@ function runCli() {
   const repo = args.repo || currentRepo?.repo || '';
   const port = createGithubProviderAdapter(owner, repo);
   const issueNumber = args.issue ?? 0;
-  const rawIssue = port.getWorkItem(issueNumber);
-  if (!rawIssue) {
-    throw new Error(`issue #${issueNumber} not found`);
-  }
+  // Fetch the (potentially slow, paginated) comment log BEFORE the issue
+  // body, and hash the body immediately after fetching it below -- the
+  // whole point of this check is a fresh read taken as close as possible
+  // to the comparison, so the body fetch must be the last network call
+  // before hashing, not the first (kurone-kito/idd-skill#2901 review,
+  // chatgpt-codex-connector round 5: fetching the body first left a
+  // window, spanning the comment fetch, during which a live edit would
+  // go undetected).
   const comments = port.listWorkItemComments(issueNumber).map((comment) => ({
     id: comment.id,
     authorLogin: comment.authorLogin,
     body: comment.body,
     createdAt: comment.createdAt,
+    updatedAt: comment.updatedAt,
   }));
+  const rawIssue = port.getWorkItem(issueNumber);
+  if (!rawIssue) {
+    throw new Error(`issue #${issueNumber} not found`);
+  }
   const policy = loadPolicyConfig(args.policy || undefined);
   const config = policy.config;
   const markerPrefix = normalizeMarkerPrefix(

--- a/scripts/authoring-owner-provenance.mjs
+++ b/scripts/authoring-owner-provenance.mjs
@@ -36,6 +36,23 @@
 // target issue (never on a different anchor issue), so the live body and
 // the marker to compare it against always come from the one `--issue`
 // argument.
+//
+// Two accepted limitations, both fail-closed (never a false `pass`), not
+// defects: (1) a marker whose own `anchor` differs from its own `target`
+// declares itself a multi-target set's non-anchor child, out of scope
+// for this single-target-orphan helper (kurone-kito/idd-skill#2901
+// review, Copilot round 5). (2) a trusted actor who *deletes* the true
+// Stage 1 acquire comment outright (rather than editing it) leaves no
+// trace in any API response this helper can read -- detectable tampering
+// (an edit) fails closed (`findStageOneAcquire`'s pre-pass), but
+// undetectable tampering (a deletion) cannot be caught by a live
+// comment-log reader at all (kurone-kito/idd-skill#2901 review round 6,
+// chatgpt-codex-connector). contract.md's own remedy for that case is a
+// durable record the *authoring session itself* persists in its hold
+// state, not an artifact this read-only helper can independently fetch;
+// kurone-kito/idd-skill#2891's acceptance criteria scope this helper to
+// comparing the live body against the marker's own recorded digest, not
+// to designing that separate durable-record mechanism.
 import { createHash } from 'node:crypto';
 import { parseCliArgs } from './cli-args.mjs';
 import { loadPolicyConfig } from './idd-config.mjs';
@@ -94,19 +111,18 @@ const REAL_DIGEST_PATTERN = /^[0-9a-f]{64}$/;
  *   non-anchor child, out of scope for this helper's single-target
  *   orphan design (kurone-kito/idd-skill#2891's own acceptance
  *   criteria; kurone-kito/idd-skill#2901 review, Copilot round 5).
- * - `comment.updatedAt === comment.createdAt`: contract.md requires
- *   owner comments to be "append-only and must not be edited or
- *   deleted" -- an edited comment could have had its `body-sha256`
- *   silently rewritten to match a body modified after Stage 1, so this
- *   fails closed instead of trusting an editable field
- *   (kurone-kito/idd-skill#2901 review, chatgpt-codex-connector
- *   round 5).
+ *
+ * The append-only edit check (contract.md: owner comments "must not be
+ * edited or deleted") lives in `findStageOneAcquire`'s own pre-pass, not
+ * here -- it must run over every trusted marker-shaped comment before
+ * target filtering, not just the one this function receives (see that
+ * function's doc comment).
  *
  * Returns `null` when valid, or a short human-readable reason string
  * when not (surfaced in the `acquire_marker_found` check's evidence).
  */
 function invalidStageOneAcquireReason(event, target) {
-  const { parsed, comment } = event;
+  const { parsed } = event;
   if (parsed.mode !== 'acquire') {
     return `first trusted marker has mode=${parsed.mode}, not acquire`;
   }
@@ -119,10 +135,22 @@ function invalidStageOneAcquireReason(event, target) {
   if (!sameIssueRef(parsed.anchor, target)) {
     return `acquire marker's anchor (${parsed.anchor}) differs from its target -- a multi-target set's non-anchor child is out of scope for this helper`;
   }
-  if (comment.updatedAt !== comment.createdAt) {
-    return `acquire marker comment was edited after posting (createdAt=${comment.createdAt}, updatedAt=${comment.updatedAt}) -- owner comments must be append-only`;
-  }
   return null;
+}
+/**
+ * True when `comment.body` looks like it once was (or currently attempts
+ * to be) an `authoring-owner` marker -- either it still opens with the
+ * canonical `<!--` HTML-comment-first byte, or it at least still contains
+ * the `<marker-prefix>-authoring-owner:` token somewhere (an edit that
+ * broke the opener but left the token recognizable). Used only to decide
+ * whether an *edited* comment is suspicious enough to fail closed, not to
+ * parse it -- a comment failing this check is confidently unrelated to
+ * ownership (kurone-kito/idd-skill#2901 review, Copilot round 6).
+ */
+function looksLikeOwnerMarker(body, markerPrefix) {
+  return (
+    body.startsWith('<!--') || body.includes(`${markerPrefix}-authoring-owner:`)
+  );
 }
 /**
  * Find `target`'s own first trusted `authoring-owner` marker in
@@ -150,10 +178,35 @@ function invalidStageOneAcquireReason(event, target) {
  *   general "first valid marker by GitHub comment order wins" rule and
  *   this helper's own round-1/round-3 regression tests.
  *
+ * Before selecting a first marker at all, a pre-pass rejects the whole
+ * log if ANY trusted, owner-marker-shaped comment (`looksLikeOwnerMarker`)
+ * was edited (`updatedAt !== createdAt`) -- not just the comment that
+ * would otherwise be selected. An editor who edits the true Stage 1
+ * acquire into something that no longer parses, or retargets it to a
+ * different issue, would otherwise make it silently vanish from the
+ * target-matching candidates below, letting a later (legitimate-looking)
+ * acquire become `events[0]` unchallenged (kurone-kito/idd-skill#2901
+ * review, Copilot round 6: the round-5 `updatedAt` check only inspected
+ * the marker this function was about to select, which the edited marker
+ * itself is no longer once tampering breaks its parse or its target).
+ * This is deliberately over-broad in one direction: an edited `heartbeat`
+ * (or any other owner-marker-shaped comment, for any target) also trips
+ * it, even though only the eventual Stage 1 acquire matters semantically
+ * -- accepted, since contract.md's append-only rule covers "owner
+ * comments" generically, and failing closed on any detected edit is the
+ * safe direction.
+ *
+ * Undetectable tampering -- a trusted actor deleting the true Stage 1
+ * acquire outright, rather than editing it -- is out of scope: a deleted
+ * comment is absent from every API response, so no comment-log reader
+ * can see it happened (kurone-kito/idd-skill#2901 review round 6,
+ * chatgpt-codex-connector; accepted limitation, same footing as the
+ * non-anchor-child limitation above -- see this file's header comment).
+ *
  * Returns `{ event: null, rejectReason }` (never a false `pass`) when
- * the first marker exists but fails validation, `{ event: null,
- * rejectReason: null }` when no trusted marker exists at all, or
- * `{ event, rejectReason: null }` on success.
+ * the log is rejected by the pre-pass or the first marker fails
+ * validation, `{ event: null, rejectReason: null }` when no trusted
+ * marker exists at all, or `{ event, rejectReason: null }` on success.
  */
 function findStageOneAcquire(
   comments,
@@ -164,11 +217,25 @@ function findStageOneAcquire(
   const trusted = new Set(
     trustedMarkerLogins.map((login) => login.toLowerCase()),
   );
-  const events = [];
-  for (const comment of comments) {
-    if (!trusted.has(String(comment.authorLogin ?? '').toLowerCase())) {
-      continue;
+  const trustedComments = comments.filter((comment) =>
+    trusted.has(String(comment.authorLogin ?? '').toLowerCase()),
+  );
+  for (const comment of trustedComments) {
+    if (
+      comment.updatedAt !== comment.createdAt &&
+      looksLikeOwnerMarker(comment.body, markerPrefix)
+    ) {
+      return {
+        event: null,
+        rejectReason:
+          `trusted comment #${comment.id} looks like an authoring-owner ` +
+          `marker and was edited after posting (createdAt=${comment.createdAt}, ` +
+          `updatedAt=${comment.updatedAt}) -- owner comments must be append-only`,
+      };
     }
+  }
+  const events = [];
+  for (const comment of trustedComments) {
     const parsed = parseAuthoringOwnerComment(comment.body, markerPrefix);
     if (!parsed || !sameIssueRef(parsed.target, target)) {
       continue;
@@ -357,14 +424,25 @@ review round 5): mode=acquire itself (every other mode -- bootstrap,
 resume, heartbeat, release, ... -- presupposes a prior acquire, so a
 well-formed history never opens with one); supersedes=none (contract.md
 requires this specifically for acquire); a real 64-hex body-sha256, never
-the shape-valid sentinel "none"; its own anchor names the same issue as
-its own target (a mismatch declares the marker a multi-target set's
-non-anchor child, out of scope for this single-target-orphan helper); and
-the underlying comment's updatedAt equals its createdAt (contract.md:
-owner comments are append-only and must not be edited or deleted -- an
-edited comment could have had its body-sha256 rewritten after the fact).
+the shape-valid sentinel "none"; and its own anchor names the same issue
+as its own target (a mismatch declares the marker a multi-target set's
+non-anchor child, out of scope for this single-target-orphan helper).
 --verbose surfaces which condition failed in the acquire_marker_found
 check's evidence.
+
+Before selecting a marker at all, this also rejects the whole log (with
+not-found) if ANY trusted, owner-marker-shaped comment was edited after
+posting (its updatedAt differs from its createdAt) -- not just the one
+that would otherwise be selected, so an editor cannot make the true
+Stage 1 acquire vanish from consideration by editing it into something
+unparseable or retargeting it, letting a later acquire silently win
+instead (kurone-kito/idd-skill#2901 review round 6, Copilot). This is
+deliberately over-broad in one direction (an edited heartbeat, for
+example, also trips it) since contract.md's append-only rule covers
+owner comments generically. A trusted actor who deletes the true Stage 1
+acquire outright, rather than editing it, is an accepted limitation: a
+deleted comment leaves no trace in any API response this helper can read
+(kurone-kito/idd-skill#2901 review round 6, chatgpt-codex-connector).
 
 Output schema:
 {

--- a/scripts/authoring-owner-provenance.mjs
+++ b/scripts/authoring-owner-provenance.mjs
@@ -10,10 +10,13 @@
 // bullet, kurone-kito/idd-skill#2891): before honoring that exception, a
 // releasing session must recompute a target issue's current body-sha256
 // from a fresh read and compare it against that same target's own
-// `mode=acquire` `authoring-owner` marker's recorded `body-sha256`. That
-// comparison previously relied entirely on a releasing session's own
-// manual judgment; this helper performs and verifies it mechanically
-// instead.
+// winning `authoring-owner` ownership generation marker's recorded
+// `body-sha256` -- normally a `mode=acquire` marker, but a stale-hold
+// `bootstrap` or interrupted-set `resume` can legitimately win a
+// generation too (contract.md; see `findWinningAcquire`'s own doc
+// comment). That comparison previously relied entirely on a releasing
+// session's own manual judgment; this helper performs and verifies it
+// mechanically instead.
 //
 // Read-only evidence collector (docs/idd-helper-scripts.md's "Helper
 // contract classes"): it never posts comments, applies labels, or mutates
@@ -34,8 +37,9 @@
 // exact. A non-anchor child in a multi-target set never carries its own
 // `release-complete`, so this helper (which reads only the named
 // `--issue`'s own log, never an anchor's) cannot see a child's true
-// generation boundary; every acquire on such a child reads as one
-// still-open generation. That is the fail-closed direction -- a
+// generation boundary; every generation-opening marker (acquire,
+// bootstrap, or resume) on such a child reads as one still-open
+// generation. That is the fail-closed direction -- a
 // legitimately re-acquired child compares against the first
 // generation's digest and reports `mismatch`, never a false `pass` --
 // so it is an accepted limitation, not a defect. Fetching the anchor's
@@ -59,33 +63,37 @@ function normalizeMarkerPrefix(prefix) {
  * Replay `target`'s own trusted `authoring-owner` marker log in
  * chronological order (ties broken by comment `id`, ascending — the
  * deterministic order contract.md's replay rule requires) and return the
- * `mode=acquire` marker that won the log's last generation, or `null` if
- * none exists.
+ * generation-opening marker that won the log's last generation, or
+ * `null` if none exists.
  *
- * A generation opens at an acquire marker when no generation is
- * currently open; the first acquire in an open generation keeps
- * ownership through the whole generation (contract.md: "choose the
- * winner by deterministic comment order"), so a second acquire while a
- * generation is already open is a same-generation race — a losing
- * racer or a duplicate — and never overrides the winner (kurone-kito/idd-skill#2891
- * review: this previously picked the globally-last acquire instead,
- * which could authorize the auto-release exception against a losing
- * racer's edited-body digest). A generation closes only on a
- * `mode=release-complete` that retains the exact owner/set/session/
- * anchor of the currently open generation's winning acquire and
- * supersedes that same owner token (`isMatchingCompletion` below) — a
- * stale or malformed release-complete for a different owner/set never
- * closes it (kurone-kito/idd-skill#2901 review, chatgpt-codex-connector:
- * closing on any release-complete for the target, unchecked, could let
- * an unrelated completion evict a still-legitimate winner). `release` /
+ * A generation opens at the first `acquire`, `bootstrap`, or `resume`
+ * marker (`GENERATION_OPENER_MODES` below) when no generation is
+ * currently open; contract.md: "the first valid acquisition, bootstrap,
+ * or resume marker by GitHub comment order wins", so a second
+ * generation-opening marker while a generation is already open is a
+ * same-generation race — a losing racer or a duplicate — and never
+ * overrides the winner. Whichever mode wins, its own `body-sha256` field
+ * is the digest this comparison uses (kurone-kito/idd-skill#2901 review,
+ * chatgpt-codex-connector round 3: the earlier form recognized only
+ * `acquire` as a generation opener, so a legitimate `bootstrap`/`resume`
+ * winner could be silently displaced by a later competing `acquire`).
+ *
+ * A generation closes only on a `mode=release-complete` that
+ * `isValidReleaseComplete` (below) accepts as a genuine closure of the
+ * currently open generation — a stale, malformed, or unrelated
+ * completion never closes it (kurone-kito/idd-skill#2901 review,
+ * chatgpt-codex-connector rounds 2-3: closing on any release-complete
+ * for the target, unchecked, could let an unrelated or incomplete
+ * completion evict a still-legitimate winner). `release` /
  * `release-guard` alone never close a generation either, since
  * contract.md allows a new acquisition to start "only once the anchor
- * completion is reconciled" — an acquire after `release` but before
- * `release-complete` is still a same-generation race, not a fresh
- * generation. See this file's header comment for the anchor-only
- * `release-complete` caveat this replay accepts for a non-anchor child
- * target.
+ * completion is reconciled" — a generation-opening marker after
+ * `release` but before `release-complete` is still a same-generation
+ * race, not a fresh generation. See this file's header comment for the
+ * anchor-only `release-complete` caveat this replay accepts for a
+ * non-anchor child target.
  */
+const GENERATION_OPENER_MODES = new Set(['acquire', 'bootstrap', 'resume']);
 function findWinningAcquire(
   comments,
   target,
@@ -115,53 +123,64 @@ function findWinningAcquire(
   let winner = null;
   let generationOpen = false;
   for (const event of events) {
-    if (event.parsed.mode === 'acquire') {
+    if (GENERATION_OPENER_MODES.has(event.parsed.mode)) {
       if (!generationOpen) {
         winner = event;
         generationOpen = true;
       }
-      // else: same-generation race -- the first acquire keeps ownership.
+      // else: same-generation race -- the first generation-opening
+      // marker (acquire, bootstrap, or resume) keeps ownership.
     } else if (
       event.parsed.mode === 'release-complete' &&
       winner &&
-      isMatchingCompletion(event.parsed, winner.parsed)
+      isValidReleaseComplete(event.parsed, winner.parsed)
     ) {
-      // #2901 review, chatgpt-codex-connector: a release-complete marker
-      // closes the CURRENT generation only when it retains that
-      // generation's exact owner/set/session/anchor and supersedes that
-      // same owner token (contract.md: "It retains the anchor's current
-      // owner, set, anchor, and session, and sets supersedes to that
-      // owner token"). A stale or malformed release-complete for a
-      // different owner/set never closes this generation -- ignoring it
-      // (rather than closing on any release-complete for the target) is
-      // what keeps a still-open generation's winner from being displaced
-      // by an unrelated completion.
       generationOpen = false;
     }
   }
   return winner;
 }
-/** True when `completion` (a `mode=release-complete` event) retains the
- * exact owner/set/session/anchor of `winningAcquire` and supersedes that
- * same owner token -- the only shape contract.md recognizes as a valid
- * closure of the generation `winningAcquire` opened. */
-function isMatchingCompletion(completion, winningAcquire) {
+/**
+ * True when `completion` (a `mode=release-complete` event) is a valid
+ * closure of the generation `winner` opened. contract.md requires all of:
+ * - **anchor-only** ("release-complete is valid only on the set
+ *   anchor"): `completion.target === completion.anchor` -- a
+ *   release-complete recorded on a non-anchor child's own comment
+ *   thread (this replay only ever reads the named target's own log, so
+ *   `completion.target` is always this issue) can never legitimately
+ *   close a generation here.
+ * - **required snapshot digest** ("carries the required canonical set
+ *   snapshot digest"): `completion.snapshotSha256 !== 'none'` --
+ *   `'none'` is release-guard's own sentinel, not a valid completion.
+ * - **retains the winning generation's identity** ("retains the
+ *   anchor's current owner, set, anchor, and session, and sets
+ *   supersedes to that owner token"): owner/set/session/anchor match
+ *   `winner`'s, and `supersedes` equals `winner`'s own owner token.
+ *
+ * A release-complete failing any of these is stale, malformed, or for
+ * an unrelated generation, and is ignored rather than closing the
+ * current one (#2901 review, chatgpt-codex-connector rounds 2-3).
+ */
+function isValidReleaseComplete(completion, winner) {
   return (
-    completion.owner === winningAcquire.owner &&
-    completion.set === winningAcquire.set &&
-    completion.session === winningAcquire.session &&
-    completion.anchor === winningAcquire.anchor &&
-    completion.supersedes === winningAcquire.owner
+    completion.target === completion.anchor &&
+    completion.snapshotSha256 !== 'none' &&
+    completion.owner === winner.owner &&
+    completion.set === winner.set &&
+    completion.session === winner.session &&
+    completion.anchor === winner.anchor &&
+    completion.supersedes === winner.owner
   );
 }
 /**
  * Compute the sha256 of `input.liveBody` (exact UTF-8 content, matching how
  * the `authoring-owner` marker's `body-sha256` field is documented to be
  * computed — contract.md's "Per-target ownership" section) and compare it
- * against `input.target`'s own trusted `mode=acquire` marker.
+ * against `input.target`'s own trusted winning generation marker (see
+ * `findWinningAcquire`).
  *
- * `verdict` is `not-found` when no matching trusted acquire marker exists
- * for `input.target`; `pass`/`mismatch` otherwise based on exact digest
+ * `verdict` is `not-found` when no generation marker won for
+ * `input.target`; `pass`/`mismatch` otherwise based on exact digest
  * equality. This never fails open on ambiguity: a missing marker is
  * `not-found`, not `pass`.
  */
@@ -184,16 +203,16 @@ export function evaluateAuthoringOwnerProvenance(input) {
       marker: null,
       checks: [
         {
-          id: 'acquire_marker_found',
-          name: 'Trusted mode=acquire owner marker found for target',
+          id: 'generation_marker_found',
+          name: 'A trusted acquire/bootstrap/resume marker won a generation for target',
           result: 'fail',
-          evidence: `No trusted mode=acquire authoring-owner marker for target ${input.target} won an open generation in the replayed log.`,
+          evidence: `No trusted acquire/bootstrap/resume authoring-owner marker for target ${input.target} won an open generation in the replayed log.`,
         },
         {
           id: 'body_sha256_match',
-          name: 'Live body sha256 matches acquire-time recorded digest',
+          name: "Live body sha256 matches the winning marker's recorded digest",
           result: 'fail',
-          evidence: 'No acquire marker to compare against.',
+          evidence: 'No generation marker to compare against.',
         },
       ],
     };
@@ -208,6 +227,7 @@ export function evaluateAuthoringOwnerProvenance(input) {
     marker: {
       author: winner.comment.authorLogin,
       createdAt: winner.comment.createdAt,
+      mode: winner.parsed.mode,
       owner: winner.parsed.owner,
       set: winner.parsed.set,
       session: winner.parsed.session,
@@ -215,14 +235,14 @@ export function evaluateAuthoringOwnerProvenance(input) {
     },
     checks: [
       {
-        id: 'acquire_marker_found',
-        name: 'Trusted mode=acquire owner marker found for target',
+        id: 'generation_marker_found',
+        name: 'A trusted acquire/bootstrap/resume marker won a generation for target',
         result: 'pass',
-        evidence: `Winning acquire posted by ${winner.comment.authorLogin} at ${winner.comment.createdAt} (owner=${winner.parsed.owner}).`,
+        evidence: `Winning mode=${winner.parsed.mode} marker posted by ${winner.comment.authorLogin} at ${winner.comment.createdAt} (owner=${winner.parsed.owner}).`,
       },
       {
         id: 'body_sha256_match',
-        name: 'Live body sha256 matches acquire-time recorded digest',
+        name: "Live body sha256 matches the winning marker's recorded digest",
         result: matches ? 'pass' : 'fail',
         evidence: matches
           ? `computed ${computedBodySha256} matches recorded ${recordedBodySha256}.`
@@ -280,20 +300,25 @@ function printHelp() {
   node scripts/authoring-owner-provenance.mjs --issue <number> [--owner <owner> --repo <repo>] [--policy <path>] [--marker-prefix <prefix>] [--gh-token <token>] [--trusted-marker-logins <login1,login2>] [--verbose]
 
 Mechanically compares a live issue body's sha256 against that same issue's
-own trusted mode=acquire authoring-owner marker's recorded body-sha256
-(kurone-kito/idd-skill#2891). Read-only: never posts, labels, or mutates
-anything. --owner and --repo must be given together or not at all.
+own trusted winning ownership-generation authoring-owner marker's recorded
+body-sha256 (kurone-kito/idd-skill#2891). Read-only: never posts, labels, or
+mutates anything. --owner and --repo must be given together or not at all.
 
 The comparison replays this issue's own authoring-owner marker log to find
-the acquire marker that won its last generation (a same-generation race
-between two competing acquires resolves to the first one, per contract.md's
-deterministic-comment-order tie-break); a generation closes only on
-mode=release-complete. Caveat: release-complete is anchor-only, so for a
-non-anchor child target in a multi-target set this replay cannot see the
-child's true generation boundary and treats every acquire on it as one
-still-open generation -- fail-closed (mismatch, never a false pass), not a
-security gap; a review-fix-loop-cutoff follow-up (the case this helper
-exists for) is always a single-target orphan, never a set member.
+the acquire/bootstrap/resume marker that won its last generation (a
+same-generation race between two competing generation-opening markers
+resolves to the first one -- contract.md: choose the winner by
+deterministic comment order); a generation closes only on a
+mode=release-complete that retains that generation's exact
+owner/set/session/anchor, supersedes that same owner token, is itself
+anchor-scoped (target === anchor), and carries a real snapshot digest (not
+the release-guard sentinel "none"). Caveat: release-complete is
+anchor-only, so for a non-anchor child target in a multi-target set this
+replay cannot see the child's true generation boundary and treats every
+generation-opening marker on it as one still-open generation -- fail-closed
+(mismatch, never a false pass), not a security gap; a review-fix-loop-cutoff
+follow-up (the case this helper exists for) is always a single-target
+orphan, never a set member.
 
 Output schema:
 {
@@ -303,16 +328,17 @@ Output schema:
   "verdict": "pass|mismatch|not-found",
   "computedBodySha256": "<64-hex>",
   "recordedBodySha256": "<64-hex-or-the-literal-string-none>|null",
-  "marker": {"author": "...", "createdAt": "...", "owner": "...", "set": "...", "session": "...", "bodySha256": "<64-hex-or-the-literal-string-none>"} | null,
-  "checks": [{"id":"acquire_marker_found","name":"...","result":"pass|fail"}, {"id":"body_sha256_match","name":"...","result":"pass|fail"}]
+  "marker": {"author": "...", "createdAt": "...", "mode": "acquire|bootstrap|resume", "owner": "...", "set": "...", "session": "...", "bodySha256": "<64-hex-or-the-literal-string-none>"} | null,
+  "checks": [{"id":"generation_marker_found","name":"...","result":"pass|fail"}, {"id":"body_sha256_match","name":"...","result":"pass|fail"}]
 }
 
-"not-found" means no trusted mode=acquire authoring-owner marker exists for
-this issue's own target -- never treated as a pass. "mismatch" means the
-live body has changed since the acquire-time marker was posted, including
-when the winning acquire's own body-sha256 is the malformed-but-shape-valid
-sentinel "none" -- it can never equal a real 64-hex computed digest, so
-this stays fail-closed rather than silently passing.
+"not-found" means no trusted acquire/bootstrap/resume authoring-owner
+marker won a generation for this issue's own target -- never treated as a
+pass. "mismatch" means the live body has changed since the winning
+marker's own snapshot, including when its body-sha256 is the
+malformed-but-shape-valid sentinel "none" -- it can never equal a real
+64-hex computed digest, so this stays fail-closed rather than silently
+passing.
 
 --verbose adds an "evidence" string to each checks[] entry (the computed
 and recorded digests, or the winning marker's author/timestamp); omitted by

--- a/scripts/authoring-owner-provenance.mjs
+++ b/scripts/authoring-owner-provenance.mjs
@@ -70,12 +70,19 @@ function normalizeMarkerPrefix(prefix) {
  * racer or a duplicate — and never overrides the winner (kurone-kito/idd-skill#2891
  * review: this previously picked the globally-last acquire instead,
  * which could authorize the auto-release exception against a losing
- * racer's edited-body digest). A generation closes only on
- * `mode=release-complete`: release / release-guard alone do not,
- * since contract.md allows a new acquisition to start "only once the
- * anchor completion is reconciled" — an acquire after `release` but
- * before `release-complete` is still a same-generation race, not a
- * fresh generation. See this file's header comment for the anchor-only
+ * racer's edited-body digest). A generation closes only on a
+ * `mode=release-complete` that retains the exact owner/set/session/
+ * anchor of the currently open generation's winning acquire and
+ * supersedes that same owner token (`isMatchingCompletion` below) — a
+ * stale or malformed release-complete for a different owner/set never
+ * closes it (kurone-kito/idd-skill#2901 review, chatgpt-codex-connector:
+ * closing on any release-complete for the target, unchecked, could let
+ * an unrelated completion evict a still-legitimate winner). `release` /
+ * `release-guard` alone never close a generation either, since
+ * contract.md allows a new acquisition to start "only once the anchor
+ * completion is reconciled" — an acquire after `release` but before
+ * `release-complete` is still a same-generation race, not a fresh
+ * generation. See this file's header comment for the anchor-only
  * `release-complete` caveat this replay accepts for a non-anchor child
  * target.
  */
@@ -114,11 +121,38 @@ function findWinningAcquire(
         generationOpen = true;
       }
       // else: same-generation race -- the first acquire keeps ownership.
-    } else if (event.parsed.mode === 'release-complete') {
+    } else if (
+      event.parsed.mode === 'release-complete' &&
+      winner &&
+      isMatchingCompletion(event.parsed, winner.parsed)
+    ) {
+      // #2901 review, chatgpt-codex-connector: a release-complete marker
+      // closes the CURRENT generation only when it retains that
+      // generation's exact owner/set/session/anchor and supersedes that
+      // same owner token (contract.md: "It retains the anchor's current
+      // owner, set, anchor, and session, and sets supersedes to that
+      // owner token"). A stale or malformed release-complete for a
+      // different owner/set never closes this generation -- ignoring it
+      // (rather than closing on any release-complete for the target) is
+      // what keeps a still-open generation's winner from being displaced
+      // by an unrelated completion.
       generationOpen = false;
     }
   }
   return winner;
+}
+/** True when `completion` (a `mode=release-complete` event) retains the
+ * exact owner/set/session/anchor of `winningAcquire` and supersedes that
+ * same owner token -- the only shape contract.md recognizes as a valid
+ * closure of the generation `winningAcquire` opened. */
+function isMatchingCompletion(completion, winningAcquire) {
+  return (
+    completion.owner === winningAcquire.owner &&
+    completion.set === winningAcquire.set &&
+    completion.session === winningAcquire.session &&
+    completion.anchor === winningAcquire.anchor &&
+    completion.supersedes === winningAcquire.owner
+  );
 }
 /**
  * Compute the sha256 of `input.liveBody` (exact UTF-8 content, matching how
@@ -268,14 +302,17 @@ Output schema:
   "target": "owner/repo#2891",
   "verdict": "pass|mismatch|not-found",
   "computedBodySha256": "<64-hex>",
-  "recordedBodySha256": "<64-hex>|null",
-  "marker": {"author": "...", "createdAt": "...", "owner": "...", "set": "...", "session": "...", "bodySha256": "<64-hex>"} | null,
+  "recordedBodySha256": "<64-hex-or-the-literal-string-none>|null",
+  "marker": {"author": "...", "createdAt": "...", "owner": "...", "set": "...", "session": "...", "bodySha256": "<64-hex-or-the-literal-string-none>"} | null,
   "checks": [{"id":"acquire_marker_found","name":"...","result":"pass|fail"}, {"id":"body_sha256_match","name":"...","result":"pass|fail"}]
 }
 
 "not-found" means no trusted mode=acquire authoring-owner marker exists for
 this issue's own target -- never treated as a pass. "mismatch" means the
-live body has changed since the acquire-time marker was posted.
+live body has changed since the acquire-time marker was posted, including
+when the winning acquire's own body-sha256 is the malformed-but-shape-valid
+sentinel "none" -- it can never equal a real 64-hex computed digest, so
+this stays fail-closed rather than silently passing.
 
 --verbose adds an "evidence" string to each checks[] entry (the computed
 and recorded digests, or the winning marker's author/timestamp); omitted by

--- a/scripts/authoring-owner-provenance.mjs
+++ b/scripts/authoring-owner-provenance.mjs
@@ -25,6 +25,21 @@
 // target issue (never on a different anchor issue), so the live body and
 // the marker to compare it against always come from the one `--issue`
 // argument.
+//
+// Generation-boundary caveat: `mode=release-complete` is anchor-only
+// (contract.md). For `target === anchor` -- the single-target hold shape
+// this helper is built for (a review-fix-loop-cutoff follow-up is always
+// orphan-shaped, never a set member) -- the target's own comment log
+// carries every generation boundary directly and the replay below is
+// exact. A non-anchor child in a multi-target set never carries its own
+// `release-complete`, so this helper (which reads only the named
+// `--issue`'s own log, never an anchor's) cannot see a child's true
+// generation boundary; every acquire on such a child reads as one
+// still-open generation. That is the fail-closed direction -- a
+// legitimately re-acquired child compares against the first
+// generation's digest and reports `mismatch`, never a false `pass` --
+// so it is an accepted limitation, not a defect. Fetching the anchor's
+// own log to resolve it is out of scope for kurone-kito/idd-skill#2891.
 import { createHash } from 'node:crypto';
 import { parseCliArgs } from './cli-args.mjs';
 import { loadPolicyConfig } from './idd-config.mjs';
@@ -41,14 +56,30 @@ function normalizeMarkerPrefix(prefix) {
   return trimmed.length > 0 ? trimmed : DEFAULT_MARKER_PREFIX;
 }
 /**
- * Find every trusted-actor `mode=acquire` `authoring-owner` marker on
- * `comments` whose `target` field exactly equals `target`, sorted ascending
- * by comment `createdAt`. There should normally be exactly one per
- * acquisition generation; a re-acquisition after a full release cycle can
- * legitimately produce more than one over an issue's lifetime, so the
- * caller takes the most recent (last) entry rather than the first.
+ * Replay `target`'s own trusted `authoring-owner` marker log in
+ * chronological order (ties broken by comment `id`, ascending — the
+ * deterministic order contract.md's replay rule requires) and return the
+ * `mode=acquire` marker that won the log's last generation, or `null` if
+ * none exists.
+ *
+ * A generation opens at an acquire marker when no generation is
+ * currently open; the first acquire in an open generation keeps
+ * ownership through the whole generation (contract.md: "choose the
+ * winner by deterministic comment order"), so a second acquire while a
+ * generation is already open is a same-generation race — a losing
+ * racer or a duplicate — and never overrides the winner (kurone-kito/idd-skill#2891
+ * review: this previously picked the globally-last acquire instead,
+ * which could authorize the auto-release exception against a losing
+ * racer's edited-body digest). A generation closes only on
+ * `mode=release-complete`: release / release-guard alone do not,
+ * since contract.md allows a new acquisition to start "only once the
+ * anchor completion is reconciled" — an acquire after `release` but
+ * before `release-complete` is still a same-generation race, not a
+ * fresh generation. See this file's header comment for the anchor-only
+ * `release-complete` caveat this replay accepts for a non-anchor child
+ * target.
  */
-function findAcquireCandidates(
+function findWinningAcquire(
   comments,
   target,
   markerPrefix,
@@ -57,24 +88,37 @@ function findAcquireCandidates(
   const trusted = new Set(
     trustedMarkerLogins.map((login) => login.toLowerCase()),
   );
-  const candidates = [];
+  const events = [];
   for (const comment of comments) {
     if (!trusted.has(String(comment.authorLogin ?? '').toLowerCase())) {
       continue;
     }
     const parsed = parseAuthoringOwnerComment(comment.body, markerPrefix);
-    if (!parsed || parsed.mode !== 'acquire' || parsed.target !== target) {
+    if (!parsed || parsed.target !== target) {
       continue;
     }
-    candidates.push({ comment, parsed });
+    events.push({ comment, parsed });
   }
-  return candidates.sort((a, b) =>
-    a.comment.createdAt < b.comment.createdAt
-      ? -1
-      : a.comment.createdAt > b.comment.createdAt
-        ? 1
-        : 0,
-  );
+  events.sort((a, b) => {
+    if (a.comment.createdAt !== b.comment.createdAt) {
+      return a.comment.createdAt < b.comment.createdAt ? -1 : 1;
+    }
+    return a.comment.id - b.comment.id;
+  });
+  let winner = null;
+  let generationOpen = false;
+  for (const event of events) {
+    if (event.parsed.mode === 'acquire') {
+      if (!generationOpen) {
+        winner = event;
+        generationOpen = true;
+      }
+      // else: same-generation race -- the first acquire keeps ownership.
+    } else if (event.parsed.mode === 'release-complete') {
+      generationOpen = false;
+    }
+  }
+  return winner;
 }
 /**
  * Compute the sha256 of `input.liveBody` (exact UTF-8 content, matching how
@@ -91,13 +135,12 @@ export function evaluateAuthoringOwnerProvenance(input) {
   const computedBodySha256 = createHash('sha256')
     .update(input.liveBody, 'utf8')
     .digest('hex');
-  const candidates = findAcquireCandidates(
+  const winner = findWinningAcquire(
     input.comments ?? [],
     input.target,
     input.markerPrefix,
     input.trustedMarkerLogins ?? [],
   );
-  const winner = candidates.at(-1) ?? null;
   if (!winner) {
     return {
       verdict: 'not-found',
@@ -110,11 +153,13 @@ export function evaluateAuthoringOwnerProvenance(input) {
           id: 'acquire_marker_found',
           name: 'Trusted mode=acquire owner marker found for target',
           result: 'fail',
+          evidence: `No trusted mode=acquire authoring-owner marker for target ${input.target} won an open generation in the replayed log.`,
         },
         {
           id: 'body_sha256_match',
           name: 'Live body sha256 matches acquire-time recorded digest',
           result: 'fail',
+          evidence: 'No acquire marker to compare against.',
         },
       ],
     };
@@ -139,11 +184,15 @@ export function evaluateAuthoringOwnerProvenance(input) {
         id: 'acquire_marker_found',
         name: 'Trusted mode=acquire owner marker found for target',
         result: 'pass',
+        evidence: `Winning acquire posted by ${winner.comment.authorLogin} at ${winner.comment.createdAt} (owner=${winner.parsed.owner}).`,
       },
       {
         id: 'body_sha256_match',
         name: 'Live body sha256 matches acquire-time recorded digest',
         result: matches ? 'pass' : 'fail',
+        evidence: matches
+          ? `computed ${computedBodySha256} matches recorded ${recordedBodySha256}.`
+          : `computed ${computedBodySha256} does not match recorded ${recordedBodySha256}.`,
       },
     ],
   };
@@ -168,10 +217,22 @@ function parseArgs(argv) {
     AUTHORING_OWNER_PROVENANCE_FLAG_SPEC,
   );
   const issueToken = values.issue;
+  const owner = (values.owner ?? '').trim();
+  const repo = (values.repo ?? '').trim();
+  // Copilot review finding on PR #2901: exactly one of --owner/--repo would
+  // mix a caller-supplied repo with resolveCurrentGithubRepository()'s
+  // current-directory repo, potentially targeting the wrong repository for
+  // the issue lookup. Mirrors suitability-close-execute.mts's own
+  // --owner/--repo pairing guard: require both or neither.
+  if ((owner === '') !== (repo === '')) {
+    throw new Error(
+      'authoring-owner-provenance: --owner and --repo must be provided together or not at all',
+    );
+  }
   return {
     issue: issueToken === undefined ? null : Number.parseInt(issueToken, 10),
-    owner: values.owner ?? '',
-    repo: values.repo ?? '',
+    owner,
+    repo,
     policy: values.policy ?? '',
     markerPrefix: values['marker-prefix'] ?? '',
     ghToken: values['gh-token'] ?? '',
@@ -182,12 +243,23 @@ function parseArgs(argv) {
 }
 function printHelp() {
   process.stdout.write(`Usage:
-  node scripts/authoring-owner-provenance.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--policy <path>] [--marker-prefix <prefix>] [--gh-token <token>] [--trusted-marker-logins <login1,login2>] [--verbose]
+  node scripts/authoring-owner-provenance.mjs --issue <number> [--owner <owner> --repo <repo>] [--policy <path>] [--marker-prefix <prefix>] [--gh-token <token>] [--trusted-marker-logins <login1,login2>] [--verbose]
 
 Mechanically compares a live issue body's sha256 against that same issue's
 own trusted mode=acquire authoring-owner marker's recorded body-sha256
 (kurone-kito/idd-skill#2891). Read-only: never posts, labels, or mutates
-anything.
+anything. --owner and --repo must be given together or not at all.
+
+The comparison replays this issue's own authoring-owner marker log to find
+the acquire marker that won its last generation (a same-generation race
+between two competing acquires resolves to the first one, per contract.md's
+deterministic-comment-order tie-break); a generation closes only on
+mode=release-complete. Caveat: release-complete is anchor-only, so for a
+non-anchor child target in a multi-target set this replay cannot see the
+child's true generation boundary and treats every acquire on it as one
+still-open generation -- fail-closed (mismatch, never a false pass), not a
+security gap; a review-fix-loop-cutoff follow-up (the case this helper
+exists for) is always a single-target orphan, never a set member.
 
 Output schema:
 {
@@ -197,13 +269,17 @@ Output schema:
   "verdict": "pass|mismatch|not-found",
   "computedBodySha256": "<64-hex>",
   "recordedBodySha256": "<64-hex>|null",
-  "marker": {"author": "...", "createdAt": "...", "owner": "...", "set": "...", "session": "..."} | null,
+  "marker": {"author": "...", "createdAt": "...", "owner": "...", "set": "...", "session": "...", "bodySha256": "<64-hex>"} | null,
   "checks": [{"id":"acquire_marker_found","name":"...","result":"pass|fail"}, {"id":"body_sha256_match","name":"...","result":"pass|fail"}]
 }
 
 "not-found" means no trusted mode=acquire authoring-owner marker exists for
 this issue's own target -- never treated as a pass. "mismatch" means the
 live body has changed since the acquire-time marker was posted.
+
+--verbose adds an "evidence" string to each checks[] entry (the computed
+and recorded digests, or the winning marker's author/timestamp); omitted by
+default to keep default output terse.
 `);
 }
 function runCli() {
@@ -230,6 +306,7 @@ function runCli() {
     throw new Error(`issue #${issueNumber} not found`);
   }
   const comments = port.listWorkItemComments(issueNumber).map((comment) => ({
+    id: comment.id,
     authorLogin: comment.authorLogin,
     body: comment.body,
     createdAt: comment.createdAt,
@@ -264,7 +341,13 @@ function runCli() {
     computedBodySha256: result.computedBodySha256,
     recordedBodySha256: result.recordedBodySha256,
     marker: result.marker,
-    checks: result.checks,
+    checks: args.verbose
+      ? result.checks
+      : result.checks.map((check) => ({
+          id: check.id,
+          name: check.name,
+          result: check.result,
+        })),
   };
   process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
 }

--- a/scripts/authoring-owner-provenance.mjs
+++ b/scripts/authoring-owner-provenance.mjs
@@ -1,0 +1,270 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/authoring-owner-provenance.mts
+//
+// The scripts/authoring-owner-provenance.mjs copy is generated from the
+// .mts source named above by `pnpm run build`. Edit the .mts source, never
+// the generated .mjs. See docs/typescript-sources.md.
+//
+// Mechanical provenance check for the review-fix-loop-cutoff auto-release
+// exception's precondition (kurone-kito/idd-skill#2877's contract.md
+// bullet, kurone-kito/idd-skill#2891): before honoring that exception, a
+// releasing session must recompute a target issue's current body-sha256
+// from a fresh read and compare it against that same target's own
+// `mode=acquire` `authoring-owner` marker's recorded `body-sha256`. That
+// comparison previously relied entirely on a releasing session's own
+// manual judgment; this helper performs and verifies it mechanically
+// instead.
+//
+// Read-only evidence collector (docs/idd-helper-scripts.md's "Helper
+// contract classes"): it never posts comments, applies labels, or mutates
+// anything. A releasing session (or a future automated Stage 2
+// release-sequence helper) still decides what to do with the verdict.
+//
+// Per contract.md's "Per-target ownership" section, a target's own
+// `authoring-owner` marker is always posted as a comment on that same
+// target issue (never on a different anchor issue), so the live body and
+// the marker to compare it against always come from the one `--issue`
+// argument.
+import { createHash } from 'node:crypto';
+import { parseCliArgs } from './cli-args.mjs';
+import { loadPolicyConfig } from './idd-config.mjs';
+import { parseAuthoringOwnerComment } from './marker-helpers.mjs';
+import { resolveTrustedMarkerActors } from './protocol-helpers.mjs';
+import {
+  createGithubProviderAdapter,
+  resolveCurrentGithubRepository,
+} from './provider-adapter-github.mjs';
+
+const DEFAULT_MARKER_PREFIX = 'idd-skill';
+function normalizeMarkerPrefix(prefix) {
+  const trimmed = typeof prefix === 'string' ? prefix.trim() : '';
+  return trimmed.length > 0 ? trimmed : DEFAULT_MARKER_PREFIX;
+}
+/**
+ * Find every trusted-actor `mode=acquire` `authoring-owner` marker on
+ * `comments` whose `target` field exactly equals `target`, sorted ascending
+ * by comment `createdAt`. There should normally be exactly one per
+ * acquisition generation; a re-acquisition after a full release cycle can
+ * legitimately produce more than one over an issue's lifetime, so the
+ * caller takes the most recent (last) entry rather than the first.
+ */
+function findAcquireCandidates(
+  comments,
+  target,
+  markerPrefix,
+  trustedMarkerLogins,
+) {
+  const trusted = new Set(
+    trustedMarkerLogins.map((login) => login.toLowerCase()),
+  );
+  const candidates = [];
+  for (const comment of comments) {
+    if (!trusted.has(String(comment.authorLogin ?? '').toLowerCase())) {
+      continue;
+    }
+    const parsed = parseAuthoringOwnerComment(comment.body, markerPrefix);
+    if (!parsed || parsed.mode !== 'acquire' || parsed.target !== target) {
+      continue;
+    }
+    candidates.push({ comment, parsed });
+  }
+  return candidates.sort((a, b) =>
+    a.comment.createdAt < b.comment.createdAt
+      ? -1
+      : a.comment.createdAt > b.comment.createdAt
+        ? 1
+        : 0,
+  );
+}
+/**
+ * Compute the sha256 of `input.liveBody` (exact UTF-8 content, matching how
+ * the `authoring-owner` marker's `body-sha256` field is documented to be
+ * computed — contract.md's "Per-target ownership" section) and compare it
+ * against `input.target`'s own trusted `mode=acquire` marker.
+ *
+ * `verdict` is `not-found` when no matching trusted acquire marker exists
+ * for `input.target`; `pass`/`mismatch` otherwise based on exact digest
+ * equality. This never fails open on ambiguity: a missing marker is
+ * `not-found`, not `pass`.
+ */
+export function evaluateAuthoringOwnerProvenance(input) {
+  const computedBodySha256 = createHash('sha256')
+    .update(input.liveBody, 'utf8')
+    .digest('hex');
+  const candidates = findAcquireCandidates(
+    input.comments ?? [],
+    input.target,
+    input.markerPrefix,
+    input.trustedMarkerLogins ?? [],
+  );
+  const winner = candidates.at(-1) ?? null;
+  if (!winner) {
+    return {
+      verdict: 'not-found',
+      target: input.target,
+      computedBodySha256,
+      recordedBodySha256: null,
+      marker: null,
+      checks: [
+        {
+          id: 'acquire_marker_found',
+          name: 'Trusted mode=acquire owner marker found for target',
+          result: 'fail',
+        },
+        {
+          id: 'body_sha256_match',
+          name: 'Live body sha256 matches acquire-time recorded digest',
+          result: 'fail',
+        },
+      ],
+    };
+  }
+  const recordedBodySha256 = winner.parsed.bodySha256;
+  const matches = recordedBodySha256 === computedBodySha256;
+  return {
+    verdict: matches ? 'pass' : 'mismatch',
+    target: input.target,
+    computedBodySha256,
+    recordedBodySha256,
+    marker: {
+      author: winner.comment.authorLogin,
+      createdAt: winner.comment.createdAt,
+      owner: winner.parsed.owner,
+      set: winner.parsed.set,
+      session: winner.parsed.session,
+      bodySha256: winner.parsed.bodySha256,
+    },
+    checks: [
+      {
+        id: 'acquire_marker_found',
+        name: 'Trusted mode=acquire owner marker found for target',
+        result: 'pass',
+      },
+      {
+        id: 'body_sha256_match',
+        name: 'Live body sha256 matches acquire-time recorded digest',
+        result: matches ? 'pass' : 'fail',
+      },
+    ],
+  };
+}
+const AUTHORING_OWNER_PROVENANCE_FLAG_SPEC = {
+  '--issue': { type: 'string' },
+  '--owner': { type: 'string' },
+  '--repo': { type: 'string' },
+  '--policy': { type: 'string' },
+  '--marker-prefix': { type: 'string' },
+  '--gh-token': { type: 'string' },
+  '--trusted-marker-logins': { type: 'string', default: '' },
+  '--verbose': { type: 'boolean', default: false },
+  '--help': { type: 'boolean', short: 'h' },
+};
+if (import.meta.main) {
+  runCli();
+}
+function parseArgs(argv) {
+  const { values, help } = parseCliArgs(
+    argv,
+    AUTHORING_OWNER_PROVENANCE_FLAG_SPEC,
+  );
+  const issueToken = values.issue;
+  return {
+    issue: issueToken === undefined ? null : Number.parseInt(issueToken, 10),
+    owner: values.owner ?? '',
+    repo: values.repo ?? '',
+    policy: values.policy ?? '',
+    markerPrefix: values['marker-prefix'] ?? '',
+    ghToken: values['gh-token'] ?? '',
+    trustedMarkerLogins: values['trusted-marker-logins'] ?? '',
+    verbose: values.verbose,
+    help,
+  };
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/authoring-owner-provenance.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--policy <path>] [--marker-prefix <prefix>] [--gh-token <token>] [--trusted-marker-logins <login1,login2>] [--verbose]
+
+Mechanically compares a live issue body's sha256 against that same issue's
+own trusted mode=acquire authoring-owner marker's recorded body-sha256
+(kurone-kito/idd-skill#2891). Read-only: never posts, labels, or mutates
+anything.
+
+Output schema:
+{
+  "repository": {"owner": "...", "repo": "..."},
+  "issue": {"number": 2891, "title": "...", "url": "..."},
+  "target": "owner/repo#2891",
+  "verdict": "pass|mismatch|not-found",
+  "computedBodySha256": "<64-hex>",
+  "recordedBodySha256": "<64-hex>|null",
+  "marker": {"author": "...", "createdAt": "...", "owner": "...", "set": "...", "session": "..."} | null,
+  "checks": [{"id":"acquire_marker_found","name":"...","result":"pass|fail"}, {"id":"body_sha256_match","name":"...","result":"pass|fail"}]
+}
+
+"not-found" means no trusted mode=acquire authoring-owner marker exists for
+this issue's own target -- never treated as a pass. "mismatch" means the
+live body has changed since the acquire-time marker was posted.
+`);
+}
+function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (!Number.isInteger(args.issue) || (args.issue ?? 0) <= 0) {
+    throw new Error('--issue is required and must be a positive integer');
+  }
+  if (args.ghToken) {
+    process.env.GH_TOKEN = args.ghToken;
+    process.env.GITHUB_TOKEN = args.ghToken;
+  }
+  const currentRepo =
+    args.owner && args.repo ? null : resolveCurrentGithubRepository();
+  const owner = args.owner || currentRepo?.owner || '';
+  const repo = args.repo || currentRepo?.repo || '';
+  const port = createGithubProviderAdapter(owner, repo);
+  const issueNumber = args.issue ?? 0;
+  const rawIssue = port.getWorkItem(issueNumber);
+  if (!rawIssue) {
+    throw new Error(`issue #${issueNumber} not found`);
+  }
+  const comments = port.listWorkItemComments(issueNumber).map((comment) => ({
+    authorLogin: comment.authorLogin,
+    body: comment.body,
+    createdAt: comment.createdAt,
+  }));
+  const policy = loadPolicyConfig(args.policy || undefined);
+  const config = policy.config;
+  const markerPrefix = normalizeMarkerPrefix(
+    args.markerPrefix || config?.markerPrefix,
+  );
+  const { actors: trustedMarkerLogins } = resolveTrustedMarkerActors({
+    flagValue: args.trustedMarkerLogins,
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+    config: config,
+  });
+  const target = `${owner}/${repo}#${issueNumber}`;
+  const result = evaluateAuthoringOwnerProvenance({
+    target,
+    liveBody: rawIssue.body,
+    comments,
+    markerPrefix,
+    trustedMarkerLogins,
+  });
+  const output = {
+    repository: { owner, repo },
+    issue: {
+      number: rawIssue.number,
+      title: rawIssue.title,
+      url: rawIssue.htmlUrl ?? rawIssue.url ?? '',
+    },
+    target: result.target,
+    verdict: result.verdict,
+    computedBodySha256: result.computedBodySha256,
+    recordedBodySha256: result.recordedBodySha256,
+    marker: result.marker,
+    checks: result.checks,
+  };
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+}

--- a/scripts/authoring-owner-provenance.mjs
+++ b/scripts/authoring-owner-provenance.mjs
@@ -60,6 +60,19 @@ function normalizeMarkerPrefix(prefix) {
   return trimmed.length > 0 ? trimmed : DEFAULT_MARKER_PREFIX;
 }
 /**
+ * True when two `owner/repo#number` issue-reference strings name the same
+ * issue. GitHub owner and repository names are case-insensitive (the
+ * canonical casing an API response reports need not match the casing a
+ * marker author typed or a URL preserved), so every comparison against a
+ * `target` or `anchor` field in this replay must fold case rather than
+ * compare bytes -- a byte comparison would let a marker that differs only
+ * by capitalization fall through to `not-found` even though it names the
+ * same issue (kurone-kito/idd-skill#2901 review, Copilot round 4).
+ */
+function sameIssueRef(a, b) {
+  return a.toLowerCase() === b.toLowerCase();
+}
+/**
  * Replay `target`'s own trusted `authoring-owner` marker log in
  * chronological order (ties broken by comment `id`, ascending — the
  * deterministic order contract.md's replay rule requires) and return the
@@ -109,7 +122,7 @@ function findWinningAcquire(
       continue;
     }
     const parsed = parseAuthoringOwnerComment(comment.body, markerPrefix);
-    if (!parsed || parsed.target !== target) {
+    if (!parsed || !sameIssueRef(parsed.target, target)) {
       continue;
     }
     events.push({ comment, parsed });
@@ -144,18 +157,24 @@ function findWinningAcquire(
  * True when `completion` (a `mode=release-complete` event) is a valid
  * closure of the generation `winner` opened. contract.md requires all of:
  * - **anchor-only** ("release-complete is valid only on the set
- *   anchor"): `completion.target === completion.anchor` -- a
- *   release-complete recorded on a non-anchor child's own comment
- *   thread (this replay only ever reads the named target's own log, so
- *   `completion.target` is always this issue) can never legitimately
- *   close a generation here.
+ *   anchor"): `completion.target` names the same issue as
+ *   `completion.anchor` -- a release-complete recorded on a non-anchor
+ *   child's own comment thread (this replay only ever reads the named
+ *   target's own log, so `completion.target` is always this issue) can
+ *   never legitimately close a generation here.
  * - **required snapshot digest** ("carries the required canonical set
  *   snapshot digest"): `completion.snapshotSha256 !== 'none'` --
  *   `'none'` is release-guard's own sentinel, not a valid completion.
  * - **retains the winning generation's identity** ("retains the
  *   anchor's current owner, set, anchor, and session, and sets
- *   supersedes to that owner token"): owner/set/session/anchor match
- *   `winner`'s, and `supersedes` equals `winner`'s own owner token.
+ *   supersedes to that owner token"): owner/set/session match `winner`'s
+ *   exactly, `completion.anchor` names the same issue as `winner.anchor`,
+ *   and `supersedes` equals `winner`'s own owner token.
+ *
+ * `target`/`anchor` comparisons fold case (`sameIssueRef`): GitHub
+ * owner/repo names are case-insensitive, so a completion typed or quoted
+ * with different capitalization than the winner's own `anchor` still
+ * names the same issue (#2901 review, Copilot round 4).
  *
  * A release-complete failing any of these is stale, malformed, or for
  * an unrelated generation, and is ignored rather than closing the
@@ -163,12 +182,12 @@ function findWinningAcquire(
  */
 function isValidReleaseComplete(completion, winner) {
   return (
-    completion.target === completion.anchor &&
+    sameIssueRef(completion.target, completion.anchor) &&
     completion.snapshotSha256 !== 'none' &&
     completion.owner === winner.owner &&
     completion.set === winner.set &&
     completion.session === winner.session &&
-    completion.anchor === winner.anchor &&
+    sameIssueRef(completion.anchor, winner.anchor) &&
     completion.supersedes === winner.owner
   );
 }
@@ -310,9 +329,11 @@ same-generation race between two competing generation-opening markers
 resolves to the first one -- contract.md: choose the winner by
 deterministic comment order); a generation closes only on a
 mode=release-complete that retains that generation's exact
-owner/set/session/anchor, supersedes that same owner token, is itself
-anchor-scoped (target === anchor), and carries a real snapshot digest (not
-the release-guard sentinel "none"). Caveat: release-complete is
+owner/set/session, names the same anchor, supersedes that same owner
+token, is itself anchor-scoped (its target names the same issue as its
+own anchor), and carries a real snapshot digest (not the release-guard
+sentinel "none"). target/anchor comparisons fold case, since GitHub
+owner/repo names are case-insensitive. Caveat: release-complete is
 anchor-only, so for a non-anchor child target in a multi-target set this
 replay cannot see the child's true generation boundary and treats every
 generation-opening marker on it as one still-open generation -- fail-closed

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -154,6 +154,15 @@ const HELPER_COMMANDS = [
     description: 'Audit or apply post-merge comment cleanup.',
   },
   {
+    id: 'authoring-owner-provenance',
+    scriptName: 'idd:authoring-owner-provenance',
+    binName: 'idd-authoring-owner-provenance',
+    entryPath: 'scripts/authoring-owner-provenance.mjs',
+    vendoredCommand: 'node scripts/authoring-owner-provenance.mjs',
+    description:
+      "Compare a live issue body sha256 against that same issue's own trusted mode=acquire authoring-owner marker digest (review-fix-loop-cutoff provenance check).",
+  },
+  {
     id: 'branch-conflict-state',
     scriptName: 'idd:branch-conflict-state',
     binName: 'idd-branch-conflict-state',

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -1871,9 +1871,10 @@ only approval boundary.
   each removal for owner/set/anchor/session and the expected
   label/body snapshot -- so a body edit landing between an earlier
   check and the actual removal cannot silently bypass this
-  precondition. A dedicated helper/test to perform and verify this
-  comparison mechanically is tracked as a follow-up rather than
-  designed here. This
+  precondition. The `authoring-owner-provenance` helper (`node
+  scripts/authoring-owner-provenance.mjs --issue <number>`; see
+  `docs/idd-helper-scripts.md`) performs and verifies this comparison
+  mechanically (`#2891`). This
   exists because
   `idd-review-triage.instructions.md`'s round-count cutoff files this
   exact marker on a follow-up issue during unattended autonomous

--- a/src/bin/idd-authoring-owner-provenance.mts
+++ b/src/bin/idd-authoring-owner-provenance.mts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-authoring-owner-provenance.mts
+//
+// The bin/idd-authoring-owner-provenance.mjs copy is generated from the .mts source named above
+// by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+
+import { runHelper } from './run-helper.mts';
+
+runHelper('../scripts/authoring-owner-provenance.mjs');

--- a/src/scripts/authoring-owner-provenance.mts
+++ b/src/scripts/authoring-owner-provenance.mts
@@ -10,13 +10,21 @@
 // bullet, kurone-kito/idd-skill#2891): before honoring that exception, a
 // releasing session must recompute a target issue's current body-sha256
 // from a fresh read and compare it against that same target's own
-// winning `authoring-owner` ownership generation marker's recorded
-// `body-sha256` -- normally a `mode=acquire` marker, but a stale-hold
-// `bootstrap` or interrupted-set `resume` can legitimately win a
-// generation too (contract.md; see `findWinningAcquire`'s own doc
-// comment). That comparison previously relied entirely on a releasing
-// session's own manual judgment; this helper performs and verifies it
-// mechanically instead.
+// `mode=acquire` owner marker's recorded `body-sha256` -- specifically
+// the target's *first* trusted `mode=acquire` marker (the Stage 1
+// acquire), never a later one. contract.md is explicit that this digest
+// is "hashed from the fresh read taken immediately before that marker
+// was posted, so it already reflects the published body" -- that
+// property holds only for the very first acquire, since every acquire
+// (including a legitimate re-acquisition after a full release cycle)
+// hashes whatever body is live *at its own posting time*, not the
+// originally published one. Anchoring on "whichever generation currently
+// owns the target" instead of the first acquire would make the check
+// tautological for any edit landing before a later re-acquisition
+// (kurone-kito/idd-skill#2901 review, chatgpt-codex-connector round 4 --
+// see `findStageOneAcquire`'s own doc comment). That comparison
+// previously relied entirely on a releasing session's own manual
+// judgment; this helper performs and verifies it mechanically instead.
 //
 // Read-only evidence collector (docs/idd-helper-scripts.md's "Helper
 // contract classes"): it never posts comments, applies labels, or mutates
@@ -28,22 +36,6 @@
 // target issue (never on a different anchor issue), so the live body and
 // the marker to compare it against always come from the one `--issue`
 // argument.
-//
-// Generation-boundary caveat: `mode=release-complete` is anchor-only
-// (contract.md). For `target === anchor` -- the single-target hold shape
-// this helper is built for (a review-fix-loop-cutoff follow-up is always
-// orphan-shaped, never a set member) -- the target's own comment log
-// carries every generation boundary directly and the replay below is
-// exact. A non-anchor child in a multi-target set never carries its own
-// `release-complete`, so this helper (which reads only the named
-// `--issue`'s own log, never an anchor's) cannot see a child's true
-// generation boundary; every generation-opening marker (acquire,
-// bootstrap, or resume) on such a child reads as one still-open
-// generation. That is the fail-closed direction -- a
-// legitimately re-acquired child compares against the first
-// generation's digest and reports `mismatch`, never a false `pass` --
-// so it is an accepted limitation, not a defect. Fetching the anchor's
-// own log to resolve it is out of scope for kurone-kito/idd-skill#2891.
 
 import { createHash } from 'node:crypto';
 import { parseCliArgs } from './cli-args.mts';
@@ -124,42 +116,40 @@ function sameIssueRef(a: string, b: string): boolean {
 }
 
 /**
- * Replay `target`'s own trusted `authoring-owner` marker log in
- * chronological order (ties broken by comment `id`, ascending — the
- * deterministic order contract.md's replay rule requires) and return the
- * generation-opening marker that won the log's last generation, or
- * `null` if none exists.
+ * Find `target`'s own first trusted `mode=acquire` `authoring-owner`
+ * marker in deterministic comment order (`createdAt`, ties broken by
+ * comment `id` ascending), or `null` if none exists.
  *
- * A generation opens at the first `acquire`, `bootstrap`, or `resume`
- * marker (`GENERATION_OPENER_MODES` below) when no generation is
- * currently open; contract.md: "the first valid acquisition, bootstrap,
- * or resume marker by GitHub comment order wins", so a second
- * generation-opening marker while a generation is already open is a
- * same-generation race — a losing racer or a duplicate — and never
- * overrides the winner. Whichever mode wins, its own `body-sha256` field
- * is the digest this comparison uses (kurone-kito/idd-skill#2901 review,
- * chatgpt-codex-connector round 3: the earlier form recognized only
- * `acquire` as a generation opener, so a legitimate `bootstrap`/`resume`
- * winner could be silently displaced by a later competing `acquire`).
+ * This is deliberately narrower than "whichever marker currently owns
+ * the target": contract.md's provenance-check clause and
+ * kurone-kito/idd-skill#2891's own acceptance criteria both name "a
+ * named target's `mode=acquire` owner marker" -- singular, tied to
+ * Stage 1 publication, not a general ownership-resolution query. Only
+ * the target's *first* trusted marker can carry that property, and only
+ * when that first marker is itself a `mode=acquire`:
  *
- * A generation closes only on a `mode=release-complete` that
- * `isValidReleaseComplete` (below) accepts as a genuine closure of the
- * currently open generation — a stale, malformed, or unrelated
- * completion never closes it (kurone-kito/idd-skill#2901 review,
- * chatgpt-codex-connector rounds 2-3: closing on any release-complete
- * for the target, unchecked, could let an unrelated or incomplete
- * completion evict a still-legitimate winner). `release` /
- * `release-guard` alone never close a generation either, since
- * contract.md allows a new acquisition to start "only once the anchor
- * completion is reconciled" — a generation-opening marker after
- * `release` but before `release-complete` is still a same-generation
- * race, not a fresh generation. See this file's header comment for the
- * anchor-only `release-complete` caveat this replay accepts for a
- * non-anchor child target.
+ * - A later `mode=acquire` (a legitimate re-acquisition after a full
+ *   release cycle) hashes whatever body is live at *its own* posting
+ *   time, not the originally published one -- comparing against it
+ *   would make this check pass trivially for a body edited between the
+ *   original acquire and the re-acquisition, defeating the point of the
+ *   check (kurone-kito/idd-skill#2901 review, chatgpt-codex-connector
+ *   round 4: the earlier "winning ownership generation" replay design
+ *   picked exactly this kind of later marker).
+ * - A same-generation race (two competing `mode=acquire` markers before
+ *   any release) still resolves to the first one, matching contract.md's
+ *   general "first valid marker by GitHub comment order wins" rule and
+ *   this helper's own round-1/round-3 regression tests.
+ * - If the target's first trusted marker is some other mode (`bootstrap`,
+ *   `resume`, `heartbeat`, `release`, ...), that is an anomaly: every
+ *   one of those modes presupposes a prior acquire, so a well-formed
+ *   history never opens with them. Reporting `not-found` (fail-closed)
+ *   for that case, rather than silently accepting a non-acquire first
+ *   marker's own digest, is the only defensible reading of "the
+ *   target's own `mode=acquire` owner marker" when no such marker heads
+ *   the log.
  */
-const GENERATION_OPENER_MODES = new Set(['acquire', 'bootstrap', 'resume']);
-
-function findWinningAcquire(
+function findStageOneAcquire(
   comments: readonly AuthoringOwnerProvenanceComment[],
   target: string,
   markerPrefix: string,
@@ -186,80 +176,25 @@ function findWinningAcquire(
     return a.comment.id - b.comment.id;
   });
 
-  let winner: OwnerMarkerEvent | null = null;
-  let generationOpen = false;
-  for (const event of events) {
-    if (GENERATION_OPENER_MODES.has(event.parsed.mode)) {
-      if (!generationOpen) {
-        winner = event;
-        generationOpen = true;
-      }
-      // else: same-generation race -- the first generation-opening
-      // marker (acquire, bootstrap, or resume) keeps ownership.
-    } else if (
-      event.parsed.mode === 'release-complete' &&
-      winner &&
-      isValidReleaseComplete(event.parsed, winner.parsed)
-    ) {
-      generationOpen = false;
-    }
+  const first = events[0];
+  if (!first || first.parsed.mode !== 'acquire') {
+    return null;
   }
-  return winner;
-}
-
-/**
- * True when `completion` (a `mode=release-complete` event) is a valid
- * closure of the generation `winner` opened. contract.md requires all of:
- * - **anchor-only** ("release-complete is valid only on the set
- *   anchor"): `completion.target` names the same issue as
- *   `completion.anchor` -- a release-complete recorded on a non-anchor
- *   child's own comment thread (this replay only ever reads the named
- *   target's own log, so `completion.target` is always this issue) can
- *   never legitimately close a generation here.
- * - **required snapshot digest** ("carries the required canonical set
- *   snapshot digest"): `completion.snapshotSha256 !== 'none'` --
- *   `'none'` is release-guard's own sentinel, not a valid completion.
- * - **retains the winning generation's identity** ("retains the
- *   anchor's current owner, set, anchor, and session, and sets
- *   supersedes to that owner token"): owner/set/session match `winner`'s
- *   exactly, `completion.anchor` names the same issue as `winner.anchor`,
- *   and `supersedes` equals `winner`'s own owner token.
- *
- * `target`/`anchor` comparisons fold case (`sameIssueRef`): GitHub
- * owner/repo names are case-insensitive, so a completion typed or quoted
- * with different capitalization than the winner's own `anchor` still
- * names the same issue (#2901 review, Copilot round 4).
- *
- * A release-complete failing any of these is stale, malformed, or for
- * an unrelated generation, and is ignored rather than closing the
- * current one (#2901 review, chatgpt-codex-connector rounds 2-3).
- */
-function isValidReleaseComplete(
-  completion: ParsedAuthoringOwnerMarker,
-  winner: ParsedAuthoringOwnerMarker,
-): boolean {
-  return (
-    sameIssueRef(completion.target, completion.anchor) &&
-    completion.snapshotSha256 !== 'none' &&
-    completion.owner === winner.owner &&
-    completion.set === winner.set &&
-    completion.session === winner.session &&
-    sameIssueRef(completion.anchor, winner.anchor) &&
-    completion.supersedes === winner.owner
-  );
+  return first;
 }
 
 /**
  * Compute the sha256 of `input.liveBody` (exact UTF-8 content, matching how
  * the `authoring-owner` marker's `body-sha256` field is documented to be
  * computed — contract.md's "Per-target ownership" section) and compare it
- * against `input.target`'s own trusted winning generation marker (see
- * `findWinningAcquire`).
+ * against `input.target`'s own first trusted `mode=acquire` marker (see
+ * `findStageOneAcquire`) -- the Stage 1 acquire, never a later
+ * re-acquisition.
  *
- * `verdict` is `not-found` when no generation marker won for
- * `input.target`; `pass`/`mismatch` otherwise based on exact digest
- * equality. This never fails open on ambiguity: a missing marker is
- * `not-found`, not `pass`.
+ * `verdict` is `not-found` when no trusted marker log for `input.target`
+ * opens with a `mode=acquire` marker; `pass`/`mismatch` otherwise based
+ * on exact digest equality. This never fails open on ambiguity: a
+ * missing or non-acquire-first marker is `not-found`, not `pass`.
  */
 export function evaluateAuthoringOwnerProvenance(
   input: AuthoringOwnerProvenanceInput,
@@ -267,14 +202,14 @@ export function evaluateAuthoringOwnerProvenance(
   const computedBodySha256 = createHash('sha256')
     .update(input.liveBody, 'utf8')
     .digest('hex');
-  const winner = findWinningAcquire(
+  const acquire = findStageOneAcquire(
     input.comments ?? [],
     input.target,
     input.markerPrefix,
     input.trustedMarkerLogins ?? [],
   );
 
-  if (!winner) {
+  if (!acquire) {
     return {
       verdict: 'not-found',
       target: input.target,
@@ -283,22 +218,22 @@ export function evaluateAuthoringOwnerProvenance(
       marker: null,
       checks: [
         {
-          id: 'generation_marker_found',
-          name: 'A trusted acquire/bootstrap/resume marker won a generation for target',
+          id: 'acquire_marker_found',
+          name: "Target's marker log opens with a trusted mode=acquire marker",
           result: 'fail',
-          evidence: `No trusted acquire/bootstrap/resume authoring-owner marker for target ${input.target} won an open generation in the replayed log.`,
+          evidence: `No trusted authoring-owner marker log for target ${input.target} opens with a mode=acquire marker.`,
         },
         {
           id: 'body_sha256_match',
-          name: "Live body sha256 matches the winning marker's recorded digest",
+          name: "Live body sha256 matches the Stage 1 acquire marker's recorded digest",
           result: 'fail',
-          evidence: 'No generation marker to compare against.',
+          evidence: 'No Stage 1 acquire marker to compare against.',
         },
       ],
     };
   }
 
-  const recordedBodySha256 = winner.parsed.bodySha256;
+  const recordedBodySha256 = acquire.parsed.bodySha256;
   const matches = recordedBodySha256 === computedBodySha256;
   return {
     verdict: matches ? 'pass' : 'mismatch',
@@ -306,24 +241,24 @@ export function evaluateAuthoringOwnerProvenance(
     computedBodySha256,
     recordedBodySha256,
     marker: {
-      author: winner.comment.authorLogin,
-      createdAt: winner.comment.createdAt,
-      mode: winner.parsed.mode,
-      owner: winner.parsed.owner,
-      set: winner.parsed.set,
-      session: winner.parsed.session,
-      bodySha256: winner.parsed.bodySha256,
+      author: acquire.comment.authorLogin,
+      createdAt: acquire.comment.createdAt,
+      mode: acquire.parsed.mode,
+      owner: acquire.parsed.owner,
+      set: acquire.parsed.set,
+      session: acquire.parsed.session,
+      bodySha256: acquire.parsed.bodySha256,
     },
     checks: [
       {
-        id: 'generation_marker_found',
-        name: 'A trusted acquire/bootstrap/resume marker won a generation for target',
+        id: 'acquire_marker_found',
+        name: "Target's marker log opens with a trusted mode=acquire marker",
         result: 'pass',
-        evidence: `Winning mode=${winner.parsed.mode} marker posted by ${winner.comment.authorLogin} at ${winner.comment.createdAt} (owner=${winner.parsed.owner}).`,
+        evidence: `Stage 1 mode=acquire marker posted by ${acquire.comment.authorLogin} at ${acquire.comment.createdAt} (owner=${acquire.parsed.owner}).`,
       },
       {
         id: 'body_sha256_match',
-        name: "Live body sha256 matches the winning marker's recorded digest",
+        name: "Live body sha256 matches the Stage 1 acquire marker's recorded digest",
         result: matches ? 'pass' : 'fail',
         evidence: matches
           ? `computed ${computedBodySha256} matches recorded ${recordedBodySha256}.`
@@ -398,27 +333,27 @@ function printHelp(): void {
   node scripts/authoring-owner-provenance.mjs --issue <number> [--owner <owner> --repo <repo>] [--policy <path>] [--marker-prefix <prefix>] [--gh-token <token>] [--trusted-marker-logins <login1,login2>] [--verbose]
 
 Mechanically compares a live issue body's sha256 against that same issue's
-own trusted winning ownership-generation authoring-owner marker's recorded
-body-sha256 (kurone-kito/idd-skill#2891). Read-only: never posts, labels, or
-mutates anything. --owner and --repo must be given together or not at all.
+own Stage 1 mode=acquire authoring-owner marker's recorded body-sha256
+(kurone-kito/idd-skill#2891). Read-only: never posts, labels, or mutates
+anything. --owner and --repo must be given together or not at all.
 
-The comparison replays this issue's own authoring-owner marker log to find
-the acquire/bootstrap/resume marker that won its last generation (a
-same-generation race between two competing generation-opening markers
-resolves to the first one -- contract.md: choose the winner by
-deterministic comment order); a generation closes only on a
-mode=release-complete that retains that generation's exact
-owner/set/session, names the same anchor, supersedes that same owner
-token, is itself anchor-scoped (its target names the same issue as its
-own anchor), and carries a real snapshot digest (not the release-guard
-sentinel "none"). target/anchor comparisons fold case, since GitHub
-owner/repo names are case-insensitive. Caveat: release-complete is
-anchor-only, so for a non-anchor child target in a multi-target set this
-replay cannot see the child's true generation boundary and treats every
-generation-opening marker on it as one still-open generation -- fail-closed
-(mismatch, never a false pass), not a security gap; a review-fix-loop-cutoff
-follow-up (the case this helper exists for) is always a single-target
-orphan, never a set member.
+The comparison anchors on this issue's own trusted authoring-owner marker
+log's *first* marker, in deterministic comment order (createdAt, ties
+broken by comment id ascending) -- contract.md and this issue's own
+acceptance criteria both name "a named target's mode=acquire owner
+marker", singular, tied to Stage 1 publication. That first marker must
+itself be mode=acquire: only it is guaranteed to have hashed the body as
+published, since every later marker (a same-generation racer, a
+bootstrap/resume recovery, or a legitimate re-acquisition after a full
+release cycle) hashes whatever body is live at its own posting time, not
+the originally published one -- comparing against a later acquire would
+make this check pass trivially for a body edited before that later
+marker (kurone-kito/idd-skill#2901 review, chatgpt-codex-connector round
+4). target comparisons fold case, since GitHub owner/repo names are
+case-insensitive. If the target's first trusted marker is some other mode
+(bootstrap, resume, heartbeat, release, ...), that is an anomaly -- every
+one of those modes presupposes a prior acquire -- and reports not-found
+rather than accepting a non-acquire first marker's own digest.
 
 Output schema:
 {
@@ -428,21 +363,21 @@ Output schema:
   "verdict": "pass|mismatch|not-found",
   "computedBodySha256": "<64-hex>",
   "recordedBodySha256": "<64-hex-or-the-literal-string-none>|null",
-  "marker": {"author": "...", "createdAt": "...", "mode": "acquire|bootstrap|resume", "owner": "...", "set": "...", "session": "...", "bodySha256": "<64-hex-or-the-literal-string-none>"} | null,
-  "checks": [{"id":"generation_marker_found","name":"...","result":"pass|fail"}, {"id":"body_sha256_match","name":"...","result":"pass|fail"}]
+  "marker": {"author": "...", "createdAt": "...", "mode": "acquire", "owner": "...", "set": "...", "session": "...", "bodySha256": "<64-hex-or-the-literal-string-none>"} | null,
+  "checks": [{"id":"acquire_marker_found","name":"...","result":"pass|fail"}, {"id":"body_sha256_match","name":"...","result":"pass|fail"}]
 }
 
-"not-found" means no trusted acquire/bootstrap/resume authoring-owner
-marker won a generation for this issue's own target -- never treated as a
-pass. "mismatch" means the live body has changed since the winning
-marker's own snapshot, including when its body-sha256 is the
+"not-found" means this issue's own trusted authoring-owner marker log does
+not open with a mode=acquire marker for this target -- never treated as a
+pass. "mismatch" means the live body has changed since the Stage 1
+acquire marker's own snapshot, including when its body-sha256 is the
 malformed-but-shape-valid sentinel "none" -- it can never equal a real
 64-hex computed digest, so this stays fail-closed rather than silently
 passing.
 
 --verbose adds an "evidence" string to each checks[] entry (the computed
-and recorded digests, or the winning marker's author/timestamp); omitted by
-default to keep default output terse.
+and recorded digests, or the acquire marker's author/timestamp); omitted
+by default to keep default output terse.
 `);
 }
 

--- a/src/scripts/authoring-owner-provenance.mts
+++ b/src/scripts/authoring-owner-provenance.mts
@@ -119,12 +119,19 @@ function normalizeMarkerPrefix(prefix: unknown): string {
  * racer or a duplicate — and never overrides the winner (kurone-kito/idd-skill#2891
  * review: this previously picked the globally-last acquire instead,
  * which could authorize the auto-release exception against a losing
- * racer's edited-body digest). A generation closes only on
- * `mode=release-complete`: release / release-guard alone do not,
- * since contract.md allows a new acquisition to start "only once the
- * anchor completion is reconciled" — an acquire after `release` but
- * before `release-complete` is still a same-generation race, not a
- * fresh generation. See this file's header comment for the anchor-only
+ * racer's edited-body digest). A generation closes only on a
+ * `mode=release-complete` that retains the exact owner/set/session/
+ * anchor of the currently open generation's winning acquire and
+ * supersedes that same owner token (`isMatchingCompletion` below) — a
+ * stale or malformed release-complete for a different owner/set never
+ * closes it (kurone-kito/idd-skill#2901 review, chatgpt-codex-connector:
+ * closing on any release-complete for the target, unchecked, could let
+ * an unrelated completion evict a still-legitimate winner). `release` /
+ * `release-guard` alone never close a generation either, since
+ * contract.md allows a new acquisition to start "only once the anchor
+ * completion is reconciled" — an acquire after `release` but before
+ * `release-complete` is still a same-generation race, not a fresh
+ * generation. See this file's header comment for the anchor-only
  * `release-complete` caveat this replay accepts for a non-anchor child
  * target.
  */
@@ -164,11 +171,42 @@ function findWinningAcquire(
         generationOpen = true;
       }
       // else: same-generation race -- the first acquire keeps ownership.
-    } else if (event.parsed.mode === 'release-complete') {
+    } else if (
+      event.parsed.mode === 'release-complete' &&
+      winner &&
+      isMatchingCompletion(event.parsed, winner.parsed)
+    ) {
+      // #2901 review, chatgpt-codex-connector: a release-complete marker
+      // closes the CURRENT generation only when it retains that
+      // generation's exact owner/set/session/anchor and supersedes that
+      // same owner token (contract.md: "It retains the anchor's current
+      // owner, set, anchor, and session, and sets supersedes to that
+      // owner token"). A stale or malformed release-complete for a
+      // different owner/set never closes this generation -- ignoring it
+      // (rather than closing on any release-complete for the target) is
+      // what keeps a still-open generation's winner from being displaced
+      // by an unrelated completion.
       generationOpen = false;
     }
   }
   return winner;
+}
+
+/** True when `completion` (a `mode=release-complete` event) retains the
+ * exact owner/set/session/anchor of `winningAcquire` and supersedes that
+ * same owner token -- the only shape contract.md recognizes as a valid
+ * closure of the generation `winningAcquire` opened. */
+function isMatchingCompletion(
+  completion: ParsedAuthoringOwnerMarker,
+  winningAcquire: ParsedAuthoringOwnerMarker,
+): boolean {
+  return (
+    completion.owner === winningAcquire.owner &&
+    completion.set === winningAcquire.set &&
+    completion.session === winningAcquire.session &&
+    completion.anchor === winningAcquire.anchor &&
+    completion.supersedes === winningAcquire.owner
+  );
 }
 
 /**
@@ -340,14 +378,17 @@ Output schema:
   "target": "owner/repo#2891",
   "verdict": "pass|mismatch|not-found",
   "computedBodySha256": "<64-hex>",
-  "recordedBodySha256": "<64-hex>|null",
-  "marker": {"author": "...", "createdAt": "...", "owner": "...", "set": "...", "session": "...", "bodySha256": "<64-hex>"} | null,
+  "recordedBodySha256": "<64-hex-or-the-literal-string-none>|null",
+  "marker": {"author": "...", "createdAt": "...", "owner": "...", "set": "...", "session": "...", "bodySha256": "<64-hex-or-the-literal-string-none>"} | null,
   "checks": [{"id":"acquire_marker_found","name":"...","result":"pass|fail"}, {"id":"body_sha256_match","name":"...","result":"pass|fail"}]
 }
 
 "not-found" means no trusted mode=acquire authoring-owner marker exists for
 this issue's own target -- never treated as a pass. "mismatch" means the
-live body has changed since the acquire-time marker was posted.
+live body has changed since the acquire-time marker was posted, including
+when the winning acquire's own body-sha256 is the malformed-but-shape-valid
+sentinel "none" -- it can never equal a real 64-hex computed digest, so
+this stays fail-closed rather than silently passing.
 
 --verbose adds an "evidence" string to each checks[] entry (the computed
 and recorded digests, or the winning marker's author/timestamp); omitted by

--- a/src/scripts/authoring-owner-provenance.mts
+++ b/src/scripts/authoring-owner-provenance.mts
@@ -10,10 +10,13 @@
 // bullet, kurone-kito/idd-skill#2891): before honoring that exception, a
 // releasing session must recompute a target issue's current body-sha256
 // from a fresh read and compare it against that same target's own
-// `mode=acquire` `authoring-owner` marker's recorded `body-sha256`. That
-// comparison previously relied entirely on a releasing session's own
-// manual judgment; this helper performs and verifies it mechanically
-// instead.
+// winning `authoring-owner` ownership generation marker's recorded
+// `body-sha256` -- normally a `mode=acquire` marker, but a stale-hold
+// `bootstrap` or interrupted-set `resume` can legitimately win a
+// generation too (contract.md; see `findWinningAcquire`'s own doc
+// comment). That comparison previously relied entirely on a releasing
+// session's own manual judgment; this helper performs and verifies it
+// mechanically instead.
 //
 // Read-only evidence collector (docs/idd-helper-scripts.md's "Helper
 // contract classes"): it never posts comments, applies labels, or mutates
@@ -34,8 +37,9 @@
 // exact. A non-anchor child in a multi-target set never carries its own
 // `release-complete`, so this helper (which reads only the named
 // `--issue`'s own log, never an anchor's) cannot see a child's true
-// generation boundary; every acquire on such a child reads as one
-// still-open generation. That is the fail-closed direction -- a
+// generation boundary; every generation-opening marker (acquire,
+// bootstrap, or resume) on such a child reads as one still-open
+// generation. That is the fail-closed direction -- a
 // legitimately re-acquired child compares against the first
 // generation's digest and reports `mismatch`, never a false `pass` --
 // so it is an accepted limitation, not a defect. Fetching the anchor's
@@ -79,6 +83,7 @@ export interface AuthoringOwnerProvenanceCheck {
 export interface AuthoringOwnerProvenanceMarkerEvidence {
   author: string;
   createdAt: string;
+  mode: string;
   owner: string;
   set: string;
   session: string;
@@ -108,33 +113,38 @@ function normalizeMarkerPrefix(prefix: unknown): string {
  * Replay `target`'s own trusted `authoring-owner` marker log in
  * chronological order (ties broken by comment `id`, ascending — the
  * deterministic order contract.md's replay rule requires) and return the
- * `mode=acquire` marker that won the log's last generation, or `null` if
- * none exists.
+ * generation-opening marker that won the log's last generation, or
+ * `null` if none exists.
  *
- * A generation opens at an acquire marker when no generation is
- * currently open; the first acquire in an open generation keeps
- * ownership through the whole generation (contract.md: "choose the
- * winner by deterministic comment order"), so a second acquire while a
- * generation is already open is a same-generation race — a losing
- * racer or a duplicate — and never overrides the winner (kurone-kito/idd-skill#2891
- * review: this previously picked the globally-last acquire instead,
- * which could authorize the auto-release exception against a losing
- * racer's edited-body digest). A generation closes only on a
- * `mode=release-complete` that retains the exact owner/set/session/
- * anchor of the currently open generation's winning acquire and
- * supersedes that same owner token (`isMatchingCompletion` below) — a
- * stale or malformed release-complete for a different owner/set never
- * closes it (kurone-kito/idd-skill#2901 review, chatgpt-codex-connector:
- * closing on any release-complete for the target, unchecked, could let
- * an unrelated completion evict a still-legitimate winner). `release` /
+ * A generation opens at the first `acquire`, `bootstrap`, or `resume`
+ * marker (`GENERATION_OPENER_MODES` below) when no generation is
+ * currently open; contract.md: "the first valid acquisition, bootstrap,
+ * or resume marker by GitHub comment order wins", so a second
+ * generation-opening marker while a generation is already open is a
+ * same-generation race — a losing racer or a duplicate — and never
+ * overrides the winner. Whichever mode wins, its own `body-sha256` field
+ * is the digest this comparison uses (kurone-kito/idd-skill#2901 review,
+ * chatgpt-codex-connector round 3: the earlier form recognized only
+ * `acquire` as a generation opener, so a legitimate `bootstrap`/`resume`
+ * winner could be silently displaced by a later competing `acquire`).
+ *
+ * A generation closes only on a `mode=release-complete` that
+ * `isValidReleaseComplete` (below) accepts as a genuine closure of the
+ * currently open generation — a stale, malformed, or unrelated
+ * completion never closes it (kurone-kito/idd-skill#2901 review,
+ * chatgpt-codex-connector rounds 2-3: closing on any release-complete
+ * for the target, unchecked, could let an unrelated or incomplete
+ * completion evict a still-legitimate winner). `release` /
  * `release-guard` alone never close a generation either, since
  * contract.md allows a new acquisition to start "only once the anchor
- * completion is reconciled" — an acquire after `release` but before
- * `release-complete` is still a same-generation race, not a fresh
- * generation. See this file's header comment for the anchor-only
- * `release-complete` caveat this replay accepts for a non-anchor child
- * target.
+ * completion is reconciled" — a generation-opening marker after
+ * `release` but before `release-complete` is still a same-generation
+ * race, not a fresh generation. See this file's header comment for the
+ * anchor-only `release-complete` caveat this replay accepts for a
+ * non-anchor child target.
  */
+const GENERATION_OPENER_MODES = new Set(['acquire', 'bootstrap', 'resume']);
+
 function findWinningAcquire(
   comments: readonly AuthoringOwnerProvenanceComment[],
   target: string,
@@ -165,47 +175,57 @@ function findWinningAcquire(
   let winner: OwnerMarkerEvent | null = null;
   let generationOpen = false;
   for (const event of events) {
-    if (event.parsed.mode === 'acquire') {
+    if (GENERATION_OPENER_MODES.has(event.parsed.mode)) {
       if (!generationOpen) {
         winner = event;
         generationOpen = true;
       }
-      // else: same-generation race -- the first acquire keeps ownership.
+      // else: same-generation race -- the first generation-opening
+      // marker (acquire, bootstrap, or resume) keeps ownership.
     } else if (
       event.parsed.mode === 'release-complete' &&
       winner &&
-      isMatchingCompletion(event.parsed, winner.parsed)
+      isValidReleaseComplete(event.parsed, winner.parsed)
     ) {
-      // #2901 review, chatgpt-codex-connector: a release-complete marker
-      // closes the CURRENT generation only when it retains that
-      // generation's exact owner/set/session/anchor and supersedes that
-      // same owner token (contract.md: "It retains the anchor's current
-      // owner, set, anchor, and session, and sets supersedes to that
-      // owner token"). A stale or malformed release-complete for a
-      // different owner/set never closes this generation -- ignoring it
-      // (rather than closing on any release-complete for the target) is
-      // what keeps a still-open generation's winner from being displaced
-      // by an unrelated completion.
       generationOpen = false;
     }
   }
   return winner;
 }
 
-/** True when `completion` (a `mode=release-complete` event) retains the
- * exact owner/set/session/anchor of `winningAcquire` and supersedes that
- * same owner token -- the only shape contract.md recognizes as a valid
- * closure of the generation `winningAcquire` opened. */
-function isMatchingCompletion(
+/**
+ * True when `completion` (a `mode=release-complete` event) is a valid
+ * closure of the generation `winner` opened. contract.md requires all of:
+ * - **anchor-only** ("release-complete is valid only on the set
+ *   anchor"): `completion.target === completion.anchor` -- a
+ *   release-complete recorded on a non-anchor child's own comment
+ *   thread (this replay only ever reads the named target's own log, so
+ *   `completion.target` is always this issue) can never legitimately
+ *   close a generation here.
+ * - **required snapshot digest** ("carries the required canonical set
+ *   snapshot digest"): `completion.snapshotSha256 !== 'none'` --
+ *   `'none'` is release-guard's own sentinel, not a valid completion.
+ * - **retains the winning generation's identity** ("retains the
+ *   anchor's current owner, set, anchor, and session, and sets
+ *   supersedes to that owner token"): owner/set/session/anchor match
+ *   `winner`'s, and `supersedes` equals `winner`'s own owner token.
+ *
+ * A release-complete failing any of these is stale, malformed, or for
+ * an unrelated generation, and is ignored rather than closing the
+ * current one (#2901 review, chatgpt-codex-connector rounds 2-3).
+ */
+function isValidReleaseComplete(
   completion: ParsedAuthoringOwnerMarker,
-  winningAcquire: ParsedAuthoringOwnerMarker,
+  winner: ParsedAuthoringOwnerMarker,
 ): boolean {
   return (
-    completion.owner === winningAcquire.owner &&
-    completion.set === winningAcquire.set &&
-    completion.session === winningAcquire.session &&
-    completion.anchor === winningAcquire.anchor &&
-    completion.supersedes === winningAcquire.owner
+    completion.target === completion.anchor &&
+    completion.snapshotSha256 !== 'none' &&
+    completion.owner === winner.owner &&
+    completion.set === winner.set &&
+    completion.session === winner.session &&
+    completion.anchor === winner.anchor &&
+    completion.supersedes === winner.owner
   );
 }
 
@@ -213,10 +233,11 @@ function isMatchingCompletion(
  * Compute the sha256 of `input.liveBody` (exact UTF-8 content, matching how
  * the `authoring-owner` marker's `body-sha256` field is documented to be
  * computed — contract.md's "Per-target ownership" section) and compare it
- * against `input.target`'s own trusted `mode=acquire` marker.
+ * against `input.target`'s own trusted winning generation marker (see
+ * `findWinningAcquire`).
  *
- * `verdict` is `not-found` when no matching trusted acquire marker exists
- * for `input.target`; `pass`/`mismatch` otherwise based on exact digest
+ * `verdict` is `not-found` when no generation marker won for
+ * `input.target`; `pass`/`mismatch` otherwise based on exact digest
  * equality. This never fails open on ambiguity: a missing marker is
  * `not-found`, not `pass`.
  */
@@ -242,16 +263,16 @@ export function evaluateAuthoringOwnerProvenance(
       marker: null,
       checks: [
         {
-          id: 'acquire_marker_found',
-          name: 'Trusted mode=acquire owner marker found for target',
+          id: 'generation_marker_found',
+          name: 'A trusted acquire/bootstrap/resume marker won a generation for target',
           result: 'fail',
-          evidence: `No trusted mode=acquire authoring-owner marker for target ${input.target} won an open generation in the replayed log.`,
+          evidence: `No trusted acquire/bootstrap/resume authoring-owner marker for target ${input.target} won an open generation in the replayed log.`,
         },
         {
           id: 'body_sha256_match',
-          name: 'Live body sha256 matches acquire-time recorded digest',
+          name: "Live body sha256 matches the winning marker's recorded digest",
           result: 'fail',
-          evidence: 'No acquire marker to compare against.',
+          evidence: 'No generation marker to compare against.',
         },
       ],
     };
@@ -267,6 +288,7 @@ export function evaluateAuthoringOwnerProvenance(
     marker: {
       author: winner.comment.authorLogin,
       createdAt: winner.comment.createdAt,
+      mode: winner.parsed.mode,
       owner: winner.parsed.owner,
       set: winner.parsed.set,
       session: winner.parsed.session,
@@ -274,14 +296,14 @@ export function evaluateAuthoringOwnerProvenance(
     },
     checks: [
       {
-        id: 'acquire_marker_found',
-        name: 'Trusted mode=acquire owner marker found for target',
+        id: 'generation_marker_found',
+        name: 'A trusted acquire/bootstrap/resume marker won a generation for target',
         result: 'pass',
-        evidence: `Winning acquire posted by ${winner.comment.authorLogin} at ${winner.comment.createdAt} (owner=${winner.parsed.owner}).`,
+        evidence: `Winning mode=${winner.parsed.mode} marker posted by ${winner.comment.authorLogin} at ${winner.comment.createdAt} (owner=${winner.parsed.owner}).`,
       },
       {
         id: 'body_sha256_match',
-        name: 'Live body sha256 matches acquire-time recorded digest',
+        name: "Live body sha256 matches the winning marker's recorded digest",
         result: matches ? 'pass' : 'fail',
         evidence: matches
           ? `computed ${computedBodySha256} matches recorded ${recordedBodySha256}.`
@@ -356,20 +378,25 @@ function printHelp(): void {
   node scripts/authoring-owner-provenance.mjs --issue <number> [--owner <owner> --repo <repo>] [--policy <path>] [--marker-prefix <prefix>] [--gh-token <token>] [--trusted-marker-logins <login1,login2>] [--verbose]
 
 Mechanically compares a live issue body's sha256 against that same issue's
-own trusted mode=acquire authoring-owner marker's recorded body-sha256
-(kurone-kito/idd-skill#2891). Read-only: never posts, labels, or mutates
-anything. --owner and --repo must be given together or not at all.
+own trusted winning ownership-generation authoring-owner marker's recorded
+body-sha256 (kurone-kito/idd-skill#2891). Read-only: never posts, labels, or
+mutates anything. --owner and --repo must be given together or not at all.
 
 The comparison replays this issue's own authoring-owner marker log to find
-the acquire marker that won its last generation (a same-generation race
-between two competing acquires resolves to the first one, per contract.md's
-deterministic-comment-order tie-break); a generation closes only on
-mode=release-complete. Caveat: release-complete is anchor-only, so for a
-non-anchor child target in a multi-target set this replay cannot see the
-child's true generation boundary and treats every acquire on it as one
-still-open generation -- fail-closed (mismatch, never a false pass), not a
-security gap; a review-fix-loop-cutoff follow-up (the case this helper
-exists for) is always a single-target orphan, never a set member.
+the acquire/bootstrap/resume marker that won its last generation (a
+same-generation race between two competing generation-opening markers
+resolves to the first one -- contract.md: choose the winner by
+deterministic comment order); a generation closes only on a
+mode=release-complete that retains that generation's exact
+owner/set/session/anchor, supersedes that same owner token, is itself
+anchor-scoped (target === anchor), and carries a real snapshot digest (not
+the release-guard sentinel "none"). Caveat: release-complete is
+anchor-only, so for a non-anchor child target in a multi-target set this
+replay cannot see the child's true generation boundary and treats every
+generation-opening marker on it as one still-open generation -- fail-closed
+(mismatch, never a false pass), not a security gap; a review-fix-loop-cutoff
+follow-up (the case this helper exists for) is always a single-target
+orphan, never a set member.
 
 Output schema:
 {
@@ -379,16 +406,17 @@ Output schema:
   "verdict": "pass|mismatch|not-found",
   "computedBodySha256": "<64-hex>",
   "recordedBodySha256": "<64-hex-or-the-literal-string-none>|null",
-  "marker": {"author": "...", "createdAt": "...", "owner": "...", "set": "...", "session": "...", "bodySha256": "<64-hex-or-the-literal-string-none>"} | null,
-  "checks": [{"id":"acquire_marker_found","name":"...","result":"pass|fail"}, {"id":"body_sha256_match","name":"...","result":"pass|fail"}]
+  "marker": {"author": "...", "createdAt": "...", "mode": "acquire|bootstrap|resume", "owner": "...", "set": "...", "session": "...", "bodySha256": "<64-hex-or-the-literal-string-none>"} | null,
+  "checks": [{"id":"generation_marker_found","name":"...","result":"pass|fail"}, {"id":"body_sha256_match","name":"...","result":"pass|fail"}]
 }
 
-"not-found" means no trusted mode=acquire authoring-owner marker exists for
-this issue's own target -- never treated as a pass. "mismatch" means the
-live body has changed since the acquire-time marker was posted, including
-when the winning acquire's own body-sha256 is the malformed-but-shape-valid
-sentinel "none" -- it can never equal a real 64-hex computed digest, so
-this stays fail-closed rather than silently passing.
+"not-found" means no trusted acquire/bootstrap/resume authoring-owner
+marker won a generation for this issue's own target -- never treated as a
+pass. "mismatch" means the live body has changed since the winning
+marker's own snapshot, including when its body-sha256 is the
+malformed-but-shape-valid sentinel "none" -- it can never equal a real
+64-hex computed digest, so this stays fail-closed rather than silently
+passing.
 
 --verbose adds an "evidence" string to each checks[] entry (the computed
 and recorded digests, or the winning marker's author/timestamp); omitted by

--- a/src/scripts/authoring-owner-provenance.mts
+++ b/src/scripts/authoring-owner-provenance.mts
@@ -110,6 +110,20 @@ function normalizeMarkerPrefix(prefix: unknown): string {
 }
 
 /**
+ * True when two `owner/repo#number` issue-reference strings name the same
+ * issue. GitHub owner and repository names are case-insensitive (the
+ * canonical casing an API response reports need not match the casing a
+ * marker author typed or a URL preserved), so every comparison against a
+ * `target` or `anchor` field in this replay must fold case rather than
+ * compare bytes -- a byte comparison would let a marker that differs only
+ * by capitalization fall through to `not-found` even though it names the
+ * same issue (kurone-kito/idd-skill#2901 review, Copilot round 4).
+ */
+function sameIssueRef(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase();
+}
+
+/**
  * Replay `target`'s own trusted `authoring-owner` marker log in
  * chronological order (ties broken by comment `id`, ascending — the
  * deterministic order contract.md's replay rule requires) and return the
@@ -160,7 +174,7 @@ function findWinningAcquire(
       continue;
     }
     const parsed = parseAuthoringOwnerComment(comment.body, markerPrefix);
-    if (!parsed || parsed.target !== target) {
+    if (!parsed || !sameIssueRef(parsed.target, target)) {
       continue;
     }
     events.push({ comment, parsed });
@@ -197,18 +211,24 @@ function findWinningAcquire(
  * True when `completion` (a `mode=release-complete` event) is a valid
  * closure of the generation `winner` opened. contract.md requires all of:
  * - **anchor-only** ("release-complete is valid only on the set
- *   anchor"): `completion.target === completion.anchor` -- a
- *   release-complete recorded on a non-anchor child's own comment
- *   thread (this replay only ever reads the named target's own log, so
- *   `completion.target` is always this issue) can never legitimately
- *   close a generation here.
+ *   anchor"): `completion.target` names the same issue as
+ *   `completion.anchor` -- a release-complete recorded on a non-anchor
+ *   child's own comment thread (this replay only ever reads the named
+ *   target's own log, so `completion.target` is always this issue) can
+ *   never legitimately close a generation here.
  * - **required snapshot digest** ("carries the required canonical set
  *   snapshot digest"): `completion.snapshotSha256 !== 'none'` --
  *   `'none'` is release-guard's own sentinel, not a valid completion.
  * - **retains the winning generation's identity** ("retains the
  *   anchor's current owner, set, anchor, and session, and sets
- *   supersedes to that owner token"): owner/set/session/anchor match
- *   `winner`'s, and `supersedes` equals `winner`'s own owner token.
+ *   supersedes to that owner token"): owner/set/session match `winner`'s
+ *   exactly, `completion.anchor` names the same issue as `winner.anchor`,
+ *   and `supersedes` equals `winner`'s own owner token.
+ *
+ * `target`/`anchor` comparisons fold case (`sameIssueRef`): GitHub
+ * owner/repo names are case-insensitive, so a completion typed or quoted
+ * with different capitalization than the winner's own `anchor` still
+ * names the same issue (#2901 review, Copilot round 4).
  *
  * A release-complete failing any of these is stale, malformed, or for
  * an unrelated generation, and is ignored rather than closing the
@@ -219,12 +239,12 @@ function isValidReleaseComplete(
   winner: ParsedAuthoringOwnerMarker,
 ): boolean {
   return (
-    completion.target === completion.anchor &&
+    sameIssueRef(completion.target, completion.anchor) &&
     completion.snapshotSha256 !== 'none' &&
     completion.owner === winner.owner &&
     completion.set === winner.set &&
     completion.session === winner.session &&
-    completion.anchor === winner.anchor &&
+    sameIssueRef(completion.anchor, winner.anchor) &&
     completion.supersedes === winner.owner
   );
 }
@@ -388,9 +408,11 @@ same-generation race between two competing generation-opening markers
 resolves to the first one -- contract.md: choose the winner by
 deterministic comment order); a generation closes only on a
 mode=release-complete that retains that generation's exact
-owner/set/session/anchor, supersedes that same owner token, is itself
-anchor-scoped (target === anchor), and carries a real snapshot digest (not
-the release-guard sentinel "none"). Caveat: release-complete is
+owner/set/session, names the same anchor, supersedes that same owner
+token, is itself anchor-scoped (its target names the same issue as its
+own anchor), and carries a real snapshot digest (not the release-guard
+sentinel "none"). target/anchor comparisons fold case, since GitHub
+owner/repo names are case-insensitive. Caveat: release-complete is
 anchor-only, so for a non-anchor child target in a multi-target set this
 replay cannot see the child's true generation boundary and treats every
 generation-opening marker on it as one still-open generation -- fail-closed

--- a/src/scripts/authoring-owner-provenance.mts
+++ b/src/scripts/authoring-owner-provenance.mts
@@ -36,6 +36,23 @@
 // target issue (never on a different anchor issue), so the live body and
 // the marker to compare it against always come from the one `--issue`
 // argument.
+//
+// Two accepted limitations, both fail-closed (never a false `pass`), not
+// defects: (1) a marker whose own `anchor` differs from its own `target`
+// declares itself a multi-target set's non-anchor child, out of scope
+// for this single-target-orphan helper (kurone-kito/idd-skill#2901
+// review, Copilot round 5). (2) a trusted actor who *deletes* the true
+// Stage 1 acquire comment outright (rather than editing it) leaves no
+// trace in any API response this helper can read -- detectable tampering
+// (an edit) fails closed (`findStageOneAcquire`'s pre-pass), but
+// undetectable tampering (a deletion) cannot be caught by a live
+// comment-log reader at all (kurone-kito/idd-skill#2901 review round 6,
+// chatgpt-codex-connector). contract.md's own remedy for that case is a
+// durable record the *authoring session itself* persists in its hold
+// state, not an artifact this read-only helper can independently fetch;
+// kurone-kito/idd-skill#2891's acceptance criteria scope this helper to
+// comparing the live body against the marker's own recorded digest, not
+// to designing that separate durable-record mechanism.
 
 import { createHash } from 'node:crypto';
 import { parseCliArgs } from './cli-args.mts';
@@ -147,13 +164,12 @@ const REAL_DIGEST_PATTERN = /^[0-9a-f]{64}$/;
  *   non-anchor child, out of scope for this helper's single-target
  *   orphan design (kurone-kito/idd-skill#2891's own acceptance
  *   criteria; kurone-kito/idd-skill#2901 review, Copilot round 5).
- * - `comment.updatedAt === comment.createdAt`: contract.md requires
- *   owner comments to be "append-only and must not be edited or
- *   deleted" -- an edited comment could have had its `body-sha256`
- *   silently rewritten to match a body modified after Stage 1, so this
- *   fails closed instead of trusting an editable field
- *   (kurone-kito/idd-skill#2901 review, chatgpt-codex-connector
- *   round 5).
+ *
+ * The append-only edit check (contract.md: owner comments "must not be
+ * edited or deleted") lives in `findStageOneAcquire`'s own pre-pass, not
+ * here -- it must run over every trusted marker-shaped comment before
+ * target filtering, not just the one this function receives (see that
+ * function's doc comment).
  *
  * Returns `null` when valid, or a short human-readable reason string
  * when not (surfaced in the `acquire_marker_found` check's evidence).
@@ -162,7 +178,7 @@ function invalidStageOneAcquireReason(
   event: OwnerMarkerEvent,
   target: string,
 ): string | null {
-  const { parsed, comment } = event;
+  const { parsed } = event;
   if (parsed.mode !== 'acquire') {
     return `first trusted marker has mode=${parsed.mode}, not acquire`;
   }
@@ -175,10 +191,23 @@ function invalidStageOneAcquireReason(
   if (!sameIssueRef(parsed.anchor, target)) {
     return `acquire marker's anchor (${parsed.anchor}) differs from its target -- a multi-target set's non-anchor child is out of scope for this helper`;
   }
-  if (comment.updatedAt !== comment.createdAt) {
-    return `acquire marker comment was edited after posting (createdAt=${comment.createdAt}, updatedAt=${comment.updatedAt}) -- owner comments must be append-only`;
-  }
   return null;
+}
+
+/**
+ * True when `comment.body` looks like it once was (or currently attempts
+ * to be) an `authoring-owner` marker -- either it still opens with the
+ * canonical `<!--` HTML-comment-first byte, or it at least still contains
+ * the `<marker-prefix>-authoring-owner:` token somewhere (an edit that
+ * broke the opener but left the token recognizable). Used only to decide
+ * whether an *edited* comment is suspicious enough to fail closed, not to
+ * parse it -- a comment failing this check is confidently unrelated to
+ * ownership (kurone-kito/idd-skill#2901 review, Copilot round 6).
+ */
+function looksLikeOwnerMarker(body: string, markerPrefix: string): boolean {
+  return (
+    body.startsWith('<!--') || body.includes(`${markerPrefix}-authoring-owner:`)
+  );
 }
 
 /**
@@ -207,10 +236,35 @@ function invalidStageOneAcquireReason(
  *   general "first valid marker by GitHub comment order wins" rule and
  *   this helper's own round-1/round-3 regression tests.
  *
+ * Before selecting a first marker at all, a pre-pass rejects the whole
+ * log if ANY trusted, owner-marker-shaped comment (`looksLikeOwnerMarker`)
+ * was edited (`updatedAt !== createdAt`) -- not just the comment that
+ * would otherwise be selected. An editor who edits the true Stage 1
+ * acquire into something that no longer parses, or retargets it to a
+ * different issue, would otherwise make it silently vanish from the
+ * target-matching candidates below, letting a later (legitimate-looking)
+ * acquire become `events[0]` unchallenged (kurone-kito/idd-skill#2901
+ * review, Copilot round 6: the round-5 `updatedAt` check only inspected
+ * the marker this function was about to select, which the edited marker
+ * itself is no longer once tampering breaks its parse or its target).
+ * This is deliberately over-broad in one direction: an edited `heartbeat`
+ * (or any other owner-marker-shaped comment, for any target) also trips
+ * it, even though only the eventual Stage 1 acquire matters semantically
+ * -- accepted, since contract.md's append-only rule covers "owner
+ * comments" generically, and failing closed on any detected edit is the
+ * safe direction.
+ *
+ * Undetectable tampering -- a trusted actor deleting the true Stage 1
+ * acquire outright, rather than editing it -- is out of scope: a deleted
+ * comment is absent from every API response, so no comment-log reader
+ * can see it happened (kurone-kito/idd-skill#2901 review round 6,
+ * chatgpt-codex-connector; accepted limitation, same footing as the
+ * non-anchor-child limitation above -- see this file's header comment).
+ *
  * Returns `{ event: null, rejectReason }` (never a false `pass`) when
- * the first marker exists but fails validation, `{ event: null,
- * rejectReason: null }` when no trusted marker exists at all, or
- * `{ event, rejectReason: null }` on success.
+ * the log is rejected by the pre-pass or the first marker fails
+ * validation, `{ event: null, rejectReason: null }` when no trusted
+ * marker exists at all, or `{ event, rejectReason: null }` on success.
  */
 function findStageOneAcquire(
   comments: readonly AuthoringOwnerProvenanceComment[],
@@ -221,11 +275,27 @@ function findStageOneAcquire(
   const trusted = new Set(
     trustedMarkerLogins.map((login) => login.toLowerCase()),
   );
-  const events: OwnerMarkerEvent[] = [];
-  for (const comment of comments) {
-    if (!trusted.has(String(comment.authorLogin ?? '').toLowerCase())) {
-      continue;
+  const trustedComments = comments.filter((comment) =>
+    trusted.has(String(comment.authorLogin ?? '').toLowerCase()),
+  );
+
+  for (const comment of trustedComments) {
+    if (
+      comment.updatedAt !== comment.createdAt &&
+      looksLikeOwnerMarker(comment.body, markerPrefix)
+    ) {
+      return {
+        event: null,
+        rejectReason:
+          `trusted comment #${comment.id} looks like an authoring-owner ` +
+          `marker and was edited after posting (createdAt=${comment.createdAt}, ` +
+          `updatedAt=${comment.updatedAt}) -- owner comments must be append-only`,
+      };
     }
+  }
+
+  const events: OwnerMarkerEvent[] = [];
+  for (const comment of trustedComments) {
     const parsed = parseAuthoringOwnerComment(comment.body, markerPrefix);
     if (!parsed || !sameIssueRef(parsed.target, target)) {
       continue;
@@ -437,14 +507,25 @@ review round 5): mode=acquire itself (every other mode -- bootstrap,
 resume, heartbeat, release, ... -- presupposes a prior acquire, so a
 well-formed history never opens with one); supersedes=none (contract.md
 requires this specifically for acquire); a real 64-hex body-sha256, never
-the shape-valid sentinel "none"; its own anchor names the same issue as
-its own target (a mismatch declares the marker a multi-target set's
-non-anchor child, out of scope for this single-target-orphan helper); and
-the underlying comment's updatedAt equals its createdAt (contract.md:
-owner comments are append-only and must not be edited or deleted -- an
-edited comment could have had its body-sha256 rewritten after the fact).
+the shape-valid sentinel "none"; and its own anchor names the same issue
+as its own target (a mismatch declares the marker a multi-target set's
+non-anchor child, out of scope for this single-target-orphan helper).
 --verbose surfaces which condition failed in the acquire_marker_found
 check's evidence.
+
+Before selecting a marker at all, this also rejects the whole log (with
+not-found) if ANY trusted, owner-marker-shaped comment was edited after
+posting (its updatedAt differs from its createdAt) -- not just the one
+that would otherwise be selected, so an editor cannot make the true
+Stage 1 acquire vanish from consideration by editing it into something
+unparseable or retargeting it, letting a later acquire silently win
+instead (kurone-kito/idd-skill#2901 review round 6, Copilot). This is
+deliberately over-broad in one direction (an edited heartbeat, for
+example, also trips it) since contract.md's append-only rule covers
+owner comments generically. A trusted actor who deletes the true Stage 1
+acquire outright, rather than editing it, is an accepted limitation: a
+deleted comment leaves no trace in any API response this helper can read
+(kurone-kito/idd-skill#2901 review round 6, chatgpt-codex-connector).
 
 Output schema:
 {

--- a/src/scripts/authoring-owner-provenance.mts
+++ b/src/scripts/authoring-owner-provenance.mts
@@ -1,0 +1,347 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/authoring-owner-provenance.mts
+//
+// The scripts/authoring-owner-provenance.mjs copy is generated from the
+// .mts source named above by `pnpm run build`. Edit the .mts source, never
+// the generated .mjs. See docs/typescript-sources.md.
+//
+// Mechanical provenance check for the review-fix-loop-cutoff auto-release
+// exception's precondition (kurone-kito/idd-skill#2877's contract.md
+// bullet, kurone-kito/idd-skill#2891): before honoring that exception, a
+// releasing session must recompute a target issue's current body-sha256
+// from a fresh read and compare it against that same target's own
+// `mode=acquire` `authoring-owner` marker's recorded `body-sha256`. That
+// comparison previously relied entirely on a releasing session's own
+// manual judgment; this helper performs and verifies it mechanically
+// instead.
+//
+// Read-only evidence collector (docs/idd-helper-scripts.md's "Helper
+// contract classes"): it never posts comments, applies labels, or mutates
+// anything. A releasing session (or a future automated Stage 2
+// release-sequence helper) still decides what to do with the verdict.
+//
+// Per contract.md's "Per-target ownership" section, a target's own
+// `authoring-owner` marker is always posted as a comment on that same
+// target issue (never on a different anchor issue), so the live body and
+// the marker to compare it against always come from the one `--issue`
+// argument.
+
+import { createHash } from 'node:crypto';
+import { parseCliArgs } from './cli-args.mts';
+import { loadPolicyConfig } from './idd-config.mts';
+import type { ParsedAuthoringOwnerMarker } from './marker-helpers.mts';
+import { parseAuthoringOwnerComment } from './marker-helpers.mts';
+import { resolveTrustedMarkerActors } from './protocol-helpers.mts';
+import {
+  createGithubProviderAdapter,
+  resolveCurrentGithubRepository,
+} from './provider-adapter-github.mts';
+
+const DEFAULT_MARKER_PREFIX = 'idd-skill';
+
+export interface AuthoringOwnerProvenanceComment {
+  authorLogin: string;
+  body: string;
+  createdAt: string;
+}
+
+export interface AuthoringOwnerProvenanceInput {
+  target: string;
+  liveBody: string;
+  comments: AuthoringOwnerProvenanceComment[];
+  markerPrefix: string;
+  trustedMarkerLogins: string[];
+}
+
+export interface AuthoringOwnerProvenanceCheck {
+  id: string;
+  name: string;
+  result: 'pass' | 'fail';
+}
+
+export interface AuthoringOwnerProvenanceMarkerEvidence {
+  author: string;
+  createdAt: string;
+  owner: string;
+  set: string;
+  session: string;
+  bodySha256: string;
+}
+
+export interface AuthoringOwnerProvenanceResult {
+  verdict: 'pass' | 'mismatch' | 'not-found';
+  target: string;
+  computedBodySha256: string;
+  recordedBodySha256: string | null;
+  marker: AuthoringOwnerProvenanceMarkerEvidence | null;
+  checks: AuthoringOwnerProvenanceCheck[];
+}
+
+interface AcquireCandidate {
+  comment: AuthoringOwnerProvenanceComment;
+  parsed: ParsedAuthoringOwnerMarker;
+}
+
+function normalizeMarkerPrefix(prefix: unknown): string {
+  const trimmed = typeof prefix === 'string' ? prefix.trim() : '';
+  return trimmed.length > 0 ? trimmed : DEFAULT_MARKER_PREFIX;
+}
+
+/**
+ * Find every trusted-actor `mode=acquire` `authoring-owner` marker on
+ * `comments` whose `target` field exactly equals `target`, sorted ascending
+ * by comment `createdAt`. There should normally be exactly one per
+ * acquisition generation; a re-acquisition after a full release cycle can
+ * legitimately produce more than one over an issue's lifetime, so the
+ * caller takes the most recent (last) entry rather than the first.
+ */
+function findAcquireCandidates(
+  comments: readonly AuthoringOwnerProvenanceComment[],
+  target: string,
+  markerPrefix: string,
+  trustedMarkerLogins: readonly string[],
+): AcquireCandidate[] {
+  const trusted = new Set(
+    trustedMarkerLogins.map((login) => login.toLowerCase()),
+  );
+  const candidates: AcquireCandidate[] = [];
+  for (const comment of comments) {
+    if (!trusted.has(String(comment.authorLogin ?? '').toLowerCase())) {
+      continue;
+    }
+    const parsed = parseAuthoringOwnerComment(comment.body, markerPrefix);
+    if (!parsed || parsed.mode !== 'acquire' || parsed.target !== target) {
+      continue;
+    }
+    candidates.push({ comment, parsed });
+  }
+  return candidates.sort((a, b) =>
+    a.comment.createdAt < b.comment.createdAt
+      ? -1
+      : a.comment.createdAt > b.comment.createdAt
+        ? 1
+        : 0,
+  );
+}
+
+/**
+ * Compute the sha256 of `input.liveBody` (exact UTF-8 content, matching how
+ * the `authoring-owner` marker's `body-sha256` field is documented to be
+ * computed — contract.md's "Per-target ownership" section) and compare it
+ * against `input.target`'s own trusted `mode=acquire` marker.
+ *
+ * `verdict` is `not-found` when no matching trusted acquire marker exists
+ * for `input.target`; `pass`/`mismatch` otherwise based on exact digest
+ * equality. This never fails open on ambiguity: a missing marker is
+ * `not-found`, not `pass`.
+ */
+export function evaluateAuthoringOwnerProvenance(
+  input: AuthoringOwnerProvenanceInput,
+): AuthoringOwnerProvenanceResult {
+  const computedBodySha256 = createHash('sha256')
+    .update(input.liveBody, 'utf8')
+    .digest('hex');
+  const candidates = findAcquireCandidates(
+    input.comments ?? [],
+    input.target,
+    input.markerPrefix,
+    input.trustedMarkerLogins ?? [],
+  );
+  const winner = candidates.at(-1) ?? null;
+
+  if (!winner) {
+    return {
+      verdict: 'not-found',
+      target: input.target,
+      computedBodySha256,
+      recordedBodySha256: null,
+      marker: null,
+      checks: [
+        {
+          id: 'acquire_marker_found',
+          name: 'Trusted mode=acquire owner marker found for target',
+          result: 'fail',
+        },
+        {
+          id: 'body_sha256_match',
+          name: 'Live body sha256 matches acquire-time recorded digest',
+          result: 'fail',
+        },
+      ],
+    };
+  }
+
+  const recordedBodySha256 = winner.parsed.bodySha256;
+  const matches = recordedBodySha256 === computedBodySha256;
+  return {
+    verdict: matches ? 'pass' : 'mismatch',
+    target: input.target,
+    computedBodySha256,
+    recordedBodySha256,
+    marker: {
+      author: winner.comment.authorLogin,
+      createdAt: winner.comment.createdAt,
+      owner: winner.parsed.owner,
+      set: winner.parsed.set,
+      session: winner.parsed.session,
+      bodySha256: winner.parsed.bodySha256,
+    },
+    checks: [
+      {
+        id: 'acquire_marker_found',
+        name: 'Trusted mode=acquire owner marker found for target',
+        result: 'pass',
+      },
+      {
+        id: 'body_sha256_match',
+        name: 'Live body sha256 matches acquire-time recorded digest',
+        result: matches ? 'pass' : 'fail',
+      },
+    ],
+  };
+}
+
+const AUTHORING_OWNER_PROVENANCE_FLAG_SPEC = {
+  '--issue': { type: 'string' },
+  '--owner': { type: 'string' },
+  '--repo': { type: 'string' },
+  '--policy': { type: 'string' },
+  '--marker-prefix': { type: 'string' },
+  '--gh-token': { type: 'string' },
+  '--trusted-marker-logins': { type: 'string', default: '' },
+  '--verbose': { type: 'boolean', default: false },
+  '--help': { type: 'boolean', short: 'h' },
+} as const;
+
+if (import.meta.main) {
+  runCli();
+}
+
+interface ParsedArgs {
+  issue: number | null;
+  owner: string;
+  repo: string;
+  policy: string;
+  markerPrefix: string;
+  ghToken: string;
+  trustedMarkerLogins: string;
+  verbose: boolean;
+  help: boolean;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const { values, help } = parseCliArgs(
+    argv,
+    AUTHORING_OWNER_PROVENANCE_FLAG_SPEC,
+  );
+  const issueToken = values.issue as string | undefined;
+  return {
+    issue: issueToken === undefined ? null : Number.parseInt(issueToken, 10),
+    owner: (values.owner as string | undefined) ?? '',
+    repo: (values.repo as string | undefined) ?? '',
+    policy: (values.policy as string | undefined) ?? '',
+    markerPrefix: (values['marker-prefix'] as string | undefined) ?? '',
+    ghToken: (values['gh-token'] as string | undefined) ?? '',
+    trustedMarkerLogins:
+      (values['trusted-marker-logins'] as string | undefined) ?? '',
+    verbose: values.verbose as boolean,
+    help,
+  };
+}
+
+function printHelp(): void {
+  process.stdout.write(`Usage:
+  node scripts/authoring-owner-provenance.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--policy <path>] [--marker-prefix <prefix>] [--gh-token <token>] [--trusted-marker-logins <login1,login2>] [--verbose]
+
+Mechanically compares a live issue body's sha256 against that same issue's
+own trusted mode=acquire authoring-owner marker's recorded body-sha256
+(kurone-kito/idd-skill#2891). Read-only: never posts, labels, or mutates
+anything.
+
+Output schema:
+{
+  "repository": {"owner": "...", "repo": "..."},
+  "issue": {"number": 2891, "title": "...", "url": "..."},
+  "target": "owner/repo#2891",
+  "verdict": "pass|mismatch|not-found",
+  "computedBodySha256": "<64-hex>",
+  "recordedBodySha256": "<64-hex>|null",
+  "marker": {"author": "...", "createdAt": "...", "owner": "...", "set": "...", "session": "..."} | null,
+  "checks": [{"id":"acquire_marker_found","name":"...","result":"pass|fail"}, {"id":"body_sha256_match","name":"...","result":"pass|fail"}]
+}
+
+"not-found" means no trusted mode=acquire authoring-owner marker exists for
+this issue's own target -- never treated as a pass. "mismatch" means the
+live body has changed since the acquire-time marker was posted.
+`);
+}
+
+function runCli(): void {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (!Number.isInteger(args.issue) || (args.issue ?? 0) <= 0) {
+    throw new Error('--issue is required and must be a positive integer');
+  }
+  if (args.ghToken) {
+    process.env.GH_TOKEN = args.ghToken;
+    process.env.GITHUB_TOKEN = args.ghToken;
+  }
+
+  const currentRepo =
+    args.owner && args.repo ? null : resolveCurrentGithubRepository();
+  const owner = args.owner || currentRepo?.owner || '';
+  const repo = args.repo || currentRepo?.repo || '';
+  const port = createGithubProviderAdapter(owner, repo);
+  const issueNumber = args.issue ?? 0;
+  const rawIssue = port.getWorkItem(issueNumber);
+  if (!rawIssue) {
+    throw new Error(`issue #${issueNumber} not found`);
+  }
+  const comments: AuthoringOwnerProvenanceComment[] = port
+    .listWorkItemComments(issueNumber)
+    .map((comment) => ({
+      authorLogin: comment.authorLogin,
+      body: comment.body,
+      createdAt: comment.createdAt,
+    }));
+
+  const policy = loadPolicyConfig(args.policy || undefined);
+  const config = policy.config as { markerPrefix?: unknown } | null;
+  const markerPrefix = normalizeMarkerPrefix(
+    args.markerPrefix || config?.markerPrefix,
+  );
+  const { actors: trustedMarkerLogins } = resolveTrustedMarkerActors({
+    flagValue: args.trustedMarkerLogins,
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
+    config: config as { trustedMarkerActors?: unknown } | null,
+  });
+
+  const target = `${owner}/${repo}#${issueNumber}`;
+  const result = evaluateAuthoringOwnerProvenance({
+    target,
+    liveBody: rawIssue.body,
+    comments,
+    markerPrefix,
+    trustedMarkerLogins,
+  });
+
+  const output = {
+    repository: { owner, repo },
+    issue: {
+      number: rawIssue.number,
+      title: rawIssue.title,
+      url: rawIssue.htmlUrl ?? rawIssue.url ?? '',
+    },
+    target: result.target,
+    verdict: result.verdict,
+    computedBodySha256: result.computedBodySha256,
+    recordedBodySha256: result.recordedBodySha256,
+    marker: result.marker,
+    checks: result.checks,
+  };
+
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+}

--- a/src/scripts/authoring-owner-provenance.mts
+++ b/src/scripts/authoring-owner-provenance.mts
@@ -25,6 +25,21 @@
 // target issue (never on a different anchor issue), so the live body and
 // the marker to compare it against always come from the one `--issue`
 // argument.
+//
+// Generation-boundary caveat: `mode=release-complete` is anchor-only
+// (contract.md). For `target === anchor` -- the single-target hold shape
+// this helper is built for (a review-fix-loop-cutoff follow-up is always
+// orphan-shaped, never a set member) -- the target's own comment log
+// carries every generation boundary directly and the replay below is
+// exact. A non-anchor child in a multi-target set never carries its own
+// `release-complete`, so this helper (which reads only the named
+// `--issue`'s own log, never an anchor's) cannot see a child's true
+// generation boundary; every acquire on such a child reads as one
+// still-open generation. That is the fail-closed direction -- a
+// legitimately re-acquired child compares against the first
+// generation's digest and reports `mismatch`, never a false `pass` --
+// so it is an accepted limitation, not a defect. Fetching the anchor's
+// own log to resolve it is out of scope for kurone-kito/idd-skill#2891.
 
 import { createHash } from 'node:crypto';
 import { parseCliArgs } from './cli-args.mts';
@@ -40,6 +55,7 @@ import {
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
 
 export interface AuthoringOwnerProvenanceComment {
+  id: number;
   authorLogin: string;
   body: string;
   createdAt: string;
@@ -57,6 +73,7 @@ export interface AuthoringOwnerProvenanceCheck {
   id: string;
   name: string;
   result: 'pass' | 'fail';
+  evidence: string;
 }
 
 export interface AuthoringOwnerProvenanceMarkerEvidence {
@@ -77,7 +94,7 @@ export interface AuthoringOwnerProvenanceResult {
   checks: AuthoringOwnerProvenanceCheck[];
 }
 
-interface AcquireCandidate {
+interface OwnerMarkerEvent {
   comment: AuthoringOwnerProvenanceComment;
   parsed: ParsedAuthoringOwnerMarker;
 }
@@ -88,40 +105,70 @@ function normalizeMarkerPrefix(prefix: unknown): string {
 }
 
 /**
- * Find every trusted-actor `mode=acquire` `authoring-owner` marker on
- * `comments` whose `target` field exactly equals `target`, sorted ascending
- * by comment `createdAt`. There should normally be exactly one per
- * acquisition generation; a re-acquisition after a full release cycle can
- * legitimately produce more than one over an issue's lifetime, so the
- * caller takes the most recent (last) entry rather than the first.
+ * Replay `target`'s own trusted `authoring-owner` marker log in
+ * chronological order (ties broken by comment `id`, ascending — the
+ * deterministic order contract.md's replay rule requires) and return the
+ * `mode=acquire` marker that won the log's last generation, or `null` if
+ * none exists.
+ *
+ * A generation opens at an acquire marker when no generation is
+ * currently open; the first acquire in an open generation keeps
+ * ownership through the whole generation (contract.md: "choose the
+ * winner by deterministic comment order"), so a second acquire while a
+ * generation is already open is a same-generation race — a losing
+ * racer or a duplicate — and never overrides the winner (kurone-kito/idd-skill#2891
+ * review: this previously picked the globally-last acquire instead,
+ * which could authorize the auto-release exception against a losing
+ * racer's edited-body digest). A generation closes only on
+ * `mode=release-complete`: release / release-guard alone do not,
+ * since contract.md allows a new acquisition to start "only once the
+ * anchor completion is reconciled" — an acquire after `release` but
+ * before `release-complete` is still a same-generation race, not a
+ * fresh generation. See this file's header comment for the anchor-only
+ * `release-complete` caveat this replay accepts for a non-anchor child
+ * target.
  */
-function findAcquireCandidates(
+function findWinningAcquire(
   comments: readonly AuthoringOwnerProvenanceComment[],
   target: string,
   markerPrefix: string,
   trustedMarkerLogins: readonly string[],
-): AcquireCandidate[] {
+): OwnerMarkerEvent | null {
   const trusted = new Set(
     trustedMarkerLogins.map((login) => login.toLowerCase()),
   );
-  const candidates: AcquireCandidate[] = [];
+  const events: OwnerMarkerEvent[] = [];
   for (const comment of comments) {
     if (!trusted.has(String(comment.authorLogin ?? '').toLowerCase())) {
       continue;
     }
     const parsed = parseAuthoringOwnerComment(comment.body, markerPrefix);
-    if (!parsed || parsed.mode !== 'acquire' || parsed.target !== target) {
+    if (!parsed || parsed.target !== target) {
       continue;
     }
-    candidates.push({ comment, parsed });
+    events.push({ comment, parsed });
   }
-  return candidates.sort((a, b) =>
-    a.comment.createdAt < b.comment.createdAt
-      ? -1
-      : a.comment.createdAt > b.comment.createdAt
-        ? 1
-        : 0,
-  );
+  events.sort((a, b) => {
+    if (a.comment.createdAt !== b.comment.createdAt) {
+      return a.comment.createdAt < b.comment.createdAt ? -1 : 1;
+    }
+    return a.comment.id - b.comment.id;
+  });
+
+  let winner: OwnerMarkerEvent | null = null;
+  let generationOpen = false;
+  for (const event of events) {
+    if (event.parsed.mode === 'acquire') {
+      if (!generationOpen) {
+        winner = event;
+        generationOpen = true;
+      }
+      // else: same-generation race -- the first acquire keeps ownership.
+    } else if (event.parsed.mode === 'release-complete') {
+      generationOpen = false;
+    }
+  }
+  return winner;
 }
 
 /**
@@ -141,13 +188,12 @@ export function evaluateAuthoringOwnerProvenance(
   const computedBodySha256 = createHash('sha256')
     .update(input.liveBody, 'utf8')
     .digest('hex');
-  const candidates = findAcquireCandidates(
+  const winner = findWinningAcquire(
     input.comments ?? [],
     input.target,
     input.markerPrefix,
     input.trustedMarkerLogins ?? [],
   );
-  const winner = candidates.at(-1) ?? null;
 
   if (!winner) {
     return {
@@ -161,11 +207,13 @@ export function evaluateAuthoringOwnerProvenance(
           id: 'acquire_marker_found',
           name: 'Trusted mode=acquire owner marker found for target',
           result: 'fail',
+          evidence: `No trusted mode=acquire authoring-owner marker for target ${input.target} won an open generation in the replayed log.`,
         },
         {
           id: 'body_sha256_match',
           name: 'Live body sha256 matches acquire-time recorded digest',
           result: 'fail',
+          evidence: 'No acquire marker to compare against.',
         },
       ],
     };
@@ -191,11 +239,15 @@ export function evaluateAuthoringOwnerProvenance(
         id: 'acquire_marker_found',
         name: 'Trusted mode=acquire owner marker found for target',
         result: 'pass',
+        evidence: `Winning acquire posted by ${winner.comment.authorLogin} at ${winner.comment.createdAt} (owner=${winner.parsed.owner}).`,
       },
       {
         id: 'body_sha256_match',
         name: 'Live body sha256 matches acquire-time recorded digest',
         result: matches ? 'pass' : 'fail',
+        evidence: matches
+          ? `computed ${computedBodySha256} matches recorded ${recordedBodySha256}.`
+          : `computed ${computedBodySha256} does not match recorded ${recordedBodySha256}.`,
       },
     ],
   };
@@ -235,10 +287,22 @@ function parseArgs(argv: string[]): ParsedArgs {
     AUTHORING_OWNER_PROVENANCE_FLAG_SPEC,
   );
   const issueToken = values.issue as string | undefined;
+  const owner = ((values.owner as string | undefined) ?? '').trim();
+  const repo = ((values.repo as string | undefined) ?? '').trim();
+  // Copilot review finding on PR #2901: exactly one of --owner/--repo would
+  // mix a caller-supplied repo with resolveCurrentGithubRepository()'s
+  // current-directory repo, potentially targeting the wrong repository for
+  // the issue lookup. Mirrors suitability-close-execute.mts's own
+  // --owner/--repo pairing guard: require both or neither.
+  if ((owner === '') !== (repo === '')) {
+    throw new Error(
+      'authoring-owner-provenance: --owner and --repo must be provided together or not at all',
+    );
+  }
   return {
     issue: issueToken === undefined ? null : Number.parseInt(issueToken, 10),
-    owner: (values.owner as string | undefined) ?? '',
-    repo: (values.repo as string | undefined) ?? '',
+    owner,
+    repo,
     policy: (values.policy as string | undefined) ?? '',
     markerPrefix: (values['marker-prefix'] as string | undefined) ?? '',
     ghToken: (values['gh-token'] as string | undefined) ?? '',
@@ -251,12 +315,23 @@ function parseArgs(argv: string[]): ParsedArgs {
 
 function printHelp(): void {
   process.stdout.write(`Usage:
-  node scripts/authoring-owner-provenance.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--policy <path>] [--marker-prefix <prefix>] [--gh-token <token>] [--trusted-marker-logins <login1,login2>] [--verbose]
+  node scripts/authoring-owner-provenance.mjs --issue <number> [--owner <owner> --repo <repo>] [--policy <path>] [--marker-prefix <prefix>] [--gh-token <token>] [--trusted-marker-logins <login1,login2>] [--verbose]
 
 Mechanically compares a live issue body's sha256 against that same issue's
 own trusted mode=acquire authoring-owner marker's recorded body-sha256
 (kurone-kito/idd-skill#2891). Read-only: never posts, labels, or mutates
-anything.
+anything. --owner and --repo must be given together or not at all.
+
+The comparison replays this issue's own authoring-owner marker log to find
+the acquire marker that won its last generation (a same-generation race
+between two competing acquires resolves to the first one, per contract.md's
+deterministic-comment-order tie-break); a generation closes only on
+mode=release-complete. Caveat: release-complete is anchor-only, so for a
+non-anchor child target in a multi-target set this replay cannot see the
+child's true generation boundary and treats every acquire on it as one
+still-open generation -- fail-closed (mismatch, never a false pass), not a
+security gap; a review-fix-loop-cutoff follow-up (the case this helper
+exists for) is always a single-target orphan, never a set member.
 
 Output schema:
 {
@@ -266,13 +341,17 @@ Output schema:
   "verdict": "pass|mismatch|not-found",
   "computedBodySha256": "<64-hex>",
   "recordedBodySha256": "<64-hex>|null",
-  "marker": {"author": "...", "createdAt": "...", "owner": "...", "set": "...", "session": "..."} | null,
+  "marker": {"author": "...", "createdAt": "...", "owner": "...", "set": "...", "session": "...", "bodySha256": "<64-hex>"} | null,
   "checks": [{"id":"acquire_marker_found","name":"...","result":"pass|fail"}, {"id":"body_sha256_match","name":"...","result":"pass|fail"}]
 }
 
 "not-found" means no trusted mode=acquire authoring-owner marker exists for
 this issue's own target -- never treated as a pass. "mismatch" means the
 live body has changed since the acquire-time marker was posted.
+
+--verbose adds an "evidence" string to each checks[] entry (the computed
+and recorded digests, or the winning marker's author/timestamp); omitted by
+default to keep default output terse.
 `);
 }
 
@@ -303,6 +382,7 @@ function runCli(): void {
   const comments: AuthoringOwnerProvenanceComment[] = port
     .listWorkItemComments(issueNumber)
     .map((comment) => ({
+      id: comment.id,
       authorLogin: comment.authorLogin,
       body: comment.body,
       createdAt: comment.createdAt,
@@ -340,7 +420,13 @@ function runCli(): void {
     computedBodySha256: result.computedBodySha256,
     recordedBodySha256: result.recordedBodySha256,
     marker: result.marker,
-    checks: result.checks,
+    checks: args.verbose
+      ? result.checks
+      : result.checks.map((check) => ({
+          id: check.id,
+          name: check.name,
+          result: check.result,
+        })),
   };
 
   process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);

--- a/src/scripts/authoring-owner-provenance.mts
+++ b/src/scripts/authoring-owner-provenance.mts
@@ -55,6 +55,7 @@ export interface AuthoringOwnerProvenanceComment {
   authorLogin: string;
   body: string;
   createdAt: string;
+  updatedAt: string;
 }
 
 export interface AuthoringOwnerProvenanceInput {
@@ -116,17 +117,82 @@ function sameIssueRef(a: string, b: string): boolean {
 }
 
 /**
- * Find `target`'s own first trusted `mode=acquire` `authoring-owner`
- * marker in deterministic comment order (`createdAt`, ties broken by
- * comment `id` ascending), or `null` if none exists.
+ * Matches a real 64-lowercase-hex sha256 digest, excluding the
+ * shape-valid-but-malformed sentinel `none` that a marker's own
+ * `body-sha256`/`snapshot-sha256` field can legitimately carry for other
+ * modes (`release-guard`'s `body-sha256=none`, for example) but never for
+ * a genuine Stage 1 `mode=acquire` marker, whose entire purpose is
+ * recording the published body's digest.
+ */
+const REAL_DIGEST_PATTERN = /^[0-9a-f]{64}$/;
+
+/**
+ * True when `event` is a genuine, unedited Stage 1 `mode=acquire` marker
+ * for `target` -- every condition contract.md attaches to a valid
+ * acquisition, checked explicitly rather than assumed:
+ *
+ * - `mode === 'acquire'`: every other mode (`bootstrap`, `resume`,
+ *   `heartbeat`, `release`, `release-complete`, ...) presupposes a prior
+ *   acquire, so a well-formed history never opens with one of them.
+ * - `supersedes === 'none'`: contract.md requires this for `acquire` (and
+ *   `bootstrap`) specifically -- only `resume` names a prior owner token
+ *   (kurone-kito/idd-skill#2901 review, chatgpt-codex-connector round 5).
+ * - `bodySha256` is a real 64-hex digest, never the shape-valid sentinel
+ *   `none` -- a Stage 1 acquire's whole purpose is recording the
+ *   published body's digest, so `none` here is malformed, not merely
+ *   unlucky.
+ * - the marker's own `anchor` names the same issue as `target`: per
+ *   contract.md, "the anchor's own marker uses its target as the
+ *   anchor" -- a marker with a different anchor is a multi-target set's
+ *   non-anchor child, out of scope for this helper's single-target
+ *   orphan design (kurone-kito/idd-skill#2891's own acceptance
+ *   criteria; kurone-kito/idd-skill#2901 review, Copilot round 5).
+ * - `comment.updatedAt === comment.createdAt`: contract.md requires
+ *   owner comments to be "append-only and must not be edited or
+ *   deleted" -- an edited comment could have had its `body-sha256`
+ *   silently rewritten to match a body modified after Stage 1, so this
+ *   fails closed instead of trusting an editable field
+ *   (kurone-kito/idd-skill#2901 review, chatgpt-codex-connector
+ *   round 5).
+ *
+ * Returns `null` when valid, or a short human-readable reason string
+ * when not (surfaced in the `acquire_marker_found` check's evidence).
+ */
+function invalidStageOneAcquireReason(
+  event: OwnerMarkerEvent,
+  target: string,
+): string | null {
+  const { parsed, comment } = event;
+  if (parsed.mode !== 'acquire') {
+    return `first trusted marker has mode=${parsed.mode}, not acquire`;
+  }
+  if (parsed.supersedes !== 'none') {
+    return `acquire marker has supersedes=${parsed.supersedes} (acquire requires none)`;
+  }
+  if (!REAL_DIGEST_PATTERN.test(parsed.bodySha256)) {
+    return `acquire marker's body-sha256 is not a real digest (got ${parsed.bodySha256})`;
+  }
+  if (!sameIssueRef(parsed.anchor, target)) {
+    return `acquire marker's anchor (${parsed.anchor}) differs from its target -- a multi-target set's non-anchor child is out of scope for this helper`;
+  }
+  if (comment.updatedAt !== comment.createdAt) {
+    return `acquire marker comment was edited after posting (createdAt=${comment.createdAt}, updatedAt=${comment.updatedAt}) -- owner comments must be append-only`;
+  }
+  return null;
+}
+
+/**
+ * Find `target`'s own first trusted `authoring-owner` marker in
+ * deterministic comment order (`createdAt`, ties broken by comment `id`
+ * ascending) and validate it as a genuine Stage 1 `mode=acquire` marker
+ * (see `invalidStageOneAcquireReason`).
  *
  * This is deliberately narrower than "whichever marker currently owns
  * the target": contract.md's provenance-check clause and
  * kurone-kito/idd-skill#2891's own acceptance criteria both name "a
  * named target's `mode=acquire` owner marker" -- singular, tied to
  * Stage 1 publication, not a general ownership-resolution query. Only
- * the target's *first* trusted marker can carry that property, and only
- * when that first marker is itself a `mode=acquire`:
+ * the target's *first* trusted marker can carry that property:
  *
  * - A later `mode=acquire` (a legitimate re-acquisition after a full
  *   release cycle) hashes whatever body is live at *its own* posting
@@ -140,21 +206,18 @@ function sameIssueRef(a: string, b: string): boolean {
  *   any release) still resolves to the first one, matching contract.md's
  *   general "first valid marker by GitHub comment order wins" rule and
  *   this helper's own round-1/round-3 regression tests.
- * - If the target's first trusted marker is some other mode (`bootstrap`,
- *   `resume`, `heartbeat`, `release`, ...), that is an anomaly: every
- *   one of those modes presupposes a prior acquire, so a well-formed
- *   history never opens with them. Reporting `not-found` (fail-closed)
- *   for that case, rather than silently accepting a non-acquire first
- *   marker's own digest, is the only defensible reading of "the
- *   target's own `mode=acquire` owner marker" when no such marker heads
- *   the log.
+ *
+ * Returns `{ event: null, rejectReason }` (never a false `pass`) when
+ * the first marker exists but fails validation, `{ event: null,
+ * rejectReason: null }` when no trusted marker exists at all, or
+ * `{ event, rejectReason: null }` on success.
  */
 function findStageOneAcquire(
   comments: readonly AuthoringOwnerProvenanceComment[],
   target: string,
   markerPrefix: string,
   trustedMarkerLogins: readonly string[],
-): OwnerMarkerEvent | null {
+): { event: OwnerMarkerEvent | null; rejectReason: string | null } {
   const trusted = new Set(
     trustedMarkerLogins.map((login) => login.toLowerCase()),
   );
@@ -177,10 +240,14 @@ function findStageOneAcquire(
   });
 
   const first = events[0];
-  if (!first || first.parsed.mode !== 'acquire') {
-    return null;
+  if (!first) {
+    return { event: null, rejectReason: null };
   }
-  return first;
+  const rejectReason = invalidStageOneAcquireReason(first, target);
+  if (rejectReason) {
+    return { event: null, rejectReason };
+  }
+  return { event: first, rejectReason: null };
 }
 
 /**
@@ -202,7 +269,7 @@ export function evaluateAuthoringOwnerProvenance(
   const computedBodySha256 = createHash('sha256')
     .update(input.liveBody, 'utf8')
     .digest('hex');
-  const acquire = findStageOneAcquire(
+  const { event: acquire, rejectReason } = findStageOneAcquire(
     input.comments ?? [],
     input.target,
     input.markerPrefix,
@@ -219,9 +286,11 @@ export function evaluateAuthoringOwnerProvenance(
       checks: [
         {
           id: 'acquire_marker_found',
-          name: "Target's marker log opens with a trusted mode=acquire marker",
+          name: "Target's marker log opens with a valid trusted mode=acquire marker",
           result: 'fail',
-          evidence: `No trusted authoring-owner marker log for target ${input.target} opens with a mode=acquire marker.`,
+          evidence: rejectReason
+            ? `Target ${input.target}'s first trusted authoring-owner marker is not a valid Stage 1 acquire: ${rejectReason}.`
+            : `No trusted authoring-owner marker log for target ${input.target} opens with a mode=acquire marker.`,
         },
         {
           id: 'body_sha256_match',
@@ -252,9 +321,9 @@ export function evaluateAuthoringOwnerProvenance(
     checks: [
       {
         id: 'acquire_marker_found',
-        name: "Target's marker log opens with a trusted mode=acquire marker",
+        name: "Target's marker log opens with a valid trusted mode=acquire marker",
         result: 'pass',
-        evidence: `Stage 1 mode=acquire marker posted by ${acquire.comment.authorLogin} at ${acquire.comment.createdAt} (owner=${acquire.parsed.owner}).`,
+        evidence: `Valid Stage 1 mode=acquire marker posted by ${acquire.comment.authorLogin} at ${acquire.comment.createdAt} (owner=${acquire.parsed.owner}).`,
       },
       {
         id: 'body_sha256_match',
@@ -314,8 +383,17 @@ function parseArgs(argv: string[]): ParsedArgs {
       'authoring-owner-provenance: --owner and --repo must be provided together or not at all',
     );
   }
+  // `Number.parseInt` accepts trailing garbage ("2891junk" -> 2891), so a
+  // typo'd --issue would silently target the wrong issue instead of
+  // failing loudly (kurone-kito/idd-skill#2901 review, Copilot round 5).
+  // Require the whole token to be digits, matching
+  // suitability-close-execute.mts's own --issue parsing.
+  const issue =
+    issueToken !== undefined && /^\d+$/.test(issueToken)
+      ? Number(issueToken)
+      : null;
   return {
-    issue: issueToken === undefined ? null : Number.parseInt(issueToken, 10),
+    issue,
     owner,
     repo,
     policy: (values.policy as string | undefined) ?? '',
@@ -350,10 +428,23 @@ the originally published one -- comparing against a later acquire would
 make this check pass trivially for a body edited before that later
 marker (kurone-kito/idd-skill#2901 review, chatgpt-codex-connector round
 4). target comparisons fold case, since GitHub owner/repo names are
-case-insensitive. If the target's first trusted marker is some other mode
-(bootstrap, resume, heartbeat, release, ...), that is an anomaly -- every
-one of those modes presupposes a prior acquire -- and reports not-found
-rather than accepting a non-acquire first marker's own digest.
+case-insensitive.
+
+The first marker must also pass every validity condition contract.md
+attaches to a genuine Stage 1 acquire, or this reports not-found rather
+than accepting an invalid marker's own digest (kurone-kito/idd-skill#2901
+review round 5): mode=acquire itself (every other mode -- bootstrap,
+resume, heartbeat, release, ... -- presupposes a prior acquire, so a
+well-formed history never opens with one); supersedes=none (contract.md
+requires this specifically for acquire); a real 64-hex body-sha256, never
+the shape-valid sentinel "none"; its own anchor names the same issue as
+its own target (a mismatch declares the marker a multi-target set's
+non-anchor child, out of scope for this single-target-orphan helper); and
+the underlying comment's updatedAt equals its createdAt (contract.md:
+owner comments are append-only and must not be edited or deleted -- an
+edited comment could have had its body-sha256 rewritten after the fact).
+--verbose surfaces which condition failed in the acquire_marker_found
+check's evidence.
 
 Output schema:
 {
@@ -362,18 +453,15 @@ Output schema:
   "target": "owner/repo#2891",
   "verdict": "pass|mismatch|not-found",
   "computedBodySha256": "<64-hex>",
-  "recordedBodySha256": "<64-hex-or-the-literal-string-none>|null",
-  "marker": {"author": "...", "createdAt": "...", "mode": "acquire", "owner": "...", "set": "...", "session": "...", "bodySha256": "<64-hex-or-the-literal-string-none>"} | null,
+  "recordedBodySha256": "<64-hex>|null",
+  "marker": {"author": "...", "createdAt": "...", "mode": "acquire", "owner": "...", "set": "...", "session": "...", "bodySha256": "<64-hex>"} | null,
   "checks": [{"id":"acquire_marker_found","name":"...","result":"pass|fail"}, {"id":"body_sha256_match","name":"...","result":"pass|fail"}]
 }
 
 "not-found" means this issue's own trusted authoring-owner marker log does
-not open with a mode=acquire marker for this target -- never treated as a
-pass. "mismatch" means the live body has changed since the Stage 1
-acquire marker's own snapshot, including when its body-sha256 is the
-malformed-but-shape-valid sentinel "none" -- it can never equal a real
-64-hex computed digest, so this stays fail-closed rather than silently
-passing.
+not open with a valid mode=acquire marker for this target -- never
+treated as a pass. "mismatch" means a valid Stage 1 acquire marker exists
+but the live body has changed since its own snapshot.
 
 --verbose adds an "evidence" string to each checks[] entry (the computed
 and recorded digests, or the acquire marker's author/timestamp); omitted
@@ -401,10 +489,14 @@ function runCli(): void {
   const repo = args.repo || currentRepo?.repo || '';
   const port = createGithubProviderAdapter(owner, repo);
   const issueNumber = args.issue ?? 0;
-  const rawIssue = port.getWorkItem(issueNumber);
-  if (!rawIssue) {
-    throw new Error(`issue #${issueNumber} not found`);
-  }
+  // Fetch the (potentially slow, paginated) comment log BEFORE the issue
+  // body, and hash the body immediately after fetching it below -- the
+  // whole point of this check is a fresh read taken as close as possible
+  // to the comparison, so the body fetch must be the last network call
+  // before hashing, not the first (kurone-kito/idd-skill#2901 review,
+  // chatgpt-codex-connector round 5: fetching the body first left a
+  // window, spanning the comment fetch, during which a live edit would
+  // go undetected).
   const comments: AuthoringOwnerProvenanceComment[] = port
     .listWorkItemComments(issueNumber)
     .map((comment) => ({
@@ -412,7 +504,12 @@ function runCli(): void {
       authorLogin: comment.authorLogin,
       body: comment.body,
       createdAt: comment.createdAt,
+      updatedAt: comment.updatedAt,
     }));
+  const rawIssue = port.getWorkItem(issueNumber);
+  if (!rawIssue) {
+    throw new Error(`issue #${issueNumber} not found`);
+  }
 
   const policy = loadPolicyConfig(args.policy || undefined);
   const config = policy.config as { markerPrefix?: unknown } | null;

--- a/src/scripts/authoring-owner-provenance.mts
+++ b/src/scripts/authoring-owner-provenance.mts
@@ -41,13 +41,17 @@
 // defects: (1) a marker whose own `anchor` differs from its own `target`
 // declares itself a multi-target set's non-anchor child, out of scope
 // for this single-target-orphan helper (kurone-kito/idd-skill#2901
-// review, Copilot round 5). (2) a trusted actor who *deletes* the true
-// Stage 1 acquire comment outright (rather than editing it) leaves no
-// trace in any API response this helper can read -- detectable tampering
-// (an edit) fails closed (`findStageOneAcquire`'s pre-pass), but
-// undetectable tampering (a deletion) cannot be caught by a live
-// comment-log reader at all (kurone-kito/idd-skill#2901 review round 6,
-// chatgpt-codex-connector). contract.md's own remedy for that case is a
+// review, Copilot round 5). (2) tampering with the true Stage 1 acquire
+// comment that leaves no `<marker-prefix>-authoring-owner:` trace at
+// all -- deleting it outright, or editing it into ordinary prose that
+// no longer contains the token -- cannot be detected by a live
+// comment-log reader: a deleted comment is absent from every API
+// response, and a fully rewritten one is indistinguishable from a
+// comment that was always unrelated (kurone-kito/idd-skill#2901 review
+// rounds 6-7, chatgpt-codex-connector). Detectable tampering -- an edit
+// that leaves the token recognizable, even if it breaks parsing or
+// changes the target -- does fail closed (`findStageOneAcquire`'s
+// pre-pass). contract.md's remedy for the undetectable case is a
 // durable record the *authoring session itself* persists in its hold
 // state, not an artifact this read-only helper can independently fetch;
 // kurone-kito/idd-skill#2891's acceptance criteria scope this helper to
@@ -195,19 +199,26 @@ function invalidStageOneAcquireReason(
 }
 
 /**
- * True when `comment.body` looks like it once was (or currently attempts
- * to be) an `authoring-owner` marker -- either it still opens with the
- * canonical `<!--` HTML-comment-first byte, or it at least still contains
- * the `<marker-prefix>-authoring-owner:` token somewhere (an edit that
- * broke the opener but left the token recognizable). Used only to decide
- * whether an *edited* comment is suspicious enough to fail closed, not to
- * parse it -- a comment failing this check is confidently unrelated to
- * ownership (kurone-kito/idd-skill#2901 review, Copilot round 6).
+ * True when `comment.body` still contains the `<marker-prefix>
+ * -authoring-owner:` token somewhere, case-insensitively (matching
+ * `parseAuthoringOwnerComment`'s own case-insensitive marker regex --
+ * kurone-kito/idd-skill#2901 review, Copilot round 7: an edit that
+ * changed the token's casing while breaking its `<!--` opener must still
+ * be recognized). Deliberately narrower than "starts with `<!--`":
+ * every IDD marker family (claim, activation-nonce, watermark,
+ * review-baseline, ...) opens with that same byte, and a review-fix-
+ * loop-cutoff issue's own comment log routinely carries several of them
+ * before the owner acquire -- matching on the opener alone would treat
+ * every one of those as owner-marker-shaped and misfire whenever any of
+ * them was legitimately edited (kurone-kito/idd-skill#2901 review round
+ * 7). Used only to decide whether a comment is suspicious enough to
+ * scrutinize, not to parse it -- a comment failing this check carries no
+ * detectable trace of ever being an owner marker at all.
  */
 function looksLikeOwnerMarker(body: string, markerPrefix: string): boolean {
-  return (
-    body.startsWith('<!--') || body.includes(`${markerPrefix}-authoring-owner:`)
-  );
+  return body
+    .toLowerCase()
+    .includes(`${markerPrefix.toLowerCase()}-authoring-owner:`);
 }
 
 /**
@@ -236,35 +247,57 @@ function looksLikeOwnerMarker(body: string, markerPrefix: string): boolean {
  *   general "first valid marker by GitHub comment order wins" rule and
  *   this helper's own round-1/round-3 regression tests.
  *
- * Before selecting a first marker at all, a pre-pass rejects the whole
- * log if ANY trusted, owner-marker-shaped comment (`looksLikeOwnerMarker`)
- * was edited (`updatedAt !== createdAt`) -- not just the comment that
- * would otherwise be selected. An editor who edits the true Stage 1
- * acquire into something that no longer parses, or retargets it to a
- * different issue, would otherwise make it silently vanish from the
- * target-matching candidates below, letting a later (legitimate-looking)
- * acquire become `events[0]` unchallenged (kurone-kito/idd-skill#2901
- * review, Copilot round 6: the round-5 `updatedAt` check only inspected
- * the marker this function was about to select, which the edited marker
- * itself is no longer once tampering breaks its parse or its target).
- * This is deliberately over-broad in one direction: an edited `heartbeat`
- * (or any other owner-marker-shaped comment, for any target) also trips
- * it, even though only the eventual Stage 1 acquire matters semantically
- * -- accepted, since contract.md's append-only rule covers "owner
- * comments" generically, and failing closed on any detected edit is the
- * safe direction.
+ * The candidate pool is every trusted, owner-marker-shaped comment
+ * (`looksLikeOwnerMarker`) -- not just the ones that happen to parse and
+ * match `target` -- sorted into the same deterministic comment order,
+ * with the *first* one in that order scrutinized as the Stage 1
+ * candidate, whatever its shape:
  *
- * Undetectable tampering -- a trusted actor deleting the true Stage 1
- * acquire outright, rather than editing it -- is out of scope: a deleted
- * comment is absent from every API response, so no comment-log reader
- * can see it happened (kurone-kito/idd-skill#2901 review round 6,
- * chatgpt-codex-connector; accepted limitation, same footing as the
- * non-anchor-child limitation above -- see this file's header comment).
+ * - If ANY owner-marker-shaped comment in the whole pool was edited
+ *   (`updatedAt !== createdAt`), the whole log is rejected up front,
+ *   before a first candidate is even chosen -- not only when the edited
+ *   comment would otherwise have been selected. An editor who edits the
+ *   true Stage 1 acquire into something that still carries the marker
+ *   token but no longer parses, or retargets it to a different issue,
+ *   cannot make it silently drop out of consideration and let a later
+ *   (legitimate-looking) acquire win instead (kurone-kito/idd-skill#2901
+ *   review, Copilot round 6). This is deliberately over-broad in one
+ *   direction: an edited `heartbeat` (or any other owner-marker-shaped
+ *   comment, for any target) also trips it, even though only the
+ *   eventual Stage 1 acquire matters semantically -- accepted, since
+ *   contract.md's append-only rule covers "owner comments" generically
+ *   and failing closed on any detected edit is the safe direction.
+ * - The pool's first comment, once past the edit check, must itself
+ *   parse as an `authoring-owner` marker and name `target` -- an
+ *   unedited-but-malformed first attempt (a genuine posting error, not
+ *   tampering) is rejected rather than silently skipped in favor of a
+ *   later, validly-parsing marker, matching "the target's own
+ *   `mode=acquire` owner marker" read literally: the log's first
+ *   candidate either is that marker or the log is unusable, never a
+ *   later marker standing in for it (kurone-kito/idd-skill#2901 review
+ *   round 7, Copilot: the earlier form filtered the pool down to
+ *   parsing, target-matching comments *before* taking the first one,
+ *   so a first comment that failed either check simply vanished from
+ *   consideration instead of blocking selection).
+ * - Once the first candidate parses and matches `target`, every other
+ *   Stage 1 validity condition still applies (see
+ *   `invalidStageOneAcquireReason`).
+ *
+ * Undetectable tampering is out of scope, on two related fronts,
+ * documented as accepted limitations in this file's header comment: a
+ * trusted actor who deletes the true Stage 1 acquire outright (rather
+ * than editing it), and one who edits it into ordinary prose that no
+ * longer contains the owner-marker token at all. Both leave no trace
+ * `looksLikeOwnerMarker` (or any comment-log reader) can detect --
+ * indistinguishable from a comment that was always unrelated
+ * (kurone-kito/idd-skill#2901 review round 6 and round 7,
+ * chatgpt-codex-connector).
  *
  * Returns `{ event: null, rejectReason }` (never a false `pass`) when
- * the log is rejected by the pre-pass or the first marker fails
- * validation, `{ event: null, rejectReason: null }` when no trusted
- * marker exists at all, or `{ event, rejectReason: null }` on success.
+ * the pool is rejected by the edit check or the first candidate fails
+ * parsing, target-matching, or validation; `{ event: null, rejectReason:
+ * null }` when the pool is empty; or `{ event, rejectReason: null }` on
+ * success.
  */
 function findStageOneAcquire(
   comments: readonly AuthoringOwnerProvenanceComment[],
@@ -275,15 +308,20 @@ function findStageOneAcquire(
   const trusted = new Set(
     trustedMarkerLogins.map((login) => login.toLowerCase()),
   );
-  const trustedComments = comments.filter((comment) =>
-    trusted.has(String(comment.authorLogin ?? '').toLowerCase()),
-  );
+  const shaped = comments
+    .filter((comment) =>
+      trusted.has(String(comment.authorLogin ?? '').toLowerCase()),
+    )
+    .filter((comment) => looksLikeOwnerMarker(comment.body, markerPrefix));
+  shaped.sort((a, b) => {
+    if (a.createdAt !== b.createdAt) {
+      return a.createdAt < b.createdAt ? -1 : 1;
+    }
+    return a.id - b.id;
+  });
 
-  for (const comment of trustedComments) {
-    if (
-      comment.updatedAt !== comment.createdAt &&
-      looksLikeOwnerMarker(comment.body, markerPrefix)
-    ) {
+  for (const comment of shaped) {
+    if (comment.updatedAt !== comment.createdAt) {
       return {
         event: null,
         rejectReason:
@@ -294,30 +332,29 @@ function findStageOneAcquire(
     }
   }
 
-  const events: OwnerMarkerEvent[] = [];
-  for (const comment of trustedComments) {
-    const parsed = parseAuthoringOwnerComment(comment.body, markerPrefix);
-    if (!parsed || !sameIssueRef(parsed.target, target)) {
-      continue;
-    }
-    events.push({ comment, parsed });
-  }
-  events.sort((a, b) => {
-    if (a.comment.createdAt !== b.comment.createdAt) {
-      return a.comment.createdAt < b.comment.createdAt ? -1 : 1;
-    }
-    return a.comment.id - b.comment.id;
-  });
-
-  const first = events[0];
+  const first = shaped[0];
   if (!first) {
     return { event: null, rejectReason: null };
   }
-  const rejectReason = invalidStageOneAcquireReason(first, target);
+  const parsed = parseAuthoringOwnerComment(first.body, markerPrefix);
+  if (!parsed) {
+    return {
+      event: null,
+      rejectReason: `trusted comment #${first.id} looks like an authoring-owner marker but does not parse as one`,
+    };
+  }
+  if (!sameIssueRef(parsed.target, target)) {
+    return {
+      event: null,
+      rejectReason: `trusted comment #${first.id}'s marker names a different target (${parsed.target})`,
+    };
+  }
+  const event: OwnerMarkerEvent = { comment: first, parsed };
+  const rejectReason = invalidStageOneAcquireReason(event, target);
   if (rejectReason) {
     return { event: null, rejectReason };
   }
-  return { event: first, rejectReason: null };
+  return { event, rejectReason: null };
 }
 
 /**
@@ -485,47 +522,53 @@ own Stage 1 mode=acquire authoring-owner marker's recorded body-sha256
 (kurone-kito/idd-skill#2891). Read-only: never posts, labels, or mutates
 anything. --owner and --repo must be given together or not at all.
 
-The comparison anchors on this issue's own trusted authoring-owner marker
-log's *first* marker, in deterministic comment order (createdAt, ties
-broken by comment id ascending) -- contract.md and this issue's own
-acceptance criteria both name "a named target's mode=acquire owner
-marker", singular, tied to Stage 1 publication. That first marker must
-itself be mode=acquire: only it is guaranteed to have hashed the body as
-published, since every later marker (a same-generation racer, a
-bootstrap/resume recovery, or a legitimate re-acquisition after a full
-release cycle) hashes whatever body is live at its own posting time, not
-the originally published one -- comparing against a later acquire would
-make this check pass trivially for a body edited before that later
-marker (kurone-kito/idd-skill#2901 review, chatgpt-codex-connector round
-4). target comparisons fold case, since GitHub owner/repo names are
-case-insensitive.
+The comparison anchors on this issue's own trusted, owner-marker-shaped
+comments -- every one still containing the case-insensitive
+"<marker-prefix>-authoring-owner:" token, whether or not it actually
+parses -- taken in deterministic comment order (createdAt, ties broken
+by comment id ascending). If ANY of those comments was edited after
+posting (its updatedAt differs from its createdAt), the whole log is
+rejected up front, before a first candidate is even chosen: an editor
+cannot make the true Stage 1 acquire vanish from consideration by
+editing it into something unparseable or retargeting it, letting a
+later acquire silently win instead (kurone-kito/idd-skill#2901 review
+round 6, Copilot). This is deliberately over-broad in one direction (an
+edited heartbeat, for example, also trips it) since contract.md's
+append-only rule covers owner comments generically.
 
-The first marker must also pass every validity condition contract.md
-attaches to a genuine Stage 1 acquire, or this reports not-found rather
-than accepting an invalid marker's own digest (kurone-kito/idd-skill#2901
-review round 5): mode=acquire itself (every other mode -- bootstrap,
-resume, heartbeat, release, ... -- presupposes a prior acquire, so a
-well-formed history never opens with one); supersedes=none (contract.md
-requires this specifically for acquire); a real 64-hex body-sha256, never
-the shape-valid sentinel "none"; and its own anchor names the same issue
-as its own target (a mismatch declares the marker a multi-target set's
+Past that check, the *first* candidate in comment order is scrutinized,
+whatever its shape -- not merely the first one that happens to parse and
+match this target. It must parse as an authoring-owner marker at all,
+name this issue as its own target, and itself be a valid Stage 1
+mode=acquire marker, or this reports not-found rather than silently
+skipping it in favor of a later, validly-parsing marker
+(kurone-kito/idd-skill#2901 review round 7, Copilot). "Valid" means
+every condition contract.md attaches to a genuine Stage 1 acquire:
+mode=acquire itself (every other mode -- bootstrap, resume, heartbeat,
+release, ... -- presupposes a prior acquire, so a well-formed history
+never opens with one); supersedes=none (contract.md requires this
+specifically for acquire); a real 64-hex body-sha256, never the
+shape-valid sentinel "none"; and its own anchor names the same issue as
+its own target (a mismatch declares the marker a multi-target set's
 non-anchor child, out of scope for this single-target-orphan helper).
---verbose surfaces which condition failed in the acquire_marker_found
-check's evidence.
+Only it, not any later marker, is guaranteed to have hashed the body as
+published: a same-generation racer, a bootstrap/resume recovery, or a
+legitimate re-acquisition after a full release cycle all hash whatever
+body is live at their own posting time, not the originally published
+one -- comparing against any of those instead would make this check
+pass trivially for a body edited before that later marker
+(kurone-kito/idd-skill#2901 review, chatgpt-codex-connector round 4).
+target comparisons fold case, since GitHub owner/repo names are
+case-insensitive. --verbose surfaces which condition failed in the
+acquire_marker_found check's evidence.
 
-Before selecting a marker at all, this also rejects the whole log (with
-not-found) if ANY trusted, owner-marker-shaped comment was edited after
-posting (its updatedAt differs from its createdAt) -- not just the one
-that would otherwise be selected, so an editor cannot make the true
-Stage 1 acquire vanish from consideration by editing it into something
-unparseable or retargeting it, letting a later acquire silently win
-instead (kurone-kito/idd-skill#2901 review round 6, Copilot). This is
-deliberately over-broad in one direction (an edited heartbeat, for
-example, also trips it) since contract.md's append-only rule covers
-owner comments generically. A trusted actor who deletes the true Stage 1
-acquire outright, rather than editing it, is an accepted limitation: a
-deleted comment leaves no trace in any API response this helper can read
-(kurone-kito/idd-skill#2901 review round 6, chatgpt-codex-connector).
+Two accepted limitations, both fail-closed (never a false pass): a
+marker whose own anchor differs from its own target (a multi-target
+set's non-anchor child, out of scope here); and tampering with the true
+Stage 1 acquire that leaves no authoring-owner token at all -- deleting
+it outright, or editing it into ordinary prose -- which cannot be
+detected by a live comment-log reader (kurone-kito/idd-skill#2901
+review rounds 5-7, chatgpt-codex-connector and Copilot).
 
 Output schema:
 {

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -238,6 +238,15 @@ const HELPER_COMMANDS: HelperCommand[] = [
     description: 'Audit or apply post-merge comment cleanup.',
   },
   {
+    id: 'authoring-owner-provenance',
+    scriptName: 'idd:authoring-owner-provenance',
+    binName: 'idd-authoring-owner-provenance',
+    entryPath: 'scripts/authoring-owner-provenance.mjs',
+    vendoredCommand: 'node scripts/authoring-owner-provenance.mjs',
+    description:
+      "Compare a live issue body sha256 against that same issue's own trusted mode=acquire authoring-owner marker digest (review-fix-loop-cutoff provenance check).",
+  },
+  {
     id: 'branch-conflict-state',
     scriptName: 'idd:branch-conflict-state',
     binName: 'idd-branch-conflict-state',

--- a/tests/authoring-owner-provenance.test.mts
+++ b/tests/authoring-owner-provenance.test.mts
@@ -174,7 +174,7 @@ test('an untrusted actor acquire marker is ignored, falling through to not-found
   assert.equal(result.verdict, 'not-found');
 });
 
-test('a later heartbeat marker never shadows the acquire marker digest', () => {
+test('a later heartbeat marker never shadows the Stage 1 acquire marker digest', () => {
   // The realistic drift shape from this issue's own comment thread:
   // acquire -> release -> release-guard -> heartbeat -> release-complete,
   // all sharing one owner token. A heartbeat carries its own body-sha256
@@ -203,21 +203,70 @@ test('a later heartbeat marker never shadows the acquire marker digest', () => {
     trustedMarkerLogins: TRUSTED_LOGINS,
   });
   // The heartbeat's digest (matching laterBody) must not be used -- only
-  // the acquire marker's digest counts, so this must report mismatch
-  // rather than pass.
+  // the Stage 1 acquire marker's digest counts, so this must report
+  // mismatch rather than pass.
   assert.equal(result.verdict, 'mismatch');
   assert.equal(result.recordedBodySha256, sha256(acquireTimeBody));
   assert.equal(result.marker?.session, 'session-1');
 });
 
-test('a legitimate re-acquisition after a full release cycle picks the new generation', () => {
-  // A genuine second generation: the first generation is fully closed with
-  // release -> release-guard -> release-complete before the second acquire
-  // opens a new one (#2891 review, chatgpt-codex-connector: the prior
-  // implementation picked the globally-last acquire regardless of whether
-  // any generation ever closed in between).
-  const firstGenerationBody = '# Draft\n\nFirst generation.\n';
-  const secondGenerationBody = '# Draft\n\nSecond generation, re-acquired.\n';
+test('a same-generation acquire race resolves to the first acquire, never the last', () => {
+  // The exact scenario chatgpt-codex-connector's PR #2901 review flagged:
+  // two competing acquire markers post with no release-complete between
+  // them, and the issue body is edited between the two acquisitions so
+  // the SECOND (losing) acquire's digest happens to match the live body.
+  // Picking "most recent" here would incorrectly report pass and could
+  // authorize the auto-release exception against the losing racer's
+  // edited-body snapshot; the protocol's own tie-break (deterministic
+  // comment order) says the first acquire wins, so this must report
+  // mismatch against the FIRST acquire's digest instead.
+  const winningGenerationBody = '# Draft\n\nOriginal, before the edit.\n';
+  const editedLiveBody = '# Draft\n\nEdited between the two acquisitions.\n';
+  const result = evaluateAuthoringOwnerProvenance({
+    target: TARGET,
+    liveBody: editedLiveBody,
+    comments: [
+      {
+        id: 1,
+        authorLogin: 'kurone-kito',
+        body: acquireMarkerBody(sha256(winningGenerationBody), {
+          owner: 'owner-token-1',
+        }),
+        createdAt: '2026-09-10T16:48:44Z',
+      },
+      {
+        id: 2,
+        authorLogin: 'kurone-kito',
+        body: acquireMarkerBody(sha256(editedLiveBody), {
+          owner: 'owner-token-2',
+        }),
+        createdAt: '2026-09-10T16:49:00Z',
+      },
+    ],
+    markerPrefix: MARKER_PREFIX,
+    trustedMarkerLogins: TRUSTED_LOGINS,
+  });
+  assert.equal(result.verdict, 'mismatch');
+  assert.equal(result.marker?.owner, 'owner-token-1');
+  assert.equal(result.recordedBodySha256, sha256(winningGenerationBody));
+});
+
+test('a re-acquisition after a full release cycle still compares against the Stage 1 acquire, not the new one', () => {
+  // The exact scenario kurone-kito/idd-skill#2901 review's fourth round
+  // (chatgpt-codex-connector) flagged: acquire(A) -> release-complete ->
+  // body edit -> acquire(B). B's own body-sha256 was hashed from the
+  // EDITED body at B's own posting time, so comparing against B would
+  // report pass regardless of the edit -- exactly the silent bypass the
+  // provenance check exists to catch. contract.md's own wording ("that
+  // same target's own mode=acquire owner marker's body-sha256 ...
+  // already reflects the published body") and this issue's own
+  // acceptance criteria name a single acquire marker, not "whichever
+  // generation currently owns the target" -- so this must always
+  // anchor on the target's first trusted acquire and report mismatch
+  // here, never pass.
+  const firstGenerationBody = '# Draft\n\nFirst generation, as published.\n';
+  const secondGenerationBody =
+    '# Draft\n\nEdited, then re-acquired as a new generation.\n';
   const result = evaluateAuthoringOwnerProvenance({
     target: TARGET,
     liveBody: secondGenerationBody,
@@ -271,154 +320,22 @@ test('a legitimate re-acquisition after a full release cycle picks the new gener
     markerPrefix: MARKER_PREFIX,
     trustedMarkerLogins: TRUSTED_LOGINS,
   });
-  assert.equal(result.verdict, 'pass');
-  assert.equal(result.marker?.owner, 'owner-token-2');
-});
-
-test('a same-generation acquire race resolves to the first acquire, never the last', () => {
-  // The exact scenario chatgpt-codex-connector's PR #2901 review flagged:
-  // two competing acquire markers post with no release-complete between
-  // them (no generation ever closed), and the issue body is edited between
-  // the two acquisitions so the SECOND (losing) acquire's digest happens to
-  // match the live body. Picking "most recent" here would incorrectly
-  // report pass and could authorize the auto-release exception against the
-  // losing racer's edited-body snapshot; the protocol's own tie-break
-  // (deterministic comment order) says the first acquire in an open
-  // generation keeps ownership, so this must report mismatch against the
-  // FIRST acquire's digest instead.
-  const winningGenerationBody = '# Draft\n\nOriginal, before the edit.\n';
-  const editedLiveBody = '# Draft\n\nEdited between the two acquisitions.\n';
-  const result = evaluateAuthoringOwnerProvenance({
-    target: TARGET,
-    liveBody: editedLiveBody,
-    comments: [
-      {
-        id: 1,
-        authorLogin: 'kurone-kito',
-        body: acquireMarkerBody(sha256(winningGenerationBody), {
-          owner: 'owner-token-1',
-        }),
-        createdAt: '2026-09-10T16:48:44Z',
-      },
-      {
-        id: 2,
-        authorLogin: 'kurone-kito',
-        body: acquireMarkerBody(sha256(editedLiveBody), {
-          owner: 'owner-token-2',
-        }),
-        createdAt: '2026-09-10T16:49:00Z',
-      },
-    ],
-    markerPrefix: MARKER_PREFIX,
-    trustedMarkerLogins: TRUSTED_LOGINS,
-  });
   assert.equal(result.verdict, 'mismatch');
   assert.equal(result.marker?.owner, 'owner-token-1');
-  assert.equal(result.recordedBodySha256, sha256(winningGenerationBody));
+  assert.equal(result.recordedBodySha256, sha256(firstGenerationBody));
 });
 
-test('a stale or malformed release-complete for another owner never closes the current generation', () => {
-  // The exact scenario chatgpt-codex-connector's second-round PR #2901
-  // review flagged: acquire A -> a release-complete for a DIFFERENT
-  // owner/set (stale, or from an unrelated malformed generation) ->
-  // competing acquire B. The stray release-complete must not close A's
-  // generation, so B is still a same-generation race, not a fresh
-  // generation -- A must remain the winner.
-  const winningBody = '# Draft\n\nOwned by A.\n';
-  const losingRacerBody = '# Draft\n\nEdited to match B, but B never wins.\n';
-  const result = evaluateAuthoringOwnerProvenance({
-    target: TARGET,
-    liveBody: losingRacerBody,
-    comments: [
-      {
-        id: 1,
-        authorLogin: 'kurone-kito',
-        body: acquireMarkerBody(sha256(winningBody), {
-          owner: 'owner-token-a',
-        }),
-        createdAt: '2026-09-10T16:48:44Z',
-      },
-      {
-        id: 2,
-        authorLogin: 'kurone-kito',
-        // A stale/malformed completion for a DIFFERENT owner/set -- must
-        // be ignored, not treated as closing owner-token-a's generation.
-        body: ownerMarkerBody('release-complete', {
-          owner: 'owner-token-other',
-          snapshotSha256: sha256('unrelated-snapshot'),
-          supersedes: 'owner-token-other',
-        }),
-        createdAt: '2026-09-10T16:49:00Z',
-      },
-      {
-        id: 3,
-        authorLogin: 'kurone-kito',
-        body: acquireMarkerBody(sha256(losingRacerBody), {
-          owner: 'owner-token-b',
-        }),
-        createdAt: '2026-09-10T16:50:00Z',
-      },
-    ],
-    markerPrefix: MARKER_PREFIX,
-    trustedMarkerLogins: TRUSTED_LOGINS,
-  });
-  assert.equal(result.verdict, 'mismatch');
-  assert.equal(result.marker?.owner, 'owner-token-a');
-  assert.equal(result.recordedBodySha256, sha256(winningBody));
-});
-
-test('a matching release-complete does close the generation, allowing the next acquire to win', () => {
-  // The positive counterpart: a release-complete that DOES retain the
-  // winning acquire's exact owner/set/session/anchor (and supersedes
-  // that owner) legitimately closes the generation, so the following
-  // acquire is a genuine new generation and wins outright.
-  const firstBody = '# Draft\n\nFirst.\n';
-  const secondBody = '# Draft\n\nSecond, legitimately re-acquired.\n';
-  const result = evaluateAuthoringOwnerProvenance({
-    target: TARGET,
-    liveBody: secondBody,
-    comments: [
-      {
-        id: 1,
-        authorLogin: 'kurone-kito',
-        body: acquireMarkerBody(sha256(firstBody), { owner: 'owner-token-1' }),
-        createdAt: '2026-09-10T16:48:44Z',
-      },
-      {
-        id: 2,
-        authorLogin: 'kurone-kito',
-        body: ownerMarkerBody('release-complete', {
-          owner: 'owner-token-1',
-          snapshotSha256: sha256('closed-set-snapshot'),
-          supersedes: 'owner-token-1',
-        }),
-        createdAt: '2026-09-10T16:49:00Z',
-      },
-      {
-        id: 3,
-        authorLogin: 'kurone-kito',
-        body: acquireMarkerBody(sha256(secondBody), { owner: 'owner-token-2' }),
-        createdAt: '2026-09-10T16:50:00Z',
-      },
-    ],
-    markerPrefix: MARKER_PREFIX,
-    trustedMarkerLogins: TRUSTED_LOGINS,
-  });
-  assert.equal(result.verdict, 'pass');
-  assert.equal(result.marker?.owner, 'owner-token-2');
-});
-
-test('a bootstrap marker opens a generation a later competing acquire cannot displace', () => {
-  // The exact scenario chatgpt-codex-connector's third-round PR #2901
-  // review flagged: a stale orphan is recovered with a trusted bootstrap,
-  // then a competing acquire follows in the same still-open generation.
-  // contract.md: "The first valid bootstrap marker wins" -- the replay
-  // must recognize bootstrap as a generation opener, not just acquire.
+test('a target whose trusted marker log opens with bootstrap, not acquire, reports not-found', () => {
+  // Every mode other than acquire presupposes a prior acquire (bootstrap
+  // recovers a stale hold, resume recovers an interrupted set, heartbeat
+  // and release/release-complete all operate on an already-open
+  // generation) -- a well-formed history never opens with one of them.
+  // Fail closed (not-found) rather than accepting a non-acquire first
+  // marker's own digest as if it were the Stage 1 acquire.
   const bootstrapBody = '# Draft\n\nRecovered via bootstrap.\n';
-  const editedLiveBody = '# Draft\n\nEdited to match the losing acquire.\n';
   const result = evaluateAuthoringOwnerProvenance({
     target: TARGET,
-    liveBody: editedLiveBody,
+    liveBody: bootstrapBody,
     comments: [
       {
         id: 1,
@@ -428,33 +345,21 @@ test('a bootstrap marker opens a generation a later competing acquire cannot dis
         }),
         createdAt: '2026-09-10T16:48:44Z',
       },
-      {
-        id: 2,
-        authorLogin: 'kurone-kito',
-        body: acquireMarkerBody(sha256(editedLiveBody), {
-          owner: 'owner-token-losing-acquire',
-        }),
-        createdAt: '2026-09-10T16:49:00Z',
-      },
     ],
     markerPrefix: MARKER_PREFIX,
     trustedMarkerLogins: TRUSTED_LOGINS,
   });
-  assert.equal(result.verdict, 'mismatch');
-  assert.equal(result.marker?.mode, 'bootstrap');
-  assert.equal(result.marker?.owner, 'owner-token-bootstrap');
-  assert.equal(result.recordedBodySha256, sha256(bootstrapBody));
+  assert.equal(result.verdict, 'not-found');
+  assert.equal(result.marker, null);
+  assert.equal(result.recordedBodySha256, null);
 });
 
-test('a resume marker opens a generation a later competing acquire cannot displace', () => {
-  // Same shape as the bootstrap case, for an interrupted-set recovery:
-  // contract.md: "A resume marker opens a new generation only for the
-  // exact interrupted set and matching prior owner token."
+test('a target whose trusted marker log opens with resume, not acquire, reports not-found', () => {
+  // Same reasoning as the bootstrap case, for an interrupted-set recovery.
   const resumeBody = '# Draft\n\nRecovered via resume.\n';
-  const editedLiveBody = '# Draft\n\nEdited to match the losing acquire.\n';
   const result = evaluateAuthoringOwnerProvenance({
     target: TARGET,
-    liveBody: editedLiveBody,
+    liveBody: resumeBody,
     comments: [
       {
         id: 1,
@@ -464,22 +369,13 @@ test('a resume marker opens a generation a later competing acquire cannot displa
         }),
         createdAt: '2026-09-10T16:48:44Z',
       },
-      {
-        id: 2,
-        authorLogin: 'kurone-kito',
-        body: acquireMarkerBody(sha256(editedLiveBody), {
-          owner: 'owner-token-losing-acquire',
-        }),
-        createdAt: '2026-09-10T16:49:00Z',
-      },
     ],
     markerPrefix: MARKER_PREFIX,
     trustedMarkerLogins: TRUSTED_LOGINS,
   });
-  assert.equal(result.verdict, 'mismatch');
-  assert.equal(result.marker?.mode, 'resume');
-  assert.equal(result.marker?.owner, 'owner-token-resume');
-  assert.equal(result.recordedBodySha256, sha256(resumeBody));
+  assert.equal(result.verdict, 'not-found');
+  assert.equal(result.marker, null);
+  assert.equal(result.recordedBodySha256, null);
 });
 
 test('an acquire marker whose target differs only by capitalization still wins', () => {
@@ -512,49 +408,4 @@ test('an acquire marker whose target differs only by capitalization still wins',
   assert.equal(result.verdict, 'pass');
   assert.ok(result.marker);
   assert.equal(result.recordedBodySha256, sha256(liveBody));
-});
-
-test('a release-complete whose anchor differs only by capitalization still closes the generation', () => {
-  // Same case-folding requirement applies to `isValidReleaseComplete`'s
-  // own target === anchor and anchor === winner.anchor checks: a
-  // release-complete legitimately closing a generation must not be
-  // rejected merely because its anchor field's capitalization differs
-  // from the winning acquire's anchor (PR #2901 review, Copilot round 4).
-  const firstBody = '# Draft\n\nFirst.\n';
-  const secondBody = '# Draft\n\nSecond, legitimately re-acquired.\n';
-  const differentlyCasedTarget = 'Kurone-Kito/IDD-Skill#2891';
-  const result = evaluateAuthoringOwnerProvenance({
-    target: TARGET,
-    liveBody: secondBody,
-    comments: [
-      {
-        id: 1,
-        authorLogin: 'kurone-kito',
-        body: acquireMarkerBody(sha256(firstBody), { owner: 'owner-token-1' }),
-        createdAt: '2026-09-10T16:48:44Z',
-      },
-      {
-        id: 2,
-        authorLogin: 'kurone-kito',
-        body: ownerMarkerBody('release-complete', {
-          owner: 'owner-token-1',
-          snapshotSha256: sha256('closed-set-snapshot'),
-          supersedes: 'owner-token-1',
-          target: differentlyCasedTarget,
-          anchor: differentlyCasedTarget,
-        }),
-        createdAt: '2026-09-10T16:49:00Z',
-      },
-      {
-        id: 3,
-        authorLogin: 'kurone-kito',
-        body: acquireMarkerBody(sha256(secondBody), { owner: 'owner-token-2' }),
-        createdAt: '2026-09-10T16:50:00Z',
-      },
-    ],
-    markerPrefix: MARKER_PREFIX,
-    trustedMarkerLogins: TRUSTED_LOGINS,
-  });
-  assert.equal(result.verdict, 'pass');
-  assert.equal(result.marker?.owner, 'owner-token-2');
 });

--- a/tests/authoring-owner-provenance.test.mts
+++ b/tests/authoring-owner-provenance.test.mts
@@ -13,41 +13,49 @@ function sha256(value: string): string {
   return createHash('sha256').update(value, 'utf8').digest('hex');
 }
 
-function acquireMarkerBody(
-  bodySha256: string,
-  overrides: Record<string, string> = {},
+function ownerMarkerBody(
+  mode: string,
+  fields: {
+    owner: string;
+    bodySha256?: string;
+    snapshotSha256?: string;
+    supersedes?: string;
+  },
 ): string {
   return renderAuthoringOwnerMarker({
     markerPrefix: MARKER_PREFIX,
     target: TARGET,
     anchor: TARGET,
-    mode: 'acquire',
-    owner: 'owner-token-1',
+    mode,
+    owner: fields.owner,
     set: 'set-1',
     session: 'session-1',
+    bodySha256: fields.bodySha256 ?? 'none',
+    snapshotSha256: fields.snapshotSha256 ?? 'none',
+    supersedes: fields.supersedes ?? 'none',
+  });
+}
+
+function acquireMarkerBody(
+  bodySha256: string,
+  overrides: { owner?: string } = {},
+): string {
+  return ownerMarkerBody('acquire', {
+    owner: overrides.owner ?? 'owner-token-1',
     bodySha256,
-    snapshotSha256: 'none',
     supersedes: 'none',
-    ...overrides,
   });
 }
 
 function heartbeatMarkerBody(
   bodySha256: string,
-  overrides: Record<string, string> = {},
+  overrides: { owner?: string } = {},
 ): string {
-  return renderAuthoringOwnerMarker({
-    markerPrefix: MARKER_PREFIX,
-    target: TARGET,
-    anchor: TARGET,
-    mode: 'heartbeat',
-    owner: 'owner-token-1',
-    set: 'set-1',
-    session: 'session-1',
+  const owner = overrides.owner ?? 'owner-token-1';
+  return ownerMarkerBody('heartbeat', {
+    owner,
     bodySha256,
-    snapshotSha256: 'none',
-    supersedes: 'owner-token-1',
-    ...overrides,
+    supersedes: owner,
   });
 }
 
@@ -58,6 +66,7 @@ test('unchanged body with a matching acquire-time hash reports pass', () => {
     liveBody,
     comments: [
       {
+        id: 1,
         authorLogin: 'kurone-kito',
         body: acquireMarkerBody(sha256(liveBody)),
         createdAt: '2026-09-10T16:48:44Z',
@@ -84,6 +93,7 @@ test('a body edited after acquire fails closed with mismatch', () => {
     liveBody: editedLiveBody,
     comments: [
       {
+        id: 1,
         authorLogin: 'kurone-kito',
         body: acquireMarkerBody(sha256(acquireTimeBody)),
         createdAt: '2026-09-10T16:48:44Z',
@@ -105,6 +115,7 @@ test('no acquire marker for the target reports not-found, never pass', () => {
     liveBody,
     comments: [
       {
+        id: 1,
         authorLogin: 'kurone-kito',
         body: 'unrelated comment',
         createdAt: '2026-09-10T16:00:00Z',
@@ -125,6 +136,7 @@ test('an untrusted actor acquire marker is ignored, falling through to not-found
     liveBody,
     comments: [
       {
+        id: 1,
         authorLogin: 'random-untrusted-user',
         body: acquireMarkerBody(sha256(liveBody)),
         createdAt: '2026-09-10T16:48:44Z',
@@ -149,11 +161,13 @@ test('a later heartbeat marker never shadows the acquire marker digest', () => {
     liveBody: laterBody,
     comments: [
       {
+        id: 1,
         authorLogin: 'kurone-kito',
         body: acquireMarkerBody(sha256(acquireTimeBody)),
         createdAt: '2026-09-10T16:48:44Z',
       },
       {
+        id: 2,
         authorLogin: 'kurone-kito',
         body: heartbeatMarkerBody(sha256(laterBody)),
         createdAt: '2026-09-10T17:07:59Z',
@@ -170,7 +184,12 @@ test('a later heartbeat marker never shadows the acquire marker digest', () => {
   assert.equal(result.marker?.session, 'session-1');
 });
 
-test('multiple acquire generations (re-acquisition) pick the most recent', () => {
+test('a legitimate re-acquisition after a full release cycle picks the new generation', () => {
+  // A genuine second generation: the first generation is fully closed with
+  // release -> release-guard -> release-complete before the second acquire
+  // opens a new one (#2891 review, chatgpt-codex-connector: the prior
+  // implementation picked the globally-last acquire regardless of whether
+  // any generation ever closed in between).
   const firstGenerationBody = '# Draft\n\nFirst generation.\n';
   const secondGenerationBody = '# Draft\n\nSecond generation, re-acquired.\n';
   const result = evaluateAuthoringOwnerProvenance({
@@ -178,6 +197,7 @@ test('multiple acquire generations (re-acquisition) pick the most recent', () =>
     liveBody: secondGenerationBody,
     comments: [
       {
+        id: 1,
         authorLogin: 'kurone-kito',
         body: acquireMarkerBody(sha256(firstGenerationBody), {
           owner: 'owner-token-1',
@@ -185,6 +205,36 @@ test('multiple acquire generations (re-acquisition) pick the most recent', () =>
         createdAt: '2026-09-01T00:00:00Z',
       },
       {
+        id: 2,
+        authorLogin: 'kurone-kito',
+        body: ownerMarkerBody('release', {
+          owner: 'owner-token-1',
+          bodySha256: sha256(firstGenerationBody),
+          supersedes: 'owner-token-1',
+        }),
+        createdAt: '2026-09-01T01:00:00Z',
+      },
+      {
+        id: 3,
+        authorLogin: 'kurone-kito',
+        body: ownerMarkerBody('release-guard', {
+          owner: 'owner-token-1',
+          supersedes: 'owner-token-1',
+        }),
+        createdAt: '2026-09-01T01:00:05Z',
+      },
+      {
+        id: 4,
+        authorLogin: 'kurone-kito',
+        body: ownerMarkerBody('release-complete', {
+          owner: 'owner-token-1',
+          snapshotSha256: sha256('snapshot-of-closed-set'),
+          supersedes: 'owner-token-1',
+        }),
+        createdAt: '2026-09-01T01:00:10Z',
+      },
+      {
+        id: 5,
         authorLogin: 'kurone-kito',
         body: acquireMarkerBody(sha256(secondGenerationBody), {
           owner: 'owner-token-2',
@@ -197,4 +247,46 @@ test('multiple acquire generations (re-acquisition) pick the most recent', () =>
   });
   assert.equal(result.verdict, 'pass');
   assert.equal(result.marker?.owner, 'owner-token-2');
+});
+
+test('a same-generation acquire race resolves to the first acquire, never the last', () => {
+  // The exact scenario chatgpt-codex-connector's PR #2901 review flagged:
+  // two competing acquire markers post with no release-complete between
+  // them (no generation ever closed), and the issue body is edited between
+  // the two acquisitions so the SECOND (losing) acquire's digest happens to
+  // match the live body. Picking "most recent" here would incorrectly
+  // report pass and could authorize the auto-release exception against the
+  // losing racer's edited-body snapshot; the protocol's own tie-break
+  // (deterministic comment order) says the first acquire in an open
+  // generation keeps ownership, so this must report mismatch against the
+  // FIRST acquire's digest instead.
+  const winningGenerationBody = '# Draft\n\nOriginal, before the edit.\n';
+  const editedLiveBody = '# Draft\n\nEdited between the two acquisitions.\n';
+  const result = evaluateAuthoringOwnerProvenance({
+    target: TARGET,
+    liveBody: editedLiveBody,
+    comments: [
+      {
+        id: 1,
+        authorLogin: 'kurone-kito',
+        body: acquireMarkerBody(sha256(winningGenerationBody), {
+          owner: 'owner-token-1',
+        }),
+        createdAt: '2026-09-10T16:48:44Z',
+      },
+      {
+        id: 2,
+        authorLogin: 'kurone-kito',
+        body: acquireMarkerBody(sha256(editedLiveBody), {
+          owner: 'owner-token-2',
+        }),
+        createdAt: '2026-09-10T16:49:00Z',
+      },
+    ],
+    markerPrefix: MARKER_PREFIX,
+    trustedMarkerLogins: TRUSTED_LOGINS,
+  });
+  assert.equal(result.verdict, 'mismatch');
+  assert.equal(result.marker?.owner, 'owner-token-1');
+  assert.equal(result.recordedBodySha256, sha256(winningGenerationBody));
 });

--- a/tests/authoring-owner-provenance.test.mts
+++ b/tests/authoring-owner-provenance.test.mts
@@ -1,13 +1,61 @@
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
+import { join } from 'node:path';
 import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import { evaluateAuthoringOwnerProvenance } from '../src/scripts/authoring-owner-provenance.mts';
 import { renderAuthoringOwnerMarker } from '../src/scripts/marker-helpers.mts';
+import { stubExecutable } from './test-utils.mts';
+
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
 
 const TARGET = 'kurone-kito/idd-skill#2891';
 const MARKER_PREFIX = 'idd-skill';
 const TRUSTED_LOGINS = ['kurone-kito'];
+
+// Stub `gh` on PATH (the tests/gh-exec.test.mts / ci-wait-policy.test.mts
+// pattern) so the CLI tests below exercise the real execFileSync + child
+// process contract -- including the comments-before-body fetch ordering
+// and the provider/policy wiring -- without network access (#2901 review,
+// Copilot round 6: the pure-function tests above never invoke the emitted
+// CLI or its bin wrapper).
+function stubGh(scriptBody: string): () => void {
+  return stubExecutable('gh', scriptBody);
+}
+
+/** Build a stub `gh` script answering both calls `runCli` makes, in the
+ * order it now makes them (comments first, then the issue body): `gh api
+ * repos/<owner>/<repo>/issues/<n>/comments --paginate --jq .[]` (NDJSON,
+ * one comment object per line) and `gh api repos/<owner>/<repo>/issues/<n>`
+ * (a single JSON issue object). `process.argv.slice(2)` inside the stub is
+ * `['api', <path>, ...]` (`stubExecutable`'s own documented contract). */
+function ghStubScriptForIssue(
+  issueBody: string,
+  comments: readonly {
+    id: number;
+    user: { login: string };
+    body: string;
+    created_at: string;
+    updated_at: string;
+  }[],
+): string {
+  return `
+const path = process.argv[3];
+if (path && path.endsWith('/comments')) {
+  const comments = ${JSON.stringify(comments)};
+  process.stdout.write(comments.map((c) => JSON.stringify(c)).join('\\n') + '\\n');
+} else {
+  process.stdout.write(JSON.stringify({
+    number: 2891,
+    title: 'CLI test issue',
+    body: ${JSON.stringify(issueBody)},
+    html_url: 'https://github.com/kurone-kito/idd-skill/issues/2891',
+  }));
+}
+`;
+}
 
 function sha256(value: string): string {
   return createHash('sha256').update(value, 'utf8').digest('hex');
@@ -560,4 +608,219 @@ test('an acquire marker with body-sha256=none reports not-found, never pass', ()
       ?.evidence ?? '',
     /body-sha256/,
   );
+});
+
+test('a Stage 1 acquire edited into unparseable garbage fails closed, not the next acquire', () => {
+  // Copilot round 5 caught an edited marker that still PARSES with the
+  // same target -- this is the deeper variant Copilot round 6 found: the
+  // edit breaks parsing entirely (or could equally retarget the marker),
+  // so the old target-match filter silently dropped it from `events`
+  // before any validity check ever saw it, letting a later, unedited
+  // acquire become events[0] and report pass. The pre-pass in
+  // findStageOneAcquire now catches this by scanning every trusted
+  // owner-marker-shaped comment for an edit BEFORE selecting a winner,
+  // not just the one that would otherwise be selected.
+  const liveBody = '# Draft\n\nSome content.\n';
+  const result = evaluateAuthoringOwnerProvenance({
+    target: TARGET,
+    liveBody,
+    comments: [
+      {
+        id: 1,
+        authorLogin: 'kurone-kito',
+        // Still recognizable as marker-shaped (contains the token) but
+        // no longer parses as a well-formed marker at all.
+        body: `<!-- idd-skill-authoring-owner: target=${TARGET}; corrupted`,
+        createdAt: '2026-09-10T16:48:44Z',
+        updatedAt: '2026-09-10T17:00:00Z',
+      },
+      {
+        id: 2,
+        authorLogin: 'kurone-kito',
+        body: acquireMarkerBody(sha256(liveBody), { owner: 'owner-token-2' }),
+        createdAt: '2026-09-10T16:50:00Z',
+        updatedAt: '2026-09-10T16:50:00Z',
+      },
+    ],
+    markerPrefix: MARKER_PREFIX,
+    trustedMarkerLogins: TRUSTED_LOGINS,
+  });
+  assert.equal(result.verdict, 'not-found');
+  assert.equal(result.marker, null);
+  assert.match(
+    result.checks.find((check) => check.id === 'acquire_marker_found')
+      ?.evidence ?? '',
+    /edited after posting/,
+  );
+});
+
+test('a Stage 1 acquire retargeted by an edit fails closed, not the next acquire', () => {
+  // Same underlying bug, via a different corruption shape: the edit keeps
+  // the marker well-formed but changes its own `target` field to a
+  // different issue, so the old target-match filter dropped it before
+  // the anchor/validity checks could ever see it.
+  const liveBody = '# Draft\n\nSome content.\n';
+  const result = evaluateAuthoringOwnerProvenance({
+    target: TARGET,
+    liveBody,
+    comments: [
+      {
+        id: 1,
+        authorLogin: 'kurone-kito',
+        body: acquireMarkerBody(sha256(liveBody), {
+          target: 'kurone-kito/idd-skill#1',
+          anchor: 'kurone-kito/idd-skill#1',
+        }),
+        createdAt: '2026-09-10T16:48:44Z',
+        updatedAt: '2026-09-10T17:00:00Z',
+      },
+      {
+        id: 2,
+        authorLogin: 'kurone-kito',
+        body: acquireMarkerBody(sha256(liveBody), { owner: 'owner-token-2' }),
+        createdAt: '2026-09-10T16:50:00Z',
+        updatedAt: '2026-09-10T16:50:00Z',
+      },
+    ],
+    markerPrefix: MARKER_PREFIX,
+    trustedMarkerLogins: TRUSTED_LOGINS,
+  });
+  assert.equal(result.verdict, 'not-found');
+  assert.equal(result.marker, null);
+  assert.match(
+    result.checks.find((check) => check.id === 'acquire_marker_found')
+      ?.evidence ?? '',
+    /edited after posting/,
+  );
+});
+
+test('CLI: pass -- an unchanged body reports pass end to end', () => {
+  const liveBody = '# Draft\n\nSome content.\n';
+  const restore = stubGh(
+    ghStubScriptForIssue(liveBody, [
+      {
+        id: 1,
+        user: { login: 'kurone-kito' },
+        body: acquireMarkerBody(sha256(liveBody)),
+        created_at: '2026-09-10T16:48:44Z',
+        updated_at: '2026-09-10T16:48:44Z',
+      },
+    ]),
+  );
+  try {
+    const output = JSON.parse(
+      execFileSync(
+        process.execPath,
+        [
+          join(REPO_ROOT, 'scripts/authoring-owner-provenance.mjs'),
+          '--issue',
+          '2891',
+          '--owner',
+          'kurone-kito',
+          '--repo',
+          'idd-skill',
+          '--trusted-marker-logins',
+          'kurone-kito',
+        ],
+        { encoding: 'utf8' },
+      ),
+    );
+    assert.equal(output.verdict, 'pass');
+    assert.equal(output.target, TARGET);
+    assert.equal(output.recordedBodySha256, sha256(liveBody));
+  } finally {
+    restore();
+  }
+});
+
+test('CLI: mismatch -- a body edited since acquire reports mismatch end to end', () => {
+  const acquireTimeBody = '# Draft\n\nOriginal.\n';
+  const editedLiveBody = '# Draft\n\nEdited after acquire.\n';
+  const restore = stubGh(
+    ghStubScriptForIssue(editedLiveBody, [
+      {
+        id: 1,
+        user: { login: 'kurone-kito' },
+        body: acquireMarkerBody(sha256(acquireTimeBody)),
+        created_at: '2026-09-10T16:48:44Z',
+        updated_at: '2026-09-10T16:48:44Z',
+      },
+    ]),
+  );
+  try {
+    const output = JSON.parse(
+      execFileSync(
+        process.execPath,
+        [
+          join(REPO_ROOT, 'scripts/authoring-owner-provenance.mjs'),
+          '--issue',
+          '2891',
+          '--owner',
+          'kurone-kito',
+          '--repo',
+          'idd-skill',
+          '--trusted-marker-logins',
+          'kurone-kito',
+        ],
+        { encoding: 'utf8' },
+      ),
+    );
+    assert.equal(output.verdict, 'mismatch');
+    assert.equal(output.recordedBodySha256, sha256(acquireTimeBody));
+    assert.equal(output.computedBodySha256, sha256(editedLiveBody));
+  } finally {
+    restore();
+  }
+});
+
+test('CLI: not-found -- no acquire marker reports not-found end to end', () => {
+  const liveBody = 'plain issue body with no authoring marker at all';
+  const restore = stubGh(ghStubScriptForIssue(liveBody, []));
+  try {
+    const output = JSON.parse(
+      execFileSync(
+        process.execPath,
+        [
+          join(REPO_ROOT, 'scripts/authoring-owner-provenance.mjs'),
+          '--issue',
+          '2891',
+          '--owner',
+          'kurone-kito',
+          '--repo',
+          'idd-skill',
+          '--trusted-marker-logins',
+          'kurone-kito',
+        ],
+        { encoding: 'utf8' },
+      ),
+    );
+    assert.equal(output.verdict, 'not-found');
+    assert.equal(output.marker, null);
+    assert.equal(output.recordedBodySha256, null);
+  } finally {
+    restore();
+  }
+});
+
+test('CLI: --issue rejects a token with trailing garbage instead of truncating it', () => {
+  const restore = stubGh(ghStubScriptForIssue('unused', []));
+  try {
+    assert.throws(() => {
+      execFileSync(
+        process.execPath,
+        [
+          join(REPO_ROOT, 'scripts/authoring-owner-provenance.mjs'),
+          '--issue',
+          '2891junk',
+          '--owner',
+          'kurone-kito',
+          '--repo',
+          'idd-skill',
+        ],
+        { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+      );
+    }, /must be a positive integer/);
+  } finally {
+    restore();
+  }
 });

--- a/tests/authoring-owner-provenance.test.mts
+++ b/tests/authoring-owner-provenance.test.mts
@@ -40,12 +40,17 @@ function ownerMarkerBody(
 
 function acquireMarkerBody(
   bodySha256: string,
-  overrides: { owner?: string; target?: string; anchor?: string } = {},
+  overrides: {
+    owner?: string;
+    target?: string;
+    anchor?: string;
+    supersedes?: string;
+  } = {},
 ): string {
   return ownerMarkerBody('acquire', {
     owner: overrides.owner ?? 'owner-token-1',
     bodySha256,
-    supersedes: 'none',
+    supersedes: overrides.supersedes ?? 'none',
     target: overrides.target,
     anchor: overrides.anchor,
   });
@@ -96,6 +101,7 @@ test('unchanged body with a matching acquire-time hash reports pass', () => {
         authorLogin: 'kurone-kito',
         body: acquireMarkerBody(sha256(liveBody)),
         createdAt: '2026-09-10T16:48:44Z',
+        updatedAt: '2026-09-10T16:48:44Z',
       },
     ],
     markerPrefix: MARKER_PREFIX,
@@ -123,6 +129,7 @@ test('a body edited after acquire fails closed with mismatch', () => {
         authorLogin: 'kurone-kito',
         body: acquireMarkerBody(sha256(acquireTimeBody)),
         createdAt: '2026-09-10T16:48:44Z',
+        updatedAt: '2026-09-10T16:48:44Z',
       },
     ],
     markerPrefix: MARKER_PREFIX,
@@ -145,6 +152,7 @@ test('no acquire marker for the target reports not-found, never pass', () => {
         authorLogin: 'kurone-kito',
         body: 'unrelated comment',
         createdAt: '2026-09-10T16:00:00Z',
+        updatedAt: '2026-09-10T16:00:00Z',
       },
     ],
     markerPrefix: MARKER_PREFIX,
@@ -166,6 +174,7 @@ test('an untrusted actor acquire marker is ignored, falling through to not-found
         authorLogin: 'random-untrusted-user',
         body: acquireMarkerBody(sha256(liveBody)),
         createdAt: '2026-09-10T16:48:44Z',
+        updatedAt: '2026-09-10T16:48:44Z',
       },
     ],
     markerPrefix: MARKER_PREFIX,
@@ -191,12 +200,14 @@ test('a later heartbeat marker never shadows the Stage 1 acquire marker digest',
         authorLogin: 'kurone-kito',
         body: acquireMarkerBody(sha256(acquireTimeBody)),
         createdAt: '2026-09-10T16:48:44Z',
+        updatedAt: '2026-09-10T16:48:44Z',
       },
       {
         id: 2,
         authorLogin: 'kurone-kito',
         body: heartbeatMarkerBody(sha256(laterBody)),
         createdAt: '2026-09-10T17:07:59Z',
+        updatedAt: '2026-09-10T17:07:59Z',
       },
     ],
     markerPrefix: MARKER_PREFIX,
@@ -233,6 +244,7 @@ test('a same-generation acquire race resolves to the first acquire, never the la
           owner: 'owner-token-1',
         }),
         createdAt: '2026-09-10T16:48:44Z',
+        updatedAt: '2026-09-10T16:48:44Z',
       },
       {
         id: 2,
@@ -241,6 +253,7 @@ test('a same-generation acquire race resolves to the first acquire, never the la
           owner: 'owner-token-2',
         }),
         createdAt: '2026-09-10T16:49:00Z',
+        updatedAt: '2026-09-10T16:49:00Z',
       },
     ],
     markerPrefix: MARKER_PREFIX,
@@ -278,6 +291,7 @@ test('a re-acquisition after a full release cycle still compares against the Sta
           owner: 'owner-token-1',
         }),
         createdAt: '2026-09-01T00:00:00Z',
+        updatedAt: '2026-09-01T00:00:00Z',
       },
       {
         id: 2,
@@ -288,6 +302,7 @@ test('a re-acquisition after a full release cycle still compares against the Sta
           supersedes: 'owner-token-1',
         }),
         createdAt: '2026-09-01T01:00:00Z',
+        updatedAt: '2026-09-01T01:00:00Z',
       },
       {
         id: 3,
@@ -297,6 +312,7 @@ test('a re-acquisition after a full release cycle still compares against the Sta
           supersedes: 'owner-token-1',
         }),
         createdAt: '2026-09-01T01:00:05Z',
+        updatedAt: '2026-09-01T01:00:05Z',
       },
       {
         id: 4,
@@ -307,6 +323,7 @@ test('a re-acquisition after a full release cycle still compares against the Sta
           supersedes: 'owner-token-1',
         }),
         createdAt: '2026-09-01T01:00:10Z',
+        updatedAt: '2026-09-01T01:00:10Z',
       },
       {
         id: 5,
@@ -315,6 +332,7 @@ test('a re-acquisition after a full release cycle still compares against the Sta
           owner: 'owner-token-2',
         }),
         createdAt: '2026-09-10T16:48:44Z',
+        updatedAt: '2026-09-10T16:48:44Z',
       },
     ],
     markerPrefix: MARKER_PREFIX,
@@ -344,6 +362,7 @@ test('a target whose trusted marker log opens with bootstrap, not acquire, repor
           owner: 'owner-token-bootstrap',
         }),
         createdAt: '2026-09-10T16:48:44Z',
+        updatedAt: '2026-09-10T16:48:44Z',
       },
     ],
     markerPrefix: MARKER_PREFIX,
@@ -368,6 +387,7 @@ test('a target whose trusted marker log opens with resume, not acquire, reports 
           owner: 'owner-token-resume',
         }),
         createdAt: '2026-09-10T16:48:44Z',
+        updatedAt: '2026-09-10T16:48:44Z',
       },
     ],
     markerPrefix: MARKER_PREFIX,
@@ -400,6 +420,7 @@ test('an acquire marker whose target differs only by capitalization still wins',
           anchor: differentlyCasedTarget,
         }),
         createdAt: '2026-09-10T16:48:44Z',
+        updatedAt: '2026-09-10T16:48:44Z',
       },
     ],
     markerPrefix: MARKER_PREFIX,
@@ -408,4 +429,135 @@ test('an acquire marker whose target differs only by capitalization still wins',
   assert.equal(result.verdict, 'pass');
   assert.ok(result.marker);
   assert.equal(result.recordedBodySha256, sha256(liveBody));
+});
+
+test('an acquire marker comment edited after posting fails closed with not-found', () => {
+  // contract.md: "Owner comments are append-only and must not be edited
+  // or deleted." An edited comment's own createdAt is unchanged, so the
+  // deterministic-comment-order replay would still treat it as the
+  // Stage 1 acquire -- but its body-sha256 field could have been
+  // silently rewritten to match a body modified after Stage 1
+  // (kurone-kito/idd-skill#2901 review, chatgpt-codex-connector
+  // round 5). Detect the edit via updatedAt !== createdAt and fail
+  // closed instead of trusting an editable field.
+  const liveBody = '# Draft\n\nSome content.\n';
+  const result = evaluateAuthoringOwnerProvenance({
+    target: TARGET,
+    liveBody,
+    comments: [
+      {
+        id: 1,
+        authorLogin: 'kurone-kito',
+        body: acquireMarkerBody(sha256(liveBody)),
+        createdAt: '2026-09-10T16:48:44Z',
+        updatedAt: '2026-09-10T17:00:00Z',
+      },
+    ],
+    markerPrefix: MARKER_PREFIX,
+    trustedMarkerLogins: TRUSTED_LOGINS,
+  });
+  assert.equal(result.verdict, 'not-found');
+  assert.equal(result.marker, null);
+  assert.match(
+    result.checks.find((check) => check.id === 'acquire_marker_found')
+      ?.evidence ?? '',
+    /edited after posting/,
+  );
+});
+
+test('an acquire marker whose anchor differs from its own target reports not-found', () => {
+  // This helper is built for the single-target orphan case; contract.md:
+  // "the anchor's own marker uses its target as the anchor." A marker
+  // whose anchor differs from its target declares itself a multi-target
+  // set's non-anchor child, out of scope here (kurone-kito/idd-skill#2901
+  // review, Copilot round 5) -- fail closed rather than silently
+  // comparing against a child marker's digest.
+  const liveBody = '# Draft\n\nSome content.\n';
+  const result = evaluateAuthoringOwnerProvenance({
+    target: TARGET,
+    liveBody,
+    comments: [
+      {
+        id: 1,
+        authorLogin: 'kurone-kito',
+        body: acquireMarkerBody(sha256(liveBody), {
+          anchor: 'kurone-kito/idd-skill#1',
+        }),
+        createdAt: '2026-09-10T16:48:44Z',
+        updatedAt: '2026-09-10T16:48:44Z',
+      },
+    ],
+    markerPrefix: MARKER_PREFIX,
+    trustedMarkerLogins: TRUSTED_LOGINS,
+  });
+  assert.equal(result.verdict, 'not-found');
+  assert.equal(result.marker, null);
+  assert.match(
+    result.checks.find((check) => check.id === 'acquire_marker_found')
+      ?.evidence ?? '',
+    /anchor/,
+  );
+});
+
+test('an acquire marker with a non-none supersedes reports not-found', () => {
+  // contract.md: "supersedes=none for acquire and bootstrap, while
+  // resume names the prior owner token." An acquire carrying a non-none
+  // supersedes is malformed and must not authorize the exception
+  // (kurone-kito/idd-skill#2901 review, chatgpt-codex-connector
+  // round 5).
+  const liveBody = '# Draft\n\nSome content.\n';
+  const result = evaluateAuthoringOwnerProvenance({
+    target: TARGET,
+    liveBody,
+    comments: [
+      {
+        id: 1,
+        authorLogin: 'kurone-kito',
+        body: acquireMarkerBody(sha256(liveBody), {
+          supersedes: 'owner-token-stale',
+        }),
+        createdAt: '2026-09-10T16:48:44Z',
+        updatedAt: '2026-09-10T16:48:44Z',
+      },
+    ],
+    markerPrefix: MARKER_PREFIX,
+    trustedMarkerLogins: TRUSTED_LOGINS,
+  });
+  assert.equal(result.verdict, 'not-found');
+  assert.equal(result.marker, null);
+  assert.match(
+    result.checks.find((check) => check.id === 'acquire_marker_found')
+      ?.evidence ?? '',
+    /supersedes/,
+  );
+});
+
+test('an acquire marker with body-sha256=none reports not-found, never pass', () => {
+  // "none" is a shape-valid sentinel for other modes (release-guard's
+  // body-sha256=none, for example) but a genuine Stage 1 acquire's whole
+  // purpose is recording the published body's digest -- "none" here is
+  // malformed, not merely a coincidental miss.
+  const liveBody = '# Draft\n\nSome content.\n';
+  const result = evaluateAuthoringOwnerProvenance({
+    target: TARGET,
+    liveBody,
+    comments: [
+      {
+        id: 1,
+        authorLogin: 'kurone-kito',
+        body: acquireMarkerBody('none'),
+        createdAt: '2026-09-10T16:48:44Z',
+        updatedAt: '2026-09-10T16:48:44Z',
+      },
+    ],
+    markerPrefix: MARKER_PREFIX,
+    trustedMarkerLogins: TRUSTED_LOGINS,
+  });
+  assert.equal(result.verdict, 'not-found');
+  assert.equal(result.marker, null);
+  assert.match(
+    result.checks.find((check) => check.id === 'acquire_marker_found')
+      ?.evidence ?? '',
+    /body-sha256/,
+  );
 });

--- a/tests/authoring-owner-provenance.test.mts
+++ b/tests/authoring-owner-provenance.test.mts
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
@@ -25,12 +27,21 @@ function stubGh(scriptBody: string): () => void {
   return stubExecutable('gh', scriptBody);
 }
 
-/** Build a stub `gh` script answering both calls `runCli` makes, in the
- * order it now makes them (comments first, then the issue body): `gh api
+/** Build a stub `gh` script answering both calls `runCli` makes: `gh api
  * repos/<owner>/<repo>/issues/<n>/comments --paginate --jq .[]` (NDJSON,
  * one comment object per line) and `gh api repos/<owner>/<repo>/issues/<n>`
  * (a single JSON issue object). `process.argv.slice(2)` inside the stub is
- * `['api', <path>, ...]` (`stubExecutable`'s own documented contract). */
+ * `['api', <path>, ...]` (`stubExecutable`'s own documented contract).
+ *
+ * When `callLogPath` is given, each invocation appends its own `<path>`
+ * argument as one line -- since the two calls are separate `gh` child
+ * processes with no state shared between them (kurone-kito/idd-skill#2901
+ * review, Copilot round 7: a stub that only branches on the current
+ * call's own path proves nothing about which call the CLI made *first*,
+ * so it cannot actually catch a regression that swaps the documented
+ * comments-before-body fetch order). Reading this file back is what lets
+ * a test assert the real call order the CLI made, not just that both
+ * calls eventually happened. */
 function ghStubScriptForIssue(
   issueBody: string,
   comments: readonly {
@@ -40,9 +51,15 @@ function ghStubScriptForIssue(
     created_at: string;
     updated_at: string;
   }[],
+  callLogPath?: string,
 ): string {
   return `
 const path = process.argv[3];
+${
+  callLogPath
+    ? `require('node:fs').appendFileSync(${JSON.stringify(callLogPath)}, path + '\\n');`
+    : ''
+}
 if (path && path.endsWith('/comments')) {
   const comments = ${JSON.stringify(comments)};
   process.stdout.write(comments.map((c) => JSON.stringify(c)).join('\\n') + '\\n');
@@ -694,18 +711,24 @@ test('a Stage 1 acquire retargeted by an edit fails closed, not the next acquire
   );
 });
 
-test('CLI: pass -- an unchanged body reports pass end to end', () => {
+test('CLI: pass -- an unchanged body reports pass end to end, comments fetched before the body', () => {
   const liveBody = '# Draft\n\nSome content.\n';
+  const callLogDir = mkdtempSync(join(tmpdir(), 'idd-authoring-owner-cli-'));
+  const callLogPath = join(callLogDir, 'calls.log');
   const restore = stubGh(
-    ghStubScriptForIssue(liveBody, [
-      {
-        id: 1,
-        user: { login: 'kurone-kito' },
-        body: acquireMarkerBody(sha256(liveBody)),
-        created_at: '2026-09-10T16:48:44Z',
-        updated_at: '2026-09-10T16:48:44Z',
-      },
-    ]),
+    ghStubScriptForIssue(
+      liveBody,
+      [
+        {
+          id: 1,
+          user: { login: 'kurone-kito' },
+          body: acquireMarkerBody(sha256(liveBody)),
+          created_at: '2026-09-10T16:48:44Z',
+          updated_at: '2026-09-10T16:48:44Z',
+        },
+      ],
+      callLogPath,
+    ),
   );
   try {
     const output = JSON.parse(
@@ -728,8 +751,19 @@ test('CLI: pass -- an unchanged body reports pass end to end', () => {
     assert.equal(output.verdict, 'pass');
     assert.equal(output.target, TARGET);
     assert.equal(output.recordedBodySha256, sha256(liveBody));
+    // The actual regression this proves: the comments call happens
+    // before the issue-body call (kurone-kito/idd-skill#2901 review,
+    // Copilot round 7 -- the prior stub had no memory across the two
+    // separate `gh` child processes, so it could not tell which call
+    // came first and this ordering was never really exercised).
+    const calls = readFileSync(callLogPath, 'utf8').trim().split('\n');
+    assert.deepEqual(calls, [
+      'repos/kurone-kito/idd-skill/issues/2891/comments',
+      'repos/kurone-kito/idd-skill/issues/2891',
+    ]);
   } finally {
     restore();
+    rmSync(callLogDir, { recursive: true, force: true });
   }
 });
 
@@ -823,4 +857,125 @@ test('CLI: --issue rejects a token with trailing garbage instead of truncating i
   } finally {
     restore();
   }
+});
+
+test('an edited marker with a differently cased prefix token still fails closed', () => {
+  // Copilot round 7: parseAuthoringOwnerComment matches the marker
+  // prefix/suffix case-insensitively, so looksLikeOwnerMarker's own
+  // token check must too -- an edit that broke the <!-- opener while
+  // also changing the prefix's casing must not evade the edit-detection
+  // pre-pass.
+  const liveBody = '# Draft\n\nSome content.\n';
+  const result = evaluateAuthoringOwnerProvenance({
+    target: TARGET,
+    liveBody,
+    comments: [
+      {
+        id: 1,
+        authorLogin: 'kurone-kito',
+        body: 'IDD-SKILL-authoring-owner: broken, no opener',
+        createdAt: '2026-09-10T16:48:44Z',
+        updatedAt: '2026-09-10T17:00:00Z',
+      },
+      {
+        id: 2,
+        authorLogin: 'kurone-kito',
+        body: acquireMarkerBody(sha256(liveBody), { owner: 'owner-token-2' }),
+        createdAt: '2026-09-10T16:50:00Z',
+        updatedAt: '2026-09-10T16:50:00Z',
+      },
+    ],
+    markerPrefix: MARKER_PREFIX,
+    trustedMarkerLogins: TRUSTED_LOGINS,
+  });
+  assert.equal(result.verdict, 'not-found');
+  assert.equal(result.marker, null);
+  assert.match(
+    result.checks.find((check) => check.id === 'acquire_marker_found')
+      ?.evidence ?? '',
+    /edited after posting/,
+  );
+});
+
+test('an unedited but unparseable first owner-marker-shaped comment fails closed, not the next acquire', () => {
+  // Copilot round 7: the earlier form filtered the candidate pool down
+  // to parsing, target-matching comments BEFORE picking the first one,
+  // so a first comment that carried the owner-marker token but never
+  // parsed at all (a genuine posting error, not tampering -- its own
+  // updatedAt equals its createdAt) silently vanished from
+  // consideration, letting a later, validly-parsing acquire win. The
+  // log's first candidate must itself be the valid marker, not merely
+  // whichever later comment happens to parse.
+  const liveBody = '# Draft\n\nSome content.\n';
+  const result = evaluateAuthoringOwnerProvenance({
+    target: TARGET,
+    liveBody,
+    comments: [
+      {
+        id: 1,
+        authorLogin: 'kurone-kito',
+        // Never edited (updatedAt === createdAt) -- just malformed from
+        // the start, e.g. a botched initial post.
+        body: 'idd-skill-authoring-owner: this was never a well-formed marker',
+        createdAt: '2026-09-10T16:48:44Z',
+        updatedAt: '2026-09-10T16:48:44Z',
+      },
+      {
+        id: 2,
+        authorLogin: 'kurone-kito',
+        body: acquireMarkerBody(sha256(liveBody), { owner: 'owner-token-2' }),
+        createdAt: '2026-09-10T16:50:00Z',
+        updatedAt: '2026-09-10T16:50:00Z',
+      },
+    ],
+    markerPrefix: MARKER_PREFIX,
+    trustedMarkerLogins: TRUSTED_LOGINS,
+  });
+  assert.equal(result.verdict, 'not-found');
+  assert.equal(result.marker, null);
+  assert.match(
+    result.checks.find((check) => check.id === 'acquire_marker_found')
+      ?.evidence ?? '',
+    /does not parse/,
+  );
+});
+
+test('an unedited first marker for a different target fails closed, not the next acquire', () => {
+  // Same restructuring, via the target-mismatch branch: an unedited
+  // first owner-marker-shaped comment whose own target names a
+  // different issue is now a reject, not a silent skip in favor of a
+  // later, matching acquire.
+  const liveBody = '# Draft\n\nSome content.\n';
+  const result = evaluateAuthoringOwnerProvenance({
+    target: TARGET,
+    liveBody,
+    comments: [
+      {
+        id: 1,
+        authorLogin: 'kurone-kito',
+        body: acquireMarkerBody(sha256(liveBody), {
+          target: 'kurone-kito/idd-skill#1',
+          anchor: 'kurone-kito/idd-skill#1',
+        }),
+        createdAt: '2026-09-10T16:48:44Z',
+        updatedAt: '2026-09-10T16:48:44Z',
+      },
+      {
+        id: 2,
+        authorLogin: 'kurone-kito',
+        body: acquireMarkerBody(sha256(liveBody), { owner: 'owner-token-2' }),
+        createdAt: '2026-09-10T16:50:00Z',
+        updatedAt: '2026-09-10T16:50:00Z',
+      },
+    ],
+    markerPrefix: MARKER_PREFIX,
+    trustedMarkerLogins: TRUSTED_LOGINS,
+  });
+  assert.equal(result.verdict, 'not-found');
+  assert.equal(result.marker, null);
+  assert.match(
+    result.checks.find((check) => check.id === 'acquire_marker_found')
+      ?.evidence ?? '',
+    /different target/,
+  );
 });

--- a/tests/authoring-owner-provenance.test.mts
+++ b/tests/authoring-owner-provenance.test.mts
@@ -59,6 +59,28 @@ function heartbeatMarkerBody(
   });
 }
 
+function bootstrapMarkerBody(
+  bodySha256: string,
+  overrides: { owner?: string } = {},
+): string {
+  return ownerMarkerBody('bootstrap', {
+    owner: overrides.owner ?? 'owner-token-1',
+    bodySha256,
+    supersedes: 'none',
+  });
+}
+
+function resumeMarkerBody(
+  bodySha256: string,
+  overrides: { owner?: string; supersedes?: string } = {},
+): string {
+  return ownerMarkerBody('resume', {
+    owner: overrides.owner ?? 'owner-token-1',
+    bodySha256,
+    supersedes: overrides.supersedes ?? 'prior-owner-token',
+  });
+}
+
 test('unchanged body with a matching acquire-time hash reports pass', () => {
   const liveBody = '# Draft\n\nSome content.\n';
   const result = evaluateAuthoringOwnerProvenance({
@@ -380,4 +402,78 @@ test('a matching release-complete does close the generation, allowing the next a
   });
   assert.equal(result.verdict, 'pass');
   assert.equal(result.marker?.owner, 'owner-token-2');
+});
+
+test('a bootstrap marker opens a generation a later competing acquire cannot displace', () => {
+  // The exact scenario chatgpt-codex-connector's third-round PR #2901
+  // review flagged: a stale orphan is recovered with a trusted bootstrap,
+  // then a competing acquire follows in the same still-open generation.
+  // contract.md: "The first valid bootstrap marker wins" -- the replay
+  // must recognize bootstrap as a generation opener, not just acquire.
+  const bootstrapBody = '# Draft\n\nRecovered via bootstrap.\n';
+  const editedLiveBody = '# Draft\n\nEdited to match the losing acquire.\n';
+  const result = evaluateAuthoringOwnerProvenance({
+    target: TARGET,
+    liveBody: editedLiveBody,
+    comments: [
+      {
+        id: 1,
+        authorLogin: 'kurone-kito',
+        body: bootstrapMarkerBody(sha256(bootstrapBody), {
+          owner: 'owner-token-bootstrap',
+        }),
+        createdAt: '2026-09-10T16:48:44Z',
+      },
+      {
+        id: 2,
+        authorLogin: 'kurone-kito',
+        body: acquireMarkerBody(sha256(editedLiveBody), {
+          owner: 'owner-token-losing-acquire',
+        }),
+        createdAt: '2026-09-10T16:49:00Z',
+      },
+    ],
+    markerPrefix: MARKER_PREFIX,
+    trustedMarkerLogins: TRUSTED_LOGINS,
+  });
+  assert.equal(result.verdict, 'mismatch');
+  assert.equal(result.marker?.mode, 'bootstrap');
+  assert.equal(result.marker?.owner, 'owner-token-bootstrap');
+  assert.equal(result.recordedBodySha256, sha256(bootstrapBody));
+});
+
+test('a resume marker opens a generation a later competing acquire cannot displace', () => {
+  // Same shape as the bootstrap case, for an interrupted-set recovery:
+  // contract.md: "A resume marker opens a new generation only for the
+  // exact interrupted set and matching prior owner token."
+  const resumeBody = '# Draft\n\nRecovered via resume.\n';
+  const editedLiveBody = '# Draft\n\nEdited to match the losing acquire.\n';
+  const result = evaluateAuthoringOwnerProvenance({
+    target: TARGET,
+    liveBody: editedLiveBody,
+    comments: [
+      {
+        id: 1,
+        authorLogin: 'kurone-kito',
+        body: resumeMarkerBody(sha256(resumeBody), {
+          owner: 'owner-token-resume',
+        }),
+        createdAt: '2026-09-10T16:48:44Z',
+      },
+      {
+        id: 2,
+        authorLogin: 'kurone-kito',
+        body: acquireMarkerBody(sha256(editedLiveBody), {
+          owner: 'owner-token-losing-acquire',
+        }),
+        createdAt: '2026-09-10T16:49:00Z',
+      },
+    ],
+    markerPrefix: MARKER_PREFIX,
+    trustedMarkerLogins: TRUSTED_LOGINS,
+  });
+  assert.equal(result.verdict, 'mismatch');
+  assert.equal(result.marker?.mode, 'resume');
+  assert.equal(result.marker?.owner, 'owner-token-resume');
+  assert.equal(result.recordedBodySha256, sha256(resumeBody));
 });

--- a/tests/authoring-owner-provenance.test.mts
+++ b/tests/authoring-owner-provenance.test.mts
@@ -20,12 +20,14 @@ function ownerMarkerBody(
     bodySha256?: string;
     snapshotSha256?: string;
     supersedes?: string;
+    target?: string;
+    anchor?: string;
   },
 ): string {
   return renderAuthoringOwnerMarker({
     markerPrefix: MARKER_PREFIX,
-    target: TARGET,
-    anchor: TARGET,
+    target: fields.target ?? TARGET,
+    anchor: fields.anchor ?? TARGET,
     mode,
     owner: fields.owner,
     set: 'set-1',
@@ -38,12 +40,14 @@ function ownerMarkerBody(
 
 function acquireMarkerBody(
   bodySha256: string,
-  overrides: { owner?: string } = {},
+  overrides: { owner?: string; target?: string; anchor?: string } = {},
 ): string {
   return ownerMarkerBody('acquire', {
     owner: overrides.owner ?? 'owner-token-1',
     bodySha256,
     supersedes: 'none',
+    target: overrides.target,
+    anchor: overrides.anchor,
   });
 }
 
@@ -476,4 +480,81 @@ test('a resume marker opens a generation a later competing acquire cannot displa
   assert.equal(result.marker?.mode, 'resume');
   assert.equal(result.marker?.owner, 'owner-token-resume');
   assert.equal(result.recordedBodySha256, sha256(resumeBody));
+});
+
+test('an acquire marker whose target differs only by capitalization still wins', () => {
+  // GitHub owner/repo names are case-insensitive (PR #2901 review,
+  // Copilot round 4): a marker's own `target` field may preserve
+  // whatever casing an actor or URL happened to use, so the filter that
+  // matches a marker's `target` against the CLI's own `owner/repo#n`
+  // string must fold case rather than compare bytes -- a byte
+  // comparison would drop this marker and fall through to `not-found`
+  // even though it names the same issue.
+  const liveBody = '# Draft\n\nSome content.\n';
+  const differentlyCasedTarget = 'Kurone-Kito/IDD-Skill#2891';
+  const result = evaluateAuthoringOwnerProvenance({
+    target: TARGET,
+    liveBody,
+    comments: [
+      {
+        id: 1,
+        authorLogin: 'kurone-kito',
+        body: acquireMarkerBody(sha256(liveBody), {
+          target: differentlyCasedTarget,
+          anchor: differentlyCasedTarget,
+        }),
+        createdAt: '2026-09-10T16:48:44Z',
+      },
+    ],
+    markerPrefix: MARKER_PREFIX,
+    trustedMarkerLogins: TRUSTED_LOGINS,
+  });
+  assert.equal(result.verdict, 'pass');
+  assert.ok(result.marker);
+  assert.equal(result.recordedBodySha256, sha256(liveBody));
+});
+
+test('a release-complete whose anchor differs only by capitalization still closes the generation', () => {
+  // Same case-folding requirement applies to `isValidReleaseComplete`'s
+  // own target === anchor and anchor === winner.anchor checks: a
+  // release-complete legitimately closing a generation must not be
+  // rejected merely because its anchor field's capitalization differs
+  // from the winning acquire's anchor (PR #2901 review, Copilot round 4).
+  const firstBody = '# Draft\n\nFirst.\n';
+  const secondBody = '# Draft\n\nSecond, legitimately re-acquired.\n';
+  const differentlyCasedTarget = 'Kurone-Kito/IDD-Skill#2891';
+  const result = evaluateAuthoringOwnerProvenance({
+    target: TARGET,
+    liveBody: secondBody,
+    comments: [
+      {
+        id: 1,
+        authorLogin: 'kurone-kito',
+        body: acquireMarkerBody(sha256(firstBody), { owner: 'owner-token-1' }),
+        createdAt: '2026-09-10T16:48:44Z',
+      },
+      {
+        id: 2,
+        authorLogin: 'kurone-kito',
+        body: ownerMarkerBody('release-complete', {
+          owner: 'owner-token-1',
+          snapshotSha256: sha256('closed-set-snapshot'),
+          supersedes: 'owner-token-1',
+          target: differentlyCasedTarget,
+          anchor: differentlyCasedTarget,
+        }),
+        createdAt: '2026-09-10T16:49:00Z',
+      },
+      {
+        id: 3,
+        authorLogin: 'kurone-kito',
+        body: acquireMarkerBody(sha256(secondBody), { owner: 'owner-token-2' }),
+        createdAt: '2026-09-10T16:50:00Z',
+      },
+    ],
+    markerPrefix: MARKER_PREFIX,
+    trustedMarkerLogins: TRUSTED_LOGINS,
+  });
+  assert.equal(result.verdict, 'pass');
+  assert.equal(result.marker?.owner, 'owner-token-2');
 });

--- a/tests/authoring-owner-provenance.test.mts
+++ b/tests/authoring-owner-provenance.test.mts
@@ -290,3 +290,94 @@ test('a same-generation acquire race resolves to the first acquire, never the la
   assert.equal(result.marker?.owner, 'owner-token-1');
   assert.equal(result.recordedBodySha256, sha256(winningGenerationBody));
 });
+
+test('a stale or malformed release-complete for another owner never closes the current generation', () => {
+  // The exact scenario chatgpt-codex-connector's second-round PR #2901
+  // review flagged: acquire A -> a release-complete for a DIFFERENT
+  // owner/set (stale, or from an unrelated malformed generation) ->
+  // competing acquire B. The stray release-complete must not close A's
+  // generation, so B is still a same-generation race, not a fresh
+  // generation -- A must remain the winner.
+  const winningBody = '# Draft\n\nOwned by A.\n';
+  const losingRacerBody = '# Draft\n\nEdited to match B, but B never wins.\n';
+  const result = evaluateAuthoringOwnerProvenance({
+    target: TARGET,
+    liveBody: losingRacerBody,
+    comments: [
+      {
+        id: 1,
+        authorLogin: 'kurone-kito',
+        body: acquireMarkerBody(sha256(winningBody), {
+          owner: 'owner-token-a',
+        }),
+        createdAt: '2026-09-10T16:48:44Z',
+      },
+      {
+        id: 2,
+        authorLogin: 'kurone-kito',
+        // A stale/malformed completion for a DIFFERENT owner/set -- must
+        // be ignored, not treated as closing owner-token-a's generation.
+        body: ownerMarkerBody('release-complete', {
+          owner: 'owner-token-other',
+          snapshotSha256: sha256('unrelated-snapshot'),
+          supersedes: 'owner-token-other',
+        }),
+        createdAt: '2026-09-10T16:49:00Z',
+      },
+      {
+        id: 3,
+        authorLogin: 'kurone-kito',
+        body: acquireMarkerBody(sha256(losingRacerBody), {
+          owner: 'owner-token-b',
+        }),
+        createdAt: '2026-09-10T16:50:00Z',
+      },
+    ],
+    markerPrefix: MARKER_PREFIX,
+    trustedMarkerLogins: TRUSTED_LOGINS,
+  });
+  assert.equal(result.verdict, 'mismatch');
+  assert.equal(result.marker?.owner, 'owner-token-a');
+  assert.equal(result.recordedBodySha256, sha256(winningBody));
+});
+
+test('a matching release-complete does close the generation, allowing the next acquire to win', () => {
+  // The positive counterpart: a release-complete that DOES retain the
+  // winning acquire's exact owner/set/session/anchor (and supersedes
+  // that owner) legitimately closes the generation, so the following
+  // acquire is a genuine new generation and wins outright.
+  const firstBody = '# Draft\n\nFirst.\n';
+  const secondBody = '# Draft\n\nSecond, legitimately re-acquired.\n';
+  const result = evaluateAuthoringOwnerProvenance({
+    target: TARGET,
+    liveBody: secondBody,
+    comments: [
+      {
+        id: 1,
+        authorLogin: 'kurone-kito',
+        body: acquireMarkerBody(sha256(firstBody), { owner: 'owner-token-1' }),
+        createdAt: '2026-09-10T16:48:44Z',
+      },
+      {
+        id: 2,
+        authorLogin: 'kurone-kito',
+        body: ownerMarkerBody('release-complete', {
+          owner: 'owner-token-1',
+          snapshotSha256: sha256('closed-set-snapshot'),
+          supersedes: 'owner-token-1',
+        }),
+        createdAt: '2026-09-10T16:49:00Z',
+      },
+      {
+        id: 3,
+        authorLogin: 'kurone-kito',
+        body: acquireMarkerBody(sha256(secondBody), { owner: 'owner-token-2' }),
+        createdAt: '2026-09-10T16:50:00Z',
+      },
+    ],
+    markerPrefix: MARKER_PREFIX,
+    trustedMarkerLogins: TRUSTED_LOGINS,
+  });
+  assert.equal(result.verdict, 'pass');
+  assert.equal(result.marker?.owner, 'owner-token-2');
+});

--- a/tests/authoring-owner-provenance.test.mts
+++ b/tests/authoring-owner-provenance.test.mts
@@ -1,0 +1,200 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { test } from 'node:test';
+
+import { evaluateAuthoringOwnerProvenance } from '../src/scripts/authoring-owner-provenance.mts';
+import { renderAuthoringOwnerMarker } from '../src/scripts/marker-helpers.mts';
+
+const TARGET = 'kurone-kito/idd-skill#2891';
+const MARKER_PREFIX = 'idd-skill';
+const TRUSTED_LOGINS = ['kurone-kito'];
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex');
+}
+
+function acquireMarkerBody(
+  bodySha256: string,
+  overrides: Record<string, string> = {},
+): string {
+  return renderAuthoringOwnerMarker({
+    markerPrefix: MARKER_PREFIX,
+    target: TARGET,
+    anchor: TARGET,
+    mode: 'acquire',
+    owner: 'owner-token-1',
+    set: 'set-1',
+    session: 'session-1',
+    bodySha256,
+    snapshotSha256: 'none',
+    supersedes: 'none',
+    ...overrides,
+  });
+}
+
+function heartbeatMarkerBody(
+  bodySha256: string,
+  overrides: Record<string, string> = {},
+): string {
+  return renderAuthoringOwnerMarker({
+    markerPrefix: MARKER_PREFIX,
+    target: TARGET,
+    anchor: TARGET,
+    mode: 'heartbeat',
+    owner: 'owner-token-1',
+    set: 'set-1',
+    session: 'session-1',
+    bodySha256,
+    snapshotSha256: 'none',
+    supersedes: 'owner-token-1',
+    ...overrides,
+  });
+}
+
+test('unchanged body with a matching acquire-time hash reports pass', () => {
+  const liveBody = '# Draft\n\nSome content.\n';
+  const result = evaluateAuthoringOwnerProvenance({
+    target: TARGET,
+    liveBody,
+    comments: [
+      {
+        authorLogin: 'kurone-kito',
+        body: acquireMarkerBody(sha256(liveBody)),
+        createdAt: '2026-09-10T16:48:44Z',
+      },
+    ],
+    markerPrefix: MARKER_PREFIX,
+    trustedMarkerLogins: TRUSTED_LOGINS,
+  });
+  assert.equal(result.verdict, 'pass');
+  assert.equal(result.computedBodySha256, sha256(liveBody));
+  assert.equal(result.recordedBodySha256, sha256(liveBody));
+  assert.ok(result.marker);
+  assert.equal(
+    result.checks.find((check) => check.id === 'body_sha256_match')?.result,
+    'pass',
+  );
+});
+
+test('a body edited after acquire fails closed with mismatch', () => {
+  const acquireTimeBody = '# Draft\n\nOriginal content.\n';
+  const editedLiveBody = '# Draft\n\nEdited content after acquire.\n';
+  const result = evaluateAuthoringOwnerProvenance({
+    target: TARGET,
+    liveBody: editedLiveBody,
+    comments: [
+      {
+        authorLogin: 'kurone-kito',
+        body: acquireMarkerBody(sha256(acquireTimeBody)),
+        createdAt: '2026-09-10T16:48:44Z',
+      },
+    ],
+    markerPrefix: MARKER_PREFIX,
+    trustedMarkerLogins: TRUSTED_LOGINS,
+  });
+  assert.equal(result.verdict, 'mismatch');
+  assert.equal(result.computedBodySha256, sha256(editedLiveBody));
+  assert.equal(result.recordedBodySha256, sha256(acquireTimeBody));
+  assert.notEqual(result.computedBodySha256, result.recordedBodySha256);
+});
+
+test('no acquire marker for the target reports not-found, never pass', () => {
+  const liveBody = 'plain issue body with no authoring marker at all';
+  const result = evaluateAuthoringOwnerProvenance({
+    target: TARGET,
+    liveBody,
+    comments: [
+      {
+        authorLogin: 'kurone-kito',
+        body: 'unrelated comment',
+        createdAt: '2026-09-10T16:00:00Z',
+      },
+    ],
+    markerPrefix: MARKER_PREFIX,
+    trustedMarkerLogins: TRUSTED_LOGINS,
+  });
+  assert.equal(result.verdict, 'not-found');
+  assert.equal(result.recordedBodySha256, null);
+  assert.equal(result.marker, null);
+});
+
+test('an untrusted actor acquire marker is ignored, falling through to not-found', () => {
+  const liveBody = '# Draft\n\nSome content.\n';
+  const result = evaluateAuthoringOwnerProvenance({
+    target: TARGET,
+    liveBody,
+    comments: [
+      {
+        authorLogin: 'random-untrusted-user',
+        body: acquireMarkerBody(sha256(liveBody)),
+        createdAt: '2026-09-10T16:48:44Z',
+      },
+    ],
+    markerPrefix: MARKER_PREFIX,
+    trustedMarkerLogins: TRUSTED_LOGINS,
+  });
+  assert.equal(result.verdict, 'not-found');
+});
+
+test('a later heartbeat marker never shadows the acquire marker digest', () => {
+  // The realistic drift shape from this issue's own comment thread:
+  // acquire -> release -> release-guard -> heartbeat -> release-complete,
+  // all sharing one owner token. A heartbeat carries its own body-sha256
+  // (re-hashed at heartbeat time) but must never substitute for the
+  // acquire-time digest this comparison is specifically about.
+  const acquireTimeBody = '# Draft\n\nOriginal content.\n';
+  const laterBody = '# Draft\n\nContent as of the heartbeat.\n';
+  const result = evaluateAuthoringOwnerProvenance({
+    target: TARGET,
+    liveBody: laterBody,
+    comments: [
+      {
+        authorLogin: 'kurone-kito',
+        body: acquireMarkerBody(sha256(acquireTimeBody)),
+        createdAt: '2026-09-10T16:48:44Z',
+      },
+      {
+        authorLogin: 'kurone-kito',
+        body: heartbeatMarkerBody(sha256(laterBody)),
+        createdAt: '2026-09-10T17:07:59Z',
+      },
+    ],
+    markerPrefix: MARKER_PREFIX,
+    trustedMarkerLogins: TRUSTED_LOGINS,
+  });
+  // The heartbeat's digest (matching laterBody) must not be used -- only
+  // the acquire marker's digest counts, so this must report mismatch
+  // rather than pass.
+  assert.equal(result.verdict, 'mismatch');
+  assert.equal(result.recordedBodySha256, sha256(acquireTimeBody));
+  assert.equal(result.marker?.session, 'session-1');
+});
+
+test('multiple acquire generations (re-acquisition) pick the most recent', () => {
+  const firstGenerationBody = '# Draft\n\nFirst generation.\n';
+  const secondGenerationBody = '# Draft\n\nSecond generation, re-acquired.\n';
+  const result = evaluateAuthoringOwnerProvenance({
+    target: TARGET,
+    liveBody: secondGenerationBody,
+    comments: [
+      {
+        authorLogin: 'kurone-kito',
+        body: acquireMarkerBody(sha256(firstGenerationBody), {
+          owner: 'owner-token-1',
+        }),
+        createdAt: '2026-09-01T00:00:00Z',
+      },
+      {
+        authorLogin: 'kurone-kito',
+        body: acquireMarkerBody(sha256(secondGenerationBody), {
+          owner: 'owner-token-2',
+        }),
+        createdAt: '2026-09-10T16:48:44Z',
+      },
+    ],
+    markerPrefix: MARKER_PREFIX,
+    trustedMarkerLogins: TRUSTED_LOGINS,
+  });
+  assert.equal(result.verdict, 'pass');
+  assert.equal(result.marker?.owner, 'owner-token-2');
+});

--- a/tests/help-text-flags.test.mts
+++ b/tests/help-text-flags.test.mts
@@ -169,6 +169,7 @@ const COVERED_HELPERS = [
   'advisory-wait-state',
   'audit-authored-issue',
   'audit-pr-cleanup',
+  'authoring-owner-provenance',
   'branch-conflict-state',
   'branch-name',
   'ci-wait-policy',


### PR DESCRIPTION
# Summary

The review-fix-loop-cutoff auto-release exception's provenance check
(`skills/issue-authoring/references/contract.md`, `#2877`) relies
entirely on a releasing session manually recomputing a target issue's
current body-sha256 and comparing it against the Stage 1 acquire
marker's recorded digest, with nothing to catch a session that skips
the check or gets the comparison wrong.

This adds `scripts/authoring-owner-provenance.mjs`, a read-only
evidence-collector helper that:

- Fetches a live issue body and its comments.
- Computes the sha256 of the exact UTF-8 body content.
- Compares it against that same issue's own trusted `mode=acquire`
  `authoring-owner` marker's recorded `body-sha256`.
- Reports a machine-readable `pass`/`mismatch`/`not-found` verdict —
  `not-found` is never treated as a pass.

It is registered through the usual helper-runtime surface
(`package.json` `bin`, `helper-runtime-manifest.mts`
`HELPER_COMMANDS`), and `skills/issue-authoring/references/contract.md`,
`docs/issue-authoring-skill.md`, and `idd-template/docs/idd-helper-scripts.md`
(source for the `docs/idd-helper-scripts.md` mirror) now name it in
place of the "tracked as a follow-up" note.

## Linked issue

Closes #2891

## Follow-up issues (if any)

- [x] The issue author's own comment on #2891 also asked for "a
      regression test covering exactly that interleaving" (a body edit
      landing between the helper's check and a Stage 2 label-removal
      step). That interleaving orchestration belongs to a future
      automated Stage 2 release-sequence helper that does not exist
      yet in this repository — this PR's mismatch test
      (`a body edited after acquire fails closed with mismatch`) is
      the atomic comparison such an orchestrator would call
      repeatedly, including immediately before label removal, but the
      orchestration itself is out of scope here.

## Background / rationale (if material)

- Verified live against real repository data: running the helper
  against issue #2891 itself correctly reported `mismatch` — its
  acquire-time digest predates a legitimate, documented pre-release
  body edit (the "Blocked by #2877" dependency correction applied
  during Stage 2 hold-release review) — and against issue #2884 (no
  authoring marker at all) correctly reported `not-found`.
- The helper is intentionally scoped to the mechanical comparison
  only, not the full Stage 2 release-sequence automation the issue
  body names as a possible future consumer.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`biome check`, `dprint check`, `markdownlint-cli2`)
- [x] `pnpm test` (`node --test tests/*.test.mts`, 6004 passed)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)
- [x] `pnpm run typecheck`
- [x] `pnpm run build:check`
- [x] `node scripts/token-cost-report.mjs --check`

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdQ5SPdFLaDGus5PNdBUhw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a read-only provenance checker that compares an issue’s current body with its trusted authoring-owner record.
  - Reports `pass`, `mismatch`, or fail-closed `not-found` results with optional evidence.
  - Added the `idd-authoring-owner-provenance` command for accessing this validation.

- **Documentation**
  - Documented provenance validation rules, outcomes, and limitations.
  - Updated auto-release guidance to require the automated provenance check before label removal.

- **Tests**
  - Added comprehensive coverage for hashing, marker validation, issue updates, CLI behavior, and malformed records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->