### PR TITLE
docs(idd-review-fix): add a third tier for spec-coverage loops

### DIFF
--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -142,6 +142,35 @@ specifically because the issue's acceptance criteria only ever
 required an acquire/release interface, never automatic stale-lock
 recovery.
 
+**Third escalation tier (heuristic, not a hard rule): open-ended
+correctness-domain findings against an external spec.** A different
+shape from both tiers above: each new finding is a genuine, distinct
+gap in the feature's own coverage of an open-ended external
+correctness domain (a document/markup grammar, a protocol, a wire
+format), not a symptom of one internal mechanism -- so neither "one
+structural fix" (Tier 1) nor "simplify/remove the mechanism" (Tier 2)
+is available, because the mechanism's correctness against that domain
+**is** the acceptance criterion itself. Reaching "stop for a
+maintainer decision" here does not depend on Tier 2's
+mechanism-simplification precondition, since there is no mechanism
+safe to remove: once several rounds each keep surfacing a genuinely
+new, in-scope spec-coverage gap rather than repeating one, summarize
+the recurring finding category and round count in a PR comment and
+stop for a maintainer decision. Once a maintainer decision accepts the
+residual gaps, apply it via PATH B disposition-and-resolve
+(`idd-review-triage.instructions.md` E4-E7) on the remaining threads,
+and file a scoped follow-up issue for the accepted gaps rather than
+continuing rounds indefinitely. Worked example:
+kurone-kito/idd-skill#2767 (PR kurone-kito/idd-skill#2840) implemented
+a CommonMark-compliant structural-evidence parser
+(`triage-structural-evidence.mts` / `markdown-code.mts`); an
+adversarial automated reviewer kept surfacing genuine, distinct
+CommonMark spec-compliance gaps across 27 review rounds, each an
+in-scope correctness gap rather than a repeating symptom of one
+mechanism -- the loop ended only once the operator accepted 3
+remaining findings as a documented known limitation and filed
+kurone-kito/idd-skill#2865 as the scoped follow-up.
+
 ## E11 — Resolve conflicts with {development-branch}
 
 Same read-only check as

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -157,15 +157,16 @@ safe to remove: once several rounds each keep surfacing a genuinely
 new, in-scope spec-coverage gap rather than repeating one, summarize
 the recurring finding category and round count in a PR comment and
 stop for a maintainer decision. Once a maintainer decision accepts the
-residual gaps, apply it through whichever path E4 assigned the
-finding: PATH A's `**Awaiting maintainer decision**` resolution
-(`idd-review-triage.instructions.md` E6) for an E10 critique-pass
-finding with no advisory thread of its own, or PATH B
-disposition-and-resolve (E4-E7) for an actual Copilot/CI advisory
-thread. Either way, open the follow-up issue for the accepted gaps
-through `idd-pr-submit.instructions.md` D3's follow-up-issue rule
-(never `gh issue create` directly; use the `issue-authoring` skill)
-rather than continuing rounds indefinitely. Worked example:
+residual gaps, close the hold the same way any other hold resolves
+(`idd-overview-appendix.instructions.md`'s Hold / suspend rules) for a
+session-local E10 critique-pass finding with no advisory thread of its
+own, or apply PATH B disposition-and-resolve
+(`idd-review-triage.instructions.md` E4-E7) when the recurring
+findings did surface through an actual Copilot/CI advisory thread.
+Either way, open the follow-up issue for the accepted gaps through
+`idd-pr-submit.instructions.md` D3's follow-up-issue rule (never
+`gh issue create` directly; use the `issue-authoring` skill) rather
+than continuing rounds indefinitely. Worked example:
 kurone-kito/idd-skill#2767 (PR kurone-kito/idd-skill#2840) implemented
 a CommonMark-compliant structural-evidence parser
 (`triage-structural-evidence.mts` / `markdown-code.mts`); an

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -155,9 +155,10 @@ maintainer decision" here does not depend on Tier 2's
 mechanism-simplification precondition, since there is no mechanism
 safe to remove: once several rounds each keep surfacing a genuinely
 new, in-scope spec-coverage gap rather than repeating one, list each
