### PR TITLE
docs(idd-workflow): namespace delegated-worker scratchpad filenames

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -524,6 +524,12 @@ variant](../../docs/idd-workflow.md#orchestrator-fan-out-variant));
 without it, a worker can stall indefinitely on an unconfirmed
 backgrounded wait (#2210).
 
+**Restate the scratchpad file-naming requirement.** See
+[docs/idd-workflow.md's Orchestrator fan-out
+variant](../../docs/idd-workflow.md#orchestrator-fan-out-variant):
+each worker must prefix scratchpad filenames with the issue number,
+or use an issue-numbered subdirectory.
+
 ### Hide displaced claim chain on takeover
 
 When the verified new claim used `supersedes: <prior-id>` (stale

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -817,6 +817,22 @@ Running this variant safely requires:
   worker reports its final result back to the orchestrator instead of
   independently entering F5's Discover step, so Discover/Claim
   ownership stays with the orchestrator alone.
+- **A delegation brief that requires issue-number-namespaced
+  scratchpad filenames.** Concurrently delegated workers share the
+  orchestrating session's own scratchpad directory — it is
+  session-scoped, not subagent-scoped — so a generic filename
+  (`pr-body.md`, `commit-msg.txt`, `plan-draft.md`, etc.) written by
+  one worker's brief can collide with, and be silently overwritten
+  by, a sibling worker's own brief producing the same name. Each
+  delegation brief must instruct its worker to prefix every
+  scratchpad file it creates with the issue number (for example
+  `2878-pr-body.md`), or to create and use an issue-numbered
+  scratchpad subdirectory, instead of a generic filename a sibling
+  worker's own brief might independently produce too (observed
+  2026-09-10, kurone-kito/idd-skill#2900). This is a separate
+  requirement from the background-wait topology-safety condition
+  above — a namespacing convention for concurrent scratchpad writes,
+  not a wake-up-discipline concern.
 - **The delegation brief carries the claim token verbatim, nonce
   included — and the worker actively revalidates it.** The worker
   adopts the orchestrator's already-verified `{agent-id}` / `{claim-id}`

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -821,14 +821,14 @@ Running this variant safely requires:
   scratchpad filenames.** Concurrently delegated workers share the
   orchestrating session's own scratchpad directory — it is
   session-scoped, not subagent-scoped — so a generic filename
-  (`pr-body.md`, `commit-msg.txt`, `plan-draft.md`, etc.) written by
-  one worker's brief can collide with, and be silently overwritten
-  by, a sibling worker's own brief producing the same name. Each
-  delegation brief must instruct its worker to prefix every
-  scratchpad file it creates with the issue number (for example
-  `2878-pr-body.md`), or to create and use an issue-numbered
+  (`pr-body.md`, `commit-msg.txt`, `plan-draft.md`, etc.) one worker
+  writes under its brief can collide with, and be silently
+  overwritten by, a sibling worker writing the same name under its
+  own brief. Each delegation brief must instruct its worker to
+  prefix every scratchpad file it creates with the issue number (for
+  example `2878-pr-body.md`), or to create and use an issue-numbered
   scratchpad subdirectory, instead of a generic filename a sibling
-  worker's own brief might independently produce too (observed
+  worker might independently produce too under its own brief (observed
   2026-09-10, kurone-kito/idd-skill#2900). This is a separate
   requirement from the background-wait topology-safety condition
   above — a namespacing convention for concurrent scratchpad writes,

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -519,6 +519,12 @@ variant](../../docs/idd-workflow.md#orchestrator-fan-out-variant));
 without it, a worker can stall indefinitely on an unconfirmed
 backgrounded wait (#2210).
 
+**Restate the scratchpad file-naming requirement.** See
+[docs/idd-workflow.md's Orchestrator fan-out
+variant](../../docs/idd-workflow.md#orchestrator-fan-out-variant):
+each worker must prefix scratchpad filenames with the issue number,
+or use an issue-numbered subdirectory.
+
 ### Hide displaced claim chain on takeover
 
 When the verified new claim used `supersedes: <prior-id>` (stale

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -798,6 +798,23 @@ Running this variant safely requires:
   reports its final result back to the orchestrator instead of
   independently entering F5's Discover step, so Discover/Claim
   ownership stays with the orchestrator alone.
+- **A delegation brief that requires issue-number-namespaced
+  scratchpad filenames.** Concurrently delegated workers can share
+  the orchestrating session's own scratchpad directory —
+  session-scoped rather than subagent-scoped in at least one harness
+  (e.g. Claude Code) — so a generic filename (`pr-body.md`,
+  `commit-msg.txt`, `plan-draft.md`, etc.) written by one worker's
+  brief can collide with, and be silently overwritten by, a sibling
+  worker's own brief producing the same name. Each delegation brief
+  must instruct its worker to prefix every scratchpad file it
+  creates with the issue number (for example `2878-pr-body.md`), or
+  to create and use an issue-numbered scratchpad subdirectory,
+  instead of a generic filename a sibling worker's own brief might
+  independently produce too (observed 2026-09-10,
+  kurone-kito/idd-skill#2900). This is a separate requirement from
+  the background-wait topology-safety condition above — a
+  namespacing convention for concurrent scratchpad writes, not a
+  wake-up-discipline concern.
 - **The delegation brief carries the claim token verbatim, nonce
   included — and the worker actively revalidates it.** The worker
   adopts the orchestrator's already-verified `{agent-id}` / `{claim-id}`

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -803,14 +803,15 @@ Running this variant safely requires:
   the orchestrating session's own scratchpad directory —
   session-scoped rather than subagent-scoped in at least one harness
   (e.g. Claude Code) — so a generic filename (`pr-body.md`,
-  `commit-msg.txt`, `plan-draft.md`, etc.) written by one worker's
-  brief can collide with, and be silently overwritten by, a sibling
-  worker's own brief producing the same name. Each delegation brief
-  must instruct its worker to prefix every scratchpad file it
-  creates with the issue number (for example `2878-pr-body.md`), or
-  to create and use an issue-numbered scratchpad subdirectory,
-  instead of a generic filename a sibling worker's own brief might
-  independently produce too (observed 2026-09-10,
+  `commit-msg.txt`, `plan-draft.md`, etc.) one worker writes under
+  its brief can collide with, and be silently overwritten by, a
+  sibling worker writing the same name under its own brief. Each
+  delegation brief must instruct its worker to prefix every
+  scratchpad file it creates with the issue number (for example
+  `2878-pr-body.md`), or to create and use an issue-numbered
+  scratchpad subdirectory, instead of a generic filename a sibling
+  worker might independently produce too under its own brief
+  (observed 2026-09-10,
   kurone-kito/idd-skill#2900). This is a separate requirement from
   the background-wait topology-safety condition above — a
   namespacing convention for concurrent scratchpad writes, not a


### PR DESCRIPTION
# Summary

Adds one delegation-brief requirement to the Orchestrator fan-out
variant: each worker must prefix every scratchpad file it creates with
the issue number (for example `2878-pr-body.md`), or create and use an
issue-numbered scratchpad subdirectory, instead of a generic filename
(`pr-body.md`, `commit-msg.txt`, `plan-draft.md`, etc.) a concurrently
delegated sibling worker's own brief might independently produce too.
Concurrently delegated workers share the orchestrating session's own
scratchpad directory — it is session-scoped, not subagent-scoped (at
least under Claude Code, the harness that produced the observed
incident) — so a generic scratch filename can be silently overwritten
by a sibling worker.

Stated in `docs/idd-workflow.md`'s Orchestrator fan-out variant section
(both the dogfood copy and the `idd-template/` portable mirror — the
template copy hedges the session-scoped-vs-subagent-scoped mechanism
claim as harness-specific rather than universal, since it ships to
Codex/Copilot/OpenCode/Grok adopters too) and cross-referenced from
`idd-claim.instructions.md`'s Orchestrator delegation section (edited
at its canonical `idd-template/` source and regenerated via
`sync-docs.mjs --apply`). The added text is scoped to scratchpad file
naming only and does not touch the existing background-wait /
wake-up-discipline topology-safety wording in either file.

## Linked issue

Closes #2900

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Observed 2026-09-10 (UTC) in a live Orchestrator fan-out variant run on
this repository: one orchestrating session delegated B-through-F4
execution for four issues (#2878, #2885, #2892, #2896) to four separate
`general-purpose` subagent workers in the same run, none of whose
delegation briefs specified a scratchpad file-naming convention. The
orchestrator's own scratchpad directory ended up with several
issue-number-less filenames (`pr-body.md`, `commit-msg.txt`,
`plan-draft.md`, etc.) written by different workers, and the worker
delegated for #2892 flagged a `pr-body.md` collision with a sibling
worker's #2896 work directly in its final report.

The instructions-file wording (`idd-claim.instructions.md`) stays
deliberately terse and carries no incident citation: the per-file
`instructionSizeBudgets` cap on that file had only 293 bytes of
headroom before this change (now 17), and a brand-new
`.github/instructions/` passage naming a failure mode is exempt from
the citation requirement in
`docs/idd-design-rationale.md#cite-the-observed-incident`.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDJpTELrY2SnjHW9m5Aw7i
