### PR TITLE
fix(sync-manifest): concrete idd-overview-appendix, guard exact-mode placeholders

### DIFF
--- a/.github/instructions/idd-overview-appendix.instructions.md
+++ b/.github/instructions/idd-overview-appendix.instructions.md
@@ -150,7 +150,7 @@ code, config, or a local customization).
 a local issue through `skills/issue-authoring/` as usual, additionally
 carrying the GitHub label `status:upstream-candidate` (create it on
 first use) and the hidden marker
-`<!-- {{PROJECT_MARKER_PREFIX}}-upstream-candidate: true -->`.
+`<!-- idd-skill-upstream-candidate: true -->`.
 
 **What never to do.** Never write to `kurone-kito/idd-skill` or any
 other repository — no comment, no issue, no mutation of any kind.

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -592,7 +592,13 @@
       "id": "idd-helper-scripts-doc",
       "source": "idd-template/docs/idd-helper-scripts.md",
       "target": "docs/idd-helper-scripts.md",
-      "mode": "exact"
+      "mode": "concreted",
+      "replacements": [
+        {
+          "from": "{{PROJECT_MARKER_PREFIX}}",
+          "to": "idd-skill"
+        }
+      ]
     },
     {
       "id": "idd-merge-handoff-instructions",
@@ -616,7 +622,13 @@
       "id": "idd-overview-appendix-instructions",
       "source": "idd-template/.github/instructions/idd-overview-appendix.instructions.md",
       "target": ".github/instructions/idd-overview-appendix.instructions.md",
-      "mode": "exact"
+      "mode": "concreted",
+      "replacements": [
+        {
+          "from": "{{PROJECT_MARKER_PREFIX}}",
+          "to": "idd-skill"
+        }
+      ]
     },
     {
       "id": "idd-overview-core-instructions",

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -504,7 +504,7 @@ default below is unchanged.
     `maxDepth: number }`
 - **Cross-roadmap autopilot mode (`--all-roadmaps`)**: discovers every
   **open** roadmap root (an open issue carrying the `roadmap` label **or**
-  an `<!-- {{PROJECT_MARKER_PREFIX}}-roadmap-id: ... -->` marker **or** a
+  an `<!-- idd-skill-roadmap-id: ... -->` marker **or** a
   configured `discover.legacyRoots` issue number, deduped against the
   label/marker roots), runs the single-root enumeration above from each
   root, and returns a **union** of open execution leaves. The output
@@ -545,7 +545,7 @@ default below is unchanged.
     `readiness: { ready: boolean, reasons: string[], authoringHeld: boolean,`
     `startable: boolean }` — the A3 startability of each open leaf (dependency
     resolution across visible `Blocked by #N` / `Depends on #N` / task-list refs
-    and hidden `{{PROJECT_MARKER_PREFIX}}-blocked-by` markers, plus
+    and hidden `idd-skill-blocked-by` markers, plus
     authoring-hold), where `reasons` lists the sorted filter reasons (e.g.
     `blocked_by_open_issue:#N`) and is empty when `ready`, and `startable` is
     `ready` **and** not claim-blocked (it folds
@@ -585,7 +585,7 @@ default below is unchanged.
 - **Legacy roots (`discover.legacyRoots`, #1315)**: a repository that
   adopted IDD after already running an ad-hoc "umbrella issue"
   convention may have legacy roots that predate both the `roadmap`
-  label and the `{{PROJECT_MARKER_PREFIX}}-roadmap-id` marker, so they
+  label and the `idd-skill-roadmap-id` marker, so they
   are never found by the two searches above (the graph walker still
   follows their `Blocked by #NNN` references once reached from
   elsewhere; only root _discovery_ has no path to them). Two

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -75,16 +75,16 @@ const ENGINES_RANGE_MIRRORS = [
   { file: 'src/scripts/helper-runtime-manifest.mts', mode: 'full-range' },
 ];
 // Sync pair `id`s allowed to keep a known onboarding placeholder token
-// literal in an `"exact"`-mode pair's *post-replacement* source (see
-// checkExactModePlaceholders below -- "exact" mode is not itself
-// substitution-free, since `checkSyncPairs` above and `sync-docs.mts` both
-// apply a pair's own `replacements` array regardless of mode). Any other
-// pair whose post-replacement source still carries one of these tokens
-// would leak it byte-for-byte into this repository's own live mirror
-// (kurone-kito/idd-skill#2899). Each entry needs a one-line justification;
-// prefer adding (or extending) a `replacements` entry that resolves the
-// token over adding here, unless it is genuinely meant to stay literal.
-const EXACT_MODE_PLACEHOLDER_EXEMPTIONS = {
+// literal in an `"exact"`- or `"concreted"`-mode pair's *post-replacement*
+// source (see checkGeneratedModePlaceholders below -- both modes apply a
+// pair's own `replacements` array the same way; neither is substitution-free
+// by mode name alone). Any other pair whose post-replacement source still
+// carries one of these tokens would leak it byte-for-byte into this
+// repository's own live mirror (kurone-kito/idd-skill#2899, PR #2904
+// review). Each entry needs a one-line justification; prefer adding (or
+// extending) a `replacements` entry that resolves the token over adding
+// here, unless it is genuinely meant to stay literal.
+const GENERATED_MODE_PLACEHOLDER_EXEMPTIONS = {
   // `docs/customization.md` is the placeholder-mapping table itself: the
   // literal `{{...}}` tokens ARE the reference content this page teaches
   // adopters, not an unresolved leftover from a live marker instance.
@@ -98,7 +98,7 @@ checkShellFileLists(
   manifest.generatedBlocks ?? [],
 );
 checkSyncPairs(manifest.syncPairs ?? []);
-checkExactModePlaceholders(manifest.syncPairs ?? []);
+checkGeneratedModePlaceholders(manifest.syncPairs ?? []);
 checkGeneratedFromBanners(manifest.syncPairs ?? []);
 checkInstructionSizeBudgets(manifest.instructionSizeBudgets);
 {
@@ -490,23 +490,25 @@ function checkSyncPairs(pairs) {
     errors.push(`${pair.id}: unsupported sync mode ${pair.mode}`);
   }
 }
-// Fails any `"mode": "exact"` sync pair whose *post-replacement* source
-// still contains an unresolved onboarding placeholder token from the
-// canonical seven-entry table in `idd-onboard.mts` (ONBOARDING_PLACEHOLDERS,
-// mirroring `idd-template/docs/onboarding/placeholders.md`'s "Final
-// placeholder meanings" table) -- not a bare `{{...}}` scan, which would
-// also flag an unrelated GitHub Actions expression such as
-// `${{ github.token }}` inside an imported workflow file. `"exact"` mode is
-// not itself substitution-free: `checkSyncPairs` above and `sync-docs.mts`
-// both apply `pair.replacements` regardless of mode (`tests/sync-docs.
-// test.mts` covers an "exact" pair with a replacement), so this check must
-// apply the same `applyReplacements` step before scanning, or it would
-// reject a pair whose own `replacements` array already resolves the token
-// (kurone-kito/idd-skill#2899, PR #2904 review). A leftover token *after*
-// replacements always leaks into this repository's own live mirror;
-// `checkSyncPairs` only compares source and target for byte equality and
-// cannot see this on its own, since an identical placeholder on both sides
-// produces zero drift.
+// Fails any `"exact"`- or `"concreted"`-mode sync pair whose
+// *post-replacement* source still contains an unresolved onboarding
+// placeholder token from the canonical seven-entry table in
+// `idd-onboard.mts` (ONBOARDING_PLACEHOLDERS, mirroring `idd-template/docs/
+// onboarding/placeholders.md`'s "Final placeholder meanings" table) -- not
+// a bare `{{...}}` scan, which would also flag an unrelated GitHub Actions
+// expression such as `${{ github.token }}` inside an imported workflow
+// file. Both modes need this check, not just `"exact"`: `checkSyncPairs`
+// above and `sync-docs.mts` treat `"exact"` and `"concreted"` identically
+// (`pair.mode === 'exact' || pair.mode === 'concreted'`), applying
+// `pair.replacements` regardless of mode (`tests/sync-docs.test.mts`
+// covers an `"exact"` pair with a replacement) -- so an incomplete
+// `replacements` array on a `"concreted"` pair (or a new placeholder its
+// existing entries don't cover) is exactly the same live-leak risk as an
+// `"exact"` pair with none at all (kurone-kito/idd-skill#2899, PR #2904
+// review, Codex). A leftover token *after* replacements always leaks into
+// this repository's own live mirror; `checkSyncPairs` only compares
+// source and target for byte equality and cannot see this on its own,
+// since an identical placeholder on both sides produces zero drift.
 //
 // `idd-doctor.mts`'s own `checkPlaceholders` (see `findPlaceholders` /
 // `isIddManagedPlaceholderScanPath`) is deliberately left unchanged rather
@@ -514,19 +516,19 @@ function checkSyncPairs(pairs) {
 // this class (kurone-kito/idd-skill#2899 Background): it scans
 // already-generated repository files for onboarding hygiene in general,
 // not sync-pair sources specifically, so it is not the right place to
-// special-case one sync mode. This check runs earlier, against the
+// special-case these two sync modes. This check runs earlier, against the
 // sync-pair source before generation, and is the sufficient
 // complementary guard for this specific bug class -- an unresolved
-// placeholder can no longer reach a committed `"exact"`-mode mirror in
-// the first place, so `idd-doctor.mts`'s post-generation scan gaps stay
-// a documented, intentional residual.
-function checkExactModePlaceholders(pairs) {
+// placeholder can no longer reach a committed generated mirror in the
+// first place, so `idd-doctor.mts`'s post-generation scan gaps stay a
+// documented, intentional residual.
+function checkGeneratedModePlaceholders(pairs) {
   const tokens = ONBOARDING_PLACEHOLDERS.map((entry) => entry.token);
   for (const pair of pairs) {
-    if (pair.mode !== 'exact') {
+    if (pair.mode !== 'exact' && pair.mode !== 'concreted') {
       continue;
     }
-    if (Object.hasOwn(EXACT_MODE_PLACEHOLDER_EXEMPTIONS, pair.id)) {
+    if (Object.hasOwn(GENERATED_MODE_PLACEHOLDER_EXEMPTIONS, pair.id)) {
       continue;
     }
     const source = applyReplacements(
@@ -536,7 +538,7 @@ function checkExactModePlaceholders(pairs) {
     const hits = tokens.filter((token) => source.includes(token));
     if (hits.length > 0) {
       errors.push(
-        `${pair.id}: ${pair.source} is "exact" mode but still contains unresolved placeholder(s) ${hits.join(', ')} after applying its replacements -- add a "replacements" entry (or flip to "mode": "concreted" with one), or add "${pair.id}" to EXACT_MODE_PLACEHOLDER_EXEMPTIONS with a one-line justification`,
+        `${pair.id}: ${pair.source} is "${pair.mode}" mode but still contains unresolved placeholder(s) ${hits.join(', ')} after applying its replacements -- add or extend a "replacements" entry to resolve them, or add "${pair.id}" to GENERATED_MODE_PLACEHOLDER_EXEMPTIONS with a one-line justification`,
       );
     }
   }

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -35,6 +35,7 @@ import {
   collectDocumentedHelperInvocationFlags,
   collectHelperFlagDriftViolations,
 } from './helper-flag-drift.mjs';
+import { ONBOARDING_PLACEHOLDERS } from './idd-onboard.mjs';
 import { collectMarkdownLinkAuditViolations } from './markdown-link-audit.mjs';
 
 const root = process.cwd();
@@ -73,6 +74,21 @@ const ENGINES_RANGE_MIRRORS = [
   { file: 'docs/stalled-session-quiet-check.md', mode: 'components' },
   { file: 'src/scripts/helper-runtime-manifest.mts', mode: 'full-range' },
 ];
+// Sync pair `id`s allowed to keep a known onboarding placeholder token
+// literal in an `"exact"`-mode source. `"exact"` mode has no `replacements`
+// array, so any other pair whose source still carries one of these tokens
+// would leak it byte-for-byte into this repository's own live mirror --
+// exactly the bug class checkExactModePlaceholders below exists to catch
+// (kurone-kito/idd-skill#2899). Each entry needs a one-line justification;
+// prefer flipping the pair to `"mode": "concreted"` with a matching
+// `replacements` entry over adding here, unless the token is genuinely
+// meant to stay literal.
+const EXACT_MODE_PLACEHOLDER_EXEMPTIONS = {
+  // `docs/customization.md` is the placeholder-mapping table itself: the
+  // literal `{{...}}` tokens ARE the reference content this page teaches
+  // adopters, not an unresolved leftover from a live marker instance.
+  'customization-doc': 'documents the placeholder-mapping table for adopters',
+};
 checkReadmePairs(manifest.readmePairs ?? []);
 checkFileSets(manifest.fileSets ?? [], manifest.syncPairs ?? []);
 checkGeneratedBlocks(manifest.generatedBlocks ?? []);
@@ -81,6 +97,7 @@ checkShellFileLists(
   manifest.generatedBlocks ?? [],
 );
 checkSyncPairs(manifest.syncPairs ?? []);
+checkExactModePlaceholders(manifest.syncPairs ?? []);
 checkGeneratedFromBanners(manifest.syncPairs ?? []);
 checkInstructionSizeBudgets(manifest.instructionSizeBudgets);
 {
@@ -470,6 +487,48 @@ function checkSyncPairs(pairs) {
       continue;
     }
     errors.push(`${pair.id}: unsupported sync mode ${pair.mode}`);
+  }
+}
+// Fails any `"mode": "exact"` sync pair whose source still contains an
+// unresolved onboarding placeholder token from the canonical seven-entry
+// table in `idd-onboard.mts` (ONBOARDING_PLACEHOLDERS, mirroring
+// `idd-template/docs/onboarding/placeholders.md`'s "Final placeholder
+// meanings" table) -- not a bare `{{...}}` scan, which would also flag an
+// unrelated GitHub Actions expression such as `${{ github.token }}` inside
+// an imported workflow file. `"exact"` mode copies bytes verbatim with no
+// substitution step, so a leftover token here always leaks into this
+// repository's own live mirror; `checkSyncPairs` above only compares
+// source and target for byte equality and cannot see this, since an
+// identical placeholder on both sides produces zero drift.
+//
+// `idd-doctor.mts`'s own `checkPlaceholders` (see `findPlaceholders` /
+// `isIddManagedPlaceholderScanPath`) is deliberately left unchanged rather
+// than also fixed for the two gaps that let it miss both known bugs of
+// this class (kurone-kito/idd-skill#2899 Background): it scans
+// already-generated repository files for onboarding hygiene in general,
+// not sync-pair sources specifically, so it is not the right place to
+// special-case one sync mode. This check runs earlier, against the
+// sync-pair source before generation, and is the sufficient
+// complementary guard for this specific bug class -- an unresolved
+// placeholder can no longer reach a committed `"exact"`-mode mirror in
+// the first place, so `idd-doctor.mts`'s post-generation scan gaps stay
+// a documented, intentional residual.
+function checkExactModePlaceholders(pairs) {
+  const tokens = ONBOARDING_PLACEHOLDERS.map((entry) => entry.token);
+  for (const pair of pairs) {
+    if (pair.mode !== 'exact') {
+      continue;
+    }
+    if (Object.hasOwn(EXACT_MODE_PLACEHOLDER_EXEMPTIONS, pair.id)) {
+      continue;
+    }
+    const source = readText(pair.source);
+    const hits = tokens.filter((token) => source.includes(token));
+    if (hits.length > 0) {
+      errors.push(
+        `${pair.id}: ${pair.source} is "exact" mode but still contains unresolved placeholder(s) ${hits.join(', ')} -- flip to "mode": "concreted" with a matching replacement, or add "${pair.id}" to EXACT_MODE_PLACEHOLDER_EXEMPTIONS with a one-line justification`,
+      );
+    }
   }
 }
 // Verify that every generated instruction target carries the exact

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -489,17 +489,23 @@ function checkSyncPairs(pairs) {
     errors.push(`${pair.id}: unsupported sync mode ${pair.mode}`);
   }
 }
-// Fails any `"mode": "exact"` sync pair whose source still contains an
-// unresolved onboarding placeholder token from the canonical seven-entry
-// table in `idd-onboard.mts` (ONBOARDING_PLACEHOLDERS, mirroring
-// `idd-template/docs/onboarding/placeholders.md`'s "Final placeholder
-// meanings" table) -- not a bare `{{...}}` scan, which would also flag an
-// unrelated GitHub Actions expression such as `${{ github.token }}` inside
-// an imported workflow file. `"exact"` mode copies bytes verbatim with no
-// substitution step, so a leftover token here always leaks into this
-// repository's own live mirror; `checkSyncPairs` above only compares
-// source and target for byte equality and cannot see this, since an
-// identical placeholder on both sides produces zero drift.
+// Fails any `"mode": "exact"` sync pair whose *post-replacement* source
+// still contains an unresolved onboarding placeholder token from the
+// canonical seven-entry table in `idd-onboard.mts` (ONBOARDING_PLACEHOLDERS,
+// mirroring `idd-template/docs/onboarding/placeholders.md`'s "Final
+// placeholder meanings" table) -- not a bare `{{...}}` scan, which would
+// also flag an unrelated GitHub Actions expression such as
+// `${{ github.token }}` inside an imported workflow file. `"exact"` mode is
+// not itself substitution-free: `checkSyncPairs` above and `sync-docs.mts`
+// both apply `pair.replacements` regardless of mode (`tests/sync-docs.
+// test.mts` covers an "exact" pair with a replacement), so this check must
+// apply the same `applyReplacements` step before scanning, or it would
+// reject a pair whose own `replacements` array already resolves the token
+// (kurone-kito/idd-skill#2899, PR #2904 review). A leftover token *after*
+// replacements always leaks into this repository's own live mirror;
+// `checkSyncPairs` only compares source and target for byte equality and
+// cannot see this on its own, since an identical placeholder on both sides
+// produces zero drift.
 //
 // `idd-doctor.mts`'s own `checkPlaceholders` (see `findPlaceholders` /
 // `isIddManagedPlaceholderScanPath`) is deliberately left unchanged rather
@@ -522,11 +528,14 @@ function checkExactModePlaceholders(pairs) {
     if (Object.hasOwn(EXACT_MODE_PLACEHOLDER_EXEMPTIONS, pair.id)) {
       continue;
     }
-    const source = readText(pair.source);
+    const source = applyReplacements(
+      readText(pair.source),
+      pair.replacements ?? [],
+    );
     const hits = tokens.filter((token) => source.includes(token));
     if (hits.length > 0) {
       errors.push(
-        `${pair.id}: ${pair.source} is "exact" mode but still contains unresolved placeholder(s) ${hits.join(', ')} -- flip to "mode": "concreted" with a matching replacement, or add "${pair.id}" to EXACT_MODE_PLACEHOLDER_EXEMPTIONS with a one-line justification`,
+        `${pair.id}: ${pair.source} is "exact" mode but still contains unresolved placeholder(s) ${hits.join(', ')} after applying its replacements -- add a "replacements" entry (or flip to "mode": "concreted" with one), or add "${pair.id}" to EXACT_MODE_PLACEHOLDER_EXEMPTIONS with a one-line justification`,
       );
     }
   }

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -75,14 +75,15 @@ const ENGINES_RANGE_MIRRORS = [
   { file: 'src/scripts/helper-runtime-manifest.mts', mode: 'full-range' },
 ];
 // Sync pair `id`s allowed to keep a known onboarding placeholder token
-// literal in an `"exact"`-mode source. `"exact"` mode has no `replacements`
-// array, so any other pair whose source still carries one of these tokens
-// would leak it byte-for-byte into this repository's own live mirror --
-// exactly the bug class checkExactModePlaceholders below exists to catch
+// literal in an `"exact"`-mode pair's *post-replacement* source (see
+// checkExactModePlaceholders below -- "exact" mode is not itself
+// substitution-free, since `checkSyncPairs` above and `sync-docs.mts` both
+// apply a pair's own `replacements` array regardless of mode). Any other
+// pair whose post-replacement source still carries one of these tokens
+// would leak it byte-for-byte into this repository's own live mirror
 // (kurone-kito/idd-skill#2899). Each entry needs a one-line justification;
-// prefer flipping the pair to `"mode": "concreted"` with a matching
-// `replacements` entry over adding here, unless the token is genuinely
-// meant to stay literal.
+// prefer adding (or extending) a `replacements` entry that resolves the
+// token over adding here, unless it is genuinely meant to stay literal.
 const EXACT_MODE_PLACEHOLDER_EXEMPTIONS = {
   // `docs/customization.md` is the placeholder-mapping table itself: the
   // literal `{{...}}` tokens ARE the reference content this page teaches

--- a/src/scripts/audit-docs.mts
+++ b/src/scripts/audit-docs.mts
@@ -47,6 +47,7 @@ import {
   collectDocumentedHelperInvocationFlags,
   collectHelperFlagDriftViolations,
 } from './helper-flag-drift.mts';
+import { ONBOARDING_PLACEHOLDERS } from './idd-onboard.mts';
 import type { MarkdownLinkAuditConfig } from './markdown-link-audit.mts';
 import { collectMarkdownLinkAuditViolations } from './markdown-link-audit.mts';
 
@@ -173,6 +174,22 @@ const ENGINES_RANGE_MIRRORS: EnginesRangeMirrorSpec[] = [
   { file: 'src/scripts/helper-runtime-manifest.mts', mode: 'full-range' },
 ];
 
+// Sync pair `id`s allowed to keep a known onboarding placeholder token
+// literal in an `"exact"`-mode source. `"exact"` mode has no `replacements`
+// array, so any other pair whose source still carries one of these tokens
+// would leak it byte-for-byte into this repository's own live mirror --
+// exactly the bug class checkExactModePlaceholders below exists to catch
+// (kurone-kito/idd-skill#2899). Each entry needs a one-line justification;
+// prefer flipping the pair to `"mode": "concreted"` with a matching
+// `replacements` entry over adding here, unless the token is genuinely
+// meant to stay literal.
+const EXACT_MODE_PLACEHOLDER_EXEMPTIONS: Readonly<Record<string, string>> = {
+  // `docs/customization.md` is the placeholder-mapping table itself: the
+  // literal `{{...}}` tokens ARE the reference content this page teaches
+  // adopters, not an unresolved leftover from a live marker instance.
+  'customization-doc': 'documents the placeholder-mapping table for adopters',
+};
+
 checkReadmePairs(manifest.readmePairs ?? []);
 checkFileSets(manifest.fileSets ?? [], manifest.syncPairs ?? []);
 checkGeneratedBlocks(manifest.generatedBlocks ?? []);
@@ -181,6 +198,7 @@ checkShellFileLists(
   manifest.generatedBlocks ?? [],
 );
 checkSyncPairs(manifest.syncPairs ?? []);
+checkExactModePlaceholders(manifest.syncPairs ?? []);
 checkGeneratedFromBanners(manifest.syncPairs ?? []);
 checkInstructionSizeBudgets(manifest.instructionSizeBudgets);
 {
@@ -611,6 +629,49 @@ function checkSyncPairs(pairs: SyncPair[]) {
     }
 
     errors.push(`${pair.id}: unsupported sync mode ${pair.mode}`);
+  }
+}
+
+// Fails any `"mode": "exact"` sync pair whose source still contains an
+// unresolved onboarding placeholder token from the canonical seven-entry
+// table in `idd-onboard.mts` (ONBOARDING_PLACEHOLDERS, mirroring
+// `idd-template/docs/onboarding/placeholders.md`'s "Final placeholder
+// meanings" table) -- not a bare `{{...}}` scan, which would also flag an
+// unrelated GitHub Actions expression such as `${{ github.token }}` inside
+// an imported workflow file. `"exact"` mode copies bytes verbatim with no
+// substitution step, so a leftover token here always leaks into this
+// repository's own live mirror; `checkSyncPairs` above only compares
+// source and target for byte equality and cannot see this, since an
+// identical placeholder on both sides produces zero drift.
+//
+// `idd-doctor.mts`'s own `checkPlaceholders` (see `findPlaceholders` /
+// `isIddManagedPlaceholderScanPath`) is deliberately left unchanged rather
+// than also fixed for the two gaps that let it miss both known bugs of
+// this class (kurone-kito/idd-skill#2899 Background): it scans
+// already-generated repository files for onboarding hygiene in general,
+// not sync-pair sources specifically, so it is not the right place to
+// special-case one sync mode. This check runs earlier, against the
+// sync-pair source before generation, and is the sufficient
+// complementary guard for this specific bug class -- an unresolved
+// placeholder can no longer reach a committed `"exact"`-mode mirror in
+// the first place, so `idd-doctor.mts`'s post-generation scan gaps stay
+// a documented, intentional residual.
+function checkExactModePlaceholders(pairs: SyncPair[]) {
+  const tokens = ONBOARDING_PLACEHOLDERS.map((entry) => entry.token);
+  for (const pair of pairs) {
+    if (pair.mode !== 'exact') {
+      continue;
+    }
+    if (Object.hasOwn(EXACT_MODE_PLACEHOLDER_EXEMPTIONS, pair.id)) {
+      continue;
+    }
+    const source = readText(pair.source);
+    const hits = tokens.filter((token) => source.includes(token));
+    if (hits.length > 0) {
+      errors.push(
+        `${pair.id}: ${pair.source} is "exact" mode but still contains unresolved placeholder(s) ${hits.join(', ')} -- flip to "mode": "concreted" with a matching replacement, or add "${pair.id}" to EXACT_MODE_PLACEHOLDER_EXEMPTIONS with a one-line justification`,
+      );
+    }
   }
 }
 

--- a/src/scripts/audit-docs.mts
+++ b/src/scripts/audit-docs.mts
@@ -632,17 +632,23 @@ function checkSyncPairs(pairs: SyncPair[]) {
   }
 }
 
-// Fails any `"mode": "exact"` sync pair whose source still contains an
-// unresolved onboarding placeholder token from the canonical seven-entry
-// table in `idd-onboard.mts` (ONBOARDING_PLACEHOLDERS, mirroring
-// `idd-template/docs/onboarding/placeholders.md`'s "Final placeholder
-// meanings" table) -- not a bare `{{...}}` scan, which would also flag an
-// unrelated GitHub Actions expression such as `${{ github.token }}` inside
-// an imported workflow file. `"exact"` mode copies bytes verbatim with no
-// substitution step, so a leftover token here always leaks into this
-// repository's own live mirror; `checkSyncPairs` above only compares
-// source and target for byte equality and cannot see this, since an
-// identical placeholder on both sides produces zero drift.
+// Fails any `"mode": "exact"` sync pair whose *post-replacement* source
+// still contains an unresolved onboarding placeholder token from the
+// canonical seven-entry table in `idd-onboard.mts` (ONBOARDING_PLACEHOLDERS,
+// mirroring `idd-template/docs/onboarding/placeholders.md`'s "Final
+// placeholder meanings" table) -- not a bare `{{...}}` scan, which would
+// also flag an unrelated GitHub Actions expression such as
+// `${{ github.token }}` inside an imported workflow file. `"exact"` mode is
+// not itself substitution-free: `checkSyncPairs` above and `sync-docs.mts`
+// both apply `pair.replacements` regardless of mode (`tests/sync-docs.
+// test.mts` covers an "exact" pair with a replacement), so this check must
+// apply the same `applyReplacements` step before scanning, or it would
+// reject a pair whose own `replacements` array already resolves the token
+// (kurone-kito/idd-skill#2899, PR #2904 review). A leftover token *after*
+// replacements always leaks into this repository's own live mirror;
+// `checkSyncPairs` only compares source and target for byte equality and
+// cannot see this on its own, since an identical placeholder on both sides
+// produces zero drift.
 //
 // `idd-doctor.mts`'s own `checkPlaceholders` (see `findPlaceholders` /
 // `isIddManagedPlaceholderScanPath`) is deliberately left unchanged rather
@@ -665,11 +671,14 @@ function checkExactModePlaceholders(pairs: SyncPair[]) {
     if (Object.hasOwn(EXACT_MODE_PLACEHOLDER_EXEMPTIONS, pair.id)) {
       continue;
     }
-    const source = readText(pair.source);
+    const source = applyReplacements(
+      readText(pair.source),
+      pair.replacements ?? [],
+    );
     const hits = tokens.filter((token) => source.includes(token));
     if (hits.length > 0) {
       errors.push(
-        `${pair.id}: ${pair.source} is "exact" mode but still contains unresolved placeholder(s) ${hits.join(', ')} -- flip to "mode": "concreted" with a matching replacement, or add "${pair.id}" to EXACT_MODE_PLACEHOLDER_EXEMPTIONS with a one-line justification`,
+        `${pair.id}: ${pair.source} is "exact" mode but still contains unresolved placeholder(s) ${hits.join(', ')} after applying its replacements -- add a "replacements" entry (or flip to "mode": "concreted" with one), or add "${pair.id}" to EXACT_MODE_PLACEHOLDER_EXEMPTIONS with a one-line justification`,
       );
     }
   }

--- a/src/scripts/audit-docs.mts
+++ b/src/scripts/audit-docs.mts
@@ -175,14 +175,15 @@ const ENGINES_RANGE_MIRRORS: EnginesRangeMirrorSpec[] = [
 ];
 
 // Sync pair `id`s allowed to keep a known onboarding placeholder token
-// literal in an `"exact"`-mode source. `"exact"` mode has no `replacements`
-// array, so any other pair whose source still carries one of these tokens
-// would leak it byte-for-byte into this repository's own live mirror --
-// exactly the bug class checkExactModePlaceholders below exists to catch
+// literal in an `"exact"`-mode pair's *post-replacement* source (see
+// checkExactModePlaceholders below -- "exact" mode is not itself
+// substitution-free, since `checkSyncPairs` above and `sync-docs.mts` both
+// apply a pair's own `replacements` array regardless of mode). Any other
+// pair whose post-replacement source still carries one of these tokens
+// would leak it byte-for-byte into this repository's own live mirror
 // (kurone-kito/idd-skill#2899). Each entry needs a one-line justification;
-// prefer flipping the pair to `"mode": "concreted"` with a matching
-// `replacements` entry over adding here, unless the token is genuinely
-// meant to stay literal.
+// prefer adding (or extending) a `replacements` entry that resolves the
+// token over adding here, unless it is genuinely meant to stay literal.
 const EXACT_MODE_PLACEHOLDER_EXEMPTIONS: Readonly<Record<string, string>> = {
   // `docs/customization.md` is the placeholder-mapping table itself: the
   // literal `{{...}}` tokens ARE the reference content this page teaches

--- a/src/scripts/audit-docs.mts
+++ b/src/scripts/audit-docs.mts
@@ -175,21 +175,22 @@ const ENGINES_RANGE_MIRRORS: EnginesRangeMirrorSpec[] = [
 ];
 
 // Sync pair `id`s allowed to keep a known onboarding placeholder token
-// literal in an `"exact"`-mode pair's *post-replacement* source (see
-// checkExactModePlaceholders below -- "exact" mode is not itself
-// substitution-free, since `checkSyncPairs` above and `sync-docs.mts` both
-// apply a pair's own `replacements` array regardless of mode). Any other
-// pair whose post-replacement source still carries one of these tokens
-// would leak it byte-for-byte into this repository's own live mirror
-// (kurone-kito/idd-skill#2899). Each entry needs a one-line justification;
-// prefer adding (or extending) a `replacements` entry that resolves the
-// token over adding here, unless it is genuinely meant to stay literal.
-const EXACT_MODE_PLACEHOLDER_EXEMPTIONS: Readonly<Record<string, string>> = {
-  // `docs/customization.md` is the placeholder-mapping table itself: the
-  // literal `{{...}}` tokens ARE the reference content this page teaches
-  // adopters, not an unresolved leftover from a live marker instance.
-  'customization-doc': 'documents the placeholder-mapping table for adopters',
-};
+// literal in an `"exact"`- or `"concreted"`-mode pair's *post-replacement*
+// source (see checkGeneratedModePlaceholders below -- both modes apply a
+// pair's own `replacements` array the same way; neither is substitution-free
+// by mode name alone). Any other pair whose post-replacement source still
+// carries one of these tokens would leak it byte-for-byte into this
+// repository's own live mirror (kurone-kito/idd-skill#2899, PR #2904
+// review). Each entry needs a one-line justification; prefer adding (or
+// extending) a `replacements` entry that resolves the token over adding
+// here, unless it is genuinely meant to stay literal.
+const GENERATED_MODE_PLACEHOLDER_EXEMPTIONS: Readonly<Record<string, string>> =
+  {
+    // `docs/customization.md` is the placeholder-mapping table itself: the
+    // literal `{{...}}` tokens ARE the reference content this page teaches
+    // adopters, not an unresolved leftover from a live marker instance.
+    'customization-doc': 'documents the placeholder-mapping table for adopters',
+  };
 
 checkReadmePairs(manifest.readmePairs ?? []);
 checkFileSets(manifest.fileSets ?? [], manifest.syncPairs ?? []);
@@ -199,7 +200,7 @@ checkShellFileLists(
   manifest.generatedBlocks ?? [],
 );
 checkSyncPairs(manifest.syncPairs ?? []);
-checkExactModePlaceholders(manifest.syncPairs ?? []);
+checkGeneratedModePlaceholders(manifest.syncPairs ?? []);
 checkGeneratedFromBanners(manifest.syncPairs ?? []);
 checkInstructionSizeBudgets(manifest.instructionSizeBudgets);
 {
@@ -633,23 +634,25 @@ function checkSyncPairs(pairs: SyncPair[]) {
   }
 }
 
-// Fails any `"mode": "exact"` sync pair whose *post-replacement* source
-// still contains an unresolved onboarding placeholder token from the
-// canonical seven-entry table in `idd-onboard.mts` (ONBOARDING_PLACEHOLDERS,
-// mirroring `idd-template/docs/onboarding/placeholders.md`'s "Final
-// placeholder meanings" table) -- not a bare `{{...}}` scan, which would
-// also flag an unrelated GitHub Actions expression such as
-// `${{ github.token }}` inside an imported workflow file. `"exact"` mode is
-// not itself substitution-free: `checkSyncPairs` above and `sync-docs.mts`
-// both apply `pair.replacements` regardless of mode (`tests/sync-docs.
-// test.mts` covers an "exact" pair with a replacement), so this check must
-// apply the same `applyReplacements` step before scanning, or it would
-// reject a pair whose own `replacements` array already resolves the token
-// (kurone-kito/idd-skill#2899, PR #2904 review). A leftover token *after*
-// replacements always leaks into this repository's own live mirror;
-// `checkSyncPairs` only compares source and target for byte equality and
-// cannot see this on its own, since an identical placeholder on both sides
-// produces zero drift.
+// Fails any `"exact"`- or `"concreted"`-mode sync pair whose
+// *post-replacement* source still contains an unresolved onboarding
+// placeholder token from the canonical seven-entry table in
+// `idd-onboard.mts` (ONBOARDING_PLACEHOLDERS, mirroring `idd-template/docs/
+// onboarding/placeholders.md`'s "Final placeholder meanings" table) -- not
+// a bare `{{...}}` scan, which would also flag an unrelated GitHub Actions
+// expression such as `${{ github.token }}` inside an imported workflow
+// file. Both modes need this check, not just `"exact"`: `checkSyncPairs`
+// above and `sync-docs.mts` treat `"exact"` and `"concreted"` identically
+// (`pair.mode === 'exact' || pair.mode === 'concreted'`), applying
+// `pair.replacements` regardless of mode (`tests/sync-docs.test.mts`
+// covers an `"exact"` pair with a replacement) -- so an incomplete
+// `replacements` array on a `"concreted"` pair (or a new placeholder its
+// existing entries don't cover) is exactly the same live-leak risk as an
+// `"exact"` pair with none at all (kurone-kito/idd-skill#2899, PR #2904
+// review, Codex). A leftover token *after* replacements always leaks into
+// this repository's own live mirror; `checkSyncPairs` only compares
+// source and target for byte equality and cannot see this on its own,
+// since an identical placeholder on both sides produces zero drift.
 //
 // `idd-doctor.mts`'s own `checkPlaceholders` (see `findPlaceholders` /
 // `isIddManagedPlaceholderScanPath`) is deliberately left unchanged rather
@@ -657,19 +660,19 @@ function checkSyncPairs(pairs: SyncPair[]) {
 // this class (kurone-kito/idd-skill#2899 Background): it scans
 // already-generated repository files for onboarding hygiene in general,
 // not sync-pair sources specifically, so it is not the right place to
-// special-case one sync mode. This check runs earlier, against the
+// special-case these two sync modes. This check runs earlier, against the
 // sync-pair source before generation, and is the sufficient
 // complementary guard for this specific bug class -- an unresolved
-// placeholder can no longer reach a committed `"exact"`-mode mirror in
-// the first place, so `idd-doctor.mts`'s post-generation scan gaps stay
-// a documented, intentional residual.
-function checkExactModePlaceholders(pairs: SyncPair[]) {
+// placeholder can no longer reach a committed generated mirror in the
+// first place, so `idd-doctor.mts`'s post-generation scan gaps stay a
+// documented, intentional residual.
+function checkGeneratedModePlaceholders(pairs: SyncPair[]) {
   const tokens = ONBOARDING_PLACEHOLDERS.map((entry) => entry.token);
   for (const pair of pairs) {
-    if (pair.mode !== 'exact') {
+    if (pair.mode !== 'exact' && pair.mode !== 'concreted') {
       continue;
     }
-    if (Object.hasOwn(EXACT_MODE_PLACEHOLDER_EXEMPTIONS, pair.id)) {
+    if (Object.hasOwn(GENERATED_MODE_PLACEHOLDER_EXEMPTIONS, pair.id)) {
       continue;
     }
     const source = applyReplacements(
@@ -679,7 +682,7 @@ function checkExactModePlaceholders(pairs: SyncPair[]) {
     const hits = tokens.filter((token) => source.includes(token));
     if (hits.length > 0) {
       errors.push(
-        `${pair.id}: ${pair.source} is "exact" mode but still contains unresolved placeholder(s) ${hits.join(', ')} after applying its replacements -- add a "replacements" entry (or flip to "mode": "concreted" with one), or add "${pair.id}" to EXACT_MODE_PLACEHOLDER_EXEMPTIONS with a one-line justification`,
+        `${pair.id}: ${pair.source} is "${pair.mode}" mode but still contains unresolved placeholder(s) ${hits.join(', ')} after applying its replacements -- add or extend a "replacements" entry to resolve them, or add "${pair.id}" to GENERATED_MODE_PLACEHOLDER_EXEMPTIONS with a one-line justification`,
       );
     }
   }

--- a/tests/audit-docs-exact-mode-placeholders.test.mts
+++ b/tests/audit-docs-exact-mode-placeholders.test.mts
@@ -9,12 +9,16 @@ import { fileURLToPath } from 'node:url';
 import { fixtureEnv } from './test-utils.mts';
 
 // Coverage for checkExactModePlaceholders in src/scripts/audit-docs.mts
-// (kurone-kito/idd-skill#2899): a `"mode": "exact"` sync pair has no
-// `replacements` array, so an unresolved onboarding placeholder token
-// (e.g. `{{PROJECT_MARKER_PREFIX}}`) left in its source leaks byte-for-byte
-// into this repository's own live mirror -- checkSyncPairs alone cannot see
-// this, since an identical placeholder on both sides of an "exact" pair
-// produces zero drift. Same subprocess-fixture pattern as
+// (kurone-kito/idd-skill#2899): an unresolved onboarding placeholder token
+// (e.g. `{{PROJECT_MARKER_PREFIX}}`) left in a `"mode": "exact"` pair's
+// *post-replacement* source leaks byte-for-byte into this repository's own
+// live mirror -- checkSyncPairs alone cannot see this, since an identical
+// placeholder on both sides of an "exact" pair produces zero drift. "exact"
+// mode is not itself substitution-free (PR #2904 review, Copilot): both
+// checkSyncPairs and sync-docs.mts apply a pair's own `replacements` array
+// regardless of mode, so the guard must do the same before reporting a
+// remaining placeholder, or it would reject a pair whose own replacement
+// already resolves the token. Same subprocess-fixture pattern as
 // tests/audit-docs-file-sets.test.mts (checkExactModePlaceholders is not
 // exported; the module is a top-level side-effecting CLI script).
 
@@ -114,6 +118,38 @@ test('the same pair passes once flipped to "concreted" with a matching replaceme
   writeFile(
     dir,
     'docs/fixture-guide.md',
+    '# Fixture guide\n\nMarker syntax: `<!-- idd-skill-roadmap-id: ... -->`\n',
+  );
+
+  const result = runAuditDocs(dir);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+});
+
+test('an "exact" mode pair whose own replacements resolve the placeholder passes', (t) => {
+  // "exact" mode is not substitution-free: checkSyncPairs and sync-docs.mts
+  // both apply `pair.replacements` regardless of mode (tests/sync-
+  // docs.test.mts covers this same "exact" + replacements combination), so
+  // checkExactModePlaceholders must scan the post-replacement source, not
+  // the raw one.
+  const { dir, cleanup } = makeFixture([
+    {
+      id: 'fixture-exact-with-replacement',
+      source: 'idd-template/docs/fixture-resolved.md',
+      target: 'docs/fixture-resolved.md',
+      mode: 'exact',
+      replacements: [{ from: PLACEHOLDER_TOKEN, to: 'idd-skill' }],
+    },
+  ]);
+  t.after(cleanup);
+
+  writeFile(
+    dir,
+    'idd-template/docs/fixture-resolved.md',
+    `# Fixture guide\n\nMarker syntax: \`<!-- ${PLACEHOLDER_TOKEN}-roadmap-id: ... -->\`\n`,
+  );
+  writeFile(
+    dir,
+    'docs/fixture-resolved.md',
     '# Fixture guide\n\nMarker syntax: `<!-- idd-skill-roadmap-id: ... -->`\n',
   );
 

--- a/tests/audit-docs-exact-mode-placeholders.test.mts
+++ b/tests/audit-docs-exact-mode-placeholders.test.mts
@@ -8,19 +8,21 @@ import { fileURLToPath } from 'node:url';
 
 import { fixtureEnv } from './test-utils.mts';
 
-// Coverage for checkExactModePlaceholders in src/scripts/audit-docs.mts
+// Coverage for checkGeneratedModePlaceholders in src/scripts/audit-docs.mts
 // (kurone-kito/idd-skill#2899): an unresolved onboarding placeholder token
-// (e.g. `{{PROJECT_MARKER_PREFIX}}`) left in a `"mode": "exact"` pair's
-// *post-replacement* source leaks byte-for-byte into this repository's own
-// live mirror -- checkSyncPairs alone cannot see this, since an identical
-// placeholder on both sides of an "exact" pair produces zero drift. "exact"
-// mode is not itself substitution-free (PR #2904 review, Copilot): both
-// checkSyncPairs and sync-docs.mts apply a pair's own `replacements` array
-// regardless of mode, so the guard must do the same before reporting a
-// remaining placeholder, or it would reject a pair whose own replacement
-// already resolves the token. Same subprocess-fixture pattern as
-// tests/audit-docs-file-sets.test.mts (checkExactModePlaceholders is not
-// exported; the module is a top-level side-effecting CLI script).
+// (e.g. `{{PROJECT_MARKER_PREFIX}}`) left in an `"exact"`- or
+// `"concreted"`-mode pair's *post-replacement* source leaks byte-for-byte
+// into this repository's own live mirror -- checkSyncPairs alone cannot see
+// this, since an identical placeholder on both sides produces zero drift.
+// Neither mode is substitution-free by name alone (PR #2904 review,
+// Copilot + Codex): checkSyncPairs and sync-docs.mts both apply a pair's
+// own `replacements` array regardless of mode, so the guard must do the
+// same before reporting a remaining placeholder -- both to avoid rejecting
+// a pair whose own replacement already resolves the token, and to still
+// catch a `"concreted"` pair whose `replacements` array is missing or
+// incomplete. Same subprocess-fixture pattern as
+// tests/audit-docs-file-sets.test.mts (checkGeneratedModePlaceholders is
+// not exported; the module is a top-level side-effecting CLI script).
 
 const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
 const PLACEHOLDER_TOKEN = '{{PROJECT_MARKER_PREFIX}}';
@@ -85,7 +87,7 @@ test('"exact" mode pair whose source still carries a known placeholder fails', (
   t.after(cleanup);
 
   // Source and target are identical so checkSyncPairs itself sees no drift
-  // and this failure is isolated to checkExactModePlaceholders alone.
+  // and this failure is isolated to checkGeneratedModePlaceholders alone.
   const content = `# Fixture guide\n\nMarker syntax: \`<!-- ${PLACEHOLDER_TOKEN}-roadmap-id: ... -->\`\n`;
   writeFile(dir, 'idd-template/docs/fixture-guide.md', content);
   writeFile(dir, 'docs/fixture-guide.md', content);
@@ -125,12 +127,44 @@ test('the same pair passes once flipped to "concreted" with a matching replaceme
   assert.equal(result.status, 0, result.stderr || result.stdout);
 });
 
+test('a "concreted" mode pair whose replacements do not resolve a placeholder fails', (t) => {
+  // Codex (PR #2904 review): the guard originally skipped every
+  // "concreted" pair outright, so an incomplete or missing replacement on
+  // a "concreted" pair -- the same live-leak risk as an "exact" pair with
+  // no replacements at all -- went uncaught. checkSyncPairs alone cannot
+  // catch it either: an identical leftover placeholder on both source and
+  // target sides of a "concreted" pair still produces zero byte-drift.
+  const { dir, cleanup } = makeFixture([
+    {
+      id: 'fixture-concreted-incomplete',
+      source: 'idd-template/docs/fixture-incomplete.md',
+      target: 'docs/fixture-incomplete.md',
+      mode: 'concreted',
+      // Resolves an unrelated token, leaving PLACEHOLDER_TOKEN itself
+      // untouched -- an incomplete `replacements` array, not an absent one.
+      replacements: [{ from: '{{REPO_NAME}}', to: 'idd-skill' }],
+    },
+  ]);
+  t.after(cleanup);
+
+  const content = `# Fixture guide\n\nMarker syntax: \`<!-- ${PLACEHOLDER_TOKEN}-roadmap-id: ... -->\`\n`;
+  writeFile(dir, 'idd-template/docs/fixture-incomplete.md', content);
+  writeFile(dir, 'docs/fixture-incomplete.md', content);
+
+  const result = runAuditDocs(dir);
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /fixture-concreted-incomplete: idd-template\/docs\/fixture-incomplete\.md is "concreted" mode but still contains unresolved placeholder\(s\) \{\{PROJECT_MARKER_PREFIX\}\}/,
+  );
+});
+
 test('an "exact" mode pair whose own replacements resolve the placeholder passes', (t) => {
   // "exact" mode is not substitution-free: checkSyncPairs and sync-docs.mts
   // both apply `pair.replacements` regardless of mode (tests/sync-
   // docs.test.mts covers this same "exact" + replacements combination), so
-  // checkExactModePlaceholders must scan the post-replacement source, not
-  // the raw one.
+  // checkGeneratedModePlaceholders must scan the post-replacement source,
+  // not the raw one.
   const { dir, cleanup } = makeFixture([
     {
       id: 'fixture-exact-with-replacement',
@@ -159,7 +193,7 @@ test('an "exact" mode pair whose own replacements resolve the placeholder passes
 
 test('an exempted "exact" mode pair passes despite an unresolved placeholder', (t) => {
   // "customization-doc" is the one real entry in audit-docs.mts's
-  // EXACT_MODE_PLACEHOLDER_EXEMPTIONS constant -- the exemption is an
+  // GENERATED_MODE_PLACEHOLDER_EXEMPTIONS constant -- the exemption is an
   // id-keyed allowlist inside the script itself, not a manifest field, so
   // exercising it means reusing that exact id here rather than an
   // arbitrary fixture name.

--- a/tests/audit-docs-exact-mode-placeholders.test.mts
+++ b/tests/audit-docs-exact-mode-placeholders.test.mts
@@ -1,0 +1,146 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { fixtureEnv } from './test-utils.mts';
+
+// Coverage for checkExactModePlaceholders in src/scripts/audit-docs.mts
+// (kurone-kito/idd-skill#2899): a `"mode": "exact"` sync pair has no
+// `replacements` array, so an unresolved onboarding placeholder token
+// (e.g. `{{PROJECT_MARKER_PREFIX}}`) left in its source leaks byte-for-byte
+// into this repository's own live mirror -- checkSyncPairs alone cannot see
+// this, since an identical placeholder on both sides of an "exact" pair
+// produces zero drift. Same subprocess-fixture pattern as
+// tests/audit-docs-file-sets.test.mts (checkExactModePlaceholders is not
+// exported; the module is a top-level side-effecting CLI script).
+
+const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
+const PLACEHOLDER_TOKEN = '{{PROJECT_MARKER_PREFIX}}';
+
+interface RunResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runAuditDocs(cwd: string): RunResult {
+  try {
+    const stdout = execFileSync(
+      process.execPath,
+      [join(REPO_ROOT, 'scripts', 'audit-docs.mjs'), '--check'],
+      {
+        cwd,
+        env: fixtureEnv(),
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
+    return { status: 0, stdout, stderr: '' };
+  } catch (error) {
+    const e = error as { status?: unknown; stdout?: unknown; stderr?: unknown };
+    return {
+      status: typeof e.status === 'number' ? e.status : 1,
+      stdout: typeof e.stdout === 'string' ? e.stdout : '',
+      stderr: typeof e.stderr === 'string' ? e.stderr : '',
+    };
+  }
+}
+
+function writeFile(dir: string, relativePath: string, content: string) {
+  const absolute = join(dir, relativePath);
+  mkdirSync(dirname(absolute), { recursive: true });
+  writeFileSync(absolute, content, 'utf8');
+}
+
+function makeFixture(syncPairs: unknown[]): {
+  dir: string;
+  cleanup: () => void;
+} {
+  const dir = mkdtempSync(join(tmpdir(), 'audit-docs-exact-placeholders-'));
+  execFileSync('git', ['init', '--quiet'], { cwd: dir, env: fixtureEnv() });
+  writeFile(dir, 'audit/sync-manifest.json', JSON.stringify({ syncPairs }));
+  return {
+    dir,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+test('"exact" mode pair whose source still carries a known placeholder fails', (t) => {
+  const { dir, cleanup } = makeFixture([
+    {
+      id: 'fixture-exact-placeholder',
+      source: 'idd-template/docs/fixture-guide.md',
+      target: 'docs/fixture-guide.md',
+      mode: 'exact',
+    },
+  ]);
+  t.after(cleanup);
+
+  // Source and target are identical so checkSyncPairs itself sees no drift
+  // and this failure is isolated to checkExactModePlaceholders alone.
+  const content = `# Fixture guide\n\nMarker syntax: \`<!-- ${PLACEHOLDER_TOKEN}-roadmap-id: ... -->\`\n`;
+  writeFile(dir, 'idd-template/docs/fixture-guide.md', content);
+  writeFile(dir, 'docs/fixture-guide.md', content);
+
+  const result = runAuditDocs(dir);
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /fixture-exact-placeholder: idd-template\/docs\/fixture-guide\.md is "exact" mode but still contains unresolved placeholder\(s\) \{\{PROJECT_MARKER_PREFIX\}\}/,
+  );
+});
+
+test('the same pair passes once flipped to "concreted" with a matching replacement', (t) => {
+  const { dir, cleanup } = makeFixture([
+    {
+      id: 'fixture-exact-placeholder',
+      source: 'idd-template/docs/fixture-guide.md',
+      target: 'docs/fixture-guide.md',
+      mode: 'concreted',
+      replacements: [{ from: PLACEHOLDER_TOKEN, to: 'idd-skill' }],
+    },
+  ]);
+  t.after(cleanup);
+
+  writeFile(
+    dir,
+    'idd-template/docs/fixture-guide.md',
+    `# Fixture guide\n\nMarker syntax: \`<!-- ${PLACEHOLDER_TOKEN}-roadmap-id: ... -->\`\n`,
+  );
+  writeFile(
+    dir,
+    'docs/fixture-guide.md',
+    '# Fixture guide\n\nMarker syntax: `<!-- idd-skill-roadmap-id: ... -->`\n',
+  );
+
+  const result = runAuditDocs(dir);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+});
+
+test('an exempted "exact" mode pair passes despite an unresolved placeholder', (t) => {
+  // "customization-doc" is the one real entry in audit-docs.mts's
+  // EXACT_MODE_PLACEHOLDER_EXEMPTIONS constant -- the exemption is an
+  // id-keyed allowlist inside the script itself, not a manifest field, so
+  // exercising it means reusing that exact id here rather than an
+  // arbitrary fixture name.
+  const { dir, cleanup } = makeFixture([
+    {
+      id: 'customization-doc',
+      source: 'idd-template/docs/fixture-customization.md',
+      target: 'docs/fixture-customization.md',
+      mode: 'exact',
+    },
+  ]);
+  t.after(cleanup);
+
+  const content = `# Placeholders\n\n| Placeholder | Meaning |\n| --- | --- |\n| \`${PLACEHOLDER_TOKEN}\` | marker prefix |\n`;
+  writeFile(dir, 'idd-template/docs/fixture-customization.md', content);
+  writeFile(dir, 'docs/fixture-customization.md', content);
+
+  const result = runAuditDocs(dir);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+});

--- a/tests/helper-runtime-profiles.test.mts
+++ b/tests/helper-runtime-profiles.test.mts
@@ -462,7 +462,15 @@ test('helper script docs keep the discover viability gate helper in sync', () =>
     'utf8',
   );
 
-  assert.equal(template, live);
+  // `idd-helper-scripts-doc` is `"mode": "concreted"` (audit/sync-manifest.json,
+  // kurone-kito/idd-skill#2899): the live mirror resolves the template's
+  // `{{PROJECT_MARKER_PREFIX}}` placeholder to this repository's own
+  // `idd-skill` marker prefix, so the two files are no longer expected to
+  // be byte-identical -- apply the same replacement before comparing.
+  assert.equal(
+    template.split('{{PROJECT_MARKER_PREFIX}}').join('idd-skill'),
+    live,
+  );
   assert.match(live, /discover-roadmap-graph\.mjs/);
   assert.match(live, /Discover Roadmap Graph Contract/);
   assert.match(live, /discover-viability-gate\.mjs/);


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Fixes two `"mode": "exact"` sync pairs that leaked an unresolved
`{{PROJECT_MARKER_PREFIX}}` handlebars placeholder into this
repository's own live mirrors (the same bug class PR #2894 fixed for
`idd-review-triage-instructions`), and adds a mechanical guard so
this bug class fails CI instead of landing silently again:

1. **`idd-overview-appendix-instructions`** flipped from `"exact"` to
   `"concreted"` with the standard `{{PROJECT_MARKER_PREFIX}}` ->
   `idd-skill` replacement. `.github/instructions/idd-overview-
   appendix.instructions.md` now carries the resolved
   `idd-skill-upstream-candidate` marker instead of the placeholder
   literal.
2. **Investigated `idd-helper-scripts-doc`** (three occurrences in
   `docs/idd-helper-scripts.md`, describing the actual `<!--
   ...-roadmap-id -->` / `<!-- ...-blocked-by -->` marker syntax
   `discover-roadmap-graph.mjs` recognizes when run against this
   repository) and concluded it is the **same live bug**, not a
   legitimate false positive: `docs/idd-design-rationale.md` already
   shows the resolved `idd-skill-` prefix for the same
   describe-a-live-marker role, and `idd-helper-scripts-doc` is not
   among the contract's literal-placeholder exceptions (`docs/
   customization.md`'s deliberate placeholder-mapping glossary table
   is the one legitimate exception, and it is unrelated in purpose).
   Flipped to `"concreted"` with the same replacement and re-synced.
3. **Added `checkExactModePlaceholders`** to `src/scripts/audit-
   docs.mts` (root-cause fix): fails any `"exact"`-mode sync pair
   whose source still contains a token from the seven-entry
   onboarding placeholder table (reusing `ONBOARDING_PLACEHOLDERS`
   from `idd-onboard.mts` rather than a second hardcoded list), not a
   bare `{{...}}` scan that would false-positive on something like
   `${{ github.token }}` in an imported workflow file. A pair-id-keyed
   `EXACT_MODE_PLACEHOLDER_EXEMPTIONS` constant covers the one
   legitimate exception (`customization-doc`) with an inline
   justification. A code comment on the new check records that `idd-
   doctor.mts`'s own placeholder-scan gaps (`.github/instructions/`
   exclusion in dogfooding mode; inline-code-span stripping under
   `docs/`) are deliberately left as-is -- this new, earlier,
   sync-pair-source-scoped check is the sufficient complementary
   guard, since it stops an unresolved token from reaching a committed
   mirror in the first place.

A collateral test fix was needed: `tests/helper-runtime-
profiles.test.mts` asserted `idd-template/docs/idd-helper-
scripts.md` and `docs/idd-helper-scripts.md` were byte-identical --
exactly the assumption that hid the bug fixed in commit 2 above. It
now applies the same `{{PROJECT_MARKER_PREFIX}}` -> `idd-skill`
replacement before comparing.

`node scripts/audit-docs.mjs --check` and `node scripts/idd-
doctor.mjs` both exit 0 on the current tree.

## Linked issue

Closes #2899

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Item 2's discriminators (per the issue body): `idd-helper-scripts-doc`
is not in the contract's literal-placeholder exception list, and
`docs/idd-design-rationale.md` already establishes the convention of
showing this repository's resolved `idd-skill-` marker prefix when
describing a real, live marker instance (as opposed to `docs/
customization.md`'s glossary table, which is *about* the placeholder
syntax itself). The three `idd-helper-scripts.md` occurrences describe
`discover-roadmap-graph.mjs`'s actual recognized marker syntax when
run against this repository, matching the live-instance role, not the
glossary role -- hence "live bug", not "false positive".

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [x] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiWpghp4ViMu6DUDKLzzxz