-outstanding gap with its evidence, and the round count, in a PR
+outstanding gap with its evidence, and the round count, in a hold
 comment and stop for a maintainer decision. Once a maintainer decision
-accepts the residual gaps, record the decision and close out the
+accepts the residual gaps as a known limitation, record the decision
+and close out the
 finding the same way this workflow already disposes of any review
 item or resolves any hold (`idd-review-triage.instructions.md`,
 `idd-overview-appendix.instructions.md`), and file any follow-up

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -157,10 +157,15 @@ safe to remove: once several rounds each keep surfacing a genuinely
 new, in-scope spec-coverage gap rather than repeating one, summarize
 the recurring finding category and round count in a PR comment and
 stop for a maintainer decision. Once a maintainer decision accepts the
-residual gaps, apply it via PATH B disposition-and-resolve
-(`idd-review-triage.instructions.md` E4-E7) on the remaining threads,
-and file a scoped follow-up issue for the accepted gaps rather than
-continuing rounds indefinitely. Worked example:
+residual gaps, apply it through whichever path E4 assigned the
+finding: PATH A's `**Awaiting maintainer decision**` resolution
+(`idd-review-triage.instructions.md` E6) for an E10 critique-pass
+finding with no advisory thread of its own, or PATH B
+disposition-and-resolve (E4-E7) for an actual Copilot/CI advisory
+thread. Either way, open the follow-up issue for the accepted gaps
+through `idd-pr-submit.instructions.md` D3's follow-up-issue rule
+(never `gh issue create` directly; use the `issue-authoring` skill)
+rather than continuing rounds indefinitely. Worked example:
 kurone-kito/idd-skill#2767 (PR kurone-kito/idd-skill#2840) implemented
 a CommonMark-compliant structural-evidence parser
 (`triage-structural-evidence.mts` / `markdown-code.mts`); an

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -154,19 +154,15 @@ is available, because the mechanism's correctness against that domain
 maintainer decision" here does not depend on Tier 2's
 mechanism-simplification precondition, since there is no mechanism
 safe to remove: once several rounds each keep surfacing a genuinely
-new, in-scope spec-coverage gap rather than repeating one, summarize
-the recurring finding category and round count in a PR comment and
-stop for a maintainer decision. Once a maintainer decision accepts the
-residual gaps, close the hold the same way any other hold resolves
-(`idd-overview-appendix.instructions.md`'s Hold / suspend rules) for a
-session-local E10 critique-pass finding with no advisory thread of its
-own, or apply PATH B disposition-and-resolve
-(`idd-review-triage.instructions.md` E4-E7) when the recurring
-findings did surface through an actual Copilot/CI advisory thread.
-Either way, open the follow-up issue for the accepted gaps through
-`idd-pr-submit.instructions.md` D3's follow-up-issue rule (never
-`gh issue create` directly; use the `issue-authoring` skill) rather
-than continuing rounds indefinitely. Worked example:
+new, in-scope spec-coverage gap rather than repeating one, list each
+outstanding gap with its evidence, and the round count, in a PR
+comment and stop for a maintainer decision. Once a maintainer decision
+accepts the residual gaps, record the decision and close out the
+finding the same way this workflow already disposes of any review
+item or resolves any hold (`idd-review-triage.instructions.md`,
+`idd-overview-appendix.instructions.md`), and file any follow-up
+through `idd-review-triage.instructions.md`'s E6 follow-up-issue rule,
+rather than continuing rounds indefinitely. Worked example:
 kurone-kito/idd-skill#2767 (PR kurone-kito/idd-skill#2840) implemented
 a CommonMark-compliant structural-evidence parser
 (`triage-structural-evidence.mts` / `markdown-code.mts`); an

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -150,9 +150,10 @@ maintainer decision" here does not depend on Tier 2's
 mechanism-simplification precondition, since there is no mechanism
 safe to remove: once several rounds each keep surfacing a genuinely
 new, in-scope spec-coverage gap rather than repeating one, list each
