### PR TITLE
fix(advisory-convergence): bind auto-waiver markers to posting run

### DIFF
--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -294,7 +294,7 @@ the shipped template config leaves all of this unset, in which case the
 job is a documented no-op rather than a failure). See
 [Customizing IDD](../../docs/customization.md) for how to opt in, and
 [External-check waiver contract](../../docs/idd-helper-scripts.md#external-check-waiver-contract)
-for the marker shape, the five acceptance conditions, and why this one
+for the marker shape, the seven acceptance conditions, and why this one
 waiver kind is evaluated independent of the deadline/terminal-unavailable
 gate. This does not replace the manual flow for any other reason token,
 actor, or check.

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -454,8 +454,10 @@ jobs:
   # scoped, run-bound `idd-external-check-waiver` marker for exactly that
   # case. See docs/idd-helper-scripts.md's "External-check waiver
   # contract" (self-referential-bootstrap-auto section) for the full
-  # trust model and the five acceptance conditions
-  # `advisory-convergence.mts` verifies before ever honoring the marker;
+  # trust model and the seven acceptance conditions
+  # (kurone-kito/idd-skill#2912 added two run-provenance conditions to
+  # the original five) `advisory-convergence.mts` verifies before ever
+  # honoring the marker;
   # this job's own job is only to detect the trigger and post it --
   # trust is established entirely at consume time, not here.
   #

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -582,15 +582,20 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_ENTERPRISE_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        # kurone-kito/idd-skill#2912 (round 2): the CLI's own JSON report
-        # (default `--format json`, never overridden here) is captured to
-        # a file, not just streamed to the log, so the two fields the
-        # NEXT step needs (`applied`, `commentId`) can be read back out --
-        # `node -e` (never `jq`, whose presence on the runner is never
-        # explicitly asserted, unlike Node's own floor above) parses it
-        # defensively: a parse failure (should not happen, `tee` writes
-        # exactly what stdout produced) degrades to "nothing to record",
-        # never a crashed job.
+        # kurone-kito/idd-skill#2912 (round 2, extended round 3): the
+        # CLI's own JSON report (default `--format json`, never overridden
+        # here) is captured to a file, not just streamed to the log, so
+        # the fields the NEXT step needs (`applied`, `commentId`, and --
+        # round 3 -- `bodyDigest`) can be read back out -- `node -e`
+        # (never `jq`, whose presence on the runner is never explicitly
+        # asserted, unlike Node's own floor above) parses it defensively:
+        # a parse failure (should not happen, `tee` writes exactly what
+        # stdout produced) degrades to "nothing to record", never a
+        # crashed job. `bodyDigest` is the SHA-256 hex digest of the
+        # posted comment's body as this CLI read it BACK from the GitHub
+        # API in its own post-write reconcile (never the locally-sent
+        # string) -- see `ExternalCheckWaiverReport.bodyDigest`'s own doc
+        # comment in `external-check-waiver.mts`.
         run: |
           node scripts/external-check-waiver.mjs \
             --pr "$PR_NUMBER" \
@@ -615,34 +620,48 @@ jobs:
               process.stdout.write("");
             }
           ')
+          BODY_DIGEST=$(node -e '
+            try {
+              const report = JSON.parse(require("fs").readFileSync("/tmp/idd-waiver-report.json", "utf8"));
+              process.stdout.write(String(report.bodyDigest ?? ""));
+            } catch {
+              process.stdout.write("");
+            }
+          ')
           echo "applied=$APPLIED" >> "$GITHUB_OUTPUT"
           echo "comment-id=$COMMENT_ID" >> "$GITHUB_OUTPUT"
+          echo "body-digest=$BODY_DIGEST" >> "$GITHUB_OUTPUT"
       - name: Record the posted marker's provenance
-        # kurone-kito/idd-skill#2912 (round 2): a run-scoped Actions
-        # artifact naming the EXACT comment id this run's own trusted job
-        # just posted -- the binding primitive
-        # `verifySelfReferentialBootstrapWaiverArtifactBinding`
+        # kurone-kito/idd-skill#2912 (round 2, extended round 3): a
+        # run-scoped Actions artifact naming the EXACT comment id AND body
+        # digest this run's own trusted job just posted -- the binding
+        # primitive `verifySelfReferentialBootstrapWaiverArtifactBinding`
         # (advisory-convergence.mts) reads to prove a candidate marker
         # IS the one this run's own execution posted, not merely that no
-        # OTHER candidate is currently visible (a property an attacker
-        # with `issues: write` can falsify by deleting the genuine
-        # comment after the fact). Only when a NEW comment was actually
-        # posted this run (`applied == 'true'`) -- the reuse path (an
-        # existing valid waiver found, nothing newly posted) has no
-        # comment of THIS run's own to record. Needs no `permissions:`
-        # entry: `actions/upload-artifact` uses the Actions runtime's own
+        # OTHER candidate is currently visible (round 1's gap) or that
+        # some candidate with a matching id exists regardless of whether
+        # its body was since edited in place (round 2's gap, a
+        # same-repository `issues: write` workflow can rewrite an
+        # existing comment's body without changing its id or createdAt).
+        # Only when a NEW comment was actually posted this run
+        # (`applied == 'true'`) -- the reuse path (an existing valid
+        # waiver found, nothing newly posted) has no comment of THIS
+        # run's own to record. Needs no `permissions:` entry:
+        # `actions/upload-artifact` uses the Actions runtime's own
         # dedicated upload token, entirely separate from `GITHUB_TOKEN`.
-        if: steps.post-waiver.outputs.applied == 'true' && steps.post-waiver.outputs.comment-id != ''
+        if: steps.post-waiver.outputs.applied == 'true' && steps.post-waiver.outputs.comment-id != '' && steps.post-waiver.outputs.body-digest != ''
         env:
           COMMENT_ID: ${{ steps.post-waiver.outputs.comment-id }}
+          BODY_DIGEST: ${{ steps.post-waiver.outputs.body-digest }}
         run: |
           mkdir -p /tmp/idd-self-waiver-marker
-          printf '%s\n' "$COMMENT_ID" > "/tmp/idd-self-waiver-marker/idd-self-waiver-marker-${COMMENT_ID}"
+          printf 'commentId=%s\nbodyDigest=%s\n' "$COMMENT_ID" "$BODY_DIGEST" \
+            > "/tmp/idd-self-waiver-marker/idd-self-waiver-marker-${COMMENT_ID}-${BODY_DIGEST}"
       - name: Upload the posted marker's provenance artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: steps.post-waiver.outputs.applied == 'true' && steps.post-waiver.outputs.comment-id != ''
+        if: steps.post-waiver.outputs.applied == 'true' && steps.post-waiver.outputs.comment-id != '' && steps.post-waiver.outputs.body-digest != ''
         with:
-          name: idd-self-waiver-marker-${{ steps.post-waiver.outputs.comment-id }}
+          name: idd-self-waiver-marker-${{ steps.post-waiver.outputs.comment-id }}-${{ steps.post-waiver.outputs.body-digest }}
           path: /tmp/idd-self-waiver-marker/
           # Loud failure, not a silent empty artifact, if the previous
           # step somehow produced no file -- the consumer's own binding

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -582,20 +582,25 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_ENTERPRISE_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        # kurone-kito/idd-skill#2912 (round 2, extended round 3): the
-        # CLI's own JSON report (default `--format json`, never overridden
-        # here) is captured to a file, not just streamed to the log, so
-        # the fields the NEXT step needs (`applied`, `commentId`, and --
-        # round 3 -- `bodyDigest`) can be read back out -- `node -e`
-        # (never `jq`, whose presence on the runner is never explicitly
-        # asserted, unlike Node's own floor above) parses it defensively:
-        # a parse failure (should not happen, `tee` writes exactly what
-        # stdout produced) degrades to "nothing to record", never a
-        # crashed job. `bodyDigest` is the SHA-256 hex digest of the
-        # posted comment's body as this CLI read it BACK from the GitHub
-        # API in its own post-write reconcile (never the locally-sent
-        # string) -- see `ExternalCheckWaiverReport.bodyDigest`'s own doc
-        # comment in `external-check-waiver.mts`.
+        # kurone-kito/idd-skill#2912 (round 2, extended round 3, extended
+        # round 4): the CLI's own JSON report (default `--format json`,
+        # never overridden here) is captured to a file, not just streamed
+        # to the log, so the fields the NEXT step needs (`applied`,
+        # `commentId`, and -- round 3 -- `bodyDigest`) can be read back
+        # out -- `node -e` (never `jq`, whose presence on the runner is
+        # never explicitly asserted, unlike Node's own floor above) parses
+        # it defensively: a parse failure (should not happen, `tee` writes
+        # exactly what stdout produced) degrades to "nothing to record",
+        # never a crashed job. `bodyDigest` is the SHA-256 hex digest of
+        # the posted comment's body, taken ONLY from the `body` field
+        # GitHub's create-comment API response returned for this exact
+        # POST -- round 3 originally preferred a LATER, separate re-read
+        # instead, but round 4 removed that in favor of the POST response
+        # alone, which has no window for an intervening edit; see
+        # `ExternalCheckWaiverReport.bodyDigest`'s own doc comment in
+        # `external-check-waiver.mts`. Absent (empty string here) whenever
+        # that response lacked a body -- the two `if:` conditions below
+        # already fail closed on that via `body-digest != ''`.
         run: |
           node scripts/external-check-waiver.mjs \
             --pr "$PR_NUMBER" \

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -566,10 +566,31 @@ jobs:
         # this repository), so this avoids a doomed post and the API
         # calls it would cost.
         if: steps.allowlist.outputs.touched == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+        id: post-waiver
+        # kurone-kito/idd-skill#2912 (round 2): this workflow has no
+        # workflow-level `defaults: run: shell: bash` (unlike the
+        # `idd-template/` mirror), so the runner's implicit default shell
+        # for a `run:` step with no explicit `shell:` does NOT set
+        # `pipefail` -- the `| tee` pipe below would otherwise let a
+        # failed CLI invocation still report success (tee's own exit
+        # code), silently swallowing a broken post instead of failing
+        # this step loudly. Explicit `shell: bash` requests GitHub
+        # Actions' own `bash --noprofile --norc -eo pipefail {0}`
+        # invocation, which does set it.
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           GH_ENTERPRISE_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+        # kurone-kito/idd-skill#2912 (round 2): the CLI's own JSON report
+        # (default `--format json`, never overridden here) is captured to
+        # a file, not just streamed to the log, so the two fields the
+        # NEXT step needs (`applied`, `commentId`) can be read back out --
+        # `node -e` (never `jq`, whose presence on the runner is never
+        # explicitly asserted, unlike Node's own floor above) parses it
+        # defensively: a parse failure (should not happen, `tee` writes
+        # exactly what stdout produced) degrades to "nothing to record",
+        # never a crashed job.
         run: |
           node scripts/external-check-waiver.mjs \
             --pr "$PR_NUMBER" \
@@ -577,4 +598,62 @@ jobs:
             --reason self-referential-bootstrap-auto \
             --run-id "$GITHUB_RUN_ID" \
             --auto-bootstrap \
-            --apply --yes
+            --apply --yes | tee /tmp/idd-waiver-report.json
+          APPLIED=$(node -e '
+            try {
+              const report = JSON.parse(require("fs").readFileSync("/tmp/idd-waiver-report.json", "utf8"));
+              process.stdout.write(String(report.applied ?? false));
+            } catch {
+              process.stdout.write("false");
+            }
+          ')
+          COMMENT_ID=$(node -e '
+            try {
+              const report = JSON.parse(require("fs").readFileSync("/tmp/idd-waiver-report.json", "utf8"));
+              process.stdout.write(String(report.commentId ?? ""));
+            } catch {
+              process.stdout.write("");
+            }
+          ')
+          echo "applied=$APPLIED" >> "$GITHUB_OUTPUT"
+          echo "comment-id=$COMMENT_ID" >> "$GITHUB_OUTPUT"
+      - name: Record the posted marker's provenance
+        # kurone-kito/idd-skill#2912 (round 2): a run-scoped Actions
+        # artifact naming the EXACT comment id this run's own trusted job
+        # just posted -- the binding primitive
+        # `verifySelfReferentialBootstrapWaiverArtifactBinding`
+        # (advisory-convergence.mts) reads to prove a candidate marker
+        # IS the one this run's own execution posted, not merely that no
+        # OTHER candidate is currently visible (a property an attacker
+        # with `issues: write` can falsify by deleting the genuine
+        # comment after the fact). Only when a NEW comment was actually
+        # posted this run (`applied == 'true'`) -- the reuse path (an
+        # existing valid waiver found, nothing newly posted) has no
+        # comment of THIS run's own to record. Needs no `permissions:`
+        # entry: `actions/upload-artifact` uses the Actions runtime's own
+        # dedicated upload token, entirely separate from `GITHUB_TOKEN`.
+        if: steps.post-waiver.outputs.applied == 'true' && steps.post-waiver.outputs.comment-id != ''
+        env:
+          COMMENT_ID: ${{ steps.post-waiver.outputs.comment-id }}
+        run: |
+          mkdir -p /tmp/idd-self-waiver-marker
+          printf '%s\n' "$COMMENT_ID" > "/tmp/idd-self-waiver-marker/idd-self-waiver-marker-${COMMENT_ID}"
+      - name: Upload the posted marker's provenance artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: steps.post-waiver.outputs.applied == 'true' && steps.post-waiver.outputs.comment-id != ''
+        with:
+          name: idd-self-waiver-marker-${{ steps.post-waiver.outputs.comment-id }}
+          path: /tmp/idd-self-waiver-marker/
+          # Loud failure, not a silent empty artifact, if the previous
+          # step somehow produced no file -- the consumer's own binding
+          # check already fails closed on a missing artifact either way,
+          # but this surfaces the CI-side bug immediately instead of only
+          # as a downstream "no auto-waiver" symptom.
+          if-no-files-found: error
+          # Deliberately NOT retention-days: 1 -- a later re-evaluation
+          # (issue_comment-triggered, or rerun-advisory-convergence.mts)
+          # can run well after this run finishes, and the marker's own
+          # validity window (SELF_REFERENTIAL_BOOTSTRAP_AUTO_EXPIRY)
+          # outlives a short artifact retention -- keep the repository
+          # default so the artifact stays listable for the marker's full
+          # validity window.

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1497,7 +1497,19 @@ idd-external-check-waiver --pr 123 \
   `run-id:` and trick this job into believing a valid waiver already
   exists, skipping its own post. Always attempting to post is at worst
   a harmless extra marker; the consumer's trust check below already
-  accepts any candidate that verifies.
+  accepts any candidate that verifies;
+- when the post succeeds, the job's own workflow steps additionally
+  upload a run-scoped GitHub Actions artifact named
+  `idd-self-waiver-marker-<comment-id>` (kurone-kito/idd-skill#2912,
+  round 2) -- the posted comment's own numeric id, and nothing else, as
+  the artifact's name (never its content, so the consumer never needs to
+  download or unzip it). This is the channel condition 7 below reads to
+  bind a marker to the run's own trusted execution: artifacts are scoped
+  to the run that uploaded them by the Actions runtime's own dedicated
+  upload token, never by the shared `GITHUB_TOKEN` `permissions:`
+  surface an issue comment (or a check run) is created and mutated
+  through, so no OTHER same-repository workflow run can add, edit, or
+  remove an entry from this specific run's own artifact list.
 
 The marker is honored only when **all** of the following hold, verified
 by `advisory-convergence.mts` itself (not the generic
@@ -1542,23 +1554,48 @@ needs a live per-marker run lookup no other consumer needs):
    in a forged marker, satisfying conditions 1-5 without having been
    posted by that run's job at all. Binding to the post step's own
    recorded conclusion and execution window closes this; and
-7. no second candidate marker (same author, reason, and check selector)
-   also cites this exact `run-id:` (kurone-kito/idd-skill#2912) -- since
-   the genuine posting job always attempts to post regardless of whether
-   a marker already exists for this HEAD (`--auto-bootstrap` explicitly
-   skips the generic reuse scan, see above), a legitimate marker and a
-   forged one sharing the same cited run id can only mean one of the two
-   is fraudulent; rather than pick a winner, both are rejected, falling
-   back to the pre-existing maintainer-authorized waiver as the escape
-   hatch.
+7. the marker's own comment `id` appears in the SET of comment ids the
+   cited `run-id:`'s own trusted job execution recorded actually posting,
+   recovered from a run-scoped GitHub Actions artifact that job uploads
+   immediately after posting (named `idd-self-waiver-marker-<comment-id>`
+   -- see `listWorkflowRunArtifacts` in `provider-adapter-github.mts`)
+   (kurone-kito/idd-skill#2912, round 2) -- condition 6 above proves only
+   that the cited run's job succeeded and posted SOME comment within a
+   tight execution window, never THIS EXACT comment; a same-repository
+   `pull_request`-triggered workflow can post a forged marker inside that
+   same window, wait for the genuine marker to post, and then DELETE it
+   (`issues: write` permits deleting ANY issue comment on the repository,
+   not only ones the deleting token itself authored), leaving the forged
+   marker as the sole survivor of a plain "no duplicate currently
+   visible" scan -- the mechanism this condition replaced. Artifacts
+   close this because they are scoped to the run that uploaded them by
+   the Actions runtime's own dedicated upload token, never by the shared
+   `GITHUB_TOKEN` `permissions:` surface comments (and condition 6's own
+   job/step data) are read and, in the comment's case, mutated through --
+   so no unrelated run can add, edit, or remove an entry from that
+   trusted set regardless of which `permissions:` it self-grants.
+   Deleting the genuine comment only removes it from the live comment
+   scan condition 7 itself needs to correlate an entry back to its own
+   `id` (two distinct candidates sharing the same cited run id AND the
+   same wall-clock second are ambiguous for that correlation and both
+   fail closed, never guessing a winner) -- it degrades this mechanism to
+   "no auto-waiver", never "the forged marker validates". The one
+   residual: an attacker who additionally self-grants the broader,
+   repository-wide `actions: write` permission could delete the genuine
+   run's own artifact through Actions' own artifact-management endpoint,
+   which still only degrades to "no auto-waiver", never a forged one --
+   outside the `issues: write`-scoped threat model this condition (and
+   the two independent review findings that prompted it) are framed
+   against.
 
-A marker missing `run-id:`, whose run or run-jobs data cannot be
-resolved, targets another head SHA or repository, ran under any event
-other than `pull_request_target`, whose PR diff does not touch the
-trigger-file allowlist, whose cited run's own posting step did not
-report `success` within its own execution window, or that shares its
-cited `run-id:` with another candidate marker, is rejected the same way
-a manual waiver from an untrusted actor is today. Unlike an ordinary
+A marker missing `run-id:`, whose run, run-jobs, or run-artifacts data
+cannot be resolved, targets another head SHA or repository, ran under
+any event other than `pull_request_target`, whose PR diff does not touch
+the trigger-file allowlist, whose cited run's own posting step did not
+report `success` within its own execution window, or whose own comment
+`id` is absent from (or ambiguous within) the cited run's artifact-
+recorded trusted set, is rejected the same way a manual waiver from an
+untrusted actor is today. Unlike an ordinary
 maintainer-authorized waiver (gated behind
 `deadlinePassed || terminalUnavailable`), a valid
 self-referential-bootstrap-auto waiver is evaluated **unconditionally** --
@@ -1582,12 +1619,13 @@ repository's default branch, never the PR head -- required so neither
 job ever executes PR-controlled code with `issues: write` -- so a bug
 specifically WITHIN the code that decides whether/how to invoke
 `--auto-bootstrap` (its own branches in `external-check-waiver.mts`),
-the three Actions-API methods the trust chain above itself calls
-(`getWorkflowRun`, `getWorkflowRunJobs`, `listChangeRequestChangedFiles`
-in `provider-adapter-github.mts`), or the seven conditions' own
-verification functions in `advisory-convergence.mts`
+the four Actions-API methods the trust chain above itself calls
+(`getWorkflowRun`, `getWorkflowRunJobs`, `listWorkflowRunArtifacts`,
+`listChangeRequestChangedFiles` in `provider-adapter-github.mts`), or the
+seven conditions' own verification functions in `advisory-convergence.mts`
 (`verifySelfReferentialBootstrapWaiverRun`,
-`verifySelfReferentialBootstrapWaiverProvenance`, and the rest) cannot
+`verifySelfReferentialBootstrapWaiverProvenance`,
+`verifySelfReferentialBootstrapWaiverArtifactBinding`, and the rest) cannot
 be rescued by this mechanism: the OLD, buggy version of exactly that
 code is what would have to decide to trust the fix. This is the same
 fixed point every self-hosting bootstrap has, and isolating marker

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1500,16 +1500,27 @@ idd-external-check-waiver --pr 123 \
   accepts any candidate that verifies;
 - when the post succeeds, the job's own workflow steps additionally
   upload a run-scoped GitHub Actions artifact named
-  `idd-self-waiver-marker-<comment-id>` (kurone-kito/idd-skill#2912,
-  round 2) -- the posted comment's own numeric id, and nothing else, as
-  the artifact's name (never its content, so the consumer never needs to
+  `idd-self-waiver-marker-<comment-id>-<body-digest>`
+  (kurone-kito/idd-skill#2912, round 2, extended round 3) -- the posted
+  comment's own numeric id, a literal `-`, and the SHA-256 hex digest of
+  that comment's exact body as this same job read it BACK from the
+  GitHub API immediately after posting, and nothing else, as the
+  artifact's name (never its content, so the consumer never needs to
   download or unzip it). This is the channel condition 7 below reads to
   bind a marker to the run's own trusted execution: artifacts are scoped
   to the run that uploaded them by the Actions runtime's own dedicated
   upload token, never by the shared `GITHUB_TOKEN` `permissions:`
   surface an issue comment (or a check run) is created and mutated
   through, so no OTHER same-repository workflow run can add, edit, or
-  remove an entry from this specific run's own artifact list.
+  remove an entry from this specific run's own artifact list. The body
+  digest is hashed from an API-returned body on BOTH the posting and
+  consuming sides whenever that read-back is available -- a
+  locally-constructed string is only ever a fallback on the posting side,
+  used when its own post-write reconcile could not find the just-posted
+  comment (`ExternalCheckWaiverReport.bodyDigestSource`), and is always
+  labeled as such rather than silently treated the same as a
+  GitHub-attested digest -- so an unedited comment digests identically on
+  both sides in the ordinary case, regardless of which side computed it.
 
 The marker is honored only when **all** of the following hold, verified
 by `advisory-convergence.mts` itself (not the generic
@@ -1554,48 +1565,56 @@ needs a live per-marker run lookup no other consumer needs):
    in a forged marker, satisfying conditions 1-5 without having been
    posted by that run's job at all. Binding to the post step's own
    recorded conclusion and execution window closes this; and
-7. the marker's own comment `id` appears in the SET of comment ids the
-   cited `run-id:`'s own trusted job execution recorded actually posting,
-   recovered from a run-scoped GitHub Actions artifact that job uploads
-   immediately after posting (named `idd-self-waiver-marker-<comment-id>`
-   -- see `listWorkflowRunArtifacts` in `provider-adapter-github.mts`)
-   (kurone-kito/idd-skill#2912, round 2) -- condition 6 above proves only
-   that the cited run's job succeeded and posted SOME comment within a
-   tight execution window, never THIS EXACT comment; a same-repository
+7. the marker's own comment `(id, body digest)` pair appears in the SET
+   of such pairs the cited `run-id:`'s own trusted job execution recorded
+   actually posting, recovered from a run-scoped GitHub Actions artifact
+   that job uploads immediately after posting (named
+   `idd-self-waiver-marker-<comment-id>-<body-digest>` -- see
+   `listWorkflowRunArtifacts` in `provider-adapter-github.mts`)
+   (kurone-kito/idd-skill#2912, round 2, extended round 3) -- condition 6
+   above proves only that the cited run's job succeeded and posted SOME
+   comment within a tight execution window, never THIS EXACT comment (and
+   never that its content stayed unchanged since); a same-repository
    `pull_request`-triggered workflow can post a forged marker inside that
-   same window, wait for the genuine marker to post, and then DELETE it
-   (`issues: write` permits deleting ANY issue comment on the repository,
-   not only ones the deleting token itself authored), leaving the forged
-   marker as the sole survivor of a plain "no duplicate currently
-   visible" scan -- the mechanism this condition replaced. Artifacts
-   close this because they are scoped to the run that uploaded them by
-   the Actions runtime's own dedicated upload token, never by the shared
-   `GITHUB_TOKEN` `permissions:` surface comments (and condition 6's own
-   job/step data) are read and, in the comment's case, mutated through --
-   so no unrelated run can add, edit, or remove an entry from that
-   trusted set regardless of which `permissions:` it self-grants.
-   Deleting the genuine comment only removes it from the live comment
-   scan condition 7 itself needs to correlate an entry back to its own
-   `id` (two distinct candidates sharing the same cited run id AND the
-   same wall-clock second are ambiguous for that correlation and both
-   fail closed, never guessing a winner) -- it degrades this mechanism to
-   "no auto-waiver", never "the forged marker validates". The one
-   residual: an attacker who additionally self-grants the broader,
-   repository-wide `actions: write` permission could delete the genuine
-   run's own artifact through Actions' own artifact-management endpoint,
-   which still only degrades to "no auto-waiver", never a forged one --
-   outside the `issues: write`-scoped threat model this condition (and
-   the two independent review findings that prompted it) are framed
-   against.
+   same window, wait for the genuine marker to post, and then either
+   DELETE it (`issues: write` permits deleting ANY issue comment on the
+   repository, not only ones the deleting token itself authored), leaving
+   the forged marker as the sole survivor of a plain "no duplicate
+   currently visible" scan (round 1's gap), or EDIT it in place --
+   `issues: write` permits rewriting an existing comment's body too,
+   which preserves that comment's `id` and `createdAt` while replacing
+   its content, so binding on `id` alone (round 2) would still accept the
+   rewritten body. Binding on the `(id, body digest)` pair instead of `id`
+   alone closes both: artifacts are scoped to the run that uploaded them
+   by the Actions runtime's own dedicated upload token, never by the
+   shared `GITHUB_TOKEN` `permissions:` surface comments (and condition
+   6's own job/step data) are read and, in the comment's case, mutated
+   through -- so no unrelated run can add, edit, or remove an entry from
+   that trusted set regardless of which `permissions:` it self-grants,
+   and a LATER edit to the live comment changes its digest without being
+   able to retroactively change what the artifact already recorded.
+   Deleting or editing the genuine comment only removes/changes it in the
+   live comment scan condition 7 itself needs to correlate an entry back
+   to its own `id` (two distinct candidates sharing the same cited run id
+   AND the same wall-clock second are ambiguous for that correlation and
+   both fail closed, never guessing a winner) -- it degrades this
+   mechanism to "no auto-waiver", never "the forged or edited marker
+   validates". The one residual: an attacker who additionally
+   self-grants the broader, repository-wide `actions: write` permission
+   could delete the genuine run's own artifact through Actions' own
+   artifact-management endpoint, which still only degrades to "no
+   auto-waiver", never a forged one -- outside the `issues: write`-scoped
+   threat model this condition (and the independent review findings that
+   prompted both rounds) are framed against.
 
 A marker missing `run-id:`, whose run, run-jobs, or run-artifacts data
 cannot be resolved, targets another head SHA or repository, ran under
 any event other than `pull_request_target`, whose PR diff does not touch
 the trigger-file allowlist, whose cited run's own posting step did not
 report `success` within its own execution window, or whose own comment
-`id` is absent from (or ambiguous within) the cited run's artifact-
-recorded trusted set, is rejected the same way a manual waiver from an
-untrusted actor is today. Unlike an ordinary
+`(id, body digest)` pair is absent from (or ambiguous within) the cited
+run's artifact-recorded trusted set, is rejected the same way a manual
+waiver from an untrusted actor is today. Unlike an ordinary
 maintainer-authorized waiver (gated behind
 `deadlinePassed || terminalUnavailable`), a valid
 self-referential-bootstrap-auto waiver is evaluated **unconditionally** --

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1501,11 +1501,10 @@ idd-external-check-waiver --pr 123 \
 - when the post succeeds, the job's own workflow steps additionally
   upload a run-scoped GitHub Actions artifact named
   `idd-self-waiver-marker-<comment-id>-<body-digest>`
-  (kurone-kito/idd-skill#2912, round 2, extended round 3) -- the posted
-  comment's own numeric id, a literal `-`, and the SHA-256 hex digest of
-  that comment's exact body as this same job read it BACK from the
-  GitHub API immediately after posting, and nothing else, as the
-  artifact's name (never its content, so the consumer never needs to
+  (kurone-kito/idd-skill#2912, round 2, extended round 3, extended round
+  4) -- the posted comment's own numeric id, a literal `-`, and the
+  SHA-256 hex digest of that comment's exact body, and nothing else, as
+  the artifact's name (never its content, so the consumer never needs to
   download or unzip it). This is the channel condition 7 below reads to
   bind a marker to the run's own trusted execution: artifacts are scoped
   to the run that uploaded them by the Actions runtime's own dedicated
@@ -1513,14 +1512,23 @@ idd-external-check-waiver --pr 123 \
   surface an issue comment (or a check run) is created and mutated
   through, so no OTHER same-repository workflow run can add, edit, or
   remove an entry from this specific run's own artifact list. The body
-  digest is hashed from an API-returned body on BOTH the posting and
-  consuming sides whenever that read-back is available -- a
-  locally-constructed string is only ever a fallback on the posting side,
-  used when its own post-write reconcile could not find the just-posted
-  comment (`ExternalCheckWaiverReport.bodyDigestSource`), and is always
-  labeled as such rather than silently treated the same as a
-  GitHub-attested digest -- so an unedited comment digests identically on
-  both sides in the ordinary case, regardless of which side computed it.
+  digest is hashed from an API-returned body on both the posting and
+  consuming sides, so an unedited comment digests identically regardless
+  of which side computed it -- specifically, the posting side hashes
+  ONLY the `body` field GitHub's create-comment response returns for the
+  exact POST that created the comment, never a later re-read. An earlier
+  design (round 3) instead preferred a body observed in a LATER, separate
+  post-write re-read (falling back to the locally-sent string only when
+  that re-read came up empty, and labeling the result
+  `ExternalCheckWaiverReport.bodyDigestSource: 'constructed'` when it
+  did) -- a Copilot review of that round's own commit found this opened a
+  window: a same-repository `issues: write` workflow could edit the
+  genuine comment's body between the POST returning and that later
+  re-read running, and the reconcile-preferring design would then hash
+  and report the FORGED body as trustworthy. Round 4 removed that
+  fallback entirely; `bodyDigestSource` no longer exists, and the digest
+  is reported only when the create-comment response itself carried a
+  body.
 
 The marker is honored only when **all** of the following hold, verified
 by `advisory-convergence.mts` itself (not the generic
@@ -1571,7 +1579,8 @@ needs a live per-marker run lookup no other consumer needs):
    that job uploads immediately after posting (named
    `idd-self-waiver-marker-<comment-id>-<body-digest>` -- see
    `listWorkflowRunArtifacts` in `provider-adapter-github.mts`)
-   (kurone-kito/idd-skill#2912, round 2, extended round 3) -- condition 6
+   (kurone-kito/idd-skill#2912, round 2, extended round 3, extended round
+   4) -- condition 6
    above proves only that the cited run's job succeeded and posted SOME
    comment within a tight execution window, never THIS EXACT comment (and
    never that its content stayed unchanged since); a same-repository

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1515,7 +1515,7 @@ needs a live per-marker run lookup no other consumer needs):
    never `pull_request` -- closing the gap where a same-repository PR
    editing the workflow YAML can still trigger a `pull_request`-triggered
    run of it during a `pull_request`/`pull_request_target` migration
-   window (kurone-kito/idd-skill#2764 Phase 1); and
+   window (kurone-kito/idd-skill#2764 Phase 1);
 5. the PR's own changed files (fetched independently at consume time,
    never trusted from the posting job's own internal check) include at
    least one path from the trigger-file allowlist above
@@ -1526,14 +1526,41 @@ needs a live per-marker run lookup no other consumer needs):
    same-repository PR could forge a marker citing the ordinary verdict
    job's own trivially-discoverable run id for its own HEAD and bypass
    advisory convergence for a change that never touched the allowlist at
-   all.
+   all;
+6. `GET /repos/{owner}/{repo}/actions/runs/{run-id}/jobs` for that same
+   `run-id:` reports the run's own `idd-advisory-convergence-self-waiver`
+   job's "Post the self-referential-bootstrap-auto waiver" step with
+   `conclusion: success`, AND the marker comment's own `createdAt` falls
+   within that step's `[started_at, completed_at]` execution window
+   (kurone-kito/idd-skill#2912) -- conditions 3 and 4 alone prove only
+   that SOME genuine run of the right shape exists, never that THAT run's
+   own job actually posted THIS specific comment; a same-repository
+   `pull_request`-triggered workflow (untrusted, but able to post
+   `github-actions[bot]`-authored comments the same way the genuine
+   posting job does) can discover a legitimate, concurrently running
+   `pull_request_target` run's id via the public Actions API and cite it
+   in a forged marker, satisfying conditions 1-5 without having been
+   posted by that run's job at all. Binding to the post step's own
+   recorded conclusion and execution window closes this; and
+7. no second candidate marker (same author, reason, and check selector)
+   also cites this exact `run-id:` (kurone-kito/idd-skill#2912) -- since
+   the genuine posting job always attempts to post regardless of whether
+   a marker already exists for this HEAD (`--auto-bootstrap` explicitly
+   skips the generic reuse scan, see above), a legitimate marker and a
+   forged one sharing the same cited run id can only mean one of the two
+   is fraudulent; rather than pick a winner, both are rejected, falling
+   back to the pre-existing maintainer-authorized waiver as the escape
+   hatch.
 
-A marker missing `run-id:`, whose run cannot be resolved, targets another
-head SHA or repository, ran under any event other than
-`pull_request_target`, or whose PR diff does not touch the trigger-file
-allowlist, is rejected the same way a manual waiver from an untrusted
-actor is today. Unlike an ordinary maintainer-authorized waiver
-(gated behind `deadlinePassed || terminalUnavailable`), a valid
+A marker missing `run-id:`, whose run or run-jobs data cannot be
+resolved, targets another head SHA or repository, ran under any event
+other than `pull_request_target`, whose PR diff does not touch the
+trigger-file allowlist, whose cited run's own posting step did not
+report `success` within its own execution window, or that shares its
+cited `run-id:` with another candidate marker, is rejected the same way
+a manual waiver from an untrusted actor is today. Unlike an ordinary
+maintainer-authorized waiver (gated behind
+`deadlinePassed || terminalUnavailable`), a valid
 self-referential-bootstrap-auto waiver is evaluated **unconditionally** --
 it makes `ready` true immediately, without waiting for the deadline clock
 or a proven Copilot outage, since the whole point is bootstrapping a fix
@@ -1555,13 +1582,16 @@ repository's default branch, never the PR head -- required so neither
 job ever executes PR-controlled code with `issues: write` -- so a bug
 specifically WITHIN the code that decides whether/how to invoke
 `--auto-bootstrap` (its own branches in `external-check-waiver.mts`),
-the two Actions-API methods the trust chain above itself calls
-(`getWorkflowRun`, `listChangeRequestChangedFiles` in
-`provider-adapter-github.mts`), or the five conditions' own verification
-functions in `advisory-convergence.mts` cannot be rescued by this
-mechanism: the OLD, buggy version of exactly that code is what would
-have to decide to trust the fix. This is the same fixed point every
-self-hosting bootstrap has, and isolating marker emission into a
+the three Actions-API methods the trust chain above itself calls
+(`getWorkflowRun`, `getWorkflowRunJobs`, `listChangeRequestChangedFiles`
+in `provider-adapter-github.mts`), or the seven conditions' own
+verification functions in `advisory-convergence.mts`
+(`verifySelfReferentialBootstrapWaiverRun`,
+`verifySelfReferentialBootstrapWaiverProvenance`, and the rest) cannot
+be rescued by this mechanism: the OLD, buggy version of exactly that
+code is what would have to decide to trust the fix. This is the same
+fixed point every self-hosting bootstrap has, and isolating marker
+emission into a
 smaller module would shrink it, never eliminate it. The rest of each
 listed file's surface -- most of it, since each implements far more
 than this one trust path -- remains genuinely bootstrappable as

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -289,7 +289,7 @@ the shipped template config leaves all of this unset, in which case the
 job is a documented no-op rather than a failure). See
 [Customizing IDD](../../docs/customization.md) for how to opt in, and
 [External-check waiver contract](../../docs/idd-helper-scripts.md#external-check-waiver-contract)
-for the marker shape, the five acceptance conditions, and why this one
+for the marker shape, the seven acceptance conditions, and why this one
 waiver kind is evaluated independent of the deadline/terminal-unavailable
 gate. This does not replace the manual flow for any other reason token,
 actor, or check.

--- a/idd-template/.github/workflows/idd-advisory-convergence.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence.yml
@@ -684,20 +684,26 @@ jobs:
           PROFILE: ${{ steps.profile.outputs.profile }}
           PACKAGE_SPEC: ${{ steps.profile.outputs.package-spec }}
           MANAGER: ${{ steps.manager.outputs.manager }}
-        # kurone-kito/idd-skill#2912 (round 2, extended round 3): every
-        # profile branch below pipes its own invocation through the SAME
-        # `tee`, so the common post-processing after the `case` (reading
-        # `applied`/`commentId`/`bodyDigest` back out of the CLI's own
-        # JSON report) is written once rather than duplicated per profile.
-        # `node -e` (never `jq`, whose presence on the runner is never
-        # explicitly asserted, unlike Node's own floor above) parses it
-        # defensively: a parse failure (should not happen, `tee` writes
-        # exactly what stdout produced) degrades to "nothing to record",
-        # never a crashed job. `bodyDigest` is the SHA-256 hex digest of
-        # the posted comment's body as the CLI read it BACK from the
-        # GitHub API in its own post-write reconcile (never the locally-
-        # sent string) -- see `ExternalCheckWaiverReport.bodyDigest`'s own
-        # doc comment in `external-check-waiver.mts`.
+        # kurone-kito/idd-skill#2912 (round 2, extended round 3, extended
+        # round 4): every profile branch below pipes its own invocation
+        # through the SAME `tee`, so the common post-processing after the
+        # `case` (reading `applied`/`commentId`/`bodyDigest` back out of
+        # the CLI's own JSON report) is written once rather than
+        # duplicated per profile. `node -e` (never `jq`, whose presence on
+        # the runner is never explicitly asserted, unlike Node's own floor
+        # above) parses it defensively: a parse failure (should not
+        # happen, `tee` writes exactly what stdout produced) degrades to
+        # "nothing to record", never a crashed job. `bodyDigest` is the
+        # SHA-256 hex digest of the posted comment's body, taken ONLY from
+        # the `body` field GitHub's create-comment API response returned
+        # for this exact POST -- round 3 originally preferred a LATER,
+        # separate re-read instead, but round 4 removed that in favor of
+        # the POST response alone, which has no window for an intervening
+        # edit; see `ExternalCheckWaiverReport.bodyDigest`'s own doc
+        # comment in `external-check-waiver.mts`. Absent (empty string
+        # here) whenever that response lacked a body -- the two `if:`
+        # conditions below already fail closed on that via
+        # `body-digest != ''`.
         run: |
           case "$PROFILE" in
             vendored-node)
@@ -709,7 +715,37 @@ jobs:
                   pnpm exec idd-external-check-waiver --pr "$PR_NUMBER" --check idd-advisory-convergence --reason self-referential-bootstrap-auto --run-id "$GITHUB_RUN_ID" --auto-bootstrap --apply --yes | tee /tmp/idd-waiver-report.json
                   ;;
                 yarn)
-                  yarn idd-external-check-waiver --pr "$PR_NUMBER" --check idd-advisory-convergence --reason self-referential-bootstrap-auto --run-id "$GITHUB_RUN_ID" --auto-bootstrap --apply --yes | tee /tmp/idd-waiver-report.json
+                  # kurone-kito/idd-skill#2912 (round 4, Codex review, PR
+                  # #2914): Yarn Classic (v1) writes its own banner
+                  # ("yarn run v1.x.x") and trailer ("Done in Ns.") lines
+                  # to stdout around the wrapped script's own output --
+                  # unlike `pnpm exec`/`npm exec` above, neither of which
+                  # does this. Left unsilenced, those lines land inside
+                  # the same `tee`'d file the `node -e` steps below parse
+                  # as JSON, breaking every `JSON.parse` call on this
+                  # profile (including `bodyDigest`, so the provenance
+                  # artifact silently stops being recorded even on a
+                  # successful post). `--silent` (a Yarn 1 global flag,
+                  # placed immediately after `yarn`) suppresses Yarn's own
+                  # console output while leaving the wrapped script's
+                  # stdout untouched -- but Yarn Berry (2+, also matched
+                  # by this same "yarn" branch: `steps.manager` never
+                  # distinguishes majors) already produces clean stdout
+                  # with no banner to suppress, and its clipanion CLI
+                  # parser does not recognize a bare `--silent` before the
+                  # script name at all -- it exits with "Unknown Syntax
+                  # Error" on stdout instead of ever running the script,
+                  # corrupting the capture worse than the bug this exists
+                  # to fix (self-review of this round's own commit caught
+                  # this empirically, running both `yarn@1` and `yarn@4`).
+                  # Detect the installed major at run time and apply
+                  # `--silent` only for v1, never unconditionally.
+                  YARN_MAJOR="$(yarn --version 2>/dev/null | cut -d. -f1)"
+                  if [ "$YARN_MAJOR" = "1" ]; then
+                    yarn --silent idd-external-check-waiver --pr "$PR_NUMBER" --check idd-advisory-convergence --reason self-referential-bootstrap-auto --run-id "$GITHUB_RUN_ID" --auto-bootstrap --apply --yes | tee /tmp/idd-waiver-report.json
+                  else
+                    yarn idd-external-check-waiver --pr "$PR_NUMBER" --check idd-advisory-convergence --reason self-referential-bootstrap-auto --run-id "$GITHUB_RUN_ID" --auto-bootstrap --apply --yes | tee /tmp/idd-waiver-report.json
+                  fi
                   ;;
                 *)
                   npm exec idd-external-check-waiver -- --pr "$PR_NUMBER" --check idd-advisory-convergence --reason self-referential-bootstrap-auto --run-id "$GITHUB_RUN_ID" --auto-bootstrap --apply --yes | tee /tmp/idd-waiver-report.json

--- a/idd-template/.github/workflows/idd-advisory-convergence.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence.yml
@@ -385,10 +385,11 @@ jobs:
   # `idd-external-check-waiver` marker for exactly that case. See
   # docs/idd-helper-scripts.md's "External-check waiver contract"
   # (self-referential-bootstrap-auto section) for the full trust model
-  # and the five acceptance conditions `advisory-convergence.mts`
-  # verifies before ever honoring the marker -- this job's only role is
-  # to detect the trigger and post it; trust is established entirely at
-  # consume time, not here.
+  # and the seven acceptance conditions (kurone-kito/idd-skill#2912 added
+  # two run-provenance conditions to the original five)
+  # `advisory-convergence.mts` verifies before ever honoring the marker --
+  # this job's only role is to detect the trigger and post it; trust is
+  # established entirely at consume time, not here.
   #
   # `if: pull_request_target` only, never `pull_request`: a
   # same-repository PR editing this YAML could otherwise also run this

--- a/idd-template/.github/workflows/idd-advisory-convergence.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence.yml
@@ -676,6 +676,7 @@ jobs:
         # intended route for a profile the "Notice" step above already
         # explained and let pass without failing the job.
         if: steps.allowlist.outputs.touched == 'true' && steps.profile.outputs.profile != 'instructions-only' && github.event.pull_request.head.repo.full_name == github.repository
+        id: post-waiver
         env:
           GH_TOKEN: ${{ github.token }}
           GH_ENTERPRISE_TOKEN: ${{ github.token }}
@@ -683,30 +684,97 @@ jobs:
           PROFILE: ${{ steps.profile.outputs.profile }}
           PACKAGE_SPEC: ${{ steps.profile.outputs.package-spec }}
           MANAGER: ${{ steps.manager.outputs.manager }}
+        # kurone-kito/idd-skill#2912 (round 2): every profile branch below
+        # pipes its own invocation through the SAME `tee`, so the common
+        # post-processing after the `case` (reading `applied`/`commentId`
+        # back out of the CLI's own JSON report) is written once rather
+        # than duplicated per profile. `node -e` (never `jq`, whose
+        # presence on the runner is never explicitly asserted, unlike
+        # Node's own floor above) parses it defensively: a parse failure
+        # (should not happen, `tee` writes exactly what stdout produced)
+        # degrades to "nothing to record", never a crashed job.
         run: |
           case "$PROFILE" in
             vendored-node)
-              node scripts/external-check-waiver.mjs --pr "$PR_NUMBER" --check idd-advisory-convergence --reason self-referential-bootstrap-auto --run-id "$GITHUB_RUN_ID" --auto-bootstrap --apply --yes
+              node scripts/external-check-waiver.mjs --pr "$PR_NUMBER" --check idd-advisory-convergence --reason self-referential-bootstrap-auto --run-id "$GITHUB_RUN_ID" --auto-bootstrap --apply --yes | tee /tmp/idd-waiver-report.json
               ;;
             package-manager)
               case "$MANAGER" in
                 pnpm)
-                  pnpm exec idd-external-check-waiver --pr "$PR_NUMBER" --check idd-advisory-convergence --reason self-referential-bootstrap-auto --run-id "$GITHUB_RUN_ID" --auto-bootstrap --apply --yes
+                  pnpm exec idd-external-check-waiver --pr "$PR_NUMBER" --check idd-advisory-convergence --reason self-referential-bootstrap-auto --run-id "$GITHUB_RUN_ID" --auto-bootstrap --apply --yes | tee /tmp/idd-waiver-report.json
                   ;;
                 yarn)
-                  yarn idd-external-check-waiver --pr "$PR_NUMBER" --check idd-advisory-convergence --reason self-referential-bootstrap-auto --run-id "$GITHUB_RUN_ID" --auto-bootstrap --apply --yes
+                  yarn idd-external-check-waiver --pr "$PR_NUMBER" --check idd-advisory-convergence --reason self-referential-bootstrap-auto --run-id "$GITHUB_RUN_ID" --auto-bootstrap --apply --yes | tee /tmp/idd-waiver-report.json
                   ;;
                 *)
-                  npm exec idd-external-check-waiver -- --pr "$PR_NUMBER" --check idd-advisory-convergence --reason self-referential-bootstrap-auto --run-id "$GITHUB_RUN_ID" --auto-bootstrap --apply --yes
+                  npm exec idd-external-check-waiver -- --pr "$PR_NUMBER" --check idd-advisory-convergence --reason self-referential-bootstrap-auto --run-id "$GITHUB_RUN_ID" --auto-bootstrap --apply --yes | tee /tmp/idd-waiver-report.json
                   ;;
               esac
               ;;
             ephemeral-npx)
               SPEC="${PACKAGE_SPEC:-https://codeload.github.com/kurone-kito/idd-skill/tar.gz/refs/heads/main}"
-              npx --yes --package "$SPEC" idd-external-check-waiver --pr "$PR_NUMBER" --check idd-advisory-convergence --reason self-referential-bootstrap-auto --run-id "$GITHUB_RUN_ID" --auto-bootstrap --apply --yes
+              npx --yes --package "$SPEC" idd-external-check-waiver --pr "$PR_NUMBER" --check idd-advisory-convergence --reason self-referential-bootstrap-auto --run-id "$GITHUB_RUN_ID" --auto-bootstrap --apply --yes | tee /tmp/idd-waiver-report.json
               ;;
             *)
               echo "::error::unrecognized helper-runtime profile \"$PROFILE\""
               exit 1
               ;;
           esac
+          APPLIED=$(node -e '
+            try {
+              const report = JSON.parse(require("fs").readFileSync("/tmp/idd-waiver-report.json", "utf8"));
+              process.stdout.write(String(report.applied ?? false));
+            } catch {
+              process.stdout.write("false");
+            }
+          ')
+          COMMENT_ID=$(node -e '
+            try {
+              const report = JSON.parse(require("fs").readFileSync("/tmp/idd-waiver-report.json", "utf8"));
+              process.stdout.write(String(report.commentId ?? ""));
+            } catch {
+              process.stdout.write("");
+            }
+          ')
+          echo "applied=$APPLIED" >> "$GITHUB_OUTPUT"
+          echo "comment-id=$COMMENT_ID" >> "$GITHUB_OUTPUT"
+      - name: Record the posted marker's provenance
+        # kurone-kito/idd-skill#2912 (round 2): a run-scoped Actions
+        # artifact naming the EXACT comment id this run's own trusted job
+        # just posted -- the binding primitive
+        # `verifySelfReferentialBootstrapWaiverArtifactBinding`
+        # (advisory-convergence.mts) reads to prove a candidate marker
+        # IS the one this run's own execution posted, not merely that no
+        # OTHER candidate is currently visible (a property an attacker
+        # with `issues: write` can falsify by deleting the genuine
+        # comment after the fact). Only when a NEW comment was actually
+        # posted this run (`applied == 'true'`) -- the reuse path (an
+        # existing valid waiver found, nothing newly posted) has no
+        # comment of THIS run's own to record. Needs no `permissions:`
+        # entry: `actions/upload-artifact` uses the Actions runtime's own
+        # dedicated upload token, entirely separate from `GITHUB_TOKEN`.
+        if: steps.post-waiver.outputs.applied == 'true' && steps.post-waiver.outputs.comment-id != ''
+        env:
+          COMMENT_ID: ${{ steps.post-waiver.outputs.comment-id }}
+        run: |
+          mkdir -p /tmp/idd-self-waiver-marker
+          printf '%s\n' "$COMMENT_ID" > "/tmp/idd-self-waiver-marker/idd-self-waiver-marker-${COMMENT_ID}"
+      - name: Upload the posted marker's provenance artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: steps.post-waiver.outputs.applied == 'true' && steps.post-waiver.outputs.comment-id != ''
+        with:
+          name: idd-self-waiver-marker-${{ steps.post-waiver.outputs.comment-id }}
+          path: /tmp/idd-self-waiver-marker/
+          # Loud failure, not a silent empty artifact, if the previous
+          # step somehow produced no file -- the consumer's own binding
+          # check already fails closed on a missing artifact either way,
+          # but this surfaces the CI-side bug immediately instead of only
+          # as a downstream "no auto-waiver" symptom.
+          if-no-files-found: error
+          # Deliberately NOT retention-days: 1 -- a later re-evaluation
+          # (issue_comment-triggered, or rerun-advisory-convergence.mts)
+          # can run well after this run finishes, and the marker's own
+          # validity window (SELF_REFERENTIAL_BOOTSTRAP_AUTO_EXPIRY)
+          # outlives a short artifact retention -- keep the repository
+          # default so the artifact stays listable for the marker's full
+          # validity window.

--- a/idd-template/.github/workflows/idd-advisory-convergence.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence.yml
@@ -684,15 +684,20 @@ jobs:
           PROFILE: ${{ steps.profile.outputs.profile }}
           PACKAGE_SPEC: ${{ steps.profile.outputs.package-spec }}
           MANAGER: ${{ steps.manager.outputs.manager }}
-        # kurone-kito/idd-skill#2912 (round 2): every profile branch below
-        # pipes its own invocation through the SAME `tee`, so the common
-        # post-processing after the `case` (reading `applied`/`commentId`
-        # back out of the CLI's own JSON report) is written once rather
-        # than duplicated per profile. `node -e` (never `jq`, whose
-        # presence on the runner is never explicitly asserted, unlike
-        # Node's own floor above) parses it defensively: a parse failure
-        # (should not happen, `tee` writes exactly what stdout produced)
-        # degrades to "nothing to record", never a crashed job.
+        # kurone-kito/idd-skill#2912 (round 2, extended round 3): every
+        # profile branch below pipes its own invocation through the SAME
+        # `tee`, so the common post-processing after the `case` (reading
+        # `applied`/`commentId`/`bodyDigest` back out of the CLI's own
+        # JSON report) is written once rather than duplicated per profile.
+        # `node -e` (never `jq`, whose presence on the runner is never
+        # explicitly asserted, unlike Node's own floor above) parses it
+        # defensively: a parse failure (should not happen, `tee` writes
+        # exactly what stdout produced) degrades to "nothing to record",
+        # never a crashed job. `bodyDigest` is the SHA-256 hex digest of
+        # the posted comment's body as the CLI read it BACK from the
+        # GitHub API in its own post-write reconcile (never the locally-
+        # sent string) -- see `ExternalCheckWaiverReport.bodyDigest`'s own
+        # doc comment in `external-check-waiver.mts`.
         run: |
           case "$PROFILE" in
             vendored-node)
@@ -736,34 +741,48 @@ jobs:
               process.stdout.write("");
             }
           ')
+          BODY_DIGEST=$(node -e '
+            try {
+              const report = JSON.parse(require("fs").readFileSync("/tmp/idd-waiver-report.json", "utf8"));
+              process.stdout.write(String(report.bodyDigest ?? ""));
+            } catch {
+              process.stdout.write("");
+            }
+          ')
           echo "applied=$APPLIED" >> "$GITHUB_OUTPUT"
           echo "comment-id=$COMMENT_ID" >> "$GITHUB_OUTPUT"
+          echo "body-digest=$BODY_DIGEST" >> "$GITHUB_OUTPUT"
       - name: Record the posted marker's provenance
-        # kurone-kito/idd-skill#2912 (round 2): a run-scoped Actions
-        # artifact naming the EXACT comment id this run's own trusted job
-        # just posted -- the binding primitive
-        # `verifySelfReferentialBootstrapWaiverArtifactBinding`
+        # kurone-kito/idd-skill#2912 (round 2, extended round 3): a
+        # run-scoped Actions artifact naming the EXACT comment id AND body
+        # digest this run's own trusted job just posted -- the binding
+        # primitive `verifySelfReferentialBootstrapWaiverArtifactBinding`
         # (advisory-convergence.mts) reads to prove a candidate marker
         # IS the one this run's own execution posted, not merely that no
-        # OTHER candidate is currently visible (a property an attacker
-        # with `issues: write` can falsify by deleting the genuine
-        # comment after the fact). Only when a NEW comment was actually
-        # posted this run (`applied == 'true'`) -- the reuse path (an
-        # existing valid waiver found, nothing newly posted) has no
-        # comment of THIS run's own to record. Needs no `permissions:`
-        # entry: `actions/upload-artifact` uses the Actions runtime's own
+        # OTHER candidate is currently visible (round 1's gap) or that
+        # some candidate with a matching id exists regardless of whether
+        # its body was since edited in place (round 2's gap, a
+        # same-repository `issues: write` workflow can rewrite an
+        # existing comment's body without changing its id or createdAt).
+        # Only when a NEW comment was actually posted this run
+        # (`applied == 'true'`) -- the reuse path (an existing valid
+        # waiver found, nothing newly posted) has no comment of THIS
+        # run's own to record. Needs no `permissions:` entry:
+        # `actions/upload-artifact` uses the Actions runtime's own
         # dedicated upload token, entirely separate from `GITHUB_TOKEN`.
-        if: steps.post-waiver.outputs.applied == 'true' && steps.post-waiver.outputs.comment-id != ''
+        if: steps.post-waiver.outputs.applied == 'true' && steps.post-waiver.outputs.comment-id != '' && steps.post-waiver.outputs.body-digest != ''
         env:
           COMMENT_ID: ${{ steps.post-waiver.outputs.comment-id }}
+          BODY_DIGEST: ${{ steps.post-waiver.outputs.body-digest }}
         run: |
           mkdir -p /tmp/idd-self-waiver-marker
-          printf '%s\n' "$COMMENT_ID" > "/tmp/idd-self-waiver-marker/idd-self-waiver-marker-${COMMENT_ID}"
+          printf 'commentId=%s\nbodyDigest=%s\n' "$COMMENT_ID" "$BODY_DIGEST" \
+            > "/tmp/idd-self-waiver-marker/idd-self-waiver-marker-${COMMENT_ID}-${BODY_DIGEST}"
       - name: Upload the posted marker's provenance artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: steps.post-waiver.outputs.applied == 'true' && steps.post-waiver.outputs.comment-id != ''
+        if: steps.post-waiver.outputs.applied == 'true' && steps.post-waiver.outputs.comment-id != '' && steps.post-waiver.outputs.body-digest != ''
         with:
-          name: idd-self-waiver-marker-${{ steps.post-waiver.outputs.comment-id }}
+          name: idd-self-waiver-marker-${{ steps.post-waiver.outputs.comment-id }}-${{ steps.post-waiver.outputs.body-digest }}
           path: /tmp/idd-self-waiver-marker/
           # Loud failure, not a silent empty artifact, if the previous
           # step somehow produced no file -- the consumer's own binding

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1497,7 +1497,19 @@ idd-external-check-waiver --pr 123 \
   `run-id:` and trick this job into believing a valid waiver already
   exists, skipping its own post. Always attempting to post is at worst
   a harmless extra marker; the consumer's trust check below already
-  accepts any candidate that verifies.
+  accepts any candidate that verifies;
+- when the post succeeds, the job's own workflow steps additionally
+  upload a run-scoped GitHub Actions artifact named
+  `idd-self-waiver-marker-<comment-id>` (kurone-kito/idd-skill#2912,
+  round 2) -- the posted comment's own numeric id, and nothing else, as
+  the artifact's name (never its content, so the consumer never needs to
+  download or unzip it). This is the channel condition 7 below reads to
+  bind a marker to the run's own trusted execution: artifacts are scoped
+  to the run that uploaded them by the Actions runtime's own dedicated
+  upload token, never by the shared `GITHUB_TOKEN` `permissions:`
+  surface an issue comment (or a check run) is created and mutated
+  through, so no OTHER same-repository workflow run can add, edit, or
+  remove an entry from this specific run's own artifact list.
 
 The marker is honored only when **all** of the following hold, verified
 by `advisory-convergence.mts` itself (not the generic
@@ -1542,23 +1554,48 @@ needs a live per-marker run lookup no other consumer needs):
    in a forged marker, satisfying conditions 1-5 without having been
    posted by that run's job at all. Binding to the post step's own
    recorded conclusion and execution window closes this; and
-7. no second candidate marker (same author, reason, and check selector)
-   also cites this exact `run-id:` (kurone-kito/idd-skill#2912) -- since
-   the genuine posting job always attempts to post regardless of whether
-   a marker already exists for this HEAD (`--auto-bootstrap` explicitly
-   skips the generic reuse scan, see above), a legitimate marker and a
-   forged one sharing the same cited run id can only mean one of the two
-   is fraudulent; rather than pick a winner, both are rejected, falling
-   back to the pre-existing maintainer-authorized waiver as the escape
-   hatch.
+7. the marker's own comment `id` appears in the SET of comment ids the
+   cited `run-id:`'s own trusted job execution recorded actually posting,
+   recovered from a run-scoped GitHub Actions artifact that job uploads
+   immediately after posting (named `idd-self-waiver-marker-<comment-id>`
+   -- see `listWorkflowRunArtifacts` in `provider-adapter-github.mts`)
+   (kurone-kito/idd-skill#2912, round 2) -- condition 6 above proves only
+   that the cited run's job succeeded and posted SOME comment within a
+   tight execution window, never THIS EXACT comment; a same-repository
+   `pull_request`-triggered workflow can post a forged marker inside that
+   same window, wait for the genuine marker to post, and then DELETE it
+   (`issues: write` permits deleting ANY issue comment on the repository,
+   not only ones the deleting token itself authored), leaving the forged
+   marker as the sole survivor of a plain "no duplicate currently
+   visible" scan -- the mechanism this condition replaced. Artifacts
+   close this because they are scoped to the run that uploaded them by
+   the Actions runtime's own dedicated upload token, never by the shared
+   `GITHUB_TOKEN` `permissions:` surface comments (and condition 6's own
+   job/step data) are read and, in the comment's case, mutated through --
+   so no unrelated run can add, edit, or remove an entry from that
+   trusted set regardless of which `permissions:` it self-grants.
+   Deleting the genuine comment only removes it from the live comment
+   scan condition 7 itself needs to correlate an entry back to its own
+   `id` (two distinct candidates sharing the same cited run id AND the
+   same wall-clock second are ambiguous for that correlation and both
+   fail closed, never guessing a winner) -- it degrades this mechanism to
+   "no auto-waiver", never "the forged marker validates". The one
+   residual: an attacker who additionally self-grants the broader,
+   repository-wide `actions: write` permission could delete the genuine
+   run's own artifact through Actions' own artifact-management endpoint,
+   which still only degrades to "no auto-waiver", never a forged one --
+   outside the `issues: write`-scoped threat model this condition (and
+   the two independent review findings that prompted it) are framed
+   against.
 
-A marker missing `run-id:`, whose run or run-jobs data cannot be
-resolved, targets another head SHA or repository, ran under any event
-other than `pull_request_target`, whose PR diff does not touch the
-trigger-file allowlist, whose cited run's own posting step did not
-report `success` within its own execution window, or that shares its
-cited `run-id:` with another candidate marker, is rejected the same way
-a manual waiver from an untrusted actor is today. Unlike an ordinary
+A marker missing `run-id:`, whose run, run-jobs, or run-artifacts data
+cannot be resolved, targets another head SHA or repository, ran under
+any event other than `pull_request_target`, whose PR diff does not touch
+the trigger-file allowlist, whose cited run's own posting step did not
+report `success` within its own execution window, or whose own comment
+`id` is absent from (or ambiguous within) the cited run's artifact-
+recorded trusted set, is rejected the same way a manual waiver from an
+untrusted actor is today. Unlike an ordinary
 maintainer-authorized waiver (gated behind
 `deadlinePassed || terminalUnavailable`), a valid
 self-referential-bootstrap-auto waiver is evaluated **unconditionally** --
@@ -1582,12 +1619,13 @@ repository's default branch, never the PR head -- required so neither
 job ever executes PR-controlled code with `issues: write` -- so a bug
 specifically WITHIN the code that decides whether/how to invoke
 `--auto-bootstrap` (its own branches in `external-check-waiver.mts`),
-the three Actions-API methods the trust chain above itself calls
-(`getWorkflowRun`, `getWorkflowRunJobs`, `listChangeRequestChangedFiles`
-in `provider-adapter-github.mts`), or the seven conditions' own
-verification functions in `advisory-convergence.mts`
+the four Actions-API methods the trust chain above itself calls
+(`getWorkflowRun`, `getWorkflowRunJobs`, `listWorkflowRunArtifacts`,
+`listChangeRequestChangedFiles` in `provider-adapter-github.mts`), or the
+seven conditions' own verification functions in `advisory-convergence.mts`
 (`verifySelfReferentialBootstrapWaiverRun`,
-`verifySelfReferentialBootstrapWaiverProvenance`, and the rest) cannot
+`verifySelfReferentialBootstrapWaiverProvenance`,
+`verifySelfReferentialBootstrapWaiverArtifactBinding`, and the rest) cannot
 be rescued by this mechanism: the OLD, buggy version of exactly that
 code is what would have to decide to trust the fix. This is the same
 fixed point every self-hosting bootstrap has, and isolating marker

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1500,16 +1500,27 @@ idd-external-check-waiver --pr 123 \
   accepts any candidate that verifies;
 - when the post succeeds, the job's own workflow steps additionally
   upload a run-scoped GitHub Actions artifact named
-  `idd-self-waiver-marker-<comment-id>` (kurone-kito/idd-skill#2912,
-  round 2) -- the posted comment's own numeric id, and nothing else, as
-  the artifact's name (never its content, so the consumer never needs to
+  `idd-self-waiver-marker-<comment-id>-<body-digest>`
+  (kurone-kito/idd-skill#2912, round 2, extended round 3) -- the posted
+  comment's own numeric id, a literal `-`, and the SHA-256 hex digest of
+  that comment's exact body as this same job read it BACK from the
+  GitHub API immediately after posting, and nothing else, as the
+  artifact's name (never its content, so the consumer never needs to
   download or unzip it). This is the channel condition 7 below reads to
   bind a marker to the run's own trusted execution: artifacts are scoped
   to the run that uploaded them by the Actions runtime's own dedicated
   upload token, never by the shared `GITHUB_TOKEN` `permissions:`
   surface an issue comment (or a check run) is created and mutated
   through, so no OTHER same-repository workflow run can add, edit, or
-  remove an entry from this specific run's own artifact list.
+  remove an entry from this specific run's own artifact list. The body
+  digest is hashed from an API-returned body on BOTH the posting and
+  consuming sides whenever that read-back is available -- a
+  locally-constructed string is only ever a fallback on the posting side,
+  used when its own post-write reconcile could not find the just-posted
+  comment (`ExternalCheckWaiverReport.bodyDigestSource`), and is always
+  labeled as such rather than silently treated the same as a
+  GitHub-attested digest -- so an unedited comment digests identically on
+  both sides in the ordinary case, regardless of which side computed it.
 
 The marker is honored only when **all** of the following hold, verified
 by `advisory-convergence.mts` itself (not the generic
@@ -1554,48 +1565,56 @@ needs a live per-marker run lookup no other consumer needs):
    in a forged marker, satisfying conditions 1-5 without having been
    posted by that run's job at all. Binding to the post step's own
    recorded conclusion and execution window closes this; and
-7. the marker's own comment `id` appears in the SET of comment ids the
-   cited `run-id:`'s own trusted job execution recorded actually posting,
-   recovered from a run-scoped GitHub Actions artifact that job uploads
-   immediately after posting (named `idd-self-waiver-marker-<comment-id>`
-   -- see `listWorkflowRunArtifacts` in `provider-adapter-github.mts`)
-   (kurone-kito/idd-skill#2912, round 2) -- condition 6 above proves only
-   that the cited run's job succeeded and posted SOME comment within a
-   tight execution window, never THIS EXACT comment; a same-repository
+7. the marker's own comment `(id, body digest)` pair appears in the SET
+   of such pairs the cited `run-id:`'s own trusted job execution recorded
+   actually posting, recovered from a run-scoped GitHub Actions artifact
+   that job uploads immediately after posting (named
+   `idd-self-waiver-marker-<comment-id>-<body-digest>` -- see
+   `listWorkflowRunArtifacts` in `provider-adapter-github.mts`)
+   (kurone-kito/idd-skill#2912, round 2, extended round 3) -- condition 6
+   above proves only that the cited run's job succeeded and posted SOME
+   comment within a tight execution window, never THIS EXACT comment (and
+   never that its content stayed unchanged since); a same-repository
    `pull_request`-triggered workflow can post a forged marker inside that
-   same window, wait for the genuine marker to post, and then DELETE it
-   (`issues: write` permits deleting ANY issue comment on the repository,
-   not only ones the deleting token itself authored), leaving the forged
-   marker as the sole survivor of a plain "no duplicate currently
-   visible" scan -- the mechanism this condition replaced. Artifacts
-   close this because they are scoped to the run that uploaded them by
-   the Actions runtime's own dedicated upload token, never by the shared
-   `GITHUB_TOKEN` `permissions:` surface comments (and condition 6's own
-   job/step data) are read and, in the comment's case, mutated through --
-   so no unrelated run can add, edit, or remove an entry from that
-   trusted set regardless of which `permissions:` it self-grants.
-   Deleting the genuine comment only removes it from the live comment
-   scan condition 7 itself needs to correlate an entry back to its own
-   `id` (two distinct candidates sharing the same cited run id AND the
-   same wall-clock second are ambiguous for that correlation and both
-   fail closed, never guessing a winner) -- it degrades this mechanism to
-   "no auto-waiver", never "the forged marker validates". The one
-   residual: an attacker who additionally self-grants the broader,
-   repository-wide `actions: write` permission could delete the genuine
-   run's own artifact through Actions' own artifact-management endpoint,
-   which still only degrades to "no auto-waiver", never a forged one --
-   outside the `issues: write`-scoped threat model this condition (and
-   the two independent review findings that prompted it) are framed
-   against.
+   same window, wait for the genuine marker to post, and then either
+   DELETE it (`issues: write` permits deleting ANY issue comment on the
+   repository, not only ones the deleting token itself authored), leaving
+   the forged marker as the sole survivor of a plain "no duplicate
+   currently visible" scan (round 1's gap), or EDIT it in place --
+   `issues: write` permits rewriting an existing comment's body too,
+   which preserves that comment's `id` and `createdAt` while replacing
+   its content, so binding on `id` alone (round 2) would still accept the
+   rewritten body. Binding on the `(id, body digest)` pair instead of `id`
+   alone closes both: artifacts are scoped to the run that uploaded them
+   by the Actions runtime's own dedicated upload token, never by the
+   shared `GITHUB_TOKEN` `permissions:` surface comments (and condition
+   6's own job/step data) are read and, in the comment's case, mutated
+   through -- so no unrelated run can add, edit, or remove an entry from
+   that trusted set regardless of which `permissions:` it self-grants,
+   and a LATER edit to the live comment changes its digest without being
+   able to retroactively change what the artifact already recorded.
+   Deleting or editing the genuine comment only removes/changes it in the
+   live comment scan condition 7 itself needs to correlate an entry back
+   to its own `id` (two distinct candidates sharing the same cited run id
+   AND the same wall-clock second are ambiguous for that correlation and
+   both fail closed, never guessing a winner) -- it degrades this
+   mechanism to "no auto-waiver", never "the forged or edited marker
+   validates". The one residual: an attacker who additionally
+   self-grants the broader, repository-wide `actions: write` permission
+   could delete the genuine run's own artifact through Actions' own
+   artifact-management endpoint, which still only degrades to "no
+   auto-waiver", never a forged one -- outside the `issues: write`-scoped
+   threat model this condition (and the independent review findings that
+   prompted both rounds) are framed against.
 
 A marker missing `run-id:`, whose run, run-jobs, or run-artifacts data
 cannot be resolved, targets another head SHA or repository, ran under
 any event other than `pull_request_target`, whose PR diff does not touch
 the trigger-file allowlist, whose cited run's own posting step did not
 report `success` within its own execution window, or whose own comment
-`id` is absent from (or ambiguous within) the cited run's artifact-
-recorded trusted set, is rejected the same way a manual waiver from an
-untrusted actor is today. Unlike an ordinary
+`(id, body digest)` pair is absent from (or ambiguous within) the cited
+run's artifact-recorded trusted set, is rejected the same way a manual
+waiver from an untrusted actor is today. Unlike an ordinary
 maintainer-authorized waiver (gated behind
 `deadlinePassed || terminalUnavailable`), a valid
 self-referential-bootstrap-auto waiver is evaluated **unconditionally** --

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1501,11 +1501,10 @@ idd-external-check-waiver --pr 123 \
 - when the post succeeds, the job's own workflow steps additionally
   upload a run-scoped GitHub Actions artifact named
   `idd-self-waiver-marker-<comment-id>-<body-digest>`
-  (kurone-kito/idd-skill#2912, round 2, extended round 3) -- the posted
-  comment's own numeric id, a literal `-`, and the SHA-256 hex digest of
-  that comment's exact body as this same job read it BACK from the
-  GitHub API immediately after posting, and nothing else, as the
-  artifact's name (never its content, so the consumer never needs to
+  (kurone-kito/idd-skill#2912, round 2, extended round 3, extended round
+  4) -- the posted comment's own numeric id, a literal `-`, and the
+  SHA-256 hex digest of that comment's exact body, and nothing else, as
+  the artifact's name (never its content, so the consumer never needs to
   download or unzip it). This is the channel condition 7 below reads to
   bind a marker to the run's own trusted execution: artifacts are scoped
   to the run that uploaded them by the Actions runtime's own dedicated
@@ -1513,14 +1512,23 @@ idd-external-check-waiver --pr 123 \
   surface an issue comment (or a check run) is created and mutated
   through, so no OTHER same-repository workflow run can add, edit, or
   remove an entry from this specific run's own artifact list. The body
-  digest is hashed from an API-returned body on BOTH the posting and
-  consuming sides whenever that read-back is available -- a
-  locally-constructed string is only ever a fallback on the posting side,
-  used when its own post-write reconcile could not find the just-posted
-  comment (`ExternalCheckWaiverReport.bodyDigestSource`), and is always
-  labeled as such rather than silently treated the same as a
-  GitHub-attested digest -- so an unedited comment digests identically on
-  both sides in the ordinary case, regardless of which side computed it.
+  digest is hashed from an API-returned body on both the posting and
+  consuming sides, so an unedited comment digests identically regardless
+  of which side computed it -- specifically, the posting side hashes
+  ONLY the `body` field GitHub's create-comment response returns for the
+  exact POST that created the comment, never a later re-read. An earlier
+  design (round 3) instead preferred a body observed in a LATER, separate
+  post-write re-read (falling back to the locally-sent string only when
+  that re-read came up empty, and labeling the result
+  `ExternalCheckWaiverReport.bodyDigestSource: 'constructed'` when it
+  did) -- a Copilot review of that round's own commit found this opened a
+  window: a same-repository `issues: write` workflow could edit the
+  genuine comment's body between the POST returning and that later
+  re-read running, and the reconcile-preferring design would then hash
+  and report the FORGED body as trustworthy. Round 4 removed that
+  fallback entirely; `bodyDigestSource` no longer exists, and the digest
+  is reported only when the create-comment response itself carried a
+  body.
 
 The marker is honored only when **all** of the following hold, verified
 by `advisory-convergence.mts` itself (not the generic
@@ -1571,7 +1579,8 @@ needs a live per-marker run lookup no other consumer needs):
    that job uploads immediately after posting (named
    `idd-self-waiver-marker-<comment-id>-<body-digest>` -- see
    `listWorkflowRunArtifacts` in `provider-adapter-github.mts`)
-   (kurone-kito/idd-skill#2912, round 2, extended round 3) -- condition 6
+   (kurone-kito/idd-skill#2912, round 2, extended round 3, extended round
+   4) -- condition 6
    above proves only that the cited run's job succeeded and posted SOME
    comment within a tight execution window, never THIS EXACT comment (and
    never that its content stayed unchanged since); a same-repository

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1515,7 +1515,7 @@ needs a live per-marker run lookup no other consumer needs):
    never `pull_request` -- closing the gap where a same-repository PR
    editing the workflow YAML can still trigger a `pull_request`-triggered
    run of it during a `pull_request`/`pull_request_target` migration
-   window (kurone-kito/idd-skill#2764 Phase 1); and
+   window (kurone-kito/idd-skill#2764 Phase 1);
 5. the PR's own changed files (fetched independently at consume time,
    never trusted from the posting job's own internal check) include at
    least one path from the trigger-file allowlist above
@@ -1526,14 +1526,41 @@ needs a live per-marker run lookup no other consumer needs):
    same-repository PR could forge a marker citing the ordinary verdict
    job's own trivially-discoverable run id for its own HEAD and bypass
    advisory convergence for a change that never touched the allowlist at
-   all.
+   all;
+6. `GET /repos/{owner}/{repo}/actions/runs/{run-id}/jobs` for that same
+   `run-id:` reports the run's own `idd-advisory-convergence-self-waiver`
+   job's "Post the self-referential-bootstrap-auto waiver" step with
+   `conclusion: success`, AND the marker comment's own `createdAt` falls
+   within that step's `[started_at, completed_at]` execution window
+   (kurone-kito/idd-skill#2912) -- conditions 3 and 4 alone prove only
+   that SOME genuine run of the right shape exists, never that THAT run's
+   own job actually posted THIS specific comment; a same-repository
+   `pull_request`-triggered workflow (untrusted, but able to post
+   `github-actions[bot]`-authored comments the same way the genuine
+   posting job does) can discover a legitimate, concurrently running
+   `pull_request_target` run's id via the public Actions API and cite it
+   in a forged marker, satisfying conditions 1-5 without having been
+   posted by that run's job at all. Binding to the post step's own
+   recorded conclusion and execution window closes this; and
+7. no second candidate marker (same author, reason, and check selector)
+   also cites this exact `run-id:` (kurone-kito/idd-skill#2912) -- since
+   the genuine posting job always attempts to post regardless of whether
+   a marker already exists for this HEAD (`--auto-bootstrap` explicitly
+   skips the generic reuse scan, see above), a legitimate marker and a
+   forged one sharing the same cited run id can only mean one of the two
+   is fraudulent; rather than pick a winner, both are rejected, falling
+   back to the pre-existing maintainer-authorized waiver as the escape
+   hatch.
 
-A marker missing `run-id:`, whose run cannot be resolved, targets another
-head SHA or repository, ran under any event other than
-`pull_request_target`, or whose PR diff does not touch the trigger-file
-allowlist, is rejected the same way a manual waiver from an untrusted
-actor is today. Unlike an ordinary maintainer-authorized waiver
-(gated behind `deadlinePassed || terminalUnavailable`), a valid
+A marker missing `run-id:`, whose run or run-jobs data cannot be
+resolved, targets another head SHA or repository, ran under any event
+other than `pull_request_target`, whose PR diff does not touch the
+trigger-file allowlist, whose cited run's own posting step did not
+report `success` within its own execution window, or that shares its
+cited `run-id:` with another candidate marker, is rejected the same way
+a manual waiver from an untrusted actor is today. Unlike an ordinary
+maintainer-authorized waiver (gated behind
+`deadlinePassed || terminalUnavailable`), a valid
 self-referential-bootstrap-auto waiver is evaluated **unconditionally** --
 it makes `ready` true immediately, without waiting for the deadline clock
 or a proven Copilot outage, since the whole point is bootstrapping a fix
@@ -1555,13 +1582,16 @@ repository's default branch, never the PR head -- required so neither
 job ever executes PR-controlled code with `issues: write` -- so a bug
 specifically WITHIN the code that decides whether/how to invoke
 `--auto-bootstrap` (its own branches in `external-check-waiver.mts`),
-the two Actions-API methods the trust chain above itself calls
-(`getWorkflowRun`, `listChangeRequestChangedFiles` in
-`provider-adapter-github.mts`), or the five conditions' own verification
-functions in `advisory-convergence.mts` cannot be rescued by this
-mechanism: the OLD, buggy version of exactly that code is what would
-have to decide to trust the fix. This is the same fixed point every
-self-hosting bootstrap has, and isolating marker emission into a
+the three Actions-API methods the trust chain above itself calls
+(`getWorkflowRun`, `getWorkflowRunJobs`, `listChangeRequestChangedFiles`
+in `provider-adapter-github.mts`), or the seven conditions' own
+verification functions in `advisory-convergence.mts`
+(`verifySelfReferentialBootstrapWaiverRun`,
+`verifySelfReferentialBootstrapWaiverProvenance`, and the rest) cannot
+be rescued by this mechanism: the OLD, buggy version of exactly that
+code is what would have to decide to trust the fix. This is the same
+fixed point every self-hosting bootstrap has, and isolating marker
+emission into a
 smaller module would shrink it, never eliminate it. The rest of each
 listed file's surface -- most of it, since each implements far more
 than this one trust path -- remains genuinely bootstrappable as

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -229,11 +229,12 @@ export const ADVISORY_CONVERGENCE_CHECK_SELECTOR =
  * A bug specifically WITHIN the code that decides whether/how to invoke
  * `--auto-bootstrap` (`runExternalCheckWaiver`'s own auto-bootstrap
  * branches and `planExternalCheckWaiver`'s `autoBootstrap`-gated
- * checks, both in `external-check-waiver.mts`), the two Actions-API
+ * checks, both in `external-check-waiver.mts`), the three Actions-API
  * methods the trust chain itself calls (`getWorkflowRun`,
- * `listChangeRequestChangedFiles` in `provider-adapter-github.mts`), or
- * this file's own verification functions
- * ({@link verifySelfReferentialBootstrapWaiverRun},
+ * `getWorkflowRunJobs`, `listChangeRequestChangedFiles` in
+ * `provider-adapter-github.mts`), or this file's own verification
+ * functions ({@link verifySelfReferentialBootstrapWaiverRun},
+ * {@link verifySelfReferentialBootstrapWaiverProvenance},
  * {@link resolveSelfReferentialTriggerFiles}, `autoWaiverValid`) cannot
  * be rescued by THIS mechanism, because the OLD, buggy version of
  * exactly that code is what would have to decide to trust the fix --
@@ -252,31 +253,76 @@ export const ADVISORY_CONVERGENCE_CHECK_SELECTOR =
  *
  * kurone-kito/idd-skill#2657 (Codex review, PR #2895, round 16): a
  * SEPARATE, narrower residual gap in {@link verifySelfReferentialBootstrapWaiverRun}
- * itself, tracked rather than closed here -- its `run-id:` check proves
- * only that the CITED run has the right path/head-sha/repository/event,
- * never that the cited run is the one that actually POSTED this
- * specific comment. A same-repository `pull_request`-triggered
- * workflow with `issues: write` (the same actor this file's own
- * comments already assume can post arbitrary `github-actions[bot]`-
- * authored comments) can discover a legitimate, concurrently running
- * `pull_request_target` run of THIS workflow for its own PR and cite
- * that run's id in a forged marker -- the run-id is bearer evidence,
- * not provenance-bound. This does NOT widen what such a forgery can
- * actually waive, though: `touchesSelfReferentialAllowlist` is fetched
- * independently from the PR's own live file-changes API, never from
- * the comment, so a forged marker can only cause a PR that genuinely
- * touches the allowlist to get its (otherwise-legitimate) waiver via
- * forgery instead of via the real job -- the allowlist check remains
- * the load-bearing security boundary. The one CONCRETE exploit this
- * bearer-evidence gap enabled -- a forged `claim-id:none` marker
+ * itself -- its `run-id:` check proves only that the CITED run has the
+ * right path/head-sha/repository/event, never that the cited run is the
+ * one that actually POSTED this specific comment. A same-repository
+ * `pull_request`-triggered workflow with `issues: write` (the same actor
+ * this file's own comments already assume can post arbitrary
+ * `github-actions[bot]`-authored comments) can discover a legitimate,
+ * concurrently running `pull_request_target` run of THIS workflow for
+ * its own PR and cite that run's id in a forged marker -- the run-id is
+ * bearer evidence, not provenance-bound. This does NOT widen what such a
+ * forgery can actually waive, though: `touchesSelfReferentialAllowlist`
+ * is fetched independently from the PR's own live file-changes API,
+ * never from the comment, so a forged marker can only cause a PR that
+ * genuinely touches the allowlist to get its (otherwise-legitimate)
+ * waiver via forgery instead of via the real job -- the allowlist check
+ * remains the load-bearing security boundary. The one CONCRETE exploit
+ * this bearer-evidence gap enabled -- a forged `claim-id:none` marker
  * validating on a PR whose closing issues expose ambiguous, multiple
  * active claims, a state the posting helper itself always refuses to
- * post ANY marker for -- is closed directly in `autoWaiverValid`'s own
- * `claimCandidateAmbiguous` check below. Full provenance binding
- * (proving WHICH run posted a given comment, not just that some
- * qualifying run exists) needs new I/O this pure verdict function does
- * not have (the run's own job/log data) and is out of scope for a
- * live-review patch; tracked in a follow-up issue. */
+ * post ANY marker for -- was closed directly in `autoWaiverValid`'s own
+ * `claimCandidateAmbiguous` check below.
+ *
+ * kurone-kito/idd-skill#2912: the general provenance-binding gap the
+ * paragraph above described is now closed too, by
+ * {@link verifySelfReferentialBootstrapWaiverProvenance} plus the
+ * `autoWaiverRunIdCandidateTimestamps` duplicate-run-id check
+ * `autoWaiverValid` also applies. Together they prove the cited run's
+ * own `idd-advisory-convergence-self-waiver` job actually executed the
+ * step that posts this waiver kind, at (within a few seconds of) the
+ * exact moment this specific comment was created, and that no OTHER
+ * candidate marker citing the same run id ALSO independently proves
+ * that -- rather than trusting that SOME qualifying run merely exists.
+ * Uniqueness is deliberately scoped to provenance-PASSING candidates
+ * only (not every structurally-qualifying one): the Actions jobs API
+ * reports only the LATEST run attempt, so a legitimate re-run (`gh run
+ * rerun <run-id>`, this repository's own standard automated recovery
+ * path for a stuck `idd-advisory-convergence` instance,
+ * `rerun-advisory-convergence.mts`) that re-executes an already-
+ * succeeded self-waiver job produces a second GENUINE marker for the
+ * same run id, whose earlier sibling from the prior attempt no longer
+ * falls inside the current attempt's execution window and so fails
+ * provenance on its own, never reaching the uniqueness tally -- this
+ * keeps self-bootstrap working across a legitimate rerun instead of
+ * treating it as a forgery collision. A same-window race between a
+ * genuine marker and a forged one both citing the same run id, by
+ * contrast, still has both pass provenance and both get rejected -- the
+ * security property holds regardless. An attacker can still cause this
+ * mechanism to fail closed (denial of service on the optimization, e.g.
+ * by winning that race), but can no longer make a forged marker
+ * validate on its own; the pre-existing maintainer-authorized waiver
+ * remains the documented escape hatch either way.
+ *
+ * Precondition on "the cited job's step conclusion is `success`"
+ * actually implying it posted a marker: `runExternalCheckWaiver`'s own
+ * `--auto-bootstrap` path can report step-level `success` on a
+ * deliberate no-op skip (never posting) when
+ * `ciGate.externalCheckWaivers.mode` is not `maintainer-authorized` or
+ * the selector is not registered under
+ * `ciGate.externalChecks.waivable` (`external-check-waiver.mts`'s
+ * `benignAutoBootstrapSkipReasons` set). This is self-consistent by
+ * construction, not a separate gap to close: `summarizeExternalCheckWaivers`
+ * gates `.valid` classification on that exact same
+ * `mode`/`waivableSelectors` policy, read from the same trusted
+ * checkout at consume time -- when the benign-skip path is reachable,
+ * no self-referential-bootstrap-auto marker (genuine or forged) ever
+ * reaches `.valid` for `autoWaiverValid`'s `.some()` to iterate in the
+ * first place, so the step-success-without-posting case never actually
+ * gets evaluated for provenance. Still worth stating explicitly, since
+ * an adopter who reads only this file's own trust chain (not
+ * `external-check-waiver.mts`'s posting-side logic too) could otherwise
+ * read "step succeeded" as an unconditional proof of posting. */
 export const SELF_REFERENTIAL_WAIVER_TRIGGER_FILES = [
   'src/scripts/advisory-convergence.mts',
   'src/scripts/advisory-wait-state.mts',
@@ -505,6 +551,71 @@ function verifySelfReferentialBootstrapWaiverRun(run, expected) {
       expected.repositoryFullName.toLowerCase() &&
     run.event === 'pull_request_target'
   );
+}
+/** kurone-kito/idd-skill#2912: this gate's own self-waiver job id, as
+ * reported by the GitHub Actions jobs API's `name` field (no `name:`
+ * override in the workflow, so the reported name is literally the job
+ * id) -- the job {@link verifySelfReferentialBootstrapWaiverProvenance}
+ * requires proof of execution from. Declared as its own explicit
+ * literal, mirroring {@link ADVISORY_CONVERGENCE_WORKFLOW_PATH}'s own
+ * "kept in sync by hand with the YAML" convention; a dedicated test
+ * pins both this and {@link SELF_REFERENTIAL_WAIVER_POST_STEP_NAME}
+ * against the workflow file's own literal text. */
+export const SELF_REFERENTIAL_WAIVER_JOB_ID =
+  'idd-advisory-convergence-self-waiver';
+/** kurone-kito/idd-skill#2912: the exact `name:` of the step, within
+ * {@link SELF_REFERENTIAL_WAIVER_JOB_ID}, that actually posts a
+ * self-referential-bootstrap-auto marker -- kept in sync by hand with
+ * `.github/workflows/idd-advisory-convergence.yml`'s own "Post the
+ * self-referential-bootstrap-auto waiver" step, the same convention as
+ * {@link SELF_REFERENTIAL_WAIVER_JOB_ID} above. */
+export const SELF_REFERENTIAL_WAIVER_POST_STEP_NAME =
+  'Post the self-referential-bootstrap-auto waiver';
+/**
+ * kurone-kito/idd-skill#2912: whether the cited run's own jobs-API
+ * evidence proves its {@link SELF_REFERENTIAL_WAIVER_JOB_ID} job actually
+ * completed {@link SELF_REFERENTIAL_WAIVER_POST_STEP_NAME}, rather than
+ * merely having the right run-level shape
+ * ({@link verifySelfReferentialBootstrapWaiverRun}'s own job). This is
+ * the binding step that closes the residual gap the module header notes
+ * (#2657, round 16): a run whose own path/head-sha/repository/event all
+ * check out does not by itself prove THAT run's own job posted THIS
+ * specific comment -- a same-repository `pull_request`-triggered
+ * workflow can discover a legitimate run's id via the public Actions API
+ * and cite it in a forged marker. Requiring the post step's own
+ * `conclusion: 'success'` AND that the marker's own `createdAt` falls
+ * within that step's `[startedAt, completedAt]` execution window makes
+ * this practically unforgeable: a forged marker would need the cited
+ * run's post step to have actually run and succeeded at almost exactly
+ * the moment the forged comment was created, which only the run's own
+ * job -- not an unrelated, concurrently-running one -- controls. Pure
+ * and fail-closed, matching {@link verifySelfReferentialBootstrapWaiverRun}'s
+ * own contract: an absent/errored lookup, a non-`success` conclusion, or
+ * a missing/unparseable window is always `false`, never a thrown
+ * exception. */
+function verifySelfReferentialBootstrapWaiverProvenance(
+  jobLookup,
+  markerCreatedAt,
+) {
+  if (!jobLookup || 'error' in jobLookup) {
+    return false;
+  }
+  if (jobLookup.conclusion !== 'success') {
+    return false;
+  }
+  const startedAt = String(jobLookup.startedAt ?? '');
+  const completedAt = String(jobLookup.completedAt ?? '');
+  if (
+    !isValidIsoTimestamp(markerCreatedAt) ||
+    !isValidIsoTimestamp(startedAt) ||
+    !isValidIsoTimestamp(completedAt)
+  ) {
+    return false;
+  }
+  const markerMs = Date.parse(markerCreatedAt);
+  const startedMs = Date.parse(startedAt);
+  const completedMs = Date.parse(completedAt);
+  return markerMs >= startedMs && markerMs <= completedMs;
 }
 /**
  * Compute the deterministic advisory-convergence verdict from already-
@@ -1306,12 +1417,16 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
   // `selectLinkedIssueCandidate` (`external-check-waiver.mts`) refuses
   // to auto-post a marker for in the first place. Without this, a
   // forged `claim-id:none` marker citing a legitimate, concurrently
-  // running `pull_request_target` run's id (the run-id check verifies
-  // only that CITED run's own metadata, not that it actually posted
-  // this comment -- a separate, tracked gap, see the module header's
-  // dead-zone note) could validate on such a PR even though the
-  // legitimate posting helper would have refused to post ANY marker
-  // for it. `claimCandidateAmbiguous` is the SAME signal the producer
+  // running `pull_request_target` run's id (the run-id check alone
+  // verifies only that CITED run's own metadata, not that it actually
+  // posted this comment -- the general form of that gap is closed by
+  // `verifySelfReferentialBootstrapWaiverProvenance` and the
+  // duplicate-run-id check below, kurone-kito/idd-skill#2912; this
+  // `claimCandidateAmbiguous` guard is independent defense-in-depth for
+  // the SPECIFIC claim-ambiguity shape, not a substitute for either)
+  // could validate on such a PR even though the legitimate posting
+  // helper would have refused to post ANY marker for it.
+  // `claimCandidateAmbiguous` is the SAME signal the producer
   // uses (`classifyClaimCandidateAmbiguity`), independent of
   // `convergenceScope`, so gate on it directly here too rather than
   // only through the scope-specific check above.
@@ -1333,7 +1448,36 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
             headSha: prHeadSha,
             repositoryFullName: autoWaiverRepositoryFullName,
           },
-        ),
+        ) &&
+        // kurone-kito/idd-skill#2912: prove the cited run's OWN job
+        // posted THIS comment, not merely that some run with the right
+        // shape exists -- see `verifySelfReferentialBootstrapWaiverProvenance`'s
+        // own doc comment for the gap this closes.
+        verifySelfReferentialBootstrapWaiverProvenance(
+          inputs.autoWaiverRunJobLookups?.[entry.runId],
+          entry.createdAt,
+        ) &&
+        // kurone-kito/idd-skill#2912: exactly one candidate marker
+        // citing this run id may ALSO independently pass the same
+        // provenance check above -- see
+        // `autoWaiverRunIdCandidateTimestamps`'s own doc comment for
+        // why this is scoped to provenance-PASSING candidates only
+        // (never a bare structural count), which is what lets a
+        // legitimate CI rerun (a second genuine marker for the same
+        // run id, whose earlier sibling now falls outside the latest
+        // attempt's window and so fails provenance on its own) keep
+        // validating instead of being treated as a forgery collision.
+        // Two or more candidates BOTH passing provenance (a forged
+        // marker racing a genuine one inside the same execution
+        // window) fails closed to "no auto-waiver", never picks a
+        // winner.
+        (inputs.autoWaiverRunIdCandidateTimestamps?.[entry.runId] ?? []).filter(
+          (createdAt) =>
+            verifySelfReferentialBootstrapWaiverProvenance(
+              inputs.autoWaiverRunJobLookups?.[entry.runId],
+              createdAt,
+            ),
+        ).length === 1,
     );
   const waiver = {
     mode: waiverMode,
@@ -2383,9 +2527,27 @@ export function collectFromGitHub(
   // making a reliable crowd-out require posting dozens of distinct
   // spam comments on the PR -- conspicuous, and itself rate-limited by
   // GitHub's own comment-creation API, unlike an unbounded lookup loop.
+  // kurone-kito/idd-skill#2912: this same bound now also caps a SECOND
+  // lookup per run id (`getWorkflowRunJobs`, for
+  // `verifySelfReferentialBootstrapWaiverProvenance`), so worst-case
+  // cost is up to 2 * MAX_AUTO_WAIVER_RUN_LOOKUPS Actions-API calls, not
+  // a new, separately-bounded budget of its own.
   const MAX_AUTO_WAIVER_RUN_LOOKUPS = 20;
   const autoWaiverCandidates = [];
   const seenAutoWaiverRunIds = new Set();
+  // kurone-kito/idd-skill#2912: collected over EVERY qualifying comment
+  // (not deduplicated by `seenAutoWaiverRunIds`, which exists only to
+  // bound the number of Actions-API lookups) -- `autoWaiverValid` below
+  // requires exactly one provenance-passing candidate per cited run id,
+  // so a second, forged marker sharing a legitimate run's id must still
+  // be recorded even though it triggers no additional lookup. Kept as
+  // `createdAt` timestamps, not a bare count, so the pure verdict
+  // function can independently re-check each candidate's own provenance
+  // against the run's (single, shared) jobs-API window -- see
+  // `AdvisoryConvergenceInputs.autoWaiverRunIdCandidateTimestamps`'s own
+  // doc comment for why a bare count would misclassify a legitimate CI
+  // rerun as a forgery collision.
+  const autoWaiverRunIdCandidateTimestamps = new Map();
   for (const comment of comments) {
     const body = String(comment.body ?? '');
     if (!/^<!--\s*idd-external-check-waiver:/i.test(body)) {
@@ -2431,13 +2593,21 @@ export function collectFromGitHub(
       parsed.checkSelector === ADVISORY_CONVERGENCE_CHECK_SELECTOR &&
       parsed.runId &&
       parseCanonicalIntegerOrNull(parsed.runId) !== null &&
-      !seenAutoWaiverRunIds.has(parsed.runId) &&
       String(parsed.headSha ?? '')
         .trim()
         .toLowerCase() === prHeadSha
     ) {
-      seenAutoWaiverRunIds.add(parsed.runId);
-      autoWaiverCandidates.push({ runId: parsed.runId, createdAt });
+      // kurone-kito/idd-skill#2912: every qualifying comment's own
+      // `createdAt` is recorded against its cited run id, regardless of
+      // whether this is the first (lookup-triggering) sighting.
+      autoWaiverRunIdCandidateTimestamps.set(parsed.runId, [
+        ...(autoWaiverRunIdCandidateTimestamps.get(parsed.runId) ?? []),
+        createdAt,
+      ]);
+      if (!seenAutoWaiverRunIds.has(parsed.runId)) {
+        seenAutoWaiverRunIds.add(parsed.runId);
+        autoWaiverCandidates.push({ runId: parsed.runId, createdAt });
+      }
     }
   }
   const autoWaiverRunIds = new Set(
@@ -2462,6 +2632,38 @@ export function collectFromGitHub(
       // `verifySelfReferentialBootstrapWaiverRun` already treats an
       // `{error}` entry the same as an absent one -- always a rejection.
       autoWaiverRunLookups[runId] = {
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+  // kurone-kito/idd-skill#2912: a second, per-run-id lookup sharing the
+  // exact same `autoWaiverRunIds` budget as the run-metadata lookup
+  // above (so worst case doubles the lookup call count, still bounded
+  // by `MAX_AUTO_WAIVER_RUN_LOOKUPS`) -- see
+  // `AdvisoryConvergenceInputs.autoWaiverRunJobLookups`'s own doc
+  // comment for why the run-metadata lookup alone is insufficient.
+  const autoWaiverRunJobLookups = {};
+  for (const runId of autoWaiverRunIds) {
+    try {
+      const raw = port.getWorkflowRunJobs(owner, repo, runId);
+      const selfWaiverJob = (raw?.jobs ?? []).find(
+        (job) => job?.name === SELF_REFERENTIAL_WAIVER_JOB_ID,
+      );
+      const postStep = (selfWaiverJob?.steps ?? []).find(
+        (step) => step?.name === SELF_REFERENTIAL_WAIVER_POST_STEP_NAME,
+      );
+      autoWaiverRunJobLookups[runId] = {
+        conclusion: postStep?.conclusion ?? null,
+        startedAt: postStep?.started_at ?? null,
+        completedAt: postStep?.completed_at ?? null,
+      };
+    } catch (error) {
+      // Fail closed per run id, mirroring the run-metadata lookup above:
+      // a lookup failure must never crash the whole collection, and
+      // `verifySelfReferentialBootstrapWaiverProvenance` already treats
+      // an `{error}` entry the same as an absent one -- always a
+      // rejection.
+      autoWaiverRunJobLookups[runId] = {
         error: error instanceof Error ? error.message : String(error),
       };
     }
@@ -2502,6 +2704,10 @@ export function collectFromGitHub(
       claimCandidateAmbiguous,
       prAuthorIsBot,
       autoWaiverRunLookups,
+      autoWaiverRunJobLookups,
+      autoWaiverRunIdCandidateTimestamps: Object.fromEntries(
+        autoWaiverRunIdCandidateTimestamps,
+      ),
       changedFilePaths,
     },
     options: {

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -229,12 +229,14 @@ export const ADVISORY_CONVERGENCE_CHECK_SELECTOR =
  * A bug specifically WITHIN the code that decides whether/how to invoke
  * `--auto-bootstrap` (`runExternalCheckWaiver`'s own auto-bootstrap
  * branches and `planExternalCheckWaiver`'s `autoBootstrap`-gated
- * checks, both in `external-check-waiver.mts`), the three Actions-API
+ * checks, both in `external-check-waiver.mts`), the four Actions-API
  * methods the trust chain itself calls (`getWorkflowRun`,
- * `getWorkflowRunJobs`, `listChangeRequestChangedFiles` in
- * `provider-adapter-github.mts`), or this file's own verification
- * functions ({@link verifySelfReferentialBootstrapWaiverRun},
+ * `getWorkflowRunJobs`, `listWorkflowRunArtifacts`,
+ * `listChangeRequestChangedFiles` in `provider-adapter-github.mts`), or
+ * this file's own verification functions
+ * ({@link verifySelfReferentialBootstrapWaiverRun},
  * {@link verifySelfReferentialBootstrapWaiverProvenance},
+ * {@link verifySelfReferentialBootstrapWaiverArtifactBinding},
  * {@link resolveSelfReferentialTriggerFiles}, `autoWaiverValid`) cannot
  * be rescued by THIS mechanism, because the OLD, buggy version of
  * exactly that code is what would have to decide to trust the fix --
@@ -274,35 +276,56 @@ export const ADVISORY_CONVERGENCE_CHECK_SELECTOR =
  * post ANY marker for -- was closed directly in `autoWaiverValid`'s own
  * `claimCandidateAmbiguous` check below.
  *
- * kurone-kito/idd-skill#2912: the general provenance-binding gap the
- * paragraph above described is now closed too, by
- * {@link verifySelfReferentialBootstrapWaiverProvenance} plus the
- * `autoWaiverRunIdCandidateTimestamps` duplicate-run-id check
- * `autoWaiverValid` also applies. Together they prove the cited run's
- * own `idd-advisory-convergence-self-waiver` job actually executed the
- * step that posts this waiver kind, at (within a few seconds of) the
- * exact moment this specific comment was created, and that no OTHER
- * candidate marker citing the same run id ALSO independently proves
- * that -- rather than trusting that SOME qualifying run merely exists.
- * Uniqueness is deliberately scoped to provenance-PASSING candidates
- * only (not every structurally-qualifying one): the Actions jobs API
- * reports only the LATEST run attempt, so a legitimate re-run (`gh run
- * rerun <run-id>`, this repository's own standard automated recovery
- * path for a stuck `idd-advisory-convergence` instance,
- * `rerun-advisory-convergence.mts`) that re-executes an already-
- * succeeded self-waiver job produces a second GENUINE marker for the
- * same run id, whose earlier sibling from the prior attempt no longer
- * falls inside the current attempt's execution window and so fails
- * provenance on its own, never reaching the uniqueness tally -- this
- * keeps self-bootstrap working across a legitimate rerun instead of
- * treating it as a forgery collision. A same-window race between a
- * genuine marker and a forged one both citing the same run id, by
- * contrast, still has both pass provenance and both get rejected -- the
- * security property holds regardless. An attacker can still cause this
- * mechanism to fail closed (denial of service on the optimization, e.g.
- * by winning that race), but can no longer make a forged marker
- * validate on its own; the pre-existing maintainer-authorized waiver
- * remains the documented escape hatch either way.
+ * kurone-kito/idd-skill#2912 (round 1): the general provenance-binding
+ * gap the paragraph above described was first closed by
+ * {@link verifySelfReferentialBootstrapWaiverProvenance} (proving the
+ * cited run's own job actually executed the posting step, within a few
+ * seconds of this specific comment's `createdAt`) paired with a
+ * duplicate-run-id uniqueness check: no OTHER candidate marker citing
+ * the same run id may ALSO independently pass that same provenance
+ * check, scoped to provenance-PASSING candidates only so a legitimate
+ * `gh run rerun <run-id>` (this repository's own standard automated
+ * recovery path for a stuck `idd-advisory-convergence` instance,
+ * `rerun-advisory-convergence.mts`) keeps working: its second, equally
+ * genuine marker no longer shares the first attempt's window, so the
+ * stale sibling fails provenance on its own rather than being
+ * misclassified as a forgery collision.
+ *
+ * kurone-kito/idd-skill#2912 (round 2): that round-1 uniqueness check
+ * had its own gap -- it trusted "no OTHER candidate is CURRENTLY
+ * VISIBLE", a property an attacker with `issues: write` can falsify
+ * after the fact by deleting the genuine marker once it posts (that
+ * scope permits deleting ANY issue comment on the repository, not only
+ * ones the deleting token itself authored), leaving a forged sibling as
+ * the sole survivor of the next scan (independently found by both the
+ * Codex and Copilot reviews of PR #2914). {@link verifySelfReferentialBootstrapWaiverArtifactBinding}
+ * replaces the visibility-based uniqueness check with a positive-binding
+ * one: the cited run's own trusted job execution now uploads a
+ * run-scoped Actions artifact naming the exact comment id it posted
+ * ({@link SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX}), and a marker
+ * only validates when it IS that exact, artifact-named comment.
+ * Artifacts are scoped to the run that uploaded them by the Actions
+ * runtime's own dedicated upload token, never by the shared
+ * `GITHUB_TOKEN` `permissions:` surface comments (and check runs, which
+ * share the same "any same-repository workflow can mutate them"
+ * exposure) are created and mutated through, so no unrelated run can
+ * add, edit, or remove an entry from that trusted set regardless of
+ * which `permissions:` it self-grants. Deleting the genuine comment now
+ * only removes it from the LIVE candidate scan the correlation step
+ * needs -- degrading this mechanism to "no auto-waiver" (fail closed),
+ * never "the forged one wins". {@link verifySelfReferentialBootstrapWaiverProvenance}'s
+ * window check remains in place as defense in depth (and still does the
+ * rerun-disambiguation work described above); the round-1 duplicate-
+ * timestamp-count mechanism it used to pair with has been removed
+ * entirely, subsumed by the strictly stronger artifact binding. The one
+ * residual this round does NOT close: an attacker who additionally
+ * self-grants the broader, repository-wide `actions: write` permission
+ * could delete the genuine run's artifact through Actions' own
+ * artifact-management endpoint -- still only "no auto-waiver", never a
+ * forged one, and outside the `issues: write`-scoped threat model both
+ * findings (and this fix) are framed against. The pre-existing
+ * maintainer-authorized waiver remains the documented escape hatch
+ * either way.
  *
  * Precondition on "the cited job's step conclusion is `success`"
  * actually implying it posted a marker: `runExternalCheckWaiver`'s own
@@ -616,6 +639,104 @@ function verifySelfReferentialBootstrapWaiverProvenance(
   const startedMs = Date.parse(startedAt);
   const completedMs = Date.parse(completedAt);
   return markerMs >= startedMs && markerMs <= completedMs;
+}
+/** kurone-kito/idd-skill#2912 (round 2): the fixed prefix of the Actions
+ * artifact name {@link SELF_REFERENTIAL_WAIVER_JOB_ID}'s own posting job
+ * uploads immediately after successfully posting a
+ * `self-referential-bootstrap-auto` marker, followed by the posted
+ * comment's own decimal `id` (e.g. `idd-self-waiver-marker-123456789`).
+ * The id lives in the artifact's NAME, never its content, so recovering
+ * it costs one `list artifacts` JSON call per cited run id -- no zip
+ * download/extraction is needed. Kept in sync by hand with
+ * `.github/workflows/idd-advisory-convergence.yml`'s own "Upload the
+ * posted marker's provenance artifact" step (the `with: name:` value
+ * there, not the preceding "Record the posted marker's provenance" step
+ * that only stages the local file `actions/upload-artifact` reads), the
+ * same convention {@link SELF_REFERENTIAL_WAIVER_JOB_ID} and
+ * {@link SELF_REFERENTIAL_WAIVER_POST_STEP_NAME} already follow; a
+ * dedicated test pins all three against the workflow file's own literal
+ * text (both the repository-root copy and its `idd-template/` mirror). */
+export const SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX =
+  'idd-self-waiver-marker-';
+/**
+ * kurone-kito/idd-skill#2912 (round 2): whether the `.valid` marker
+ * `entry` under evaluation is one the cited run id's own trusted
+ * {@link SELF_REFERENTIAL_WAIVER_JOB_ID} job execution actually recorded
+ * posting, via the run-scoped Actions artifact
+ * {@link SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX} describes. This
+ * is the binding step that closes a gap
+ * {@link verifySelfReferentialBootstrapWaiverProvenance} alone cannot:
+ * that check alone only proves the cited run's job succeeded and posted
+ * SOME comment within a tight time window, never THIS EXACT comment --
+ * a same-repository `pull_request`-triggered workflow (untrusted,
+ * PR-controlled code, `issues: write`) can post a forged marker citing
+ * a legitimate, concurrently-running `pull_request_target` run's id
+ * inside that same window, wait for the genuine marker to post, and
+ * then DELETE it (`issues: write` permits deleting ANY issue comment on
+ * the repository, not only ones the deleting token itself authored) --
+ * leaving the forged marker as the sole survivor of a plain "no
+ * duplicate candidate currently visible" scan, which is exactly the
+ * property this file's PRIOR round-1 uniqueness check depended on
+ * (kurone-kito/idd-skill#2912, closed here).
+ *
+ * `entry` carries no comment `id` of its own (`ExternalCheckWaiverEvidence.valid`
+ * is a shared type many other callers use unchanged), so this
+ * correlates `entry.createdAt` back to `candidates` -- the SAME
+ * `{id, createdAt}` pairs `collectFromGitHub` derived from the identical
+ * raw comment scan that produced `entry` in the first place -- and
+ * requires the match to be UNIQUE: two distinct candidates sharing the
+ * same wall-clock second (a genuine marker and a same-window forged
+ * sibling) is ambiguous and fails closed for both, never guesses a
+ * winner. The uniquely-correlated candidate's `id` must then appear in
+ * `trustedCommentIds` -- the cited run's own artifact-recorded set.
+ *
+ * Because artifacts are scoped to the run that uploaded them by the
+ * Actions runtime's own dedicated upload token (never the shared
+ * `GITHUB_TOKEN` `permissions:` surface comments and check runs are
+ * both mutable through), no unrelated run -- however it scopes its own
+ * `permissions:` block -- can add, edit, or remove an entry from
+ * `trustedCommentIds`. A forged comment's `id` therefore never appears
+ * there regardless of timing or deletion tricks; deleting the GENUINE
+ * comment only removes it from `candidates` (a live re-fetch), which
+ * degrades this to "no correlated candidate -- fail closed", never "the
+ * forged one wins". The one residual: an attacker who additionally
+ * self-grants the broader, repository-wide `actions: write` permission
+ * (distinct from `issues: write`) could delete the genuine run's
+ * artifact through Actions' own artifact-management endpoint, which
+ * still only degrades to "no auto-waiver" (fail closed), never "a
+ * forged waiver validates" -- and is outside the `issues: write`-scoped
+ * threat model this fix (and the two independent review findings that
+ * prompted it) are both framed against.
+ *
+ * Pure and fail-closed like every other verification function in this
+ * file: an absent/empty `trustedCommentIds`, no unique correlated
+ * candidate, or a correlated candidate whose `id` is not in
+ * `trustedCommentIds` are all `false`, never a thrown exception.
+ */
+function verifySelfReferentialBootstrapWaiverArtifactBinding(
+  candidates,
+  trustedCommentIds,
+  entryCreatedAt,
+) {
+  const trusted = new Set(
+    (trustedCommentIds ?? [])
+      .map((id) => String(id ?? '').trim())
+      .filter((id) => id.length > 0),
+  );
+  if (trusted.size === 0) {
+    return false;
+  }
+  const matches = (candidates ?? []).filter(
+    (candidate) => candidate.createdAt === entryCreatedAt,
+  );
+  if (matches.length !== 1) {
+    // Zero: no live candidate at all for this exact timestamp (e.g. the
+    // genuine comment was deleted). More than one: two distinct comments
+    // citing the same run id share the same wall-clock second -- fail
+    // closed rather than guessing which one `entry` actually is.
+    return false;
+  }
+  return trusted.has(String(matches[0]?.id ?? '').trim());
 }
 /**
  * Compute the deterministic advisory-convergence verdict from already-
@@ -1420,9 +1541,10 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
   // running `pull_request_target` run's id (the run-id check alone
   // verifies only that CITED run's own metadata, not that it actually
   // posted this comment -- the general form of that gap is closed by
-  // `verifySelfReferentialBootstrapWaiverProvenance` and the
-  // duplicate-run-id check below, kurone-kito/idd-skill#2912; this
-  // `claimCandidateAmbiguous` guard is independent defense-in-depth for
+  // `verifySelfReferentialBootstrapWaiverProvenance` and
+  // `verifySelfReferentialBootstrapWaiverArtifactBinding` below,
+  // kurone-kito/idd-skill#2912; this `claimCandidateAmbiguous` guard is
+  // independent defense-in-depth for
   // the SPECIFIC claim-ambiguity shape, not a substitute for either)
   // could validate on such a PR even though the legitimate posting
   // helper would have refused to post ANY marker for it.
@@ -1457,27 +1579,20 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
           inputs.autoWaiverRunJobLookups?.[entry.runId],
           entry.createdAt,
         ) &&
-        // kurone-kito/idd-skill#2912: exactly one candidate marker
-        // citing this run id may ALSO independently pass the same
-        // provenance check above -- see
-        // `autoWaiverRunIdCandidateTimestamps`'s own doc comment for
-        // why this is scoped to provenance-PASSING candidates only
-        // (never a bare structural count), which is what lets a
-        // legitimate CI rerun (a second genuine marker for the same
-        // run id, whose earlier sibling now falls outside the latest
-        // attempt's window and so fails provenance on its own) keep
-        // validating instead of being treated as a forgery collision.
-        // Two or more candidates BOTH passing provenance (a forged
-        // marker racing a genuine one inside the same execution
-        // window) fails closed to "no auto-waiver", never picks a
-        // winner.
-        (inputs.autoWaiverRunIdCandidateTimestamps?.[entry.runId] ?? []).filter(
-          (createdAt) =>
-            verifySelfReferentialBootstrapWaiverProvenance(
-              inputs.autoWaiverRunJobLookups?.[entry.runId],
-              createdAt,
-            ),
-        ).length === 1,
+        // kurone-kito/idd-skill#2912 (round 2): prove the cited run's own
+        // trusted execution positively recorded posting THIS EXACT
+        // comment (via a run-scoped Actions artifact only that run's own
+        // upload token could have created), not merely that no OTHER
+        // candidate currently happens to be visible -- see
+        // `verifySelfReferentialBootstrapWaiverArtifactBinding`'s own
+        // doc comment for the comment-deletion forgery this replaces the
+        // file's prior round-1 "no duplicate visible" uniqueness check
+        // to close.
+        verifySelfReferentialBootstrapWaiverArtifactBinding(
+          inputs.autoWaiverRunIdCandidates?.[entry.runId],
+          inputs.autoWaiverRunArtifactCommentIds?.[entry.runId],
+          entry.createdAt,
+        ),
     );
   const waiver = {
     mode: waiverMode,
@@ -2528,26 +2643,24 @@ export function collectFromGitHub(
   // spam comments on the PR -- conspicuous, and itself rate-limited by
   // GitHub's own comment-creation API, unlike an unbounded lookup loop.
   // kurone-kito/idd-skill#2912: this same bound now also caps a SECOND
-  // lookup per run id (`getWorkflowRunJobs`, for
-  // `verifySelfReferentialBootstrapWaiverProvenance`), so worst-case
-  // cost is up to 2 * MAX_AUTO_WAIVER_RUN_LOOKUPS Actions-API calls, not
+  // and THIRD lookup per run id (`getWorkflowRunJobs`, for
+  // `verifySelfReferentialBootstrapWaiverProvenance`; and
+  // `listWorkflowRunArtifacts`, for
+  // `verifySelfReferentialBootstrapWaiverArtifactBinding`), so worst-case
+  // cost is up to 3 * MAX_AUTO_WAIVER_RUN_LOOKUPS Actions-API calls, not
   // a new, separately-bounded budget of its own.
   const MAX_AUTO_WAIVER_RUN_LOOKUPS = 20;
   const autoWaiverCandidates = [];
   const seenAutoWaiverRunIds = new Set();
-  // kurone-kito/idd-skill#2912: collected over EVERY qualifying comment
-  // (not deduplicated by `seenAutoWaiverRunIds`, which exists only to
-  // bound the number of Actions-API lookups) -- `autoWaiverValid` below
-  // requires exactly one provenance-passing candidate per cited run id,
-  // so a second, forged marker sharing a legitimate run's id must still
-  // be recorded even though it triggers no additional lookup. Kept as
-  // `createdAt` timestamps, not a bare count, so the pure verdict
-  // function can independently re-check each candidate's own provenance
-  // against the run's (single, shared) jobs-API window -- see
-  // `AdvisoryConvergenceInputs.autoWaiverRunIdCandidateTimestamps`'s own
-  // doc comment for why a bare count would misclassify a legitimate CI
-  // rerun as a forgery collision.
-  const autoWaiverRunIdCandidateTimestamps = new Map();
+  // kurone-kito/idd-skill#2912 (round 2): collected over EVERY qualifying
+  // comment (not deduplicated by `seenAutoWaiverRunIds`, which exists
+  // only to bound the number of Actions-API lookups), each paired with
+  // its own comment `id` -- `verifySelfReferentialBootstrapWaiverArtifactBinding`
+  // needs the id to correlate a `.valid` evidence entry (which carries
+  // no id of its own) back to the specific live comment it came from.
+  // See `AdvisoryConvergenceInputs.autoWaiverRunIdCandidates`'s own doc
+  // comment for the full correlation contract.
+  const autoWaiverRunIdCandidates = new Map();
   for (const comment of comments) {
     const body = String(comment.body ?? '');
     if (!/^<!--\s*idd-external-check-waiver:/i.test(body)) {
@@ -2597,13 +2710,18 @@ export function collectFromGitHub(
         .trim()
         .toLowerCase() === prHeadSha
     ) {
-      // kurone-kito/idd-skill#2912: every qualifying comment's own
-      // `createdAt` is recorded against its cited run id, regardless of
-      // whether this is the first (lookup-triggering) sighting.
-      autoWaiverRunIdCandidateTimestamps.set(parsed.runId, [
-        ...(autoWaiverRunIdCandidateTimestamps.get(parsed.runId) ?? []),
-        createdAt,
-      ]);
+      // kurone-kito/idd-skill#2912 (round 2): every qualifying comment's
+      // own `id`/`createdAt` pair is recorded against its cited run id,
+      // regardless of whether this is the first (lookup-triggering)
+      // sighting. Appended via `.push`, not a spread-rebuild, so this
+      // stays linear in the comment count (Copilot review, PR #2914).
+      const candidateList = autoWaiverRunIdCandidates.get(parsed.runId);
+      const candidate = { id: String(comment.id ?? ''), createdAt };
+      if (candidateList) {
+        candidateList.push(candidate);
+      } else {
+        autoWaiverRunIdCandidates.set(parsed.runId, [candidate]);
+      }
       if (!seenAutoWaiverRunIds.has(parsed.runId)) {
         seenAutoWaiverRunIds.add(parsed.runId);
         autoWaiverCandidates.push({ runId: parsed.runId, createdAt });
@@ -2668,6 +2786,41 @@ export function collectFromGitHub(
       };
     }
   }
+  // kurone-kito/idd-skill#2912 (round 2): a THIRD per-run-id lookup
+  // sharing the exact same `autoWaiverRunIds` budget as the two above
+  // (so worst case triples the lookup call count, still bounded by
+  // `MAX_AUTO_WAIVER_RUN_LOOKUPS`) -- recovers the SET of comment ids
+  // the cited run's own trusted job execution recorded posting, via the
+  // artifact-name convention `SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX`
+  // documents. See `AdvisoryConvergenceInputs.autoWaiverRunArtifactCommentIds`'s
+  // own doc comment for why this closes a gap the run-metadata and
+  // job-provenance lookups above cannot.
+  const autoWaiverArtifactNamePattern = new RegExp(
+    `^${SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX}([1-9][0-9]*)$`,
+  );
+  const autoWaiverRunArtifactCommentIds = {};
+  for (const runId of autoWaiverRunIds) {
+    try {
+      const raw = port.listWorkflowRunArtifacts(owner, repo, runId);
+      const ids = [];
+      for (const artifact of raw?.artifacts ?? []) {
+        const match = autoWaiverArtifactNamePattern.exec(
+          String(artifact?.name ?? ''),
+        );
+        if (match) {
+          ids.push(match[1]);
+        }
+      }
+      autoWaiverRunArtifactCommentIds[runId] = ids;
+    } catch {
+      // Fail closed per run id, mirroring the two lookups above: a
+      // lookup failure must never crash the whole collection, and an
+      // empty trusted-id set already means "nothing trusted" to
+      // `verifySelfReferentialBootstrapWaiverArtifactBinding` -- no
+      // separate `{error}` union variant is needed here.
+      autoWaiverRunArtifactCommentIds[runId] = [];
+    }
+  }
   // kurone-kito/idd-skill#2657 (Codex review, PR #2895): fetched only
   // when a candidate marker exists (same cost-optimization scope as the
   // run-id lookups above) -- see `AdvisoryConvergenceInputs.changedFilePaths`'s
@@ -2705,9 +2858,8 @@ export function collectFromGitHub(
       prAuthorIsBot,
       autoWaiverRunLookups,
       autoWaiverRunJobLookups,
-      autoWaiverRunIdCandidateTimestamps: Object.fromEntries(
-        autoWaiverRunIdCandidateTimestamps,
-      ),
+      autoWaiverRunIdCandidates: Object.fromEntries(autoWaiverRunIdCandidates),
+      autoWaiverRunArtifactCommentIds,
       changedFilePaths,
     },
     options: {

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -352,14 +352,37 @@ export const ADVISORY_CONVERGENCE_CHECK_SELECTOR =
  * body also transitively binds `headSha` and `run-id`, both embedded in
  * it, so an edit that tries to redirect a trusted marker at a different
  * commit or run is caught by the same mechanism, not a separate one. Both
- * sides hash an API-returned body verbatim whenever that read-back is
- * available -- a locally-constructed string is only ever a fallback on
- * the posting side (`ExternalCheckWaiverReport.bodyDigestSource`,
- * labeled as such rather than treated the same as a GitHub-attested
- * digest) -- so GitHub-side content normalization (if any) cancels out
- * identically on both sides in the ordinary case, instead of producing a
- * false-negative on a genuine, unedited marker -- see that function's own
- * doc comment for why.
+ * sides hash an API-returned body verbatim -- so GitHub-side content
+ * normalization (if any) cancels out identically on both sides in the
+ * ordinary case, instead of producing a false-negative on a genuine,
+ * unedited marker -- see {@link digestExternalCheckWaiverMarkerBody}'s own
+ * doc comment for why, and round 4 immediately below for exactly which
+ * API-returned body the posting side now hashes.
+ *
+ * kurone-kito/idd-skill#2912 (round 4): round 3's posting side had its
+ * own race, found by a Copilot review of PR #2914's round-3 commit --
+ * `ExternalCheckWaiverReport.bodyDigest` preferred a body observed in a
+ * LATER, separate post-write re-read (`external-check-waiver.mts`'s own
+ * `readPrComments()` reconcile, run for an unrelated reason: detecting a
+ * concurrent duplicate waiver) over the body GitHub's create-comment API
+ * call itself returned, falling back to the locally-sent string only when
+ * that later re-read came up empty. That preference opened the same class
+ * of window round 3 closes on THIS consumer's side: a same-repository
+ * `issues: write` workflow could edit the genuine comment's body in the
+ * interval between the POST returning and that later re-read running, and
+ * the posting side would then hash and report the FORGED body as
+ * `bodyDigest` -- which this consumer's own live-body scan (reading that
+ * SAME, now-edited comment) would then match, validating the edit as if
+ * the trusted job had posted it verbatim. Round 4 removes that fallback
+ * entirely: the posting side now hashes ONLY the `body` field the
+ * create-comment response returns for the exact POST that created the
+ * comment -- returned atomically, in the same API call, with no window
+ * for an intervening edit -- and reports no `bodyDigest` at all (never
+ * substituting a later, mutable read) when that response lacks a body
+ * string. This consumer needs no change for round 4: it already hashes
+ * the live comment's CURRENT body during its own scan, and a body edited
+ * after posting already fails to match the (now correctly
+ * POST-response-bound) trusted digest either way.
  *
  * Precondition on "the cited job's step conclusion is `success`"
  * actually implying it posted a marker: `runExternalCheckWaiver`'s own

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -124,6 +124,7 @@ import {
 import { deriveGhHttpStatus } from './gh-http-status.mjs';
 import { loadIddConfig } from './idd-config.mjs';
 import {
+  digestExternalCheckWaiverMarkerBody,
   isValidIsoTimestamp,
   parseClaimComment,
   parseExternalCheckWaiverComment,
@@ -326,6 +327,39 @@ export const ADVISORY_CONVERGENCE_CHECK_SELECTOR =
  * findings (and this fix) are framed against. The pre-existing
  * maintainer-authorized waiver remains the documented escape hatch
  * either way.
+ *
+ * kurone-kito/idd-skill#2912 (round 3): round 2's artifact binding had
+ * its own sibling gap, found by a Copilot review of PR #2914's round-2
+ * commit -- it trusted a candidate's comment `id` alone, and `issues:
+ * write` permits EDITING an existing issue comment's body in place, not
+ * only deleting one, which preserves that comment's `id` AND `createdAt`
+ * while replacing its content. An attacker could therefore wait for the
+ * genuine marker to post (its `id` becomes artifact-trusted), then edit
+ * that SAME comment's body to a forged marker citing the same run id --
+ * round 2's check would still accept it, since it never looked at
+ * content. {@link verifySelfReferentialBootstrapWaiverArtifactBinding}
+ * now binds to the pair (comment `id`, SHA-256 digest of that comment's
+ * exact body -- {@link digestExternalCheckWaiverMarkerBody}) rather than
+ * `id` alone: the posting job hashes the body it reads back from the
+ * GitHub API immediately after posting (`external-check-waiver.mts`'s
+ * `ExternalCheckWaiverReport.bodyDigest`) and uploads it as part of the
+ * artifact's name (`idd-self-waiver-marker-<comment-id>-<body-digest>`);
+ * this consumer hashes the SAME live comment's CURRENT body during its
+ * own scan. An edited body digests differently, so the `(id, bodyDigest)`
+ * pair no longer matches any trusted binding and correlation fails
+ * closed -- exactly the "no auto-waiver" degradation round 2 already
+ * guarantees for deletion, now also covering in-place edits. Hashing the
+ * body also transitively binds `headSha` and `run-id`, both embedded in
+ * it, so an edit that tries to redirect a trusted marker at a different
+ * commit or run is caught by the same mechanism, not a separate one. Both
+ * sides hash an API-returned body verbatim whenever that read-back is
+ * available -- a locally-constructed string is only ever a fallback on
+ * the posting side (`ExternalCheckWaiverReport.bodyDigestSource`,
+ * labeled as such rather than treated the same as a GitHub-attested
+ * digest) -- so GitHub-side content normalization (if any) cancels out
+ * identically on both sides in the ordinary case, instead of producing a
+ * false-negative on a genuine, unedited marker -- see that function's own
+ * doc comment for why.
  *
  * Precondition on "the cited job's step conclusion is `success`"
  * actually implying it posted a marker: `runExternalCheckWaiver`'s own
@@ -640,29 +674,35 @@ function verifySelfReferentialBootstrapWaiverProvenance(
   const completedMs = Date.parse(completedAt);
   return markerMs >= startedMs && markerMs <= completedMs;
 }
-/** kurone-kito/idd-skill#2912 (round 2): the fixed prefix of the Actions
- * artifact name {@link SELF_REFERENTIAL_WAIVER_JOB_ID}'s own posting job
- * uploads immediately after successfully posting a
+/** kurone-kito/idd-skill#2912 (round 2, extended round 3): the fixed
+ * prefix of the Actions artifact name {@link SELF_REFERENTIAL_WAIVER_JOB_ID}'s
+ * own posting job uploads immediately after successfully posting a
  * `self-referential-bootstrap-auto` marker, followed by the posted
- * comment's own decimal `id` (e.g. `idd-self-waiver-marker-123456789`).
- * The id lives in the artifact's NAME, never its content, so recovering
- * it costs one `list artifacts` JSON call per cited run id -- no zip
- * download/extraction is needed. Kept in sync by hand with
- * `.github/workflows/idd-advisory-convergence.yml`'s own "Upload the
- * posted marker's provenance artifact" step (the `with: name:` value
- * there, not the preceding "Record the posted marker's provenance" step
- * that only stages the local file `actions/upload-artifact` reads), the
- * same convention {@link SELF_REFERENTIAL_WAIVER_JOB_ID} and
+ * comment's own decimal `id`, a literal `-`, and the SHA-256 hex digest
+ * of that comment's exact posted body
+ * ({@link digestExternalCheckWaiverMarkerBody}) -- e.g.
+ * `idd-self-waiver-marker-123456789-<64 lowercase hex characters>`. Round
+ * 2 named the artifact with the id alone; round 3 appends the body digest
+ * because the id alone does not survive an in-place body edit (see
+ * {@link verifySelfReferentialBootstrapWaiverArtifactBinding}'s own doc
+ * comment for that exploit). Both fields live in the artifact's NAME,
+ * never its content, so recovering them costs one `list artifacts` JSON
+ * call per cited run id -- no zip download/extraction is needed. Kept in
+ * sync by hand with `.github/workflows/idd-advisory-convergence.yml`'s
+ * own "Upload the posted marker's provenance artifact" step (the `with:
+ * name:` value there, not the preceding "Record the posted marker's
+ * provenance" step that only stages the local file `actions/upload-artifact`
+ * reads), the same convention {@link SELF_REFERENTIAL_WAIVER_JOB_ID} and
  * {@link SELF_REFERENTIAL_WAIVER_POST_STEP_NAME} already follow; a
  * dedicated test pins all three against the workflow file's own literal
  * text (both the repository-root copy and its `idd-template/` mirror). */
 export const SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX =
   'idd-self-waiver-marker-';
 /**
- * kurone-kito/idd-skill#2912 (round 2): whether the `.valid` marker
- * `entry` under evaluation is one the cited run id's own trusted
- * {@link SELF_REFERENTIAL_WAIVER_JOB_ID} job execution actually recorded
- * posting, via the run-scoped Actions artifact
+ * kurone-kito/idd-skill#2912 (round 2, extended round 3): whether the
+ * `.valid` marker `entry` under evaluation is one the cited run id's own
+ * trusted {@link SELF_REFERENTIAL_WAIVER_JOB_ID} job execution actually
+ * recorded posting, via the run-scoped Actions artifact
  * {@link SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX} describes. This
  * is the binding step that closes a gap
  * {@link verifySelfReferentialBootstrapWaiverProvenance} alone cannot:
@@ -677,51 +717,76 @@ export const SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX =
  * leaving the forged marker as the sole survivor of a plain "no
  * duplicate candidate currently visible" scan, which is exactly the
  * property this file's PRIOR round-1 uniqueness check depended on
- * (kurone-kito/idd-skill#2912, closed here).
+ * (kurone-kito/idd-skill#2912, closed in round 2).
  *
- * `entry` carries no comment `id` of its own (`ExternalCheckWaiverEvidence.valid`
+ * Round 2's id-only binding had its own sibling gap (a Copilot review of
+ * PR #2914's round-2 commit): `issues: write` also permits EDITING an
+ * existing comment's body in place, preserving its `id` AND `createdAt`
+ * while replacing the content -- an attacker could wait for the genuine
+ * marker to post (its `id` becomes artifact-trusted), then rewrite that
+ * SAME comment's body to a forged marker, which round 2's id-only check
+ * would still accept. Round 3 closes this by binding to the PAIR
+ * (comment `id`, SHA-256 digest of that comment's exact body) instead of
+ * `id` alone -- see the module header's round-3 paragraph for the full
+ * exploit and fix description.
+ *
+ * `entry` carries no comment `id`/body of its own (`ExternalCheckWaiverEvidence.valid`
  * is a shared type many other callers use unchanged), so this
  * correlates `entry.createdAt` back to `candidates` -- the SAME
- * `{id, createdAt}` pairs `collectFromGitHub` derived from the identical
- * raw comment scan that produced `entry` in the first place -- and
- * requires the match to be UNIQUE: two distinct candidates sharing the
- * same wall-clock second (a genuine marker and a same-window forged
- * sibling) is ambiguous and fails closed for both, never guesses a
- * winner. The uniquely-correlated candidate's `id` must then appear in
- * `trustedCommentIds` -- the cited run's own artifact-recorded set.
+ * `{id, createdAt, bodyDigest}` triples `collectFromGitHub` derived from
+ * the identical raw comment scan that produced `entry` in the first
+ * place -- and requires the match to be UNIQUE: two distinct candidates
+ * sharing the same wall-clock second (a genuine marker and a same-window
+ * forged sibling) is ambiguous and fails closed for both, never guesses
+ * a winner. `createdAt` alone (not the full pair) still drives THIS
+ * correlation step -- an edited body never changes `createdAt`, only
+ * `id` uniquely names which live comment `entry` came from -- and the
+ * uniquely-correlated candidate's OWN `(id, bodyDigest)` pair must then
+ * appear in `trustedBindings` -- the cited run's own artifact-recorded
+ * set.
  *
  * Because artifacts are scoped to the run that uploaded them by the
  * Actions runtime's own dedicated upload token (never the shared
  * `GITHUB_TOKEN` `permissions:` surface comments and check runs are
  * both mutable through), no unrelated run -- however it scopes its own
  * `permissions:` block -- can add, edit, or remove an entry from
- * `trustedCommentIds`. A forged comment's `id` therefore never appears
- * there regardless of timing or deletion tricks; deleting the GENUINE
- * comment only removes it from `candidates` (a live re-fetch), which
- * degrades this to "no correlated candidate -- fail closed", never "the
- * forged one wins". The one residual: an attacker who additionally
- * self-grants the broader, repository-wide `actions: write` permission
- * (distinct from `issues: write`) could delete the genuine run's
- * artifact through Actions' own artifact-management endpoint, which
- * still only degrades to "no auto-waiver" (fail closed), never "a
- * forged waiver validates" -- and is outside the `issues: write`-scoped
- * threat model this fix (and the two independent review findings that
- * prompted it) are both framed against.
+ * `trustedBindings`. A forged OR edited comment's `(id, bodyDigest)`
+ * pair therefore never appears there regardless of timing, deletion, or
+ * in-place editing tricks; deleting the GENUINE comment only removes it
+ * from `candidates` (a live re-fetch), which degrades this to "no
+ * correlated candidate -- fail closed", never "the forged one wins". The
+ * one residual: an attacker who additionally self-grants the broader,
+ * repository-wide `actions: write` permission (distinct from `issues:
+ * write`) could delete the genuine run's artifact through Actions' own
+ * artifact-management endpoint, which still only degrades to "no
+ * auto-waiver" (fail closed), never "a forged waiver validates" -- and
+ * is outside the `issues: write`-scoped threat model this fix (and the
+ * independent review findings that prompted both rounds) are all framed
+ * against.
  *
  * Pure and fail-closed like every other verification function in this
- * file: an absent/empty `trustedCommentIds`, no unique correlated
- * candidate, or a correlated candidate whose `id` is not in
- * `trustedCommentIds` are all `false`, never a thrown exception.
+ * file: an absent/empty `trustedBindings`, no unique correlated
+ * candidate, or a correlated candidate whose `(id, bodyDigest)` pair is
+ * not in `trustedBindings` are all `false`, never a thrown exception.
  */
 function verifySelfReferentialBootstrapWaiverArtifactBinding(
   candidates,
-  trustedCommentIds,
+  trustedBindings,
   entryCreatedAt,
 ) {
+  const bindingKey = (id, bodyDigest) => {
+    const normalizedId = String(id ?? '').trim();
+    const normalizedDigest = String(bodyDigest ?? '')
+      .trim()
+      .toLowerCase();
+    return normalizedId && normalizedDigest
+      ? `${normalizedId}:${normalizedDigest}`
+      : '';
+  };
   const trusted = new Set(
-    (trustedCommentIds ?? [])
-      .map((id) => String(id ?? '').trim())
-      .filter((id) => id.length > 0),
+    (trustedBindings ?? [])
+      .map((binding) => bindingKey(binding?.id, binding?.bodyDigest))
+      .filter((key) => key.length > 0),
   );
   if (trusted.size === 0) {
     return false;
@@ -736,7 +801,8 @@ function verifySelfReferentialBootstrapWaiverArtifactBinding(
     // closed rather than guessing which one `entry` actually is.
     return false;
   }
-  return trusted.has(String(matches[0]?.id ?? '').trim());
+  const key = bindingKey(matches[0]?.id, matches[0]?.bodyDigest);
+  return key.length > 0 && trusted.has(key);
 }
 /**
  * Compute the deterministic advisory-convergence verdict from already-
@@ -1579,18 +1645,20 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
           inputs.autoWaiverRunJobLookups?.[entry.runId],
           entry.createdAt,
         ) &&
-        // kurone-kito/idd-skill#2912 (round 2): prove the cited run's own
-        // trusted execution positively recorded posting THIS EXACT
-        // comment (via a run-scoped Actions artifact only that run's own
-        // upload token could have created), not merely that no OTHER
-        // candidate currently happens to be visible -- see
+        // kurone-kito/idd-skill#2912 (round 2, extended round 3): prove
+        // the cited run's own trusted execution positively recorded
+        // posting THIS EXACT comment, by id AND body content (via a
+        // run-scoped Actions artifact only that run's own upload token
+        // could have created), not merely that no OTHER candidate
+        // currently happens to be visible (round 1) or that some
+        // candidate with a matching id exists regardless of whether its
+        // body was since edited in place (round 2) -- see
         // `verifySelfReferentialBootstrapWaiverArtifactBinding`'s own
-        // doc comment for the comment-deletion forgery this replaces the
-        // file's prior round-1 "no duplicate visible" uniqueness check
-        // to close.
+        // doc comment for the comment-deletion and edit-in-place
+        // forgeries this closes.
         verifySelfReferentialBootstrapWaiverArtifactBinding(
           inputs.autoWaiverRunIdCandidates?.[entry.runId],
-          inputs.autoWaiverRunArtifactCommentIds?.[entry.runId],
+          inputs.autoWaiverRunArtifactBindings?.[entry.runId],
           entry.createdAt,
         ),
     );
@@ -2652,13 +2720,17 @@ export function collectFromGitHub(
   const MAX_AUTO_WAIVER_RUN_LOOKUPS = 20;
   const autoWaiverCandidates = [];
   const seenAutoWaiverRunIds = new Set();
-  // kurone-kito/idd-skill#2912 (round 2): collected over EVERY qualifying
-  // comment (not deduplicated by `seenAutoWaiverRunIds`, which exists
-  // only to bound the number of Actions-API lookups), each paired with
-  // its own comment `id` -- `verifySelfReferentialBootstrapWaiverArtifactBinding`
-  // needs the id to correlate a `.valid` evidence entry (which carries
-  // no id of its own) back to the specific live comment it came from.
-  // See `AdvisoryConvergenceInputs.autoWaiverRunIdCandidates`'s own doc
+  // kurone-kito/idd-skill#2912 (round 2, extended round 3): collected
+  // over EVERY qualifying comment (not deduplicated by
+  // `seenAutoWaiverRunIds`, which exists only to bound the number of
+  // Actions-API lookups), each paired with its own comment `id` AND
+  // (round 3) a SHA-256 digest of its own live body --
+  // `verifySelfReferentialBootstrapWaiverArtifactBinding` needs the id
+  // to correlate a `.valid` evidence entry (which carries no id of its
+  // own) back to the specific live comment it came from, and the body
+  // digest to detect whether that specific comment's content has since
+  // been edited in place (round 2's id-only binding could not). See
+  // `AdvisoryConvergenceInputs.autoWaiverRunIdCandidates`'s own doc
   // comment for the full correlation contract.
   const autoWaiverRunIdCandidates = new Map();
   for (const comment of comments) {
@@ -2710,13 +2782,22 @@ export function collectFromGitHub(
         .trim()
         .toLowerCase() === prHeadSha
     ) {
-      // kurone-kito/idd-skill#2912 (round 2): every qualifying comment's
-      // own `id`/`createdAt` pair is recorded against its cited run id,
-      // regardless of whether this is the first (lookup-triggering)
-      // sighting. Appended via `.push`, not a spread-rebuild, so this
-      // stays linear in the comment count (Copilot review, PR #2914).
+      // kurone-kito/idd-skill#2912 (round 2, extended round 3): every
+      // qualifying comment's own `id`/`createdAt`/`bodyDigest` triple is
+      // recorded against its cited run id, regardless of whether this is
+      // the first (lookup-triggering) sighting. Appended via `.push`,
+      // not a spread-rebuild, so this stays linear in the comment count
+      // (Copilot review, PR #2914). `digestExternalCheckWaiverMarkerBody`
+      // hashes `body` verbatim -- the exact string this scan already read
+      // from the live comment -- never a locally-reconstructed one, the
+      // same API-returned-body-on-both-sides contract that function's
+      // own doc comment requires.
       const candidateList = autoWaiverRunIdCandidates.get(parsed.runId);
-      const candidate = { id: String(comment.id ?? ''), createdAt };
+      const candidate = {
+        id: String(comment.id ?? ''),
+        createdAt,
+        bodyDigest: digestExternalCheckWaiverMarkerBody(body),
+      };
       if (candidateList) {
         candidateList.push(candidate);
       } else {
@@ -2786,39 +2867,44 @@ export function collectFromGitHub(
       };
     }
   }
-  // kurone-kito/idd-skill#2912 (round 2): a THIRD per-run-id lookup
-  // sharing the exact same `autoWaiverRunIds` budget as the two above
-  // (so worst case triples the lookup call count, still bounded by
-  // `MAX_AUTO_WAIVER_RUN_LOOKUPS`) -- recovers the SET of comment ids
-  // the cited run's own trusted job execution recorded posting, via the
-  // artifact-name convention `SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX`
-  // documents. See `AdvisoryConvergenceInputs.autoWaiverRunArtifactCommentIds`'s
-  // own doc comment for why this closes a gap the run-metadata and
+  // kurone-kito/idd-skill#2912 (round 2, extended round 3): a THIRD
+  // per-run-id lookup sharing the exact same `autoWaiverRunIds` budget
+  // as the two above (so worst case triples the lookup call count,
+  // still bounded by `MAX_AUTO_WAIVER_RUN_LOOKUPS`) -- recovers the SET
+  // of `(comment id, body digest)` bindings the cited run's own trusted
+  // job execution recorded posting, via the artifact-name convention
+  // `SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX` documents (round 3
+  // extended that convention with a trailing `-<body-digest>` segment).
+  // See `AdvisoryConvergenceInputs.autoWaiverRunArtifactBindings`'s own
+  // doc comment for why this closes a gap the run-metadata and
   // job-provenance lookups above cannot.
   const autoWaiverArtifactNamePattern = new RegExp(
-    `^${SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX}([1-9][0-9]*)$`,
+    `^${SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX}([1-9][0-9]*)-([0-9a-f]{64})$`,
   );
-  const autoWaiverRunArtifactCommentIds = {};
+  const autoWaiverRunArtifactBindings = {};
   for (const runId of autoWaiverRunIds) {
     try {
       const raw = port.listWorkflowRunArtifacts(owner, repo, runId);
-      const ids = [];
+      const bindings = [];
       for (const artifact of raw?.artifacts ?? []) {
         const match = autoWaiverArtifactNamePattern.exec(
           String(artifact?.name ?? ''),
         );
         if (match) {
-          ids.push(match[1]);
+          bindings.push({
+            id: match[1],
+            bodyDigest: match[2],
+          });
         }
       }
-      autoWaiverRunArtifactCommentIds[runId] = ids;
+      autoWaiverRunArtifactBindings[runId] = bindings;
     } catch {
       // Fail closed per run id, mirroring the two lookups above: a
       // lookup failure must never crash the whole collection, and an
-      // empty trusted-id set already means "nothing trusted" to
+      // empty trusted-binding set already means "nothing trusted" to
       // `verifySelfReferentialBootstrapWaiverArtifactBinding` -- no
       // separate `{error}` union variant is needed here.
-      autoWaiverRunArtifactCommentIds[runId] = [];
+      autoWaiverRunArtifactBindings[runId] = [];
     }
   }
   // kurone-kito/idd-skill#2657 (Codex review, PR #2895): fetched only
@@ -2859,7 +2945,7 @@ export function collectFromGitHub(
       autoWaiverRunLookups,
       autoWaiverRunJobLookups,
       autoWaiverRunIdCandidates: Object.fromEntries(autoWaiverRunIdCandidates),
-      autoWaiverRunArtifactCommentIds,
+      autoWaiverRunArtifactBindings,
       changedFilePaths,
     },
     options: {

--- a/scripts/external-check-waiver.mjs
+++ b/scripts/external-check-waiver.mjs
@@ -972,6 +972,7 @@ export async function runExternalCheckWaiver(options = {}) {
       applied: false,
       reusedWaiver: existingWaiver,
       commentUrl: existingWaiver.commentUrl,
+      commentId: existingWaiver.commentId,
     };
     renderReport(reusedReport, args.format);
     return { exitCode: 0, report: reusedReport };
@@ -1100,6 +1101,7 @@ export async function runExternalCheckWaiver(options = {}) {
     ...report,
     applied: true,
     commentUrl: String(result.html_url ?? result.url ?? ''),
+    commentId: String(result.id ?? ''),
     ...(concurrentWaivers.length > 1 ? { concurrentWaivers } : {}),
     ...(reconcileInconclusive ? { reconcileInconclusive: true } : {}),
   };

--- a/scripts/external-check-waiver.mjs
+++ b/scripts/external-check-waiver.mjs
@@ -27,6 +27,7 @@ import {
   resolveCollaboratorMarkerTrust,
 } from './policy-helpers.mjs';
 import {
+  digestExternalCheckWaiverMarkerBody,
   parseExternalCheckWaiverComment,
   parsePaginatedGhNdjson,
   renderExternalCheckWaiverComment,
@@ -1097,11 +1098,33 @@ export async function runExternalCheckWaiver(options = {}) {
         'minimize the rest so a later session does not have to disambiguate.\n',
     );
   }
+  // kurone-kito/idd-skill#2912 (round 3): hash the body this helper reads
+  // BACK from the GitHub API (the same `postWriteComments` reconcile scan
+  // above), matched by the posted comment's own id -- never `report.body`,
+  // the string this process constructed and sent -- so the digest reflects
+  // what GitHub actually stored, the same guarantee `bodyDigest`'s own doc
+  // comment describes. Fall back to `report.body` only when the reconcile
+  // could not find that comment (a failed re-read, or a race with a
+  // concurrent edit/delete already flagged by `reconcileInconclusive`
+  // above, or -- more simply -- a `postComment` test double that never
+  // reaches `readPrComments()`), and say so via `bodyDigestSource` so a
+  // consumer can tell a GitHub-attested digest from a merely-sent one.
+  const postedCommentId = String(result.id ?? '');
+  const reconciledComment = postWriteComments.find(
+    (comment) => String(comment?.id ?? '') === postedCommentId,
+  );
+  const bodyDigestSource =
+    typeof reconciledComment?.body === 'string' ? 'reconciled' : 'constructed';
+  const bodyDigest = digestExternalCheckWaiverMarkerBody(
+    bodyDigestSource === 'reconciled' ? reconciledComment?.body : report.body,
+  );
   const appliedReport = {
     ...report,
     applied: true,
     commentUrl: String(result.html_url ?? result.url ?? ''),
-    commentId: String(result.id ?? ''),
+    commentId: postedCommentId,
+    bodyDigest,
+    bodyDigestSource,
     ...(concurrentWaivers.length > 1 ? { concurrentWaivers } : {}),
     ...(reconcileInconclusive ? { reconcileInconclusive: true } : {}),
   };

--- a/scripts/external-check-waiver.mjs
+++ b/scripts/external-check-waiver.mjs
@@ -1098,33 +1098,36 @@ export async function runExternalCheckWaiver(options = {}) {
         'minimize the rest so a later session does not have to disambiguate.\n',
     );
   }
-  // kurone-kito/idd-skill#2912 (round 3): hash the body this helper reads
-  // BACK from the GitHub API (the same `postWriteComments` reconcile scan
-  // above), matched by the posted comment's own id -- never `report.body`,
-  // the string this process constructed and sent -- so the digest reflects
-  // what GitHub actually stored, the same guarantee `bodyDigest`'s own doc
-  // comment describes. Fall back to `report.body` only when the reconcile
-  // could not find that comment (a failed re-read, or a race with a
-  // concurrent edit/delete already flagged by `reconcileInconclusive`
-  // above, or -- more simply -- a `postComment` test double that never
-  // reaches `readPrComments()`), and say so via `bodyDigestSource` so a
-  // consumer can tell a GitHub-attested digest from a merely-sent one.
+  // kurone-kito/idd-skill#2912 (round 4; supersedes round 3, PR #2914
+  // review): hash the `body` field GitHub's OWN create-comment response
+  // (`result`) returned for THIS exact POST -- never `postWriteComments`,
+  // the LATER, separate `readPrComments()` re-read used above for
+  // concurrent-duplicate detection. Round 3 preferred that later re-read,
+  // reasoning it reflects what GitHub "actually stored" -- but the two
+  // reads are not the same instant: a same-repository `issues: write`
+  // workflow can edit the genuine comment's body in the window between
+  // this POST returning and that later re-read running, and round 3's
+  // reconcile-preferring design would then hash and attest to the FORGED
+  // body as if it were genuine (the P1 Copilot found reviewing round 3's
+  // own commit). The create-comment response has no such window: GitHub
+  // returns it atomically, in the same API call that created the comment,
+  // before any other request could possibly have touched it. Absent
+  // (never backfilled from `postWriteComments` or `report.body`) when
+  // that response did not carry a `body` string -- fails closed via the
+  // workflow's own `body-digest != ''` gate rather than uploading a
+  // provenance artifact for a digest this process cannot prove GitHub
+  // stored.
   const postedCommentId = String(result.id ?? '');
-  const reconciledComment = postWriteComments.find(
-    (comment) => String(comment?.id ?? '') === postedCommentId,
-  );
-  const bodyDigestSource =
-    typeof reconciledComment?.body === 'string' ? 'reconciled' : 'constructed';
-  const bodyDigest = digestExternalCheckWaiverMarkerBody(
-    bodyDigestSource === 'reconciled' ? reconciledComment?.body : report.body,
-  );
+  const bodyDigest =
+    typeof result.body === 'string'
+      ? digestExternalCheckWaiverMarkerBody(result.body)
+      : undefined;
   const appliedReport = {
     ...report,
     applied: true,
     commentUrl: String(result.html_url ?? result.url ?? ''),
     commentId: postedCommentId,
-    bodyDigest,
-    bodyDigestSource,
+    ...(typeof bodyDigest === 'string' ? { bodyDigest } : {}),
     ...(concurrentWaivers.length > 1 ? { concurrentWaivers } : {}),
     ...(reconcileInconclusive ? { reconcileInconclusive: true } : {}),
   };

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -864,26 +864,34 @@ export function renderExternalCheckWaiverComment(payload) {
  * replacing the content -- round 2's check alone would still accept the
  * edited body because it only ever looked at the id.
  *
- * Every caller on both sides of this check (the posting CLI's post-write
- * reconcile in `external-check-waiver.mts`, and
- * `advisory-convergence.mts`'s live comment scan) SHOULD hash a body
- * obtained the SAME way -- read back from the GitHub API, not a
- * locally-constructed string -- so an unedited comment always digests
- * identically regardless of which side computed it. Hashing a
- * writer-constructed string against a GitHub-returned one risks a
- * false-negative on any GitHub-side content normalization this project
- * does not control (trailing-newline handling, etc.). No normalization is
- * applied here for that reason: both sides are expected to pass an
- * API-returned body verbatim in the ordinary case. The one documented
- * exception is the posting CLI's own fallback when its post-write
- * reconcile cannot find the just-posted comment: it hashes the
- * locally-sent body instead and labels the result accordingly
- * (`ExternalCheckWaiverReport.bodyDigestSource: 'constructed'`) rather
- * than presenting it as a GitHub-attested digest. This follows the same
- * `bodySha256` / `body-sha256` convention `authoring-owner-provenance.mts`
- * and the issue-authoring skill already use for the identical purpose
- * (binding a marker to an exact API-observed body rather than trusting an
- * id alone).
+ * Every caller on both sides of this check (the posting CLI in
+ * `external-check-waiver.mts`, and `advisory-convergence.mts`'s live
+ * comment scan) MUST hash a body obtained the SAME way -- read back from
+ * the GitHub API, not a locally-constructed string -- so an unedited
+ * comment always digests identically regardless of which side computed
+ * it. Hashing a writer-constructed string against a GitHub-returned one
+ * risks a false-negative on any GitHub-side content normalization this
+ * project does not control (trailing-newline handling, etc.). No
+ * normalization is applied here for that reason: both sides are expected
+ * to pass an API-returned body verbatim.
+ *
+ * Round 3 initially let the posting CLI hash a body observed in a LATER,
+ * separate re-read (its own post-write reconcile) when available, falling
+ * back to the locally-sent string only when that reconcile came up empty.
+ * Copilot's review of round 3's own commit (PR #2914) found this
+ * introduced a race: the later re-read is mutable in a way the original
+ * POST response is not, so a same-repository `issues: write` workflow
+ * that edited the genuine comment's body in the window between POST and
+ * reconcile would have its forged body hashed and attested as genuine.
+ * Round 4 removed that fallback entirely -- the posting CLI now hashes
+ * ONLY the `body` field GitHub's create-comment response returns for the
+ * exact POST that created the comment, atomically, with no such window;
+ * see `ExternalCheckWaiverReport.bodyDigest`'s own doc comment
+ * (external-check-waiver.mts) for the full reasoning. This follows the
+ * same `bodySha256` / `body-sha256` convention
+ * `authoring-owner-provenance.mts` and the issue-authoring skill already
+ * use for the identical purpose (binding a marker to an exact
+ * API-observed body rather than trusting an id alone).
  */
 export function digestExternalCheckWaiverMarkerBody(body) {
   return createHash('sha256').update(body, 'utf8').digest('hex');

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -20,6 +20,7 @@
 // resolution machinery there (normalizeTrustedMarkerLogins and friends), and
 // moving them here would force exactly that forbidden back-import. Only the
 // single-marker parse/render primitives move in this wave.
+import { createHash } from 'node:crypto';
 import { createMarkerRegex, escapeRegex } from './marker-regex.mjs';
 
 const ISO8601_UTC_PATTERN = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/;
@@ -850,6 +851,42 @@ export function renderExternalCheckWaiverComment(payload) {
       expiresAt,
     }),
   ].join('\n');
+}
+/**
+ * SHA-256 hex digest of `body`'s exact UTF-8 bytes, used to bind a
+ * `idd-self-waiver-marker-*` Actions artifact (kurone-kito/idd-skill#2912,
+ * round 3) to the precise content of the comment it attests, not merely
+ * that comment's id. Round 2's artifact-binding closed the
+ * comment-deletion forgery (an attacker deletes the genuine marker,
+ * leaving a same-run-id forged sibling as the sole survivor) but left a
+ * sibling gap open: `issues: write` also permits EDITING an existing
+ * comment's body in place, which preserves its `id` and `createdAt` while
+ * replacing the content -- round 2's check alone would still accept the
+ * edited body because it only ever looked at the id.
+ *
+ * Every caller on both sides of this check (the posting CLI's post-write
+ * reconcile in `external-check-waiver.mts`, and
+ * `advisory-convergence.mts`'s live comment scan) SHOULD hash a body
+ * obtained the SAME way -- read back from the GitHub API, not a
+ * locally-constructed string -- so an unedited comment always digests
+ * identically regardless of which side computed it. Hashing a
+ * writer-constructed string against a GitHub-returned one risks a
+ * false-negative on any GitHub-side content normalization this project
+ * does not control (trailing-newline handling, etc.). No normalization is
+ * applied here for that reason: both sides are expected to pass an
+ * API-returned body verbatim in the ordinary case. The one documented
+ * exception is the posting CLI's own fallback when its post-write
+ * reconcile cannot find the just-posted comment: it hashes the
+ * locally-sent body instead and labels the result accordingly
+ * (`ExternalCheckWaiverReport.bodyDigestSource: 'constructed'`) rather
+ * than presenting it as a GitHub-attested digest. This follows the same
+ * `bodySha256` / `body-sha256` convention `authoring-owner-provenance.mts`
+ * and the issue-authoring skill already use for the identical purpose
+ * (binding a marker to an exact API-observed body rather than trusting an
+ * id alone).
+ */
+export function digestExternalCheckWaiverMarkerBody(body) {
+  return createHash('sha256').update(body, 'utf8').digest('hex');
 }
 function renderProviderOutageDeclarationNote(normalized) {
   return `_${normalized.actor}: provider outage declaration for \`${normalized.service}\` until \`${normalized.expiresAt}\` — IDD automation marker. Do not edit._`;

--- a/scripts/provider-adapter-fake.mjs
+++ b/scripts/provider-adapter-fake.mjs
@@ -383,6 +383,17 @@ export function createFakeProviderAdapter(fixture) {
       }
       return value;
     },
+    listWorkflowRunArtifacts(artifactsOwner, artifactsRepo, runId) {
+      // Same throw-on-missing contract as getWorkflowRunJobs above.
+      const key = `${artifactsOwner}/${artifactsRepo}/${runId}`;
+      const value = fixture.workflowRunArtifacts?.[key];
+      if (value === undefined) {
+        throw new Error(
+          `fake provider: no workflow-run-artifacts fixture for ${key}`,
+        );
+      }
+      return value;
+    },
     listWorkflowRuns(runsOwner, runsRepo, workflowName, limit) {
       // Honors `limit`, matching the GitHub adapter's own `gh run list
       // --limit N` call (Copilot review, PR #2429) -- an ignored limit let

--- a/scripts/provider-adapter-fake.mjs
+++ b/scripts/provider-adapter-fake.mjs
@@ -372,6 +372,17 @@ export function createFakeProviderAdapter(fixture) {
       }
       return value;
     },
+    getWorkflowRunJobs(jobsOwner, jobsRepo, runId) {
+      // Same throw-on-missing contract as getWorkflowRun above.
+      const key = `${jobsOwner}/${jobsRepo}/${runId}`;
+      const value = fixture.workflowRunJobs?.[key];
+      if (value === undefined) {
+        throw new Error(
+          `fake provider: no workflow-run-jobs fixture for ${key}`,
+        );
+      }
+      return value;
+    },
     listWorkflowRuns(runsOwner, runsRepo, workflowName, limit) {
       // Honors `limit`, matching the GitHub adapter's own `gh run list
       // --limit N` call (Copilot review, PR #2429) -- an ignored limit let

--- a/scripts/provider-adapter-github.mjs
+++ b/scripts/provider-adapter-github.mjs
@@ -1899,6 +1899,17 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
       );
       return JSON.parse(raw.trim() || '{}');
     },
+    getWorkflowRunJobs(jobsOwner, jobsRepo, runId) {
+      // Not `--paginate`: bounded to a handful of jobs per run (this
+      // workflow declares two), well under the API's own per-page cap, and
+      // `--paginate` without `--jq` would emit one JSON object per page
+      // rather than a single parseable document.
+      const raw = deps.ghText(
+        ['api', `repos/${jobsOwner}/${jobsRepo}/actions/runs/${runId}/jobs`],
+        GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+      );
+      return JSON.parse(raw.trim() || '{}');
+    },
     listWorkflowRuns(runsOwner, runsRepo, workflowName, limit) {
       const raw = deps.ghText(
         [

--- a/scripts/provider-adapter-github.mjs
+++ b/scripts/provider-adapter-github.mjs
@@ -1910,6 +1910,19 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
       );
       return JSON.parse(raw.trim() || '{}');
     },
+    listWorkflowRunArtifacts(artifactsOwner, artifactsRepo, runId) {
+      // Not `--paginate`, same rationale as getWorkflowRunJobs above: a
+      // run legitimately uploads at most a handful of artifacts, well
+      // under the API's own per-page cap.
+      const raw = deps.ghText(
+        [
+          'api',
+          `repos/${artifactsOwner}/${artifactsRepo}/actions/runs/${runId}/artifacts`,
+        ],
+        GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+      );
+      return JSON.parse(raw.trim() || '{}');
+    },
     listWorkflowRuns(runsOwner, runsRepo, workflowName, limit) {
       const raw = deps.ghText(
         [

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -376,14 +376,37 @@ export const ADVISORY_CONVERGENCE_CHECK_SELECTOR =
  * body also transitively binds `headSha` and `run-id`, both embedded in
  * it, so an edit that tries to redirect a trusted marker at a different
  * commit or run is caught by the same mechanism, not a separate one. Both
- * sides hash an API-returned body verbatim whenever that read-back is
- * available -- a locally-constructed string is only ever a fallback on
- * the posting side (`ExternalCheckWaiverReport.bodyDigestSource`,
- * labeled as such rather than treated the same as a GitHub-attested
- * digest) -- so GitHub-side content normalization (if any) cancels out
- * identically on both sides in the ordinary case, instead of producing a
- * false-negative on a genuine, unedited marker -- see that function's own
- * doc comment for why.
+ * sides hash an API-returned body verbatim -- so GitHub-side content
+ * normalization (if any) cancels out identically on both sides in the
+ * ordinary case, instead of producing a false-negative on a genuine,
+ * unedited marker -- see {@link digestExternalCheckWaiverMarkerBody}'s own
+ * doc comment for why, and round 4 immediately below for exactly which
+ * API-returned body the posting side now hashes.
+ *
+ * kurone-kito/idd-skill#2912 (round 4): round 3's posting side had its
+ * own race, found by a Copilot review of PR #2914's round-3 commit --
+ * `ExternalCheckWaiverReport.bodyDigest` preferred a body observed in a
+ * LATER, separate post-write re-read (`external-check-waiver.mts`'s own
+ * `readPrComments()` reconcile, run for an unrelated reason: detecting a
+ * concurrent duplicate waiver) over the body GitHub's create-comment API
+ * call itself returned, falling back to the locally-sent string only when
+ * that later re-read came up empty. That preference opened the same class
+ * of window round 3 closes on THIS consumer's side: a same-repository
+ * `issues: write` workflow could edit the genuine comment's body in the
+ * interval between the POST returning and that later re-read running, and
+ * the posting side would then hash and report the FORGED body as
+ * `bodyDigest` -- which this consumer's own live-body scan (reading that
+ * SAME, now-edited comment) would then match, validating the edit as if
+ * the trusted job had posted it verbatim. Round 4 removes that fallback
+ * entirely: the posting side now hashes ONLY the `body` field the
+ * create-comment response returns for the exact POST that created the
+ * comment -- returned atomically, in the same API call, with no window
+ * for an intervening edit -- and reports no `bodyDigest` at all (never
+ * substituting a later, mutable read) when that response lacks a body
+ * string. This consumer needs no change for round 4: it already hashes
+ * the live comment's CURRENT body during its own scan, and a body edited
+ * after posting already fails to match the (now correctly
+ * POST-response-bound) trusted digest either way.
  *
  * Precondition on "the cited job's step conclusion is `success`"
  * actually implying it posted a marker: `runExternalCheckWaiver`'s own

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -130,6 +130,7 @@ import {
 import { deriveGhHttpStatus } from './gh-http-status.mts';
 import { loadIddConfig } from './idd-config.mts';
 import {
+  digestExternalCheckWaiverMarkerBody,
   isValidIsoTimestamp,
   parseClaimComment,
   parseExternalCheckWaiverComment,
@@ -350,6 +351,39 @@ export const ADVISORY_CONVERGENCE_CHECK_SELECTOR =
  * findings (and this fix) are framed against. The pre-existing
  * maintainer-authorized waiver remains the documented escape hatch
  * either way.
+ *
+ * kurone-kito/idd-skill#2912 (round 3): round 2's artifact binding had
+ * its own sibling gap, found by a Copilot review of PR #2914's round-2
+ * commit -- it trusted a candidate's comment `id` alone, and `issues:
+ * write` permits EDITING an existing issue comment's body in place, not
+ * only deleting one, which preserves that comment's `id` AND `createdAt`
+ * while replacing its content. An attacker could therefore wait for the
+ * genuine marker to post (its `id` becomes artifact-trusted), then edit
+ * that SAME comment's body to a forged marker citing the same run id --
+ * round 2's check would still accept it, since it never looked at
+ * content. {@link verifySelfReferentialBootstrapWaiverArtifactBinding}
+ * now binds to the pair (comment `id`, SHA-256 digest of that comment's
+ * exact body -- {@link digestExternalCheckWaiverMarkerBody}) rather than
+ * `id` alone: the posting job hashes the body it reads back from the
+ * GitHub API immediately after posting (`external-check-waiver.mts`'s
+ * `ExternalCheckWaiverReport.bodyDigest`) and uploads it as part of the
+ * artifact's name (`idd-self-waiver-marker-<comment-id>-<body-digest>`);
+ * this consumer hashes the SAME live comment's CURRENT body during its
+ * own scan. An edited body digests differently, so the `(id, bodyDigest)`
+ * pair no longer matches any trusted binding and correlation fails
+ * closed -- exactly the "no auto-waiver" degradation round 2 already
+ * guarantees for deletion, now also covering in-place edits. Hashing the
+ * body also transitively binds `headSha` and `run-id`, both embedded in
+ * it, so an edit that tries to redirect a trusted marker at a different
+ * commit or run is caught by the same mechanism, not a separate one. Both
+ * sides hash an API-returned body verbatim whenever that read-back is
+ * available -- a locally-constructed string is only ever a fallback on
+ * the posting side (`ExternalCheckWaiverReport.bodyDigestSource`,
+ * labeled as such rather than treated the same as a GitHub-attested
+ * digest) -- so GitHub-side content normalization (if any) cancels out
+ * identically on both sides in the ordinary case, instead of producing a
+ * false-negative on a genuine, unedited marker -- see that function's own
+ * doc comment for why.
  *
  * Precondition on "the cited job's step conclusion is `success`"
  * actually implying it posted a marker: `runExternalCheckWaiver`'s own
@@ -922,22 +956,33 @@ export interface AdvisoryConvergenceInputs {
    * own) back to the specific live comment it came from, by matching
    * `createdAt` -- ambiguous when two DISTINCT comments citing the same
    * run id share the same wall-clock second, which fails closed for
-   * BOTH rather than guessing (see that function's own doc comment). */
+   * BOTH rather than guessing (see that function's own doc comment).
+   *
+   * kurone-kito/idd-skill#2912 (round 3): also carries each candidate's
+   * own `bodyDigest` -- the SHA-256 hex digest of THIS candidate's live
+   * body ({@link digestExternalCheckWaiverMarkerBody}) -- required,
+   * alongside `id`, for {@link verifySelfReferentialBootstrapWaiverArtifactBinding}
+   * to reject an edited-in-place forgery that kept the genuine comment's
+   * `id` and `createdAt` but replaced its content: `id` alone (round 2)
+   * is no longer sufficient once an attacker can rewrite a trusted
+   * comment's body without changing its `id`. See that function's own
+   * doc comment. */
   autoWaiverRunIdCandidates?: Record<
     string,
-    { id: string; createdAt: string }[]
+    { id: string; createdAt: string; bodyDigest: string }[]
   >;
-  /** kurone-kito/idd-skill#2912 (round 2): the SET of issue-comment ids
-   * a cited run id's own trusted `idd-advisory-convergence-self-waiver`
-   * job execution recorded actually posting, recovered from the `name`
-   * of every `idd-self-waiver-marker-<comment-id>`-prefixed Actions
+  /** kurone-kito/idd-skill#2912 (round 2, extended round 3): the SET of
+   * `(comment id, body digest)` bindings a cited run id's own trusted
+   * `idd-advisory-convergence-self-waiver` job execution recorded
+   * actually posting, recovered from the `name` of every
+   * `idd-self-waiver-marker-<comment-id>-<body-digest>`-prefixed Actions
    * artifact that run uploaded (see
    * {@link SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX}). More than one
-   * id is expected, not anomalous, across a legitimate `gh run rerun`:
-   * each attempt uploads its own artifact rather than replacing the
-   * prior one, so the trusted set only grows: the provenance/window
+   * binding is expected, not anomalous, across a legitimate `gh run
+   * rerun`: each attempt uploads its own artifact rather than replacing
+   * the prior one, so the trusted set only grows: the provenance/window
    * check (`autoWaiverRunJobLookups` above) still disambiguates which
-   * ONE of those ids belongs to the LATEST attempt. `collectFromGitHub`
+   * ONE of those bindings belongs to the LATEST attempt. `collectFromGitHub`
    * fetches this (network, same `MAX_AUTO_WAIVER_RUN_LOOKUPS`-bounded
    * run-id set); this pure verdict function only reads it -- a lookup
    * failure or an absent/empty set both fail closed to "nothing
@@ -950,12 +995,17 @@ export interface AdvisoryConvergenceInputs {
    * scope this file's own comments already assume such an attacker
    * has, permits deleting ANY issue comment on the repository, not only
    * ones the deleting token itself authored) -- leaving the forged
-   * marker as the sole survivor of the scan. See
-   * {@link verifySelfReferentialBootstrapWaiverArtifactBinding}'s own
-   * doc comment for the full exploit and why a run-scoped Actions
-   * artifact (created through a token the shared `GITHUB_TOKEN`
-   * `permissions:` surface cannot reach) closes it. */
-  autoWaiverRunArtifactCommentIds?: Record<string, string[]>;
+   * marker as the sole survivor of the scan. Round 2 bound the id alone;
+   * round 3 additionally binds the exact body a same id must carry
+   * (`bodyDigest`), closing the sibling edit-in-place gap round 2 left
+   * open -- see {@link verifySelfReferentialBootstrapWaiverArtifactBinding}'s
+   * own doc comment for the full exploit chain both rounds close and why
+   * a run-scoped Actions artifact (created through a token the shared
+   * `GITHUB_TOKEN` `permissions:` surface cannot reach) closes it. */
+  autoWaiverRunArtifactBindings?: Record<
+    string,
+    { id: string; bodyDigest: string }[]
+  >;
   /** kurone-kito/idd-skill#2657 (Codex review, PR #2895): the PR's own
    * changed file paths, fetched by `collectFromGitHub` only when at
    * least one candidate self-referential-bootstrap-auto marker exists
@@ -1285,19 +1335,25 @@ function verifySelfReferentialBootstrapWaiverProvenance(
   return markerMs >= startedMs && markerMs <= completedMs;
 }
 
-/** kurone-kito/idd-skill#2912 (round 2): the fixed prefix of the Actions
- * artifact name {@link SELF_REFERENTIAL_WAIVER_JOB_ID}'s own posting job
- * uploads immediately after successfully posting a
+/** kurone-kito/idd-skill#2912 (round 2, extended round 3): the fixed
+ * prefix of the Actions artifact name {@link SELF_REFERENTIAL_WAIVER_JOB_ID}'s
+ * own posting job uploads immediately after successfully posting a
  * `self-referential-bootstrap-auto` marker, followed by the posted
- * comment's own decimal `id` (e.g. `idd-self-waiver-marker-123456789`).
- * The id lives in the artifact's NAME, never its content, so recovering
- * it costs one `list artifacts` JSON call per cited run id -- no zip
- * download/extraction is needed. Kept in sync by hand with
- * `.github/workflows/idd-advisory-convergence.yml`'s own "Upload the
- * posted marker's provenance artifact" step (the `with: name:` value
- * there, not the preceding "Record the posted marker's provenance" step
- * that only stages the local file `actions/upload-artifact` reads), the
- * same convention {@link SELF_REFERENTIAL_WAIVER_JOB_ID} and
+ * comment's own decimal `id`, a literal `-`, and the SHA-256 hex digest
+ * of that comment's exact posted body
+ * ({@link digestExternalCheckWaiverMarkerBody}) -- e.g.
+ * `idd-self-waiver-marker-123456789-<64 lowercase hex characters>`. Round
+ * 2 named the artifact with the id alone; round 3 appends the body digest
+ * because the id alone does not survive an in-place body edit (see
+ * {@link verifySelfReferentialBootstrapWaiverArtifactBinding}'s own doc
+ * comment for that exploit). Both fields live in the artifact's NAME,
+ * never its content, so recovering them costs one `list artifacts` JSON
+ * call per cited run id -- no zip download/extraction is needed. Kept in
+ * sync by hand with `.github/workflows/idd-advisory-convergence.yml`'s
+ * own "Upload the posted marker's provenance artifact" step (the `with:
+ * name:` value there, not the preceding "Record the posted marker's
+ * provenance" step that only stages the local file `actions/upload-artifact`
+ * reads), the same convention {@link SELF_REFERENTIAL_WAIVER_JOB_ID} and
  * {@link SELF_REFERENTIAL_WAIVER_POST_STEP_NAME} already follow; a
  * dedicated test pins all three against the workflow file's own literal
  * text (both the repository-root copy and its `idd-template/` mirror). */
@@ -1305,10 +1361,10 @@ export const SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX =
   'idd-self-waiver-marker-';
 
 /**
- * kurone-kito/idd-skill#2912 (round 2): whether the `.valid` marker
- * `entry` under evaluation is one the cited run id's own trusted
- * {@link SELF_REFERENTIAL_WAIVER_JOB_ID} job execution actually recorded
- * posting, via the run-scoped Actions artifact
+ * kurone-kito/idd-skill#2912 (round 2, extended round 3): whether the
+ * `.valid` marker `entry` under evaluation is one the cited run id's own
+ * trusted {@link SELF_REFERENTIAL_WAIVER_JOB_ID} job execution actually
+ * recorded posting, via the run-scoped Actions artifact
  * {@link SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX} describes. This
  * is the binding step that closes a gap
  * {@link verifySelfReferentialBootstrapWaiverProvenance} alone cannot:
@@ -1323,51 +1379,78 @@ export const SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX =
  * leaving the forged marker as the sole survivor of a plain "no
  * duplicate candidate currently visible" scan, which is exactly the
  * property this file's PRIOR round-1 uniqueness check depended on
- * (kurone-kito/idd-skill#2912, closed here).
+ * (kurone-kito/idd-skill#2912, closed in round 2).
  *
- * `entry` carries no comment `id` of its own (`ExternalCheckWaiverEvidence.valid`
+ * Round 2's id-only binding had its own sibling gap (a Copilot review of
+ * PR #2914's round-2 commit): `issues: write` also permits EDITING an
+ * existing comment's body in place, preserving its `id` AND `createdAt`
+ * while replacing the content -- an attacker could wait for the genuine
+ * marker to post (its `id` becomes artifact-trusted), then rewrite that
+ * SAME comment's body to a forged marker, which round 2's id-only check
+ * would still accept. Round 3 closes this by binding to the PAIR
+ * (comment `id`, SHA-256 digest of that comment's exact body) instead of
+ * `id` alone -- see the module header's round-3 paragraph for the full
+ * exploit and fix description.
+ *
+ * `entry` carries no comment `id`/body of its own (`ExternalCheckWaiverEvidence.valid`
  * is a shared type many other callers use unchanged), so this
  * correlates `entry.createdAt` back to `candidates` -- the SAME
- * `{id, createdAt}` pairs `collectFromGitHub` derived from the identical
- * raw comment scan that produced `entry` in the first place -- and
- * requires the match to be UNIQUE: two distinct candidates sharing the
- * same wall-clock second (a genuine marker and a same-window forged
- * sibling) is ambiguous and fails closed for both, never guesses a
- * winner. The uniquely-correlated candidate's `id` must then appear in
- * `trustedCommentIds` -- the cited run's own artifact-recorded set.
+ * `{id, createdAt, bodyDigest}` triples `collectFromGitHub` derived from
+ * the identical raw comment scan that produced `entry` in the first
+ * place -- and requires the match to be UNIQUE: two distinct candidates
+ * sharing the same wall-clock second (a genuine marker and a same-window
+ * forged sibling) is ambiguous and fails closed for both, never guesses
+ * a winner. `createdAt` alone (not the full pair) still drives THIS
+ * correlation step -- an edited body never changes `createdAt`, only
+ * `id` uniquely names which live comment `entry` came from -- and the
+ * uniquely-correlated candidate's OWN `(id, bodyDigest)` pair must then
+ * appear in `trustedBindings` -- the cited run's own artifact-recorded
+ * set.
  *
  * Because artifacts are scoped to the run that uploaded them by the
  * Actions runtime's own dedicated upload token (never the shared
  * `GITHUB_TOKEN` `permissions:` surface comments and check runs are
  * both mutable through), no unrelated run -- however it scopes its own
  * `permissions:` block -- can add, edit, or remove an entry from
- * `trustedCommentIds`. A forged comment's `id` therefore never appears
- * there regardless of timing or deletion tricks; deleting the GENUINE
- * comment only removes it from `candidates` (a live re-fetch), which
- * degrades this to "no correlated candidate -- fail closed", never "the
- * forged one wins". The one residual: an attacker who additionally
- * self-grants the broader, repository-wide `actions: write` permission
- * (distinct from `issues: write`) could delete the genuine run's
- * artifact through Actions' own artifact-management endpoint, which
- * still only degrades to "no auto-waiver" (fail closed), never "a
- * forged waiver validates" -- and is outside the `issues: write`-scoped
- * threat model this fix (and the two independent review findings that
- * prompted it) are both framed against.
+ * `trustedBindings`. A forged OR edited comment's `(id, bodyDigest)`
+ * pair therefore never appears there regardless of timing, deletion, or
+ * in-place editing tricks; deleting the GENUINE comment only removes it
+ * from `candidates` (a live re-fetch), which degrades this to "no
+ * correlated candidate -- fail closed", never "the forged one wins". The
+ * one residual: an attacker who additionally self-grants the broader,
+ * repository-wide `actions: write` permission (distinct from `issues:
+ * write`) could delete the genuine run's artifact through Actions' own
+ * artifact-management endpoint, which still only degrades to "no
+ * auto-waiver" (fail closed), never "a forged waiver validates" -- and
+ * is outside the `issues: write`-scoped threat model this fix (and the
+ * independent review findings that prompted both rounds) are all framed
+ * against.
  *
  * Pure and fail-closed like every other verification function in this
- * file: an absent/empty `trustedCommentIds`, no unique correlated
- * candidate, or a correlated candidate whose `id` is not in
- * `trustedCommentIds` are all `false`, never a thrown exception.
+ * file: an absent/empty `trustedBindings`, no unique correlated
+ * candidate, or a correlated candidate whose `(id, bodyDigest)` pair is
+ * not in `trustedBindings` are all `false`, never a thrown exception.
  */
 function verifySelfReferentialBootstrapWaiverArtifactBinding(
-  candidates: { id: string; createdAt: string }[] | undefined,
-  trustedCommentIds: string[] | undefined,
+  candidates:
+    | { id: string; createdAt: string; bodyDigest: string }[]
+    | undefined,
+  trustedBindings: { id: string; bodyDigest: string }[] | undefined,
   entryCreatedAt: string,
 ): boolean {
+  const bindingKey = (id: unknown, bodyDigest: unknown): string => {
+    const normalizedId = String(id ?? '').trim();
+    const normalizedDigest = String(bodyDigest ?? '')
+      .trim()
+      .toLowerCase();
+    return normalizedId && normalizedDigest
+      ? `${normalizedId}:${normalizedDigest}`
+      : '';
+  };
   const trusted = new Set(
-    (trustedCommentIds ?? [])
-      .map((id) => String(id ?? '').trim())
-      .filter((id) => id.length > 0),
+    (trustedBindings ?? [])
+      .map((binding) => bindingKey(binding?.id, binding?.bodyDigest))
+      .filter((key) => key.length > 0),
   );
   if (trusted.size === 0) {
     return false;
@@ -1382,7 +1465,8 @@ function verifySelfReferentialBootstrapWaiverArtifactBinding(
     // closed rather than guessing which one `entry` actually is.
     return false;
   }
-  return trusted.has(String(matches[0]?.id ?? '').trim());
+  const key = bindingKey(matches[0]?.id, matches[0]?.bodyDigest);
+  return key.length > 0 && trusted.has(key);
 }
 
 /**
@@ -2245,18 +2329,20 @@ export function computeAdvisoryConvergenceVerdict(
           inputs.autoWaiverRunJobLookups?.[entry.runId],
           entry.createdAt,
         ) &&
-        // kurone-kito/idd-skill#2912 (round 2): prove the cited run's own
-        // trusted execution positively recorded posting THIS EXACT
-        // comment (via a run-scoped Actions artifact only that run's own
-        // upload token could have created), not merely that no OTHER
-        // candidate currently happens to be visible -- see
+        // kurone-kito/idd-skill#2912 (round 2, extended round 3): prove
+        // the cited run's own trusted execution positively recorded
+        // posting THIS EXACT comment, by id AND body content (via a
+        // run-scoped Actions artifact only that run's own upload token
+        // could have created), not merely that no OTHER candidate
+        // currently happens to be visible (round 1) or that some
+        // candidate with a matching id exists regardless of whether its
+        // body was since edited in place (round 2) -- see
         // `verifySelfReferentialBootstrapWaiverArtifactBinding`'s own
-        // doc comment for the comment-deletion forgery this replaces the
-        // file's prior round-1 "no duplicate visible" uniqueness check
-        // to close.
+        // doc comment for the comment-deletion and edit-in-place
+        // forgeries this closes.
         verifySelfReferentialBootstrapWaiverArtifactBinding(
           inputs.autoWaiverRunIdCandidates?.[entry.runId],
-          inputs.autoWaiverRunArtifactCommentIds?.[entry.runId],
+          inputs.autoWaiverRunArtifactBindings?.[entry.runId],
           entry.createdAt,
         ),
     );
@@ -3447,17 +3533,21 @@ export function collectFromGitHub(
   const MAX_AUTO_WAIVER_RUN_LOOKUPS = 20;
   const autoWaiverCandidates: { runId: string; createdAt: string }[] = [];
   const seenAutoWaiverRunIds = new Set<string>();
-  // kurone-kito/idd-skill#2912 (round 2): collected over EVERY qualifying
-  // comment (not deduplicated by `seenAutoWaiverRunIds`, which exists
-  // only to bound the number of Actions-API lookups), each paired with
-  // its own comment `id` -- `verifySelfReferentialBootstrapWaiverArtifactBinding`
-  // needs the id to correlate a `.valid` evidence entry (which carries
-  // no id of its own) back to the specific live comment it came from.
-  // See `AdvisoryConvergenceInputs.autoWaiverRunIdCandidates`'s own doc
+  // kurone-kito/idd-skill#2912 (round 2, extended round 3): collected
+  // over EVERY qualifying comment (not deduplicated by
+  // `seenAutoWaiverRunIds`, which exists only to bound the number of
+  // Actions-API lookups), each paired with its own comment `id` AND
+  // (round 3) a SHA-256 digest of its own live body --
+  // `verifySelfReferentialBootstrapWaiverArtifactBinding` needs the id
+  // to correlate a `.valid` evidence entry (which carries no id of its
+  // own) back to the specific live comment it came from, and the body
+  // digest to detect whether that specific comment's content has since
+  // been edited in place (round 2's id-only binding could not). See
+  // `AdvisoryConvergenceInputs.autoWaiverRunIdCandidates`'s own doc
   // comment for the full correlation contract.
   const autoWaiverRunIdCandidates = new Map<
     string,
-    { id: string; createdAt: string }[]
+    { id: string; createdAt: string; bodyDigest: string }[]
   >();
   for (const comment of comments) {
     const body = String(comment.body ?? '');
@@ -3508,13 +3598,22 @@ export function collectFromGitHub(
         .trim()
         .toLowerCase() === prHeadSha
     ) {
-      // kurone-kito/idd-skill#2912 (round 2): every qualifying comment's
-      // own `id`/`createdAt` pair is recorded against its cited run id,
-      // regardless of whether this is the first (lookup-triggering)
-      // sighting. Appended via `.push`, not a spread-rebuild, so this
-      // stays linear in the comment count (Copilot review, PR #2914).
+      // kurone-kito/idd-skill#2912 (round 2, extended round 3): every
+      // qualifying comment's own `id`/`createdAt`/`bodyDigest` triple is
+      // recorded against its cited run id, regardless of whether this is
+      // the first (lookup-triggering) sighting. Appended via `.push`,
+      // not a spread-rebuild, so this stays linear in the comment count
+      // (Copilot review, PR #2914). `digestExternalCheckWaiverMarkerBody`
+      // hashes `body` verbatim -- the exact string this scan already read
+      // from the live comment -- never a locally-reconstructed one, the
+      // same API-returned-body-on-both-sides contract that function's
+      // own doc comment requires.
       const candidateList = autoWaiverRunIdCandidates.get(parsed.runId);
-      const candidate = { id: String(comment.id ?? ''), createdAt };
+      const candidate = {
+        id: String(comment.id ?? ''),
+        createdAt,
+        bodyDigest: digestExternalCheckWaiverMarkerBody(body),
+      };
       if (candidateList) {
         candidateList.push(candidate);
       } else {
@@ -3609,43 +3708,48 @@ export function collectFromGitHub(
     }
   }
 
-  // kurone-kito/idd-skill#2912 (round 2): a THIRD per-run-id lookup
-  // sharing the exact same `autoWaiverRunIds` budget as the two above
-  // (so worst case triples the lookup call count, still bounded by
-  // `MAX_AUTO_WAIVER_RUN_LOOKUPS`) -- recovers the SET of comment ids
-  // the cited run's own trusted job execution recorded posting, via the
-  // artifact-name convention `SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX`
-  // documents. See `AdvisoryConvergenceInputs.autoWaiverRunArtifactCommentIds`'s
-  // own doc comment for why this closes a gap the run-metadata and
+  // kurone-kito/idd-skill#2912 (round 2, extended round 3): a THIRD
+  // per-run-id lookup sharing the exact same `autoWaiverRunIds` budget
+  // as the two above (so worst case triples the lookup call count,
+  // still bounded by `MAX_AUTO_WAIVER_RUN_LOOKUPS`) -- recovers the SET
+  // of `(comment id, body digest)` bindings the cited run's own trusted
+  // job execution recorded posting, via the artifact-name convention
+  // `SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX` documents (round 3
+  // extended that convention with a trailing `-<body-digest>` segment).
+  // See `AdvisoryConvergenceInputs.autoWaiverRunArtifactBindings`'s own
+  // doc comment for why this closes a gap the run-metadata and
   // job-provenance lookups above cannot.
   const autoWaiverArtifactNamePattern = new RegExp(
-    `^${SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX}([1-9][0-9]*)$`,
+    `^${SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX}([1-9][0-9]*)-([0-9a-f]{64})$`,
   );
-  const autoWaiverRunArtifactCommentIds: NonNullable<
-    AdvisoryConvergenceInputs['autoWaiverRunArtifactCommentIds']
+  const autoWaiverRunArtifactBindings: NonNullable<
+    AdvisoryConvergenceInputs['autoWaiverRunArtifactBindings']
   > = {};
   for (const runId of autoWaiverRunIds) {
     try {
       const raw = port.listWorkflowRunArtifacts(owner, repo, runId) as {
         artifacts?: { name?: string | null }[] | null;
       };
-      const ids: string[] = [];
+      const bindings: { id: string; bodyDigest: string }[] = [];
       for (const artifact of raw?.artifacts ?? []) {
         const match = autoWaiverArtifactNamePattern.exec(
           String(artifact?.name ?? ''),
         );
         if (match) {
-          ids.push(match[1] as string);
+          bindings.push({
+            id: match[1] as string,
+            bodyDigest: match[2] as string,
+          });
         }
       }
-      autoWaiverRunArtifactCommentIds[runId] = ids;
+      autoWaiverRunArtifactBindings[runId] = bindings;
     } catch {
       // Fail closed per run id, mirroring the two lookups above: a
       // lookup failure must never crash the whole collection, and an
-      // empty trusted-id set already means "nothing trusted" to
+      // empty trusted-binding set already means "nothing trusted" to
       // `verifySelfReferentialBootstrapWaiverArtifactBinding` -- no
       // separate `{error}` union variant is needed here.
-      autoWaiverRunArtifactCommentIds[runId] = [];
+      autoWaiverRunArtifactBindings[runId] = [];
     }
   }
 
@@ -3688,7 +3792,7 @@ export function collectFromGitHub(
       autoWaiverRunLookups,
       autoWaiverRunJobLookups,
       autoWaiverRunIdCandidates: Object.fromEntries(autoWaiverRunIdCandidates),
-      autoWaiverRunArtifactCommentIds,
+      autoWaiverRunArtifactBindings,
       changedFilePaths,
     },
     options: {

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -253,11 +253,12 @@ export const ADVISORY_CONVERGENCE_CHECK_SELECTOR =
  * A bug specifically WITHIN the code that decides whether/how to invoke
  * `--auto-bootstrap` (`runExternalCheckWaiver`'s own auto-bootstrap
  * branches and `planExternalCheckWaiver`'s `autoBootstrap`-gated
- * checks, both in `external-check-waiver.mts`), the two Actions-API
+ * checks, both in `external-check-waiver.mts`), the three Actions-API
  * methods the trust chain itself calls (`getWorkflowRun`,
- * `listChangeRequestChangedFiles` in `provider-adapter-github.mts`), or
- * this file's own verification functions
- * ({@link verifySelfReferentialBootstrapWaiverRun},
+ * `getWorkflowRunJobs`, `listChangeRequestChangedFiles` in
+ * `provider-adapter-github.mts`), or this file's own verification
+ * functions ({@link verifySelfReferentialBootstrapWaiverRun},
+ * {@link verifySelfReferentialBootstrapWaiverProvenance},
  * {@link resolveSelfReferentialTriggerFiles}, `autoWaiverValid`) cannot
  * be rescued by THIS mechanism, because the OLD, buggy version of
  * exactly that code is what would have to decide to trust the fix --
@@ -276,31 +277,76 @@ export const ADVISORY_CONVERGENCE_CHECK_SELECTOR =
  *
  * kurone-kito/idd-skill#2657 (Codex review, PR #2895, round 16): a
  * SEPARATE, narrower residual gap in {@link verifySelfReferentialBootstrapWaiverRun}
- * itself, tracked rather than closed here -- its `run-id:` check proves
- * only that the CITED run has the right path/head-sha/repository/event,
- * never that the cited run is the one that actually POSTED this
- * specific comment. A same-repository `pull_request`-triggered
- * workflow with `issues: write` (the same actor this file's own
- * comments already assume can post arbitrary `github-actions[bot]`-
- * authored comments) can discover a legitimate, concurrently running
- * `pull_request_target` run of THIS workflow for its own PR and cite
- * that run's id in a forged marker -- the run-id is bearer evidence,
- * not provenance-bound. This does NOT widen what such a forgery can
- * actually waive, though: `touchesSelfReferentialAllowlist` is fetched
- * independently from the PR's own live file-changes API, never from
- * the comment, so a forged marker can only cause a PR that genuinely
- * touches the allowlist to get its (otherwise-legitimate) waiver via
- * forgery instead of via the real job -- the allowlist check remains
- * the load-bearing security boundary. The one CONCRETE exploit this
- * bearer-evidence gap enabled -- a forged `claim-id:none` marker
+ * itself -- its `run-id:` check proves only that the CITED run has the
+ * right path/head-sha/repository/event, never that the cited run is the
+ * one that actually POSTED this specific comment. A same-repository
+ * `pull_request`-triggered workflow with `issues: write` (the same actor
+ * this file's own comments already assume can post arbitrary
+ * `github-actions[bot]`-authored comments) can discover a legitimate,
+ * concurrently running `pull_request_target` run of THIS workflow for
+ * its own PR and cite that run's id in a forged marker -- the run-id is
+ * bearer evidence, not provenance-bound. This does NOT widen what such a
+ * forgery can actually waive, though: `touchesSelfReferentialAllowlist`
+ * is fetched independently from the PR's own live file-changes API,
+ * never from the comment, so a forged marker can only cause a PR that
+ * genuinely touches the allowlist to get its (otherwise-legitimate)
+ * waiver via forgery instead of via the real job -- the allowlist check
+ * remains the load-bearing security boundary. The one CONCRETE exploit
+ * this bearer-evidence gap enabled -- a forged `claim-id:none` marker
  * validating on a PR whose closing issues expose ambiguous, multiple
  * active claims, a state the posting helper itself always refuses to
- * post ANY marker for -- is closed directly in `autoWaiverValid`'s own
- * `claimCandidateAmbiguous` check below. Full provenance binding
- * (proving WHICH run posted a given comment, not just that some
- * qualifying run exists) needs new I/O this pure verdict function does
- * not have (the run's own job/log data) and is out of scope for a
- * live-review patch; tracked in a follow-up issue. */
+ * post ANY marker for -- was closed directly in `autoWaiverValid`'s own
+ * `claimCandidateAmbiguous` check below.
+ *
+ * kurone-kito/idd-skill#2912: the general provenance-binding gap the
+ * paragraph above described is now closed too, by
+ * {@link verifySelfReferentialBootstrapWaiverProvenance} plus the
+ * `autoWaiverRunIdCandidateTimestamps` duplicate-run-id check
+ * `autoWaiverValid` also applies. Together they prove the cited run's
+ * own `idd-advisory-convergence-self-waiver` job actually executed the
+ * step that posts this waiver kind, at (within a few seconds of) the
+ * exact moment this specific comment was created, and that no OTHER
+ * candidate marker citing the same run id ALSO independently proves
+ * that -- rather than trusting that SOME qualifying run merely exists.
+ * Uniqueness is deliberately scoped to provenance-PASSING candidates
+ * only (not every structurally-qualifying one): the Actions jobs API
+ * reports only the LATEST run attempt, so a legitimate re-run (`gh run
+ * rerun <run-id>`, this repository's own standard automated recovery
+ * path for a stuck `idd-advisory-convergence` instance,
+ * `rerun-advisory-convergence.mts`) that re-executes an already-
+ * succeeded self-waiver job produces a second GENUINE marker for the
+ * same run id, whose earlier sibling from the prior attempt no longer
+ * falls inside the current attempt's execution window and so fails
+ * provenance on its own, never reaching the uniqueness tally -- this
+ * keeps self-bootstrap working across a legitimate rerun instead of
+ * treating it as a forgery collision. A same-window race between a
+ * genuine marker and a forged one both citing the same run id, by
+ * contrast, still has both pass provenance and both get rejected -- the
+ * security property holds regardless. An attacker can still cause this
+ * mechanism to fail closed (denial of service on the optimization, e.g.
+ * by winning that race), but can no longer make a forged marker
+ * validate on its own; the pre-existing maintainer-authorized waiver
+ * remains the documented escape hatch either way.
+ *
+ * Precondition on "the cited job's step conclusion is `success`"
+ * actually implying it posted a marker: `runExternalCheckWaiver`'s own
+ * `--auto-bootstrap` path can report step-level `success` on a
+ * deliberate no-op skip (never posting) when
+ * `ciGate.externalCheckWaivers.mode` is not `maintainer-authorized` or
+ * the selector is not registered under
+ * `ciGate.externalChecks.waivable` (`external-check-waiver.mts`'s
+ * `benignAutoBootstrapSkipReasons` set). This is self-consistent by
+ * construction, not a separate gap to close: `summarizeExternalCheckWaivers`
+ * gates `.valid` classification on that exact same
+ * `mode`/`waivableSelectors` policy, read from the same trusted
+ * checkout at consume time -- when the benign-skip path is reachable,
+ * no self-referential-bootstrap-auto marker (genuine or forged) ever
+ * reaches `.valid` for `autoWaiverValid`'s `.some()` to iterate in the
+ * first place, so the step-success-without-posting case never actually
+ * gets evaluated for provenance. Still worth stating explicitly, since
+ * an adopter who reads only this file's own trust chain (not
+ * `external-check-waiver.mts`'s posting-side logic too) could otherwise
+ * read "step succeeded" as an unconditional proof of posting. */
 export const SELF_REFERENTIAL_WAIVER_TRIGGER_FILES = [
   'src/scripts/advisory-convergence.mts',
   'src/scripts/advisory-wait-state.mts',
@@ -810,6 +856,66 @@ export interface AdvisoryConvergenceInputs {
       }
     | { error: string }
   >;
+  /** kurone-kito/idd-skill#2912: pre-resolved `GET
+   * /repos/{owner}/{repo}/actions/runs/{run-id}/jobs` evidence for the
+   * SAME run ids `autoWaiverRunLookups` above resolves, narrowed at
+   * collect time to the one job/step this consumer cares about: the
+   * cited run's own `idd-advisory-convergence-self-waiver` job's "Post
+   * the self-referential-bootstrap-auto waiver" step. `autoWaiverRunLookups`
+   * alone proves the cited run has the right path/head-sha/repository/
+   * event shape; it does NOT prove that run's own job actually executed
+   * the step that posts this waiver kind -- a marker forged by an
+   * unrelated same-repository `pull_request`-triggered workflow can cite
+   * a real run's id and pass every run-level condition without having
+   * been posted by that run's own job at all. `collectFromGitHub` fetches
+   * this (network, same `MAX_AUTO_WAIVER_RUN_LOOKUPS`-bounded run-id set);
+   * this pure verdict function only reads it -- an absent key, an
+   * `{error}` entry, a non-`success` `conclusion`, or a missing/invalid
+   * `startedAt`/`completedAt` window all fail closed to "not proven",
+   * never a pass. See {@link verifySelfReferentialBootstrapWaiverProvenance}. */
+  autoWaiverRunJobLookups?: Record<
+    string,
+    | {
+        conclusion?: string | null;
+        startedAt?: string | null;
+        completedAt?: string | null;
+      }
+    | { error: string }
+  >;
+  /** kurone-kito/idd-skill#2912: the `createdAt` of every DISTINCT
+   * candidate `self-referential-bootstrap-auto` marker (bot-authored,
+   * exact reason token, exact check selector, a canonical
+   * positive-integer `run-id:`, HEAD matching this PR's current HEAD)
+   * found citing a given run id, collected over the FULL, unfiltered
+   * comment set -- deliberately not `autoWaiverEvidence.valid`'s own
+   * post-expiry/claim-binding filtering, which could let a genuine
+   * marker drop out (expired) while a freshly-forged marker citing the
+   * SAME run id remains `.valid`, defeating duplicate detection exactly
+   * when it matters. `collectFromGitHub` derives this for free from the
+   * same comment scan that already builds the bounded run-id lookup set
+   * (no extra network call).
+   *
+   * `autoWaiverValid` below counts how many of a cited run id's entries
+   * ALSO independently pass {@link verifySelfReferentialBootstrapWaiverProvenance}
+   * against that same run's job-lookup window -- not a bare count of
+   * every structurally-qualifying candidate. This distinction matters
+   * for a re-run: `gh run rerun <run-id>` (this repository's own
+   * standard automated recovery path for a stuck `idd-advisory-
+   * convergence` instance, `rerun-advisory-convergence.mts`) re-executes
+   * every job under the SAME run id, including a self-waiver job that
+   * already posted a genuine marker on attempt 1 -- producing a second,
+   * equally genuine marker for the same run id on attempt 2. Since the
+   * jobs-API lookup reports only the LATEST attempt, attempt 1's marker
+   * no longer falls within attempt 2's `[startedAt, completedAt]`
+   * window and fails provenance on its own -- it never counts toward
+   * the uniqueness tally, so attempt 2's marker still validates alone.
+   * A forged marker racing to land inside the SAME window as a genuine
+   * one, by contrast, passes provenance just as the genuine one does,
+   * so both count and both are rejected -- the security property this
+   * mechanism exists for holds regardless. Exactly one
+   * provenance-passing candidate for a cited run id is required for
+   * that marker to ever validate. */
+  autoWaiverRunIdCandidateTimestamps?: Record<string, string[]>;
   /** kurone-kito/idd-skill#2657 (Codex review, PR #2895): the PR's own
    * changed file paths, fetched by `collectFromGitHub` only when at
    * least one candidate self-referential-bootstrap-auto marker exists
@@ -1061,6 +1167,82 @@ function verifySelfReferentialBootstrapWaiverRun(
       expected.repositoryFullName.toLowerCase() &&
     run.event === 'pull_request_target'
   );
+}
+
+/** kurone-kito/idd-skill#2912: this gate's own self-waiver job id, as
+ * reported by the GitHub Actions jobs API's `name` field (no `name:`
+ * override in the workflow, so the reported name is literally the job
+ * id) -- the job {@link verifySelfReferentialBootstrapWaiverProvenance}
+ * requires proof of execution from. Declared as its own explicit
+ * literal, mirroring {@link ADVISORY_CONVERGENCE_WORKFLOW_PATH}'s own
+ * "kept in sync by hand with the YAML" convention; a dedicated test
+ * pins both this and {@link SELF_REFERENTIAL_WAIVER_POST_STEP_NAME}
+ * against the workflow file's own literal text. */
+export const SELF_REFERENTIAL_WAIVER_JOB_ID =
+  'idd-advisory-convergence-self-waiver';
+
+/** kurone-kito/idd-skill#2912: the exact `name:` of the step, within
+ * {@link SELF_REFERENTIAL_WAIVER_JOB_ID}, that actually posts a
+ * self-referential-bootstrap-auto marker -- kept in sync by hand with
+ * `.github/workflows/idd-advisory-convergence.yml`'s own "Post the
+ * self-referential-bootstrap-auto waiver" step, the same convention as
+ * {@link SELF_REFERENTIAL_WAIVER_JOB_ID} above. */
+export const SELF_REFERENTIAL_WAIVER_POST_STEP_NAME =
+  'Post the self-referential-bootstrap-auto waiver';
+
+/**
+ * kurone-kito/idd-skill#2912: whether the cited run's own jobs-API
+ * evidence proves its {@link SELF_REFERENTIAL_WAIVER_JOB_ID} job actually
+ * completed {@link SELF_REFERENTIAL_WAIVER_POST_STEP_NAME}, rather than
+ * merely having the right run-level shape
+ * ({@link verifySelfReferentialBootstrapWaiverRun}'s own job). This is
+ * the binding step that closes the residual gap the module header notes
+ * (#2657, round 16): a run whose own path/head-sha/repository/event all
+ * check out does not by itself prove THAT run's own job posted THIS
+ * specific comment -- a same-repository `pull_request`-triggered
+ * workflow can discover a legitimate run's id via the public Actions API
+ * and cite it in a forged marker. Requiring the post step's own
+ * `conclusion: 'success'` AND that the marker's own `createdAt` falls
+ * within that step's `[startedAt, completedAt]` execution window makes
+ * this practically unforgeable: a forged marker would need the cited
+ * run's post step to have actually run and succeeded at almost exactly
+ * the moment the forged comment was created, which only the run's own
+ * job -- not an unrelated, concurrently-running one -- controls. Pure
+ * and fail-closed, matching {@link verifySelfReferentialBootstrapWaiverRun}'s
+ * own contract: an absent/errored lookup, a non-`success` conclusion, or
+ * a missing/unparseable window is always `false`, never a thrown
+ * exception. */
+function verifySelfReferentialBootstrapWaiverProvenance(
+  jobLookup:
+    | {
+        conclusion?: string | null;
+        startedAt?: string | null;
+        completedAt?: string | null;
+      }
+    | { error: string }
+    | null
+    | undefined,
+  markerCreatedAt: string,
+): boolean {
+  if (!jobLookup || 'error' in jobLookup) {
+    return false;
+  }
+  if (jobLookup.conclusion !== 'success') {
+    return false;
+  }
+  const startedAt = String(jobLookup.startedAt ?? '');
+  const completedAt = String(jobLookup.completedAt ?? '');
+  if (
+    !isValidIsoTimestamp(markerCreatedAt) ||
+    !isValidIsoTimestamp(startedAt) ||
+    !isValidIsoTimestamp(completedAt)
+  ) {
+    return false;
+  }
+  const markerMs = Date.parse(markerCreatedAt);
+  const startedMs = Date.parse(startedAt);
+  const completedMs = Date.parse(completedAt);
+  return markerMs >= startedMs && markerMs <= completedMs;
 }
 
 /**
@@ -1882,12 +2064,16 @@ export function computeAdvisoryConvergenceVerdict(
   // `selectLinkedIssueCandidate` (`external-check-waiver.mts`) refuses
   // to auto-post a marker for in the first place. Without this, a
   // forged `claim-id:none` marker citing a legitimate, concurrently
-  // running `pull_request_target` run's id (the run-id check verifies
-  // only that CITED run's own metadata, not that it actually posted
-  // this comment -- a separate, tracked gap, see the module header's
-  // dead-zone note) could validate on such a PR even though the
-  // legitimate posting helper would have refused to post ANY marker
-  // for it. `claimCandidateAmbiguous` is the SAME signal the producer
+  // running `pull_request_target` run's id (the run-id check alone
+  // verifies only that CITED run's own metadata, not that it actually
+  // posted this comment -- the general form of that gap is closed by
+  // `verifySelfReferentialBootstrapWaiverProvenance` and the
+  // duplicate-run-id check below, kurone-kito/idd-skill#2912; this
+  // `claimCandidateAmbiguous` guard is independent defense-in-depth for
+  // the SPECIFIC claim-ambiguity shape, not a substitute for either)
+  // could validate on such a PR even though the legitimate posting
+  // helper would have refused to post ANY marker for it.
+  // `claimCandidateAmbiguous` is the SAME signal the producer
   // uses (`classifyClaimCandidateAmbiguity`), independent of
   // `convergenceScope`, so gate on it directly here too rather than
   // only through the scope-specific check above.
@@ -1909,7 +2095,36 @@ export function computeAdvisoryConvergenceVerdict(
             headSha: prHeadSha,
             repositoryFullName: autoWaiverRepositoryFullName,
           },
-        ),
+        ) &&
+        // kurone-kito/idd-skill#2912: prove the cited run's OWN job
+        // posted THIS comment, not merely that some run with the right
+        // shape exists -- see `verifySelfReferentialBootstrapWaiverProvenance`'s
+        // own doc comment for the gap this closes.
+        verifySelfReferentialBootstrapWaiverProvenance(
+          inputs.autoWaiverRunJobLookups?.[entry.runId],
+          entry.createdAt,
+        ) &&
+        // kurone-kito/idd-skill#2912: exactly one candidate marker
+        // citing this run id may ALSO independently pass the same
+        // provenance check above -- see
+        // `autoWaiverRunIdCandidateTimestamps`'s own doc comment for
+        // why this is scoped to provenance-PASSING candidates only
+        // (never a bare structural count), which is what lets a
+        // legitimate CI rerun (a second genuine marker for the same
+        // run id, whose earlier sibling now falls outside the latest
+        // attempt's window and so fails provenance on its own) keep
+        // validating instead of being treated as a forgery collision.
+        // Two or more candidates BOTH passing provenance (a forged
+        // marker racing a genuine one inside the same execution
+        // window) fails closed to "no auto-waiver", never picks a
+        // winner.
+        (inputs.autoWaiverRunIdCandidateTimestamps?.[entry.runId] ?? []).filter(
+          (createdAt) =>
+            verifySelfReferentialBootstrapWaiverProvenance(
+              inputs.autoWaiverRunJobLookups?.[entry.runId],
+              createdAt,
+            ),
+        ).length === 1,
     );
 
   const waiver: AdvisoryConvergenceWaiver = {
@@ -3088,9 +3303,27 @@ export function collectFromGitHub(
   // making a reliable crowd-out require posting dozens of distinct
   // spam comments on the PR -- conspicuous, and itself rate-limited by
   // GitHub's own comment-creation API, unlike an unbounded lookup loop.
+  // kurone-kito/idd-skill#2912: this same bound now also caps a SECOND
+  // lookup per run id (`getWorkflowRunJobs`, for
+  // `verifySelfReferentialBootstrapWaiverProvenance`), so worst-case
+  // cost is up to 2 * MAX_AUTO_WAIVER_RUN_LOOKUPS Actions-API calls, not
+  // a new, separately-bounded budget of its own.
   const MAX_AUTO_WAIVER_RUN_LOOKUPS = 20;
   const autoWaiverCandidates: { runId: string; createdAt: string }[] = [];
   const seenAutoWaiverRunIds = new Set<string>();
+  // kurone-kito/idd-skill#2912: collected over EVERY qualifying comment
+  // (not deduplicated by `seenAutoWaiverRunIds`, which exists only to
+  // bound the number of Actions-API lookups) -- `autoWaiverValid` below
+  // requires exactly one provenance-passing candidate per cited run id,
+  // so a second, forged marker sharing a legitimate run's id must still
+  // be recorded even though it triggers no additional lookup. Kept as
+  // `createdAt` timestamps, not a bare count, so the pure verdict
+  // function can independently re-check each candidate's own provenance
+  // against the run's (single, shared) jobs-API window -- see
+  // `AdvisoryConvergenceInputs.autoWaiverRunIdCandidateTimestamps`'s own
+  // doc comment for why a bare count would misclassify a legitimate CI
+  // rerun as a forgery collision.
+  const autoWaiverRunIdCandidateTimestamps = new Map<string, string[]>();
   for (const comment of comments) {
     const body = String(comment.body ?? '');
     if (!/^<!--\s*idd-external-check-waiver:/i.test(body)) {
@@ -3136,13 +3369,21 @@ export function collectFromGitHub(
       parsed.checkSelector === ADVISORY_CONVERGENCE_CHECK_SELECTOR &&
       parsed.runId &&
       parseCanonicalIntegerOrNull(parsed.runId) !== null &&
-      !seenAutoWaiverRunIds.has(parsed.runId) &&
       String(parsed.headSha ?? '')
         .trim()
         .toLowerCase() === prHeadSha
     ) {
-      seenAutoWaiverRunIds.add(parsed.runId);
-      autoWaiverCandidates.push({ runId: parsed.runId, createdAt });
+      // kurone-kito/idd-skill#2912: every qualifying comment's own
+      // `createdAt` is recorded against its cited run id, regardless of
+      // whether this is the first (lookup-triggering) sighting.
+      autoWaiverRunIdCandidateTimestamps.set(parsed.runId, [
+        ...(autoWaiverRunIdCandidateTimestamps.get(parsed.runId) ?? []),
+        createdAt,
+      ]);
+      if (!seenAutoWaiverRunIds.has(parsed.runId)) {
+        seenAutoWaiverRunIds.add(parsed.runId);
+        autoWaiverCandidates.push({ runId: parsed.runId, createdAt });
+      }
     }
   }
   const autoWaiverRunIds = new Set(
@@ -3174,6 +3415,55 @@ export function collectFromGitHub(
       // `verifySelfReferentialBootstrapWaiverRun` already treats an
       // `{error}` entry the same as an absent one -- always a rejection.
       autoWaiverRunLookups[runId] = {
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  // kurone-kito/idd-skill#2912: a second, per-run-id lookup sharing the
+  // exact same `autoWaiverRunIds` budget as the run-metadata lookup
+  // above (so worst case doubles the lookup call count, still bounded
+  // by `MAX_AUTO_WAIVER_RUN_LOOKUPS`) -- see
+  // `AdvisoryConvergenceInputs.autoWaiverRunJobLookups`'s own doc
+  // comment for why the run-metadata lookup alone is insufficient.
+  const autoWaiverRunJobLookups: NonNullable<
+    AdvisoryConvergenceInputs['autoWaiverRunJobLookups']
+  > = {};
+  for (const runId of autoWaiverRunIds) {
+    try {
+      const raw = port.getWorkflowRunJobs(owner, repo, runId) as {
+        jobs?:
+          | {
+              name?: string | null;
+              steps?:
+                | {
+                    name?: string | null;
+                    conclusion?: string | null;
+                    started_at?: string | null;
+                    completed_at?: string | null;
+                  }[]
+                | null;
+            }[]
+          | null;
+      };
+      const selfWaiverJob = (raw?.jobs ?? []).find(
+        (job) => job?.name === SELF_REFERENTIAL_WAIVER_JOB_ID,
+      );
+      const postStep = (selfWaiverJob?.steps ?? []).find(
+        (step) => step?.name === SELF_REFERENTIAL_WAIVER_POST_STEP_NAME,
+      );
+      autoWaiverRunJobLookups[runId] = {
+        conclusion: postStep?.conclusion ?? null,
+        startedAt: postStep?.started_at ?? null,
+        completedAt: postStep?.completed_at ?? null,
+      };
+    } catch (error) {
+      // Fail closed per run id, mirroring the run-metadata lookup above:
+      // a lookup failure must never crash the whole collection, and
+      // `verifySelfReferentialBootstrapWaiverProvenance` already treats
+      // an `{error}` entry the same as an absent one -- always a
+      // rejection.
+      autoWaiverRunJobLookups[runId] = {
         error: error instanceof Error ? error.message : String(error),
       };
     }
@@ -3216,6 +3506,10 @@ export function collectFromGitHub(
       claimCandidateAmbiguous,
       prAuthorIsBot,
       autoWaiverRunLookups,
+      autoWaiverRunJobLookups,
+      autoWaiverRunIdCandidateTimestamps: Object.fromEntries(
+        autoWaiverRunIdCandidateTimestamps,
+      ),
       changedFilePaths,
     },
     options: {

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -253,12 +253,14 @@ export const ADVISORY_CONVERGENCE_CHECK_SELECTOR =
  * A bug specifically WITHIN the code that decides whether/how to invoke
  * `--auto-bootstrap` (`runExternalCheckWaiver`'s own auto-bootstrap
  * branches and `planExternalCheckWaiver`'s `autoBootstrap`-gated
- * checks, both in `external-check-waiver.mts`), the three Actions-API
+ * checks, both in `external-check-waiver.mts`), the four Actions-API
  * methods the trust chain itself calls (`getWorkflowRun`,
- * `getWorkflowRunJobs`, `listChangeRequestChangedFiles` in
- * `provider-adapter-github.mts`), or this file's own verification
- * functions ({@link verifySelfReferentialBootstrapWaiverRun},
+ * `getWorkflowRunJobs`, `listWorkflowRunArtifacts`,
+ * `listChangeRequestChangedFiles` in `provider-adapter-github.mts`), or
+ * this file's own verification functions
+ * ({@link verifySelfReferentialBootstrapWaiverRun},
  * {@link verifySelfReferentialBootstrapWaiverProvenance},
+ * {@link verifySelfReferentialBootstrapWaiverArtifactBinding},
  * {@link resolveSelfReferentialTriggerFiles}, `autoWaiverValid`) cannot
  * be rescued by THIS mechanism, because the OLD, buggy version of
  * exactly that code is what would have to decide to trust the fix --
@@ -298,35 +300,56 @@ export const ADVISORY_CONVERGENCE_CHECK_SELECTOR =
  * post ANY marker for -- was closed directly in `autoWaiverValid`'s own
  * `claimCandidateAmbiguous` check below.
  *
- * kurone-kito/idd-skill#2912: the general provenance-binding gap the
- * paragraph above described is now closed too, by
- * {@link verifySelfReferentialBootstrapWaiverProvenance} plus the
- * `autoWaiverRunIdCandidateTimestamps` duplicate-run-id check
- * `autoWaiverValid` also applies. Together they prove the cited run's
- * own `idd-advisory-convergence-self-waiver` job actually executed the
- * step that posts this waiver kind, at (within a few seconds of) the
- * exact moment this specific comment was created, and that no OTHER
- * candidate marker citing the same run id ALSO independently proves
- * that -- rather than trusting that SOME qualifying run merely exists.
- * Uniqueness is deliberately scoped to provenance-PASSING candidates
- * only (not every structurally-qualifying one): the Actions jobs API
- * reports only the LATEST run attempt, so a legitimate re-run (`gh run
- * rerun <run-id>`, this repository's own standard automated recovery
- * path for a stuck `idd-advisory-convergence` instance,
- * `rerun-advisory-convergence.mts`) that re-executes an already-
- * succeeded self-waiver job produces a second GENUINE marker for the
- * same run id, whose earlier sibling from the prior attempt no longer
- * falls inside the current attempt's execution window and so fails
- * provenance on its own, never reaching the uniqueness tally -- this
- * keeps self-bootstrap working across a legitimate rerun instead of
- * treating it as a forgery collision. A same-window race between a
- * genuine marker and a forged one both citing the same run id, by
- * contrast, still has both pass provenance and both get rejected -- the
- * security property holds regardless. An attacker can still cause this
- * mechanism to fail closed (denial of service on the optimization, e.g.
- * by winning that race), but can no longer make a forged marker
- * validate on its own; the pre-existing maintainer-authorized waiver
- * remains the documented escape hatch either way.
+ * kurone-kito/idd-skill#2912 (round 1): the general provenance-binding
+ * gap the paragraph above described was first closed by
+ * {@link verifySelfReferentialBootstrapWaiverProvenance} (proving the
+ * cited run's own job actually executed the posting step, within a few
+ * seconds of this specific comment's `createdAt`) paired with a
+ * duplicate-run-id uniqueness check: no OTHER candidate marker citing
+ * the same run id may ALSO independently pass that same provenance
+ * check, scoped to provenance-PASSING candidates only so a legitimate
+ * `gh run rerun <run-id>` (this repository's own standard automated
+ * recovery path for a stuck `idd-advisory-convergence` instance,
+ * `rerun-advisory-convergence.mts`) keeps working: its second, equally
+ * genuine marker no longer shares the first attempt's window, so the
+ * stale sibling fails provenance on its own rather than being
+ * misclassified as a forgery collision.
+ *
+ * kurone-kito/idd-skill#2912 (round 2): that round-1 uniqueness check
+ * had its own gap -- it trusted "no OTHER candidate is CURRENTLY
+ * VISIBLE", a property an attacker with `issues: write` can falsify
+ * after the fact by deleting the genuine marker once it posts (that
+ * scope permits deleting ANY issue comment on the repository, not only
+ * ones the deleting token itself authored), leaving a forged sibling as
+ * the sole survivor of the next scan (independently found by both the
+ * Codex and Copilot reviews of PR #2914). {@link verifySelfReferentialBootstrapWaiverArtifactBinding}
+ * replaces the visibility-based uniqueness check with a positive-binding
+ * one: the cited run's own trusted job execution now uploads a
+ * run-scoped Actions artifact naming the exact comment id it posted
+ * ({@link SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX}), and a marker
+ * only validates when it IS that exact, artifact-named comment.
+ * Artifacts are scoped to the run that uploaded them by the Actions
+ * runtime's own dedicated upload token, never by the shared
+ * `GITHUB_TOKEN` `permissions:` surface comments (and check runs, which
+ * share the same "any same-repository workflow can mutate them"
+ * exposure) are created and mutated through, so no unrelated run can
+ * add, edit, or remove an entry from that trusted set regardless of
+ * which `permissions:` it self-grants. Deleting the genuine comment now
+ * only removes it from the LIVE candidate scan the correlation step
+ * needs -- degrading this mechanism to "no auto-waiver" (fail closed),
+ * never "the forged one wins". {@link verifySelfReferentialBootstrapWaiverProvenance}'s
+ * window check remains in place as defense in depth (and still does the
+ * rerun-disambiguation work described above); the round-1 duplicate-
+ * timestamp-count mechanism it used to pair with has been removed
+ * entirely, subsumed by the strictly stronger artifact binding. The one
+ * residual this round does NOT close: an attacker who additionally
+ * self-grants the broader, repository-wide `actions: write` permission
+ * could delete the genuine run's artifact through Actions' own
+ * artifact-management endpoint -- still only "no auto-waiver", never a
+ * forged one, and outside the `issues: write`-scoped threat model both
+ * findings (and this fix) are framed against. The pre-existing
+ * maintainer-authorized waiver remains the documented escape hatch
+ * either way.
  *
  * Precondition on "the cited job's step conclusion is `success`"
  * actually implying it posted a marker: `runExternalCheckWaiver`'s own
@@ -882,40 +905,57 @@ export interface AdvisoryConvergenceInputs {
       }
     | { error: string }
   >;
-  /** kurone-kito/idd-skill#2912: the `createdAt` of every DISTINCT
-   * candidate `self-referential-bootstrap-auto` marker (bot-authored,
-   * exact reason token, exact check selector, a canonical
-   * positive-integer `run-id:`, HEAD matching this PR's current HEAD)
-   * found citing a given run id, collected over the FULL, unfiltered
-   * comment set -- deliberately not `autoWaiverEvidence.valid`'s own
-   * post-expiry/claim-binding filtering, which could let a genuine
-   * marker drop out (expired) while a freshly-forged marker citing the
-   * SAME run id remains `.valid`, defeating duplicate detection exactly
-   * when it matters. `collectFromGitHub` derives this for free from the
-   * same comment scan that already builds the bounded run-id lookup set
-   * (no extra network call).
-   *
-   * `autoWaiverValid` below counts how many of a cited run id's entries
-   * ALSO independently pass {@link verifySelfReferentialBootstrapWaiverProvenance}
-   * against that same run's job-lookup window -- not a bare count of
-   * every structurally-qualifying candidate. This distinction matters
-   * for a re-run: `gh run rerun <run-id>` (this repository's own
-   * standard automated recovery path for a stuck `idd-advisory-
-   * convergence` instance, `rerun-advisory-convergence.mts`) re-executes
-   * every job under the SAME run id, including a self-waiver job that
-   * already posted a genuine marker on attempt 1 -- producing a second,
-   * equally genuine marker for the same run id on attempt 2. Since the
-   * jobs-API lookup reports only the LATEST attempt, attempt 1's marker
-   * no longer falls within attempt 2's `[startedAt, completedAt]`
-   * window and fails provenance on its own -- it never counts toward
-   * the uniqueness tally, so attempt 2's marker still validates alone.
-   * A forged marker racing to land inside the SAME window as a genuine
-   * one, by contrast, passes provenance just as the genuine one does,
-   * so both count and both are rejected -- the security property this
-   * mechanism exists for holds regardless. Exactly one
-   * provenance-passing candidate for a cited run id is required for
-   * that marker to ever validate. */
-  autoWaiverRunIdCandidateTimestamps?: Record<string, string[]>;
+  /** kurone-kito/idd-skill#2912 (round 2): every DISTINCT candidate
+   * `self-referential-bootstrap-auto` marker (bot-authored, exact reason
+   * token, exact check selector, a canonical positive-integer
+   * `run-id:`, HEAD matching this PR's current HEAD) found citing a
+   * given run id, paired with its own comment `id` and `createdAt`,
+   * collected over the FULL, unfiltered comment set -- deliberately not
+   * `autoWaiverEvidence.valid`'s own post-expiry/claim-binding
+   * filtering, which could let a genuine marker drop out (expired)
+   * while a freshly-forged marker citing the SAME run id remains
+   * `.valid`. `collectFromGitHub` derives this for free from the same
+   * comment scan that already builds the bounded run-id lookup set (no
+   * extra network call). Read by
+   * {@link verifySelfReferentialBootstrapWaiverArtifactBinding} to
+   * correlate a `.valid` entry (which carries no comment `id` of its
+   * own) back to the specific live comment it came from, by matching
+   * `createdAt` -- ambiguous when two DISTINCT comments citing the same
+   * run id share the same wall-clock second, which fails closed for
+   * BOTH rather than guessing (see that function's own doc comment). */
+  autoWaiverRunIdCandidates?: Record<
+    string,
+    { id: string; createdAt: string }[]
+  >;
+  /** kurone-kito/idd-skill#2912 (round 2): the SET of issue-comment ids
+   * a cited run id's own trusted `idd-advisory-convergence-self-waiver`
+   * job execution recorded actually posting, recovered from the `name`
+   * of every `idd-self-waiver-marker-<comment-id>`-prefixed Actions
+   * artifact that run uploaded (see
+   * {@link SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX}). More than one
+   * id is expected, not anomalous, across a legitimate `gh run rerun`:
+   * each attempt uploads its own artifact rather than replacing the
+   * prior one, so the trusted set only grows: the provenance/window
+   * check (`autoWaiverRunJobLookups` above) still disambiguates which
+   * ONE of those ids belongs to the LATEST attempt. `collectFromGitHub`
+   * fetches this (network, same `MAX_AUTO_WAIVER_RUN_LOOKUPS`-bounded
+   * run-id set); this pure verdict function only reads it -- a lookup
+   * failure or an absent/empty set both fail closed to "nothing
+   * trusted", never a pass. This is the binding condition that replaces
+   * this file's PRIOR "no duplicate candidate currently visible"
+   * uniqueness check (kurone-kito/idd-skill#2912, round 1): a bare
+   * count over the currently-visible comment set is defeated by an
+   * attacker who posts a forged sibling and then DELETES the genuine
+   * marker before this consumer ever runs (`issues: write`, the same
+   * scope this file's own comments already assume such an attacker
+   * has, permits deleting ANY issue comment on the repository, not only
+   * ones the deleting token itself authored) -- leaving the forged
+   * marker as the sole survivor of the scan. See
+   * {@link verifySelfReferentialBootstrapWaiverArtifactBinding}'s own
+   * doc comment for the full exploit and why a run-scoped Actions
+   * artifact (created through a token the shared `GITHUB_TOKEN`
+   * `permissions:` surface cannot reach) closes it. */
+  autoWaiverRunArtifactCommentIds?: Record<string, string[]>;
   /** kurone-kito/idd-skill#2657 (Codex review, PR #2895): the PR's own
    * changed file paths, fetched by `collectFromGitHub` only when at
    * least one candidate self-referential-bootstrap-auto marker exists
@@ -1243,6 +1283,106 @@ function verifySelfReferentialBootstrapWaiverProvenance(
   const startedMs = Date.parse(startedAt);
   const completedMs = Date.parse(completedAt);
   return markerMs >= startedMs && markerMs <= completedMs;
+}
+
+/** kurone-kito/idd-skill#2912 (round 2): the fixed prefix of the Actions
+ * artifact name {@link SELF_REFERENTIAL_WAIVER_JOB_ID}'s own posting job
+ * uploads immediately after successfully posting a
+ * `self-referential-bootstrap-auto` marker, followed by the posted
+ * comment's own decimal `id` (e.g. `idd-self-waiver-marker-123456789`).
+ * The id lives in the artifact's NAME, never its content, so recovering
+ * it costs one `list artifacts` JSON call per cited run id -- no zip
+ * download/extraction is needed. Kept in sync by hand with
+ * `.github/workflows/idd-advisory-convergence.yml`'s own "Upload the
+ * posted marker's provenance artifact" step (the `with: name:` value
+ * there, not the preceding "Record the posted marker's provenance" step
+ * that only stages the local file `actions/upload-artifact` reads), the
+ * same convention {@link SELF_REFERENTIAL_WAIVER_JOB_ID} and
+ * {@link SELF_REFERENTIAL_WAIVER_POST_STEP_NAME} already follow; a
+ * dedicated test pins all three against the workflow file's own literal
+ * text (both the repository-root copy and its `idd-template/` mirror). */
+export const SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX =
+  'idd-self-waiver-marker-';
+
+/**
+ * kurone-kito/idd-skill#2912 (round 2): whether the `.valid` marker
+ * `entry` under evaluation is one the cited run id's own trusted
+ * {@link SELF_REFERENTIAL_WAIVER_JOB_ID} job execution actually recorded
+ * posting, via the run-scoped Actions artifact
+ * {@link SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX} describes. This
+ * is the binding step that closes a gap
+ * {@link verifySelfReferentialBootstrapWaiverProvenance} alone cannot:
+ * that check alone only proves the cited run's job succeeded and posted
+ * SOME comment within a tight time window, never THIS EXACT comment --
+ * a same-repository `pull_request`-triggered workflow (untrusted,
+ * PR-controlled code, `issues: write`) can post a forged marker citing
+ * a legitimate, concurrently-running `pull_request_target` run's id
+ * inside that same window, wait for the genuine marker to post, and
+ * then DELETE it (`issues: write` permits deleting ANY issue comment on
+ * the repository, not only ones the deleting token itself authored) --
+ * leaving the forged marker as the sole survivor of a plain "no
+ * duplicate candidate currently visible" scan, which is exactly the
+ * property this file's PRIOR round-1 uniqueness check depended on
+ * (kurone-kito/idd-skill#2912, closed here).
+ *
+ * `entry` carries no comment `id` of its own (`ExternalCheckWaiverEvidence.valid`
+ * is a shared type many other callers use unchanged), so this
+ * correlates `entry.createdAt` back to `candidates` -- the SAME
+ * `{id, createdAt}` pairs `collectFromGitHub` derived from the identical
+ * raw comment scan that produced `entry` in the first place -- and
+ * requires the match to be UNIQUE: two distinct candidates sharing the
+ * same wall-clock second (a genuine marker and a same-window forged
+ * sibling) is ambiguous and fails closed for both, never guesses a
+ * winner. The uniquely-correlated candidate's `id` must then appear in
+ * `trustedCommentIds` -- the cited run's own artifact-recorded set.
+ *
+ * Because artifacts are scoped to the run that uploaded them by the
+ * Actions runtime's own dedicated upload token (never the shared
+ * `GITHUB_TOKEN` `permissions:` surface comments and check runs are
+ * both mutable through), no unrelated run -- however it scopes its own
+ * `permissions:` block -- can add, edit, or remove an entry from
+ * `trustedCommentIds`. A forged comment's `id` therefore never appears
+ * there regardless of timing or deletion tricks; deleting the GENUINE
+ * comment only removes it from `candidates` (a live re-fetch), which
+ * degrades this to "no correlated candidate -- fail closed", never "the
+ * forged one wins". The one residual: an attacker who additionally
+ * self-grants the broader, repository-wide `actions: write` permission
+ * (distinct from `issues: write`) could delete the genuine run's
+ * artifact through Actions' own artifact-management endpoint, which
+ * still only degrades to "no auto-waiver" (fail closed), never "a
+ * forged waiver validates" -- and is outside the `issues: write`-scoped
+ * threat model this fix (and the two independent review findings that
+ * prompted it) are both framed against.
+ *
+ * Pure and fail-closed like every other verification function in this
+ * file: an absent/empty `trustedCommentIds`, no unique correlated
+ * candidate, or a correlated candidate whose `id` is not in
+ * `trustedCommentIds` are all `false`, never a thrown exception.
+ */
+function verifySelfReferentialBootstrapWaiverArtifactBinding(
+  candidates: { id: string; createdAt: string }[] | undefined,
+  trustedCommentIds: string[] | undefined,
+  entryCreatedAt: string,
+): boolean {
+  const trusted = new Set(
+    (trustedCommentIds ?? [])
+      .map((id) => String(id ?? '').trim())
+      .filter((id) => id.length > 0),
+  );
+  if (trusted.size === 0) {
+    return false;
+  }
+  const matches = (candidates ?? []).filter(
+    (candidate) => candidate.createdAt === entryCreatedAt,
+  );
+  if (matches.length !== 1) {
+    // Zero: no live candidate at all for this exact timestamp (e.g. the
+    // genuine comment was deleted). More than one: two distinct comments
+    // citing the same run id share the same wall-clock second -- fail
+    // closed rather than guessing which one `entry` actually is.
+    return false;
+  }
+  return trusted.has(String(matches[0]?.id ?? '').trim());
 }
 
 /**
@@ -2067,9 +2207,10 @@ export function computeAdvisoryConvergenceVerdict(
   // running `pull_request_target` run's id (the run-id check alone
   // verifies only that CITED run's own metadata, not that it actually
   // posted this comment -- the general form of that gap is closed by
-  // `verifySelfReferentialBootstrapWaiverProvenance` and the
-  // duplicate-run-id check below, kurone-kito/idd-skill#2912; this
-  // `claimCandidateAmbiguous` guard is independent defense-in-depth for
+  // `verifySelfReferentialBootstrapWaiverProvenance` and
+  // `verifySelfReferentialBootstrapWaiverArtifactBinding` below,
+  // kurone-kito/idd-skill#2912; this `claimCandidateAmbiguous` guard is
+  // independent defense-in-depth for
   // the SPECIFIC claim-ambiguity shape, not a substitute for either)
   // could validate on such a PR even though the legitimate posting
   // helper would have refused to post ANY marker for it.
@@ -2104,27 +2245,20 @@ export function computeAdvisoryConvergenceVerdict(
           inputs.autoWaiverRunJobLookups?.[entry.runId],
           entry.createdAt,
         ) &&
-        // kurone-kito/idd-skill#2912: exactly one candidate marker
-        // citing this run id may ALSO independently pass the same
-        // provenance check above -- see
-        // `autoWaiverRunIdCandidateTimestamps`'s own doc comment for
-        // why this is scoped to provenance-PASSING candidates only
-        // (never a bare structural count), which is what lets a
-        // legitimate CI rerun (a second genuine marker for the same
-        // run id, whose earlier sibling now falls outside the latest
-        // attempt's window and so fails provenance on its own) keep
-        // validating instead of being treated as a forgery collision.
-        // Two or more candidates BOTH passing provenance (a forged
-        // marker racing a genuine one inside the same execution
-        // window) fails closed to "no auto-waiver", never picks a
-        // winner.
-        (inputs.autoWaiverRunIdCandidateTimestamps?.[entry.runId] ?? []).filter(
-          (createdAt) =>
-            verifySelfReferentialBootstrapWaiverProvenance(
-              inputs.autoWaiverRunJobLookups?.[entry.runId],
-              createdAt,
-            ),
-        ).length === 1,
+        // kurone-kito/idd-skill#2912 (round 2): prove the cited run's own
+        // trusted execution positively recorded posting THIS EXACT
+        // comment (via a run-scoped Actions artifact only that run's own
+        // upload token could have created), not merely that no OTHER
+        // candidate currently happens to be visible -- see
+        // `verifySelfReferentialBootstrapWaiverArtifactBinding`'s own
+        // doc comment for the comment-deletion forgery this replaces the
+        // file's prior round-1 "no duplicate visible" uniqueness check
+        // to close.
+        verifySelfReferentialBootstrapWaiverArtifactBinding(
+          inputs.autoWaiverRunIdCandidates?.[entry.runId],
+          inputs.autoWaiverRunArtifactCommentIds?.[entry.runId],
+          entry.createdAt,
+        ),
     );
 
   const waiver: AdvisoryConvergenceWaiver = {
@@ -3304,26 +3438,27 @@ export function collectFromGitHub(
   // spam comments on the PR -- conspicuous, and itself rate-limited by
   // GitHub's own comment-creation API, unlike an unbounded lookup loop.
   // kurone-kito/idd-skill#2912: this same bound now also caps a SECOND
-  // lookup per run id (`getWorkflowRunJobs`, for
-  // `verifySelfReferentialBootstrapWaiverProvenance`), so worst-case
-  // cost is up to 2 * MAX_AUTO_WAIVER_RUN_LOOKUPS Actions-API calls, not
+  // and THIRD lookup per run id (`getWorkflowRunJobs`, for
+  // `verifySelfReferentialBootstrapWaiverProvenance`; and
+  // `listWorkflowRunArtifacts`, for
+  // `verifySelfReferentialBootstrapWaiverArtifactBinding`), so worst-case
+  // cost is up to 3 * MAX_AUTO_WAIVER_RUN_LOOKUPS Actions-API calls, not
   // a new, separately-bounded budget of its own.
   const MAX_AUTO_WAIVER_RUN_LOOKUPS = 20;
   const autoWaiverCandidates: { runId: string; createdAt: string }[] = [];
   const seenAutoWaiverRunIds = new Set<string>();
-  // kurone-kito/idd-skill#2912: collected over EVERY qualifying comment
-  // (not deduplicated by `seenAutoWaiverRunIds`, which exists only to
-  // bound the number of Actions-API lookups) -- `autoWaiverValid` below
-  // requires exactly one provenance-passing candidate per cited run id,
-  // so a second, forged marker sharing a legitimate run's id must still
-  // be recorded even though it triggers no additional lookup. Kept as
-  // `createdAt` timestamps, not a bare count, so the pure verdict
-  // function can independently re-check each candidate's own provenance
-  // against the run's (single, shared) jobs-API window -- see
-  // `AdvisoryConvergenceInputs.autoWaiverRunIdCandidateTimestamps`'s own
-  // doc comment for why a bare count would misclassify a legitimate CI
-  // rerun as a forgery collision.
-  const autoWaiverRunIdCandidateTimestamps = new Map<string, string[]>();
+  // kurone-kito/idd-skill#2912 (round 2): collected over EVERY qualifying
+  // comment (not deduplicated by `seenAutoWaiverRunIds`, which exists
+  // only to bound the number of Actions-API lookups), each paired with
+  // its own comment `id` -- `verifySelfReferentialBootstrapWaiverArtifactBinding`
+  // needs the id to correlate a `.valid` evidence entry (which carries
+  // no id of its own) back to the specific live comment it came from.
+  // See `AdvisoryConvergenceInputs.autoWaiverRunIdCandidates`'s own doc
+  // comment for the full correlation contract.
+  const autoWaiverRunIdCandidates = new Map<
+    string,
+    { id: string; createdAt: string }[]
+  >();
   for (const comment of comments) {
     const body = String(comment.body ?? '');
     if (!/^<!--\s*idd-external-check-waiver:/i.test(body)) {
@@ -3373,13 +3508,18 @@ export function collectFromGitHub(
         .trim()
         .toLowerCase() === prHeadSha
     ) {
-      // kurone-kito/idd-skill#2912: every qualifying comment's own
-      // `createdAt` is recorded against its cited run id, regardless of
-      // whether this is the first (lookup-triggering) sighting.
-      autoWaiverRunIdCandidateTimestamps.set(parsed.runId, [
-        ...(autoWaiverRunIdCandidateTimestamps.get(parsed.runId) ?? []),
-        createdAt,
-      ]);
+      // kurone-kito/idd-skill#2912 (round 2): every qualifying comment's
+      // own `id`/`createdAt` pair is recorded against its cited run id,
+      // regardless of whether this is the first (lookup-triggering)
+      // sighting. Appended via `.push`, not a spread-rebuild, so this
+      // stays linear in the comment count (Copilot review, PR #2914).
+      const candidateList = autoWaiverRunIdCandidates.get(parsed.runId);
+      const candidate = { id: String(comment.id ?? ''), createdAt };
+      if (candidateList) {
+        candidateList.push(candidate);
+      } else {
+        autoWaiverRunIdCandidates.set(parsed.runId, [candidate]);
+      }
       if (!seenAutoWaiverRunIds.has(parsed.runId)) {
         seenAutoWaiverRunIds.add(parsed.runId);
         autoWaiverCandidates.push({ runId: parsed.runId, createdAt });
@@ -3469,6 +3609,46 @@ export function collectFromGitHub(
     }
   }
 
+  // kurone-kito/idd-skill#2912 (round 2): a THIRD per-run-id lookup
+  // sharing the exact same `autoWaiverRunIds` budget as the two above
+  // (so worst case triples the lookup call count, still bounded by
+  // `MAX_AUTO_WAIVER_RUN_LOOKUPS`) -- recovers the SET of comment ids
+  // the cited run's own trusted job execution recorded posting, via the
+  // artifact-name convention `SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX`
+  // documents. See `AdvisoryConvergenceInputs.autoWaiverRunArtifactCommentIds`'s
+  // own doc comment for why this closes a gap the run-metadata and
+  // job-provenance lookups above cannot.
+  const autoWaiverArtifactNamePattern = new RegExp(
+    `^${SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX}([1-9][0-9]*)$`,
+  );
+  const autoWaiverRunArtifactCommentIds: NonNullable<
+    AdvisoryConvergenceInputs['autoWaiverRunArtifactCommentIds']
+  > = {};
+  for (const runId of autoWaiverRunIds) {
+    try {
+      const raw = port.listWorkflowRunArtifacts(owner, repo, runId) as {
+        artifacts?: { name?: string | null }[] | null;
+      };
+      const ids: string[] = [];
+      for (const artifact of raw?.artifacts ?? []) {
+        const match = autoWaiverArtifactNamePattern.exec(
+          String(artifact?.name ?? ''),
+        );
+        if (match) {
+          ids.push(match[1] as string);
+        }
+      }
+      autoWaiverRunArtifactCommentIds[runId] = ids;
+    } catch {
+      // Fail closed per run id, mirroring the two lookups above: a
+      // lookup failure must never crash the whole collection, and an
+      // empty trusted-id set already means "nothing trusted" to
+      // `verifySelfReferentialBootstrapWaiverArtifactBinding` -- no
+      // separate `{error}` union variant is needed here.
+      autoWaiverRunArtifactCommentIds[runId] = [];
+    }
+  }
+
   // kurone-kito/idd-skill#2657 (Codex review, PR #2895): fetched only
   // when a candidate marker exists (same cost-optimization scope as the
   // run-id lookups above) -- see `AdvisoryConvergenceInputs.changedFilePaths`'s
@@ -3507,9 +3687,8 @@ export function collectFromGitHub(
       prAuthorIsBot,
       autoWaiverRunLookups,
       autoWaiverRunJobLookups,
-      autoWaiverRunIdCandidateTimestamps: Object.fromEntries(
-        autoWaiverRunIdCandidateTimestamps,
-      ),
+      autoWaiverRunIdCandidates: Object.fromEntries(autoWaiverRunIdCandidates),
+      autoWaiverRunArtifactCommentIds,
       changedFilePaths,
     },
     options: {

--- a/src/scripts/external-check-waiver.mts
+++ b/src/scripts/external-check-waiver.mts
@@ -32,6 +32,7 @@ import type {
   ExternalCheckWaiverEvidence,
 } from './protocol-helpers.mts';
 import {
+  digestExternalCheckWaiverMarkerBody,
   parseExternalCheckWaiverComment,
   parsePaginatedGhNdjson,
   renderExternalCheckWaiverComment,
@@ -322,6 +323,36 @@ interface ExternalCheckWaiverReport {
    * `verifySelfReferentialBootstrapWaiverArtifactBinding`'s own doc
    * comment there for the forgery this closes. */
   commentId?: string;
+  /** kurone-kito/idd-skill#2912 (round 3): the SHA-256 hex digest
+   * ({@link digestExternalCheckWaiverMarkerBody}) of `--apply`'s posted
+   * comment's body, computed from the body this helper reads back from
+   * the GitHub API in the post-write reconcile below -- never from
+   * `report.body`, the locally-constructed string this process sent --
+   * so it reflects whatever GitHub actually stored. Absent when the
+   * reconcile could not find the posted comment in its re-read (falls
+   * back to `report.body` and sets `bodyDigestSource: 'constructed'`
+   * instead; see that field). The self-waiver CI job reads this
+   * alongside `commentId` to name the provenance artifact
+   * `idd-self-waiver-marker-<comment-id>-<body-digest>`, closing the
+   * round-2 artifact-binding gap Copilot found in PR #2914's review of
+   * that round: `issues: write` also permits EDITING an existing
+   * comment's body while preserving its `id`/`createdAt`, so trusting
+   * the id alone (round 2) still let a same-repository attacker rewrite
+   * a genuine, already-trusted comment's content in place. Binding to
+   * `(id, bodyDigest)` instead means an edited body no longer matches
+   * the trusted pair `advisory-convergence.mts`'s
+   * `verifySelfReferentialBootstrapWaiverArtifactBinding` looks up. */
+  bodyDigest?: string;
+  /** kurone-kito/idd-skill#2912 (round 3): `'reconciled'` when
+   * {@link bodyDigest} was computed from the post-write re-read of the
+   * actual posted comment (the trustworthy case); `'constructed'` when
+   * the re-read did not find it (the reconcile failed, or raced a
+   * concurrent edit/delete) and this helper fell back to hashing the
+   * locally-built `report.body` instead -- still reported so a genuine
+   * marker is never silently unattested, but weaker: it proves what this
+   * process SENT, not what GitHub stored. Absent alongside an absent
+   * `bodyDigest` (dry-run / non-`--apply` paths never set either). */
+  bodyDigestSource?: 'reconciled' | 'constructed';
   /**
    * #2328: set when `--apply` found an existing valid waiver for this
    * selector and reused it rather than appending a second marker.
@@ -1524,11 +1555,36 @@ export async function runExternalCheckWaiver(
     );
   }
 
+  // kurone-kito/idd-skill#2912 (round 3): hash the body this helper reads
+  // BACK from the GitHub API (the same `postWriteComments` reconcile scan
+  // above), matched by the posted comment's own id -- never `report.body`,
+  // the string this process constructed and sent -- so the digest reflects
+  // what GitHub actually stored, the same guarantee `bodyDigest`'s own doc
+  // comment describes. Fall back to `report.body` only when the reconcile
+  // could not find that comment (a failed re-read, or a race with a
+  // concurrent edit/delete already flagged by `reconcileInconclusive`
+  // above, or -- more simply -- a `postComment` test double that never
+  // reaches `readPrComments()`), and say so via `bodyDigestSource` so a
+  // consumer can tell a GitHub-attested digest from a merely-sent one.
+  const postedCommentId = String(result.id ?? '');
+  const reconciledComment = postWriteComments.find(
+    (comment) => String(comment?.id ?? '') === postedCommentId,
+  );
+  const bodyDigestSource: 'reconciled' | 'constructed' =
+    typeof reconciledComment?.body === 'string' ? 'reconciled' : 'constructed';
+  const bodyDigest = digestExternalCheckWaiverMarkerBody(
+    bodyDigestSource === 'reconciled'
+      ? (reconciledComment?.body as string)
+      : report.body,
+  );
+
   const appliedReport = {
     ...report,
     applied: true,
     commentUrl: String(result.html_url ?? result.url ?? ''),
-    commentId: String(result.id ?? ''),
+    commentId: postedCommentId,
+    bodyDigest,
+    bodyDigestSource,
     ...(concurrentWaivers.length > 1 ? { concurrentWaivers } : {}),
     ...(reconcileInconclusive ? { reconcileInconclusive: true } : {}),
   };

--- a/src/scripts/external-check-waiver.mts
+++ b/src/scripts/external-check-waiver.mts
@@ -323,16 +323,29 @@ interface ExternalCheckWaiverReport {
    * `verifySelfReferentialBootstrapWaiverArtifactBinding`'s own doc
    * comment there for the forgery this closes. */
   commentId?: string;
-  /** kurone-kito/idd-skill#2912 (round 3): the SHA-256 hex digest
+  /** kurone-kito/idd-skill#2912 (round 4; supersedes round 3's
+   * reconcile-based design): the SHA-256 hex digest
    * ({@link digestExternalCheckWaiverMarkerBody}) of `--apply`'s posted
-   * comment's body, computed from the body this helper reads back from
-   * the GitHub API in the post-write reconcile below -- never from
-   * `report.body`, the locally-constructed string this process sent --
-   * so it reflects whatever GitHub actually stored. Absent when the
-   * reconcile could not find the posted comment in its re-read (falls
-   * back to `report.body` and sets `bodyDigestSource: 'constructed'`
-   * instead; see that field). The self-waiver CI job reads this
-   * alongside `commentId` to name the provenance artifact
+   * comment body, computed ONLY from the `body` field GitHub's own
+   * create-comment response returned for THIS specific POST -- never a
+   * later re-read. Round 3 hashed the body a separate, LATER
+   * `readPrComments()` re-read observed instead, reasoning that it
+   * reflects "whatever GitHub actually stored" -- but Copilot's review of
+   * round 3's own commit (PR #2914) found the gap that reasoning missed:
+   * that later read is itself mutable between the POST and the reconcile,
+   * so a same-repository `issues: write` workflow that edits the
+   * just-posted comment inside that window would have had its FORGED body
+   * hashed and attested as genuine, defeating the very binding round 3
+   * introduced. The create-comment response has no such window: GitHub
+   * returns it atomically, in the same API call that created the comment,
+   * before any other request could possibly have touched it. Absent
+   * whenever that response did not carry a `body` string (an unexpected
+   * API shape, or a `postComment` test double that omits it) --
+   * deliberately NOT backfilled from `report.body` or any later read, so
+   * the workflow's own `body-digest != ''` gate fails closed instead of
+   * uploading a provenance artifact for a digest this process cannot
+   * prove GitHub stored. The self-waiver CI job reads this alongside
+   * `commentId` to name the provenance artifact
    * `idd-self-waiver-marker-<comment-id>-<body-digest>`, closing the
    * round-2 artifact-binding gap Copilot found in PR #2914's review of
    * that round: `issues: write` also permits EDITING an existing
@@ -343,16 +356,6 @@ interface ExternalCheckWaiverReport {
    * the trusted pair `advisory-convergence.mts`'s
    * `verifySelfReferentialBootstrapWaiverArtifactBinding` looks up. */
   bodyDigest?: string;
-  /** kurone-kito/idd-skill#2912 (round 3): `'reconciled'` when
-   * {@link bodyDigest} was computed from the post-write re-read of the
-   * actual posted comment (the trustworthy case); `'constructed'` when
-   * the re-read did not find it (the reconcile failed, or raced a
-   * concurrent edit/delete) and this helper fell back to hashing the
-   * locally-built `report.body` instead -- still reported so a genuine
-   * marker is never silently unattested, but weaker: it proves what this
-   * process SENT, not what GitHub stored. Absent alongside an absent
-   * `bodyDigest` (dry-run / non-`--apply` paths never set either). */
-  bodyDigestSource?: 'reconciled' | 'constructed';
   /**
    * #2328: set when `--apply` found an existing valid waiver for this
    * selector and reused it rather than appending a second marker.
@@ -401,6 +404,12 @@ interface PostedCommentPayload {
   id?: string | number | null;
   html_url?: string | null;
   url?: string | null;
+  /** kurone-kito/idd-skill#2912 (round 4): the created comment's own
+   * body, exactly as GitHub's create-comment response returns it -- the
+   * ONLY source `ExternalCheckWaiverReport.bodyDigest` trusts. See that
+   * field's own doc comment for why a later re-read is deliberately
+   * never used instead. */
+  body?: string | null;
 }
 
 /** GitHub API call result with a parsed JSON body and HTTP status. */
@@ -1555,36 +1564,37 @@ export async function runExternalCheckWaiver(
     );
   }
 
-  // kurone-kito/idd-skill#2912 (round 3): hash the body this helper reads
-  // BACK from the GitHub API (the same `postWriteComments` reconcile scan
-  // above), matched by the posted comment's own id -- never `report.body`,
-  // the string this process constructed and sent -- so the digest reflects
-  // what GitHub actually stored, the same guarantee `bodyDigest`'s own doc
-  // comment describes. Fall back to `report.body` only when the reconcile
-  // could not find that comment (a failed re-read, or a race with a
-  // concurrent edit/delete already flagged by `reconcileInconclusive`
-  // above, or -- more simply -- a `postComment` test double that never
-  // reaches `readPrComments()`), and say so via `bodyDigestSource` so a
-  // consumer can tell a GitHub-attested digest from a merely-sent one.
+  // kurone-kito/idd-skill#2912 (round 4; supersedes round 3, PR #2914
+  // review): hash the `body` field GitHub's OWN create-comment response
+  // (`result`) returned for THIS exact POST -- never `postWriteComments`,
+  // the LATER, separate `readPrComments()` re-read used above for
+  // concurrent-duplicate detection. Round 3 preferred that later re-read,
+  // reasoning it reflects what GitHub "actually stored" -- but the two
+  // reads are not the same instant: a same-repository `issues: write`
+  // workflow can edit the genuine comment's body in the window between
+  // this POST returning and that later re-read running, and round 3's
+  // reconcile-preferring design would then hash and attest to the FORGED
+  // body as if it were genuine (the P1 Copilot found reviewing round 3's
+  // own commit). The create-comment response has no such window: GitHub
+  // returns it atomically, in the same API call that created the comment,
+  // before any other request could possibly have touched it. Absent
+  // (never backfilled from `postWriteComments` or `report.body`) when
+  // that response did not carry a `body` string -- fails closed via the
+  // workflow's own `body-digest != ''` gate rather than uploading a
+  // provenance artifact for a digest this process cannot prove GitHub
+  // stored.
   const postedCommentId = String(result.id ?? '');
-  const reconciledComment = postWriteComments.find(
-    (comment) => String(comment?.id ?? '') === postedCommentId,
-  );
-  const bodyDigestSource: 'reconciled' | 'constructed' =
-    typeof reconciledComment?.body === 'string' ? 'reconciled' : 'constructed';
-  const bodyDigest = digestExternalCheckWaiverMarkerBody(
-    bodyDigestSource === 'reconciled'
-      ? (reconciledComment?.body as string)
-      : report.body,
-  );
+  const bodyDigest =
+    typeof result.body === 'string'
+      ? digestExternalCheckWaiverMarkerBody(result.body)
+      : undefined;
 
   const appliedReport = {
     ...report,
     applied: true,
     commentUrl: String(result.html_url ?? result.url ?? ''),
     commentId: postedCommentId,
-    bodyDigest,
-    bodyDigestSource,
+    ...(typeof bodyDigest === 'string' ? { bodyDigest } : {}),
     ...(concurrentWaivers.length > 1 ? { concurrentWaivers } : {}),
     ...(reconcileInconclusive ? { reconcileInconclusive: true } : {}),
   };

--- a/src/scripts/external-check-waiver.mts
+++ b/src/scripts/external-check-waiver.mts
@@ -310,6 +310,18 @@ interface ExternalCheckWaiverReport {
   body: string;
   applied?: boolean;
   commentUrl?: string;
+  /** kurone-kito/idd-skill#2912 (round 2): the numeric id (as a string)
+   * of the comment this invocation posted (`--apply`, a fresh post) or
+   * reused (`reusedWaiver`'s own `commentId`) -- absent when neither
+   * applies (e.g. a dry-run plan). The self-waiver CI job reads this
+   * from the JSON report to record a run-scoped Actions artifact naming
+   * the posted comment's id, which `advisory-convergence.mts`'s
+   * self-referential-bootstrap-auto trust chain later fetches to bind a
+   * marker to the SPECIFIC comment its own trusted job posted, not
+   * merely "some comment exists" -- see
+   * `verifySelfReferentialBootstrapWaiverArtifactBinding`'s own doc
+   * comment there for the forgery this closes. */
+  commentId?: string;
   /**
    * #2328: set when `--apply` found an existing valid waiver for this
    * selector and reused it rather than appending a second marker.
@@ -351,6 +363,11 @@ interface ExternalCheckWaiverArgs {
 
 /** Posted-comment payload fields consumed by this helper. */
 interface PostedCommentPayload {
+  /** kurone-kito/idd-skill#2912 (round 2): threaded into
+   * `ExternalCheckWaiverReport.commentId` so a caller (the self-waiver
+   * CI job) can record which comment THIS invocation actually posted,
+   * without having to re-derive it from `commentUrl`. */
+  id?: string | number | null;
   html_url?: string | null;
   url?: string | null;
 }
@@ -1375,6 +1392,7 @@ export async function runExternalCheckWaiver(
       applied: false,
       reusedWaiver: existingWaiver,
       commentUrl: existingWaiver.commentUrl,
+      commentId: existingWaiver.commentId,
     };
     renderReport(reusedReport, args.format);
     return { exitCode: 0, report: reusedReport };
@@ -1510,6 +1528,7 @@ export async function runExternalCheckWaiver(
     ...report,
     applied: true,
     commentUrl: String(result.html_url ?? result.url ?? ''),
+    commentId: String(result.id ?? ''),
     ...(concurrentWaivers.length > 1 ? { concurrentWaivers } : {}),
     ...(reconcileInconclusive ? { reconcileInconclusive: true } : {}),
   };

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -21,6 +21,7 @@
 // moving them here would force exactly that forbidden back-import. Only the
 // single-marker parse/render primitives move in this wave.
 
+import { createHash } from 'node:crypto';
 import { createMarkerRegex, escapeRegex } from './marker-regex.mts';
 
 /** Operational marker matcher entry. */
@@ -1254,6 +1255,43 @@ export function renderExternalCheckWaiverComment(
       expiresAt,
     }),
   ].join('\n');
+}
+
+/**
+ * SHA-256 hex digest of `body`'s exact UTF-8 bytes, used to bind a
+ * `idd-self-waiver-marker-*` Actions artifact (kurone-kito/idd-skill#2912,
+ * round 3) to the precise content of the comment it attests, not merely
+ * that comment's id. Round 2's artifact-binding closed the
+ * comment-deletion forgery (an attacker deletes the genuine marker,
+ * leaving a same-run-id forged sibling as the sole survivor) but left a
+ * sibling gap open: `issues: write` also permits EDITING an existing
+ * comment's body in place, which preserves its `id` and `createdAt` while
+ * replacing the content -- round 2's check alone would still accept the
+ * edited body because it only ever looked at the id.
+ *
+ * Every caller on both sides of this check (the posting CLI's post-write
+ * reconcile in `external-check-waiver.mts`, and
+ * `advisory-convergence.mts`'s live comment scan) SHOULD hash a body
+ * obtained the SAME way -- read back from the GitHub API, not a
+ * locally-constructed string -- so an unedited comment always digests
+ * identically regardless of which side computed it. Hashing a
+ * writer-constructed string against a GitHub-returned one risks a
+ * false-negative on any GitHub-side content normalization this project
+ * does not control (trailing-newline handling, etc.). No normalization is
+ * applied here for that reason: both sides are expected to pass an
+ * API-returned body verbatim in the ordinary case. The one documented
+ * exception is the posting CLI's own fallback when its post-write
+ * reconcile cannot find the just-posted comment: it hashes the
+ * locally-sent body instead and labels the result accordingly
+ * (`ExternalCheckWaiverReport.bodyDigestSource: 'constructed'`) rather
+ * than presenting it as a GitHub-attested digest. This follows the same
+ * `bodySha256` / `body-sha256` convention `authoring-owner-provenance.mts`
+ * and the issue-authoring skill already use for the identical purpose
+ * (binding a marker to an exact API-observed body rather than trusting an
+ * id alone).
+ */
+export function digestExternalCheckWaiverMarkerBody(body: string): string {
+  return createHash('sha256').update(body, 'utf8').digest('hex');
 }
 
 function renderProviderOutageDeclarationNote(normalized: {

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -1269,26 +1269,34 @@ export function renderExternalCheckWaiverComment(
  * replacing the content -- round 2's check alone would still accept the
  * edited body because it only ever looked at the id.
  *
- * Every caller on both sides of this check (the posting CLI's post-write
- * reconcile in `external-check-waiver.mts`, and
- * `advisory-convergence.mts`'s live comment scan) SHOULD hash a body
- * obtained the SAME way -- read back from the GitHub API, not a
- * locally-constructed string -- so an unedited comment always digests
- * identically regardless of which side computed it. Hashing a
- * writer-constructed string against a GitHub-returned one risks a
- * false-negative on any GitHub-side content normalization this project
- * does not control (trailing-newline handling, etc.). No normalization is
- * applied here for that reason: both sides are expected to pass an
- * API-returned body verbatim in the ordinary case. The one documented
- * exception is the posting CLI's own fallback when its post-write
- * reconcile cannot find the just-posted comment: it hashes the
- * locally-sent body instead and labels the result accordingly
- * (`ExternalCheckWaiverReport.bodyDigestSource: 'constructed'`) rather
- * than presenting it as a GitHub-attested digest. This follows the same
- * `bodySha256` / `body-sha256` convention `authoring-owner-provenance.mts`
- * and the issue-authoring skill already use for the identical purpose
- * (binding a marker to an exact API-observed body rather than trusting an
- * id alone).
+ * Every caller on both sides of this check (the posting CLI in
+ * `external-check-waiver.mts`, and `advisory-convergence.mts`'s live
+ * comment scan) MUST hash a body obtained the SAME way -- read back from
+ * the GitHub API, not a locally-constructed string -- so an unedited
+ * comment always digests identically regardless of which side computed
+ * it. Hashing a writer-constructed string against a GitHub-returned one
+ * risks a false-negative on any GitHub-side content normalization this
+ * project does not control (trailing-newline handling, etc.). No
+ * normalization is applied here for that reason: both sides are expected
+ * to pass an API-returned body verbatim.
+ *
+ * Round 3 initially let the posting CLI hash a body observed in a LATER,
+ * separate re-read (its own post-write reconcile) when available, falling
+ * back to the locally-sent string only when that reconcile came up empty.
+ * Copilot's review of round 3's own commit (PR #2914) found this
+ * introduced a race: the later re-read is mutable in a way the original
+ * POST response is not, so a same-repository `issues: write` workflow
+ * that edited the genuine comment's body in the window between POST and
+ * reconcile would have its forged body hashed and attested as genuine.
+ * Round 4 removed that fallback entirely -- the posting CLI now hashes
+ * ONLY the `body` field GitHub's create-comment response returns for the
+ * exact POST that created the comment, atomically, with no such window;
+ * see `ExternalCheckWaiverReport.bodyDigest`'s own doc comment
+ * (external-check-waiver.mts) for the full reasoning. This follows the
+ * same `bodySha256` / `body-sha256` convention
+ * `authoring-owner-provenance.mts` and the issue-authoring skill already
+ * use for the identical purpose (binding a marker to an exact
+ * API-observed body rather than trusting an id alone).
  */
 export function digestExternalCheckWaiverMarkerBody(body: string): string {
   return createHash('sha256').update(body, 'utf8').digest('hex');

--- a/src/scripts/provider-adapter-fake.mts
+++ b/src/scripts/provider-adapter-fake.mts
@@ -212,6 +212,10 @@ export interface FakeProviderFixture {
    * `${owner}/${repo}/${runId}`; an absent key throws (matches the
    * adapter's own no-catch, throw-on-failure contract). */
   workflowRunJobs?: Record<string, unknown>;
+  /** Backs {@link ProviderPort.listWorkflowRunArtifacts}, keyed by
+   * `${owner}/${repo}/${runId}`; an absent key throws (matches the
+   * adapter's own no-catch, throw-on-failure contract). */
+  workflowRunArtifacts?: Record<string, unknown>;
   /** Backs {@link ProviderPort.listWorkflowRuns}, keyed by `${owner}/${repo}/${workflowName}`. */
   workflowRunLists?: Record<
     string,
@@ -782,6 +786,22 @@ export function createFakeProviderAdapter(
       if (value === undefined) {
         throw new Error(
           `fake provider: no workflow-run-jobs fixture for ${key}`,
+        );
+      }
+      return value;
+    },
+
+    listWorkflowRunArtifacts(
+      artifactsOwner: string,
+      artifactsRepo: string,
+      runId: string | number,
+    ): unknown {
+      // Same throw-on-missing contract as getWorkflowRunJobs above.
+      const key = `${artifactsOwner}/${artifactsRepo}/${runId}`;
+      const value = fixture.workflowRunArtifacts?.[key];
+      if (value === undefined) {
+        throw new Error(
+          `fake provider: no workflow-run-artifacts fixture for ${key}`,
         );
       }
       return value;

--- a/src/scripts/provider-adapter-fake.mts
+++ b/src/scripts/provider-adapter-fake.mts
@@ -208,6 +208,10 @@ export interface FakeProviderFixture {
    * `${owner}/${repo}/${runId}`; an absent key throws (matches the
    * adapter's own no-catch, throw-on-failure contract). */
   workflowRuns?: Record<string, unknown>;
+  /** Backs {@link ProviderPort.getWorkflowRunJobs}, keyed by
+   * `${owner}/${repo}/${runId}`; an absent key throws (matches the
+   * adapter's own no-catch, throw-on-failure contract). */
+  workflowRunJobs?: Record<string, unknown>;
   /** Backs {@link ProviderPort.listWorkflowRuns}, keyed by `${owner}/${repo}/${workflowName}`. */
   workflowRunLists?: Record<
     string,
@@ -763,6 +767,22 @@ export function createFakeProviderAdapter(
       const value = fixture.workflowRuns?.[key];
       if (value === undefined) {
         throw new Error(`fake provider: no workflow-run fixture for ${key}`);
+      }
+      return value;
+    },
+
+    getWorkflowRunJobs(
+      jobsOwner: string,
+      jobsRepo: string,
+      runId: string | number,
+    ): unknown {
+      // Same throw-on-missing contract as getWorkflowRun above.
+      const key = `${jobsOwner}/${jobsRepo}/${runId}`;
+      const value = fixture.workflowRunJobs?.[key];
+      if (value === undefined) {
+        throw new Error(
+          `fake provider: no workflow-run-jobs fixture for ${key}`,
+        );
       }
       return value;
     },

--- a/src/scripts/provider-adapter-github.mts
+++ b/src/scripts/provider-adapter-github.mts
@@ -2466,6 +2466,22 @@ export function createGithubProviderAdapter(
       return JSON.parse(raw.trim() || '{}');
     },
 
+    getWorkflowRunJobs(
+      jobsOwner: string,
+      jobsRepo: string,
+      runId: string | number,
+    ): unknown {
+      // Not `--paginate`: bounded to a handful of jobs per run (this
+      // workflow declares two), well under the API's own per-page cap, and
+      // `--paginate` without `--jq` would emit one JSON object per page
+      // rather than a single parseable document.
+      const raw = deps.ghText(
+        ['api', `repos/${jobsOwner}/${jobsRepo}/actions/runs/${runId}/jobs`],
+        GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+      );
+      return JSON.parse(raw.trim() || '{}');
+    },
+
     listWorkflowRuns(
       runsOwner: string,
       runsRepo: string,

--- a/src/scripts/provider-adapter-github.mts
+++ b/src/scripts/provider-adapter-github.mts
@@ -2482,6 +2482,24 @@ export function createGithubProviderAdapter(
       return JSON.parse(raw.trim() || '{}');
     },
 
+    listWorkflowRunArtifacts(
+      artifactsOwner: string,
+      artifactsRepo: string,
+      runId: string | number,
+    ): unknown {
+      // Not `--paginate`, same rationale as getWorkflowRunJobs above: a
+      // run legitimately uploads at most a handful of artifacts, well
+      // under the API's own per-page cap.
+      const raw = deps.ghText(
+        [
+          'api',
+          `repos/${artifactsOwner}/${artifactsRepo}/actions/runs/${runId}/artifacts`,
+        ],
+        GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+      );
+      return JSON.parse(raw.trim() || '{}');
+    },
+
     listWorkflowRuns(
       runsOwner: string,
       runsRepo: string,

--- a/src/scripts/provider-port.mts
+++ b/src/scripts/provider-port.mts
@@ -1129,6 +1129,40 @@ export interface ProviderPort {
     runId: string | number,
   ): unknown;
 
+  /** checks. `actions/runs/{runId}/artifacts` -- the run-scoped Actions
+   * artifacts a single workflow run uploaded, raw passthrough (name + id
+   * only; small enough not to need `--paginate` -- a run legitimately
+   * uploads at most a handful). kurone-kito/idd-skill#2912 (round 2):
+   * `advisory-convergence.mts`'s self-referential-bootstrap-auto trust
+   * chain reads this to recover the SET of issue-comment ids the cited
+   * run's own trusted `idd-advisory-convergence-self-waiver` job attests
+   * to having posted, encoded in each artifact's own `name` (never its
+   * content, so no zip download/extraction is needed here -- listing
+   * alone is enough). Artifacts are the correct binding primitive for
+   * this specific purpose because they are scoped to the run that
+   * uploaded them by the Actions runtime's own dedicated upload token,
+   * never by the shared `GITHUB_TOKEN` `permissions:` surface every
+   * OTHER resource this trust chain touches (issue comments, check
+   * runs) is created and mutated through -- so a same-repository
+   * `pull_request`-triggered workflow (untrusted, PR-controlled code)
+   * cannot create, edit, or delete an artifact belonging to a different,
+   * legitimate `pull_request_target` run no matter which `permissions:`
+   * it self-grants, closing the comment-deletion gap a plain "no
+   * duplicate marker currently visible" scan left open (see
+   * `verifySelfReferentialBootstrapWaiverArtifactBinding`'s own doc
+   * comment for the full exploit and residual). Same `string | number`
+   * `runId` type as {@link getWorkflowRun}, for the same above-
+   * `Number.MAX_SAFE_INTEGER` reason; no new `GITHUB_TOKEN` permission is
+   * required -- this endpoint shares the `actions: read` scope
+   * {@link getWorkflowRun} already needs, and uploading the artifact in
+   * the posting job needs no `permissions:` entry at all (the Actions
+   * runtime's upload token is separate from `GITHUB_TOKEN`). */
+  listWorkflowRunArtifacts(
+    owner: string,
+    repo: string,
+    runId: string | number,
+  ): unknown;
+
   /** checks. `gh run list --workflow {name} --limit N --json
    * databaseId,conclusion,status,createdAt` -- distinct `gh run list`
    * shape, not a `gh api` call. */

--- a/src/scripts/provider-port.mts
+++ b/src/scripts/provider-port.mts
@@ -1108,6 +1108,27 @@ export interface ProviderPort {
    * Number.MAX_SAFE_INTEGER exactly" case). */
   getWorkflowRun(owner: string, repo: string, runId: string | number): unknown;
 
+  /** checks. `actions/runs/{runId}/jobs` -- per-job/per-step status for a
+   * single workflow run, raw passthrough. kurone-kito/idd-skill#2912:
+   * {@link getWorkflowRun} alone proves a self-referential-bootstrap-auto
+   * marker's cited run has the right path/head-sha/repository/event
+   * shape, never that the run's OWN `idd-advisory-convergence-self-waiver`
+   * job actually executed the step that posts the marker -- a forged
+   * marker citing a real, unrelated run can satisfy every run-level
+   * condition without having been posted by that run's own job. This lets
+   * the consumer additionally verify that specific step's own recorded
+   * `conclusion`/`started_at`/`completed_at`, closing that gap without
+   * needing the run's log output. Same `string | number` `runId` type as
+   * {@link getWorkflowRun}, for the same above-`Number.MAX_SAFE_INTEGER`
+   * reason; no new `GITHUB_TOKEN` permission is required (this endpoint
+   * shares the `actions: read` scope {@link getWorkflowRun} already
+   * needs). */
+  getWorkflowRunJobs(
+    owner: string,
+    repo: string,
+    runId: string | number,
+  ): unknown;
+
   /** checks. `gh run list --workflow {name} --limit N --json
    * databaseId,conclusion,status,createdAt` -- distinct `gh run list`
    * shape, not a `gh api` call. */

--- a/tests/advisory-convergence-fake-provider.test.mts
+++ b/tests/advisory-convergence-fake-provider.test.mts
@@ -14,7 +14,10 @@ import {
   SELF_REFERENTIAL_WAIVER_POST_STEP_NAME,
 } from '../src/scripts/advisory-convergence.mts';
 import { DEFAULT_ADVISORY_TERMINAL_WINDOW_MINUTES } from '../src/scripts/advisory-wait-policy.mts';
-import { renderExternalCheckWaiverComment } from '../src/scripts/marker-helpers.mts';
+import {
+  digestExternalCheckWaiverMarkerBody,
+  renderExternalCheckWaiverComment,
+} from '../src/scripts/marker-helpers.mts';
 import { createFakeProviderAdapter } from '../src/scripts/provider-adapter-fake.mts';
 
 // ---------------------------------------------------------------------------
@@ -873,7 +876,11 @@ test("end-to-end: a genuine marker whose comment id matches the cited run's own 
       workflowRunJobs: { [`o/r/${RUN_ID}`]: acceptedRunJobsFixture() },
       workflowRunArtifacts: {
         [`o/r/${RUN_ID}`]: {
-          artifacts: [{ name: 'idd-self-waiver-marker-1' }],
+          artifacts: [
+            {
+              name: `idd-self-waiver-marker-1-${digestExternalCheckWaiverMarkerBody(autoWaiverComment().body)}`,
+            },
+          ],
         },
       },
       changedFiles: { [PR_NUMBER]: [ADVISORY_CONVERGENCE_WORKFLOW_PATH] },
@@ -906,7 +913,7 @@ test("end-to-end: a genuine marker whose comment id matches the cited run's own 
   });
 });
 
-test('collectFromGitHub records two distinct comments citing the same run id as two candidates, each carrying its own comment id (autoWaiverRunIdCandidates); the genuine one still validates despite a forged sibling being present (kurone-kito/idd-skill#2912, round 2)', () => {
+test('collectFromGitHub records two distinct comments citing the same run id as two candidates, each carrying its own comment id and body digest (autoWaiverRunIdCandidates); the genuine one still validates despite a forged sibling being present (kurone-kito/idd-skill#2912, round 2, extended round 3)', () => {
   withHermeticCwd(() => {
     const forgedSibling = forgedSiblingComment();
     const port = createFakeProviderAdapter({
@@ -921,11 +928,16 @@ test('collectFromGitHub records two distinct comments citing the same run id as 
         },
       },
       workflowRunJobs: { [`o/r/${RUN_ID}`]: acceptedRunJobsFixture() },
-      // The trusted artifact names ONLY the genuine comment's id (1) --
-      // this run's own trusted job posted exactly one comment.
+      // The trusted artifact names ONLY the genuine comment's (id, body
+      // digest) pair -- this run's own trusted job posted exactly one
+      // comment.
       workflowRunArtifacts: {
         [`o/r/${RUN_ID}`]: {
-          artifacts: [{ name: 'idd-self-waiver-marker-1' }],
+          artifacts: [
+            {
+              name: `idd-self-waiver-marker-1-${digestExternalCheckWaiverMarkerBody(autoWaiverComment().body)}`,
+            },
+          ],
         },
       },
       changedFiles: { [PR_NUMBER]: [ADVISORY_CONVERGENCE_WORKFLOW_PATH] },
@@ -937,10 +949,27 @@ test('collectFromGitHub records two distinct comments citing the same run id as 
     );
 
     assert.deepEqual(inputs.autoWaiverRunIdCandidates?.[RUN_ID], [
-      { id: '1', createdAt: autoWaiverComment().createdAt },
-      { id: '2', createdAt: forgedSibling.createdAt },
+      {
+        id: '1',
+        createdAt: autoWaiverComment().createdAt,
+        bodyDigest: digestExternalCheckWaiverMarkerBody(
+          autoWaiverComment().body,
+        ),
+      },
+      {
+        id: '2',
+        createdAt: forgedSibling.createdAt,
+        bodyDigest: digestExternalCheckWaiverMarkerBody(forgedSibling.body),
+      },
     ]);
-    assert.deepEqual(inputs.autoWaiverRunArtifactCommentIds?.[RUN_ID], ['1']);
+    assert.deepEqual(inputs.autoWaiverRunArtifactBindings?.[RUN_ID], [
+      {
+        id: '1',
+        bodyDigest: digestExternalCheckWaiverMarkerBody(
+          autoWaiverComment().body,
+        ),
+      },
+    ]);
 
     // End-to-end: unlike this file's ROUND-1 mechanism (a bare "no
     // duplicate visible" scan, which fail-closed BOTH markers the moment
@@ -997,10 +1026,15 @@ test('end-to-end: a genuine marker deleted after posting leaves a same-run-id fo
       workflowRunJobs: { [`o/r/${RUN_ID}`]: acceptedRunJobsFixture() },
       // The trusted artifact -- uploaded by the run's own trusted job
       // execution, unaffected by the comment's later deletion -- still
-      // names the GENUINE (now-deleted) comment's id.
+      // names the GENUINE (now-deleted) comment's (id, original body
+      // digest) pair.
       workflowRunArtifacts: {
         [`o/r/${RUN_ID}`]: {
-          artifacts: [{ name: 'idd-self-waiver-marker-1' }],
+          artifacts: [
+            {
+              name: `idd-self-waiver-marker-1-${digestExternalCheckWaiverMarkerBody(autoWaiverComment().body)}`,
+            },
+          ],
         },
       },
       changedFiles: { [PR_NUMBER]: [ADVISORY_CONVERGENCE_WORKFLOW_PATH] },
@@ -1012,9 +1046,20 @@ test('end-to-end: a genuine marker deleted after posting leaves a same-run-id fo
     );
 
     assert.deepEqual(inputs.autoWaiverRunIdCandidates?.[RUN_ID], [
-      { id: '2', createdAt: forgedSibling.createdAt },
+      {
+        id: '2',
+        createdAt: forgedSibling.createdAt,
+        bodyDigest: digestExternalCheckWaiverMarkerBody(forgedSibling.body),
+      },
     ]);
-    assert.deepEqual(inputs.autoWaiverRunArtifactCommentIds?.[RUN_ID], ['1']);
+    assert.deepEqual(inputs.autoWaiverRunArtifactBindings?.[RUN_ID], [
+      {
+        id: '1',
+        bodyDigest: digestExternalCheckWaiverMarkerBody(
+          autoWaiverComment().body,
+        ),
+      },
+    ]);
 
     const verdict = computeAdvisoryConvergenceVerdict(
       { ...inputs, claimEvents: [] },
@@ -1027,6 +1072,105 @@ test('end-to-end: a genuine marker deleted after posting leaves a same-run-id fo
         // resolved it to, i.e. actual test-run time) would classify
         // these markers `expired` regardless of the mechanism under
         // test.
+        now: '2026-07-31T09:05:00Z',
+        waiverMode: 'maintainer-authorized',
+        waivableSelectors: [
+          { selector: 'idd-advisory-convergence', matchMode: 'exact' },
+        ],
+      },
+    );
+    assert.equal(verdict.waiver.autoWaiverValid, false);
+  });
+});
+
+// kurone-kito/idd-skill#2912 (round 3, Copilot review, PR #2914 round 2):
+// SAME id/createdAt as `autoWaiverComment()`, but rendered with a
+// different `agentId` -- the one field on an external-check-waiver marker
+// no classification/trust condition anywhere in this file's own trust
+// chain consumes (see `parsed.agentId`'s absence from every grep hit in
+// advisory-convergence.mts/protocol-helpers.mts), so this changes the
+// posted body's exact text/digest without ALSO tripping an earlier,
+// unrelated rejection (wrong claim/HEAD/reason/run-id) that would mask
+// which check actually caused `autoWaiverValid: false` below. Models an
+// attacker who edited the genuine, already-artifact-trusted comment in
+// place (`issues: write` permits this) rather than deleting it.
+function editedGenuineComment() {
+  return {
+    id: 1,
+    body: renderExternalCheckWaiverComment({
+      agentId: 'a-different-agent-id',
+      claimId: 'none',
+      headSha: HEAD_SHA,
+      checkSelector: 'idd-advisory-convergence',
+      reason: SELF_REFERENTIAL_BOOTSTRAP_AUTO_REASON,
+      expiresAt: '2026-07-31T20:00:00Z',
+      actor: 'github-actions[bot]',
+      runId: RUN_ID,
+    }),
+    createdAt: '2026-07-31T09:00:00Z',
+    updatedAt: '2026-07-31T09:10:00Z',
+    authorLogin: 'github-actions[bot]',
+  };
+}
+
+test('end-to-end: a genuine comment EDITED in place after posting is rejected even though its id and createdAt are unchanged (kurone-kito/idd-skill#2912, round 3 P1: Copilot review, PR #2914 round 2)', () => {
+  withHermeticCwd(() => {
+    const edited = editedGenuineComment();
+    const port = createFakeProviderAdapter({
+      ...baseFixture(),
+      // The SAME comment id (1) as the genuine marker's own -- only the
+      // body has been rewritten in place; the id and createdAt this run's
+      // trusted job originally posted with are unchanged.
+      comments: { [PR_NUMBER]: [edited] },
+      workflowRuns: {
+        [`o/r/${RUN_ID}`]: {
+          path: ADVISORY_CONVERGENCE_WORKFLOW_PATH,
+          head_sha: HEAD_SHA,
+          head_repository: { full_name: 'o/r' },
+          event: 'pull_request_target',
+        },
+      },
+      workflowRunJobs: { [`o/r/${RUN_ID}`]: acceptedRunJobsFixture() },
+      // The trusted artifact still names the digest of the ORIGINAL,
+      // genuine body -- uploaded once, immediately after posting, and
+      // immutable thereafter; it cannot follow a LATER edit to the live
+      // comment.
+      workflowRunArtifacts: {
+        [`o/r/${RUN_ID}`]: {
+          artifacts: [
+            {
+              name: `idd-self-waiver-marker-1-${digestExternalCheckWaiverMarkerBody(autoWaiverComment().body)}`,
+            },
+          ],
+        },
+      },
+      changedFiles: { [PR_NUMBER]: [ADVISORY_CONVERGENCE_WORKFLOW_PATH] },
+    });
+
+    const { inputs, options } = collectFromGitHub(
+      parseArgs(['--pr', String(PR_NUMBER), '--owner', 'o', '--repo', 'r']),
+      () => port,
+    );
+
+    // The live candidate's own digest reflects the EDITED body -- never
+    // equal to the trusted artifact's ORIGINAL digest, since the two
+    // bodies now differ.
+    assert.deepEqual(inputs.autoWaiverRunIdCandidates?.[RUN_ID], [
+      {
+        id: '1',
+        createdAt: edited.createdAt,
+        bodyDigest: digestExternalCheckWaiverMarkerBody(edited.body),
+      },
+    ]);
+    assert.notEqual(
+      inputs.autoWaiverRunIdCandidates?.[RUN_ID]?.[0]?.bodyDigest,
+      inputs.autoWaiverRunArtifactBindings?.[RUN_ID]?.[0]?.bodyDigest,
+    );
+
+    const verdict = computeAdvisoryConvergenceVerdict(
+      { ...inputs, claimEvents: [] },
+      {
+        ...options,
         now: '2026-07-31T09:05:00Z',
         waiverMode: 'maintainer-authorized',
         waivableSelectors: [

--- a/tests/advisory-convergence-fake-provider.test.mts
+++ b/tests/advisory-convergence-fake-provider.test.mts
@@ -253,11 +253,32 @@ function autoWaiverComment() {
     id: 1,
     body: renderExternalCheckWaiverComment({
       agentId: 'github-actions-bot',
-      claimId: 'claim-abc',
+      // kurone-kito/idd-skill#2912 (round 2): 'none', not an arbitrary
+      // claim id -- the end-to-end tests below compute a verdict with
+      // `claimEvents: []` (no active claim resolves), and the sentinel is
+      // the only claimId that satisfies claim-binding when
+      // `activeClaimId` is empty (protocol-helpers.mts's
+      // `claimBindingSatisfied`). A non-'none' claimId there would make
+      // every marker fail claim-binding before the artifact-binding
+      // check under test is ever reached.
+      claimId: 'none',
       headSha: HEAD_SHA,
       checkSelector: 'idd-advisory-convergence',
       reason: SELF_REFERENTIAL_BOOTSTRAP_AUTO_REASON,
-      expiresAt: '2099-01-01T00:00:00Z',
+      // kurone-kito/idd-skill#2912 (round 2): within the default
+      // `ciGate.externalCheckWaivers.maxValidity` window (`PT24H`) of
+      // `createdAt` below -- `summarizeExternalCheckWaivers` re-checks
+      // `expiresAt - createdAt` against that window at consume time
+      // regardless of how far `expiresAt` sits from the CURRENT wall
+      // clock, so a far-future `expiresAt` (e.g. year 2099) with a fixed
+      // 2026 `createdAt` classifies as `expired` there, never reaching
+      // `.valid` at all -- silently short-circuiting every end-to-end
+      // verdict test in this file to `autoWaiverValid: false` for the
+      // WRONG reason regardless of the artifact-binding mechanism under
+      // test. The end-to-end tests below pin `options.now` near
+      // `createdAt` (not real wall-clock time) so this stays valid
+      // there too.
+      expiresAt: '2026-07-31T20:00:00Z',
       actor: 'github-actions[bot]',
       runId: RUN_ID,
     }),
@@ -809,24 +830,85 @@ test('collectFromGitHub never fetches getWorkflowRunJobs when no candidate auto-
   });
 });
 
-test('collectFromGitHub records two distinct comments citing the same run id as two candidate timestamps (autoWaiverRunIdCandidateTimestamps)', () => {
+function forgedSiblingComment() {
+  return {
+    id: 2,
+    body: renderExternalCheckWaiverComment({
+      agentId: 'github-actions-bot',
+      // Same 'none' rationale as autoWaiverComment() above.
+      claimId: 'none',
+      headSha: HEAD_SHA,
+      checkSelector: 'idd-advisory-convergence',
+      reason: SELF_REFERENTIAL_BOOTSTRAP_AUTO_REASON,
+      // Same maxValidity rationale as autoWaiverComment() above.
+      expiresAt: '2026-07-31T20:00:05Z',
+      actor: 'github-actions[bot]',
+      runId: RUN_ID,
+    }),
+    createdAt: '2026-07-31T09:00:05Z',
+    updatedAt: '2026-07-31T09:00:05Z',
+    authorLogin: 'github-actions[bot]',
+  };
+}
+
+test("end-to-end: a genuine marker whose comment id matches the cited run's own trusted artifact validates the auto-waiver (positive control, kurone-kito/idd-skill#2912, round 2)", () => {
+  // Proves the artifact-binding mechanism actually ACCEPTS a genuine
+  // marker end to end (collectFromGitHub -> computeAdvisoryConvergenceVerdict),
+  // not merely that it rejects forgeries -- a `false` assertion alone
+  // cannot distinguish "the mechanism correctly rejected this" from "the
+  // mechanism (or the test's own fixture) is broken and rejects
+  // everything".
   withHermeticCwd(() => {
-    const forgedSibling = {
-      id: 2,
-      body: renderExternalCheckWaiverComment({
-        agentId: 'github-actions-bot',
-        claimId: 'claim-def',
-        headSha: HEAD_SHA,
-        checkSelector: 'idd-advisory-convergence',
-        reason: SELF_REFERENTIAL_BOOTSTRAP_AUTO_REASON,
-        expiresAt: '2099-01-01T00:00:00Z',
-        actor: 'github-actions[bot]',
-        runId: RUN_ID,
-      }),
-      createdAt: '2026-07-31T09:00:05Z',
-      updatedAt: '2026-07-31T09:00:05Z',
-      authorLogin: 'github-actions[bot]',
-    };
+    const port = createFakeProviderAdapter({
+      ...baseFixture(),
+      comments: { [PR_NUMBER]: [autoWaiverComment()] },
+      workflowRuns: {
+        [`o/r/${RUN_ID}`]: {
+          path: ADVISORY_CONVERGENCE_WORKFLOW_PATH,
+          head_sha: HEAD_SHA,
+          head_repository: { full_name: 'o/r' },
+          event: 'pull_request_target',
+        },
+      },
+      workflowRunJobs: { [`o/r/${RUN_ID}`]: acceptedRunJobsFixture() },
+      workflowRunArtifacts: {
+        [`o/r/${RUN_ID}`]: {
+          artifacts: [{ name: 'idd-self-waiver-marker-1' }],
+        },
+      },
+      changedFiles: { [PR_NUMBER]: [ADVISORY_CONVERGENCE_WORKFLOW_PATH] },
+    });
+
+    const { inputs, options } = collectFromGitHub(
+      parseArgs(['--pr', String(PR_NUMBER), '--owner', 'o', '--repo', 'r']),
+      () => port,
+    );
+
+    const verdict = computeAdvisoryConvergenceVerdict(
+      { ...inputs, claimEvents: [] },
+      {
+        ...options,
+        // kurone-kito/idd-skill#2912 (round 2): pinned near the fixture
+        // markers' own createdAt/expiresAt (2026-07-31), not real
+        // wall-clock time -- see autoWaiverComment()'s own doc comment
+        // for why an unpinned `now` (whatever `collectFromGitHub`
+        // resolved it to, i.e. actual test-run time) would classify
+        // these markers `expired` regardless of the mechanism under
+        // test.
+        now: '2026-07-31T09:05:00Z',
+        waiverMode: 'maintainer-authorized',
+        waivableSelectors: [
+          { selector: 'idd-advisory-convergence', matchMode: 'exact' },
+        ],
+      },
+    );
+    assert.equal(verdict.waiver.autoWaiverValid, true);
+  });
+});
+
+test('collectFromGitHub records two distinct comments citing the same run id as two candidates, each carrying its own comment id (autoWaiverRunIdCandidates); the genuine one still validates despite a forged sibling being present (kurone-kito/idd-skill#2912, round 2)', () => {
+  withHermeticCwd(() => {
+    const forgedSibling = forgedSiblingComment();
     const port = createFakeProviderAdapter({
       ...baseFixture(),
       comments: { [PR_NUMBER]: [autoWaiverComment(), forgedSibling] },
@@ -839,6 +921,13 @@ test('collectFromGitHub records two distinct comments citing the same run id as 
         },
       },
       workflowRunJobs: { [`o/r/${RUN_ID}`]: acceptedRunJobsFixture() },
+      // The trusted artifact names ONLY the genuine comment's id (1) --
+      // this run's own trusted job posted exactly one comment.
+      workflowRunArtifacts: {
+        [`o/r/${RUN_ID}`]: {
+          artifacts: [{ name: 'idd-self-waiver-marker-1' }],
+        },
+      },
       changedFiles: { [PR_NUMBER]: [ADVISORY_CONVERGENCE_WORKFLOW_PATH] },
     });
 
@@ -847,19 +936,98 @@ test('collectFromGitHub records two distinct comments citing the same run id as 
       () => port,
     );
 
-    assert.deepEqual(inputs.autoWaiverRunIdCandidateTimestamps?.[RUN_ID], [
-      autoWaiverComment().createdAt,
-      forgedSibling.createdAt,
+    assert.deepEqual(inputs.autoWaiverRunIdCandidates?.[RUN_ID], [
+      { id: '1', createdAt: autoWaiverComment().createdAt },
+      { id: '2', createdAt: forgedSibling.createdAt },
     ]);
+    assert.deepEqual(inputs.autoWaiverRunArtifactCommentIds?.[RUN_ID], ['1']);
 
-    // End-to-end (kurone-kito/idd-skill#2912 acceptance criterion 1): a
-    // forged marker sharing a legitimate, fully-verified run's id with a
-    // genuine marker must never let the auto-waiver validate, all the
-    // way from the fake-provider collection through the pure verdict.
+    // End-to-end: unlike this file's ROUND-1 mechanism (a bare "no
+    // duplicate visible" scan, which fail-closed BOTH markers the moment
+    // any second candidate for the same run id existed), round 2's
+    // artifact-binding check evaluates each candidate against the
+    // trusted set independently -- the genuine marker (id 1, named by
+    // the artifact) still validates on its own merits even though a
+    // forged sibling (id 2, never named by any artifact) also cites the
+    // same run id. This is a deliberate precision improvement: a forged
+    // sibling can no longer collaterally deny a genuine marker its
+    // auto-waiver, it just never validates itself (see the P1-regression
+    // test below for the case that actually matters -- the genuine one
+    // deleted, only the forged one surviving).
     const verdict = computeAdvisoryConvergenceVerdict(
       { ...inputs, claimEvents: [] },
       {
         ...options,
+        // kurone-kito/idd-skill#2912 (round 2): pinned near the fixture
+        // markers' own createdAt/expiresAt (2026-07-31), not real
+        // wall-clock time -- see autoWaiverComment()'s own doc comment
+        // for why an unpinned `now` (whatever `collectFromGitHub`
+        // resolved it to, i.e. actual test-run time) would classify
+        // these markers `expired` regardless of the mechanism under
+        // test.
+        now: '2026-07-31T09:05:00Z',
+        waiverMode: 'maintainer-authorized',
+        waivableSelectors: [
+          { selector: 'idd-advisory-convergence', matchMode: 'exact' },
+        ],
+      },
+    );
+    assert.equal(verdict.waiver.autoWaiverValid, true);
+  });
+});
+
+test('end-to-end: a genuine marker deleted after posting leaves a same-run-id forged sibling rejected, never validating the auto-waiver (kurone-kito/idd-skill#2912, round 2 P1: Codex + Copilot review, PR #2914)', () => {
+  withHermeticCwd(() => {
+    const forgedSibling = forgedSiblingComment();
+    const port = createFakeProviderAdapter({
+      ...baseFixture(),
+      // The genuine comment (id 1, `autoWaiverComment()`) has been
+      // deleted -- `issues: write` permits deleting ANY issue comment on
+      // the repository, not only ones the deleting token authored. Only
+      // the forged sibling (id 2) is still live.
+      comments: { [PR_NUMBER]: [forgedSibling] },
+      workflowRuns: {
+        [`o/r/${RUN_ID}`]: {
+          path: ADVISORY_CONVERGENCE_WORKFLOW_PATH,
+          head_sha: HEAD_SHA,
+          head_repository: { full_name: 'o/r' },
+          event: 'pull_request_target',
+        },
+      },
+      workflowRunJobs: { [`o/r/${RUN_ID}`]: acceptedRunJobsFixture() },
+      // The trusted artifact -- uploaded by the run's own trusted job
+      // execution, unaffected by the comment's later deletion -- still
+      // names the GENUINE (now-deleted) comment's id.
+      workflowRunArtifacts: {
+        [`o/r/${RUN_ID}`]: {
+          artifacts: [{ name: 'idd-self-waiver-marker-1' }],
+        },
+      },
+      changedFiles: { [PR_NUMBER]: [ADVISORY_CONVERGENCE_WORKFLOW_PATH] },
+    });
+
+    const { inputs, options } = collectFromGitHub(
+      parseArgs(['--pr', String(PR_NUMBER), '--owner', 'o', '--repo', 'r']),
+      () => port,
+    );
+
+    assert.deepEqual(inputs.autoWaiverRunIdCandidates?.[RUN_ID], [
+      { id: '2', createdAt: forgedSibling.createdAt },
+    ]);
+    assert.deepEqual(inputs.autoWaiverRunArtifactCommentIds?.[RUN_ID], ['1']);
+
+    const verdict = computeAdvisoryConvergenceVerdict(
+      { ...inputs, claimEvents: [] },
+      {
+        ...options,
+        // kurone-kito/idd-skill#2912 (round 2): pinned near the fixture
+        // markers' own createdAt/expiresAt (2026-07-31), not real
+        // wall-clock time -- see autoWaiverComment()'s own doc comment
+        // for why an unpinned `now` (whatever `collectFromGitHub`
+        // resolved it to, i.e. actual test-run time) would classify
+        // these markers `expired` regardless of the mechanism under
+        // test.
+        now: '2026-07-31T09:05:00Z',
         waiverMode: 'maintainer-authorized',
         waivableSelectors: [
           { selector: 'idd-advisory-convergence', matchMode: 'exact' },

--- a/tests/advisory-convergence-fake-provider.test.mts
+++ b/tests/advisory-convergence-fake-provider.test.mts
@@ -7,8 +7,11 @@ import { test } from 'node:test';
 import {
   ADVISORY_CONVERGENCE_WORKFLOW_PATH,
   collectFromGitHub,
+  computeAdvisoryConvergenceVerdict,
   parseArgs,
   SELF_REFERENTIAL_BOOTSTRAP_AUTO_REASON,
+  SELF_REFERENTIAL_WAIVER_JOB_ID,
+  SELF_REFERENTIAL_WAIVER_POST_STEP_NAME,
 } from '../src/scripts/advisory-convergence.mts';
 import { DEFAULT_ADVISORY_TERMINAL_WINDOW_MINUTES } from '../src/scripts/advisory-wait-policy.mts';
 import { renderExternalCheckWaiverComment } from '../src/scripts/marker-helpers.mts';
@@ -700,5 +703,169 @@ test('collectFromGitHub rejects a run-id token that is not a canonical positive 
     );
 
     assert.deepEqual(inputs.autoWaiverRunLookups, {});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// run-jobs provenance lookup and duplicate-run-id candidate counting
+// (kurone-kito/idd-skill#2912): closes the residual bearer-evidence gap
+// #2657 round 16 tracked but did not close -- a marker citing a real,
+// legitimate run's id must also be proven to have been POSTED by that
+// run's own idd-advisory-convergence-self-waiver job, not merely to cite
+// a run of the right shape.
+// ---------------------------------------------------------------------------
+
+function acceptedRunJobsFixture() {
+  return {
+    jobs: [
+      {
+        name: SELF_REFERENTIAL_WAIVER_JOB_ID,
+        conclusion: 'success',
+        steps: [
+          {
+            name: SELF_REFERENTIAL_WAIVER_POST_STEP_NAME,
+            conclusion: 'success',
+            started_at: '2026-07-31T08:59:30Z',
+            completed_at: '2026-07-31T09:00:30Z',
+          },
+        ],
+      },
+    ],
+  };
+}
+
+test("collectFromGitHub fetches getWorkflowRunJobs and threads the cited run's self-waiver post-step evidence into inputs.autoWaiverRunJobLookups", () => {
+  withHermeticCwd(() => {
+    const port = createFakeProviderAdapter({
+      ...baseFixture(),
+      comments: { [PR_NUMBER]: [autoWaiverComment()] },
+      workflowRuns: {
+        [`o/r/${RUN_ID}`]: {
+          path: ADVISORY_CONVERGENCE_WORKFLOW_PATH,
+          head_sha: HEAD_SHA,
+          head_repository: { full_name: 'o/r' },
+          event: 'pull_request_target',
+        },
+      },
+      workflowRunJobs: { [`o/r/${RUN_ID}`]: acceptedRunJobsFixture() },
+    });
+
+    const { inputs } = collectFromGitHub(
+      parseArgs(['--pr', String(PR_NUMBER), '--owner', 'o', '--repo', 'r']),
+      () => port,
+    );
+
+    assert.deepEqual(inputs.autoWaiverRunJobLookups?.[RUN_ID], {
+      conclusion: 'success',
+      startedAt: '2026-07-31T08:59:30Z',
+      completedAt: '2026-07-31T09:00:30Z',
+    });
+  });
+});
+
+test('collectFromGitHub resolves a candidate run-jobs lookup failure to an {error} entry instead of crashing the whole collection', () => {
+  withHermeticCwd(() => {
+    const port = createFakeProviderAdapter({
+      ...baseFixture(),
+      comments: { [PR_NUMBER]: [autoWaiverComment()] },
+      workflowRuns: {
+        [`o/r/${RUN_ID}`]: {
+          path: ADVISORY_CONVERGENCE_WORKFLOW_PATH,
+          head_sha: HEAD_SHA,
+          head_repository: { full_name: 'o/r' },
+          event: 'pull_request_target',
+        },
+      },
+      // No `workflowRunJobs` fixture entry -- the fake adapter throws on
+      // lookup, matching the real adapter's own no-catch, throw-on-failure
+      // contract for an unresolvable run.
+    });
+
+    const { inputs } = collectFromGitHub(
+      parseArgs(['--pr', String(PR_NUMBER), '--owner', 'o', '--repo', 'r']),
+      () => port,
+    );
+
+    const lookup = inputs.autoWaiverRunJobLookups?.[RUN_ID];
+    assert.ok(lookup && 'error' in lookup && lookup.error.length > 0);
+  });
+});
+
+test('collectFromGitHub never fetches getWorkflowRunJobs when no candidate auto-waiver marker is present (no wasted API call)', () => {
+  withHermeticCwd(() => {
+    const port = createFakeProviderAdapter({
+      ...baseFixture(),
+      comments: { [PR_NUMBER]: [] },
+      // No `workflowRunJobs` fixture at all -- any lookup attempt would
+      // throw, so a non-empty result below would prove one was attempted.
+    });
+
+    const { inputs } = collectFromGitHub(
+      parseArgs(['--pr', String(PR_NUMBER), '--owner', 'o', '--repo', 'r']),
+      () => port,
+    );
+
+    assert.deepEqual(inputs.autoWaiverRunJobLookups, {});
+  });
+});
+
+test('collectFromGitHub records two distinct comments citing the same run id as two candidate timestamps (autoWaiverRunIdCandidateTimestamps)', () => {
+  withHermeticCwd(() => {
+    const forgedSibling = {
+      id: 2,
+      body: renderExternalCheckWaiverComment({
+        agentId: 'github-actions-bot',
+        claimId: 'claim-def',
+        headSha: HEAD_SHA,
+        checkSelector: 'idd-advisory-convergence',
+        reason: SELF_REFERENTIAL_BOOTSTRAP_AUTO_REASON,
+        expiresAt: '2099-01-01T00:00:00Z',
+        actor: 'github-actions[bot]',
+        runId: RUN_ID,
+      }),
+      createdAt: '2026-07-31T09:00:05Z',
+      updatedAt: '2026-07-31T09:00:05Z',
+      authorLogin: 'github-actions[bot]',
+    };
+    const port = createFakeProviderAdapter({
+      ...baseFixture(),
+      comments: { [PR_NUMBER]: [autoWaiverComment(), forgedSibling] },
+      workflowRuns: {
+        [`o/r/${RUN_ID}`]: {
+          path: ADVISORY_CONVERGENCE_WORKFLOW_PATH,
+          head_sha: HEAD_SHA,
+          head_repository: { full_name: 'o/r' },
+          event: 'pull_request_target',
+        },
+      },
+      workflowRunJobs: { [`o/r/${RUN_ID}`]: acceptedRunJobsFixture() },
+      changedFiles: { [PR_NUMBER]: [ADVISORY_CONVERGENCE_WORKFLOW_PATH] },
+    });
+
+    const { inputs, options } = collectFromGitHub(
+      parseArgs(['--pr', String(PR_NUMBER), '--owner', 'o', '--repo', 'r']),
+      () => port,
+    );
+
+    assert.deepEqual(inputs.autoWaiverRunIdCandidateTimestamps?.[RUN_ID], [
+      autoWaiverComment().createdAt,
+      forgedSibling.createdAt,
+    ]);
+
+    // End-to-end (kurone-kito/idd-skill#2912 acceptance criterion 1): a
+    // forged marker sharing a legitimate, fully-verified run's id with a
+    // genuine marker must never let the auto-waiver validate, all the
+    // way from the fake-provider collection through the pure verdict.
+    const verdict = computeAdvisoryConvergenceVerdict(
+      { ...inputs, claimEvents: [] },
+      {
+        ...options,
+        waiverMode: 'maintainer-authorized',
+        waivableSelectors: [
+          { selector: 'idd-advisory-convergence', matchMode: 'exact' },
+        ],
+      },
+    );
+    assert.equal(verdict.waiver.autoWaiverValid, false);
   });
 });

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -44,6 +44,7 @@ import {
   writeAdvisoryConvergenceCliOutput,
 } from '../src/scripts/advisory-convergence.mts';
 import {
+  digestExternalCheckWaiverMarkerBody,
   renderAdvisoryWaitRecoveryMarker,
   renderExternalCheckWaiverComment,
 } from '../src/scripts/marker-helpers.mts';
@@ -3172,10 +3173,21 @@ function autoWaiverBody(
     runId?: string | null;
     headSha?: string;
     claimId?: string;
+    // kurone-kito/idd-skill#2912 (round 3): `agentId` is never consumed
+    // by any classification/trust condition an external-check-waiver
+    // marker is evaluated against (it names the AGENT that requested
+    // the waiver, not the run/claim/HEAD the marker binds to -- see
+    // `digestExternalCheckWaiverMarkerBody`'s own doc comment for why
+    // that distinction matters), so overriding ONLY this field is the
+    // one way to change a marker's exact body text/digest without also
+    // tripping an earlier, unrelated rejection reason (wrong claim,
+    // wrong HEAD, etc.) -- exactly what the round-3 edit-after-post
+    // regression test below needs to isolate the digest check alone.
+    agentId?: string;
   } = {},
 ): string {
   return renderExternalCheckWaiverComment({
-    agentId: 'github-actions-bot',
+    agentId: overrides.agentId ?? 'github-actions-bot',
     claimId: overrides.claimId ?? CLAIM_ID,
     headSha: overrides.headSha ?? HEAD,
     checkSelector: 'idd-advisory-convergence',
@@ -3209,16 +3221,31 @@ function acceptedRunJobLookup() {
 // kurone-kito/idd-skill#2912 (round 2): the decimal comment id the
 // accepted marker's own comment carries in every test below that reuses
 // these fixtures -- must match `SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX
-// + COMMENT_ID` in `acceptedTrustedCommentIds()` below for
+// + COMMENT_ID` in `acceptedTrustedBindings()` below for
 // `verifySelfReferentialBootstrapWaiverArtifactBinding` to accept it.
 const COMMENT_ID = '987654321';
 
-function acceptedRunIdCandidates() {
-  return { [RUN_ID]: [{ id: COMMENT_ID, createdAt: RECENT }] };
+// kurone-kito/idd-skill#2912 (round 3): the digest both
+// `acceptedRunIdCandidates()` and `acceptedTrustedBindings()` below
+// share, computed the same way `collectFromGitHub`'s live comment scan
+// and the posting CLI's post-write reconcile both do -- hashing
+// `autoWaiverBody()`'s own rendered text, never a hand-typed literal, so
+// this fixture can never silently drift from what the render function
+// actually produces.
+function acceptedBodyDigest() {
+  return digestExternalCheckWaiverMarkerBody(autoWaiverBody());
 }
 
-function acceptedTrustedCommentIds() {
-  return { [RUN_ID]: [COMMENT_ID] };
+function acceptedRunIdCandidates() {
+  return {
+    [RUN_ID]: [
+      { id: COMMENT_ID, createdAt: RECENT, bodyDigest: acceptedBodyDigest() },
+    ],
+  };
+}
+
+function acceptedTrustedBindings() {
+  return { [RUN_ID]: [{ id: COMMENT_ID, bodyDigest: acceptedBodyDigest() }] };
 }
 
 test('self-referential-bootstrap-auto: a valid auto-waiver makes ready true immediately, before deadlinePassed/terminalUnavailable (regression for the 2026-09-10 self-cancellation shape)', () => {
@@ -3236,7 +3263,7 @@ test('self-referential-bootstrap-auto: a valid auto-waiver makes ready true imme
       autoWaiverRunLookups: { [RUN_ID]: acceptedRunLookup() },
       autoWaiverRunJobLookups: { [RUN_ID]: acceptedRunJobLookup() },
       autoWaiverRunIdCandidates: acceptedRunIdCandidates(),
-      autoWaiverRunArtifactCommentIds: acceptedTrustedCommentIds(),
+      autoWaiverRunArtifactBindings: acceptedTrustedBindings(),
       changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
     }),
     baseOptions({
@@ -3519,7 +3546,7 @@ test('self-referential-bootstrap-auto: a run reported with different repository-
       },
       autoWaiverRunJobLookups: { [RUN_ID]: acceptedRunJobLookup() },
       autoWaiverRunIdCandidates: acceptedRunIdCandidates(),
-      autoWaiverRunArtifactCommentIds: acceptedTrustedCommentIds(),
+      autoWaiverRunArtifactBindings: acceptedTrustedBindings(),
       changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
     }),
     baseOptions({
@@ -3756,7 +3783,7 @@ test('self-referential-bootstrap-auto: an indeterminate branch mismatch with a r
       autoWaiverRunLookups: { [RUN_ID]: acceptedRunLookup() },
       autoWaiverRunJobLookups: { [RUN_ID]: acceptedRunJobLookup() },
       autoWaiverRunIdCandidates: acceptedRunIdCandidates(),
-      autoWaiverRunArtifactCommentIds: acceptedTrustedCommentIds(),
+      autoWaiverRunArtifactBindings: acceptedTrustedBindings(),
       changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
     }),
     baseOptions({
@@ -3826,7 +3853,7 @@ test('self-referential-bootstrap-auto: reasons is empty when a valid auto-waiver
       autoWaiverRunLookups: { [RUN_ID]: acceptedRunLookup() },
       autoWaiverRunJobLookups: { [RUN_ID]: acceptedRunJobLookup() },
       autoWaiverRunIdCandidates: acceptedRunIdCandidates(),
-      autoWaiverRunArtifactCommentIds: acceptedTrustedCommentIds(),
+      autoWaiverRunArtifactBindings: acceptedTrustedBindings(),
       changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
     }),
     baseOptions({
@@ -4016,7 +4043,7 @@ test('self-referential-bootstrap-auto: a vendored-node adopter touching its own 
       },
       autoWaiverRunJobLookups: { [RUN_ID]: acceptedRunJobLookup() },
       autoWaiverRunIdCandidates: acceptedRunIdCandidates(),
-      autoWaiverRunArtifactCommentIds: acceptedTrustedCommentIds(),
+      autoWaiverRunArtifactBindings: acceptedTrustedBindings(),
       changedFilePaths: ['scripts/advisory-convergence.mjs'],
     }),
     baseOptions({
@@ -4051,7 +4078,7 @@ test('self-referential-bootstrap-auto: a package-manager adopter touching packag
       },
       autoWaiverRunJobLookups: { [RUN_ID]: acceptedRunJobLookup() },
       autoWaiverRunIdCandidates: acceptedRunIdCandidates(),
-      autoWaiverRunArtifactCommentIds: acceptedTrustedCommentIds(),
+      autoWaiverRunArtifactBindings: acceptedTrustedBindings(),
       changedFilePaths: ['package.json'],
     }),
     baseOptions({
@@ -4143,7 +4170,7 @@ test('self-referential-bootstrap-auto: this source repository ignores its own co
 test('self-referential-bootstrap-auto: a genuine marker deleted after posting leaves a same-run-id forged sibling rejected, never the sole winner (kurone-kito/idd-skill#2912, round 2 P1: Codex + Copilot review, PR #2914)', () => {
   // The genuine marker's own comment id (`COMMENT_ID`) is what the
   // cited run's OWN trusted job execution recorded posting, via the
-  // artifact-name-encoded `autoWaiverRunArtifactCommentIds` below -- that
+  // artifact-name-encoded `autoWaiverRunArtifactBindings` below -- that
   // record persists even after the comment itself is deleted (`issues:
   // write` permits deleting ANY comment, not only ones the deleting
   // token authored). `comments`/`autoWaiverRunIdCandidates` below model
@@ -4154,7 +4181,8 @@ test('self-referential-bootstrap-auto: a genuine marker deleted after posting le
   // recorded in the trusted set -- no same-repository `pull_request`-
   // triggered workflow can write to a different run's own artifact list
   // -- so it is rejected regardless of how convincingly it otherwise
-  // qualifies (right run shape, right job-success window).
+  // qualifies (right run shape, right job-success window, and -- round 3
+  // -- even the identical body text/digest as the genuine marker).
   const FORGED_COMMENT_ID = '111222333';
   const verdict = computeAdvisoryConvergenceVerdict(
     baseInputs({
@@ -4172,12 +4200,18 @@ test('self-referential-bootstrap-auto: a genuine marker deleted after posting le
       autoWaiverRunLookups: { [RUN_ID]: acceptedRunLookup() },
       autoWaiverRunJobLookups: { [RUN_ID]: acceptedRunJobLookup() },
       autoWaiverRunIdCandidates: {
-        [RUN_ID]: [{ id: FORGED_COMMENT_ID, createdAt: RECENT }],
+        [RUN_ID]: [
+          {
+            id: FORGED_COMMENT_ID,
+            createdAt: RECENT,
+            bodyDigest: acceptedBodyDigest(),
+          },
+        ],
       },
       // The trusted set still names the GENUINE (now-deleted) comment's
       // id -- the artifact the trusted job uploaded is immutable and
       // unaffected by the deletion.
-      autoWaiverRunArtifactCommentIds: acceptedTrustedCommentIds(),
+      autoWaiverRunArtifactBindings: acceptedTrustedBindings(),
       changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
     }),
     baseOptions({
@@ -4191,7 +4225,69 @@ test('self-referential-bootstrap-auto: a genuine marker deleted after posting le
   assert.equal(verdict.ready, false);
 });
 
-test('self-referential-bootstrap-auto: two distinct candidates sharing the same run id and the same wall-clock second are rejected, never picking a winner (round-1 duplicate-run-id property, preserved under the round-2 artifact-binding mechanism)', () => {
+test('self-referential-bootstrap-auto: a genuine comment EDITED in place after posting is rejected even though its id and createdAt are unchanged (kurone-kito/idd-skill#2912, round 3 P1: Copilot review, PR #2914 round 2)', () => {
+  // Round 2 closed comment DELETION (the genuine marker vanishes, a
+  // forged sibling with a DIFFERENT id survives). This is the sibling
+  // gap Copilot found in round 2's own fix: `issues: write` also
+  // permits EDITING an existing comment's body in place, which
+  // preserves that comment's `id` AND `createdAt` while replacing its
+  // content. `COMMENT_ID`/`RECENT` here are the SAME id/timestamp the
+  // trusted artifact binding (`acceptedTrustedBindings()`) names --
+  // round 2's id-only check would have accepted this. The live body
+  // has been rewritten (a different `agentId`, the one field no
+  // classification/trust condition consumes -- see `autoWaiverBody`'s
+  // own doc comment on that parameter for why: deliberately NOT
+  // `claimId`/`headSha`/`reason`/`runId`, any of which would make this
+  // marker fail an EARLIER, unrelated check first and no longer isolate
+  // the digest mismatch this test exists to exercise), though, so its
+  // digest no longer matches the trusted binding's `bodyDigest` (still
+  // the ORIGINAL, genuine body's digest -- an artifact is immutable
+  // once uploaded, so the trusted record itself cannot follow the
+  // edit). `verifySelfReferentialBootstrapWaiverArtifactBinding` must
+  // reject this on the digest mismatch alone.
+  const editedBody = autoWaiverBody({ agentId: 'a-different-agent-id' });
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [],
+      claimEvents: [claimComment()],
+      comments: [
+        {
+          // The SAME comment id/createdAt the genuine marker originally
+          // posted with -- only the body has been rewritten in place.
+          author: { login: BOT_LOGIN },
+          body: editedBody,
+          createdAt: RECENT,
+        },
+      ],
+      autoWaiverRunLookups: { [RUN_ID]: acceptedRunLookup() },
+      autoWaiverRunJobLookups: { [RUN_ID]: acceptedRunJobLookup() },
+      autoWaiverRunIdCandidates: {
+        [RUN_ID]: [
+          {
+            id: COMMENT_ID,
+            createdAt: RECENT,
+            bodyDigest: digestExternalCheckWaiverMarkerBody(editedBody),
+          },
+        ],
+      },
+      // The trusted set still names the digest of the ORIGINAL, genuine
+      // body -- the artifact the trusted job uploaded immediately after
+      // posting is immutable and cannot reflect a LATER edit.
+      autoWaiverRunArtifactBindings: acceptedTrustedBindings(),
+      changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
+    }),
+    baseOptions({
+      headCommittedAt: RECENT,
+      waiverMode: 'maintainer-authorized',
+      waivableSelectors: ADVISORY_CONVERGENCE_WAIVABLE,
+      repositoryFullName: REPO_FULL_NAME,
+    }),
+  );
+  assert.equal(verdict.waiver.autoWaiverValid, false);
+  assert.equal(verdict.ready, false);
+});
+
+test('self-referential-bootstrap-auto: two distinct candidates sharing the same run id and the same wall-clock second are rejected, never picking a winner (round-1 duplicate-run-id property, preserved under the round-2/3 artifact-binding mechanism)', () => {
   // A genuine marker and a forged sibling racing to land inside the
   // SAME execution window, timestamped to the SAME second -- ambiguous
   // for `verifySelfReferentialBootstrapWaiverArtifactBinding`'s own
@@ -4213,11 +4309,19 @@ test('self-referential-bootstrap-auto: two distinct candidates sharing the same 
       autoWaiverRunJobLookups: { [RUN_ID]: acceptedRunJobLookup() },
       autoWaiverRunIdCandidates: {
         [RUN_ID]: [
-          { id: COMMENT_ID, createdAt: RECENT },
-          { id: '444555666', createdAt: RECENT },
+          {
+            id: COMMENT_ID,
+            createdAt: RECENT,
+            bodyDigest: acceptedBodyDigest(),
+          },
+          {
+            id: '444555666',
+            createdAt: RECENT,
+            bodyDigest: acceptedBodyDigest(),
+          },
         ],
       },
-      autoWaiverRunArtifactCommentIds: acceptedTrustedCommentIds(),
+      autoWaiverRunArtifactBindings: acceptedTrustedBindings(),
       changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
     }),
     baseOptions({
@@ -4265,14 +4369,25 @@ test('self-referential-bootstrap-auto: a legitimate CI rerun (second genuine mar
           // earlier -- structurally qualifies (same run id) but its
           // `createdAt` never matches attempt 2's, so it is simply
           // irrelevant to attempt 2's own correlation.
-          { id: STALE_ATTEMPT_1_COMMENT_ID, createdAt: '2026-07-11T06:00:00Z' },
-          { id: COMMENT_ID, createdAt: RECENT },
+          {
+            id: STALE_ATTEMPT_1_COMMENT_ID,
+            createdAt: '2026-07-11T06:00:00Z',
+            bodyDigest: acceptedBodyDigest(),
+          },
+          {
+            id: COMMENT_ID,
+            createdAt: RECENT,
+            bodyDigest: acceptedBodyDigest(),
+          },
         ],
       },
       // Both attempts' artifacts persist -- the trusted set grows,
       // never replaces.
-      autoWaiverRunArtifactCommentIds: {
-        [RUN_ID]: [STALE_ATTEMPT_1_COMMENT_ID, COMMENT_ID],
+      autoWaiverRunArtifactBindings: {
+        [RUN_ID]: [
+          { id: STALE_ATTEMPT_1_COMMENT_ID, bodyDigest: acceptedBodyDigest() },
+          { id: COMMENT_ID, bodyDigest: acceptedBodyDigest() },
+        ],
       },
       changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
     }),
@@ -4310,7 +4425,7 @@ test('self-referential-bootstrap-auto: a marker citing a run whose self-waiver p
         [RUN_ID]: { ...acceptedRunJobLookup(), conclusion: 'skipped' },
       },
       autoWaiverRunIdCandidates: acceptedRunIdCandidates(),
-      autoWaiverRunArtifactCommentIds: acceptedTrustedCommentIds(),
+      autoWaiverRunArtifactBindings: acceptedTrustedBindings(),
       changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
     }),
     baseOptions({
@@ -4352,7 +4467,7 @@ test("self-referential-bootstrap-auto: a marker created outside the cited run's 
         },
       },
       autoWaiverRunIdCandidates: acceptedRunIdCandidates(),
-      autoWaiverRunArtifactCommentIds: acceptedTrustedCommentIds(),
+      autoWaiverRunArtifactBindings: acceptedTrustedBindings(),
       changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
     }),
     baseOptions({
@@ -4381,7 +4496,7 @@ test('self-referential-bootstrap-auto: a run-jobs lookup error fails closed the 
       autoWaiverRunLookups: { [RUN_ID]: acceptedRunLookup() },
       autoWaiverRunJobLookups: { [RUN_ID]: { error: 'HTTP 404' } },
       autoWaiverRunIdCandidates: acceptedRunIdCandidates(),
-      autoWaiverRunArtifactCommentIds: acceptedTrustedCommentIds(),
+      autoWaiverRunArtifactBindings: acceptedTrustedBindings(),
       changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
     }),
     baseOptions({
@@ -4415,7 +4530,7 @@ test('self-referential-bootstrap-auto: an absent/empty artifact-trusted-id set f
       autoWaiverRunLookups: { [RUN_ID]: acceptedRunLookup() },
       autoWaiverRunJobLookups: { [RUN_ID]: acceptedRunJobLookup() },
       autoWaiverRunIdCandidates: acceptedRunIdCandidates(),
-      autoWaiverRunArtifactCommentIds: { [RUN_ID]: [] },
+      autoWaiverRunArtifactBindings: { [RUN_ID]: [] },
       changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
     }),
     baseOptions({

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -36,6 +36,8 @@ import {
   runAdvisoryConvergenceWithPoll,
   SAME_HEAD_REROLL_INELIGIBLE_REASON,
   SELF_REFERENTIAL_BOOTSTRAP_AUTO_REASON,
+  SELF_REFERENTIAL_WAIVER_JOB_ID,
+  SELF_REFERENTIAL_WAIVER_POST_STEP_NAME,
   SELF_REFERENTIAL_WAIVER_TRIGGER_FILES,
   viewerProbeGhOptions,
   writeAdvisoryConvergenceCliOutput,
@@ -3192,6 +3194,21 @@ function acceptedRunLookup() {
   };
 }
 
+// kurone-kito/idd-skill#2912: the marker's own `createdAt` in every test
+// below that reuses this fixture is `RECENT` (2026-07-11T10:00:00Z) --
+// this window brackets it, matching a genuine ~1-minute job execution.
+function acceptedRunJobLookup() {
+  return {
+    conclusion: 'success',
+    startedAt: '2026-07-11T09:59:30Z',
+    completedAt: '2026-07-11T10:00:30Z',
+  };
+}
+
+function acceptedCandidateTimestamps() {
+  return { [RUN_ID]: [RECENT] };
+}
+
 test('self-referential-bootstrap-auto: a valid auto-waiver makes ready true immediately, before deadlinePassed/terminalUnavailable (regression for the 2026-09-10 self-cancellation shape)', () => {
   const verdict = computeAdvisoryConvergenceVerdict(
     baseInputs({
@@ -3205,6 +3222,8 @@ test('self-referential-bootstrap-auto: a valid auto-waiver makes ready true imme
         },
       ],
       autoWaiverRunLookups: { [RUN_ID]: acceptedRunLookup() },
+      autoWaiverRunJobLookups: { [RUN_ID]: acceptedRunJobLookup() },
+      autoWaiverRunIdCandidateTimestamps: acceptedCandidateTimestamps(),
       changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
     }),
     baseOptions({
@@ -3485,6 +3504,8 @@ test('self-referential-bootstrap-auto: a run reported with different repository-
           repositoryFullName: 'Kurone-Kito/IDD-Skill',
         },
       },
+      autoWaiverRunJobLookups: { [RUN_ID]: acceptedRunJobLookup() },
+      autoWaiverRunIdCandidateTimestamps: acceptedCandidateTimestamps(),
       changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
     }),
     baseOptions({
@@ -3719,6 +3740,8 @@ test('self-referential-bootstrap-auto: an indeterminate branch mismatch with a r
         },
       ],
       autoWaiverRunLookups: { [RUN_ID]: acceptedRunLookup() },
+      autoWaiverRunJobLookups: { [RUN_ID]: acceptedRunJobLookup() },
+      autoWaiverRunIdCandidateTimestamps: acceptedCandidateTimestamps(),
       changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
     }),
     baseOptions({
@@ -3786,6 +3809,8 @@ test('self-referential-bootstrap-auto: reasons is empty when a valid auto-waiver
         },
       ],
       autoWaiverRunLookups: { [RUN_ID]: acceptedRunLookup() },
+      autoWaiverRunJobLookups: { [RUN_ID]: acceptedRunJobLookup() },
+      autoWaiverRunIdCandidateTimestamps: acceptedCandidateTimestamps(),
       changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
     }),
     baseOptions({
@@ -3973,6 +3998,8 @@ test('self-referential-bootstrap-auto: a vendored-node adopter touching its own 
           repositoryFullName: 'someone-else/adopter-repo',
         },
       },
+      autoWaiverRunJobLookups: { [RUN_ID]: acceptedRunJobLookup() },
+      autoWaiverRunIdCandidateTimestamps: acceptedCandidateTimestamps(),
       changedFilePaths: ['scripts/advisory-convergence.mjs'],
     }),
     baseOptions({
@@ -4005,6 +4032,8 @@ test('self-referential-bootstrap-auto: a package-manager adopter touching packag
           repositoryFullName: 'someone-else/adopter-repo',
         },
       },
+      autoWaiverRunJobLookups: { [RUN_ID]: acceptedRunJobLookup() },
+      autoWaiverRunIdCandidateTimestamps: acceptedCandidateTimestamps(),
       changedFilePaths: ['package.json'],
     }),
     baseOptions({
@@ -4085,6 +4114,238 @@ test('self-referential-bootstrap-auto: this source repository ignores its own co
   );
   assert.equal(verdict.waiver.autoWaiverValid, false);
   assert.equal(verdict.ready, false);
+});
+
+// --- kurone-kito/idd-skill#2912: run-provenance binding -- closing the
+// --- residual bearer-evidence gap #2657 round 16 tracked but did not
+// --- close: the four run-level trust conditions above prove a marker
+// --- cites SOME genuine run of the right shape, never that THAT run's
+// --- own job actually posted THIS comment.
+
+test('self-referential-bootstrap-auto: a forged marker sharing a legitimate run id with a genuine marker is rejected (duplicate run-id, no winner picked)', () => {
+  // A same-repository `pull_request`-triggered workflow can discover
+  // this legitimate run's id via the public Actions API and post its
+  // own forged marker citing it -- both markers here independently
+  // satisfy every other condition (run shape, job success, timing
+  // window), isolating duplicate-run-id detection as the one thing
+  // that rejects this.
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [],
+      claimEvents: [claimComment()],
+      comments: [
+        {
+          author: { login: BOT_LOGIN },
+          body: autoWaiverBody(),
+          createdAt: RECENT,
+        },
+        {
+          // The forged sibling: same run id, a moment later, from a
+          // different (attacker-controlled) posting step -- but the
+          // consumer only ever sees another `github-actions[bot]`-
+          // authored comment citing the same run.
+          author: { login: BOT_LOGIN },
+          body: autoWaiverBody(),
+          createdAt: '2026-07-11T10:00:05Z',
+        },
+      ],
+      autoWaiverRunLookups: { [RUN_ID]: acceptedRunLookup() },
+      autoWaiverRunJobLookups: { [RUN_ID]: acceptedRunJobLookup() },
+      // Both candidates' own `createdAt` fall inside
+      // acceptedRunJobLookup()'s `[09:59:30, 10:00:30]` window, so both
+      // independently pass provenance -- isolating the uniqueness check
+      // (not a provenance failure) as the one thing that rejects this.
+      autoWaiverRunIdCandidateTimestamps: {
+        [RUN_ID]: [RECENT, '2026-07-11T10:00:05Z'],
+      },
+      changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
+    }),
+    baseOptions({
+      headCommittedAt: RECENT,
+      waiverMode: 'maintainer-authorized',
+      waivableSelectors: ADVISORY_CONVERGENCE_WAIVABLE,
+      repositoryFullName: REPO_FULL_NAME,
+    }),
+  );
+  assert.equal(verdict.waiver.autoWaiverValid, false);
+  assert.equal(verdict.ready, false);
+});
+
+test('self-referential-bootstrap-auto: a legitimate CI rerun (second genuine marker for the same run id, prior attempt now outside the latest window) still validates (kurone-kito/idd-skill#2912, C1 review finding #2)', () => {
+  // `gh run rerun <run-id>` (this repository's own standard automated
+  // recovery path, rerun-advisory-convergence.mts) re-executes every
+  // job under the SAME run id -- including an already-succeeded
+  // self-waiver job, which posts a second genuine marker. The jobs API
+  // reports only the LATEST attempt's window, so attempt 1's marker
+  // (createdAt far before that window) fails provenance on its own and
+  // must not count toward the uniqueness tally; attempt 2's marker
+  // (createdAt inside the window) is the sole provenance-passing
+  // candidate and must still validate.
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [],
+      claimEvents: [claimComment()],
+      comments: [
+        {
+          // Attempt 2's genuine marker -- this is the one the consumer
+          // is currently evaluating.
+          author: { login: BOT_LOGIN },
+          body: autoWaiverBody(),
+          createdAt: RECENT,
+        },
+      ],
+      autoWaiverRunLookups: { [RUN_ID]: acceptedRunLookup() },
+      // The jobs API reflects only the latest (attempt 2) run: its own
+      // post step succeeded in this window.
+      autoWaiverRunJobLookups: { [RUN_ID]: acceptedRunJobLookup() },
+      autoWaiverRunIdCandidateTimestamps: {
+        // Attempt 1's own (now-stale) genuine marker, from hours
+        // earlier -- structurally qualifies (same run id) but falls
+        // outside attempt 2's window, so it must not count as a
+        // duplicate.
+        [RUN_ID]: ['2026-07-11T06:00:00Z', RECENT],
+      },
+      changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
+    }),
+    baseOptions({
+      headCommittedAt: RECENT,
+      waiverMode: 'maintainer-authorized',
+      waivableSelectors: ADVISORY_CONVERGENCE_WAIVABLE,
+      repositoryFullName: REPO_FULL_NAME,
+    }),
+  );
+  assert.equal(verdict.waiver.autoWaiverValid, true);
+  assert.equal(verdict.ready, true);
+});
+
+test('self-referential-bootstrap-auto: a marker citing a run whose self-waiver post step never succeeded is rejected (job-status evidence insufficient)', () => {
+  // The cited run has the right path/head-sha/repository/event (every
+  // pre-#2912 condition still passes), but its own
+  // idd-advisory-convergence-self-waiver job's post step shows
+  // `skipped`, not `success` -- proving this run's own job never
+  // actually posted a marker, so whatever comment cites it must have
+  // come from somewhere else.
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [],
+      claimEvents: [claimComment()],
+      comments: [
+        {
+          author: { login: BOT_LOGIN },
+          body: autoWaiverBody(),
+          createdAt: RECENT,
+        },
+      ],
+      autoWaiverRunLookups: { [RUN_ID]: acceptedRunLookup() },
+      autoWaiverRunJobLookups: {
+        [RUN_ID]: { ...acceptedRunJobLookup(), conclusion: 'skipped' },
+      },
+      autoWaiverRunIdCandidateTimestamps: acceptedCandidateTimestamps(),
+      changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
+    }),
+    baseOptions({
+      headCommittedAt: RECENT,
+      waiverMode: 'maintainer-authorized',
+      waivableSelectors: ADVISORY_CONVERGENCE_WAIVABLE,
+      repositoryFullName: REPO_FULL_NAME,
+    }),
+  );
+  assert.equal(verdict.waiver.autoWaiverValid, false);
+  assert.equal(verdict.ready, false);
+});
+
+test("self-referential-bootstrap-auto: a marker created outside the cited run's post-step execution window is rejected (stale-run reuse)", () => {
+  // The cited run's own post step genuinely succeeded at some point in
+  // the past, but this specific comment's own `createdAt` falls hours
+  // outside that step's `[startedAt, completedAt]` window -- exactly
+  // the shape a forged marker minted long after the genuine run
+  // finished (e.g. once the genuine marker has since expired) would
+  // have, even though the run-level shape and job success both check
+  // out.
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [],
+      claimEvents: [claimComment()],
+      comments: [
+        {
+          author: { login: BOT_LOGIN },
+          body: autoWaiverBody(),
+          createdAt: RECENT,
+        },
+      ],
+      autoWaiverRunLookups: { [RUN_ID]: acceptedRunLookup() },
+      autoWaiverRunJobLookups: {
+        [RUN_ID]: {
+          conclusion: 'success',
+          startedAt: '2026-07-01T00:00:00Z',
+          completedAt: '2026-07-01T00:01:00Z',
+        },
+      },
+      autoWaiverRunIdCandidateTimestamps: acceptedCandidateTimestamps(),
+      changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
+    }),
+    baseOptions({
+      headCommittedAt: RECENT,
+      waiverMode: 'maintainer-authorized',
+      waivableSelectors: ADVISORY_CONVERGENCE_WAIVABLE,
+      repositoryFullName: REPO_FULL_NAME,
+    }),
+  );
+  assert.equal(verdict.waiver.autoWaiverValid, false);
+  assert.equal(verdict.ready, false);
+});
+
+test('self-referential-bootstrap-auto: a run-jobs lookup error fails closed the same way a run lookup error does', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [],
+      claimEvents: [claimComment()],
+      comments: [
+        {
+          author: { login: BOT_LOGIN },
+          body: autoWaiverBody(),
+          createdAt: RECENT,
+        },
+      ],
+      autoWaiverRunLookups: { [RUN_ID]: acceptedRunLookup() },
+      autoWaiverRunJobLookups: { [RUN_ID]: { error: 'HTTP 404' } },
+      autoWaiverRunIdCandidateTimestamps: acceptedCandidateTimestamps(),
+      changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
+    }),
+    baseOptions({
+      headCommittedAt: RECENT,
+      waiverMode: 'maintainer-authorized',
+      waivableSelectors: ADVISORY_CONVERGENCE_WAIVABLE,
+      repositoryFullName: REPO_FULL_NAME,
+    }),
+  );
+  assert.equal(verdict.waiver.autoWaiverValid, false);
+  assert.equal(verdict.ready, false);
+});
+
+test('self-referential-bootstrap-auto: SELF_REFERENTIAL_WAIVER_JOB_ID and SELF_REFERENTIAL_WAIVER_POST_STEP_NAME stay in sync with the workflow file (drift guard)', () => {
+  // Kept in sync by hand with `.github/workflows/idd-advisory-convergence.yml`,
+  // the same convention SELF_REFERENTIAL_WAIVER_TRIGGER_FILES and
+  // ADVISORY_CONVERGENCE_WORKFLOW_PATH already use -- a job id or step
+  // name renamed in the YAML without updating these constants would
+  // silently make `verifySelfReferentialBootstrapWaiverProvenance`
+  // reject every genuine marker (fail closed, but a self-inflicted
+  // outage rather than the workflow file drifting invisibly).
+  const workflow = readFileSync(
+    new URL(
+      '../.github/workflows/idd-advisory-convergence.yml',
+      import.meta.url,
+    ),
+    'utf8',
+  );
+  assert.ok(
+    workflow.includes(`${SELF_REFERENTIAL_WAIVER_JOB_ID}:`),
+    'workflow file no longer declares the expected self-waiver job id',
+  );
+  assert.ok(
+    workflow.includes(`name: ${SELF_REFERENTIAL_WAIVER_POST_STEP_NAME}`),
+    'workflow file no longer declares the expected post-step name',
+  );
 });
 
 // --- #1570 AC6: no code path this issue adds ever invokes `gh pr merge

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -36,6 +36,7 @@ import {
   runAdvisoryConvergenceWithPoll,
   SAME_HEAD_REROLL_INELIGIBLE_REASON,
   SELF_REFERENTIAL_BOOTSTRAP_AUTO_REASON,
+  SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX,
   SELF_REFERENTIAL_WAIVER_JOB_ID,
   SELF_REFERENTIAL_WAIVER_POST_STEP_NAME,
   SELF_REFERENTIAL_WAIVER_TRIGGER_FILES,
@@ -3205,8 +3206,19 @@ function acceptedRunJobLookup() {
   };
 }
 
-function acceptedCandidateTimestamps() {
-  return { [RUN_ID]: [RECENT] };
+// kurone-kito/idd-skill#2912 (round 2): the decimal comment id the
+// accepted marker's own comment carries in every test below that reuses
+// these fixtures -- must match `SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX
+// + COMMENT_ID` in `acceptedTrustedCommentIds()` below for
+// `verifySelfReferentialBootstrapWaiverArtifactBinding` to accept it.
+const COMMENT_ID = '987654321';
+
+function acceptedRunIdCandidates() {
+  return { [RUN_ID]: [{ id: COMMENT_ID, createdAt: RECENT }] };
+}
+
+function acceptedTrustedCommentIds() {
+  return { [RUN_ID]: [COMMENT_ID] };
 }
 
 test('self-referential-bootstrap-auto: a valid auto-waiver makes ready true immediately, before deadlinePassed/terminalUnavailable (regression for the 2026-09-10 self-cancellation shape)', () => {
@@ -3223,7 +3235,8 @@ test('self-referential-bootstrap-auto: a valid auto-waiver makes ready true imme
       ],
       autoWaiverRunLookups: { [RUN_ID]: acceptedRunLookup() },
       autoWaiverRunJobLookups: { [RUN_ID]: acceptedRunJobLookup() },
-      autoWaiverRunIdCandidateTimestamps: acceptedCandidateTimestamps(),
+      autoWaiverRunIdCandidates: acceptedRunIdCandidates(),
+      autoWaiverRunArtifactCommentIds: acceptedTrustedCommentIds(),
       changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
     }),
     baseOptions({
@@ -3505,7 +3518,8 @@ test('self-referential-bootstrap-auto: a run reported with different repository-
         },
       },
       autoWaiverRunJobLookups: { [RUN_ID]: acceptedRunJobLookup() },
-      autoWaiverRunIdCandidateTimestamps: acceptedCandidateTimestamps(),
+      autoWaiverRunIdCandidates: acceptedRunIdCandidates(),
+      autoWaiverRunArtifactCommentIds: acceptedTrustedCommentIds(),
       changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
     }),
     baseOptions({
@@ -3741,7 +3755,8 @@ test('self-referential-bootstrap-auto: an indeterminate branch mismatch with a r
       ],
       autoWaiverRunLookups: { [RUN_ID]: acceptedRunLookup() },
       autoWaiverRunJobLookups: { [RUN_ID]: acceptedRunJobLookup() },
-      autoWaiverRunIdCandidateTimestamps: acceptedCandidateTimestamps(),
+      autoWaiverRunIdCandidates: acceptedRunIdCandidates(),
+      autoWaiverRunArtifactCommentIds: acceptedTrustedCommentIds(),
       changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
     }),
     baseOptions({
@@ -3810,7 +3825,8 @@ test('self-referential-bootstrap-auto: reasons is empty when a valid auto-waiver
       ],
       autoWaiverRunLookups: { [RUN_ID]: acceptedRunLookup() },
       autoWaiverRunJobLookups: { [RUN_ID]: acceptedRunJobLookup() },
-      autoWaiverRunIdCandidateTimestamps: acceptedCandidateTimestamps(),
+      autoWaiverRunIdCandidates: acceptedRunIdCandidates(),
+      autoWaiverRunArtifactCommentIds: acceptedTrustedCommentIds(),
       changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
     }),
     baseOptions({
@@ -3999,7 +4015,8 @@ test('self-referential-bootstrap-auto: a vendored-node adopter touching its own 
         },
       },
       autoWaiverRunJobLookups: { [RUN_ID]: acceptedRunJobLookup() },
-      autoWaiverRunIdCandidateTimestamps: acceptedCandidateTimestamps(),
+      autoWaiverRunIdCandidates: acceptedRunIdCandidates(),
+      autoWaiverRunArtifactCommentIds: acceptedTrustedCommentIds(),
       changedFilePaths: ['scripts/advisory-convergence.mjs'],
     }),
     baseOptions({
@@ -4033,7 +4050,8 @@ test('self-referential-bootstrap-auto: a package-manager adopter touching packag
         },
       },
       autoWaiverRunJobLookups: { [RUN_ID]: acceptedRunJobLookup() },
-      autoWaiverRunIdCandidateTimestamps: acceptedCandidateTimestamps(),
+      autoWaiverRunIdCandidates: acceptedRunIdCandidates(),
+      autoWaiverRunArtifactCommentIds: acceptedTrustedCommentIds(),
       changedFilePaths: ['package.json'],
     }),
     baseOptions({
@@ -4122,13 +4140,64 @@ test('self-referential-bootstrap-auto: this source repository ignores its own co
 // --- cites SOME genuine run of the right shape, never that THAT run's
 // --- own job actually posted THIS comment.
 
-test('self-referential-bootstrap-auto: a forged marker sharing a legitimate run id with a genuine marker is rejected (duplicate run-id, no winner picked)', () => {
-  // A same-repository `pull_request`-triggered workflow can discover
-  // this legitimate run's id via the public Actions API and post its
-  // own forged marker citing it -- both markers here independently
-  // satisfy every other condition (run shape, job success, timing
-  // window), isolating duplicate-run-id detection as the one thing
-  // that rejects this.
+test('self-referential-bootstrap-auto: a genuine marker deleted after posting leaves a same-run-id forged sibling rejected, never the sole winner (kurone-kito/idd-skill#2912, round 2 P1: Codex + Copilot review, PR #2914)', () => {
+  // The genuine marker's own comment id (`COMMENT_ID`) is what the
+  // cited run's OWN trusted job execution recorded posting, via the
+  // artifact-name-encoded `autoWaiverRunArtifactCommentIds` below -- that
+  // record persists even after the comment itself is deleted (`issues:
+  // write` permits deleting ANY comment, not only ones the deleting
+  // token authored). `comments`/`autoWaiverRunIdCandidates` below model
+  // the POST-DELETION state: only the forged sibling (`FORGED_COMMENT_ID`)
+  // is still live, sharing the genuine marker's exact `createdAt` (an
+  // attacker racing to post within the same second the genuine job
+  // posts, then deleting it). The forged id was never, and can never be,
+  // recorded in the trusted set -- no same-repository `pull_request`-
+  // triggered workflow can write to a different run's own artifact list
+  // -- so it is rejected regardless of how convincingly it otherwise
+  // qualifies (right run shape, right job-success window).
+  const FORGED_COMMENT_ID = '111222333';
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [],
+      claimEvents: [claimComment()],
+      comments: [
+        {
+          // The forged sibling -- the ONLY comment still live; the
+          // genuine one has been deleted.
+          author: { login: BOT_LOGIN },
+          body: autoWaiverBody(),
+          createdAt: RECENT,
+        },
+      ],
+      autoWaiverRunLookups: { [RUN_ID]: acceptedRunLookup() },
+      autoWaiverRunJobLookups: { [RUN_ID]: acceptedRunJobLookup() },
+      autoWaiverRunIdCandidates: {
+        [RUN_ID]: [{ id: FORGED_COMMENT_ID, createdAt: RECENT }],
+      },
+      // The trusted set still names the GENUINE (now-deleted) comment's
+      // id -- the artifact the trusted job uploaded is immutable and
+      // unaffected by the deletion.
+      autoWaiverRunArtifactCommentIds: acceptedTrustedCommentIds(),
+      changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
+    }),
+    baseOptions({
+      headCommittedAt: RECENT,
+      waiverMode: 'maintainer-authorized',
+      waivableSelectors: ADVISORY_CONVERGENCE_WAIVABLE,
+      repositoryFullName: REPO_FULL_NAME,
+    }),
+  );
+  assert.equal(verdict.waiver.autoWaiverValid, false);
+  assert.equal(verdict.ready, false);
+});
+
+test('self-referential-bootstrap-auto: two distinct candidates sharing the same run id and the same wall-clock second are rejected, never picking a winner (round-1 duplicate-run-id property, preserved under the round-2 artifact-binding mechanism)', () => {
+  // A genuine marker and a forged sibling racing to land inside the
+  // SAME execution window, timestamped to the SAME second -- ambiguous
+  // for `verifySelfReferentialBootstrapWaiverArtifactBinding`'s own
+  // createdAt correlation (it cannot tell which of the two live
+  // candidates `entry` actually is), so both fail closed regardless of
+  // which one's id happens to be trusted.
   const verdict = computeAdvisoryConvergenceVerdict(
     baseInputs({
       reviews: [],
@@ -4139,25 +4208,16 @@ test('self-referential-bootstrap-auto: a forged marker sharing a legitimate run 
           body: autoWaiverBody(),
           createdAt: RECENT,
         },
-        {
-          // The forged sibling: same run id, a moment later, from a
-          // different (attacker-controlled) posting step -- but the
-          // consumer only ever sees another `github-actions[bot]`-
-          // authored comment citing the same run.
-          author: { login: BOT_LOGIN },
-          body: autoWaiverBody(),
-          createdAt: '2026-07-11T10:00:05Z',
-        },
       ],
       autoWaiverRunLookups: { [RUN_ID]: acceptedRunLookup() },
       autoWaiverRunJobLookups: { [RUN_ID]: acceptedRunJobLookup() },
-      // Both candidates' own `createdAt` fall inside
-      // acceptedRunJobLookup()'s `[09:59:30, 10:00:30]` window, so both
-      // independently pass provenance -- isolating the uniqueness check
-      // (not a provenance failure) as the one thing that rejects this.
-      autoWaiverRunIdCandidateTimestamps: {
-        [RUN_ID]: [RECENT, '2026-07-11T10:00:05Z'],
+      autoWaiverRunIdCandidates: {
+        [RUN_ID]: [
+          { id: COMMENT_ID, createdAt: RECENT },
+          { id: '444555666', createdAt: RECENT },
+        ],
       },
+      autoWaiverRunArtifactCommentIds: acceptedTrustedCommentIds(),
       changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
     }),
     baseOptions({
@@ -4175,12 +4235,13 @@ test('self-referential-bootstrap-auto: a legitimate CI rerun (second genuine mar
   // `gh run rerun <run-id>` (this repository's own standard automated
   // recovery path, rerun-advisory-convergence.mts) re-executes every
   // job under the SAME run id -- including an already-succeeded
-  // self-waiver job, which posts a second genuine marker. The jobs API
-  // reports only the LATEST attempt's window, so attempt 1's marker
-  // (createdAt far before that window) fails provenance on its own and
-  // must not count toward the uniqueness tally; attempt 2's marker
-  // (createdAt inside the window) is the sole provenance-passing
-  // candidate and must still validate.
+  // self-waiver job, which posts a second genuine marker AND uploads its
+  // own artifact (the trusted set only ever grows across attempts, never
+  // replaces). Attempt 1's own stale candidate (a different `createdAt`,
+  // hours earlier) must not create any ambiguity for attempt 2's own
+  // correlation -- `verifySelfReferentialBootstrapWaiverArtifactBinding`
+  // only ever looks at candidates sharing `entry`'s EXACT `createdAt`.
+  const STALE_ATTEMPT_1_COMMENT_ID = '100200300';
   const verdict = computeAdvisoryConvergenceVerdict(
     baseInputs({
       reviews: [],
@@ -4198,12 +4259,20 @@ test('self-referential-bootstrap-auto: a legitimate CI rerun (second genuine mar
       // The jobs API reflects only the latest (attempt 2) run: its own
       // post step succeeded in this window.
       autoWaiverRunJobLookups: { [RUN_ID]: acceptedRunJobLookup() },
-      autoWaiverRunIdCandidateTimestamps: {
-        // Attempt 1's own (now-stale) genuine marker, from hours
-        // earlier -- structurally qualifies (same run id) but falls
-        // outside attempt 2's window, so it must not count as a
-        // duplicate.
-        [RUN_ID]: ['2026-07-11T06:00:00Z', RECENT],
+      autoWaiverRunIdCandidates: {
+        [RUN_ID]: [
+          // Attempt 1's own (now-stale) genuine marker, from hours
+          // earlier -- structurally qualifies (same run id) but its
+          // `createdAt` never matches attempt 2's, so it is simply
+          // irrelevant to attempt 2's own correlation.
+          { id: STALE_ATTEMPT_1_COMMENT_ID, createdAt: '2026-07-11T06:00:00Z' },
+          { id: COMMENT_ID, createdAt: RECENT },
+        ],
+      },
+      // Both attempts' artifacts persist -- the trusted set grows,
+      // never replaces.
+      autoWaiverRunArtifactCommentIds: {
+        [RUN_ID]: [STALE_ATTEMPT_1_COMMENT_ID, COMMENT_ID],
       },
       changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
     }),
@@ -4240,7 +4309,8 @@ test('self-referential-bootstrap-auto: a marker citing a run whose self-waiver p
       autoWaiverRunJobLookups: {
         [RUN_ID]: { ...acceptedRunJobLookup(), conclusion: 'skipped' },
       },
-      autoWaiverRunIdCandidateTimestamps: acceptedCandidateTimestamps(),
+      autoWaiverRunIdCandidates: acceptedRunIdCandidates(),
+      autoWaiverRunArtifactCommentIds: acceptedTrustedCommentIds(),
       changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
     }),
     baseOptions({
@@ -4281,7 +4351,8 @@ test("self-referential-bootstrap-auto: a marker created outside the cited run's 
           completedAt: '2026-07-01T00:01:00Z',
         },
       },
-      autoWaiverRunIdCandidateTimestamps: acceptedCandidateTimestamps(),
+      autoWaiverRunIdCandidates: acceptedRunIdCandidates(),
+      autoWaiverRunArtifactCommentIds: acceptedTrustedCommentIds(),
       changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
     }),
     baseOptions({
@@ -4309,7 +4380,8 @@ test('self-referential-bootstrap-auto: a run-jobs lookup error fails closed the 
       ],
       autoWaiverRunLookups: { [RUN_ID]: acceptedRunLookup() },
       autoWaiverRunJobLookups: { [RUN_ID]: { error: 'HTTP 404' } },
-      autoWaiverRunIdCandidateTimestamps: acceptedCandidateTimestamps(),
+      autoWaiverRunIdCandidates: acceptedRunIdCandidates(),
+      autoWaiverRunArtifactCommentIds: acceptedTrustedCommentIds(),
       changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
     }),
     baseOptions({
@@ -4323,29 +4395,75 @@ test('self-referential-bootstrap-auto: a run-jobs lookup error fails closed the 
   assert.equal(verdict.ready, false);
 });
 
-test('self-referential-bootstrap-auto: SELF_REFERENTIAL_WAIVER_JOB_ID and SELF_REFERENTIAL_WAIVER_POST_STEP_NAME stay in sync with the workflow file (drift guard)', () => {
-  // Kept in sync by hand with `.github/workflows/idd-advisory-convergence.yml`,
-  // the same convention SELF_REFERENTIAL_WAIVER_TRIGGER_FILES and
-  // ADVISORY_CONVERGENCE_WORKFLOW_PATH already use -- a job id or step
-  // name renamed in the YAML without updating these constants would
-  // silently make `verifySelfReferentialBootstrapWaiverProvenance`
-  // reject every genuine marker (fail closed, but a self-inflicted
-  // outage rather than the workflow file drifting invisibly).
-  const workflow = readFileSync(
-    new URL(
-      '../.github/workflows/idd-advisory-convergence.yml',
-      import.meta.url,
-    ),
-    'utf8',
+test('self-referential-bootstrap-auto: an absent/empty artifact-trusted-id set fails closed (kurone-kito/idd-skill#2912, round 2)', () => {
+  // Mirrors the run-jobs-lookup-error test above, for the THIRD lookup:
+  // an artifact-list fetch failure (`collectFromGitHub` maps it to an
+  // empty array, never an `{error}` entry -- an empty trusted set already
+  // means "nothing trusted") must reject an otherwise fully-qualifying
+  // marker, not silently skip the check.
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [],
+      claimEvents: [claimComment()],
+      comments: [
+        {
+          author: { login: BOT_LOGIN },
+          body: autoWaiverBody(),
+          createdAt: RECENT,
+        },
+      ],
+      autoWaiverRunLookups: { [RUN_ID]: acceptedRunLookup() },
+      autoWaiverRunJobLookups: { [RUN_ID]: acceptedRunJobLookup() },
+      autoWaiverRunIdCandidates: acceptedRunIdCandidates(),
+      autoWaiverRunArtifactCommentIds: { [RUN_ID]: [] },
+      changedFilePaths: [ADVISORY_CONVERGENCE_WORKFLOW_PATH],
+    }),
+    baseOptions({
+      headCommittedAt: RECENT,
+      waiverMode: 'maintainer-authorized',
+      waivableSelectors: ADVISORY_CONVERGENCE_WAIVABLE,
+      repositoryFullName: REPO_FULL_NAME,
+    }),
   );
-  assert.ok(
-    workflow.includes(`${SELF_REFERENTIAL_WAIVER_JOB_ID}:`),
-    'workflow file no longer declares the expected self-waiver job id',
-  );
-  assert.ok(
-    workflow.includes(`name: ${SELF_REFERENTIAL_WAIVER_POST_STEP_NAME}`),
-    'workflow file no longer declares the expected post-step name',
-  );
+  assert.equal(verdict.waiver.autoWaiverValid, false);
+  assert.equal(verdict.ready, false);
+});
+
+test('self-referential-bootstrap-auto: SELF_REFERENTIAL_WAIVER_JOB_ID, SELF_REFERENTIAL_WAIVER_POST_STEP_NAME, and SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX stay in sync with BOTH copies of the workflow file (drift guard)', () => {
+  // Kept in sync by hand with `.github/workflows/idd-advisory-convergence.yml`
+  // AND its `idd-template/` mirror, the same convention
+  // SELF_REFERENTIAL_WAIVER_TRIGGER_FILES and
+  // ADVISORY_CONVERGENCE_WORKFLOW_PATH already use -- a job id, step
+  // name, or artifact-name prefix renamed in either copy without
+  // updating these constants would silently make
+  // `verifySelfReferentialBootstrapWaiverProvenance` or
+  // `verifySelfReferentialBootstrapWaiverArtifactBinding` reject every
+  // genuine marker (fail closed, but a self-inflicted outage rather than
+  // a workflow file drifting invisibly). Both copies are checked --
+  // Copilot review, PR #2914 flagged the round-1 version of this test as
+  // checking only the repository-root copy, leaving the `idd-template/`
+  // mirror free to drift unnoticed.
+  for (const relativePath of [
+    '../.github/workflows/idd-advisory-convergence.yml',
+    '../idd-template/.github/workflows/idd-advisory-convergence.yml',
+  ]) {
+    const workflow = readFileSync(
+      new URL(relativePath, import.meta.url),
+      'utf8',
+    );
+    assert.ok(
+      workflow.includes(`${SELF_REFERENTIAL_WAIVER_JOB_ID}:`),
+      `${relativePath}: no longer declares the expected self-waiver job id`,
+    );
+    assert.ok(
+      workflow.includes(`name: ${SELF_REFERENTIAL_WAIVER_POST_STEP_NAME}`),
+      `${relativePath}: no longer declares the expected post-step name`,
+    );
+    assert.ok(
+      workflow.includes(SELF_REFERENTIAL_WAIVER_ARTIFACT_NAME_PREFIX),
+      `${relativePath}: no longer declares the expected artifact-name prefix`,
+    );
+  }
 });
 
 // --- #1570 AC6: no code path this issue adds ever invokes `gh pr merge

--- a/tests/external-check-waiver.test.mts
+++ b/tests/external-check-waiver.test.mts
@@ -1771,36 +1771,38 @@ test('runExternalCheckWaiver: --auto-bootstrap posts end to end with no viewer-i
   // caller-suppliable and independent of advisoryWait.convergenceDeadline.
   assert.equal(parsed?.expiresAt, '2026-08-31T18:13:24Z');
   assert.equal(parsed?.claimId, 'claim-20260830T222316Z-2328');
-  // kurone-kito/idd-skill#2912 (round 3): `postComment` above returns no
-  // `id`, and `prComments` always resolves to `[]` (no post-write
-  // reconcile fixture data at all), so the reconcile can never find the
-  // posted comment -- `bodyDigest` falls back to hashing `report.body`
-  // (the locally-constructed string), reported as `'constructed'` rather
-  // than `'reconciled'` so a consumer can tell the difference. See the
-  // dedicated 'reconciled' test below for the realistic production path.
-  assert.equal(report?.bodyDigestSource, 'constructed');
-  assert.equal(
-    report?.bodyDigest,
-    digestExternalCheckWaiverMarkerBody(posted?.body ?? ''),
-  );
+  // kurone-kito/idd-skill#2912 (round 4): `postComment` above returns no
+  // `body` field at all (only `html_url`), so `bodyDigest` is omitted
+  // entirely -- round 4 deliberately never backfills it from
+  // `report.body` (the locally-constructed string) or from any later
+  // re-read; see `ExternalCheckWaiverReport.bodyDigest`'s own doc comment
+  // for why. See the dedicated POST-response test below for the
+  // realistic production path where the create-comment response DOES
+  // carry a body.
+  assert.equal(report?.bodyDigest, undefined);
 });
 
-test('runExternalCheckWaiver: --apply computes bodyDigest from the post-write RECONCILED comment body, never the locally-constructed one (kurone-kito/idd-skill#2912, round 3)', async () => {
-  // The self-waiver CI job's own JSON report is what
-  // `idd-advisory-convergence.yml`'s "Post the self-referential-bootstrap-
-  // auto waiver" step reads `bodyDigest` from, which the trusted job then
-  // uploads as part of the provenance artifact's name -- it must reflect
-  // what GitHub actually STORED (the reconciled re-read), never merely
-  // what this process SENT, so a digest computed from `report.body` could
-  // never mask GitHub-side content normalization this project does not
-  // control. The reconciled fixture's body below is deliberately a
-  // DIFFERENT string from whatever this CLI actually sent, isolating that
-  // `bodyDigest` tracks the RECONCILED value specifically (a regression
-  // that reverted to hashing `report.body` unconditionally would still
-  // produce a real, shape-valid digest here -- just the WRONG one -- so
-  // this test would still catch it).
+test('runExternalCheckWaiver: --apply computes bodyDigest from the create-comment POST response body, never a later re-read that could already reflect an edit (kurone-kito/idd-skill#2912, round 4; TOCTOU regression for the P1 Copilot found reviewing round 3, PR #2914)', async () => {
+  // Round 3 hashed the body observed in a LATER, separate post-write
+  // reconcile read (`readPrComments()`, run for the unrelated purpose of
+  // detecting a concurrent duplicate waiver) rather than the body the
+  // create-comment POST response itself returned. That preference opened
+  // a race: a same-repository `issues: write` workflow could edit the
+  // genuine comment's body in the window between the POST returning and
+  // that later reconcile running, and round 3's design would then hash
+  // and report the FORGED body as `bodyDigest` -- exactly what this test
+  // models. `postComment` below returns the GENUINE body (what the
+  // create-comment API call itself returned); the later `prComments`
+  // reconcile read returns the SAME comment id but a DIFFERENT, FORGED
+  // body (modeling an edit that landed in the race window). A correct
+  // round-4 implementation hashes ONLY the POST response's own body and
+  // never even looks at the reconcile read for this purpose, so
+  // `bodyDigest` must equal `digest(GENUINE)`, never `digest(FORGED)`; a
+  // regression back to round 3's reconcile-preferring design would
+  // produce `digest(FORGED)` here instead, which this test would catch.
   const POSTED_ID = 777;
-  const RECONCILED_BODY = 'this-is-the-body-github-actually-stored';
+  const GENUINE_BODY = 'this-is-the-body-github-actually-created';
+  const FORGED_BODY = 'this-is-a-forged-body-edited-in-the-race-window';
   let reads = 0;
 
   const { report } = await runExternalCheckWaiver({
@@ -1849,8 +1851,11 @@ test('runExternalCheckWaiver: --apply computes bodyDigest from the post-write RE
       },
     ],
     // First read (pre-write reuse scan): empty. Second read (post-write
-    // reconcile): the just-posted comment, with a body that stands in for
-    // whatever GitHub actually stored.
+    // reconcile, run for the unrelated concurrent-duplicate check): the
+    // same comment id, but a FORGED body -- modeling an edit that landed
+    // in the window between the POST below returning and this reconcile
+    // running. A correct implementation never even looks at this for
+    // `bodyDigest`.
     prComments: () => {
       reads += 1;
       return reads === 1
@@ -1861,32 +1866,34 @@ test('runExternalCheckWaiver: --apply computes bodyDigest from the post-write RE
               html_url: `https://github.com/kurone-kito/idd-skill/pull/2325#issuecomment-${POSTED_ID}`,
               created_at: '2026-08-30T18:20:00Z',
               user: { login: 'github-actions[bot]' },
-              body: RECONCILED_BODY,
+              body: FORGED_BODY,
             },
           ];
     },
     headCommittedAt: '2026-08-30T18:13:24Z',
     now: new Date('2026-08-30T18:20:00Z'),
     isTTY: false,
+    // The create-comment POST response itself, returned atomically with
+    // no window for an intervening edit -- carries the GENUINE body.
     postComment: () => ({
       id: POSTED_ID,
       html_url: `https://github.com/kurone-kito/idd-skill/pull/2325#issuecomment-${POSTED_ID}`,
+      body: GENUINE_BODY,
     }),
   });
 
   assert.equal(report?.applied, true);
   assert.equal(report?.commentId, String(POSTED_ID));
-  assert.equal(report?.bodyDigestSource, 'reconciled');
   assert.equal(
     report?.bodyDigest,
-    digestExternalCheckWaiverMarkerBody(RECONCILED_BODY),
+    digestExternalCheckWaiverMarkerBody(GENUINE_BODY),
   );
-  // Not merely a different label -- a genuinely different digest than
-  // hashing `report.body` (the locally-constructed string) would have
-  // produced, proving the reconciled value was actually used.
+  // The load-bearing assertion: a regression back to round 3's
+  // reconcile-preferring design would produce the FORGED digest here
+  // instead, silently attesting to the forgery as if it were genuine.
   assert.notEqual(
     report?.bodyDigest,
-    digestExternalCheckWaiverMarkerBody(report?.body ?? ''),
+    digestExternalCheckWaiverMarkerBody(FORGED_BODY),
   );
 });
 

--- a/tests/external-check-waiver.test.mts
+++ b/tests/external-check-waiver.test.mts
@@ -17,7 +17,10 @@ import {
   resolveActorLogin,
   runExternalCheckWaiver,
 } from '../src/scripts/external-check-waiver.mts';
-import { operationalMarkerPrefix } from '../src/scripts/marker-helpers.mts';
+import {
+  digestExternalCheckWaiverMarkerBody,
+  operationalMarkerPrefix,
+} from '../src/scripts/marker-helpers.mts';
 import { normalizePolicyConfig } from '../src/scripts/policy-helpers.mts';
 import {
   parseExternalCheckWaiverComment,
@@ -1768,6 +1771,123 @@ test('runExternalCheckWaiver: --auto-bootstrap posts end to end with no viewer-i
   // caller-suppliable and independent of advisoryWait.convergenceDeadline.
   assert.equal(parsed?.expiresAt, '2026-08-31T18:13:24Z');
   assert.equal(parsed?.claimId, 'claim-20260830T222316Z-2328');
+  // kurone-kito/idd-skill#2912 (round 3): `postComment` above returns no
+  // `id`, and `prComments` always resolves to `[]` (no post-write
+  // reconcile fixture data at all), so the reconcile can never find the
+  // posted comment -- `bodyDigest` falls back to hashing `report.body`
+  // (the locally-constructed string), reported as `'constructed'` rather
+  // than `'reconciled'` so a consumer can tell the difference. See the
+  // dedicated 'reconciled' test below for the realistic production path.
+  assert.equal(report?.bodyDigestSource, 'constructed');
+  assert.equal(
+    report?.bodyDigest,
+    digestExternalCheckWaiverMarkerBody(posted?.body ?? ''),
+  );
+});
+
+test('runExternalCheckWaiver: --apply computes bodyDigest from the post-write RECONCILED comment body, never the locally-constructed one (kurone-kito/idd-skill#2912, round 3)', async () => {
+  // The self-waiver CI job's own JSON report is what
+  // `idd-advisory-convergence.yml`'s "Post the self-referential-bootstrap-
+  // auto waiver" step reads `bodyDigest` from, which the trusted job then
+  // uploads as part of the provenance artifact's name -- it must reflect
+  // what GitHub actually STORED (the reconciled re-read), never merely
+  // what this process SENT, so a digest computed from `report.body` could
+  // never mask GitHub-side content normalization this project does not
+  // control. The reconciled fixture's body below is deliberately a
+  // DIFFERENT string from whatever this CLI actually sent, isolating that
+  // `bodyDigest` tracks the RECONCILED value specifically (a regression
+  // that reverted to hashing `report.body` unconditionally would still
+  // produce a real, shape-valid digest here -- just the WRONG one -- so
+  // this test would still catch it).
+  const POSTED_ID = 777;
+  const RECONCILED_BODY = 'this-is-the-body-github-actually-stored';
+  let reads = 0;
+
+  const { report } = await runExternalCheckWaiver({
+    args: {
+      ...parseArgs([
+        '--pr',
+        '2325',
+        '--check',
+        'idd-advisory-convergence',
+        '--reason',
+        SELF_REFERENTIAL_BOOTSTRAP_AUTO_REASON,
+        '--run-id',
+        '555',
+        '--auto-bootstrap',
+        '--apply',
+        '--yes',
+      ]),
+      repo: 'kurone-kito/idd-skill',
+    },
+    pr: {
+      number: 2325,
+      state: 'OPEN',
+      url: 'https://github.com/kurone-kito/idd-skill/pull/2325',
+      headRefName: 'issue/2328-fix-external-check-waiver-refuse-waiver',
+      headRefOid: REUSE_HEAD_SHA,
+      statusCheckRollup: [
+        {
+          __typename: 'CheckRun',
+          name: 'idd-advisory-convergence',
+          status: 'COMPLETED',
+          conclusion: 'FAILURE',
+        },
+      ],
+    },
+    issueCandidates: [
+      {
+        number: 2328,
+        url: 'https://github.com/kurone-kito/idd-skill/issues/2328',
+        activeClaim: {
+          agentId: 'claude-6043e89f',
+          claimId: 'claim-20260830T222316Z-2328',
+          supersedes: 'none',
+          branch: 'issue/2328-fix-external-check-waiver-refuse-waiver',
+          createdAt: '2026-08-30T22:23:26Z',
+        },
+      },
+    ],
+    // First read (pre-write reuse scan): empty. Second read (post-write
+    // reconcile): the just-posted comment, with a body that stands in for
+    // whatever GitHub actually stored.
+    prComments: () => {
+      reads += 1;
+      return reads === 1
+        ? []
+        : [
+            {
+              id: POSTED_ID,
+              html_url: `https://github.com/kurone-kito/idd-skill/pull/2325#issuecomment-${POSTED_ID}`,
+              created_at: '2026-08-30T18:20:00Z',
+              user: { login: 'github-actions[bot]' },
+              body: RECONCILED_BODY,
+            },
+          ];
+    },
+    headCommittedAt: '2026-08-30T18:13:24Z',
+    now: new Date('2026-08-30T18:20:00Z'),
+    isTTY: false,
+    postComment: () => ({
+      id: POSTED_ID,
+      html_url: `https://github.com/kurone-kito/idd-skill/pull/2325#issuecomment-${POSTED_ID}`,
+    }),
+  });
+
+  assert.equal(report?.applied, true);
+  assert.equal(report?.commentId, String(POSTED_ID));
+  assert.equal(report?.bodyDigestSource, 'reconciled');
+  assert.equal(
+    report?.bodyDigest,
+    digestExternalCheckWaiverMarkerBody(RECONCILED_BODY),
+  );
+  // Not merely a different label -- a genuinely different digest than
+  // hashing `report.body` (the locally-constructed string) would have
+  // produced, proving the reconciled value was actually used.
+  assert.notEqual(
+    report?.bodyDigest,
+    digestExternalCheckWaiverMarkerBody(report?.body ?? ''),
+  );
 });
 
 test('runExternalCheckWaiver: --auto-bootstrap never reuses an existing same-reason marker, even one with no verifiable run-id (Codex review, PR #2895, round 2)', async () => {

--- a/tests/marker-helpers-facade.test.mts
+++ b/tests/marker-helpers-facade.test.mts
@@ -95,7 +95,7 @@ test('protocol-helpers re-exports every sampled marker-helpers name by identity'
 // logic, so this is deliberately independent of the fuller end-to-end
 // coverage in advisory-convergence.test.mts/advisory-convergence-fake-provider.test.mts.
 test('digestExternalCheckWaiverMarkerBody is deterministic, sensitive to any byte difference, and never normalizes', () => {
-  const body = 'exact body text\nwith a trailing newline\n';
+  const body = 'exact body text v1\nwith a trailing newline\n';
   const digest = direct.digestExternalCheckWaiverMarkerBody(body);
   assert.match(digest, /^[0-9a-f]{64}$/);
   // Deterministic: the same input always yields the same digest.
@@ -111,7 +111,7 @@ test('digestExternalCheckWaiverMarkerBody is deterministic, sensitive to any byt
   );
   // Sensitive to a single interior character change.
   assert.notEqual(
-    direct.digestExternalCheckWaiverMarkerBody(body.replace('exact', 'exacz')),
+    direct.digestExternalCheckWaiverMarkerBody(body.replace('v1', 'v2')),
     digest,
   );
 });

--- a/tests/marker-helpers-facade.test.mts
+++ b/tests/marker-helpers-facade.test.mts
@@ -46,6 +46,7 @@ const SAMPLE_NAMES = [
   'renderForcedHandoffConsentNote',
   'renderExternalCheckWaiverComment',
   'parseExternalCheckWaiverComment',
+  'digestExternalCheckWaiverMarkerBody',
   'renderProviderOutageDeclarationComment',
   'parseProviderOutageDeclarationComment',
   'renderProviderOutageAdvancedComment',
@@ -83,6 +84,36 @@ test('protocol-helpers re-exports every sampled marker-helpers name by identity'
       `protocol-helpers.mts's ${name} must be the same binding as marker-helpers.mts's (re-export, not a copy)`,
     );
   }
+});
+
+// kurone-kito/idd-skill#2912 (round 3): direct unit coverage for
+// `digestExternalCheckWaiverMarkerBody` -- the artifact-binding primitive
+// `advisory-convergence.mts`'s own trust chain and
+// `external-check-waiver.mts`'s post-write reconcile both rely on to bind
+// an artifact to a marker's EXACT body content, not merely its comment id
+// (closing the round-2 edit-after-post gap Copilot found). Pure hashing
+// logic, so this is deliberately independent of the fuller end-to-end
+// coverage in advisory-convergence.test.mts/advisory-convergence-fake-provider.test.mts.
+test('digestExternalCheckWaiverMarkerBody is deterministic, sensitive to any byte difference, and never normalizes', () => {
+  const body = 'exact body text\nwith a trailing newline\n';
+  const digest = direct.digestExternalCheckWaiverMarkerBody(body);
+  assert.match(digest, /^[0-9a-f]{64}$/);
+  // Deterministic: the same input always yields the same digest.
+  assert.equal(direct.digestExternalCheckWaiverMarkerBody(body), digest);
+  // Sensitive to a single trailing-whitespace byte -- deliberately NOT
+  // normalized/trimmed, per this function's own doc comment: both call
+  // sites are expected to pass an API-returned body verbatim, so
+  // normalizing here would let two GENUINELY different stored bodies
+  // collide onto the same digest.
+  assert.notEqual(
+    direct.digestExternalCheckWaiverMarkerBody(`${body} `),
+    digest,
+  );
+  // Sensitive to a single interior character change.
+  assert.notEqual(
+    direct.digestExternalCheckWaiverMarkerBody(body.replace('exact', 'exacz')),
+    digest,
+  );
 });
 
 // #2752: guards against the drift issue #1705 hit -- a new marker family

--- a/tests/provider-adapter-fake.test.mts
+++ b/tests/provider-adapter-fake.test.mts
@@ -177,6 +177,21 @@ test('getWorkflowRun throws on a missing fixture, matching the GitHub adapter', 
   assert.throws(() => port.getWorkflowRun('o', 'r', 456), /no workflow-run/);
 });
 
+test('listWorkflowRunArtifacts throws on a missing fixture, matching the GitHub adapter (kurone-kito/idd-skill#2912, round 2)', () => {
+  const port = createFakeProviderAdapter({
+    workflowRunArtifacts: {
+      'o/r/123': { artifacts: [{ name: 'idd-self-waiver-marker-1' }] },
+    },
+  });
+  assert.deepEqual(port.listWorkflowRunArtifacts('o', 'r', 123), {
+    artifacts: [{ name: 'idd-self-waiver-marker-1' }],
+  });
+  assert.throws(
+    () => port.listWorkflowRunArtifacts('o', 'r', 456),
+    /no workflow-run-artifacts/,
+  );
+});
+
 test('listWorkflowRuns honors limit, matching the GitHub adapter', () => {
   const port = createFakeProviderAdapter({
     workflowRunLists: {

--- a/tests/provider-adapter-github.test.mts
+++ b/tests/provider-adapter-github.test.mts
@@ -1837,6 +1837,26 @@ test('getWorkflowRun preserves a string runId above Number.MAX_SAFE_INTEGER exac
   );
 });
 
+test('getWorkflowRunJobs calls the jobs sub-path and preserves a string runId above Number.MAX_SAFE_INTEGER exactly (kurone-kito/idd-skill#2912)', () => {
+  let capturedArgs: string[] | undefined;
+  const port = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: (args) => {
+        capturedArgs = args;
+        return '{}';
+      },
+    }),
+  );
+  const result = port.getWorkflowRunJobs('o', 'r', '9007199254740993');
+  assert.ok(
+    capturedArgs?.includes('repos/o/r/actions/runs/9007199254740993/jobs'),
+    `expected the exact run id in the jobs path, got: ${capturedArgs?.join(' ')}`,
+  );
+  assert.deepEqual(result, {});
+});
+
 test('listWorkflowRuns preserves a databaseId above Number.MAX_SAFE_INTEGER exactly (Codex review, PR #2429)', () => {
   const port = createGithubProviderAdapter(
     'o',

--- a/tests/provider-adapter-github.test.mts
+++ b/tests/provider-adapter-github.test.mts
@@ -1857,6 +1857,26 @@ test('getWorkflowRunJobs calls the jobs sub-path and preserves a string runId ab
   assert.deepEqual(result, {});
 });
 
+test('listWorkflowRunArtifacts calls the artifacts sub-path and preserves a string runId above Number.MAX_SAFE_INTEGER exactly (kurone-kito/idd-skill#2912, round 2)', () => {
+  let capturedArgs: string[] | undefined;
+  const port = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: (args) => {
+        capturedArgs = args;
+        return '{}';
+      },
+    }),
+  );
+  const result = port.listWorkflowRunArtifacts('o', 'r', '9007199254740993');
+  assert.ok(
+    capturedArgs?.includes('repos/o/r/actions/runs/9007199254740993/artifacts'),
+    `expected the exact run id in the artifacts path, got: ${capturedArgs?.join(' ')}`,
+  );
+  assert.deepEqual(result, {});
+});
+
 test('listWorkflowRuns preserves a databaseId above Number.MAX_SAFE_INTEGER exactly (Codex review, PR #2429)', () => {
   const port = createGithubProviderAdapter(
     'o',


### PR DESCRIPTION
# Summary

`verifySelfReferentialBootstrapWaiverRun` (the trust check for a
`self-referential-bootstrap-auto` waiver marker) proved only that the
CITED Actions run has the right `path`/`head_sha`/`repository`/`event`
shape -- never that that run's own `idd-advisory-convergence-self-waiver`
job actually posted the comment being evaluated. A same-repository
`pull_request`-triggered workflow (untrusted, PR-controlled code) could
discover a legitimate, concurrently-running `pull_request_target` run's
id via the public Actions API and cite it in a forged marker (tracked
but not closed by #2657 round 16's own review).

This PR closes that gap in three rounds (each round supersedes the
prior round's own residual, found by review on this PR -- see "Round
2"/"Round 3" below):

## Round 1: run-jobs provenance + duplicate-run-id rejection

1. **Run-jobs provenance** -- a new bounded lookup,
   `GET /repos/{owner}/{repo}/actions/runs/{run-id}/jobs` (new
   `ProviderPort.getWorkflowRunJobs` method, sharing the existing
   `MAX_AUTO_WAIVER_RUN_LOOKUPS` budget), verifies the cited run's own
   self-waiver job posting step reports `conclusion: success` AND that
   the marker's own `createdAt` falls inside that step's
   `[started_at, completed_at]` execution window.
2. **Duplicate-run-id rejection, scoped to provenance-passing
   candidates** -- counted every qualifying candidate marker per cited
   run id over the full raw comment set, keeping only candidates that
   ALSO independently passed condition 1's own window check; more than
   one such candidate for a run id failed closed for all of them.

Both were needed together: `idd-advisory-convergence-self-waiver` and
the verdict job run in the same workflow run (`needs:` sequencing), and
`--auto-bootstrap` has no dedupe-before-post, so a genuine marker and a
forged sibling sharing the same legitimate run id reliably collide --
but only when the genuine job actually manages to post; condition 1
closes the residual where it doesn't.

## Round 2: artifact binding (this round -- closes a P1 both Codex and
## Copilot independently found in round 1, reviewing this PR)

Round 1's duplicate-run-id check trusted "no OTHER candidate marker is
CURRENTLY VISIBLE" -- a property an attacker with `issues: write` can
falsify after the fact: `issues: write` permits **deleting** any issue
comment on the repository, not only ones the deleting token itself
authored. Attack: post a forged marker citing a legitimate,
concurrently-running `pull_request_target` run's id inside its
self-waiver job's execution window (satisfying round 1's provenance
check exactly as the genuine one does), wait for the genuine marker to
post, then delete it -- leaving the forged marker as the sole survivor
of the next comment scan and defeating round 1's uniqueness check
entirely.

**Fix**: replace the visibility-based uniqueness check with a
positive-binding one (`verifySelfReferentialBootstrapWaiverArtifactBinding`).
The self-waiver job now uploads a run-scoped GitHub Actions artifact,
named `idd-self-waiver-marker-<comment-id>`, immediately after
successfully posting a marker. The consumer lists that run's artifacts
(new `ProviderPort.listWorkflowRunArtifacts`, a plain JSON `list
artifacts` call -- the comment id lives in the artifact's **name**,
never its content, so no zip download is needed) and only validates a
candidate marker whose own comment id appears in that trusted set.

This closes the gap because artifacts are scoped to the run that
uploaded them by the Actions runtime's own dedicated upload token --
entirely separate from the shared `GITHUB_TOKEN` `permissions:` surface
that issue comments (and check runs, considered and rejected as an
alternative for the identical reason) are created and mutated through.
No same-repository `pull_request`-triggered workflow can forge, edit, or
delete a *different* run's artifact regardless of which `permissions:`
it self-grants itself. Deleting the genuine comment now only removes it
from the live comment scan the correlation step needs -- degrading the
mechanism to "no auto-waiver" (fail closed), never "the forged marker
validates".

Round 1's provenance/window check is kept as defense in depth (it still
does its own job disambiguating a stale prior-attempt marker from a
legitimate `gh run rerun`); round 1's duplicate-count mechanism is
removed entirely, subsumed by the strictly stronger artifact binding.
One deliberate precision change: a forged sibling with a *different*
`createdAt` than the genuine marker no longer collaterally denies the
genuine marker its waiver merely by existing -- it simply never
validates itself, since selection is now by exact-id lookup rather than
a "how many candidates exist" scan. Two DISTINCT candidates sharing the
same run id **and** the same wall-clock second remain ambiguous for the
`createdAt` correlation step and both fail closed, exactly as round 1's
own uniqueness check did for that specific race.

**Residual, explicitly accepted**: an attacker who additionally
self-grants the broader, repository-wide `actions: write` permission
(distinct from `issues: write`) could delete the genuine run's own
artifact through Actions' own artifact-management endpoint. This still
only degrades to "no auto-waiver", never a forged one -- outside the
`issues: write`-scoped threat model both review findings (and this fix)
are framed against.

## Round 3: body-digest binding (this round -- closes a P1 Copilot
## found reviewing round 2's own commit)

Round 2's artifact binding trusted a candidate marker's comment **id**
alone. `issues: write` also permits **editing** an existing comment's
body in place -- this preserves that comment's `id` AND `createdAt`
while replacing the content. Attack: wait for the genuine
self-referential-bootstrap-auto marker to post (its id becomes
artifact-trusted per round 2), then rewrite that SAME comment's body to
a forged marker citing the same run -- round 2's id-only check would
still accept it, since it never inspected content.

**Fix**: bind the trusted artifact to the *pair* (comment id, SHA-256
digest of the comment's exact posted body) instead of id alone. A new
`digestExternalCheckWaiverMarkerBody` (marker-helpers.mts) computes a
plain, unnormalized SHA-256 hex digest, following the same
`body-sha256` convention `authoring-owner-provenance.mts` already uses
for an identical purpose. The posting CLI (`external-check-waiver.mts`)
now reports `bodyDigest`/`bodyDigestSource` in its JSON report --
`'reconciled'` when computed from the body its own post-write reconcile
reads BACK from the GitHub API, `'constructed'` only as a labeled
fallback when that reconcile can't find the just-posted comment. Both
workflow YAML copies emit a `body-digest` output and name the
provenance artifact `idd-self-waiver-marker-<comment-id>-<body-digest>`
(was `-<comment-id>` alone). The consumer's
`verifySelfReferentialBootstrapWaiverArtifactBinding` now requires the
correlated live candidate's own `(id, bodyDigest)` pair to be in the
trusted set, not `id` alone.

Hashing the reconciled, API-returned body -- never the locally-sent
string -- on both the posting and consuming sides in the ordinary case
is the load-bearing detail: any GitHub-side content handling cancels
out identically on both sides instead of producing a false-negative on
a genuine, unedited marker. Hashing the body also transitively binds
`headSha` and `run-id` (both embedded in it), so an edit that tries to
redirect a trusted marker at a different commit or run is caught by the
same mechanism, not a separate one.

Two new regression tests (a pure unit test and an end-to-end
fake-provider test) model a genuine comment edited in place and assert
rejection, isolated to the digest check alone by overriding only the
marker's `agentId` field -- the one field no classification/trust
condition consumes, so an earlier unrelated gate can't mask which check
caused the rejection. Verified both are load-bearing by temporarily
patching the verification function back to round-2 id-only behavior and
confirming both fail red, then reverting.

**Separate, unrelated finding from the same review round (Codex, P2,
not fixed here)**: `actions/upload-artifact@v7.0.1` (pinned by round 2,
both workflow copies) is unsupported on GitHub Enterprise Server, which
requires the deprecated v3 line instead. This is a maintainer
version-pinning tradeoff (v3 is deprecated on github.com, v4+ is
GHES-incompatible -- trading one adopter population's breakage for
another's), not something this round judged safe to decide
unilaterally; filed as a follow-up issue instead (see below).

No new adopter-facing `GITHUB_TOKEN` `permissions:` entry is required in
any round: the jobs-API and artifacts-API endpoints both share the
`actions: read` scope the existing run-metadata lookup already has,
uploading an artifact uses the Actions runtime's own dedicated token
independent of `GITHUB_TOKEN` entirely, and the round-3 (and round-4)
digest is a pure local hash with no new API surface at all.

## Round 4: bind the body digest to the POST response, not a later re-read (this round -- closes a P1 Copilot found reviewing round 3's own commit)

Round 3's posting side (`external-check-waiver.mts`) computed
`bodyDigest` from a body observed in a LATER, separate post-write
reconcile read (`readPrComments()`, already run for the unrelated
purpose of detecting a concurrent duplicate waiver), preferring it over
the locally-sent string and labeling the result `bodyDigestSource:
'reconciled'` vs `'constructed'`. A Copilot review of round 3's own
pushed commit found this reintroduced the same class of race round 3
was meant to close: a same-repository `issues: write` workflow could
edit the genuine comment's body in the window between the create-comment
POST returning and that later reconcile running, and round 3's design
would then hash and report the FORGED body as `bodyDigest` -- which the
consumer's own live-comment scan (reading that SAME, now-edited comment)
would then match, validating the attacker's edit as if the trusted job
had posted it verbatim.

**Fix**: hash ONLY the `body` field GitHub's create-comment API response
returns for the exact POST that created the comment -- returned
atomically, in the same API call, with no window for an intervening
edit -- rather than ever falling back to a later read or the
locally-constructed string. `bodyDigestSource` is removed entirely
(there is only one source now); `bodyDigest` is omitted from the report
when the POST response carries no body, and the workflow's existing
`body-digest != ''` gate on both the "Record" and "Upload" steps already
fails closed on that with no further change needed. The consumer
(`advisory-convergence.mts`) needed no logic change: it already hashes
the live comment's current body during its own scan.

A new regression test models the exact race: `postComment` returns the
genuine body directly (the real POST response shape), while the
separate `prComments` reconcile fixture returns the same comment id with
a different, forged body. Asserts `bodyDigest` matches the genuine
body's digest, never the forged one -- verified load-bearing by tracing
it against round 3's actual reconcile-preferring implementation, which
would have produced the forged digest here instead.

**Same review round, two smaller findings also fixed here**: a stale
inline comment in both `idd-advisory-convergence.yml` copies still
describing the removed reconcile-based digest source (rewritten to
describe the POST-response source; this also resolves a separate
Copilot question about whether the upload gate should additionally check
`bodyDigestSource` -- since that field no longer exists and `bodyDigest`
is only ever populated from the trustworthy source now, the existing
`body-digest != ''` gate already fails closed correctly); and a
pre-existing, round-3-unrelated Codex-found bug in `idd-template/`'s
Yarn Classic package-manager profile, where Yarn 1's own banner/trailer
stdout lines corrupt the JSON file every downstream `node -e` parse
(including the `bodyDigest` extraction) depends on. A first attempt at
that fix (an unconditional `yarn --silent`) was itself caught by this
round's own C1 self-review before push: `steps.manager` resolves the
same `"yarn"` string for both Yarn Classic and Yarn Berry, and Berry's
clipanion CLI parser does not recognize a bare `--silent` before the
script name -- it would have regressed Berry adopters from working to
silently broken. Fixed by detecting the installed major at run time
(`yarn --version`) and applying `--silent` only for major 1, leaving
Berry's already-clean stdout untouched.

A fresh-subagent C1 self-review ran against round 1, again against
round 2's completed diff, again against round 3's, and again against
round 4's; see the four plan comments linked below for the full review
exchange, including a latent test-fixture bug (`expiresAt`/`maxValidity`
interaction) the round-2 pass caught that had been silently making
several end-to-end tests in this area pass for reasons unrelated to
what they claimed to verify, two non-blocking wording nits round 3's C1
pass caught (folded into round 3's commit before push), and the Yarn
Berry regression round 4's own C1 pass caught (described above, folded
into round 4's commit before push).

## Linked issue

Closes #2912

## Follow-up issues (if any)

- [ ] #2918 -- GHES incompatibility of the round-2
      `actions/upload-artifact` pin (Codex P2 finding, round 3 review),
      filed separately (held under `status:authoring` /
      `status:needs-decision`, a maintainer version-pinning call), not
      addressed in this PR.

## Background / rationale (if material)

Full design reasoning is recorded in four plan comments on the issue:

- Round 1: https://github.com/kurone-kito/idd-skill/issues/2912#issuecomment-5629891284
- Round 2: https://github.com/kurone-kito/idd-skill/issues/2912#issuecomment-5630637152
- Round 3: https://github.com/kurone-kito/idd-skill/issues/2912#issuecomment-5631115743
- Round 4: https://github.com/kurone-kito/idd-skill/issues/2912#issuecomment-5632258534

This PR touches `src/scripts/advisory-convergence.mts`, which is on the
checker's own self-referential trigger-file allowlist
(`SELF_REFERENTIAL_WAIVER_TRIGGER_FILES`); its
`idd-advisory-convergence-self-waiver` job should auto-post a bootstrap
waiver so this PR's own required check can pass while unmerged -- but
per that mechanism's own module-header doc comment, a bug specifically
WITHIN this file's own verification functions is exactly the residual
dead zone that mechanism cannot rescue. Round 2 (and round 3 again)
additionally means this PR's own self-waiver run (which executed an
older posting step, missing the artifact upload round 2 added or the
body-digest output round 3 added) will be rejected by the NEW consumer
once merged into the evaluation path -- an expected, fail-closed side
effect of fixing the checker's own trust chain from within, not a
defect. A maintainer-authorized waiver may be needed if the ordinary
review path
does not converge before the configured deadline.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs`

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiWpghp4ViMu6DUDKLzzxz



