### PR TITLE
docs(ci-jobs): require workflow_dispatch-first rollout for new CI jobs

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -47,6 +47,7 @@ words:
   - deprioritize
   - dofork
   - ministral
+  - nektos
   - nvmrc
   - remediations
   - ification

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -136,48 +136,48 @@ When this branch's diff introduces a **new** CI job, land it configured
 for `workflow_dispatch` only, not yet wired to `push`/`pull_request`,
 and validate it with manually dispatched runs against the pushed
 branch (for example `gh workflow run <file> --ref <branch>`) before
-making the one remaining edit that flips the trigger to its intended
-final form. GitHub only allows a `workflow_dispatch`-triggered run once
-that trigger is already registered on the repository's default branch:
-`gh workflow run` cannot dispatch a workflow file, or a newly added
-`workflow_dispatch` entry, that exists only on the pushed branch. A
-genuinely first-time job therefore needs one minimal, low-risk
-bootstrap merge -- the trigger wiring alone, with the job itself inert
-or guarded off -- before it can be dispatched against a feature branch
-at all; this dispatch-first pattern applies most directly once that
-scaffolding already exists on the default branch. `on:` is
-workflow-file-scoped, not job-scoped, so adding `workflow_dispatch` to
-an existing multi-job file makes every job in it dispatchable --
-during validation, guard the unproven job, and any existing job that
-assumes `push`/`pull_request` context, with a job-level
-`if: github.event_name == 'workflow_dispatch'` condition, removing it
-together with the trigger-flip edit once validated. This step does
-**not** by itself reduce advisory-bot (for
-example Copilot or Codex) review invocation count -- that is driven by
-push count, not by which CI jobs are wired to which triggers. Its real
-benefit is avoiding wasted CI Actions-minutes and false-failure noise
-from an unproven job auto-running on every unrelated push during the
-same PR's lifetime. See
+making the one remaining edit that flips the trigger to its final
+form. **Commit, re-run pre-push-validate, and push that edit before
+creating the PR (D3)** -- merging with the branch still dispatch-only
+would never enable the job.
+
+GitHub only allows a `workflow_dispatch` run once that trigger is
+registered on the default branch: `gh workflow run` cannot target a
+file, or a newly added `workflow_dispatch` entry, that exists only on
+the pushed branch. A first-time job needs one minimal bootstrap merge
+-- the trigger wiring alone, job inert or guarded off -- before it can
+be dispatched against a feature branch at all; this pattern applies
+most directly once that scaffolding already exists on main.
+
+`on:` is workflow-file-scoped, not job-scoped: adding
+`workflow_dispatch` to an existing multi-job file makes every job in
+it dispatchable. During validation, guard the unproven job with
+`if: github.event_name == 'workflow_dispatch'` (runs only on dispatch)
+and guard any existing job assuming `push`/`pull_request` context with
+the **inverse**, `if: github.event_name != 'workflow_dispatch'` (skips
+only the dispatch run) -- remove both once validated, with the
+trigger-flip edit. This step does **not** by itself reduce advisory-bot
+review invocation count -- that is driven by push count, not trigger
+wiring. Its real benefit is avoiding wasted CI Actions-minutes and
+false-failure noise from an unproven job auto-running on every
+unrelated push. See
 [rationale](../../docs/idd-design-rationale.md#d2--adding-a-new-ci-job-dispatch-first-rollout).
 
 For a job targeting a Linux runner, also validate it locally with
 `nektos/act` before pushing, to catch YAML/step/job-dependency
-mistakes without a push-and-wait round trip. `act`'s normal
-Docker-based execution cannot accurately validate
-`windows-latest`/`macos-latest` runner-specific behavior from a
-WSL/Linux implementation environment -- never treat "validated via
-`act`" as covering a job targeting a Windows or macOS runner.
+mistakes without a push-and-wait round trip. `act`'s Docker-based
+execution cannot validate `windows-latest`/`macos-latest`
+runner-specific behavior from a WSL/Linux environment -- never treat
+"validated via `act`" as covering a Windows or macOS job.
 
-Optionally, for a job targeting a platform `act` cannot validate where
-shakeout is expected to be long or costly, a contributor may iterate it
-on a branch with no open PR yet (or via `workflow_dispatch` runs
-against such a branch), landing only the validated final version on
-the actual PR branch. Review automation that only fires on PR-associated
-pushes never runs during that shakeout, avoiding review cost entirely
-for those iterations -- the one path here that actually reduces it.
-This deviates from the normal early-PR-then-iterate practice, so scope
-it to CI-infrastructure-focused work, and treat it as the implementer's
-choice, not a mandate.
+Optionally, for a job `act` cannot validate where shakeout is long or
+costly, a contributor may iterate it on a branch with no open PR yet,
+landing only the validated final version on the actual PR branch.
+Review automation that only fires on PR-associated pushes never runs
+during that shakeout, avoiding review cost entirely -- the one path
+here that actually reduces it. This deviates from the normal
+early-PR-then-iterate practice, so scope it to CI-infrastructure work,
+as the implementer's choice, not a mandate.
 
 ## D3 — Create PR
 

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -137,16 +137,22 @@ for `workflow_dispatch` only, not yet wired to `push`/`pull_request`,
 and validate it with manually dispatched runs against the pushed
 branch (for example `gh workflow run <file> --ref <branch>`) before
 making the one remaining edit that flips the trigger to its intended
-final form. GitHub Actions' `on:` trigger is workflow-file-scoped, not
-job-scoped: for a new job added to an existing multi-job workflow file
-that already runs on `push`/`pull_request`, either land the new job in
-its own workflow file instead, or add `workflow_dispatch` to the
-shared file's `on:` block (so `gh workflow run` can target it at all)
-**and** guard only the new job with a job-level
-`if: github.event_name == 'workflow_dispatch'` condition, so it does
-not also run on the file's existing triggers while unproven; remove
-that guard together with the trigger-flip edit once validated. This
-step does **not** by itself reduce advisory-bot (for
+final form. GitHub only allows a `workflow_dispatch`-triggered run once
+that trigger is already registered on the repository's default branch:
+`gh workflow run` cannot dispatch a workflow file, or a newly added
+`workflow_dispatch` entry, that exists only on the pushed branch. A
+genuinely first-time job therefore needs one minimal, low-risk
+bootstrap merge -- the trigger wiring alone, with the job itself inert
+or guarded off -- before it can be dispatched against a feature branch
+at all; this dispatch-first pattern applies most directly once that
+scaffolding already exists on the default branch. `on:` is
+workflow-file-scoped, not job-scoped, so adding `workflow_dispatch` to
+an existing multi-job file makes every job in it dispatchable --
+during validation, guard the unproven job, and any existing job that
+assumes `push`/`pull_request` context, with a job-level
+`if: github.event_name == 'workflow_dispatch'` condition, removing it
+together with the trigger-flip edit once validated. This step does
+**not** by itself reduce advisory-bot (for
 example Copilot or Codex) review invocation count -- that is driven by
 push count, not by which CI jobs are wired to which triggers. Its real
 benefit is avoiding wasted CI Actions-minutes and false-failure noise

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -147,7 +147,8 @@ file, or a newly added `workflow_dispatch` entry, that exists only on
 the pushed branch. A first-time job needs one minimal bootstrap merge
 -- the trigger wiring alone, job inert or guarded off -- before it can
 be dispatched against a feature branch at all; this pattern applies
-most directly once that scaffolding already exists on main.
+most directly once that scaffolding already exists on the default
+branch.
 
 `on:` is workflow-file-scoped, not job-scoped: adding
 `workflow_dispatch` to an existing multi-job file makes every job in

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -130,6 +130,49 @@ that is merely `BEHIND` does not force a branch update by itself unless
 branch protection or explicit repository policy requires an up-to-date
 head before merge.
 
+### Adding a new CI job
+
+When this branch's diff introduces a **new** CI job, land it configured
+for `workflow_dispatch` only, not yet wired to `push`/`pull_request`,
+and validate it with manually dispatched runs against the pushed
+branch (for example `gh workflow run <file> --ref <branch>`) before
+making the one remaining edit that flips the trigger to its intended
+final form. GitHub Actions' `on:` trigger is workflow-file-scoped, not
+job-scoped: for a new job added to an existing multi-job workflow file
+that already runs on `push`/`pull_request`, either land the new job in
+its own workflow file instead, or add `workflow_dispatch` to the
+shared file's `on:` block (so `gh workflow run` can target it at all)
+**and** guard only the new job with a job-level
+`if: github.event_name == 'workflow_dispatch'` condition, so it does
+not also run on the file's existing triggers while unproven; remove
+that guard together with the trigger-flip edit once validated. This
+step does **not** by itself reduce advisory-bot (for
+example Copilot or Codex) review invocation count -- that is driven by
+push count, not by which CI jobs are wired to which triggers. Its real
+benefit is avoiding wasted CI Actions-minutes and false-failure noise
+from an unproven job auto-running on every unrelated push during the
+same PR's lifetime. See
+[rationale](../../docs/idd-design-rationale.md#d2--adding-a-new-ci-job-dispatch-first-rollout).
+
+For a job targeting a Linux runner, also validate it locally with
+`nektos/act` before pushing, to catch YAML/step/job-dependency
+mistakes without a push-and-wait round trip. `act`'s normal
+Docker-based execution cannot accurately validate
+`windows-latest`/`macos-latest` runner-specific behavior from a
+WSL/Linux implementation environment -- never treat "validated via
+`act`" as covering a job targeting a Windows or macOS runner.
+
+Optionally, for a job targeting a platform `act` cannot validate where
+shakeout is expected to be long or costly, a contributor may iterate it
+on a branch with no open PR yet (or via `workflow_dispatch` runs
+against such a branch), landing only the validated final version on
+the actual PR branch. Review automation that only fires on PR-associated
+pushes never runs during that shakeout, avoiding review cost entirely
+for those iterations -- the one path here that actually reduces it.
+This deviates from the normal early-PR-then-iterate practice, so scope
+it to CI-infrastructure-focused work, and treat it as the implementer's
+choice, not a mandate.
+
 ## D3 — Create PR
 
 Before drafting the PR body, check whether the repository defines

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -141,35 +141,35 @@ form. **Commit, re-run pre-push-validate, and push that edit before
 creating the PR (D3)** -- merging with the branch still dispatch-only
 would never enable the job.
 
-GitHub only allows a `workflow_dispatch` run once that trigger is
-registered on the default branch: `gh workflow run` cannot target a
-file, or a newly added `workflow_dispatch` entry, that exists only on
-the pushed branch. A first-time job needs one minimal bootstrap merge
--- the trigger wiring alone, job inert or guarded off -- before it can
-be dispatched against a feature branch at all; this pattern applies
-most directly once that scaffolding already exists on the default
-branch.
+GitHub only allows a `workflow_dispatch` run once registered on the
+default branch: `gh workflow run` cannot target a file or trigger that
+exists only on the pushed branch. A first-time job needs a minimal
+bootstrap merge first -- trigger wiring only, job inert -- via its own
+preliminary PR (this repository merges only through PRs); this flow
+then applies to the follow-up PR adding the real job, once that
+scaffolding exists.
 
-`on:` is workflow-file-scoped, not job-scoped: adding
-`workflow_dispatch` to an existing multi-job file makes every job in
-it dispatchable. During validation, guard the unproven job with
-`if: github.event_name == 'workflow_dispatch'` (runs only on dispatch)
-and guard any existing job assuming `push`/`pull_request` context with
-the **inverse**, `if: github.event_name != 'workflow_dispatch'` (skips
-only the dispatch run) -- remove both once validated, with the
-trigger-flip edit. This step does **not** by itself reduce advisory-bot
-review invocation count -- that is driven by push count, not trigger
-wiring. Its real benefit is avoiding wasted CI Actions-minutes and
-false-failure noise from an unproven job auto-running on every
-unrelated push. See
+`on:` is workflow-file-scoped, not job-scoped: a new job in its own
+file needs no cross-job isolation, but adding `workflow_dispatch` to
+an existing multi-job file makes every job in it dispatchable.
+Isolating the unproven job then is ordinary GitHub Actions authoring
+(for example a job-level `if:`), scoped to that file's own jobs and
+dependencies -- keep it minimal, removing it with the trigger-flip
+edit once validated. This step does **not** by itself reduce
+advisory-bot review invocation count -- that is driven by push count,
+not trigger wiring. Its real benefit is avoiding wasted CI
+Actions-minutes and false-failure noise from an unproven job
+auto-running on every unrelated push. See
 [rationale](../../docs/idd-design-rationale.md#d2--adding-a-new-ci-job-dispatch-first-rollout).
 
-For a job targeting a Linux runner, also validate it locally with
-`nektos/act` before pushing, to catch YAML/step/job-dependency
-mistakes without a push-and-wait round trip. `act`'s Docker-based
-execution cannot validate `windows-latest`/`macos-latest`
-runner-specific behavior from a WSL/Linux environment -- never treat
-"validated via `act`" as covering a Windows or macOS job.
+For a Linux-runner job, also validate it locally with `nektos/act`
+before pushing when `act` (and Docker) is available -- per the
+tool-availability convention in `idd-overview-core.instructions.md`'s
+Project commands table, skip this otherwise and rely on the dispatch
+validation above plus CI. `act`'s Docker-based execution cannot
+validate `windows-latest`/`macos-latest` runner-specific behavior from
+a WSL/Linux environment -- never treat "validated via `act`" as
+covering a Windows or macOS job.
 
 Optionally, for a job `act` cannot validate where shakeout is long or
 costly, a contributor may iterate it on a branch with no open PR yet,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,19 @@ layered on top of the distributed IDD defaults:
   full hour -- a HEAD CodeRabbit has not yet reviewed still waits the
   full configured window unchanged, keeping the wait a fallback for
   genuine secondary-bot degradation rather than a tax on every merge.
+- **New-CI-job dispatch-first rollout**: `idd-pr-submit.instructions.md`'s
+  D2 "Adding a new CI job" guidance (distributed via `idd-template/`, not
+  itself local) requires landing a new CI job `workflow_dispatch`-first.
+  This source repository also records, as a local IDD dogfooding policy
+  (applies only to `kurone-kito/idd-skill`), the motivation for that
+  guidance: this repository's own `copilot_code_review` ruleset, whose
+  Copilot/Codex review cost tracks push count roughly 1:1 regardless of
+  which CI jobs a push touches -- landing a new job
+  `workflow_dispatch`-first does not reduce that review-cost line item
+  by itself, but avoids wasted CI Actions-minutes and false-failure
+  noise from an unproven job auto-running on every unrelated push. See
+  that guidance (and its linked rationale entry) for the mechanics
+  rather than duplicating them here. Refs #2892 (non-blocking).
 
 ## Branch strategy
 

--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -700,6 +700,42 @@ independently-maintained sibling implementation of the same logic --
 for the same shape before treating the fix, or a C1 critique of it, as
 complete (observed 2026-09-03, `#2552`).
 
+## PR submit
+
+### D2 — Adding a new CI job: dispatch-first rollout
+
+This repository's `copilot_code_review` ruleset re-reviews every push
+to a PR branch, so Copilot/Codex review cost tracks push count roughly
+1:1 regardless of which files or CI jobs a given push touches. A new
+CI job whose target runner cannot be exercised locally compounds this:
+each debugging attempt needs a real push-and-wait round trip, so every
+unverified hypothesis about why the job fails costs a full review
+cycle on top of the CI minutes spent. Landing the job
+`workflow_dispatch`-first and validating it via manual dispatch runs
+does not reduce that review cost by itself -- the review re-run is
+driven by the push, not by the job's trigger wiring -- but it does
+stop an unproven job from auto-running (and burning runner minutes,
+and adding failure noise) on every unrelated push during the same pull
+request's remaining lifetime. The one path that does avoid review cost
+entirely is iterating a Windows-/macOS-targeted job on a branch with no
+open PR yet: this repository's `copilot_code_review` ruleset only
+reviews PR-associated pushes, so a push to a PR-less branch never
+triggers a review at all -- this is why that non-PR shakeout pattern is
+worth documenting as an option, scoped to CI-infrastructure-focused
+work, even though it deviates from the normal early-PR-then-iterate
+practice.
+
+Observed 2026-09-10 on PR #2897 (issue #2892): three
+independently-reasoned, unverified commits debugging a
+native-Windows-only CI hang in a new `lint-windows` job each triggered
+a fresh full Copilot and Codex review and left the job's own
+regression test failing at a near-identical elapsed time each round --
+direct evidence none of the three changed anything that mattered, and
+each round could only be diagnosed by pushing and waiting on a real
+run, since this repository's own IDD implementation sessions are
+WSL/Linux-only and cannot exercise a `windows-latest` runner locally
+(Refs #2892, non-blocking).
+
 ## Review triage
 
 ### Merge-main livelock under fast-moving `main`

--- a/idd-template/.cspell.config.yml
+++ b/idd-template/.cspell.config.yml
@@ -64,6 +64,7 @@ words:
   - deprioritize
   - dofork
   - ministral
+  - nektos
   - nvmrc
   - remediations
   - vrchat

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -136,35 +136,35 @@ form. **Commit, re-run pre-push-validate, and push that edit before
 creating the PR (D3)** -- merging with the branch still dispatch-only
 would never enable the job.
 
-GitHub only allows a `workflow_dispatch` run once that trigger is
-registered on the default branch: `gh workflow run` cannot target a
-file, or a newly added `workflow_dispatch` entry, that exists only on
-the pushed branch. A first-time job needs one minimal bootstrap merge
--- the trigger wiring alone, job inert or guarded off -- before it can
-be dispatched against a feature branch at all; this pattern applies
-most directly once that scaffolding already exists on the default
-branch.
+GitHub only allows a `workflow_dispatch` run once registered on the
+default branch: `gh workflow run` cannot target a file or trigger that
+exists only on the pushed branch. A first-time job needs a minimal
+bootstrap merge first -- trigger wiring only, job inert -- via its own
+preliminary PR (this repository merges only through PRs); this flow
+then applies to the follow-up PR adding the real job, once that
+scaffolding exists.
 
-`on:` is workflow-file-scoped, not job-scoped: adding
-`workflow_dispatch` to an existing multi-job file makes every job in
-it dispatchable. During validation, guard the unproven job with
-`if: github.event_name == 'workflow_dispatch'` (runs only on dispatch)
-and guard any existing job assuming `push`/`pull_request` context with
-the **inverse**, `if: github.event_name != 'workflow_dispatch'` (skips
-only the dispatch run) -- remove both once validated, with the
-trigger-flip edit. This step does **not** by itself reduce advisory-bot
-review invocation count -- that is driven by push count, not trigger
-wiring. Its real benefit is avoiding wasted CI Actions-minutes and
-false-failure noise from an unproven job auto-running on every
-unrelated push. See
+`on:` is workflow-file-scoped, not job-scoped: a new job in its own
+file needs no cross-job isolation, but adding `workflow_dispatch` to
+an existing multi-job file makes every job in it dispatchable.
+Isolating the unproven job then is ordinary GitHub Actions authoring
+(for example a job-level `if:`), scoped to that file's own jobs and
+dependencies -- keep it minimal, removing it with the trigger-flip
+edit once validated. This step does **not** by itself reduce
+advisory-bot review invocation count -- that is driven by push count,
+not trigger wiring. Its real benefit is avoiding wasted CI
+Actions-minutes and false-failure noise from an unproven job
+auto-running on every unrelated push. See
 [rationale](../../docs/idd-design-rationale.md#d2--adding-a-new-ci-job-dispatch-first-rollout).
 
-For a job targeting a Linux runner, also validate it locally with
-`nektos/act` before pushing, to catch YAML/step/job-dependency
-mistakes without a push-and-wait round trip. `act`'s Docker-based
-execution cannot validate `windows-latest`/`macos-latest`
-runner-specific behavior from a WSL/Linux environment -- never treat
-"validated via `act`" as covering a Windows or macOS job.
+For a Linux-runner job, also validate it locally with `nektos/act`
+before pushing when `act` (and Docker) is available -- per the
+tool-availability convention in `idd-overview-core.instructions.md`'s
+Project commands table, skip this otherwise and rely on the dispatch
+validation above plus CI. `act`'s Docker-based execution cannot
+validate `windows-latest`/`macos-latest` runner-specific behavior from
+a WSL/Linux environment -- never treat "validated via `act`" as
+covering a Windows or macOS job.
 
 Optionally, for a job `act` cannot validate where shakeout is long or
 costly, a contributor may iterate it on a branch with no open PR yet,

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -131,48 +131,48 @@ When this branch's diff introduces a **new** CI job, land it configured
 for `workflow_dispatch` only, not yet wired to `push`/`pull_request`,
 and validate it with manually dispatched runs against the pushed
 branch (for example `gh workflow run <file> --ref <branch>`) before
-making the one remaining edit that flips the trigger to its intended
-final form. GitHub only allows a `workflow_dispatch`-triggered run once
-that trigger is already registered on the repository's default branch:
-`gh workflow run` cannot dispatch a workflow file, or a newly added
-`workflow_dispatch` entry, that exists only on the pushed branch. A
-genuinely first-time job therefore needs one minimal, low-risk
-bootstrap merge -- the trigger wiring alone, with the job itself inert
-or guarded off -- before it can be dispatched against a feature branch
-at all; this dispatch-first pattern applies most directly once that
-scaffolding already exists on the default branch. `on:` is
-workflow-file-scoped, not job-scoped, so adding `workflow_dispatch` to
-an existing multi-job file makes every job in it dispatchable --
-during validation, guard the unproven job, and any existing job that
-assumes `push`/`pull_request` context, with a job-level
-`if: github.event_name == 'workflow_dispatch'` condition, removing it
-together with the trigger-flip edit once validated. This step does
-**not** by itself reduce advisory-bot (for
-example Copilot or Codex) review invocation count -- that is driven by
-push count, not by which CI jobs are wired to which triggers. Its real
-benefit is avoiding wasted CI Actions-minutes and false-failure noise
-from an unproven job auto-running on every unrelated push during the
-same PR's lifetime. See
+making the one remaining edit that flips the trigger to its final
+form. **Commit, re-run pre-push-validate, and push that edit before
+creating the PR (D3)** -- merging with the branch still dispatch-only
+would never enable the job.
+
+GitHub only allows a `workflow_dispatch` run once that trigger is
+registered on the default branch: `gh workflow run` cannot target a
+file, or a newly added `workflow_dispatch` entry, that exists only on
+the pushed branch. A first-time job needs one minimal bootstrap merge
+-- the trigger wiring alone, job inert or guarded off -- before it can
+be dispatched against a feature branch at all; this pattern applies
+most directly once that scaffolding already exists on main.
+
+`on:` is workflow-file-scoped, not job-scoped: adding
+`workflow_dispatch` to an existing multi-job file makes every job in
+it dispatchable. During validation, guard the unproven job with
+`if: github.event_name == 'workflow_dispatch'` (runs only on dispatch)
+and guard any existing job assuming `push`/`pull_request` context with
+the **inverse**, `if: github.event_name != 'workflow_dispatch'` (skips
+only the dispatch run) -- remove both once validated, with the
+trigger-flip edit. This step does **not** by itself reduce advisory-bot
+review invocation count -- that is driven by push count, not trigger
+wiring. Its real benefit is avoiding wasted CI Actions-minutes and
+false-failure noise from an unproven job auto-running on every
+unrelated push. See
 [rationale](../../docs/idd-design-rationale.md#d2--adding-a-new-ci-job-dispatch-first-rollout).
 
 For a job targeting a Linux runner, also validate it locally with
 `nektos/act` before pushing, to catch YAML/step/job-dependency
-mistakes without a push-and-wait round trip. `act`'s normal
-Docker-based execution cannot accurately validate
-`windows-latest`/`macos-latest` runner-specific behavior from a
-WSL/Linux implementation environment -- never treat "validated via
-`act`" as covering a job targeting a Windows or macOS runner.
+mistakes without a push-and-wait round trip. `act`'s Docker-based
+execution cannot validate `windows-latest`/`macos-latest`
+runner-specific behavior from a WSL/Linux environment -- never treat
+"validated via `act`" as covering a Windows or macOS job.
 
-Optionally, for a job targeting a platform `act` cannot validate where
-shakeout is expected to be long or costly, a contributor may iterate it
-on a branch with no open PR yet (or via `workflow_dispatch` runs
-against such a branch), landing only the validated final version on
-the actual PR branch. Review automation that only fires on PR-associated
-pushes never runs during that shakeout, avoiding review cost entirely
-for those iterations -- the one path here that actually reduces it.
-This deviates from the normal early-PR-then-iterate practice, so scope
-it to CI-infrastructure-focused work, and treat it as the implementer's
-choice, not a mandate.
+Optionally, for a job `act` cannot validate where shakeout is long or
+costly, a contributor may iterate it on a branch with no open PR yet,
+landing only the validated final version on the actual PR branch.
+Review automation that only fires on PR-associated pushes never runs
+during that shakeout, avoiding review cost entirely -- the one path
+here that actually reduces it. This deviates from the normal
+early-PR-then-iterate practice, so scope it to CI-infrastructure work,
+as the implementer's choice, not a mandate.
 
 ## D3 — Create PR
 

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -142,7 +142,8 @@ file, or a newly added `workflow_dispatch` entry, that exists only on
 the pushed branch. A first-time job needs one minimal bootstrap merge
 -- the trigger wiring alone, job inert or guarded off -- before it can
 be dispatched against a feature branch at all; this pattern applies
-most directly once that scaffolding already exists on main.
+most directly once that scaffolding already exists on the default
+branch.
 
 `on:` is workflow-file-scoped, not job-scoped: adding
 `workflow_dispatch` to an existing multi-job file makes every job in

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -125,6 +125,49 @@ that is merely `BEHIND` does not force a branch update by itself unless
 branch protection or explicit repository policy requires an up-to-date
 head before merge.
 
+### Adding a new CI job
+
+When this branch's diff introduces a **new** CI job, land it configured
+for `workflow_dispatch` only, not yet wired to `push`/`pull_request`,
+and validate it with manually dispatched runs against the pushed
+branch (for example `gh workflow run <file> --ref <branch>`) before
+making the one remaining edit that flips the trigger to its intended
+final form. GitHub Actions' `on:` trigger is workflow-file-scoped, not
+job-scoped: for a new job added to an existing multi-job workflow file
+that already runs on `push`/`pull_request`, either land the new job in
+its own workflow file instead, or add `workflow_dispatch` to the
+shared file's `on:` block (so `gh workflow run` can target it at all)
+**and** guard only the new job with a job-level
+`if: github.event_name == 'workflow_dispatch'` condition, so it does
+not also run on the file's existing triggers while unproven; remove
+that guard together with the trigger-flip edit once validated. This
+step does **not** by itself reduce advisory-bot (for
+example Copilot or Codex) review invocation count -- that is driven by
+push count, not by which CI jobs are wired to which triggers. Its real
+benefit is avoiding wasted CI Actions-minutes and false-failure noise
+from an unproven job auto-running on every unrelated push during the
+same PR's lifetime. See
+[rationale](../../docs/idd-design-rationale.md#d2--adding-a-new-ci-job-dispatch-first-rollout).
+
+For a job targeting a Linux runner, also validate it locally with
+`nektos/act` before pushing, to catch YAML/step/job-dependency
+mistakes without a push-and-wait round trip. `act`'s normal
+Docker-based execution cannot accurately validate
+`windows-latest`/`macos-latest` runner-specific behavior from a
+WSL/Linux implementation environment -- never treat "validated via
+`act`" as covering a job targeting a Windows or macOS runner.
+
+Optionally, for a job targeting a platform `act` cannot validate where
+shakeout is expected to be long or costly, a contributor may iterate it
+on a branch with no open PR yet (or via `workflow_dispatch` runs
+against such a branch), landing only the validated final version on
+the actual PR branch. Review automation that only fires on PR-associated
+pushes never runs during that shakeout, avoiding review cost entirely
+for those iterations -- the one path here that actually reduces it.
+This deviates from the normal early-PR-then-iterate practice, so scope
+it to CI-infrastructure-focused work, and treat it as the implementer's
+choice, not a mandate.
+
 ## D3 — Create PR
 
 Before drafting the PR body, check whether the repository defines

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -132,16 +132,22 @@ for `workflow_dispatch` only, not yet wired to `push`/`pull_request`,
 and validate it with manually dispatched runs against the pushed
 branch (for example `gh workflow run <file> --ref <branch>`) before
 making the one remaining edit that flips the trigger to its intended
-final form. GitHub Actions' `on:` trigger is workflow-file-scoped, not
-job-scoped: for a new job added to an existing multi-job workflow file
-that already runs on `push`/`pull_request`, either land the new job in
-its own workflow file instead, or add `workflow_dispatch` to the
-shared file's `on:` block (so `gh workflow run` can target it at all)
-**and** guard only the new job with a job-level
-`if: github.event_name == 'workflow_dispatch'` condition, so it does
-not also run on the file's existing triggers while unproven; remove
-that guard together with the trigger-flip edit once validated. This
-step does **not** by itself reduce advisory-bot (for
+final form. GitHub only allows a `workflow_dispatch`-triggered run once
+that trigger is already registered on the repository's default branch:
+`gh workflow run` cannot dispatch a workflow file, or a newly added
+`workflow_dispatch` entry, that exists only on the pushed branch. A
+genuinely first-time job therefore needs one minimal, low-risk
+bootstrap merge -- the trigger wiring alone, with the job itself inert
+or guarded off -- before it can be dispatched against a feature branch
+at all; this dispatch-first pattern applies most directly once that
+scaffolding already exists on the default branch. `on:` is
+workflow-file-scoped, not job-scoped, so adding `workflow_dispatch` to
+an existing multi-job file makes every job in it dispatchable --
+during validation, guard the unproven job, and any existing job that
+assumes `push`/`pull_request` context, with a job-level
+`if: github.event_name == 'workflow_dispatch'` condition, removing it
+together with the trigger-flip edit once validated. This step does
+**not** by itself reduce advisory-bot (for
 example Copilot or Codex) review invocation count -- that is driven by
 push count, not by which CI jobs are wired to which triggers. Its real
 benefit is avoiding wasted CI Actions-minutes and false-failure noise

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -696,6 +696,43 @@ same logic -- for the same shape before treating the fix, or a C1
 critique of it, as complete (observed 2026-09-03,
 kurone-kito/idd-skill#2552).
 
+## PR submit
+
+### D2 — Adding a new CI job: dispatch-first rollout
+
+An adopter repository whose review automation (for example a Copilot
+or Codex code-review app) re-runs on every push accumulates review
+cost roughly 1:1 with commit count, independent of which files or CI
+jobs a given push touches. A new CI job whose target runner cannot be
+exercised locally compounds this: each debugging attempt needs a real
+push-and-wait round trip, so every unverified hypothesis about why the
+job fails costs a full review cycle on top of the CI minutes spent.
+Landing the job `workflow_dispatch`-first and validating it via manual
+dispatch runs does not reduce that review cost by itself -- the review
+re-run is driven by the push, not by the job's trigger wiring -- but
+it does stop an unproven job from auto-running (and burning runner
+minutes, and adding failure noise) on every unrelated push during the
+same pull request's remaining lifetime. The one path that does avoid
+review cost entirely is iterating a Windows-/macOS-targeted job on a
+branch with no open PR yet: review automation that only fires on
+PR-associated pushes never runs during that shakeout, so a push to a
+PR-less branch never triggers a review at all -- this is why that
+non-PR shakeout pattern is worth documenting as an option, scoped to
+CI-infrastructure-focused work, even though it deviates from the
+normal early-PR-then-iterate practice.
+
+Observed 2026-09-10 on PR kurone-kito/idd-skill#2897 (issue
+kurone-kito/idd-skill#2892): three independently-reasoned, unverified
+commits debugging a native-Windows-only CI hang in a new
+`lint-windows` job each triggered a fresh full Copilot and Codex
+review and left the job's own regression test failing at a
+near-identical elapsed time each round -- direct evidence none of the
+three changed anything that mattered, and each round could only be
+diagnosed by pushing and waiting on a real run, since the repository's
+own IDD implementation sessions are WSL/Linux-only and cannot exercise
+a `windows-latest` runner locally (kurone-kito/idd-skill#2892,
+non-blocking).
+
 ## Review triage
 
 ### Merge-main livelock under fast-moving `main`


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Adds `idd-pr-submit.instructions.md` D2 guidance ("Adding a new CI
job") requiring a new CI job to land `workflow_dispatch`-only,
validated via manual dispatch runs, before the one edit that flips
its trigger to final form -- stating plainly this does not by itself
reduce advisory-bot review invocation count. Recommends local
`nektos/act` validation scoped to Linux runners, with an explicit
caveat that `act` cannot validate `windows-latest`/`macos-latest`
behavior from this repository's WSL/Linux implementation
environments. Documents, as an explicit implementer's-choice option,
iterating an `act`-unvalidatable job on a branch with no open PR yet.
Regenerates the installed mirror, records the observed-incident
citation (PR #2897 / issue #2892) in both design-rationale docs per
this repository's own citation convention, adds `nektos` to both
cspell word lists, and records a short repository-local bullet in
`AGENTS.md` citing the Copilot-review-cost motivation.

## Linked issue

Closes #2907

## Follow-up issues (if any)

- [ ] The `lite` profile's `idd-pr-submit-lite.instructions.md` does
      not read the standard `idd-pr-submit.instructions.md` and so
      never gains this "Adding a new CI job" guidance (a weak model on
      the lite route could still land an unproven CI job wired
      directly to `push`/`pull_request`). Out of this issue's own
      scope (candidate files and acceptance criteria name only the
      standard surface); the lite copy maintains its own tight,
      separately-audited byte budget and needs its own condensation
      pass, not a copy-paste of this prose. Flagged by Codex review on
      PR #2909.

## Background / rationale (if material)

This repository's `copilot_code_review` ruleset re-reviews every push
to a PR branch, so review cost tracks push count roughly 1:1
regardless of which CI jobs a push touches. PR #2897 (issue #2892)
spent three extra review rounds debugging a native-Windows-only CI
hang with no local way to reproduce it -- direct motivation for this
guidance. See `docs/idd-design-rationale.md`'s new "PR submit" section
for the full incident writeup.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiWpghp4ViMu6DUDKLzzxz