-outstanding gap with its evidence, and the round count, in a PR
+outstanding gap with its evidence, and the round count, in a hold
 comment and stop for a maintainer decision. Once a maintainer decision
-accepts the residual gaps, record the decision and close out the
+accepts the residual gaps as a known limitation, record the decision
+and close out the
 finding the same way this workflow already disposes of any review
 item or resolves any hold (`idd-review-triage.instructions.md`,
 `idd-overview-appendix.instructions.md`), and file any follow-up

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -149,19 +149,15 @@ is available, because the mechanism's correctness against that domain
 maintainer decision" here does not depend on Tier 2's
 mechanism-simplification precondition, since there is no mechanism
 safe to remove: once several rounds each keep surfacing a genuinely
-new, in-scope spec-coverage gap rather than repeating one, summarize
-the recurring finding category and round count in a PR comment and
-stop for a maintainer decision. Once a maintainer decision accepts the
-residual gaps, close the hold the same way any other hold resolves
-(`idd-overview-appendix.instructions.md`'s Hold / suspend rules) for a
-session-local E10 critique-pass finding with no advisory thread of its
-own, or apply PATH B disposition-and-resolve
-(`idd-review-triage.instructions.md` E4-E7) when the recurring
-findings did surface through an actual Copilot/CI advisory thread.
-Either way, open the follow-up issue for the accepted gaps through
-`idd-pr-submit.instructions.md` D3's follow-up-issue rule (never
-`gh issue create` directly; use the `issue-authoring` skill) rather
-than continuing rounds indefinitely. Worked example:
+new, in-scope spec-coverage gap rather than repeating one, list each
+outstanding gap with its evidence, and the round count, in a PR
+comment and stop for a maintainer decision. Once a maintainer decision
+accepts the residual gaps, record the decision and close out the
+finding the same way this workflow already disposes of any review
+item or resolves any hold (`idd-review-triage.instructions.md`,
+`idd-overview-appendix.instructions.md`), and file any follow-up
+through `idd-review-triage.instructions.md`'s E6 follow-up-issue rule,
+rather than continuing rounds indefinitely. Worked example:
 kurone-kito/idd-skill#2767 (PR kurone-kito/idd-skill#2840) implemented
 a CommonMark-compliant structural-evidence parser
 (`triage-structural-evidence.mts` / `markdown-code.mts`); an

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -152,10 +152,15 @@ safe to remove: once several rounds each keep surfacing a genuinely
 new, in-scope spec-coverage gap rather than repeating one, summarize
 the recurring finding category and round count in a PR comment and
 stop for a maintainer decision. Once a maintainer decision accepts the
-residual gaps, apply it via PATH B disposition-and-resolve
-(`idd-review-triage.instructions.md` E4-E7) on the remaining threads,
-and file a scoped follow-up issue for the accepted gaps rather than
-continuing rounds indefinitely. Worked example:
+residual gaps, apply it through whichever path E4 assigned the
+finding: PATH A's `**Awaiting maintainer decision**` resolution
+(`idd-review-triage.instructions.md` E6) for an E10 critique-pass
+finding with no advisory thread of its own, or PATH B
+disposition-and-resolve (E4-E7) for an actual Copilot/CI advisory
+thread. Either way, open the follow-up issue for the accepted gaps
+through `idd-pr-submit.instructions.md` D3's follow-up-issue rule
+(never `gh issue create` directly; use the `issue-authoring` skill)
+rather than continuing rounds indefinitely. Worked example:
 kurone-kito/idd-skill#2767 (PR kurone-kito/idd-skill#2840) implemented
 a CommonMark-compliant structural-evidence parser
 (`triage-structural-evidence.mts` / `markdown-code.mts`); an

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -137,6 +137,35 @@ specifically because the issue's acceptance criteria only ever
 required an acquire/release interface, never automatic stale-lock
 recovery.
 
