### PR TITLE
docs(idd-helper-scripts): extend signed-commit wrapper to commits

### DIFF
--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -375,18 +375,18 @@ post the plan retroactively with an explicit note about the
 reordering, and run the C1 critique pass against the completed diff.
 
 Implement the plan, running **fix-validate** before each atomic commit
-(one logical change per commit).
+(one logical change per commit). Non-interactive-hostile signing: use
+the [signed-commit merge wrapper](../../docs/idd-helper-scripts.md#signed-commit-merge-wrapper-shared-git-procedure)
+instead.
 
 **Verify a commit actually landed before trusting a subsequent push.**
-A `commit-msg` hook (for example commitlint's body-max-line-length) can
-silently reject a commit with a long single-line body, so no commit is
-created — but the following `git push` then reports "Everything
-up-to-date", which reads as a normal no-op rather than the actual
-failure. Prefer `git commit -F <file>` with a pre-wrapped body file
-over a long single-line `-m` message to avoid tripping the hook in the
-first place, and confirm the commit landed (compare `git rev-parse HEAD`
-before/after, or check the commit hash the commit command reports)
-before treating a subsequent push as confirmation the change landed.
+A `commit-msg` hook (e.g. commitlint's body-max-line-length) can
+silently reject a long single-line body, so no commit is created but
+the next `git push` reports "Everything up-to-date" — a misleading
+no-op. Prefer `git commit -F <file>` with a pre-wrapped body over a
+long `-m` message, and confirm the commit landed (compare `git
+rev-parse HEAD` before/after, or check the reported commit hash)
+before trusting the push.
 
 **De-duplication refactors**: when consolidating a wrapper function used
 at multiple call sites, check whether any call site's old delegate path

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -3538,9 +3538,26 @@ process tree — if `pgrep`/`ps` (or an equivalent process-listing and
 signaling mechanism) are not available on the host, that dependency
 cannot be met: stop and post a hold note rather than falling back
 without the cleanup guarantee, the same fail-closed treatment the
-`lsof` case below already gets. Otherwise, snapshot the whole set to
-signal: the git PID itself **and** its descendants, found by walking
-from the git PID (for example, recursively via `pgrep -P`) — a
+`lsof` case below already gets. It also depends on already knowing
+which process is this invocation's own: "the git PID" below is the PID
+recorded when this wrapper invocation itself was launched, never one
+recovered afterward by searching the process table — launch the
+wrapper (the original invocation and every fallback or continuation
+alike) as `<wrapper command> & echo "wrapper-pid=$!"; wait "$!"` so the
+PID lands in the tool's own output at launch, an unambiguous launch
+record that survives a later timeout, since shell state such as a bare
+`$!` does not itself persist between separate tool calls. B1's
+sibling-worktree model already puts several concurrent workers on one
+host, so a generic `pgrep`/`ps` pattern match (for example, on the
+command name `git commit`) can just as easily match another worker's
+unrelated git invocation, and signaling that tree would terminate
+someone else's in-progress work instead of this one's (preventive; no
+observed incident yet — raised in PR #2906 review). If no such
+launch-time handle was recorded, that dependency is unmet too: hold,
+the same as the missing-`pgrep`/`ps` case above, rather than search for
+a substitute. Otherwise, snapshot the whole set to signal: the git PID
+itself **and** its descendants, found by walking from the git PID (for
+example, recursively via `pgrep -P`) — a
 "descendant" walk alone omits the root git process, leaving it able to
 keep running (and keep `index.lock` held) after only its children are
 signaled. Immediately send SIGTERM to every recorded PID in that
@@ -3605,17 +3622,24 @@ mid-progress, or never started at all:
 - **Plain commit**: compare `git rev-parse HEAD` before/after the
   wrapper call, the same check B3's "Verify a commit actually landed"
   paragraph already prescribes. Landed → stop, do not re-commit.
-  Otherwise, before falling back to `--no-gpg-sign`, also compare
-  `git status --porcelain` and `git diff --cached --stat` against
-  their state captured before the wrapper call: a hook that ran before
-  the timeout can leave the index or working tree mutated even though
-  `HEAD` never moved, and the fallback would then commit that
-  mutation alongside the intended change (reproduced 2026-09-11 in PR
-  #2906 review, via a hook that staged an extra file and slept). Both
-  unchanged → fall back to `--no-gpg-sign`
+  Otherwise, before falling back to `--no-gpg-sign`, also compare the
+  index's tree hash — from running `git write-tree` before the wrapper
+  call and again now — rather than comparing `git status --porcelain`
+  and `git diff --cached --stat` output: `git commit -F` commits the
+  index, so this content-addressed hash is what actually proves it
+  unchanged, whereas status/diff-stat output only shows that a hook
+  mutated the index without moving `HEAD` (reproduced 2026-09-11 in PR
+  #2906 review, via a hook that staged an extra file and slept) — it
+  cannot also catch a hook that swaps one tracked line's content for
+  another of the same shape, leaving both reports unchanged
+  (preventive; no observed incident yet). Unstaged working-tree
+  changes are intentionally excluded from this check: `git commit -F`
+  alone never commits them, so they cannot reach the fallback commit
+  regardless of what changed there. Unchanged → fall back to
+  `--no-gpg-sign`
   (`idd-overview-appendix.instructions.md`'s "Commit signing" section).
-  Either changed → stop and post a hold note for review instead of
-  falling back.
+  Changed → stop and post a hold note for review instead of falling
+  back.
 - **Merge or rebase, state still present**: name the state via git, not
   a literal path — in a linked worktree (every B1 sibling worktree)
   `.git` at the worktree root is a _file_ pointing elsewhere, so a

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -3531,11 +3531,17 @@ raised in PR #2906 review). First check whether the process is
 still running — per `idd-ci.instructions.md`'s "Wake-up discipline"
 guidance on a heavy local command that auto-backgrounds past a tool's
 default timeout, do not start a second wrapper invocation alongside it.
-If it is still running, terminate it (a plain `kill`/`SIGTERM`, not
-`-9` — git's own signal handler cleans up `index.lock`; `-9` skips that
-cleanup and the fallback below then fails on the stale lock).
+If it is still running, terminate it **and any descendants** (SIGTERM,
+not `-9` — git's own signal handler cleans up `index.lock`; `-9` skips
+that cleanup and the fallback below then fails on the stale lock; a
+descendant such as the signer subprocess can outlive a `kill` scoped to
+only the git parent, reproduced in PR #2906 review), then **wait for
+that whole process tree to exit** before checking state or falling
+back — SIGTERM is asynchronous, so proceeding immediately can race
+git's own unwind (still removing `index.lock`) or observe stale state.
 
-Either way — just terminated, or already exited on its own — verify
+Either way — the tree exited on its own, or was terminated and waited
+for above — verify
 what actually happened before falling back; a killed or already-exited
 process can leave the operation completed, mid-progress, or never
 started at all:
@@ -3563,16 +3569,20 @@ started at all:
   mode `idd-pr-submit.instructions.md`'s D1 "Post-rebase verification"
   already documents. Verify instead of assuming: current branch
   non-empty (not detached) and the expected commit present in
-  `origin/{development-branch}..HEAD` for a rebase, or `HEAD` advanced
-  past its pre-call value for a merge. Verified → stop. Not verified →
-  re-attach to the branch if detached (`git checkout {branch-name}`;
-  the commit is preserved on the branch ref) and rerun the original
-  merge or rebase command **unsigned** (`git -c commit.gpgsign=false
-  merge …` / `rebase …`, not the SSH-signing wrapper), exactly once —
-  mirroring D1's own bounded auto-recovery. If that single unsigned
-  rerun still fails the same verification, post a hold note documenting
-  the branch state and stop, the same as D1's own recovery does when it
-  is exhausted.
+  `origin/{development-branch}..HEAD` for a rebase; for a merge, either
+  `HEAD` advanced past its pre-call value or
+  `git merge-base --is-ancestor origin/{development-branch} HEAD`
+  already succeeds — an already-current merge exits `0` having created
+  neither a new `HEAD` nor `MERGE_HEAD`, and is success, not a failed
+  attempt. Verified → stop. Not verified → re-attach to the branch if
+  detached (`git checkout {branch-name}`; the commit is preserved on
+  the branch ref) and rerun the original merge or rebase command
+  **unsigned** (`git -c commit.gpgsign=false merge …` / `rebase …`, not
+  the SSH-signing wrapper), exactly once, under this same 2-minute
+  bound — mirroring D1's own bounded auto-recovery. If that rerun times
+  out or still fails the same verification, post a hold note
+  documenting the branch state and stop, the same as D1's own recovery
+  does when it is exhausted.
 
 Observed hanging with no output for an extended, unbounded period on
 2026-09-10 (issue #2844 / PR #2870, commit `7be8acc9`, later confirmed

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -3541,15 +3541,25 @@ then wait up to 30 seconds for the tree to exit; SIGTERM is
 asynchronous, so checking state immediately can race git's own unwind
 (still removing `index.lock`) or observe stale state. If the tree is
 still alive after that wait, send SIGKILL to whatever remains and wait
-once more, up to 30 seconds — `-9` skips git's signal handler, so once
-every process in the tree has actually exited, remove a leftover
-`index.lock` yourself
+once more, up to 30 seconds — `-9` skips git's signal handler, so a
+leftover `index.lock` can persist even once every process in the
+terminated tree has actually exited, and that alone does not prove
+the lock is this invocation's: a `git status` run by hand, a hook, or
+another command could hold it instead, the same ambiguity the
+clone-scoped lock's own "no automatic stale-lock recovery" convention
+already treats as unsafe to guess past. Confirm no other process
+still has the lock file open — a hook or the signer subprocess itself
+could hold it, not only another `git` command — for example with
+`lsof` on the `--git-path index.lock` path, or, where it is not
+available, by confirming no process at all still has this worktree as
+its working directory — before removing it yourself
 (`rm -f "$(git rev-parse --git-path index.lock)"`, not a literal
 `.git/index.lock` path, the same linked-worktree rule the rebase-state
-check below uses) before continuing. If the tree is still alive even
-after SIGKILL — for example, a process stuck in uninterruptible I/O —
-stop: post a hold note documenting the surviving PIDs rather than
-waiting any longer.
+check below uses); if ownership cannot be confirmed, leave the lock in
+place and stop with a hold note instead of forcing the removal. If the
+tree is still alive even after SIGKILL — for example, a process stuck
+in uninterruptible I/O — stop the same way: post a hold note
+documenting the surviving PIDs rather than waiting any longer.
 
 Either way — the tree exited on its own, or was terminated and
 confirmed clear above — verify what actually happened before falling

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -3520,40 +3520,59 @@ commit-ssh` is sufficient here — a single `commit` invocation needs no
 `--continue` step to re-sign.
 
 **Bounded timeout for every invocation** (commit, merge, or rebase): if
-the wrapper produces no output for 2 minutes, treat it as stuck rather
-than a signing failure worth retrying — a whole-command,
+the wrapper has not completed within 2 minutes, treat it as stuck
+rather than a signing failure worth retrying — a whole-command,
 root-cause-agnostic bound (it deliberately does not try to isolate the
-signer subprocess). Scope the trigger to _silence_, not merely elapsed
-time: a legitimately long-running rebase that is actively replaying
-commits (and therefore still producing output) is not this case.
-First check whether the process is still running — per
-`idd-ci.instructions.md`'s "Wake-up discipline" guidance on a heavy
-local command that auto-backgrounds past a tool's default timeout, do
-not start a second wrapper invocation alongside it. If it is still
-running, terminate it (a plain `kill`/`SIGTERM`, not `-9` — git's own
-signal handler cleans up `index.lock`; `-9` skips that cleanup and the
-fallback below then fails on the stale lock).
+signer subprocess) that applies even to an invocation still producing
+output: an inactivity-only trigger would leave a merge or rebase that
+keeps emitting output free to run indefinitely without ever completing,
+which is not actually bounded (preventive; no observed incident yet —
+raised in PR #2906 review). First check whether the process is
+still running — per `idd-ci.instructions.md`'s "Wake-up discipline"
+guidance on a heavy local command that auto-backgrounds past a tool's
+default timeout, do not start a second wrapper invocation alongside it.
+If it is still running, terminate it (a plain `kill`/`SIGTERM`, not
+`-9` — git's own signal handler cleans up `index.lock`; `-9` skips that
+cleanup and the fallback below then fails on the stale lock).
 
-Either way — just terminated, or already exited on its own — inspect
-repository state **before** falling back: the process may already have
-updated `HEAD`, or left an in-progress merge/rebase, before it stalled
-or exited.
+Either way — just terminated, or already exited on its own — verify
+what actually happened before falling back; a killed or already-exited
+process can leave the operation completed, mid-progress, or never
+started at all:
 
 - **Plain commit**: compare `git rev-parse HEAD` before/after the
   wrapper call, the same check B3's "Verify a commit actually landed"
-  paragraph already prescribes. If the commit landed, stop — do not
-  re-commit. If it did not, fall back to `--no-gpg-sign`
+  paragraph already prescribes. Landed → stop, do not re-commit.
+  Otherwise → fall back to `--no-gpg-sign`
   (`idd-overview-appendix.instructions.md`'s "Commit signing" section).
-- **Merge or rebase**: name the state via git, not a literal path — in
-  a linked worktree (every B1 sibling worktree) `.git` at the worktree
-  root is a _file_ pointing elsewhere, so a hardcoded `.git/rebase-merge`
-  check silently never matches. Use `git rev-parse -q --verify MERGE_HEAD`
-  for merge, or `test -d "$(git rev-parse --git-path rebase-merge)"`
-  (or `rebase-apply`) for rebase. If the operation already completed,
-  stop. If it is still mid-operation, complete it with
-  `-c commit.gpgsign=false` on the `--continue` form — a plain
-  `--continue` re-signs through the stalled primary signer, and
-  `--no-gpg-sign` itself is not a `--continue` flag.
+- **Merge or rebase, state still present**: name the state via git, not
+  a literal path — in a linked worktree (every B1 sibling worktree)
+  `.git` at the worktree root is a _file_ pointing elsewhere, so a
+  hardcoded `.git/rebase-merge` check silently never matches. Use
+  `git rev-parse -q --verify MERGE_HEAD` for a merge, or
+  `test -d "$(git rev-parse --git-path rebase-merge)"` (or
+  `rebase-apply`) for a rebase. Either succeeding means the operation is
+  mid-progress: complete it with `-c commit.gpgsign=false` on the
+  `--continue` form — a plain `--continue` re-signs through the stalled
+  primary signer, and `--no-gpg-sign` itself is not a `--continue` flag.
+- **Merge or rebase, no state present**: absent state alone does not
+  prove the operation succeeded — the timeout can equally fire before
+  Git ever creates that state (nothing to `--continue`), or, for a
+  rebase specifically, leave `HEAD` detached at the upstream tip
+  without replaying the local commit, the same sibling-worktree failure
+  mode `idd-pr-submit.instructions.md`'s D1 "Post-rebase verification"
+  already documents. Verify instead of assuming: current branch
+  non-empty (not detached) and the expected commit present in
+  `origin/{development-branch}..HEAD` for a rebase, or `HEAD` advanced
+  past its pre-call value for a merge. Verified → stop. Not verified →
+  re-attach to the branch if detached (`git checkout {branch-name}`;
+  the commit is preserved on the branch ref) and rerun the original
+  merge or rebase command **unsigned** (`git -c commit.gpgsign=false
+  merge …` / `rebase …`, not the SSH-signing wrapper), exactly once —
+  mirroring D1's own bounded auto-recovery. If that single unsigned
+  rerun still fails the same verification, post a hold note documenting
+  the branch state and stop, the same as D1's own recovery does when it
+  is exhausted.
 
 Observed hanging with no output for an extended, unbounded period on
 2026-09-10 (issue #2844 / PR #2870, commit `7be8acc9`, later confirmed

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -3527,24 +3527,34 @@ signer subprocess) that applies even to an invocation still producing
 output: an inactivity-only trigger would leave a merge or rebase that
 keeps emitting output free to run indefinitely without ever completing,
 which is not actually bounded (preventive; no observed incident yet —
-raised in PR #2906 review). First check whether the process is
-still running — per `idd-ci.instructions.md`'s "Wake-up discipline"
-guidance on a heavy local command that auto-backgrounds past a tool's
-default timeout, do not start a second wrapper invocation alongside it.
-If it is still running, terminate it **and any descendants** (SIGTERM,
-not `-9` — git's own signal handler cleans up `index.lock`; `-9` skips
-that cleanup and the fallback below then fails on the stale lock; a
-descendant such as the signer subprocess can outlive a `kill` scoped to
-only the git parent, reproduced in PR #2906 review), then **wait for
-that whole process tree to exit** before checking state or falling
-back — SIGTERM is asynchronous, so proceeding immediately can race
-git's own unwind (still removing `index.lock`) or observe stale state.
+raised in PR #2906 review). First check whether the process **tree** —
+the wrapper's git invocation and any descendants such as the signer
+subprocess, not just the top-level command — is still running: per
+`idd-ci.instructions.md`'s "Wake-up discipline" guidance on a heavy
+local command that auto-backgrounds past a tool's default timeout, do
+not start a second wrapper invocation alongside it. If any part of the
+tree is still running, terminate the whole tree with SIGTERM, not
+`-9` — git's own signal handler cleans up `index.lock`, and a
+descendant such as the signer subprocess can outlive a `kill` scoped
+to only the git parent (reproduced 2026-09-11 in PR #2906 review) —
+then wait up to 30 seconds for the tree to exit; SIGTERM is
+asynchronous, so checking state immediately can race git's own unwind
+(still removing `index.lock`) or observe stale state. If the tree is
+still alive after that wait, send SIGKILL to whatever remains and wait
+once more, up to 30 seconds — `-9` skips git's signal handler, so once
+every process in the tree has actually exited, remove a leftover
+`index.lock` yourself
+(`rm -f "$(git rev-parse --git-path index.lock)"`, not a literal
+`.git/index.lock` path, the same linked-worktree rule the rebase-state
+check below uses) before continuing. If the tree is still alive even
+after SIGKILL — for example, a process stuck in uninterruptible I/O —
+stop: post a hold note documenting the surviving PIDs rather than
+waiting any longer.
 
-Either way — the tree exited on its own, or was terminated and waited
-for above — verify
-what actually happened before falling back; a killed or already-exited
-process can leave the operation completed, mid-progress, or never
-started at all:
+Either way — the tree exited on its own, or was terminated and
+confirmed clear above — verify what actually happened before falling
+back; a killed or already-exited process can leave the operation
+completed, mid-progress, or never started at all:
 
 - **Plain commit**: compare `git rev-parse HEAD` before/after the
   wrapper call, the same check B3's "Verify a commit actually landed"
@@ -3567,8 +3577,8 @@ started at all:
   rebase specifically, leave `HEAD` detached at the upstream tip
   without replaying the local commit, the same sibling-worktree failure
   mode `idd-pr-submit.instructions.md`'s D1 "Post-rebase verification"
-  already documents. Verify instead of assuming: current branch
-  non-empty (not detached) and the expected commit present in
+  already documents and defines the same predicate for: current branch
+  non-empty (not detached) and the expected local commit present in
   `origin/{development-branch}..HEAD` for a rebase; for a merge, either
   `HEAD` advanced past its pre-call value or
   `git merge-base --is-ancestor origin/{development-branch} HEAD`
@@ -3583,6 +3593,18 @@ started at all:
   out or still fails the same verification, post a hold note
   documenting the branch state and stop, the same as D1's own recovery
   does when it is exhausted.
+
+No step in this recovery procedure waits indefinitely: the original
+wrapper invocation and every fallback or continuation share the same
+2-minute bound, and the termination wait above has its own 30-second
+bounds — every step that exceeds its bound routes to the same
+terminate-and-verify-or-hold outcome, not a fresh unbounded wait. A
+hook or other non-signing cause can hang the plain-commit
+`--no-gpg-sign` fallback or the `--continue` completion just as it
+hung the original attempt; if either does not itself complete within
+2 minutes, apply the same terminate-and-verify procedure to it, and if
+it still does not resolve, post a hold note and stop rather than
+retrying further.
 
 Observed hanging with no output for an extended, unbounded period on
 2026-09-10 (issue #2844 / PR #2870, commit `7be8acc9`, later confirmed

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -3538,50 +3538,46 @@ process tree — if `pgrep`/`ps` (or an equivalent process-listing and
 signaling mechanism) are not available on the host, that dependency
 cannot be met: stop and post a hold note rather than falling back
 without the cleanup guarantee, the same fail-closed treatment the
-`lsof` case below already gets. Otherwise, before signaling anything,
-snapshot the full descendant PID set by walking from the git PID (for
-example, recursively via `pgrep -P`) — walk once, before the first
-signal, and keep that recorded list: re-walking after signaling misses
-a child whose parent the signal already removed, even though the
-child itself is still alive. Record each PID together
-with its process start time (for example, `ps -o lstart=` for that
-PID), not the bare number — a PID that exits during the wait below can
-be reused by an unrelated process before the next signal, and signaling
-by number alone would then hit that unrelated process instead. If any
-part of the tree is still running, send SIGTERM to every recorded PID
-whose start time still matches, not `-9` — git's own signal handler
-cleans up `index.lock`, and a descendant such as the signer subprocess
-can outlive a `kill` scoped to only the git parent (reproduced
-2026-09-11 in PR #2906 review) — then wait up to 30 seconds for each
-recorded PID individually to exit (not a fresh tree walk); SIGTERM is
-asynchronous, so checking state immediately can race git's own unwind
-(still removing `index.lock`) or observe stale state. Even a PID
-snapshot is best-effort, not a guarantee: a child that gets reparented
-(commonly to init) before the snapshot is taken is never recorded at
-all, so it survives untouched no matter how carefully the recorded
-PIDs are signaled and awaited. Whether that is safe to proceed past
-depends on what kind of descendant it can be: a signer subprocess that
-escapes this way is only a resource leak to report, since the unsigned
-fallback below never invokes a signer and so cannot race one — but the
-whole-command timeout this section opens with is root-cause-agnostic
-(it can equally fire on a hung hook, not only a stalled signer), and a
-hook process that escapes the same way could still be reading or
+`lsof` case below already gets. Otherwise, snapshot the full
+descendant PID set by walking from the git PID (for example,
+recursively via `pgrep -P`) and immediately send SIGTERM to every
+recorded PID, not `-9` — git's own signal handler cleans up
+`index.lock`, and a descendant such as the signer subprocess can
+outlive a `kill` scoped to only the git parent (reproduced 2026-09-11
+in PR #2906 review). Snapshot and signal back-to-back, with nothing in
+between: that is what keeps a bare recorded PID number trustworthy
+without needing a separate identity check, since the gap in which an
+exited PID could be reused by an unrelated process stays sub-second on
+any real host. Then wait up to 30 seconds for each recorded PID
+individually to exit (not a fresh tree walk); SIGTERM is asynchronous,
+so checking state immediately can race git's own unwind (still
+removing `index.lock`) or observe stale state.
+
+Even a PID snapshot is best-effort, not a guarantee: a child that gets
+reparented (commonly to init) before the snapshot is taken is never
+recorded at all, so it survives untouched no matter how promptly the
+recorded PIDs are signaled. The same is true of a recorded PID that
+simply outlasts the 30-second wait — for example a process stuck in
+uninterruptible I/O, which cannot receive a signal until it leaves
+that state (preventive; no observed incident yet). Whether either kind
+of survivor is safe to proceed past depends on what it can be: a
+signer subprocess is only a resource leak to report, since the
+unsigned fallback below never invokes one and so cannot race it — but
+the whole-command timeout this section opens with is root-cause-
+agnostic (it can equally fire on a hung hook, not only a stalled
+signer), and a hook process that survives could still be reading or
 writing the working tree or index. Proceeding with the fallback while
 an unidentified or non-signer descendant might still be touching
 repository state risks the fallback's own git operation racing it, so
 treat that case as blocking: stop and post a hold note documenting the
 surviving PID(s) rather than falling back, reserving the
 resource-leak-and-continue treatment for a descendant identifiable as
-the signer itself. Before the next signal, re-check each
-recorded PID's start time again: a mismatch means it already exited
-and the number was reused, so skip signaling it rather than treat the
-new, unrelated process as the same one. If a recorded PID is still
-alive (same start time) after the SIGTERM wait, send SIGKILL to it and
-wait once more, up to 30 seconds — `-9` skips git's signal handler, so a
-leftover `index.lock` can persist even once every process in the
-terminated tree has actually exited, and that alone does not prove
-the lock is this invocation's: a `git status` run by hand, a hook, or
-another command could hold it instead, the same ambiguity the
+the signer itself.
+
+Separately, the lock-ownership check keeps its original (round-6)
+purpose: a leftover `index.lock` after the tree is confirmed gone does
+not prove it belongs to this invocation — a hook, another command, or
+the signer itself could hold it instead, the same ambiguity the
 clone-scoped lock's own "no automatic stale-lock recovery" convention
 already treats as unsafe to guess past. Confirm no other process
 still has the lock file open — a hook or the signer subprocess itself
@@ -3595,21 +3591,28 @@ it yourself
 (`rm -f "$(git rev-parse --git-path index.lock)"`, not a literal
 `.git/index.lock` path, the same linked-worktree rule the rebase-state
 check below uses); if ownership cannot be confirmed, leave the lock in
-place and stop with a hold note instead of forcing the removal. If the
-tree is still alive even after SIGKILL — for example, a process stuck
-in uninterruptible I/O — stop the same way: post a hold note
-documenting the surviving PIDs rather than waiting any longer.
+place and stop with a hold note instead of forcing the removal.
 
-Either way — the tree exited on its own, or was terminated and
-confirmed clear above — verify what actually happened before falling
-back; a killed or already-exited process can leave the operation
-completed, mid-progress, or never started at all:
+Either way — the tree exited on its own, was terminated with nothing
+left but an identified signer leak, or the checks above otherwise
+allow proceeding — verify what actually happened before falling back;
+a killed or already-exited process can leave the operation completed,
+mid-progress, or never started at all:
 
 - **Plain commit**: compare `git rev-parse HEAD` before/after the
   wrapper call, the same check B3's "Verify a commit actually landed"
   paragraph already prescribes. Landed → stop, do not re-commit.
-  Otherwise → fall back to `--no-gpg-sign`
+  Otherwise, before falling back to `--no-gpg-sign`, also compare
+  `git status --porcelain` and `git diff --cached --stat` against
+  their state captured before the wrapper call: a hook that ran before
+  the timeout can leave the index or working tree mutated even though
+  `HEAD` never moved, and the fallback would then commit that
+  mutation alongside the intended change (reproduced 2026-09-11 in PR
+  #2906 review, via a hook that staged an extra file and slept). Both
+  unchanged → fall back to `--no-gpg-sign`
   (`idd-overview-appendix.instructions.md`'s "Commit signing" section).
+  Either changed → stop and post a hold note for review instead of
+  falling back.
 - **Merge or rebase, state still present**: name the state via git, not
   a literal path — in a linked worktree (every B1 sibling worktree)
   `.git` at the worktree root is a _file_ pointing elsewhere, so a
@@ -3656,7 +3659,7 @@ completed, mid-progress, or never started at all:
 No step in this recovery procedure waits indefinitely: the original
 wrapper invocation and every fallback or continuation share the same
 2-minute bound, and the termination wait above has its own 30-second
-bounds — every step that exceeds its bound routes to the same
+bound — every step that exceeds its bound routes to the same
 terminate-and-verify-or-hold outcome, not a fresh unbounded wait. A
 hook or other non-signing cause can hang the plain-commit
 `--no-gpg-sign` fallback or the `--continue` completion just as it

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -3532,12 +3532,18 @@ the wrapper's git invocation and any descendants such as the signer
 subprocess, not just the top-level command — is still running: per
 `idd-ci.instructions.md`'s "Wake-up discipline" guidance on a heavy
 local command that auto-backgrounds past a tool's default timeout, do
-not start a second wrapper invocation alongside it. Before signaling
-anything, snapshot the full descendant PID set by walking from the
-git PID (for example, recursively via `pgrep -P`) — walk once, before
-the first signal, and keep that recorded list: re-walking after
-signaling misses a child whose parent the signal already removed,
-even though the child itself is still alive. Record each PID together
+not start a second wrapper invocation alongside it. This whole
+recovery procedure depends on being able to snapshot and signal the
+process tree — if `pgrep`/`ps` (or an equivalent process-listing and
+signaling mechanism) are not available on the host, that dependency
+cannot be met: stop and post a hold note rather than falling back
+without the cleanup guarantee, the same fail-closed treatment the
+`lsof` case below already gets. Otherwise, before signaling anything,
+snapshot the full descendant PID set by walking from the git PID (for
+example, recursively via `pgrep -P`) — walk once, before the first
+signal, and keep that recorded list: re-walking after signaling misses
+a child whose parent the signal already removed, even though the
+child itself is still alive. Record each PID together
 with its process start time (for example, `ps -o lstart=` for that
 PID), not the bare number — a PID that exits during the wait below can
 be reused by an unrelated process before the next signal, and signaling
@@ -3553,12 +3559,20 @@ asynchronous, so checking state immediately can race git's own unwind
 snapshot is best-effort, not a guarantee: a child that gets reparented
 (commonly to init) before the snapshot is taken is never recorded at
 all, so it survives untouched no matter how carefully the recorded
-PIDs are signaled and awaited — a signer that survives this way is a
-resource leak to report, not a condition this procedure can reliably
-close; list any surviving PIDs in the hold or status note rather than
-treating any later step as having caught it (the unsigned fallback
-below never invokes the signer, so a leaked signer cannot corrupt that
-path, only waste resources). Before the next signal, re-check each
+PIDs are signaled and awaited. Whether that is safe to proceed past
+depends on what kind of descendant it can be: a signer subprocess that
+escapes this way is only a resource leak to report, since the unsigned
+fallback below never invokes a signer and so cannot race one — but the
+whole-command timeout this section opens with is root-cause-agnostic
+(it can equally fire on a hung hook, not only a stalled signer), and a
+hook process that escapes the same way could still be reading or
+writing the working tree or index. Proceeding with the fallback while
+an unidentified or non-signer descendant might still be touching
+repository state risks the fallback's own git operation racing it, so
+treat that case as blocking: stop and post a hold note documenting the
+surviving PID(s) rather than falling back, reserving the
+resource-leak-and-continue treatment for a descendant identifiable as
+the signer itself. Before the next signal, re-check each
 recorded PID's start time again: a mismatch means it already exited
 and the number was reused, so skip signaling it rather than treat the
 new, unrelated process as the same one. If a recorded PID is still

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -3544,12 +3544,16 @@ or exited.
   paragraph already prescribes. If the commit landed, stop — do not
   re-commit. If it did not, fall back to `--no-gpg-sign`
   (`idd-overview-appendix.instructions.md`'s "Commit signing" section).
-- **Merge or rebase**: check whether `MERGE_HEAD` (merge) or
-  `.git/rebase-merge` / `.git/rebase-apply` (rebase) still exists. If
-  the operation already completed, stop. If it is still mid-operation,
-  complete it with `-c commit.gpgsign=false` on the `--continue` form
-  — a plain `--continue` re-signs through the stalled primary signer,
-  and `--no-gpg-sign` itself is not a `--continue` flag.
+- **Merge or rebase**: name the state via git, not a literal path — in
+  a linked worktree (every B1 sibling worktree) `.git` at the worktree
+  root is a _file_ pointing elsewhere, so a hardcoded `.git/rebase-merge`
+  check silently never matches. Use `git rev-parse -q --verify MERGE_HEAD`
+  for merge, or `test -d "$(git rev-parse --git-path rebase-merge)"`
+  (or `rebase-apply`) for rebase. If the operation already completed,
+  stop. If it is still mid-operation, complete it with
+  `-c commit.gpgsign=false` on the `--continue` form — a plain
+  `--continue` re-signs through the stalled primary signer, and
+  `--no-gpg-sign` itself is not a `--continue` flag.
 
 Observed hanging with no output for an extended, unbounded period on
 2026-09-10 (issue #2844 / PR #2870, commit `7be8acc9`, later confirmed

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -3520,20 +3520,40 @@ commit-ssh` is sufficient here — a single `commit` invocation needs no
 `--continue` step to re-sign.
 
 **Bounded timeout for every invocation** (commit, merge, or rebase): if
-the wrapper has not completed within 2 minutes, treat it as stuck
-rather than a signing failure worth retrying. First check whether the
-process is still running — per `idd-ci.instructions.md`'s "Wake-up
-discipline" guidance on a heavy local command that auto-backgrounds
-past a tool's default timeout, do not start a second wrapper
-invocation alongside it — then kill it and fall back to the
-already-documented `--no-gpg-sign` last resort
-(`idd-overview-appendix.instructions.md`'s "Commit signing" section)
-rather than waiting indefinitely. For an in-progress merge or rebase,
-complete it with `-c commit.gpgsign=false` on the `--continue` form
-instead — a plain `--continue` re-signs through the stalled primary
-signer, and `--no-gpg-sign` itself is not a `--continue` flag. Observed
-hanging with no output for an extended, unbounded period on 2026-09-10
-(issue #2844 / PR #2870, commit `7be8acc9`, later confirmed unsigned).
+the wrapper produces no output for 2 minutes, treat it as stuck rather
+than a signing failure worth retrying — a whole-command,
+root-cause-agnostic bound (it deliberately does not try to isolate the
+signer subprocess). Scope the trigger to _silence_, not merely elapsed
+time: a legitimately long-running rebase that is actively replaying
+commits (and therefore still producing output) is not this case.
+First check whether the process is still running — per
+`idd-ci.instructions.md`'s "Wake-up discipline" guidance on a heavy
+local command that auto-backgrounds past a tool's default timeout, do
+not start a second wrapper invocation alongside it. If it is still
+running, terminate it (a plain `kill`/`SIGTERM`, not `-9` — git's own
+signal handler cleans up `index.lock`; `-9` skips that cleanup and the
+fallback below then fails on the stale lock).
+
+Either way — just terminated, or already exited on its own — inspect
+repository state **before** falling back: the process may already have
+updated `HEAD`, or left an in-progress merge/rebase, before it stalled
+or exited.
+
+- **Plain commit**: compare `git rev-parse HEAD` before/after the
+  wrapper call, the same check B3's "Verify a commit actually landed"
+  paragraph already prescribes. If the commit landed, stop — do not
+  re-commit. If it did not, fall back to `--no-gpg-sign`
+  (`idd-overview-appendix.instructions.md`'s "Commit signing" section).
+- **Merge or rebase**: check whether `MERGE_HEAD` (merge) or
+  `.git/rebase-merge` / `.git/rebase-apply` (rebase) still exists. If
+  the operation already completed, stop. If it is still mid-operation,
+  complete it with `-c commit.gpgsign=false` on the `--continue` form
+  — a plain `--continue` re-signs through the stalled primary signer,
+  and `--no-gpg-sign` itself is not a `--continue` flag.
+
+Observed hanging with no output for an extended, unbounded period on
+2026-09-10 (issue #2844 / PR #2870, commit `7be8acc9`, later confirmed
+unsigned).
 
 ## Friction Inventory
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -3532,22 +3532,30 @@ the wrapper's git invocation and any descendants such as the signer
 subprocess, not just the top-level command — is still running: per
 `idd-ci.instructions.md`'s "Wake-up discipline" guidance on a heavy
 local command that auto-backgrounds past a tool's default timeout, do
-not start a second wrapper invocation alongside it. If any part of the
-tree is still running, terminate the whole tree with SIGTERM, not
-`-9` — git's own signal handler cleans up `index.lock`, and a
-descendant such as the signer subprocess can outlive a `kill` scoped
-to only the git parent (reproduced 2026-09-11 in PR #2906 review) —
-then wait up to 30 seconds for the tree to exit; SIGTERM is
-asynchronous, so checking state immediately can race git's own unwind
-(still removing `index.lock`) or observe stale state. Walking
-descendants by PID is best-effort, not a guarantee — a child whose
-immediate parent already exited is reparented (commonly to init) and
-is no longer reachable by walking down from the git PID, so "the tree
-exited" can be wrong even after this wait; that gap is exactly what
-the lock-ownership check below exists to catch, not something this
-step alone can close. If the tree is still alive after that wait, send
-SIGKILL to whatever remains and wait once more, up to 30 seconds —
-`-9` skips git's signal handler, so a
+not start a second wrapper invocation alongside it. Before signaling
+anything, snapshot the full descendant PID set by walking from the
+git PID (for example, recursively via `pgrep -P`) — walk once, before
+the first signal, and keep that recorded list: re-walking after
+signaling misses a child whose parent the signal already removed,
+even though the child itself is still alive. If any part of the tree
+is still running, send SIGTERM to every recorded PID, not `-9` —
+git's own signal handler cleans up `index.lock`, and a descendant such
+as the signer subprocess can outlive a `kill` scoped to only the git
+parent (reproduced 2026-09-11 in PR #2906 review) — then wait up to
+30 seconds for each recorded PID individually to exit (not a fresh
+tree walk); SIGTERM is asynchronous, so checking state immediately
+can race git's own unwind (still removing `index.lock`) or observe
+stale state. Even a PID snapshot is best-effort, not a guarantee: a
+child that gets reparented (commonly to init) before the snapshot is
+taken is never recorded at all, so it survives untouched no matter
+how carefully the recorded PIDs are signaled and awaited — a signer
+that survives this way is a resource leak to report, not a condition
+this procedure can reliably close; list any surviving PIDs in the
+hold or status note rather than treating any later step as having
+caught it (the unsigned fallback below never invokes the signer, so a
+leaked signer cannot corrupt that path, only waste resources). If any
+recorded PID is still alive after that wait, send SIGKILL to it and
+wait once more, up to 30 seconds — `-9` skips git's signal handler, so a
 leftover `index.lock` can persist even once every process in the
 terminated tree has actually exited, and that alone does not prove
 the lock is this invocation's: a `git status` run by hand, a hook, or
@@ -3603,7 +3611,17 @@ completed, mid-progress, or never started at all:
   `git merge-base --is-ancestor origin/{development-branch} HEAD`
   already succeeds — an already-current merge exits `0` having created
   neither a new `HEAD` nor `MERGE_HEAD`, and is success, not a failed
-  attempt. Verified → stop. Not verified → re-attach to the branch if
+  attempt. For a rebase specifically, D1's two checks alone are not
+  enough here: D1 verifies a rebase that already completed, but a
+  timeout that fires **before** the rebase ever starts leaves the
+  untouched, still-behind branch passing both checks trivially (it was
+  never detached, and its own feature commit was already present in
+  `origin/{development-branch}..HEAD` before this attempt began) —
+  require `git merge-base --is-ancestor origin/{development-branch}
+  HEAD` to succeed too, the same upstream-incorporated check the merge
+  case above already uses, so a rebase that never actually ran is not
+  mistaken for one that did. Verified → stop. Not verified → re-attach
+  to the branch if
   detached (`git checkout {branch-name}`; the commit is preserved on
   the branch ref) and rerun the original merge or rebase command
   **unsigned** (`git -c commit.gpgsign=false merge …` / `rebase …`, not

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -3539,9 +3539,15 @@ descendant such as the signer subprocess can outlive a `kill` scoped
 to only the git parent (reproduced 2026-09-11 in PR #2906 review) —
 then wait up to 30 seconds for the tree to exit; SIGTERM is
 asynchronous, so checking state immediately can race git's own unwind
-(still removing `index.lock`) or observe stale state. If the tree is
-still alive after that wait, send SIGKILL to whatever remains and wait
-once more, up to 30 seconds — `-9` skips git's signal handler, so a
+(still removing `index.lock`) or observe stale state. Walking
+descendants by PID is best-effort, not a guarantee — a child whose
+immediate parent already exited is reparented (commonly to init) and
+is no longer reachable by walking down from the git PID, so "the tree
+exited" can be wrong even after this wait; that gap is exactly what
+the lock-ownership check below exists to catch, not something this
+step alone can close. If the tree is still alive after that wait, send
+SIGKILL to whatever remains and wait once more, up to 30 seconds —
+`-9` skips git's signal handler, so a
 leftover `index.lock` can persist even once every process in the
 terminated tree has actually exited, and that alone does not prove
 the lock is this invocation's: a `git status` run by hand, a hook, or
@@ -3549,10 +3555,13 @@ another command could hold it instead, the same ambiguity the
 clone-scoped lock's own "no automatic stale-lock recovery" convention
 already treats as unsafe to guess past. Confirm no other process
 still has the lock file open — a hook or the signer subprocess itself
-could hold it, not only another `git` command — for example with
-`lsof` on the `--git-path index.lock` path, or, where it is not
-available, by confirming no process at all still has this worktree as
-its working directory — before removing it yourself
+could hold it, not only another `git` command, and not necessarily
+one running from this worktree's directory (an absolute-path or
+`git -C` invocation holds the same lock without it) — with `lsof` on
+the `--git-path index.lock` path; where `lsof` is not available,
+ownership cannot be reliably confirmed at all, so treat it as
+unconfirmed rather than substituting a weaker check — before removing
+it yourself
 (`rm -f "$(git rev-parse --git-path index.lock)"`, not a literal
 `.git/index.lock` path, the same linked-worktree rule the rebase-state
 check below uses); if ownership cannot be confirmed, leave the lock in

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -3508,6 +3508,33 @@ complement to the recovery-path re-signing in
 `idd-pr-submit.instructions.md` (Post-rebase verification) and
 `idd-overview-core.instructions.md` (cwd-vs-claim cherry-pick recovery).
 
+This wrapper also applies to an ordinary per-commit `git commit` in B3
+(`idd-work.instructions.md`), not only a merge or rebase continuation:
+
+```sh
+git -c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true commit -F <message-file>
+```
+
+Unlike the merge case above, a commit-only alias such as `git
+commit-ssh` is sufficient here — a single `commit` invocation needs no
+`--continue` step to re-sign.
+
+**Bounded timeout for every invocation** (commit, merge, or rebase): if
+the wrapper has not completed within 2 minutes, treat it as stuck
+rather than a signing failure worth retrying. First check whether the
+process is still running — per `idd-ci.instructions.md`'s "Wake-up
+discipline" guidance on a heavy local command that auto-backgrounds
+past a tool's default timeout, do not start a second wrapper
+invocation alongside it — then kill it and fall back to the
+already-documented `--no-gpg-sign` last resort
+(`idd-overview-appendix.instructions.md`'s "Commit signing" section)
+rather than waiting indefinitely. For an in-progress merge or rebase,
+complete it with `-c commit.gpgsign=false` on the `--continue` form
+instead — a plain `--continue` re-signs through the stalled primary
+signer, and `--no-gpg-sign` itself is not a `--continue` flag. Observed
+hanging with no output for an extended, unbounded period on 2026-09-10
+(issue #2844 / PR #2870, commit `7be8acc9`, later confirmed unsigned).
+
 ## Friction Inventory
 
 The workflow areas most likely to benefit from optional helpers are:

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -3538,17 +3538,20 @@ process tree — if `pgrep`/`ps` (or an equivalent process-listing and
 signaling mechanism) are not available on the host, that dependency
 cannot be met: stop and post a hold note rather than falling back
 without the cleanup guarantee, the same fail-closed treatment the
-`lsof` case below already gets. Otherwise, snapshot the full
-descendant PID set by walking from the git PID (for example,
-recursively via `pgrep -P`) and immediately send SIGTERM to every
-recorded PID, not `-9` — git's own signal handler cleans up
-`index.lock`, and a descendant such as the signer subprocess can
-outlive a `kill` scoped to only the git parent (reproduced 2026-09-11
-in PR #2906 review). Snapshot and signal back-to-back, with nothing in
-between: that is what keeps a bare recorded PID number trustworthy
-without needing a separate identity check, since the gap in which an
-exited PID could be reused by an unrelated process stays sub-second on
-any real host. Then wait up to 30 seconds for each recorded PID
+`lsof` case below already gets. Otherwise, snapshot the whole set to
+signal: the git PID itself **and** its descendants, found by walking
+from the git PID (for example, recursively via `pgrep -P`) — a
+"descendant" walk alone omits the root git process, leaving it able to
+keep running (and keep `index.lock` held) after only its children are
+signaled. Immediately send SIGTERM to every recorded PID in that
+whole set, not `-9` — git's own signal handler cleans up `index.lock`,
+and a descendant such as the signer subprocess can outlive a `kill`
+scoped to only the git parent (reproduced 2026-09-11 in PR #2906
+review). Snapshot and signal back-to-back, with nothing in between:
+that is what keeps a bare recorded PID number trustworthy without
+needing a separate identity check, since the gap in which an exited
+PID could be reused by an unrelated process stays sub-second on any
+real host. Then wait up to 30 seconds for each recorded PID
 individually to exit (not a fresh tree walk); SIGTERM is asynchronous,
 so checking state immediately can race git's own unwind (still
 removing `index.lock`) or observe stale state.

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -3537,24 +3537,32 @@ anything, snapshot the full descendant PID set by walking from the
 git PID (for example, recursively via `pgrep -P`) — walk once, before
 the first signal, and keep that recorded list: re-walking after
 signaling misses a child whose parent the signal already removed,
-even though the child itself is still alive. If any part of the tree
-is still running, send SIGTERM to every recorded PID, not `-9` —
-git's own signal handler cleans up `index.lock`, and a descendant such
-as the signer subprocess can outlive a `kill` scoped to only the git
-parent (reproduced 2026-09-11 in PR #2906 review) — then wait up to
-30 seconds for each recorded PID individually to exit (not a fresh
-tree walk); SIGTERM is asynchronous, so checking state immediately
-can race git's own unwind (still removing `index.lock`) or observe
-stale state. Even a PID snapshot is best-effort, not a guarantee: a
-child that gets reparented (commonly to init) before the snapshot is
-taken is never recorded at all, so it survives untouched no matter
-how carefully the recorded PIDs are signaled and awaited — a signer
-that survives this way is a resource leak to report, not a condition
-this procedure can reliably close; list any surviving PIDs in the
-hold or status note rather than treating any later step as having
-caught it (the unsigned fallback below never invokes the signer, so a
-leaked signer cannot corrupt that path, only waste resources). If any
-recorded PID is still alive after that wait, send SIGKILL to it and
+even though the child itself is still alive. Record each PID together
+with its process start time (for example, `ps -o lstart=` for that
+PID), not the bare number — a PID that exits during the wait below can
+be reused by an unrelated process before the next signal, and signaling
+by number alone would then hit that unrelated process instead. If any
+part of the tree is still running, send SIGTERM to every recorded PID
+whose start time still matches, not `-9` — git's own signal handler
+cleans up `index.lock`, and a descendant such as the signer subprocess
+can outlive a `kill` scoped to only the git parent (reproduced
+2026-09-11 in PR #2906 review) — then wait up to 30 seconds for each
+recorded PID individually to exit (not a fresh tree walk); SIGTERM is
+asynchronous, so checking state immediately can race git's own unwind
+(still removing `index.lock`) or observe stale state. Even a PID
+snapshot is best-effort, not a guarantee: a child that gets reparented
+(commonly to init) before the snapshot is taken is never recorded at
+all, so it survives untouched no matter how carefully the recorded
+PIDs are signaled and awaited — a signer that survives this way is a
+resource leak to report, not a condition this procedure can reliably
+close; list any surviving PIDs in the hold or status note rather than
+treating any later step as having caught it (the unsigned fallback
+below never invokes the signer, so a leaked signer cannot corrupt that
+path, only waste resources). Before the next signal, re-check each
+recorded PID's start time again: a mismatch means it already exited
+and the number was reused, so skip signaling it rather than treat the
+new, unrelated process as the same one. If a recorded PID is still
+alive (same start time) after the SIGTERM wait, send SIGKILL to it and
 wait once more, up to 30 seconds — `-9` skips git's signal handler, so a
 leftover `index.lock` can persist even once every process in the
 terminated tree has actually exited, and that alone does not prove

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -370,18 +370,18 @@ post the plan retroactively with an explicit note about the
 reordering, and run the C1 critique pass against the completed diff.
 
 Implement the plan, running **fix-validate** before each atomic commit
-(one logical change per commit).
+(one logical change per commit). Non-interactive-hostile signing: use
+the [signed-commit merge wrapper](../../docs/idd-helper-scripts.md#signed-commit-merge-wrapper-shared-git-procedure)
+instead.
 
 **Verify a commit actually landed before trusting a subsequent push.**
-A `commit-msg` hook (for example commitlint's body-max-line-length) can
-silently reject a commit with a long single-line body, so no commit is
-created — but the following `git push` then reports "Everything
-up-to-date", which reads as a normal no-op rather than the actual
-failure. Prefer `git commit -F <file>` with a pre-wrapped body file
-over a long single-line `-m` message to avoid tripping the hook in the
-first place, and confirm the commit landed (compare `git rev-parse HEAD`
-before/after, or check the commit hash the commit command reports)
-before treating a subsequent push as confirmation the change landed.
+A `commit-msg` hook (e.g. commitlint's body-max-line-length) can
+silently reject a long single-line body, so no commit is created but
+the next `git push` reports "Everything up-to-date" — a misleading
+no-op. Prefer `git commit -F <file>` with a pre-wrapped body over a
+long `-m` message, and confirm the commit landed (compare `git
+rev-parse HEAD` before/after, or check the reported commit hash)
+before trusting the push.
 
 **De-duplication refactors**: when consolidating a wrapper function used
 at multiple call sites, check whether any call site's old delegate path

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -3538,9 +3538,26 @@ process tree — if `pgrep`/`ps` (or an equivalent process-listing and
 signaling mechanism) are not available on the host, that dependency
 cannot be met: stop and post a hold note rather than falling back
 without the cleanup guarantee, the same fail-closed treatment the
-`lsof` case below already gets. Otherwise, snapshot the whole set to
-signal: the git PID itself **and** its descendants, found by walking
-from the git PID (for example, recursively via `pgrep -P`) — a
+`lsof` case below already gets. It also depends on already knowing
+which process is this invocation's own: "the git PID" below is the PID
+recorded when this wrapper invocation itself was launched, never one
+recovered afterward by searching the process table — launch the
+wrapper (the original invocation and every fallback or continuation
+alike) as `<wrapper command> & echo "wrapper-pid=$!"; wait "$!"` so the
+PID lands in the tool's own output at launch, an unambiguous launch
+record that survives a later timeout, since shell state such as a bare
+`$!` does not itself persist between separate tool calls. B1's
+sibling-worktree model already puts several concurrent workers on one
+host, so a generic `pgrep`/`ps` pattern match (for example, on the
+command name `git commit`) can just as easily match another worker's
+unrelated git invocation, and signaling that tree would terminate
+someone else's in-progress work instead of this one's (preventive; no
+observed incident yet — raised in PR #2906 review). If no such
+launch-time handle was recorded, that dependency is unmet too: hold,
+the same as the missing-`pgrep`/`ps` case above, rather than search for
+a substitute. Otherwise, snapshot the whole set to signal: the git PID
+itself **and** its descendants, found by walking from the git PID (for
+example, recursively via `pgrep -P`) — a
 "descendant" walk alone omits the root git process, leaving it able to
 keep running (and keep `index.lock` held) after only its children are
 signaled. Immediately send SIGTERM to every recorded PID in that
@@ -3605,17 +3622,24 @@ mid-progress, or never started at all:
 - **Plain commit**: compare `git rev-parse HEAD` before/after the
   wrapper call, the same check B3's "Verify a commit actually landed"
   paragraph already prescribes. Landed → stop, do not re-commit.
-  Otherwise, before falling back to `--no-gpg-sign`, also compare
-  `git status --porcelain` and `git diff --cached --stat` against
-  their state captured before the wrapper call: a hook that ran before
-  the timeout can leave the index or working tree mutated even though
-  `HEAD` never moved, and the fallback would then commit that
-  mutation alongside the intended change (reproduced 2026-09-11 in PR
-  #2906 review, via a hook that staged an extra file and slept). Both
-  unchanged → fall back to `--no-gpg-sign`
+  Otherwise, before falling back to `--no-gpg-sign`, also compare the
+  index's tree hash — from running `git write-tree` before the wrapper
+  call and again now — rather than comparing `git status --porcelain`
+  and `git diff --cached --stat` output: `git commit -F` commits the
+  index, so this content-addressed hash is what actually proves it
+  unchanged, whereas status/diff-stat output only shows that a hook
+  mutated the index without moving `HEAD` (reproduced 2026-09-11 in PR
+  #2906 review, via a hook that staged an extra file and slept) — it
+  cannot also catch a hook that swaps one tracked line's content for
+  another of the same shape, leaving both reports unchanged
+  (preventive; no observed incident yet). Unstaged working-tree
+  changes are intentionally excluded from this check: `git commit -F`
+  alone never commits them, so they cannot reach the fallback commit
+  regardless of what changed there. Unchanged → fall back to
+  `--no-gpg-sign`
   (`idd-overview-appendix.instructions.md`'s "Commit signing" section).
-  Either changed → stop and post a hold note for review instead of
-  falling back.
+  Changed → stop and post a hold note for review instead of falling
+  back.
 - **Merge or rebase, state still present**: name the state via git, not
   a literal path — in a linked worktree (every B1 sibling worktree)
   `.git` at the worktree root is a _file_ pointing elsewhere, so a

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -3531,11 +3531,17 @@ raised in PR #2906 review). First check whether the process is
 still running — per `idd-ci.instructions.md`'s "Wake-up discipline"
 guidance on a heavy local command that auto-backgrounds past a tool's
 default timeout, do not start a second wrapper invocation alongside it.
-If it is still running, terminate it (a plain `kill`/`SIGTERM`, not
-`-9` — git's own signal handler cleans up `index.lock`; `-9` skips that
-cleanup and the fallback below then fails on the stale lock).
+If it is still running, terminate it **and any descendants** (SIGTERM,
+not `-9` — git's own signal handler cleans up `index.lock`; `-9` skips
+that cleanup and the fallback below then fails on the stale lock; a
+descendant such as the signer subprocess can outlive a `kill` scoped to
+only the git parent, reproduced in PR #2906 review), then **wait for
+that whole process tree to exit** before checking state or falling
+back — SIGTERM is asynchronous, so proceeding immediately can race
+git's own unwind (still removing `index.lock`) or observe stale state.
 
-Either way — just terminated, or already exited on its own — verify
+Either way — the tree exited on its own, or was terminated and waited
+for above — verify
 what actually happened before falling back; a killed or already-exited
 process can leave the operation completed, mid-progress, or never
 started at all:
@@ -3563,16 +3569,20 @@ started at all:
   mode `idd-pr-submit.instructions.md`'s D1 "Post-rebase verification"
   already documents. Verify instead of assuming: current branch
   non-empty (not detached) and the expected commit present in
-  `origin/{development-branch}..HEAD` for a rebase, or `HEAD` advanced
-  past its pre-call value for a merge. Verified → stop. Not verified →
-  re-attach to the branch if detached (`git checkout {branch-name}`;
-  the commit is preserved on the branch ref) and rerun the original
-  merge or rebase command **unsigned** (`git -c commit.gpgsign=false
-  merge …` / `rebase …`, not the SSH-signing wrapper), exactly once —
-  mirroring D1's own bounded auto-recovery. If that single unsigned
-  rerun still fails the same verification, post a hold note documenting
-  the branch state and stop, the same as D1's own recovery does when it
-  is exhausted.
+  `origin/{development-branch}..HEAD` for a rebase; for a merge, either
+  `HEAD` advanced past its pre-call value or
+  `git merge-base --is-ancestor origin/{development-branch} HEAD`
+  already succeeds — an already-current merge exits `0` having created
+  neither a new `HEAD` nor `MERGE_HEAD`, and is success, not a failed
+  attempt. Verified → stop. Not verified → re-attach to the branch if
+  detached (`git checkout {branch-name}`; the commit is preserved on
+  the branch ref) and rerun the original merge or rebase command
+  **unsigned** (`git -c commit.gpgsign=false merge …` / `rebase …`, not
+  the SSH-signing wrapper), exactly once, under this same 2-minute
+  bound — mirroring D1's own bounded auto-recovery. If that rerun times
+  out or still fails the same verification, post a hold note
+  documenting the branch state and stop, the same as D1's own recovery
+  does when it is exhausted.
 
 Observed hanging with no output for an extended, unbounded period on
 2026-09-10 (issue #2844 / PR #2870, commit `7be8acc9`, later confirmed

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -3541,15 +3541,25 @@ then wait up to 30 seconds for the tree to exit; SIGTERM is
 asynchronous, so checking state immediately can race git's own unwind
 (still removing `index.lock`) or observe stale state. If the tree is
 still alive after that wait, send SIGKILL to whatever remains and wait
-once more, up to 30 seconds — `-9` skips git's signal handler, so once
-every process in the tree has actually exited, remove a leftover
-`index.lock` yourself
+once more, up to 30 seconds — `-9` skips git's signal handler, so a
+leftover `index.lock` can persist even once every process in the
+terminated tree has actually exited, and that alone does not prove
+the lock is this invocation's: a `git status` run by hand, a hook, or
+another command could hold it instead, the same ambiguity the
+clone-scoped lock's own "no automatic stale-lock recovery" convention
+already treats as unsafe to guess past. Confirm no other process
+still has the lock file open — a hook or the signer subprocess itself
+could hold it, not only another `git` command — for example with
+`lsof` on the `--git-path index.lock` path, or, where it is not
+available, by confirming no process at all still has this worktree as
+its working directory — before removing it yourself
 (`rm -f "$(git rev-parse --git-path index.lock)"`, not a literal
 `.git/index.lock` path, the same linked-worktree rule the rebase-state
-check below uses) before continuing. If the tree is still alive even
-after SIGKILL — for example, a process stuck in uninterruptible I/O —
-stop: post a hold note documenting the surviving PIDs rather than
-waiting any longer.
+check below uses); if ownership cannot be confirmed, leave the lock in
+place and stop with a hold note instead of forcing the removal. If the
+tree is still alive even after SIGKILL — for example, a process stuck
+in uninterruptible I/O — stop the same way: post a hold note
+documenting the surviving PIDs rather than waiting any longer.
 
 Either way — the tree exited on its own, or was terminated and
 confirmed clear above — verify what actually happened before falling

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -3520,40 +3520,59 @@ commit-ssh` is sufficient here — a single `commit` invocation needs no
 `--continue` step to re-sign.
 
 **Bounded timeout for every invocation** (commit, merge, or rebase): if
-the wrapper produces no output for 2 minutes, treat it as stuck rather
-than a signing failure worth retrying — a whole-command,
+the wrapper has not completed within 2 minutes, treat it as stuck
+rather than a signing failure worth retrying — a whole-command,
 root-cause-agnostic bound (it deliberately does not try to isolate the
-signer subprocess). Scope the trigger to _silence_, not merely elapsed
-time: a legitimately long-running rebase that is actively replaying
-commits (and therefore still producing output) is not this case.
-First check whether the process is still running — per
-`idd-ci.instructions.md`'s "Wake-up discipline" guidance on a heavy
-local command that auto-backgrounds past a tool's default timeout, do
-not start a second wrapper invocation alongside it. If it is still
-running, terminate it (a plain `kill`/`SIGTERM`, not `-9` — git's own
-signal handler cleans up `index.lock`; `-9` skips that cleanup and the
-fallback below then fails on the stale lock).
+signer subprocess) that applies even to an invocation still producing
+output: an inactivity-only trigger would leave a merge or rebase that
+keeps emitting output free to run indefinitely without ever completing,
+which is not actually bounded (preventive; no observed incident yet —
+raised in PR #2906 review). First check whether the process is
+still running — per `idd-ci.instructions.md`'s "Wake-up discipline"
+guidance on a heavy local command that auto-backgrounds past a tool's
+default timeout, do not start a second wrapper invocation alongside it.
+If it is still running, terminate it (a plain `kill`/`SIGTERM`, not
+`-9` — git's own signal handler cleans up `index.lock`; `-9` skips that
+cleanup and the fallback below then fails on the stale lock).
 
-Either way — just terminated, or already exited on its own — inspect
-repository state **before** falling back: the process may already have
-updated `HEAD`, or left an in-progress merge/rebase, before it stalled
-or exited.
+Either way — just terminated, or already exited on its own — verify
+what actually happened before falling back; a killed or already-exited
+process can leave the operation completed, mid-progress, or never
+started at all:
 
 - **Plain commit**: compare `git rev-parse HEAD` before/after the
   wrapper call, the same check B3's "Verify a commit actually landed"
-  paragraph already prescribes. If the commit landed, stop — do not
-  re-commit. If it did not, fall back to `--no-gpg-sign`
+  paragraph already prescribes. Landed → stop, do not re-commit.
+  Otherwise → fall back to `--no-gpg-sign`
   (`idd-overview-appendix.instructions.md`'s "Commit signing" section).
-- **Merge or rebase**: name the state via git, not a literal path — in
-  a linked worktree (every B1 sibling worktree) `.git` at the worktree
-  root is a _file_ pointing elsewhere, so a hardcoded `.git/rebase-merge`
-  check silently never matches. Use `git rev-parse -q --verify MERGE_HEAD`
-  for merge, or `test -d "$(git rev-parse --git-path rebase-merge)"`
-  (or `rebase-apply`) for rebase. If the operation already completed,
-  stop. If it is still mid-operation, complete it with
-  `-c commit.gpgsign=false` on the `--continue` form — a plain
-  `--continue` re-signs through the stalled primary signer, and
-  `--no-gpg-sign` itself is not a `--continue` flag.
+- **Merge or rebase, state still present**: name the state via git, not
+  a literal path — in a linked worktree (every B1 sibling worktree)
+  `.git` at the worktree root is a _file_ pointing elsewhere, so a
+  hardcoded `.git/rebase-merge` check silently never matches. Use
+  `git rev-parse -q --verify MERGE_HEAD` for a merge, or
+  `test -d "$(git rev-parse --git-path rebase-merge)"` (or
+  `rebase-apply`) for a rebase. Either succeeding means the operation is
+  mid-progress: complete it with `-c commit.gpgsign=false` on the
+  `--continue` form — a plain `--continue` re-signs through the stalled
+  primary signer, and `--no-gpg-sign` itself is not a `--continue` flag.
+- **Merge or rebase, no state present**: absent state alone does not
+  prove the operation succeeded — the timeout can equally fire before
+  Git ever creates that state (nothing to `--continue`), or, for a
+  rebase specifically, leave `HEAD` detached at the upstream tip
+  without replaying the local commit, the same sibling-worktree failure
+  mode `idd-pr-submit.instructions.md`'s D1 "Post-rebase verification"
+  already documents. Verify instead of assuming: current branch
+  non-empty (not detached) and the expected commit present in
+  `origin/{development-branch}..HEAD` for a rebase, or `HEAD` advanced
+  past its pre-call value for a merge. Verified → stop. Not verified →
+  re-attach to the branch if detached (`git checkout {branch-name}`;
+  the commit is preserved on the branch ref) and rerun the original
+  merge or rebase command **unsigned** (`git -c commit.gpgsign=false
+  merge …` / `rebase …`, not the SSH-signing wrapper), exactly once —
+  mirroring D1's own bounded auto-recovery. If that single unsigned
+  rerun still fails the same verification, post a hold note documenting
+  the branch state and stop, the same as D1's own recovery does when it
+  is exhausted.
 
 Observed hanging with no output for an extended, unbounded period on
 2026-09-10 (issue #2844 / PR #2870, commit `7be8acc9`, later confirmed

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -3527,24 +3527,34 @@ signer subprocess) that applies even to an invocation still producing
 output: an inactivity-only trigger would leave a merge or rebase that
 keeps emitting output free to run indefinitely without ever completing,
 which is not actually bounded (preventive; no observed incident yet —
-raised in PR #2906 review). First check whether the process is
-still running — per `idd-ci.instructions.md`'s "Wake-up discipline"
-guidance on a heavy local command that auto-backgrounds past a tool's
-default timeout, do not start a second wrapper invocation alongside it.
-If it is still running, terminate it **and any descendants** (SIGTERM,
-not `-9` — git's own signal handler cleans up `index.lock`; `-9` skips
-that cleanup and the fallback below then fails on the stale lock; a
-descendant such as the signer subprocess can outlive a `kill` scoped to
-only the git parent, reproduced in PR #2906 review), then **wait for
-that whole process tree to exit** before checking state or falling
-back — SIGTERM is asynchronous, so proceeding immediately can race
-git's own unwind (still removing `index.lock`) or observe stale state.
+raised in PR #2906 review). First check whether the process **tree** —
+the wrapper's git invocation and any descendants such as the signer
+subprocess, not just the top-level command — is still running: per
+`idd-ci.instructions.md`'s "Wake-up discipline" guidance on a heavy
+local command that auto-backgrounds past a tool's default timeout, do
+not start a second wrapper invocation alongside it. If any part of the
+tree is still running, terminate the whole tree with SIGTERM, not
+`-9` — git's own signal handler cleans up `index.lock`, and a
+descendant such as the signer subprocess can outlive a `kill` scoped
+to only the git parent (reproduced 2026-09-11 in PR #2906 review) —
+then wait up to 30 seconds for the tree to exit; SIGTERM is
+asynchronous, so checking state immediately can race git's own unwind
+(still removing `index.lock`) or observe stale state. If the tree is
+still alive after that wait, send SIGKILL to whatever remains and wait
+once more, up to 30 seconds — `-9` skips git's signal handler, so once
+every process in the tree has actually exited, remove a leftover
+`index.lock` yourself
+(`rm -f "$(git rev-parse --git-path index.lock)"`, not a literal
+`.git/index.lock` path, the same linked-worktree rule the rebase-state
+check below uses) before continuing. If the tree is still alive even
+after SIGKILL — for example, a process stuck in uninterruptible I/O —
+stop: post a hold note documenting the surviving PIDs rather than
+waiting any longer.
 
-Either way — the tree exited on its own, or was terminated and waited
-for above — verify
-what actually happened before falling back; a killed or already-exited
-process can leave the operation completed, mid-progress, or never
-started at all:
+Either way — the tree exited on its own, or was terminated and
+confirmed clear above — verify what actually happened before falling
+back; a killed or already-exited process can leave the operation
+completed, mid-progress, or never started at all:
 
 - **Plain commit**: compare `git rev-parse HEAD` before/after the
   wrapper call, the same check B3's "Verify a commit actually landed"
@@ -3567,8 +3577,8 @@ started at all:
   rebase specifically, leave `HEAD` detached at the upstream tip
   without replaying the local commit, the same sibling-worktree failure
   mode `idd-pr-submit.instructions.md`'s D1 "Post-rebase verification"
-  already documents. Verify instead of assuming: current branch
-  non-empty (not detached) and the expected commit present in
+  already documents and defines the same predicate for: current branch
+  non-empty (not detached) and the expected local commit present in
   `origin/{development-branch}..HEAD` for a rebase; for a merge, either
   `HEAD` advanced past its pre-call value or
   `git merge-base --is-ancestor origin/{development-branch} HEAD`
@@ -3583,6 +3593,18 @@ started at all:
   out or still fails the same verification, post a hold note
   documenting the branch state and stop, the same as D1's own recovery
   does when it is exhausted.
+
+No step in this recovery procedure waits indefinitely: the original
+wrapper invocation and every fallback or continuation share the same
+2-minute bound, and the termination wait above has its own 30-second
+bounds — every step that exceeds its bound routes to the same
+terminate-and-verify-or-hold outcome, not a fresh unbounded wait. A
+hook or other non-signing cause can hang the plain-commit
+`--no-gpg-sign` fallback or the `--continue` completion just as it
+hung the original attempt; if either does not itself complete within
+2 minutes, apply the same terminate-and-verify procedure to it, and if
+it still does not resolve, post a hold note and stop rather than
+retrying further.
 
 Observed hanging with no output for an extended, unbounded period on
 2026-09-10 (issue #2844 / PR #2870, commit `7be8acc9`, later confirmed

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -3538,50 +3538,46 @@ process tree — if `pgrep`/`ps` (or an equivalent process-listing and
 signaling mechanism) are not available on the host, that dependency
 cannot be met: stop and post a hold note rather than falling back
 without the cleanup guarantee, the same fail-closed treatment the
-`lsof` case below already gets. Otherwise, before signaling anything,
-snapshot the full descendant PID set by walking from the git PID (for
-example, recursively via `pgrep -P`) — walk once, before the first
-signal, and keep that recorded list: re-walking after signaling misses
-a child whose parent the signal already removed, even though the
-child itself is still alive. Record each PID together
-with its process start time (for example, `ps -o lstart=` for that
-PID), not the bare number — a PID that exits during the wait below can
-be reused by an unrelated process before the next signal, and signaling
-by number alone would then hit that unrelated process instead. If any
-part of the tree is still running, send SIGTERM to every recorded PID
-whose start time still matches, not `-9` — git's own signal handler
-cleans up `index.lock`, and a descendant such as the signer subprocess
-can outlive a `kill` scoped to only the git parent (reproduced
-2026-09-11 in PR #2906 review) — then wait up to 30 seconds for each
-recorded PID individually to exit (not a fresh tree walk); SIGTERM is
-asynchronous, so checking state immediately can race git's own unwind
-(still removing `index.lock`) or observe stale state. Even a PID
-snapshot is best-effort, not a guarantee: a child that gets reparented
-(commonly to init) before the snapshot is taken is never recorded at
-all, so it survives untouched no matter how carefully the recorded
-PIDs are signaled and awaited. Whether that is safe to proceed past
-depends on what kind of descendant it can be: a signer subprocess that
-escapes this way is only a resource leak to report, since the unsigned
-fallback below never invokes a signer and so cannot race one — but the
-whole-command timeout this section opens with is root-cause-agnostic
-(it can equally fire on a hung hook, not only a stalled signer), and a
-hook process that escapes the same way could still be reading or
+`lsof` case below already gets. Otherwise, snapshot the full
+descendant PID set by walking from the git PID (for example,
+recursively via `pgrep -P`) and immediately send SIGTERM to every
+recorded PID, not `-9` — git's own signal handler cleans up
+`index.lock`, and a descendant such as the signer subprocess can
+outlive a `kill` scoped to only the git parent (reproduced 2026-09-11
+in PR #2906 review). Snapshot and signal back-to-back, with nothing in
+between: that is what keeps a bare recorded PID number trustworthy
+without needing a separate identity check, since the gap in which an
+exited PID could be reused by an unrelated process stays sub-second on
+any real host. Then wait up to 30 seconds for each recorded PID
+individually to exit (not a fresh tree walk); SIGTERM is asynchronous,
+so checking state immediately can race git's own unwind (still
+removing `index.lock`) or observe stale state.
+
+Even a PID snapshot is best-effort, not a guarantee: a child that gets
+reparented (commonly to init) before the snapshot is taken is never
+recorded at all, so it survives untouched no matter how promptly the
+recorded PIDs are signaled. The same is true of a recorded PID that
+simply outlasts the 30-second wait — for example a process stuck in
+uninterruptible I/O, which cannot receive a signal until it leaves
+that state (preventive; no observed incident yet). Whether either kind
+of survivor is safe to proceed past depends on what it can be: a
+signer subprocess is only a resource leak to report, since the
+unsigned fallback below never invokes one and so cannot race it — but
+the whole-command timeout this section opens with is root-cause-
+agnostic (it can equally fire on a hung hook, not only a stalled
+signer), and a hook process that survives could still be reading or
 writing the working tree or index. Proceeding with the fallback while
 an unidentified or non-signer descendant might still be touching
 repository state risks the fallback's own git operation racing it, so
 treat that case as blocking: stop and post a hold note documenting the
 surviving PID(s) rather than falling back, reserving the
 resource-leak-and-continue treatment for a descendant identifiable as
-the signer itself. Before the next signal, re-check each
-recorded PID's start time again: a mismatch means it already exited
-and the number was reused, so skip signaling it rather than treat the
-new, unrelated process as the same one. If a recorded PID is still
-alive (same start time) after the SIGTERM wait, send SIGKILL to it and
-wait once more, up to 30 seconds — `-9` skips git's signal handler, so a
-leftover `index.lock` can persist even once every process in the
-terminated tree has actually exited, and that alone does not prove
-the lock is this invocation's: a `git status` run by hand, a hook, or
-another command could hold it instead, the same ambiguity the
+the signer itself.
+
+Separately, the lock-ownership check keeps its original (round-6)
+purpose: a leftover `index.lock` after the tree is confirmed gone does
+not prove it belongs to this invocation — a hook, another command, or
+the signer itself could hold it instead, the same ambiguity the
 clone-scoped lock's own "no automatic stale-lock recovery" convention
 already treats as unsafe to guess past. Confirm no other process
 still has the lock file open — a hook or the signer subprocess itself
@@ -3595,21 +3591,28 @@ it yourself
 (`rm -f "$(git rev-parse --git-path index.lock)"`, not a literal
 `.git/index.lock` path, the same linked-worktree rule the rebase-state
 check below uses); if ownership cannot be confirmed, leave the lock in
-place and stop with a hold note instead of forcing the removal. If the
-tree is still alive even after SIGKILL — for example, a process stuck
-in uninterruptible I/O — stop the same way: post a hold note
-documenting the surviving PIDs rather than waiting any longer.
+place and stop with a hold note instead of forcing the removal.
 
-Either way — the tree exited on its own, or was terminated and
-confirmed clear above — verify what actually happened before falling
-back; a killed or already-exited process can leave the operation
-completed, mid-progress, or never started at all:
+Either way — the tree exited on its own, was terminated with nothing
+left but an identified signer leak, or the checks above otherwise
+allow proceeding — verify what actually happened before falling back;
+a killed or already-exited process can leave the operation completed,
+mid-progress, or never started at all:
 
 - **Plain commit**: compare `git rev-parse HEAD` before/after the
   wrapper call, the same check B3's "Verify a commit actually landed"
   paragraph already prescribes. Landed → stop, do not re-commit.
-  Otherwise → fall back to `--no-gpg-sign`
+  Otherwise, before falling back to `--no-gpg-sign`, also compare
+  `git status --porcelain` and `git diff --cached --stat` against
+  their state captured before the wrapper call: a hook that ran before
+  the timeout can leave the index or working tree mutated even though
+  `HEAD` never moved, and the fallback would then commit that
+  mutation alongside the intended change (reproduced 2026-09-11 in PR
+  #2906 review, via a hook that staged an extra file and slept). Both
+  unchanged → fall back to `--no-gpg-sign`
   (`idd-overview-appendix.instructions.md`'s "Commit signing" section).
+  Either changed → stop and post a hold note for review instead of
+  falling back.
 - **Merge or rebase, state still present**: name the state via git, not
   a literal path — in a linked worktree (every B1 sibling worktree)
   `.git` at the worktree root is a _file_ pointing elsewhere, so a
@@ -3656,7 +3659,7 @@ completed, mid-progress, or never started at all:
 No step in this recovery procedure waits indefinitely: the original
 wrapper invocation and every fallback or continuation share the same
 2-minute bound, and the termination wait above has its own 30-second
-bounds — every step that exceeds its bound routes to the same
+bound — every step that exceeds its bound routes to the same
 terminate-and-verify-or-hold outcome, not a fresh unbounded wait. A
 hook or other non-signing cause can hang the plain-commit
 `--no-gpg-sign` fallback or the `--continue` completion just as it

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -3532,12 +3532,18 @@ the wrapper's git invocation and any descendants such as the signer
 subprocess, not just the top-level command — is still running: per
 `idd-ci.instructions.md`'s "Wake-up discipline" guidance on a heavy
 local command that auto-backgrounds past a tool's default timeout, do
-not start a second wrapper invocation alongside it. Before signaling
-anything, snapshot the full descendant PID set by walking from the
-git PID (for example, recursively via `pgrep -P`) — walk once, before
-the first signal, and keep that recorded list: re-walking after
-signaling misses a child whose parent the signal already removed,
-even though the child itself is still alive. Record each PID together
+not start a second wrapper invocation alongside it. This whole
+recovery procedure depends on being able to snapshot and signal the
+process tree — if `pgrep`/`ps` (or an equivalent process-listing and
+signaling mechanism) are not available on the host, that dependency
+cannot be met: stop and post a hold note rather than falling back
+without the cleanup guarantee, the same fail-closed treatment the
+`lsof` case below already gets. Otherwise, before signaling anything,
+snapshot the full descendant PID set by walking from the git PID (for
+example, recursively via `pgrep -P`) — walk once, before the first
+signal, and keep that recorded list: re-walking after signaling misses
+a child whose parent the signal already removed, even though the
+child itself is still alive. Record each PID together
 with its process start time (for example, `ps -o lstart=` for that
 PID), not the bare number — a PID that exits during the wait below can
 be reused by an unrelated process before the next signal, and signaling
@@ -3553,12 +3559,20 @@ asynchronous, so checking state immediately can race git's own unwind
 snapshot is best-effort, not a guarantee: a child that gets reparented
 (commonly to init) before the snapshot is taken is never recorded at
 all, so it survives untouched no matter how carefully the recorded
-PIDs are signaled and awaited — a signer that survives this way is a
-resource leak to report, not a condition this procedure can reliably
-close; list any surviving PIDs in the hold or status note rather than
-treating any later step as having caught it (the unsigned fallback
-below never invokes the signer, so a leaked signer cannot corrupt that
-path, only waste resources). Before the next signal, re-check each
+PIDs are signaled and awaited. Whether that is safe to proceed past
+depends on what kind of descendant it can be: a signer subprocess that
+escapes this way is only a resource leak to report, since the unsigned
+fallback below never invokes a signer and so cannot race one — but the
+whole-command timeout this section opens with is root-cause-agnostic
+(it can equally fire on a hung hook, not only a stalled signer), and a
+hook process that escapes the same way could still be reading or
+writing the working tree or index. Proceeding with the fallback while
+an unidentified or non-signer descendant might still be touching
+repository state risks the fallback's own git operation racing it, so
+treat that case as blocking: stop and post a hold note documenting the
+surviving PID(s) rather than falling back, reserving the
+resource-leak-and-continue treatment for a descendant identifiable as
+the signer itself. Before the next signal, re-check each
 recorded PID's start time again: a mismatch means it already exited
 and the number was reused, so skip signaling it rather than treat the
 new, unrelated process as the same one. If a recorded PID is still

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -3544,12 +3544,16 @@ or exited.
   paragraph already prescribes. If the commit landed, stop — do not
   re-commit. If it did not, fall back to `--no-gpg-sign`
   (`idd-overview-appendix.instructions.md`'s "Commit signing" section).
-- **Merge or rebase**: check whether `MERGE_HEAD` (merge) or
-  `.git/rebase-merge` / `.git/rebase-apply` (rebase) still exists. If
-  the operation already completed, stop. If it is still mid-operation,
-  complete it with `-c commit.gpgsign=false` on the `--continue` form
-  — a plain `--continue` re-signs through the stalled primary signer,
-  and `--no-gpg-sign` itself is not a `--continue` flag.
+- **Merge or rebase**: name the state via git, not a literal path — in
+  a linked worktree (every B1 sibling worktree) `.git` at the worktree
+  root is a _file_ pointing elsewhere, so a hardcoded `.git/rebase-merge`
+  check silently never matches. Use `git rev-parse -q --verify MERGE_HEAD`
+  for merge, or `test -d "$(git rev-parse --git-path rebase-merge)"`
+  (or `rebase-apply`) for rebase. If the operation already completed,
+  stop. If it is still mid-operation, complete it with
+  `-c commit.gpgsign=false` on the `--continue` form — a plain
+  `--continue` re-signs through the stalled primary signer, and
+  `--no-gpg-sign` itself is not a `--continue` flag.
 
 Observed hanging with no output for an extended, unbounded period on
 2026-09-10 (issue #2844 / PR #2870, commit `7be8acc9`, later confirmed

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -3520,20 +3520,40 @@ commit-ssh` is sufficient here — a single `commit` invocation needs no
 `--continue` step to re-sign.
 
 **Bounded timeout for every invocation** (commit, merge, or rebase): if
-the wrapper has not completed within 2 minutes, treat it as stuck
-rather than a signing failure worth retrying. First check whether the
-process is still running — per `idd-ci.instructions.md`'s "Wake-up
-discipline" guidance on a heavy local command that auto-backgrounds
-past a tool's default timeout, do not start a second wrapper
-invocation alongside it — then kill it and fall back to the
-already-documented `--no-gpg-sign` last resort
-(`idd-overview-appendix.instructions.md`'s "Commit signing" section)
-rather than waiting indefinitely. For an in-progress merge or rebase,
-complete it with `-c commit.gpgsign=false` on the `--continue` form
-instead — a plain `--continue` re-signs through the stalled primary
-signer, and `--no-gpg-sign` itself is not a `--continue` flag. Observed
-hanging with no output for an extended, unbounded period on 2026-09-10
-(issue #2844 / PR #2870, commit `7be8acc9`, later confirmed unsigned).
+the wrapper produces no output for 2 minutes, treat it as stuck rather
+than a signing failure worth retrying — a whole-command,
+root-cause-agnostic bound (it deliberately does not try to isolate the
+signer subprocess). Scope the trigger to _silence_, not merely elapsed
+time: a legitimately long-running rebase that is actively replaying
+commits (and therefore still producing output) is not this case.
+First check whether the process is still running — per
+`idd-ci.instructions.md`'s "Wake-up discipline" guidance on a heavy
+local command that auto-backgrounds past a tool's default timeout, do
+not start a second wrapper invocation alongside it. If it is still
+running, terminate it (a plain `kill`/`SIGTERM`, not `-9` — git's own
+signal handler cleans up `index.lock`; `-9` skips that cleanup and the
+fallback below then fails on the stale lock).
+
+Either way — just terminated, or already exited on its own — inspect
+repository state **before** falling back: the process may already have
+updated `HEAD`, or left an in-progress merge/rebase, before it stalled
+or exited.
+
+- **Plain commit**: compare `git rev-parse HEAD` before/after the
+  wrapper call, the same check B3's "Verify a commit actually landed"
+  paragraph already prescribes. If the commit landed, stop — do not
+  re-commit. If it did not, fall back to `--no-gpg-sign`
+  (`idd-overview-appendix.instructions.md`'s "Commit signing" section).
+- **Merge or rebase**: check whether `MERGE_HEAD` (merge) or
+  `.git/rebase-merge` / `.git/rebase-apply` (rebase) still exists. If
+  the operation already completed, stop. If it is still mid-operation,
+  complete it with `-c commit.gpgsign=false` on the `--continue` form
+  — a plain `--continue` re-signs through the stalled primary signer,
+  and `--no-gpg-sign` itself is not a `--continue` flag.
+
+Observed hanging with no output for an extended, unbounded period on
+2026-09-10 (issue #2844 / PR #2870, commit `7be8acc9`, later confirmed
+unsigned).
 
 ## Friction Inventory
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -3532,22 +3532,30 @@ the wrapper's git invocation and any descendants such as the signer
 subprocess, not just the top-level command — is still running: per
 `idd-ci.instructions.md`'s "Wake-up discipline" guidance on a heavy
 local command that auto-backgrounds past a tool's default timeout, do
-not start a second wrapper invocation alongside it. If any part of the
-tree is still running, terminate the whole tree with SIGTERM, not
-`-9` — git's own signal handler cleans up `index.lock`, and a
-descendant such as the signer subprocess can outlive a `kill` scoped
-to only the git parent (reproduced 2026-09-11 in PR #2906 review) —
-then wait up to 30 seconds for the tree to exit; SIGTERM is
-asynchronous, so checking state immediately can race git's own unwind
-(still removing `index.lock`) or observe stale state. Walking
-descendants by PID is best-effort, not a guarantee — a child whose
-immediate parent already exited is reparented (commonly to init) and
-is no longer reachable by walking down from the git PID, so "the tree
-exited" can be wrong even after this wait; that gap is exactly what
-the lock-ownership check below exists to catch, not something this
-step alone can close. If the tree is still alive after that wait, send
-SIGKILL to whatever remains and wait once more, up to 30 seconds —
-`-9` skips git's signal handler, so a
+not start a second wrapper invocation alongside it. Before signaling
+anything, snapshot the full descendant PID set by walking from the
+git PID (for example, recursively via `pgrep -P`) — walk once, before
+the first signal, and keep that recorded list: re-walking after
+signaling misses a child whose parent the signal already removed,
+even though the child itself is still alive. If any part of the tree
+is still running, send SIGTERM to every recorded PID, not `-9` —
+git's own signal handler cleans up `index.lock`, and a descendant such
+as the signer subprocess can outlive a `kill` scoped to only the git
+parent (reproduced 2026-09-11 in PR #2906 review) — then wait up to
+30 seconds for each recorded PID individually to exit (not a fresh
+tree walk); SIGTERM is asynchronous, so checking state immediately
+can race git's own unwind (still removing `index.lock`) or observe
+stale state. Even a PID snapshot is best-effort, not a guarantee: a
+child that gets reparented (commonly to init) before the snapshot is
+taken is never recorded at all, so it survives untouched no matter
+how carefully the recorded PIDs are signaled and awaited — a signer
+that survives this way is a resource leak to report, not a condition
+this procedure can reliably close; list any surviving PIDs in the
+hold or status note rather than treating any later step as having
+caught it (the unsigned fallback below never invokes the signer, so a
+leaked signer cannot corrupt that path, only waste resources). If any
+recorded PID is still alive after that wait, send SIGKILL to it and
+wait once more, up to 30 seconds — `-9` skips git's signal handler, so a
 leftover `index.lock` can persist even once every process in the
 terminated tree has actually exited, and that alone does not prove
 the lock is this invocation's: a `git status` run by hand, a hook, or
@@ -3603,7 +3611,17 @@ completed, mid-progress, or never started at all:
   `git merge-base --is-ancestor origin/{development-branch} HEAD`
   already succeeds — an already-current merge exits `0` having created
   neither a new `HEAD` nor `MERGE_HEAD`, and is success, not a failed
-  attempt. Verified → stop. Not verified → re-attach to the branch if
+  attempt. For a rebase specifically, D1's two checks alone are not
+  enough here: D1 verifies a rebase that already completed, but a
+  timeout that fires **before** the rebase ever starts leaves the
+  untouched, still-behind branch passing both checks trivially (it was
+  never detached, and its own feature commit was already present in
+  `origin/{development-branch}..HEAD` before this attempt began) —
+  require `git merge-base --is-ancestor origin/{development-branch}
+  HEAD` to succeed too, the same upstream-incorporated check the merge
+  case above already uses, so a rebase that never actually ran is not
+  mistaken for one that did. Verified → stop. Not verified → re-attach
+  to the branch if
   detached (`git checkout {branch-name}`; the commit is preserved on
   the branch ref) and rerun the original merge or rebase command
   **unsigned** (`git -c commit.gpgsign=false merge …` / `rebase …`, not

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -3539,9 +3539,15 @@ descendant such as the signer subprocess can outlive a `kill` scoped
 to only the git parent (reproduced 2026-09-11 in PR #2906 review) —
 then wait up to 30 seconds for the tree to exit; SIGTERM is
 asynchronous, so checking state immediately can race git's own unwind
-(still removing `index.lock`) or observe stale state. If the tree is
-still alive after that wait, send SIGKILL to whatever remains and wait
-once more, up to 30 seconds — `-9` skips git's signal handler, so a
+(still removing `index.lock`) or observe stale state. Walking
+descendants by PID is best-effort, not a guarantee — a child whose
+immediate parent already exited is reparented (commonly to init) and
+is no longer reachable by walking down from the git PID, so "the tree
+exited" can be wrong even after this wait; that gap is exactly what
+the lock-ownership check below exists to catch, not something this
+step alone can close. If the tree is still alive after that wait, send
+SIGKILL to whatever remains and wait once more, up to 30 seconds —
+`-9` skips git's signal handler, so a
 leftover `index.lock` can persist even once every process in the
 terminated tree has actually exited, and that alone does not prove
 the lock is this invocation's: a `git status` run by hand, a hook, or
@@ -3549,10 +3555,13 @@ another command could hold it instead, the same ambiguity the
 clone-scoped lock's own "no automatic stale-lock recovery" convention
 already treats as unsafe to guess past. Confirm no other process
 still has the lock file open — a hook or the signer subprocess itself
-could hold it, not only another `git` command — for example with
-`lsof` on the `--git-path index.lock` path, or, where it is not
-available, by confirming no process at all still has this worktree as
-its working directory — before removing it yourself
+could hold it, not only another `git` command, and not necessarily
+one running from this worktree's directory (an absolute-path or
+`git -C` invocation holds the same lock without it) — with `lsof` on
+the `--git-path index.lock` path; where `lsof` is not available,
+ownership cannot be reliably confirmed at all, so treat it as
+unconfirmed rather than substituting a weaker check — before removing
+it yourself
 (`rm -f "$(git rev-parse --git-path index.lock)"`, not a literal
 `.git/index.lock` path, the same linked-worktree rule the rebase-state
 check below uses); if ownership cannot be confirmed, leave the lock in

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -3508,6 +3508,33 @@ complement to the recovery-path re-signing in
 `idd-pr-submit.instructions.md` (Post-rebase verification) and
 `idd-overview-core.instructions.md` (cwd-vs-claim cherry-pick recovery).
 
+This wrapper also applies to an ordinary per-commit `git commit` in B3
+(`idd-work.instructions.md`), not only a merge or rebase continuation:
+
+```sh
+git -c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true commit -F <message-file>
+```
+
+Unlike the merge case above, a commit-only alias such as `git
+commit-ssh` is sufficient here — a single `commit` invocation needs no
+`--continue` step to re-sign.
+
+**Bounded timeout for every invocation** (commit, merge, or rebase): if
+the wrapper has not completed within 2 minutes, treat it as stuck
+rather than a signing failure worth retrying. First check whether the
+process is still running — per `idd-ci.instructions.md`'s "Wake-up
+discipline" guidance on a heavy local command that auto-backgrounds
+past a tool's default timeout, do not start a second wrapper
+invocation alongside it — then kill it and fall back to the
+already-documented `--no-gpg-sign` last resort
+(`idd-overview-appendix.instructions.md`'s "Commit signing" section)
+rather than waiting indefinitely. For an in-progress merge or rebase,
+complete it with `-c commit.gpgsign=false` on the `--continue` form
+instead — a plain `--continue` re-signs through the stalled primary
+signer, and `--no-gpg-sign` itself is not a `--continue` flag. Observed
+hanging with no output for an extended, unbounded period on 2026-09-10
+(issue #2844 / PR #2870, commit `7be8acc9`, later confirmed unsigned).
+
 ## Friction Inventory
 
 The workflow areas most likely to benefit from optional helpers are:

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -3538,17 +3538,20 @@ process tree — if `pgrep`/`ps` (or an equivalent process-listing and
 signaling mechanism) are not available on the host, that dependency
 cannot be met: stop and post a hold note rather than falling back
 without the cleanup guarantee, the same fail-closed treatment the
-`lsof` case below already gets. Otherwise, snapshot the full
-descendant PID set by walking from the git PID (for example,
-recursively via `pgrep -P`) and immediately send SIGTERM to every
-recorded PID, not `-9` — git's own signal handler cleans up
-`index.lock`, and a descendant such as the signer subprocess can
-outlive a `kill` scoped to only the git parent (reproduced 2026-09-11
-in PR #2906 review). Snapshot and signal back-to-back, with nothing in
-between: that is what keeps a bare recorded PID number trustworthy
-without needing a separate identity check, since the gap in which an
-exited PID could be reused by an unrelated process stays sub-second on
-any real host. Then wait up to 30 seconds for each recorded PID
+`lsof` case below already gets. Otherwise, snapshot the whole set to
+signal: the git PID itself **and** its descendants, found by walking
+from the git PID (for example, recursively via `pgrep -P`) — a
+"descendant" walk alone omits the root git process, leaving it able to
+keep running (and keep `index.lock` held) after only its children are
+signaled. Immediately send SIGTERM to every recorded PID in that
+whole set, not `-9` — git's own signal handler cleans up `index.lock`,
+and a descendant such as the signer subprocess can outlive a `kill`
+scoped to only the git parent (reproduced 2026-09-11 in PR #2906
+review). Snapshot and signal back-to-back, with nothing in between:
+that is what keeps a bare recorded PID number trustworthy without
+needing a separate identity check, since the gap in which an exited
+PID could be reused by an unrelated process stays sub-second on any
+real host. Then wait up to 30 seconds for each recorded PID
 individually to exit (not a fresh tree walk); SIGTERM is asynchronous,
 so checking state immediately can race git's own unwind (still
 removing `index.lock`) or observe stale state.

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -3537,24 +3537,32 @@ anything, snapshot the full descendant PID set by walking from the
 git PID (for example, recursively via `pgrep -P`) — walk once, before
 the first signal, and keep that recorded list: re-walking after
 signaling misses a child whose parent the signal already removed,
-even though the child itself is still alive. If any part of the tree
-is still running, send SIGTERM to every recorded PID, not `-9` —
-git's own signal handler cleans up `index.lock`, and a descendant such
-as the signer subprocess can outlive a `kill` scoped to only the git
-parent (reproduced 2026-09-11 in PR #2906 review) — then wait up to
-30 seconds for each recorded PID individually to exit (not a fresh
-tree walk); SIGTERM is asynchronous, so checking state immediately
-can race git's own unwind (still removing `index.lock`) or observe
-stale state. Even a PID snapshot is best-effort, not a guarantee: a
-child that gets reparented (commonly to init) before the snapshot is
-taken is never recorded at all, so it survives untouched no matter
-how carefully the recorded PIDs are signaled and awaited — a signer
-that survives this way is a resource leak to report, not a condition
-this procedure can reliably close; list any surviving PIDs in the
-hold or status note rather than treating any later step as having
-caught it (the unsigned fallback below never invokes the signer, so a
-leaked signer cannot corrupt that path, only waste resources). If any
-recorded PID is still alive after that wait, send SIGKILL to it and
+even though the child itself is still alive. Record each PID together
+with its process start time (for example, `ps -o lstart=` for that
+PID), not the bare number — a PID that exits during the wait below can
+be reused by an unrelated process before the next signal, and signaling
+by number alone would then hit that unrelated process instead. If any
+part of the tree is still running, send SIGTERM to every recorded PID
+whose start time still matches, not `-9` — git's own signal handler
+cleans up `index.lock`, and a descendant such as the signer subprocess
+can outlive a `kill` scoped to only the git parent (reproduced
+2026-09-11 in PR #2906 review) — then wait up to 30 seconds for each
+recorded PID individually to exit (not a fresh tree walk); SIGTERM is
+asynchronous, so checking state immediately can race git's own unwind
+(still removing `index.lock`) or observe stale state. Even a PID
+snapshot is best-effort, not a guarantee: a child that gets reparented
+(commonly to init) before the snapshot is taken is never recorded at
+all, so it survives untouched no matter how carefully the recorded
+PIDs are signaled and awaited — a signer that survives this way is a
+resource leak to report, not a condition this procedure can reliably
+close; list any surviving PIDs in the hold or status note rather than
+treating any later step as having caught it (the unsigned fallback
+below never invokes the signer, so a leaked signer cannot corrupt that
+path, only waste resources). Before the next signal, re-check each
+recorded PID's start time again: a mismatch means it already exited
+and the number was reused, so skip signaling it rather than treat the
+new, unrelated process as the same one. If a recorded PID is still
+alive (same start time) after the SIGTERM wait, send SIGKILL to it and
 wait once more, up to 30 seconds — `-9` skips git's signal handler, so a
 leftover `index.lock` can persist even once every process in the
 terminated tree has actually exited, and that alone does not prove


### PR DESCRIPTION
# Summary

Extends the existing signed-commit merge wrapper (documented in
`docs/idd-helper-scripts.md`'s "Signed-Commit Merge Wrapper" section)
to cover an ordinary per-commit `git commit`, not only merge and
rebase, and adds a bounded 2-minute timeout / hang-recovery rule that
applies uniformly to every invocation of the wrapper, including its
own fallback and continuation steps. Previously,
`idd-work.instructions.md`'s B3 step had no documented recourse when
the repository's configured commit signing is non-interactive-hostile
(GPG pinentry / hardware-touch), and none of the three invocation
sites said what to do if the fallback wrapper itself hangs rather than
failing fast — both gaps were observed live during work on issue
#2844 / PR #2870 (commit `7be8acc9`, confirmed unsigned only after an
unbounded hang).

Only the `idd-template/` canonical sources were edited; both mirrors
were regenerated with `node scripts/sync-docs.mjs --apply`. No
`.github/idd/config.json` key was added, and the
`#signed-commit-merge-wrapper-shared-git-procedure` anchor is
unchanged (other files already link to it by that exact anchor).

**Byte-budget note**: adding the required one-sentence B3
cross-reference alone pushed `bundle-work-phase` from 97.99% to
98.53% utilization, over the `context-ceiling-200k` gate's
`maxUtilizationPct: 98` cap (even though it stayed under the bundle's
raw byte limit). Per the issue's own acceptance criteria ("trim
wording if headroom has shrunk further"), the adjacent, unrelated
"Verify a commit actually landed before trusting a subsequent push"
paragraph in the same B3 section was tightened with no information
loss (both verification techniques — `rev-parse HEAD` before/after and
checking the reported commit hash — and the `-F <file>` recommendation
are preserved) to bring the bundle back to 97.87%, under the
pre-existing baseline. `docs/idd-helper-scripts.md` itself is not
byte-budgeted (a `docs/` surface), so no trim was needed there.

**Live reproduction note**: exercising this exact rule while
committing this PR, the primary GPG signing failed non-interactively
(pinentry/TTY), but unlike the issue's originally observed incident,
the SSH fallback via the repo's `commit-ssh` alias completed
immediately with no hang.

## Linked issue

Closes #2902

## Follow-up issues (if any)

- [ ] `disposition-non-review-notices.mjs` has an explicit in-progress
      guard for Codex (`isCodexReviewSummaryCompleteForHeadSha`) but no
      equivalent guard for CodeRabbit: at this PR's HEAD `bbadb729`, a
      CodeRabbit summary comment still reading "Currently processing
      new changes in this PR..." would have been misclassified as a
      completed walkthrough ready for `**Accepted**`. A later check at
      HEAD `2aedb873` initially looked like a second, quieter instance
      (the summary's embedded `change_assessment_commit` marker still
      named the prior HEAD with no in-progress text), but the PR
      Reviews API showed CodeRabbit had in fact posted genuine
      thread-level reviews against `2aedb873`, so that second case was
      inconclusive rather than confirmed. Only the `bbadb729`
      "Currently processing" case is a confirmed instance of the gap.
      Not fixed here since it is outside this issue's scope (a
      helper-behavior gap in E-phase disposition tooling, not the
      signed-commit wrapper this issue covers).
- [ ] The `lsof`-then-`rm -f` sequence for a leftover `index.lock` has
      a check-then-remove window: something could acquire the lock
      between the `lsof` check and the removal. Git's own documented
      stale-`index.lock` recovery accepts the same window and offers
      no barrier for it, and this text does not claim to close it,
      only to avoid removing a lock that clearly still belongs to
      someone else. Closing it fully would need a new
      repository-scoped exclusive-lock primitive (`idd-clone-lock` is
      the wrong scope — it guards `git worktree add`/`remove`/`fetch`
      against the shared primary clone, not arbitrary git operations
      inside one worktree); left as a follow-up rather than introduced
      here, since this issue's scope is the wrapper's timeout/hang
      recovery, not a new locking mechanism.
- [ ] This issue's cross-reference only wires the wrapper into
      `idd-work.instructions.md`'s B3 step. Review comments on this PR
      noted two other commit-creating steps that could hang the same
      way on non-interactive-hostile signing: `lite/idd-work-lite`'s
      mirrored B3 path, and standard-profile C5 / `idd-review-fix`'s
      E9. Both are deliberate exclusions in this issue's scope (E9
      lives in a file this issue explicitly does not touch), not
      oversights — worth their own follow-up issue.
- [ ] The rebase "no state present" branch verifies success against
      `idd-pr-submit.instructions.md` D1's own "expected local commit"
      predicate (present in `origin/{development-branch}..HEAD`) rather
      than redefining it here. A review comment on this PR noted that
      predicate does not account for a replayed commit receiving a new
      hash, or a validly-dropped empty cherry-pick. That is a potential
      gap in D1's own definition, shared by every caller that already
      cross-references it, not something specific to this wrapper —
      tightening it belongs in a D1-scoped issue, not this one.

## Background / rationale (if material)

The two other invocation sites that create or replay a commit on a
signed-commit repository (the merge step in
`idd-review-fix.instructions.md` E11 / `idd-review-triage.instructions.md`,
and the rebase step in `idd-pr-submit.instructions.md` D1) already had
a documented signing fallback; only the ordinary per-commit path in
B3 was missing one. This change intentionally does not touch those
other three instruction files or any `lite/` variant — their existing
merge/rebase cross-references already resolve to the extended section
through the same unchanged anchor.

The hang-recovery rule distinguishes three verification cases: a
plain commit (compare `HEAD` before/after), a merge or rebase with
its state still present (`MERGE_HEAD` or a rebase directory named via
`git rev-parse --git-path`, not a literal `.git/...` path, since a
linked worktree's `.git` is a file), and a merge or rebase with no
state present (verify by branch/ref position, since absent state does
not itself prove success or failure — for a rebase specifically, a
timeout firing before the rebase ever starts leaves the untouched,
still-behind branch trivially passing D1's own two checks, so this
case also requires `git merge-base --is-ancestor
origin/{development-branch} HEAD` to succeed, the same
upstream-incorporated check the merge case already uses). Recovery
first checks the whole
process tree, not just the git parent, for whether it is still
running (this whole mechanism depends on `pgrep`/`ps` — or an
equivalent — being available at all; if not, hold rather than proceed
without the cleanup guarantee, the same fail-closed treatment as the
`lsof` case below). It then snapshots the git PID itself together
with its descendants (found by walking once from the git PID) — a
"descendant" walk alone omits the root git process, which an earlier
draft did, leaving it able to keep running after only its children
were signaled — and immediately sends `SIGTERM` to every recorded PID
in that whole set, not `-9` (which skips git's own `index.lock`
cleanup), then waits up to 30 seconds for each to exit. Snapshot and
signal are
back-to-back on purpose: an exited PID's reuse window stays sub-second
on any real host, which is what keeps a bare recorded PID number
trustworthy without a separate identity check — an earlier draft
recorded each PID's `ps -o lstart=` start time and revalidated it
before signaling, but `lstart` is only second-resolution, so a same-
second reuse could still pass it; removing the second signal (see
next) removed the need for that check entirely. Even a snapshot taken
this promptly is best-effort, not a guarantee: a child reparented
(commonly to init) *before* the snapshot is never recorded at all, and
a live reproduction with a sleeping signer program showed it can
survive untouched, holding no lock and invisible to `lsof` (an
invocation-scoped process group at launch would close this more
completely, but the wrapper is already running by the time this
recovery begins, so that isn't retrofittable here). The same is true
of a recorded PID that simply outlasts the 30-second wait, such as one
stuck in uninterruptible I/O. Whether either kind of survivor is safe
to proceed past depends on what it is: a signer subprocess is only a
resource leak to report, since the unsigned fallback below never
invokes one and so cannot race it — but the whole-command timeout is
root-cause-agnostic (it can equally fire on a hung hook), and a hook
that escapes could still be touching the working tree or index, so
leak-and-continue is reserved for a descendant identifiable as the
signer, and anything else or an unconfirmed identity holds instead.
This is also why the earlier draft's SIGKILL escalation is gone
outright rather than hardened again: it was the one place a
snapshotted PID could go stale, and the issue never required a kill
escalation, only a bound and a fallback. "The git PID" itself now has
a fixed meaning too: the PID recorded when this wrapper invocation was
launched, never one recovered afterward by searching the process
table — the wrapper is launched as
`<wrapper command> & echo "wrapper-pid=$!"; wait "$!"` so the PID lands
in the tool's own output at launch, since a bare `$!` does not persist
between separate tool calls. B1's sibling-worktree model already puts
several concurrent workers on one host, so a bare `pgrep`/`ps` pattern
match could otherwise signal another worker's unrelated git invocation
(preventive; no observed incident yet); with no recorded launch-time
handle, hold — the same fail-closed treatment as the missing-
`pgrep`/`ps` and missing-`lsof` cases. Separately, the
lock-ownership check keeps its original (round-6) purpose: a leftover
`index.lock` does not prove this invocation's own tree is gone — a
hook, another command, or the signer itself could hold it instead, the
same ambiguity the clone-scoped lock's own
no-automatic-stale-lock-recovery convention already treats as unsafe
to guess past — so confirm no other process still has the lock file
open with `lsof` before removing it; where `lsof` is unavailable,
ownership cannot be reliably confirmed at all, so treat it as
unconfirmed rather than substitute a weaker check (an earlier draft
used a cwd check here, which a `git -C` or absolute-path invocation
defeats). Leave the lock in place with a hold note whenever ownership
can't be confirmed. The plain-commit verification also grew a second
check: comparing `HEAD` alone missed a hook that mutated the index
without moving `HEAD` — reproduced via a hook that staged an extra
file and then slept — so the fallback now also compares the index's
`git write-tree` tree hash before/after and holds instead of falling
back when it changed. An intermediate draft compared `git status
--porcelain` and `git diff --cached --stat` output instead, but those
report only paths, statuses, and line-count summaries, so a hook that
swapped one tracked line's content for another of the same shape would
pass both unnoticed; the content-addressed tree hash is what `git
commit -F` actually commits, so it proves the index unchanged directly
rather than by inference. Unstaged working-tree changes stay outside
this check on purpose, since `git commit -F` alone never commits them
either way. The same 2-minute bound then applies
again to every fallback or continuation step used during recovery (the
`--no-gpg-sign` retry, the `--continue` completion, the unsigned
rerun), not only to the original invocation, so no step in the whole
recovery procedure — the original invocation, the termination wait, or
any fallback — can hang open-endedly.

One flag-form detail verified locally with a throwaway repo before
writing it down: a plain `git commit` accepts `--no-gpg-sign`
directly, but `git merge --continue` / `git rebase --continue` both
reject `--no-gpg-sign` as an argument ("--continue expects no
arguments"); the working form there is `-c commit.gpgsign=false` on
the `--continue` invocation itself.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDJpTELrY2SnjHW9m5Aw7i


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded signed-commit guidance for regular commits, merges, and rebases.
  * Added timeout and process-tree termination requirements for signing operations.
  * Clarified verification of commit and push results, including detection of silently rejected or unchanged commits.
  * Added guidance for handling unsigned continuation, limited retries, detached-head recovery, and unresolved operations.
  * Recommended preparing wrapped commit-message files for non-interactive workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