+**Third escalation tier (heuristic, not a hard rule): open-ended
+correctness-domain findings against an external spec.** A different
+shape from both tiers above: each new finding is a genuine, distinct
+gap in the feature's own coverage of an open-ended external
+correctness domain (a document/markup grammar, a protocol, a wire
+format), not a symptom of one internal mechanism -- so neither "one
+structural fix" (Tier 1) nor "simplify/remove the mechanism" (Tier 2)
+is available, because the mechanism's correctness against that domain
+**is** the acceptance criterion itself. Reaching "stop for a
+maintainer decision" here does not depend on Tier 2's
+mechanism-simplification precondition, since there is no mechanism
+safe to remove: once several rounds each keep surfacing a genuinely
+new, in-scope spec-coverage gap rather than repeating one, summarize
+the recurring finding category and round count in a PR comment and
+stop for a maintainer decision. Once a maintainer decision accepts the
+residual gaps, apply it via PATH B disposition-and-resolve
+(`idd-review-triage.instructions.md` E4-E7) on the remaining threads,
+and file a scoped follow-up issue for the accepted gaps rather than
+continuing rounds indefinitely. Worked example:
+kurone-kito/idd-skill#2767 (PR kurone-kito/idd-skill#2840) implemented
+a CommonMark-compliant structural-evidence parser
+(`triage-structural-evidence.mts` / `markdown-code.mts`); an
+adversarial automated reviewer kept surfacing genuine, distinct
+CommonMark spec-compliance gaps across 27 review rounds, each an
+in-scope correctness gap rather than a repeating symptom of one
+mechanism -- the loop ended only once the operator accepted 3
+remaining findings as a documented known limitation and filed
+kurone-kito/idd-skill#2865 as the scoped follow-up.
+
 ## E11 — Resolve conflicts with {development-branch}
 
 Same read-only check as

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -152,15 +152,16 @@ safe to remove: once several rounds each keep surfacing a genuinely
 new, in-scope spec-coverage gap rather than repeating one, summarize
 the recurring finding category and round count in a PR comment and
 stop for a maintainer decision. Once a maintainer decision accepts the
-residual gaps, apply it through whichever path E4 assigned the
-finding: PATH A's `**Awaiting maintainer decision**` resolution
-(`idd-review-triage.instructions.md` E6) for an E10 critique-pass
-finding with no advisory thread of its own, or PATH B
-disposition-and-resolve (E4-E7) for an actual Copilot/CI advisory
-thread. Either way, open the follow-up issue for the accepted gaps
-through `idd-pr-submit.instructions.md` D3's follow-up-issue rule
-(never `gh issue create` directly; use the `issue-authoring` skill)
-rather than continuing rounds indefinitely. Worked example:
+residual gaps, close the hold the same way any other hold resolves
+(`idd-overview-appendix.instructions.md`'s Hold / suspend rules) for a
+session-local E10 critique-pass finding with no advisory thread of its
+own, or apply PATH B disposition-and-resolve
+(`idd-review-triage.instructions.md` E4-E7) when the recurring
+findings did surface through an actual Copilot/CI advisory thread.
+Either way, open the follow-up issue for the accepted gaps through
+`idd-pr-submit.instructions.md` D3's follow-up-issue rule (never
+`gh issue create` directly; use the `issue-authoring` skill) rather
+than continuing rounds indefinitely. Worked example:
 kurone-kito/idd-skill#2767 (PR kurone-kito/idd-skill#2840) implemented
 a CommonMark-compliant structural-evidence parser
 (`triage-structural-evidence.mts` / `markdown-code.mts`); an


### PR DESCRIPTION
# Summary

Add a third, explicitly-named escalation case to
`idd-review-fix.instructions.md`'s round-count heuristic (Convergence
guardrails) for **open-ended correctness-domain findings against an
external spec** -- distinct from Tier 1 (one structural fix) and Tier
2 (simplify/remove the fragile mechanism), since here the mechanism's
correctness against the external domain *is* the acceptance criterion,
so no mechanism is safe to remove. Cites kurone-kito/idd-skill#2767
(PR kurone-kito/idd-skill#2840) as the worked example: 27 review
rounds of genuine, distinct CommonMark spec-compliance gaps in a new
structural-evidence parser, ended only by an operator decision to
accept the residual gaps and file kurone-kito/idd-skill#2865 as a
scoped follow-up.

Regenerated `.github/instructions/idd-review-fix.instructions.md` from
the canonical `idd-template/` source via `node scripts/sync-docs.mjs
--apply`. `bundle-review-fix-phase`'s combined size stays under its
`limitBytes` ceiling in `audit/sync-manifest.json` (73,283 / 75,900
bytes after this change).

Four review rounds refined the "apply the maintainer's decision"
sentence: it originally over-specified PATH A/PATH B disposition
mechanics inline, which drew successive precision findings each round
(a wrong-marker sequencing gap, a lost-detail-on-claim-release gap, a
D3-lacks-`Refs` gap, and a PATH-A-default/thread-vs-comment gap). The
final revision stops restating another file's mechanics and instead
points at `idd-review-triage.instructions.md` and
`idd-overview-appendix.instructions.md` by name -- the same low-detail
level Tier 1/Tier 2 already use for "stop for a maintainer decision" --
and separately names the hold state and avoids colliding with E5's own
`Accepted`/`Rejected` disposition vocabulary in the hold-comment
prescription itself. This diverges from the issue's own literal
"apply it via PATH B" proposed wording (Copilot flagged the resulting
AC/implementation gap): E4 defaults an ambiguous or non-Copilot/CI
finding to PATH A, so an unconditional PATH B instruction would have
been wrong for a session-local E10 critique-pass finding with no
advisory thread.

## Linked issue

Closes #2903

## Follow-up issues (if any)

- [ ] none
- Known limitation (not fixed here, per review disposition): Codex
  flagged that `lite/idd-review-fix-lite.instructions.md` (its own E10
  section already covers Tier 1/Tier 2) has no equivalent Tier 3 stop
  condition, so a lite-profile session hitting this exact loop shape
  has no documented off-ramp. This PR's claimed issue (#2903)
  explicitly places modifying the lite file out of scope, so the
  finding was rejected under the E4 scope fence rather than fixed --
  worth a genuine follow-up issue via the `issue-authoring` skill.

## Background / rationale (if material)

Live-observed evidence from #2767 (PR #2840) showed a review-loop
shape neither existing tier fits: an adversarial automated reviewer
kept surfacing genuine, distinct CommonMark spec-compliance gaps
across 27 review rounds in a new structural-evidence parser -- each an
in-scope correctness gap in the parser's coverage of an open-ended
external spec, not a repeating symptom of one fragile mechanism. The
loop only ended when the executing session escalated to its human
operator, who accepted the 3 remaining findings as a documented known
limitation and filed #2865 as a scoped follow-up -- the same "stop for
a maintainer decision" outcome Tier 2 already names, but reached
without going through Tier 2's own mechanism-simplification
precondition, which never applied here.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `npx biome check && npx dprint check "**/*.md" && npx
      markdownlint-cli2 "**/*.md" && npx cspell lint "**"
      --no-progress`
- [x] `node --test tests/*.test.mts` (6026 tests passing)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `node scripts/sync-docs.mjs --apply` (mirror regenerated, matches)
- [x] `node scripts/idd-doctor.mjs`
- [x] `node scripts/audit-code-span-wrap.mjs`
- [x] `pnpm run build:check`
- [x] `node scripts/token-cost-report.mjs --check`

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdQ5SPdFLaDGus5PNdBUhw



