### PR TITLE
fix(pre-merge-readiness): trustworthy stale-self-waiver detection

### DIFF
--- a/fixtures/pre-merge-readiness/ack-only-current.json
+++ b/fixtures/pre-merge-readiness/ack-only-current.json
@@ -359,6 +359,14 @@
       "terminalUnavailable": false,
       "open": false
     },
+    "claimIdentityInstalledAt": "2026-05-11T23:20:00Z",
+    "staleSelfWaiver": {
+      "stale": false,
+      "checkSelector": "idd-advisory-convergence",
+      "reason": null,
+      "expiresAt": "",
+      "waiverClaimId": ""
+    },
     "branchCurrency": {
       "mergeStateStatus": "",
       "mergeable": "",

--- a/fixtures/pre-merge-readiness/changes-requested.json
+++ b/fixtures/pre-merge-readiness/changes-requested.json
@@ -293,6 +293,14 @@
       "terminalUnavailable": false,
       "open": false
     },
+    "claimIdentityInstalledAt": "2026-05-11T23:20:00Z",
+    "staleSelfWaiver": {
+      "stale": false,
+      "checkSelector": "idd-advisory-convergence",
+      "reason": null,
+      "expiresAt": "",
+      "waiverClaimId": ""
+    },
     "branchCurrency": {
       "mergeStateStatus": "",
       "mergeable": "",

--- a/fixtures/pre-merge-readiness/ci-not-ready.json
+++ b/fixtures/pre-merge-readiness/ci-not-ready.json
@@ -297,6 +297,14 @@
       "terminalUnavailable": false,
       "open": false
     },
+    "claimIdentityInstalledAt": "2026-05-11T23:20:00Z",
+    "staleSelfWaiver": {
+      "stale": false,
+      "checkSelector": "idd-advisory-convergence",
+      "reason": null,
+      "expiresAt": "",
+      "waiverClaimId": ""
+    },
     "branchCurrency": {
       "mergeStateStatus": "",
       "mergeable": "",

--- a/fixtures/pre-merge-readiness/claim-lost.json
+++ b/fixtures/pre-merge-readiness/claim-lost.json
@@ -321,6 +321,14 @@
       "terminalUnavailable": false,
       "open": false
     },
+    "claimIdentityInstalledAt": "2026-05-11T23:30:00Z",
+    "staleSelfWaiver": {
+      "stale": false,
+      "checkSelector": "idd-advisory-convergence",
+      "reason": null,
+      "expiresAt": "",
+      "waiverClaimId": ""
+    },
     "branchCurrency": {
       "mergeStateStatus": "",
       "mergeable": "",

--- a/fixtures/pre-merge-readiness/clean.json
+++ b/fixtures/pre-merge-readiness/clean.json
@@ -321,6 +321,14 @@
       "terminalUnavailable": false,
       "open": false
     },
+    "claimIdentityInstalledAt": "2026-05-11T23:20:00Z",
+    "staleSelfWaiver": {
+      "stale": false,
+      "checkSelector": "idd-advisory-convergence",
+      "reason": null,
+      "expiresAt": "",
+      "waiverClaimId": ""
+    },
     "branchCurrency": {
       "mergeStateStatus": "",
       "mergeable": "",

--- a/fixtures/pre-merge-readiness/disposition-reply-latest.json
+++ b/fixtures/pre-merge-readiness/disposition-reply-latest.json
@@ -329,6 +329,14 @@
       "terminalUnavailable": false,
       "open": false
     },
+    "claimIdentityInstalledAt": "2026-05-11T23:20:00Z",
+    "staleSelfWaiver": {
+      "stale": false,
+      "checkSelector": "idd-advisory-convergence",
+      "reason": null,
+      "expiresAt": "",
+      "waiverClaimId": ""
+    },
     "branchCurrency": {
       "mergeStateStatus": "",
       "mergeable": "",

--- a/fixtures/pre-merge-readiness/stale-watermark.json
+++ b/fixtures/pre-merge-readiness/stale-watermark.json
@@ -321,6 +321,14 @@
       "terminalUnavailable": false,
       "open": false
     },
+    "claimIdentityInstalledAt": "2026-05-11T23:20:00Z",
+    "staleSelfWaiver": {
+      "stale": false,
+      "checkSelector": "idd-advisory-convergence",
+      "reason": null,
+      "expiresAt": "",
+      "waiverClaimId": ""
+    },
     "branchCurrency": {
       "mergeStateStatus": "",
       "mergeable": "",

--- a/fixtures/pre-merge-readiness/unreplied-comment.json
+++ b/fixtures/pre-merge-readiness/unreplied-comment.json
@@ -307,6 +307,14 @@
       "terminalUnavailable": false,
       "open": false
     },
+    "claimIdentityInstalledAt": "2026-05-11T23:20:00Z",
+    "staleSelfWaiver": {
+      "stale": false,
+      "checkSelector": "idd-advisory-convergence",
+      "reason": null,
+      "expiresAt": "",
+      "waiverClaimId": ""
+    },
     "branchCurrency": {
       "mergeStateStatus": "",
       "mergeable": "",

--- a/fixtures/pre-merge-readiness/unresolved-thread.json
+++ b/fixtures/pre-merge-readiness/unresolved-thread.json
@@ -321,6 +321,14 @@
       "terminalUnavailable": false,
       "open": false
     },
+    "claimIdentityInstalledAt": "2026-05-11T23:20:00Z",
+    "staleSelfWaiver": {
+      "stale": false,
+      "checkSelector": "idd-advisory-convergence",
+      "reason": null,
+      "expiresAt": "",
+      "waiverClaimId": ""
+    },
     "branchCurrency": {
       "mergeStateStatus": "",
       "mergeable": "",

--- a/fixtures/schemas/pre-merge-readiness.valid.json
+++ b/fixtures/schemas/pre-merge-readiness.valid.json
@@ -200,6 +200,14 @@
     "terminalUnavailable": false,
     "open": false
   },
+  "claimIdentityInstalledAt": "2026-05-11T23:20:00Z",
+  "staleSelfWaiver": {
+    "stale": false,
+    "checkSelector": "idd-advisory-convergence",
+    "reason": null,
+    "expiresAt": "",
+    "waiverClaimId": ""
+  },
   "branchCurrency": {
     "mergeStateStatus": "CLEAN",
     "mergeable": "MERGEABLE",

--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -19,6 +19,8 @@
     "claim",
     "waiverEvidence",
     "advisoryConvergenceWaiverPrecondition",
+    "claimIdentityInstalledAt",
+    "staleSelfWaiver",
     "branchCurrency",
     "ready",
     "blockers"
@@ -1284,7 +1286,9 @@
             "required": [
               "authorLogin",
               "checkSelector",
-              "expiresAt"
+              "expiresAt",
+              "reason",
+              "runId"
             ],
             "additionalProperties": false,
             "properties": {
@@ -1299,6 +1303,14 @@
               "expiresAt": {
                 "type": "string",
                 "description": "Waiver's recorded expiry timestamp."
+              },
+              "reason": {
+                "type": "string",
+                "description": "kurone-kito/idd-skill#2911: the marker's reason: field, verbatim -- needed to identify a self-referential-bootstrap-auto marker even after it has expired out of the valid bucket."
+              },
+              "runId": {
+                "type": "string",
+                "description": "kurone-kito/idd-skill#2911: the marker's optional run-id: field, verbatim ('' when absent) -- mirrors the valid bucket's own runId field."
               }
             }
           }
@@ -1338,7 +1350,9 @@
             "required": [
               "authorLogin",
               "checkSelector",
-              "waiverClaimId"
+              "waiverClaimId",
+              "reason",
+              "runId"
             ],
             "additionalProperties": false,
             "properties": {
@@ -1353,6 +1367,14 @@
               "waiverClaimId": {
                 "type": "string",
                 "description": "Claim id recorded on the waiver, which does not match the active claim."
+              },
+              "reason": {
+                "type": "string",
+                "description": "kurone-kito/idd-skill#2911: see expired[].reason's description above -- the identical need applies to a wrongClaim-classified marker, which likewise never reaches the valid bucket."
+              },
+              "runId": {
+                "type": "string",
+                "description": "kurone-kito/idd-skill#2911: see expired[].runId's description above."
               }
             }
           }
@@ -1547,6 +1569,45 @@
         "declined": {
           "type": "boolean",
           "description": "#2547: true when the configured secondary advisory bot has definitively declined (a rate-limit / skip-review notice, with no later genuine comment) to review the CURRENT HEAD -- the wait is skipped entirely (elapsed: true, remainingMinutes: 0) rather than requiring the full configured window."
+        }
+      }
+    },
+    "claimIdentityInstalledAt": {
+      "type": "string",
+      "description": "kurone-kito/idd-skill#2911: the non-mutable timestamp at which the active claim's (agentId, claimId) identity was last installed (a fresh claim, a stale takeover, or a forced handoff) -- as opposed to claim.activeClaim.createdAt, which is overwritten on every same-claim heartbeat. '' when no event ever produced an active claim. Deliberately outside claim (not claim.activeClaimInstalledAt): ClaimValidationSummary's shape is embedded in schemas beyond this one, so this stays a top-level, pre-merge-readiness-only field instead."
+    },
+    "staleSelfWaiver": {
+      "type": "object",
+      "description": "kurone-kito/idd-skill#2911: evidence for the stale-self-waiver merge blocker -- whether the currently-passing idd-advisory-convergence check (the deduplicated newest instance) rests on a self-referential-bootstrap-auto waiver that has since gone stale (expired, or claim-invalid across a genuine claim-identity transition), with no rerun since. Reported unconditionally (never omitted); stale is false and reason is null whenever the blocker does not apply (including when touchesSelfReferentialAllowlist was not supplied as true, or the configured ciGate.externalCheckWaivers.mode/waivableSelectors policy could never have made this mechanism's waiver valid).",
+      "required": [
+        "stale",
+        "checkSelector",
+        "reason",
+        "expiresAt",
+        "waiverClaimId"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "stale": {
+          "type": "boolean",
+          "description": "True when the currently-passing check's pass rests on a stale, run-verified self-referential-bootstrap-auto waiver."
+        },
+        "checkSelector": {
+          "type": "string",
+          "description": "The advisory-convergence check selector this evidence evaluates."
+        },
+        "reason": {
+          "type": ["string", "null"],
+          "enum": ["expired", "wrong-claim", null],
+          "description": "Which stale condition fired: an expired marker with no rerun since, or a marker bound to a claim identity the current transition no longer matches. null when stale is false."
+        },
+        "expiresAt": {
+          "type": "string",
+          "description": "The stale marker's own recorded expiry timestamp, when reason is 'expired'; '' otherwise."
+        },
+        "waiverClaimId": {
+          "type": "string",
+          "description": "The stale marker's own recorded claim id, when reason is 'wrong-claim'; '' otherwise."
         }
       }
     },

--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -1358,7 +1358,8 @@
               "waiverClaimId",
               "reason",
               "runId",
-              "createdAt"
+              "createdAt",
+              "expiresAt"
             ],
             "additionalProperties": false,
             "properties": {
@@ -1385,6 +1386,10 @@
               "createdAt": {
                 "type": "string",
                 "description": "kurone-kito/idd-skill#2911 (Copilot review, PR #2915): see expired[].createdAt's description above -- the identical lower-bound need applies to a wrongClaim-classified marker."
+              },
+              "expiresAt": {
+                "type": "string",
+                "description": "kurone-kito/idd-skill#2911 (Codex review, PR #2915, P2): the marker's recorded expiry timestamp -- wrongClaim classification runs before the expiry check in summarizeExternalCheckWaivers, so a marker can be both wrong-claim and already-expired yet only ever reach this bucket; needed as the upper bound of the marker's validity window, paired with createdAt as the lower bound."
               }
             }
           }

--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -1288,7 +1288,8 @@
               "checkSelector",
               "expiresAt",
               "reason",
-              "runId"
+              "runId",
+              "createdAt"
             ],
             "additionalProperties": false,
             "properties": {
@@ -1311,6 +1312,10 @@
               "runId": {
                 "type": "string",
                 "description": "kurone-kito/idd-skill#2911: the marker's optional run-id: field, verbatim ('' when absent) -- mirrors the valid bucket's own runId field."
+              },
+              "createdAt": {
+                "type": "string",
+                "description": "kurone-kito/idd-skill#2911 (Copilot review, PR #2915): the marker comment's own createdAt server timestamp -- the lower bound of the marker's validity window, paired with expiresAt as the upper bound."
               }
             }
           }
@@ -1352,7 +1357,8 @@
               "checkSelector",
               "waiverClaimId",
               "reason",
-              "runId"
+              "runId",
+              "createdAt"
             ],
             "additionalProperties": false,
             "properties": {
@@ -1375,6 +1381,10 @@
               "runId": {
                 "type": "string",
                 "description": "kurone-kito/idd-skill#2911: see expired[].runId's description above."
+              },
+              "createdAt": {
+                "type": "string",
+                "description": "kurone-kito/idd-skill#2911 (Copilot review, PR #2915): see expired[].createdAt's description above -- the identical lower-bound need applies to a wrongClaim-classified marker."
               }
             }
           }

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -470,8 +470,19 @@ export function reviewPolicyNotApplicableReason(reviewPolicy) {
  * same-repository PR editing the workflow YAML can still trigger a
  * `pull_request`-triggered run of it whose `path`/`head_sha`/
  * `head_repository.full_name` all satisfy the other three conditions.
+ *
+ * kurone-kito/idd-skill#2911: exported (was module-private) so
+ * `pre-merge-readiness.mts`'s own stale-self-waiver merge blocker can
+ * reuse this exact verification rather than reimplementing it -- see
+ * that file's own doc comment on its `autoWaiverRunVerified` option
+ * for the full call site. This remains the bearer-evidence check only
+ * (proves the cited run has the right shape, not that it actually
+ * posted the comment citing it -- kurone-kito/idd-skill#2912 tracks
+ * closing that residual gap); callers still need their own
+ * independent `touchesSelfReferentialAllowlist` precondition to keep
+ * a forged-but-shape-valid citation from affecting an unrelated PR.
  */
-function verifySelfReferentialBootstrapWaiverRun(run, expected) {
+export function verifySelfReferentialBootstrapWaiverRun(run, expected) {
   if (!run || 'error' in run) {
     return false;
   }
@@ -1244,10 +1255,12 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
     maxValidity: String(options.waiverMaxValidity ?? 'PT24H'),
     mode: waiverMode,
     // kurone-kito/idd-skill#2657 (Codex review, PR #2895): one of exactly
-    // two authorized call sites -- see `allowSelfReferentialBootstrapAuto`'s
-    // own doc comment in protocol-helpers.mts for the full list and why
-    // every other caller must leave this unset. This one is the GATE
-    // decision (feeds `autoWaiverValid` directly below), paired with the
+    // three authorized call sites (kurone-kito/idd-skill#2911 added the
+    // third, in pre-merge-readiness.mts's own stale-self-waiver merge
+    // blocker) -- see `allowSelfReferentialBootstrapAuto`'s own doc
+    // comment in protocol-helpers.mts for the full list and why every
+    // other caller must leave this unset. This one is the GATE decision
+    // (feeds `autoWaiverValid` directly below), paired with the
     // independent run-id/event-type/HEAD/repository/changed-file
     // verification that follows.
     allowSelfReferentialBootstrapAuto: true,

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -659,69 +659,87 @@ export function collectPreMergeReadiness(
   // checking and letting the report incorrectly stay `ready`. Newest-
   // first keeps the candidates most likely to cover that recent
   // instance instead.
-  const autoWaiverRunIdCandidates = [];
-  const seenAutoWaiverRunIds = new Set();
-  const prHeadShaLower = prHeadSha.toLowerCase();
-  for (const comment of normalizedComments) {
-    const body = comment.body;
-    if (!/^<!--\s*idd-external-check-waiver:/i.test(body)) continue;
-    const authorLogin = comment.author.login.trim().toLowerCase();
-    if (authorLogin !== 'github-actions[bot]') continue;
-    const parsed = parseExternalCheckWaiverComment(body, comment.createdAt);
-    // kurone-kito/idd-skill#2911: mirrors `collectFromGitHub`'s own
-    // prefilter conditions verbatim -- a canonical positive-integer
-    // run-id (never percent-decoded/sanitized attacker text reaching
-    // `getWorkflowRun`'s REST path unvalidated), an EXACT (never glob)
-    // checkSelector match, and this PR's own current HEAD -- before a
-    // candidate is ever eligible to spend part of the bounded lookup
-    // budget.
-    if (
-      parsed &&
-      parsed.reason === SELF_REFERENTIAL_BOOTSTRAP_AUTO_REASON &&
-      parsed.checkSelector === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR &&
-      parsed.runId &&
-      parseCanonicalIntegerOrNull(parsed.runId) !== null &&
-      !seenAutoWaiverRunIds.has(parsed.runId) &&
-      String(parsed.headSha ?? '')
-        .trim()
-        .toLowerCase() === prHeadShaLower
-    ) {
-      seenAutoWaiverRunIds.add(parsed.runId);
-      autoWaiverRunIdCandidates.push({
-        runId: parsed.runId,
-        createdAt: comment.createdAt,
-      });
-    }
-  }
-  const boundedAutoWaiverRunIds = autoWaiverRunIdCandidates
-    .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
-    .slice(0, MAX_PRE_MERGE_AUTO_WAIVER_RUN_LOOKUPS)
-    .map((candidate) => candidate.runId);
   const autoWaiverRunVerified = {};
-  for (const runId of boundedAutoWaiverRunIds) {
-    try {
-      const raw = port.getWorkflowRun(owner, repo, runId);
-      autoWaiverRunVerified[runId] = verifySelfReferentialBootstrapWaiverRun(
-        {
-          path: raw?.path ?? null,
-          headSha: raw?.head_sha ?? null,
-          repositoryFullName: raw?.head_repository?.full_name ?? null,
-          event: raw?.event ?? null,
-        },
-        {
-          path: ADVISORY_CONVERGENCE_WORKFLOW_PATH,
-          headSha: prHeadSha,
-          repositoryFullName,
-        },
-      );
-    } catch {
-      // Fail closed per run id -- untrusted: a lookup failure (unknown
-      // run, transient API error) must never widen trust, and must never
-      // crash this whole evidence collector either. This is the
-      // deliberate fail-open-for-staleness direction documented on
-      // `buildPreMergeReadinessSummary`'s `staleSelfWaiver` computation:
-      // an unverified run suppresses the blocker rather than firing it.
-      autoWaiverRunVerified[runId] = false;
+  // kurone-kito/idd-skill#2911 (Copilot review, PR #2915): the scan below
+  // and its up-to-20 `getWorkflowRun` lookups are pure overhead whenever
+  // `touchesSelfReferentialAllowlist` is false -- `buildPreMergeReadinessSummary`
+  // never even reaches this evidence in that case (its own `staleSelfWaiver`
+  // computation is unconditionally gated on the identical flag). Skipping
+  // the whole block here means an ordinary PR (the overwhelming majority,
+  // which never touches the checker allowlist at all) can never have a
+  // flood of bot-authored comments force wasted provider round-trips no
+  // matter how many it posts. This does not also gate on the mode-open/
+  // selector-waivable preconditions `buildPreMergeReadinessSummary` checks
+  // (those live behind private matching helpers in `protocol-helpers.mts`
+  // this file deliberately avoids importing, to keep this file's footprint
+  // minimal where kurone-kito/idd-skill#2912 is concurrently working) --
+  // the residual is bounded and harmless: at most 20 avoidable
+  // `getWorkflowRun` calls, only on the narrower set of PRs that already,
+  // genuinely touch the allowlist.
+  if (touchesSelfReferentialAllowlist) {
+    const autoWaiverRunIdCandidates = [];
+    const seenAutoWaiverRunIds = new Set();
+    const prHeadShaLower = prHeadSha.toLowerCase();
+    for (const comment of normalizedComments) {
+      const body = comment.body;
+      if (!/^<!--\s*idd-external-check-waiver:/i.test(body)) continue;
+      const authorLogin = comment.author.login.trim().toLowerCase();
+      if (authorLogin !== 'github-actions[bot]') continue;
+      const parsed = parseExternalCheckWaiverComment(body, comment.createdAt);
+      // kurone-kito/idd-skill#2911: mirrors `collectFromGitHub`'s own
+      // prefilter conditions verbatim -- a canonical positive-integer
+      // run-id (never percent-decoded/sanitized attacker text reaching
+      // `getWorkflowRun`'s REST path unvalidated), an EXACT (never glob)
+      // checkSelector match, and this PR's own current HEAD -- before a
+      // candidate is ever eligible to spend part of the bounded lookup
+      // budget.
+      if (
+        parsed &&
+        parsed.reason === SELF_REFERENTIAL_BOOTSTRAP_AUTO_REASON &&
+        parsed.checkSelector === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR &&
+        parsed.runId &&
+        parseCanonicalIntegerOrNull(parsed.runId) !== null &&
+        !seenAutoWaiverRunIds.has(parsed.runId) &&
+        String(parsed.headSha ?? '')
+          .trim()
+          .toLowerCase() === prHeadShaLower
+      ) {
+        seenAutoWaiverRunIds.add(parsed.runId);
+        autoWaiverRunIdCandidates.push({
+          runId: parsed.runId,
+          createdAt: comment.createdAt,
+        });
+      }
+    }
+    const boundedAutoWaiverRunIds = autoWaiverRunIdCandidates
+      .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
+      .slice(0, MAX_PRE_MERGE_AUTO_WAIVER_RUN_LOOKUPS)
+      .map((candidate) => candidate.runId);
+    for (const runId of boundedAutoWaiverRunIds) {
+      try {
+        const raw = port.getWorkflowRun(owner, repo, runId);
+        autoWaiverRunVerified[runId] = verifySelfReferentialBootstrapWaiverRun(
+          {
+            path: raw?.path ?? null,
+            headSha: raw?.head_sha ?? null,
+            repositoryFullName: raw?.head_repository?.full_name ?? null,
+            event: raw?.event ?? null,
+          },
+          {
+            path: ADVISORY_CONVERGENCE_WORKFLOW_PATH,
+            headSha: prHeadSha,
+            repositoryFullName,
+          },
+        );
+      } catch {
+        // Fail closed per run id -- untrusted: a lookup failure (unknown
+        // run, transient API error) must never widen trust, and must
+        // never crash this whole evidence collector either. This is the
+        // deliberate fail-open-for-staleness direction documented on
+        // `buildPreMergeReadinessSummary`'s `staleSelfWaiver` computation:
+        // an unverified run suppresses the blocker rather than firing it.
+        autoWaiverRunVerified[runId] = false;
+      }
     }
   }
   const summary = buildPreMergeReadinessSummary(

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -638,12 +638,27 @@ export function collectPreMergeReadiness(
   ].some((path) => selfReferentialTriggerFiles.includes(String(path)));
   // Bounded scan for self-referential-bootstrap-auto candidate markers
   // bound to this PR's own HEAD, mirroring `collectFromGitHub`'s own
-  // anti-flood tie-break exactly (earliest-first, capped): no selection
-  // order fully closes the flood problem, but this bounds worst-case API
-  // cost the same deliberately generous way, and
+  // anti-flood budget (20, capped) but NOT its earliest-first tie-break:
+  // no selection order fully closes the flood problem, and
   // `verifySelfReferentialBootstrapWaiverRun` below still requires
   // independent Actions-run verification regardless of what this
-  // prefilter selects.
+  // prefilter selects, but the two call sites correlate against
+  // different moments in time, so the same tie-break direction is wrong
+  // for this one. `collectFromGitHub` evaluates the marker for the
+  // checker's OWN in-flight run (implicitly "now"); this call site
+  // instead correlates against `passingCompletedAtMs` -- the ALREADY-
+  // SELECTED newest required-check instance's own `completedAt`, itself
+  // already the most recent of however many reruns exist for this HEAD
+  // (kurone-kito/idd-skill#2911, Codex review on PR #2915, P1): on a
+  // checker-touching PR that sits on one HEAD long enough to accumulate
+  // more than this 20-candidate budget's worth of bootstrap-auto
+  // markers, an earliest-first cap would keep only the OLDEST
+  // candidates -- exactly the ones LEAST likely to correlate with the
+  // most-recent-required-check-instance's `completedAt` -- starving
+  // `autoWaiverRunVerified` of the one marker that actually needs
+  // checking and letting the report incorrectly stay `ready`. Newest-
+  // first keeps the candidates most likely to cover that recent
+  // instance instead.
   const autoWaiverRunIdCandidates = [];
   const seenAutoWaiverRunIds = new Set();
   const prHeadShaLower = prHeadSha.toLowerCase();
@@ -679,7 +694,7 @@ export function collectPreMergeReadiness(
     }
   }
   const boundedAutoWaiverRunIds = autoWaiverRunIdCandidates
-    .sort((left, right) => left.createdAt.localeCompare(right.createdAt))
+    .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
     .slice(0, MAX_PRE_MERGE_AUTO_WAIVER_RUN_LOOKUPS)
     .map((candidate) => candidate.runId);
   const autoWaiverRunVerified = {};

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -629,13 +629,49 @@ export function collectPreMergeReadiness(
     helperRuntimeProfile,
     repositoryFullName,
   );
-  const selfReferentialRenamedFromPaths = port
-    .listChangeRequestRenamedFromPaths(args.prNumber)
-    .filter(Boolean);
-  const touchesSelfReferentialAllowlist = [
-    ...changedFiles,
-    ...selfReferentialRenamedFromPaths,
-  ].some((path) => selfReferentialTriggerFiles.includes(String(path)));
+  const changedFilesTouchSelfReferentialAllowlist = changedFiles.some((path) =>
+    selfReferentialTriggerFiles.includes(String(path)),
+  );
+  // kurone-kito/idd-skill#2911 (Codex + CodeRabbit review, PR #2915): the
+  // renamed-from-paths lookup is a separate paginated `pulls/.../files`
+  // request that duplicates the `changedFiles` fetch above, and its
+  // result can only ever matter for a PR that (a) doesn't already prove
+  // the allowlist touch via `changedFiles` alone AND (b) carries at
+  // least one self-referential-bootstrap-auto marker candidate -- if
+  // neither the ordinary case (no marker at all) nor this case applies,
+  // `touchesSelfReferentialAllowlist`'s value can never affect the
+  // report either way, so skip the extra round-trip entirely. Cheap: the
+  // candidate scan below only re-uses `normalizedComments`, already
+  // fetched, no extra call. Wrapped in try/catch -- unlike every OTHER
+  // unguarded port call earlier in this collector, this one specifically
+  // sits behind an opt-in security gate that most PRs never need at all,
+  // so a transient failure here must not abort report generation for
+  // PRs the gate was never going to affect; fails to `[]` (never widens
+  // trust, matches `getWorkflowRun`'s own fail-closed-to-untrusted
+  // direction below).
+  const hasAnySelfReferentialMarkerCandidate = normalizedComments.some(
+    (comment) =>
+      /^<!--\s*idd-external-check-waiver:/i.test(comment.body) &&
+      comment.author.login.trim().toLowerCase() === 'github-actions[bot]',
+  );
+  let selfReferentialRenamedFromPaths = [];
+  if (
+    !changedFilesTouchSelfReferentialAllowlist &&
+    hasAnySelfReferentialMarkerCandidate
+  ) {
+    try {
+      selfReferentialRenamedFromPaths = port
+        .listChangeRequestRenamedFromPaths(args.prNumber)
+        .filter(Boolean);
+    } catch {
+      selfReferentialRenamedFromPaths = [];
+    }
+  }
+  const touchesSelfReferentialAllowlist =
+    changedFilesTouchSelfReferentialAllowlist ||
+    selfReferentialRenamedFromPaths.some((path) =>
+      selfReferentialTriggerFiles.includes(String(path)),
+    );
   // Bounded scan for self-referential-bootstrap-auto candidate markers
   // bound to this PR's own HEAD, mirroring `collectFromGitHub`'s own
   // anti-flood budget (20, capped) but NOT its earliest-first tie-break:

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -5,6 +5,11 @@
 // source named above by `pnpm run build`. Edit the .mts source, never the
 // generated .mjs. See docs/typescript-sources.md.
 import {
+  ADVISORY_CONVERGENCE_WORKFLOW_PATH,
+  resolveSelfReferentialTriggerFiles,
+  verifySelfReferentialBootstrapWaiverRun,
+} from './advisory-convergence.mjs';
+import {
   advisoryWaitSectionIsValid,
   DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
   resolveAdvisoryConvergenceDeadlineMinutes,
@@ -15,9 +20,10 @@ import {
   resolveAdvisoryWaitPolicy,
   resolveEffectiveAdvisoryTerminalWindowMinutes,
   resolveProviderOutageTerminalWindowMinutes,
+  SELF_REFERENTIAL_BOOTSTRAP_AUTO_REASON,
 } from './advisory-wait-policy.mjs';
 import { buildCopilotRecoverySummary } from './advisory-wait-state.mjs';
-import { parseCliArgs } from './cli-args.mjs';
+import { parseCanonicalIntegerOrNull, parseCliArgs } from './cli-args.mjs';
 import { isAuthorizedForcedHandoffActor } from './collaborator-permission.mjs';
 import {
   normalizeAuthorityEvidence,
@@ -38,6 +44,7 @@ import {
   deriveIddAgentLogins,
   normalizeTrustedMarkerLogins,
   operationalMarkerPrefix,
+  parseExternalCheckWaiverComment,
   resolveAdvisoryBotLogins,
   resolveCodeownersForFiles,
   resolvePrFirstCommitAt,
@@ -575,6 +582,133 @@ export function collectPreMergeReadiness(
       waivableCheckSelectors,
       now,
     });
+  // kurone-kito/idd-skill#2911: independent evidence for
+  // `buildPreMergeReadinessSummary`'s `staleSelfWaiver` blocker
+  // (protocol-helpers.mts) -- see that computation's own doc comment for
+  // the full rationale. Performed here (the I/O collector), not inside
+  // that pure function, mirroring this file's own established precedent
+  // for `copilotUnavailable` above ("precompute here rather than inside
+  // `buildPreMergeReadinessSummary`, which cannot import X without an
+  // import cycle" -- `advisory-convergence.mts` already imports FROM
+  // `protocol-helpers.mts`, so the reverse would cycle).
+  //
+  // A local, independently-valued bound rather than importing
+  // `advisory-convergence.mts`'s own `MAX_AUTO_WAIVER_RUN_LOOKUPS`: that
+  // constant is declared inside `collectFromGitHub`'s own function body --
+  // exactly the area kurone-kito/idd-skill#2912 (open now, claimed by a
+  // different session) is expected to rewrite for the same-repository
+  // bearer-evidence provenance gap. Keeping this bound independent avoids
+  // a rebase collision there; the two files must already agree on the
+  // same value by convention, not by import.
+  const MAX_PRE_MERGE_AUTO_WAIVER_RUN_LOOKUPS = 20;
+  // #2657/#2911: the same raw `helperRuntime.profile` config field
+  // `advisory-convergence.mts`'s own `collectFromGitHub` reads directly --
+  // `normalizePolicyConfig` does not carry `helperRuntime` through its
+  // normalized shape (that section is validated, not defaulted,
+  // elsewhere), and `IddConfig`'s index signature already types this
+  // access as `unknown` with no cast needed.
+  const rawHelperRuntime = iddConfig?.helperRuntime;
+  const helperRuntimeProfile =
+    rawHelperRuntime &&
+    typeof rawHelperRuntime === 'object' &&
+    typeof rawHelperRuntime.profile === 'string'
+      ? rawHelperRuntime.profile
+      : undefined;
+  const repositoryFullName = owner && repo ? `${owner}/${repo}` : '';
+  // The load-bearing security boundary (kurone-kito/idd-skill#2911's
+  // decisive finding): fetched independently from THIS PR's own live
+  // diff, never from any comment body, so a forged marker can only ever
+  // affect a PR that already, genuinely touches the checker allowlist --
+  // same mitigation `autoWaiverValid` (advisory-convergence.mts) already
+  // relies on for the identical bearer-evidence gap. Reuses the
+  // ALREADY-FETCHED `changedFiles` above (no extra round-trip) plus a
+  // renamed-from-paths fetch, mirroring `collectFromGitHub`'s own merge
+  // of both sources exactly (a rename-shaped checker repair away from an
+  // allowlisted path must still be recognized).
+  const selfReferentialTriggerFiles = resolveSelfReferentialTriggerFiles(
+    helperRuntimeProfile,
+    repositoryFullName,
+  );
+  const selfReferentialRenamedFromPaths = port
+    .listChangeRequestRenamedFromPaths(args.prNumber)
+    .filter(Boolean);
+  const touchesSelfReferentialAllowlist = [
+    ...changedFiles,
+    ...selfReferentialRenamedFromPaths,
+  ].some((path) => selfReferentialTriggerFiles.includes(String(path)));
+  // Bounded scan for self-referential-bootstrap-auto candidate markers
+  // bound to this PR's own HEAD, mirroring `collectFromGitHub`'s own
+  // anti-flood tie-break exactly (earliest-first, capped): no selection
+  // order fully closes the flood problem, but this bounds worst-case API
+  // cost the same deliberately generous way, and
+  // `verifySelfReferentialBootstrapWaiverRun` below still requires
+  // independent Actions-run verification regardless of what this
+  // prefilter selects.
+  const autoWaiverRunIdCandidates = [];
+  const seenAutoWaiverRunIds = new Set();
+  const prHeadShaLower = prHeadSha.toLowerCase();
+  for (const comment of normalizedComments) {
+    const body = comment.body;
+    if (!/^<!--\s*idd-external-check-waiver:/i.test(body)) continue;
+    const authorLogin = comment.author.login.trim().toLowerCase();
+    if (authorLogin !== 'github-actions[bot]') continue;
+    const parsed = parseExternalCheckWaiverComment(body, comment.createdAt);
+    // kurone-kito/idd-skill#2911: mirrors `collectFromGitHub`'s own
+    // prefilter conditions verbatim -- a canonical positive-integer
+    // run-id (never percent-decoded/sanitized attacker text reaching
+    // `getWorkflowRun`'s REST path unvalidated), an EXACT (never glob)
+    // checkSelector match, and this PR's own current HEAD -- before a
+    // candidate is ever eligible to spend part of the bounded lookup
+    // budget.
+    if (
+      parsed &&
+      parsed.reason === SELF_REFERENTIAL_BOOTSTRAP_AUTO_REASON &&
+      parsed.checkSelector === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR &&
+      parsed.runId &&
+      parseCanonicalIntegerOrNull(parsed.runId) !== null &&
+      !seenAutoWaiverRunIds.has(parsed.runId) &&
+      String(parsed.headSha ?? '')
+        .trim()
+        .toLowerCase() === prHeadShaLower
+    ) {
+      seenAutoWaiverRunIds.add(parsed.runId);
+      autoWaiverRunIdCandidates.push({
+        runId: parsed.runId,
+        createdAt: comment.createdAt,
+      });
+    }
+  }
+  const boundedAutoWaiverRunIds = autoWaiverRunIdCandidates
+    .sort((left, right) => left.createdAt.localeCompare(right.createdAt))
+    .slice(0, MAX_PRE_MERGE_AUTO_WAIVER_RUN_LOOKUPS)
+    .map((candidate) => candidate.runId);
+  const autoWaiverRunVerified = {};
+  for (const runId of boundedAutoWaiverRunIds) {
+    try {
+      const raw = port.getWorkflowRun(owner, repo, runId);
+      autoWaiverRunVerified[runId] = verifySelfReferentialBootstrapWaiverRun(
+        {
+          path: raw?.path ?? null,
+          headSha: raw?.head_sha ?? null,
+          repositoryFullName: raw?.head_repository?.full_name ?? null,
+          event: raw?.event ?? null,
+        },
+        {
+          path: ADVISORY_CONVERGENCE_WORKFLOW_PATH,
+          headSha: prHeadSha,
+          repositoryFullName,
+        },
+      );
+    } catch {
+      // Fail closed per run id -- untrusted: a lookup failure (unknown
+      // run, transient API error) must never widen trust, and must never
+      // crash this whole evidence collector either. This is the
+      // deliberate fail-open-for-staleness direction documented on
+      // `buildPreMergeReadinessSummary`'s `staleSelfWaiver` computation:
+      // an unverified run suppresses the blocker rather than firing it.
+      autoWaiverRunVerified[runId] = false;
+    }
+  }
   const summary = buildPreMergeReadinessSummary(
     {
       prHeadSha,
@@ -656,6 +790,8 @@ export function collectPreMergeReadiness(
       viewerAppSlug,
       configuredTrustedActors,
       collaboratorTrustEnabled,
+      touchesSelfReferentialAllowlist,
+      autoWaiverRunVerified,
     },
   );
   return {

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -713,8 +713,16 @@ export function collectPreMergeReadiness(
   // `getWorkflowRun` calls, only on the narrower set of PRs that already,
   // genuinely touch the allowlist.
   if (touchesSelfReferentialAllowlist) {
-    const autoWaiverRunIdCandidates = [];
-    const seenAutoWaiverRunIds = new Set();
+    // kurone-kito/idd-skill#2911 (Copilot review, PR #2915): keyed by
+    // `runId` (a Map, not an array + Set) so a SECOND comment citing an
+    // already-seen run id UPDATES that candidate's `createdAt` to the
+    // newer value instead of being silently dropped -- the same run can
+    // legitimately post more than one marker comment over its own
+    // lifetime (e.g. a retry within the run), and comments are typically
+    // returned oldest-first, so keeping only the first occurrence would
+    // anchor that candidate to a stale timestamp and could wrongly push
+    // it out of the newest-first bounded window under a flood.
+    const autoWaiverRunIdCandidates = new Map();
     const prHeadShaLower = prHeadSha.toLowerCase();
     for (const comment of normalizedComments) {
       const body = comment.body;
@@ -735,19 +743,21 @@ export function collectPreMergeReadiness(
         parsed.checkSelector === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR &&
         parsed.runId &&
         parseCanonicalIntegerOrNull(parsed.runId) !== null &&
-        !seenAutoWaiverRunIds.has(parsed.runId) &&
         String(parsed.headSha ?? '')
           .trim()
           .toLowerCase() === prHeadShaLower
       ) {
-        seenAutoWaiverRunIds.add(parsed.runId);
-        autoWaiverRunIdCandidates.push({
-          runId: parsed.runId,
-          createdAt: comment.createdAt,
-        });
+        const existingCreatedAt = autoWaiverRunIdCandidates.get(parsed.runId);
+        if (
+          existingCreatedAt === undefined ||
+          comment.createdAt.localeCompare(existingCreatedAt) > 0
+        ) {
+          autoWaiverRunIdCandidates.set(parsed.runId, comment.createdAt);
+        }
       }
     }
-    const boundedAutoWaiverRunIds = autoWaiverRunIdCandidates
+    const boundedAutoWaiverRunIds = [...autoWaiverRunIdCandidates]
+      .map(([runId, createdAt]) => ({ runId, createdAt }))
       .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
       .slice(0, MAX_PRE_MERGE_AUTO_WAIVER_RUN_LOOKUPS)
       .map((candidate) => candidate.runId);

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -6900,19 +6900,42 @@ export function buildPreMergeReadinessSummary(
     staleSelfWaiverModeOpen &&
     staleSelfWaiverSelectorWaivable
   ) {
-    const selfConvergenceCheckInstances = ci.checks.filter(
-      (check) =>
-        check.required === true &&
+    // kurone-kito/idd-skill#2911 (Codex review on PR #2915, P1): the
+    // pre-fix version filtered `ci.checks` -- already reduced by
+    // `summarizeRequiredChecks` and stripped of its `type`/`workflowName`
+    // producer-identity fields -- and picked a single "latest" instance
+    // with `selectLatestCheckInstance` directly over that flattened list.
+    // When two distinct PRODUCERS (e.g. an Actions check-run and a legacy
+    // status context) share the `idd-advisory-convergence` name, that
+    // flattening could let a later, genuinely-passing instance from an
+    // UNRELATED producer mask an earlier instance from the checker's own
+    // producer that is still resting on a stale waiver, since only the
+    // single most-recent-across-all-producers instance was ever
+    // inspected. Group by producer instead, over the RAW `checks`
+    // parameter (which still carries `type`/`workflowName`, unlike
+    // `ci.checks`), using `selectLatestCheckPerName` -- the identical
+    // producer-identity grouping `classifyCiChecks`/
+    // `findDiscardedNonPassingSiblings` already establish for the same
+    // reason (#1483) -- then evaluate EACH producer's own latest instance
+    // independently below (loop, `break` on the first stale match), so a
+    // fresh pass from one producer can never hide a stale pass from
+    // another.
+    const selfConvergenceRawInstances = checks
+      .filter((check) =>
         matchCheckSelectorLocal(check.name, staleSelfWaiverCheckSelector),
-    );
-    const latestSelfConvergenceCheck =
-      selfConvergenceCheckInstances.length > 0
-        ? selectLatestCheckInstance(selfConvergenceCheckInstances)
-        : null;
-    if (
-      latestSelfConvergenceCheck &&
-      CHECK_PASS_EQUIVALENT_STATES.has(latestSelfConvergenceCheck.state)
-    ) {
+      )
+      .map((check) => ({
+        name: String(check.name ?? ''),
+        state: String(check.state ?? ''),
+        completedAt: check.completedAt ?? null,
+        type: check.type ?? null,
+        workflowName: check.workflowName ?? null,
+      }))
+      .filter((check) => ci.requiredCheckNames.includes(check.name));
+    const selfConvergenceProducerCandidates = selectLatestCheckPerName(
+      selfConvergenceRawInstances,
+    ).filter((check) => CHECK_PASS_EQUIVALENT_STATES.has(check.state));
+    for (const latestSelfConvergenceCheck of selfConvergenceProducerCandidates) {
       const autoWaiverRunVerified = options.autoWaiverRunVerified ?? {};
       const isRunVerifiedSelfWaiverMarker = (entry) =>
         entry.authorLogin === 'github-actions[bot]' &&
@@ -6997,6 +7020,7 @@ export function buildPreMergeReadinessSummary(
           expiresAt: staleExpiredEntry.expiresAt,
           waiverClaimId: '',
         };
+        break;
       } else if (staleWrongClaimEntry) {
         staleSelfWaiver = {
           stale: true,
@@ -7005,6 +7029,7 @@ export function buildPreMergeReadinessSummary(
           expiresAt: '',
           waiverClaimId: staleWrongClaimEntry.waiverClaimId,
         };
+        break;
       }
     }
   }

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -265,6 +265,7 @@ export function summarizeExternalCheckWaivers(
         reason: parsed.reason,
         runId: parsed.runId,
         createdAt: parsed.createdAt,
+        expiresAt: parsed.expiresAt,
       });
       continue;
     }
@@ -7075,6 +7076,19 @@ export function buildPreMergeReadinessSummary(
       // could not have justified that pass either, regardless of the
       // claim-installation comparison below. Same stale-leaning
       // treatment of an unparseable `createdAt`.
+      //
+      // kurone-kito/idd-skill#2911 (Codex review, PR #2915, P2): ALSO
+      // requires the upper bound (`expiresAt >= passingCompletedAtMs`),
+      // mirroring `staleExpiredEntry`'s own two-sided window check --
+      // without it, a marker that had ALREADY expired before the check
+      // even completed (a real scenario here specifically: this
+      // function's own `wrongClaim` classification runs BEFORE the
+      // expiry check, so a marker can be both wrong-claim AND
+      // already-expired yet only ever reach this bucket, never
+      // `expired`) gets treated as if it could have justified a LATER,
+      // genuinely unrelated pass, purely because the claim identity also
+      // happened to change again even later -- an unnecessary blocker
+      // with no real evidence behind it.
       const staleWrongClaimEntry =
         staleExpiredEntry || hasCoveringValidMarker
           ? undefined
@@ -7082,9 +7096,16 @@ export function buildPreMergeReadinessSummary(
               if (!isRunVerifiedSelfWaiverMarker(entry)) return false;
               if (passingCompletedAtMs === null) return true;
               const entryCreatedAtMs = Date.parse(entry.createdAt);
+              const entryExpiresAtMs = Date.parse(entry.expiresAt);
               if (
                 !Number.isNaN(entryCreatedAtMs) &&
                 entryCreatedAtMs > passingCompletedAtMs
+              ) {
+                return false;
+              }
+              if (
+                !Number.isNaN(entryExpiresAtMs) &&
+                entryExpiresAtMs < passingCompletedAtMs
               ) {
                 return false;
               }

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -6935,9 +6935,31 @@ export function buildPreMergeReadinessSummary(
         workflowName: check.workflowName ?? null,
       }))
       .filter((check) => ci.requiredCheckNames.includes(check.name));
+    // kurone-kito/idd-skill#2911 (Codex review, PR #2915, P1, fresh
+    // evidence against THIS revision's own new per-producer loop): the
+    // producer grouping above intentionally keeps every distinct
+    // producer separate, but a non-Actions producer sharing this name
+    // (e.g. a legacy status context) can never legitimately be covered
+    // by a self-referential-bootstrap-auto marker in the first place --
+    // that marker only ever cites a workflow RUN
+    // (`verifySelfReferentialBootstrapWaiverRun` checks `path`/`event`
+    // against an Actions run), which a status-context producer has none
+    // of. Worse, such a producer typically has no parseable
+    // `completedAt`, which would otherwise hit this loop's stale-leaning
+    // `passingCompletedAtMs === null` branch below and flag a false
+    // positive even while the REAL convergence workflow's own instance
+    // is genuinely fresh. Exclude any producer whose `type` is populated
+    // and is not `'check-run'` before it ever becomes a candidate -- an
+    // absent `type` (the pre-#1483 data shape, including this fixture's
+    // own base checker instance) still passes through unaffected, same
+    // as `groupChecksByProducer`'s own no-conflicting-signal fallback.
     const selfConvergenceProducerCandidates = selectLatestCheckPerName(
       selfConvergenceRawInstances,
-    ).filter((check) => CHECK_PASS_EQUIVALENT_STATES.has(check.state));
+    ).filter(
+      (check) =>
+        CHECK_PASS_EQUIVALENT_STATES.has(check.state) &&
+        (!check.type || check.type === 'check-run'),
+    );
     for (const latestSelfConvergenceCheck of selfConvergenceProducerCandidates) {
       const autoWaiverRunVerified = options.autoWaiverRunVerified ?? {};
       // kurone-kito/idd-skill#2911 (CodeRabbit + Copilot review, PR #2915,

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -7044,6 +7044,32 @@ export function buildPreMergeReadinessSummary(
       // it only ever prevents THIS blocker from mis-firing on a pass that
       // a fresh marker already, genuinely covers; it can never clear a
       // blocker any OTHER evidence in this file raised.
+      //
+      // kurone-kito/idd-skill#2911 (design model, stated once here so a
+      // future review pass reads it instead of re-deriving it): the
+      // underlying question for ALL THREE finders below is interval
+      // overlap -- could this marker's own validity window,
+      // `[createdAt, expiresAt]`, have overlapped the run's observation
+      // window, `[startedAt, completedAt]`? That is
+      // `createdAt <= completedAt && expiresAt >= startedAt`. The LOWER
+      // bound stays anchored on `completedAt` (not `startedAt`)
+      // deliberately: the marker is posted BY the run itself, so its
+      // `createdAt` falls somewhere mid-run, between the run's own
+      // `startedAt` and `completedAt` -- anchoring the lower bound on
+      // `startedAt` instead would make a run's own marker unable to
+      // cover its own pass, breaking acceptance criterion 2 outright.
+      // The UPPER bound anchors on `startedAt` (via `passingStartedAtMs`,
+      // falling back to `passingCompletedAtMs` when unparseable): the run
+      // reads waiver evidence near its own start, so a marker that was
+      // still valid then, but expires before the run's slower
+      // `completedAt`, must not be misread as "expired before this pass"
+      // (Codex review, PR #2915, round 7, P2) -- the accepted residual is
+      // that a marker which expired early in the run, strictly before the
+      // run's own evidence-fetch instant (which this code cannot observe
+      // directly), still gets flagged and costs one avoidable rerun,
+      // never a false "not stale": the alternative of anchoring on
+      // `completedAt` instead risks the false negative Codex identified,
+      // which is the worse failure for a security-relevant blocker.
       const hasCoveringValidMarker =
         passingCompletedAtMs !== null &&
         autoWaiverEvidence.valid.some((entry) => {
@@ -7066,16 +7092,25 @@ export function buildPreMergeReadinessSummary(
           );
         });
       // kurone-kito/idd-skill#2911 (Copilot review, PR #2915): checking
-      // only `expiresAt >= passingCompletedAtMs` (the upper bound) is not
-      // enough on its own -- a marker CREATED after the check already
-      // completed could not possibly have justified that earlier pass no
-      // matter how far its `expiresAt` reaches, so the LOWER bound
+      // only `expiresAt >= ...` (the upper bound) is not enough on its
+      // own -- a marker CREATED after the check already completed could
+      // not possibly have justified that earlier pass no matter how far
+      // its `expiresAt` reaches, so the LOWER bound
       // (`createdAt <= passingCompletedAtMs`) must also hold before an
       // entry counts as having plausibly covered the pass. An unparseable
       // boundary on either side still counts (stale-leaning, matching this
       // blocker's established fail-toward-flagging asymmetry) -- only a
       // POSITIVE, parseable `createdAt` strictly after the pass excludes
       // an entry.
+      //
+      // kurone-kito/idd-skill#2911 (Codex review, PR #2915, round 7, P2):
+      // the UPPER bound anchors on `passingStartedAtMs` (falling back to
+      // `passingCompletedAtMs`), not `passingCompletedAtMs` directly --
+      // see the interval-overlap model documented above
+      // `hasCoveringValidMarker`. A marker that was still valid when the
+      // run observed it near its own start, but expires before the run's
+      // slower `completedAt`, must not be misread as having expired
+      // before the pass it actually covered.
       const staleExpiredEntry = hasCoveringValidMarker
         ? undefined
         : autoWaiverEvidence.expired.find((entry) => {
@@ -7083,9 +7118,11 @@ export function buildPreMergeReadinessSummary(
             if (passingCompletedAtMs === null) return true;
             const entryExpiresAtMs = Date.parse(entry.expiresAt);
             const entryCreatedAtMs = Date.parse(entry.createdAt);
+            const runObservationBoundMs =
+              passingStartedAtMs ?? passingCompletedAtMs;
             return (
               (Number.isNaN(entryExpiresAtMs) ||
-                entryExpiresAtMs >= passingCompletedAtMs) &&
+                entryExpiresAtMs >= runObservationBoundMs) &&
               (Number.isNaN(entryCreatedAtMs) ||
                 entryCreatedAtMs <= passingCompletedAtMs)
             );
@@ -7098,17 +7135,23 @@ export function buildPreMergeReadinessSummary(
       // treatment of an unparseable `createdAt`.
       //
       // kurone-kito/idd-skill#2911 (Codex review, PR #2915, P2): ALSO
-      // requires the upper bound (`expiresAt >= passingCompletedAtMs`),
-      // mirroring `staleExpiredEntry`'s own two-sided window check --
-      // without it, a marker that had ALREADY expired before the check
-      // even completed (a real scenario here specifically: this
-      // function's own `wrongClaim` classification runs BEFORE the
-      // expiry check, so a marker can be both wrong-claim AND
-      // already-expired yet only ever reach this bucket, never
-      // `expired`) gets treated as if it could have justified a LATER,
-      // genuinely unrelated pass, purely because the claim identity also
-      // happened to change again even later -- an unnecessary blocker
-      // with no real evidence behind it.
+      // requires the upper bound, mirroring `staleExpiredEntry`'s own
+      // two-sided window check -- without it, a marker that had ALREADY
+      // expired before the check even completed (a real scenario here
+      // specifically: this function's own `wrongClaim` classification
+      // runs BEFORE the expiry check, so a marker can be both
+      // wrong-claim AND already-expired yet only ever reach this bucket,
+      // never `expired`) gets treated as if it could have justified a
+      // LATER, genuinely unrelated pass, purely because the claim
+      // identity also happened to change again even later -- an
+      // unnecessary blocker with no real evidence behind it.
+      //
+      // kurone-kito/idd-skill#2911 (Codex review, PR #2915, round 7, P2):
+      // the upper-bound comparison anchors on `passingStartedAtMs`
+      // (falling back to `passingCompletedAtMs`), the same
+      // run-observation-bound reasoning as `staleExpiredEntry` above --
+      // see the interval-overlap model documented above
+      // `hasCoveringValidMarker`.
       const staleWrongClaimEntry =
         staleExpiredEntry || hasCoveringValidMarker
           ? undefined
@@ -7117,6 +7160,8 @@ export function buildPreMergeReadinessSummary(
               if (passingCompletedAtMs === null) return true;
               const entryCreatedAtMs = Date.parse(entry.createdAt);
               const entryExpiresAtMs = Date.parse(entry.expiresAt);
+              const runObservationBoundMs =
+                passingStartedAtMs ?? passingCompletedAtMs;
               if (
                 !Number.isNaN(entryCreatedAtMs) &&
                 entryCreatedAtMs > passingCompletedAtMs
@@ -7125,7 +7170,7 @@ export function buildPreMergeReadinessSummary(
               }
               if (
                 !Number.isNaN(entryExpiresAtMs) &&
-                entryExpiresAtMs < passingCompletedAtMs
+                entryExpiresAtMs < runObservationBoundMs
               ) {
                 return false;
               }
@@ -7139,9 +7184,19 @@ export function buildPreMergeReadinessSummary(
               // observed the OLD claim, so this must flag stale even
               // though the check's `completedAt` now reads after the
               // handoff.
+              //
+              // kurone-kito/idd-skill#2911 (Codex review, PR #2915,
+              // round 7, P1): uses `<=`, not `<` -- when the run's own
+              // observation bound and the claim-installation instant
+              // serialize to the EXACT same timestamp, there is no
+              // positive evidence the run's evidence-fetch actually
+              // happened after the handoff (a run can begin and read the
+              // old claim immediately before a handoff inside the same
+              // timestamp interval), so a tie must be treated as stale,
+              // not fresh.
               return (
                 Number.isNaN(installedAtMs) ||
-                (passingStartedAtMs ?? passingCompletedAtMs) < installedAtMs
+                runObservationBoundMs <= installedAtMs
               );
             });
       if (staleExpiredEntry) {

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -262,6 +262,8 @@ export function summarizeExternalCheckWaivers(
         authorLogin,
         checkSelector: parsed.checkSelector,
         waiverClaimId: parsed.claimId,
+        reason: parsed.reason,
+        runId: parsed.runId,
       });
       continue;
     }
@@ -271,6 +273,8 @@ export function summarizeExternalCheckWaivers(
         authorLogin,
         checkSelector: parsed.checkSelector,
         expiresAt: parsed.expiresAt,
+        reason: parsed.reason,
+        runId: parsed.runId,
       });
       continue;
     }
@@ -289,6 +293,8 @@ export function summarizeExternalCheckWaivers(
           authorLogin,
           checkSelector: parsed.checkSelector,
           expiresAt: parsed.expiresAt,
+          reason: parsed.reason,
+          runId: parsed.runId,
         });
         continue;
       }
@@ -5783,7 +5789,24 @@ export function resolveActiveClaimForWriteGate(events, options) {
     isStale: resolveStalePredicate(options.staleAgeMs),
   });
 }
-export function summarizeClaimValidation(claimEvents = [], options = {}) {
+export function summarizeClaimValidation(
+  claimEvents = [],
+  options = {},
+  /**
+   * kurone-kito/idd-skill#2911: optional out-parameter this function
+   * mutates in place with `resolveActiveClaimWithForcedHandoffTrace`'s
+   * `activeSince` (the non-mutable claim-identity-transition anchor --
+   * see that interface's own doc comment for why `ClaimValidationSummary
+   * .activeClaim.createdAt` is unsuitable for this). Deliberately NOT a
+   * new field on `ClaimValidationSummary` itself: that type's shape is
+   * embedded in multiple schemas beyond `pre-merge-readiness.schema.json`
+   * (e.g. `discover-roadmap-union.schema.json`), so widening it would
+   * ripple into unrelated consumers. Every existing caller passes no 3rd
+   * argument and is completely unaffected; `buildPreMergeReadinessSummary`
+   * is the sole caller that supplies one today.
+   */
+  captureTraceInto,
+) {
   const trustedMarkerLogins = new Set(
     normalizeTrustedMarkerLogins(options.trustedMarkerLogins ?? []),
   );
@@ -5820,31 +5843,43 @@ export function summarizeClaimValidation(claimEvents = [], options = {}) {
   // for the same corrected-handoff state (resume `already_owned` vs. merge
   // `claimLost`) by design; both still funnel through the single
   // resolveActiveClaim resolver.
-  const activeClaim = resolveActiveClaim(claimEvents, {
-    isTrustedAuthor: trustedAuthorPredicate,
-    isForcedHandoffEnabled:
-      typeof options.isForcedHandoffEnabled === 'function'
-        ? options.isForcedHandoffEnabled
-        : buildForcedHandoffEnableGate({
-            forcedHandoffEnabled: options.forcedHandoffEnabled === true,
-            expectedLinkedPrReferences,
-            prFirstCommitAt: options.prFirstCommitAt ?? null,
-          }),
-    isAuthorizedForcedHandoff:
-      typeof options.isAuthorizedForcedHandoff === 'function'
-        ? options.isAuthorizedForcedHandoff
-        : (forcedBy) => {
-            if (authorizedForcedHandoffLogins.size === 0) {
-              return false;
-            }
-            return authorizedForcedHandoffLogins.has(
-              String(forcedBy ?? '')
-                .trim()
-                .toLowerCase(),
-            );
-          },
-    isStale: resolveStalePredicate(options.staleAgeMs),
-  });
+  // kurone-kito/idd-skill#2911: switched from the thin `resolveActiveClaim`
+  // wrapper to the full trace, so `captureTraceInto` (when the caller
+  // supplies it) can recover `activeSince` -- the same single-pass
+  // reduction, just no longer discarding the extra field. Every existing
+  // caller only ever read `.activeClaim` off `resolveActiveClaim`'s own
+  // return, so this is behavior-identical for that value.
+  const { activeClaim, activeSince } = resolveActiveClaimWithForcedHandoffTrace(
+    claimEvents,
+    {
+      isTrustedAuthor: trustedAuthorPredicate,
+      isForcedHandoffEnabled:
+        typeof options.isForcedHandoffEnabled === 'function'
+          ? options.isForcedHandoffEnabled
+          : buildForcedHandoffEnableGate({
+              forcedHandoffEnabled: options.forcedHandoffEnabled === true,
+              expectedLinkedPrReferences,
+              prFirstCommitAt: options.prFirstCommitAt ?? null,
+            }),
+      isAuthorizedForcedHandoff:
+        typeof options.isAuthorizedForcedHandoff === 'function'
+          ? options.isAuthorizedForcedHandoff
+          : (forcedBy) => {
+              if (authorizedForcedHandoffLogins.size === 0) {
+                return false;
+              }
+              return authorizedForcedHandoffLogins.has(
+                String(forcedBy ?? '')
+                  .trim()
+                  .toLowerCase(),
+              );
+            },
+      isStale: resolveStalePredicate(options.staleAgeMs),
+    },
+  );
+  if (captureTraceInto) {
+    captureTraceInto.activeSince = activeSince;
+  }
   const expectedNonce = String(options.expectedNonce ?? '').trim();
   let reason = 'match';
   if (!activeClaim) {
@@ -6203,6 +6238,36 @@ export function computePreMergeReadinessBlockers(report) {
     }
     blockers.push({ gate: 'ci', detail });
   }
+  // kurone-kito/idd-skill#2911: the OPPOSITE direction from the block
+  // above -- CI may currently report `idd-advisory-convergence` PASSING,
+  // but `buildPreMergeReadinessSummary`'s own `staleSelfWaiver` evidence
+  // (see its computation for the full rationale and the six findings this
+  // closes) may show that pass rests on a self-referential-bootstrap-auto
+  // waiver that has since gone stale, with no rerun since. Independent of
+  // (and not gated by) `isPreMergeCiAllPassing` above, since the whole
+  // point is to catch a check that currently LOOKS all-passing.
+  const staleSelfWaiver = preMergeAsRecord(report.staleSelfWaiver);
+  if (staleSelfWaiver.stale === true) {
+    const staleSelfWaiverCheckSelector = String(
+      staleSelfWaiver.checkSelector ?? '',
+    );
+    const staleReasonDetail =
+      staleSelfWaiver.reason === 'wrong-claim'
+        ? `was bound to claim "${String(staleSelfWaiver.waiverClaimId ?? 'unknown')}", which the current claim identity (installed at "${String(report.claimIdentityInstalledAt ?? '') || 'unknown'}") no longer matches, with no rerun since`
+        : `expired at "${String(staleSelfWaiver.expiresAt ?? 'unknown')}" with no rerun since`;
+    blockers.push({
+      gate: 'ci',
+      detail:
+        `"${staleSelfWaiverCheckSelector}" currently reports a passing ` +
+        `conclusion, but the self-referential-bootstrap-auto waiver ` +
+        `posted by github-actions[bot] that may have justified it ` +
+        `${staleReasonDetail} -- GitHub does not automatically ` +
+        're-evaluate a passing check when its supporting waiver comment ' +
+        `stops being valid. Rerun "${staleSelfWaiverCheckSelector}" for ` +
+        'the current HEAD before merging so it reflects the current, ' +
+        'unwaived state.',
+    });
+  }
   const reviewerStates = preMergeAsRecord(report.reviewerStates);
   if (!isPreMergeReviewSatisfied(reviewerStates)) {
     const selfApproval = preMergeAsRecord(reviewerStates.codeownerSelfApproval);
@@ -6547,6 +6612,14 @@ export function buildPreMergeReadinessSummary(
       primaryBotLogin: options.primaryBotLogin,
     },
   );
+  // kurone-kito/idd-skill#2911: captures `resolveActiveClaimWithForcedHandoff
+  // Trace`'s `activeSince` (the non-mutable claim-identity-transition
+  // anchor `summarizeClaimValidation`'s own `captureTraceInto` parameter
+  // exposes) without widening `ClaimValidationSummary` -- see that
+  // parameter's own doc comment. Left `{}` (never populated) on the
+  // `claimless` branch below, matching that branch's own synthetic,
+  // not-applicable claim shape.
+  const claimTrace = {};
   const claim = options.claimless
     ? {
         expectedClaimId: 'none',
@@ -6563,19 +6636,28 @@ export function buildPreMergeReadinessSummary(
         claimLost: false,
         reason: 'not-applicable',
       }
-    : summarizeClaimValidation(claimEvents, {
-        trustedMarkerLogins,
-        forcedHandoffEnabled: options.forcedHandoffEnabled === true,
-        expectedLinkedPrs: options.expectedLinkedPrs ?? [],
-        prFirstCommitAt: options.prFirstCommitAt ?? null,
-        authorizedForcedHandoffLogins: options.authorizedForcedHandoffLogins,
-        isAuthorizedForcedHandoff: options.isAuthorizedForcedHandoff,
-        isForcedHandoffEnabled: options.isForcedHandoffEnabled,
-        expectedClaimId: options.expectedClaimId,
-        expectedAgentId: options.expectedAgentId,
-        expectedNonce: options.expectedNonce,
-        staleAgeMs: options.staleAgeMs,
-      });
+    : summarizeClaimValidation(
+        claimEvents,
+        {
+          trustedMarkerLogins,
+          forcedHandoffEnabled: options.forcedHandoffEnabled === true,
+          expectedLinkedPrs: options.expectedLinkedPrs ?? [],
+          prFirstCommitAt: options.prFirstCommitAt ?? null,
+          authorizedForcedHandoffLogins: options.authorizedForcedHandoffLogins,
+          isAuthorizedForcedHandoff: options.isAuthorizedForcedHandoff,
+          isForcedHandoffEnabled: options.isForcedHandoffEnabled,
+          expectedClaimId: options.expectedClaimId,
+          expectedAgentId: options.expectedAgentId,
+          expectedNonce: options.expectedNonce,
+          staleAgeMs: options.staleAgeMs,
+        },
+        claimTrace,
+      );
+  // kurone-kito/idd-skill#2911: `''` when no event ever produced an active
+  // claim (including the `claimless` branch above) -- every consumer of
+  // this field must treat that the same as "no anchor available" and fail
+  // closed (never treat an empty string as "installed at the epoch").
+  const claimIdentityInstalledAt = claimTrace.activeSince ?? '';
   const waivableCheckSelectors = options.waivableCheckSelectors ?? null;
   const waiverEvidence = summarizeExternalCheckWaivers(comments, {
     prHeadSha,
@@ -6586,6 +6668,26 @@ export function buildPreMergeReadinessSummary(
     waivableSelectors: waivableCheckSelectors,
     maxValidity: options.externalCheckWaiverMaxValidity ?? '',
     mode: options.externalCheckWaiverMode ?? '',
+  });
+  // kurone-kito/idd-skill#2911: a THIRD authorized `allowSelfReferential-
+  // BootstrapAuto` call site -- see that option's own doc comment in this
+  // file (`summarizeExternalCheckWaivers`) for the full list and why every
+  // other caller must leave it unset. Read-only, feeding only the
+  // `staleSelfWaiver` blocker evidence below; never satisfies a gate or
+  // makes `ready` true. `trustedMarkerLogins` extended with
+  // `github-actions[bot]` identically to `advisory-convergence.mts`'s own
+  // gate-decision call, so a self-referential-bootstrap-auto marker this
+  // repository's own posting job creates is visible to both.
+  const autoWaiverEvidence = summarizeExternalCheckWaivers(comments, {
+    prHeadSha,
+    activeClaimId: claim.activeClaim?.claimId ?? options.activeClaimId ?? '',
+    activeClaimSupersedes: claim.activeClaim?.supersedes ?? '',
+    trustedMarkerLogins: [...trustedMarkerLogins, 'github-actions[bot]'],
+    now,
+    waivableSelectors: waivableCheckSelectors,
+    maxValidity: options.externalCheckWaiverMaxValidity ?? '',
+    mode: options.externalCheckWaiverMode ?? '',
+    allowSelfReferentialBootstrapAuto: true,
   });
   // #1570: the caller-supplied terminal-unavailability verdict, reused below
   // both for the dedicated `copilot-terminal-unavailable` blocker and (#2021)
@@ -6691,6 +6793,221 @@ export function buildPreMergeReadinessSummary(
         ? options.advisoryConvergenceOutageRelievedSince
         : null,
   });
+  // kurone-kito/idd-skill#2911: the OPPOSITE direction from the CI blocker
+  // below -- CI may currently report `idd-advisory-convergence` PASSING,
+  // but that pass may rest on a self-referential-bootstrap-auto marker
+  // that has since gone stale (expired, or claim-invalid across a genuine
+  // claim transition) with no rerun since. GitHub never reruns an
+  // already-successful check merely because its supporting comment stops
+  // being valid, so without this a PR could merge on a stale pass with no
+  // genuine advisory review (or fresh waiver) ever having covered it.
+  // Consumed by `computePreMergeReadinessBlockers` via
+  // `report.staleSelfWaiver` -- independent of, and never gated by,
+  // `isPreMergeCiAllPassing` there, since the whole point is to catch a
+  // check that currently LOOKS all-passing.
+  //
+  // This re-implements the blocker `9ecc9954`/`863c5249`/`337f4369`
+  // introduced and PR #2895's own review then retired across three more
+  // rounds (kurone-kito/idd-skill#2911's own "Findings" history), fixing
+  // every root cause in one pass rather than live-patching this call site
+  // again:
+  // - Deduplicated newest check instance (`selectLatestCheckInstance`),
+  //   not a raw `.find()` over the full (possibly multi-instance)
+  //   `ci.checks` list (round 15, Codex P1).
+  // - Scans BOTH `expired` and `wrongClaim` (round 14, Codex P1) --
+  //   `wrongClaim` never carries a comparable expiry, so it needs the
+  //   claim-identity-transition anchor below instead.
+  // - Correlates `wrongClaim` against `claimIdentityInstalledAt` (a
+  //   non-mutable claim-identity-transition anchor -- see that field's own
+  //   doc comment), never the mutable `claim.activeClaim.createdAt`
+  //   heartbeat clock (round 15, Codex P2).
+  // - Trusts a candidate marker only after `options.autoWaiverRunVerified`
+  //   confirms the SAME run-bound trust conditions
+  //   `verifySelfReferentialBootstrapWaiverRun` already applies (reused
+  //   verbatim, not reimplemented) AND `options.touchesSelfReferential-
+  //   Allowlist` independently confirms this PR's own diff touches the
+  //   checker allowlist (round 15, Copilot -- the decisive finding: a
+  //   same-repository `pull_request`-triggered workflow with
+  //   `issues: write` could otherwise cite a real, unrelated run (e.g.
+  //   this PR's own required-check instance of `idd-advisory-
+  //   convergence.yml`, which runs for EVERY PR regardless of allowlist
+  //   touch) to forge a marker that blocks a completely unrelated PR's
+  //   merge). Both booleans are precomputed by the collector
+  //   (`pre-merge-readiness.mts`), which does the actual `getWorkflowRun`/
+  //   changed-file I/O -- this function cannot perform it directly without
+  //   an import cycle back through `advisory-convergence.mts` (which
+  //   already imports FROM this file).
+  //
+  // Fail-closed/fail-open asymmetry, by design: an unverified run
+  // (`autoWaiverRunVerified[runId]` false/absent, including a transient
+  // `getWorkflowRun` failure) makes the candidate marker untrusted and
+  // therefore SUPPRESSES this blocker -- the safe direction for the
+  // decisive finding above (a forged-or-unresolvable citation must never
+  // become a merge-denial vector), even though it is the opposite of this
+  // file's usual fail-closed default elsewhere. `touchesSelfReferential-
+  // Allowlist` not `true` (including simply omitted by an older caller)
+  // suppresses the blocker unconditionally, for the identical reason.
+  //
+  // `autoWaiverEvidence` itself (computed just above, alongside the
+  // ordinary `waiverEvidence`) is deliberately NOT added to the returned
+  // `summary`: only this derived `staleSelfWaiver` verdict is schema-
+  // locked, so the raw per-marker bucket shape stays free to evolve
+  // (kurone-kito/idd-skill#2912's own bearer-evidence-vs-provenance work
+  // is a plausible future consumer) without forcing a fixture cascade
+  // across every `fixtures/pre-merge-readiness/*.json` file.
+  //
+  // Residual (documented, not fixed here): the run-id trust check above
+  // proves the cited run has the right shape, never that it actually
+  // posted the marker citing it (kurone-kito/idd-skill#2912 tracks
+  // closing that bearer-evidence gap -- see the identical residual note
+  // on `SELF_REFERENTIAL_WAIVER_TRIGGER_FILES` in advisory-convergence.mts,
+  // ~L277-303). `touchesSelfReferentialAllowlist` bounds the blast radius
+  // to PRs that already, genuinely touch the checker allowlist -- it does
+  // not fully close repeated same-repository forgery against ONE such PR
+  // (each round costs that PR one avoidable rerun, never a bypass).
+  const staleSelfWaiverCheckSelector =
+    DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR;
+  let staleSelfWaiver = {
+    stale: false,
+    checkSelector: staleSelfWaiverCheckSelector,
+    reason: null,
+    expiresAt: '',
+    waiverClaimId: '',
+  };
+  // kurone-kito/idd-skill#2911 (Medium, self-critique against the merged
+  // #2657 gate decision): `summarizeExternalCheckWaivers` classifies a
+  // marker into `expired`/`wrongClaim` BEFORE its own `notConfigured`/
+  // `modeDisabled` checks ever run (both come later in that function's own
+  // pipeline), so those two buckets are populated regardless of
+  // `ciGate.externalCheckWaivers.mode`/`waivableSelectors` policy --
+  // unlike `valid`, which `autoWaiverValid` (advisory-convergence.mts) can
+  // only ever reach once mode/waivable ALREADY gated it. Gate this
+  // blocker on the identical precondition, so an adopter whose policy
+  // (the schema default: `mode: "disabled"`) could never have made this
+  // mechanism's waiver `valid` in the first place never sees a blocker
+  // from its `expired`/`wrongClaim` shadow either.
+  const staleSelfWaiverModeOpen =
+    (options.externalCheckWaiverMode ?? '') === '' ||
+    options.externalCheckWaiverMode === 'maintainer-authorized';
+  const staleSelfWaiverSelectorWaivable =
+    !Array.isArray(waivableCheckSelectors) ||
+    isCheckNameConfiguredWaivable(
+      staleSelfWaiverCheckSelector,
+      waivableCheckSelectors,
+    );
+  if (
+    options.touchesSelfReferentialAllowlist === true &&
+    staleSelfWaiverModeOpen &&
+    staleSelfWaiverSelectorWaivable
+  ) {
+    const selfConvergenceCheckInstances = ci.checks.filter(
+      (check) =>
+        check.required === true &&
+        matchCheckSelectorLocal(check.name, staleSelfWaiverCheckSelector),
+    );
+    const latestSelfConvergenceCheck =
+      selfConvergenceCheckInstances.length > 0
+        ? selectLatestCheckInstance(selfConvergenceCheckInstances)
+        : null;
+    if (
+      latestSelfConvergenceCheck &&
+      CHECK_PASS_EQUIVALENT_STATES.has(latestSelfConvergenceCheck.state)
+    ) {
+      const autoWaiverRunVerified = options.autoWaiverRunVerified ?? {};
+      const isRunVerifiedSelfWaiverMarker = (entry) =>
+        entry.authorLogin === 'github-actions[bot]' &&
+        entry.reason === SELF_REFERENTIAL_BOOTSTRAP_AUTO_REASON &&
+        entry.runId !== '' &&
+        autoWaiverRunVerified[entry.runId] === true;
+      // A missing/unparseable `completedAt` on the SELECTED instance
+      // fails closed (treated as stale) here, same as the pre-#2911
+      // attempt: a real rerun always posts a parseable `completedAt`, so
+      // this only ever costs one extra, avoidable rerun on malformed
+      // evidence, never a false "not stale".
+      const passingCompletedAtMs = parseCompletedAt(
+        latestSelfConvergenceCheck.completedAt,
+      );
+      // kurone-kito/idd-skill#2911 (acceptance criterion 2, self-critique
+      // against round 13's own commit message -- `git show 863c5249`
+      // promised "correlation to the passing check's own completedAt OR
+      // to a newer valid marker" but its diff only ever implemented the
+      // first half): a candidate `expired`/`wrongClaim` marker proves
+      // nothing when a DIFFERENT, currently-valid, run-verified
+      // self-referential marker's own `[createdAt, expiresAt]` window
+      // already covers the moment the check last completed -- that is
+      // exactly "a fresh rerun under a new valid marker...has already
+      // superseded a stale marker." This is a time-window correlation
+      // over evidence this SAME call site's own `autoWaiverEvidence`
+      // already computed, not a use of `valid` to satisfy or relax the
+      // OVERALL gate (that direction stays exclusively `autoWaiverValid`'s,
+      // per `allowSelfReferentialBootstrapAuto`'s own ADD-only contract) --
+      // it only ever prevents THIS blocker from mis-firing on a pass that
+      // a fresh marker already, genuinely covers; it can never clear a
+      // blocker any OTHER evidence in this file raised.
+      const hasCoveringValidMarker =
+        passingCompletedAtMs !== null &&
+        autoWaiverEvidence.valid.some((entry) => {
+          if (
+            entry.authorLogin !== 'github-actions[bot]' ||
+            entry.reason !== SELF_REFERENTIAL_BOOTSTRAP_AUTO_REASON ||
+            entry.checkSelector !== staleSelfWaiverCheckSelector ||
+            entry.runId === '' ||
+            autoWaiverRunVerified[entry.runId] !== true
+          ) {
+            return false;
+          }
+          const createdAtMs = Date.parse(entry.createdAt);
+          const expiresAtMs = Date.parse(entry.expiresAt);
+          return (
+            !Number.isNaN(createdAtMs) &&
+            !Number.isNaN(expiresAtMs) &&
+            createdAtMs <= passingCompletedAtMs &&
+            passingCompletedAtMs <= expiresAtMs
+          );
+        });
+      const staleExpiredEntry = hasCoveringValidMarker
+        ? undefined
+        : autoWaiverEvidence.expired.find((entry) => {
+            if (!isRunVerifiedSelfWaiverMarker(entry)) return false;
+            if (passingCompletedAtMs === null) return true;
+            const entryExpiresAtMs = Date.parse(entry.expiresAt);
+            return (
+              Number.isNaN(entryExpiresAtMs) ||
+              entryExpiresAtMs >= passingCompletedAtMs
+            );
+          });
+      const staleWrongClaimEntry =
+        staleExpiredEntry || hasCoveringValidMarker
+          ? undefined
+          : autoWaiverEvidence.wrongClaim.find((entry) => {
+              if (!isRunVerifiedSelfWaiverMarker(entry)) return false;
+              if (passingCompletedAtMs === null) return true;
+              if (!claimIdentityInstalledAt) return true;
+              const installedAtMs = Date.parse(claimIdentityInstalledAt);
+              return (
+                Number.isNaN(installedAtMs) ||
+                passingCompletedAtMs < installedAtMs
+              );
+            });
+      if (staleExpiredEntry) {
+        staleSelfWaiver = {
+          stale: true,
+          checkSelector: staleSelfWaiverCheckSelector,
+          reason: 'expired',
+          expiresAt: staleExpiredEntry.expiresAt,
+          waiverClaimId: '',
+        };
+      } else if (staleWrongClaimEntry) {
+        staleSelfWaiver = {
+          stale: true,
+          checkSelector: staleSelfWaiverCheckSelector,
+          reason: 'wrong-claim',
+          expiresAt: '',
+          waiverClaimId: staleWrongClaimEntry.waiverClaimId,
+        };
+      }
+    }
+  }
   // #1570: reuse the SAME raw waiver evidence above (already validated for
   // selector/HEAD/claim/authority/expiry) to decide whether the caller-
   // supplied terminal-unavailability verdict is also validly waived, filtered
@@ -6794,6 +7111,16 @@ export function buildPreMergeReadinessSummary(
     // blocker detail or a resuming agent can cite the remaining
     // time-to-deadline without re-deriving it.
     advisoryConvergenceWaiverPrecondition,
+    // kurone-kito/idd-skill#2911: reported unconditionally (never omitted),
+    // matching this file's own convention for evidence fields
+    // `computePreMergeReadinessBlockers` consumes -- see `staleSelfWaiver`'s
+    // own computation above for the full contract. Deliberately outside
+    // `claim` (not `claim.activeClaimInstalledAt`): `ClaimValidationSummary`'s
+    // shape is embedded in schemas beyond this one (e.g.
+    // `discover-roadmap-union.schema.json`), so this stays a top-level,
+    // pre-merge-readiness-only field instead.
+    claimIdentityInstalledAt,
+    staleSelfWaiver,
     branchCurrency,
   };
   if (dispositionEvidence) {
@@ -7027,6 +7354,7 @@ export function resolveActiveClaimWithForcedHandoffTrace(
   const orderedEvents = sortClaimEvents(events);
   let active = null;
   let appliedForcedHandoff = null;
+  let activeSince = '';
   for (const event of orderedEvents) {
     const previous = active;
     const next = applyClaimEvent(previous, event, options);
@@ -7048,10 +7376,16 @@ export function resolveActiveClaimWithForcedHandoffTrace(
         candidate.newClaimId === next.claimId
           ? candidate
           : null;
+      // kurone-kito/idd-skill#2911: record the transition's own event
+      // timestamp -- see `ActiveClaimResolution.activeSince`'s doc comment
+      // for why this must be captured here (at the identity-changing step
+      // itself) rather than read back from `next.createdAt`, which a LATER
+      // same-claim heartbeat mutates in place.
+      activeSince = String(event.createdAt ?? '');
     }
     active = next;
   }
-  return { activeClaim: active, appliedForcedHandoff };
+  return { activeClaim: active, appliedForcedHandoff, activeSince };
 }
 export function resolveActiveClaim(events, isTrustedAuthor = () => true) {
   return resolveActiveClaimWithForcedHandoffTrace(events, isTrustedAuthor)

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -6953,12 +6953,32 @@ export function buildPreMergeReadinessSummary(
     // absent `type` (the pre-#1483 data shape, including this fixture's
     // own base checker instance) still passes through unaffected, same
     // as `groupChecksByProducer`'s own no-conflicting-signal fallback.
+    // kurone-kito/idd-skill#2911 (Codex review, PR #2915, P1, fresh
+    // evidence against the type-only filter immediately above): a check
+    // is `type: 'check-run'` for ANY Actions workflow, not only the real
+    // checker -- a second, unrelated workflow file that happens to
+    // publish a check-run under the identical `idd-advisory-convergence`
+    // name would still pass the type filter alone. Declared independently
+    // here (mirroring `MAX_PRE_MERGE_AUTO_WAIVER_RUN_LOOKUPS`'s own
+    // rationale above) rather than importing a shared constant from
+    // `advisory-convergence.mts`, to avoid a rebase collision with
+    // #2912's concurrent work there; a dedicated test pins this literal
+    // against the workflow file's own `name:` field so the two can never
+    // silently drift apart. `workflowName` absent (`''`, the pre-#1483
+    // data shape most fixtures in this suite still use) still passes
+    // through unaffected, same as the type filter's own fallback --
+    // narrowing further only excludes a POSITIVELY different workflow
+    // identity, never an unlabeled one.
+    const ADVISORY_CONVERGENCE_WORKFLOW_DISPLAY_NAME =
+      'IDD advisory-convergence gate';
     const selfConvergenceProducerCandidates = selectLatestCheckPerName(
       selfConvergenceRawInstances,
     ).filter(
       (check) =>
         CHECK_PASS_EQUIVALENT_STATES.has(check.state) &&
-        (!check.type || check.type === 'check-run'),
+        (!check.type || check.type === 'check-run') &&
+        (!check.workflowName ||
+          check.workflowName === ADVISORY_CONVERGENCE_WORKFLOW_DISPLAY_NAME),
     );
     for (const latestSelfConvergenceCheck of selfConvergenceProducerCandidates) {
       const autoWaiverRunVerified = options.autoWaiverRunVerified ?? {};

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -264,6 +264,7 @@ export function summarizeExternalCheckWaivers(
         waiverClaimId: parsed.claimId,
         reason: parsed.reason,
         runId: parsed.runId,
+        createdAt: parsed.createdAt,
       });
       continue;
     }
@@ -275,6 +276,7 @@ export function summarizeExternalCheckWaivers(
         expiresAt: parsed.expiresAt,
         reason: parsed.reason,
         runId: parsed.runId,
+        createdAt: parsed.createdAt,
       });
       continue;
     }
@@ -295,6 +297,7 @@ export function summarizeExternalCheckWaivers(
           expiresAt: parsed.expiresAt,
           reason: parsed.reason,
           runId: parsed.runId,
+          createdAt: parsed.createdAt,
         });
         continue;
       }
@@ -6937,8 +6940,19 @@ export function buildPreMergeReadinessSummary(
     ).filter((check) => CHECK_PASS_EQUIVALENT_STATES.has(check.state));
     for (const latestSelfConvergenceCheck of selfConvergenceProducerCandidates) {
       const autoWaiverRunVerified = options.autoWaiverRunVerified ?? {};
+      // kurone-kito/idd-skill#2911 (CodeRabbit + Copilot review, PR #2915,
+      // Major): `autoWaiverRunVerified` is keyed by `runId` alone. Without
+      // also requiring `checkSelector === staleSelfWaiverCheckSelector`
+      // here, a DIFFERENT-selector marker (this function's own
+      // `autoWaiverEvidence` is never filtered to one selector -- see its
+      // own call site above) that happens to reuse an already-verified
+      // `idd-advisory-convergence` run-id would be accepted as if it were
+      // evidence about THIS check, letting an unrelated check's waiver
+      // wrongly set `staleSelfWaiver` (`hasCoveringValidMarker` is already
+      // selector-scoped and cannot compensate for this gap on its own).
       const isRunVerifiedSelfWaiverMarker = (entry) =>
         entry.authorLogin === 'github-actions[bot]' &&
+        entry.checkSelector === staleSelfWaiverCheckSelector &&
         entry.reason === SELF_REFERENTIAL_BOOTSTRAP_AUTO_REASON &&
         entry.runId !== '' &&
         autoWaiverRunVerified[entry.runId] === true;
@@ -6988,23 +7002,50 @@ export function buildPreMergeReadinessSummary(
             passingCompletedAtMs <= expiresAtMs
           );
         });
+      // kurone-kito/idd-skill#2911 (Copilot review, PR #2915): checking
+      // only `expiresAt >= passingCompletedAtMs` (the upper bound) is not
+      // enough on its own -- a marker CREATED after the check already
+      // completed could not possibly have justified that earlier pass no
+      // matter how far its `expiresAt` reaches, so the LOWER bound
+      // (`createdAt <= passingCompletedAtMs`) must also hold before an
+      // entry counts as having plausibly covered the pass. An unparseable
+      // boundary on either side still counts (stale-leaning, matching this
+      // blocker's established fail-toward-flagging asymmetry) -- only a
+      // POSITIVE, parseable `createdAt` strictly after the pass excludes
+      // an entry.
       const staleExpiredEntry = hasCoveringValidMarker
         ? undefined
         : autoWaiverEvidence.expired.find((entry) => {
             if (!isRunVerifiedSelfWaiverMarker(entry)) return false;
             if (passingCompletedAtMs === null) return true;
             const entryExpiresAtMs = Date.parse(entry.expiresAt);
+            const entryCreatedAtMs = Date.parse(entry.createdAt);
             return (
-              Number.isNaN(entryExpiresAtMs) ||
-              entryExpiresAtMs >= passingCompletedAtMs
+              (Number.isNaN(entryExpiresAtMs) ||
+                entryExpiresAtMs >= passingCompletedAtMs) &&
+              (Number.isNaN(entryCreatedAtMs) ||
+                entryCreatedAtMs <= passingCompletedAtMs)
             );
           });
+      // kurone-kito/idd-skill#2911 (Copilot review, PR #2915): the
+      // identical lower-bound reasoning as `staleExpiredEntry` above --
+      // a `wrongClaim` marker created AFTER the check already completed
+      // could not have justified that pass either, regardless of the
+      // claim-installation comparison below. Same stale-leaning
+      // treatment of an unparseable `createdAt`.
       const staleWrongClaimEntry =
         staleExpiredEntry || hasCoveringValidMarker
           ? undefined
           : autoWaiverEvidence.wrongClaim.find((entry) => {
               if (!isRunVerifiedSelfWaiverMarker(entry)) return false;
               if (passingCompletedAtMs === null) return true;
+              const entryCreatedAtMs = Date.parse(entry.createdAt);
+              if (
+                !Number.isNaN(entryCreatedAtMs) &&
+                entryCreatedAtMs > passingCompletedAtMs
+              ) {
+                return false;
+              }
               if (!claimIdentityInstalledAt) return true;
               const installedAtMs = Date.parse(claimIdentityInstalledAt);
               return (

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -6932,6 +6932,11 @@ export function buildPreMergeReadinessSummary(
         name: String(check.name ?? ''),
         state: String(check.state ?? ''),
         completedAt: check.completedAt ?? null,
+        // kurone-kito/idd-skill#2911 (Codex review, PR #2915, P1): also
+        // carried through for the wrongClaim claim-installation
+        // comparison below, which anchors on this instead of
+        // `completedAt` -- see that comparison's own doc comment.
+        startedAt: check.startedAt ?? null,
         type: check.type ?? null,
         workflowName: check.workflowName ?? null,
       }))
@@ -7007,6 +7012,21 @@ export function buildPreMergeReadinessSummary(
       const passingCompletedAtMs = parseCompletedAt(
         latestSelfConvergenceCheck.completedAt,
       );
+      // kurone-kito/idd-skill#2911 (Codex review, PR #2915, P1): a
+      // long-running check job observes state (fetches comments/waiver
+      // evidence) starting near its OWN `startedAt`, not its later
+      // `completedAt` -- a claim handoff that lands strictly between
+      // those two moments means the run still evaluated the OLD claim's
+      // waiver even though its `completedAt` now reads after the
+      // handoff. Used only by the wrongClaim claim-installation
+      // comparison below (never the createdAt/expiresAt window checks,
+      // which are about the marker's own lifecycle relative to when the
+      // check's result was finalized, a different question). Falls back
+      // to `passingCompletedAtMs` when `startedAt` is missing/unparseable
+      // (legacy data shape) rather than weakening the comparison.
+      const passingStartedAtMs =
+        parseCompletedAt(latestSelfConvergenceCheck.startedAt) ??
+        passingCompletedAtMs;
       // kurone-kito/idd-skill#2911 (acceptance criterion 2, self-critique
       // against round 13's own commit message -- `git show 863c5249`
       // promised "correlation to the passing check's own completedAt OR
@@ -7111,9 +7131,17 @@ export function buildPreMergeReadinessSummary(
               }
               if (!claimIdentityInstalledAt) return true;
               const installedAtMs = Date.parse(claimIdentityInstalledAt);
+              // kurone-kito/idd-skill#2911 (Codex review, PR #2915, P1):
+              // anchors on `passingStartedAtMs`, not `passingCompletedAtMs`
+              // -- see that variable's own doc comment. A claim handoff
+              // landing strictly between the run's start and its
+              // completion still means the run's own evidence-fetch
+              // observed the OLD claim, so this must flag stale even
+              // though the check's `completedAt` now reads after the
+              // handoff.
               return (
                 Number.isNaN(installedAtMs) ||
-                passingCompletedAtMs < installedAtMs
+                (passingStartedAtMs ?? passingCompletedAtMs) < installedAtMs
               );
             });
       if (staleExpiredEntry) {

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -1010,8 +1010,19 @@ export function reviewPolicyNotApplicableReason(
  * same-repository PR editing the workflow YAML can still trigger a
  * `pull_request`-triggered run of it whose `path`/`head_sha`/
  * `head_repository.full_name` all satisfy the other three conditions.
+ *
+ * kurone-kito/idd-skill#2911: exported (was module-private) so
+ * `pre-merge-readiness.mts`'s own stale-self-waiver merge blocker can
+ * reuse this exact verification rather than reimplementing it -- see
+ * that file's own doc comment on its `autoWaiverRunVerified` option
+ * for the full call site. This remains the bearer-evidence check only
+ * (proves the cited run has the right shape, not that it actually
+ * posted the comment citing it -- kurone-kito/idd-skill#2912 tracks
+ * closing that residual gap); callers still need their own
+ * independent `touchesSelfReferentialAllowlist` precondition to keep
+ * a forged-but-shape-valid citation from affecting an unrelated PR.
  */
-function verifySelfReferentialBootstrapWaiverRun(
+export function verifySelfReferentialBootstrapWaiverRun(
   run:
     | {
         path?: string | null;
@@ -1820,10 +1831,12 @@ export function computeAdvisoryConvergenceVerdict(
     maxValidity: String(options.waiverMaxValidity ?? 'PT24H'),
     mode: waiverMode,
     // kurone-kito/idd-skill#2657 (Codex review, PR #2895): one of exactly
-    // two authorized call sites -- see `allowSelfReferentialBootstrapAuto`'s
-    // own doc comment in protocol-helpers.mts for the full list and why
-    // every other caller must leave this unset. This one is the GATE
-    // decision (feeds `autoWaiverValid` directly below), paired with the
+    // three authorized call sites (kurone-kito/idd-skill#2911 added the
+    // third, in pre-merge-readiness.mts's own stale-self-waiver merge
+    // blocker) -- see `allowSelfReferentialBootstrapAuto`'s own doc
+    // comment in protocol-helpers.mts for the full list and why every
+    // other caller must leave this unset. This one is the GATE decision
+    // (feeds `autoWaiverValid` directly below), paired with the
     // independent run-id/event-type/HEAD/repository/changed-file
     // verification that follows.
     allowSelfReferentialBootstrapAuto: true,

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -924,9 +924,16 @@ export function collectPreMergeReadiness(
   // `getWorkflowRun` calls, only on the narrower set of PRs that already,
   // genuinely touch the allowlist.
   if (touchesSelfReferentialAllowlist) {
-    const autoWaiverRunIdCandidates: { runId: string; createdAt: string }[] =
-      [];
-    const seenAutoWaiverRunIds = new Set<string>();
+    // kurone-kito/idd-skill#2911 (Copilot review, PR #2915): keyed by
+    // `runId` (a Map, not an array + Set) so a SECOND comment citing an
+    // already-seen run id UPDATES that candidate's `createdAt` to the
+    // newer value instead of being silently dropped -- the same run can
+    // legitimately post more than one marker comment over its own
+    // lifetime (e.g. a retry within the run), and comments are typically
+    // returned oldest-first, so keeping only the first occurrence would
+    // anchor that candidate to a stale timestamp and could wrongly push
+    // it out of the newest-first bounded window under a flood.
+    const autoWaiverRunIdCandidates = new Map<string, string>();
     const prHeadShaLower = prHeadSha.toLowerCase();
     for (const comment of normalizedComments) {
       const body = comment.body;
@@ -947,19 +954,21 @@ export function collectPreMergeReadiness(
         parsed.checkSelector === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR &&
         parsed.runId &&
         parseCanonicalIntegerOrNull(parsed.runId) !== null &&
-        !seenAutoWaiverRunIds.has(parsed.runId) &&
         String(parsed.headSha ?? '')
           .trim()
           .toLowerCase() === prHeadShaLower
       ) {
-        seenAutoWaiverRunIds.add(parsed.runId);
-        autoWaiverRunIdCandidates.push({
-          runId: parsed.runId,
-          createdAt: comment.createdAt,
-        });
+        const existingCreatedAt = autoWaiverRunIdCandidates.get(parsed.runId);
+        if (
+          existingCreatedAt === undefined ||
+          comment.createdAt.localeCompare(existingCreatedAt) > 0
+        ) {
+          autoWaiverRunIdCandidates.set(parsed.runId, comment.createdAt);
+        }
       }
     }
-    const boundedAutoWaiverRunIds = autoWaiverRunIdCandidates
+    const boundedAutoWaiverRunIds = [...autoWaiverRunIdCandidates]
+      .map(([runId, createdAt]) => ({ runId, createdAt }))
       .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
       .slice(0, MAX_PRE_MERGE_AUTO_WAIVER_RUN_LOOKUPS)
       .map((candidate) => candidate.runId);

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -6,6 +6,11 @@
 // generated .mjs. See docs/typescript-sources.md.
 
 import {
+  ADVISORY_CONVERGENCE_WORKFLOW_PATH,
+  resolveSelfReferentialTriggerFiles,
+  verifySelfReferentialBootstrapWaiverRun,
+} from './advisory-convergence.mts';
+import {
   advisoryWaitSectionIsValid,
   DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
   resolveAdvisoryConvergenceDeadlineMinutes,
@@ -16,9 +21,10 @@ import {
   resolveAdvisoryWaitPolicy,
   resolveEffectiveAdvisoryTerminalWindowMinutes,
   resolveProviderOutageTerminalWindowMinutes,
+  SELF_REFERENTIAL_BOOTSTRAP_AUTO_REASON,
 } from './advisory-wait-policy.mts';
 import { buildCopilotRecoverySummary } from './advisory-wait-state.mts';
-import { parseCliArgs } from './cli-args.mts';
+import { parseCanonicalIntegerOrNull, parseCliArgs } from './cli-args.mts';
 import type { CollaboratorPermissionCache } from './collaborator-permission.mts';
 import { isAuthorizedForcedHandoffActor } from './collaborator-permission.mts';
 import {
@@ -45,6 +51,7 @@ import {
   deriveIddAgentLogins,
   normalizeTrustedMarkerLogins,
   operationalMarkerPrefix,
+  parseExternalCheckWaiverComment,
   resolveAdvisoryBotLogins,
   resolveCodeownersForFiles,
   resolvePrFirstCommitAt,
@@ -783,6 +790,142 @@ export function collectPreMergeReadiness(
       now,
     });
 
+  // kurone-kito/idd-skill#2911: independent evidence for
+  // `buildPreMergeReadinessSummary`'s `staleSelfWaiver` blocker
+  // (protocol-helpers.mts) -- see that computation's own doc comment for
+  // the full rationale. Performed here (the I/O collector), not inside
+  // that pure function, mirroring this file's own established precedent
+  // for `copilotUnavailable` above ("precompute here rather than inside
+  // `buildPreMergeReadinessSummary`, which cannot import X without an
+  // import cycle" -- `advisory-convergence.mts` already imports FROM
+  // `protocol-helpers.mts`, so the reverse would cycle).
+  //
+  // A local, independently-valued bound rather than importing
+  // `advisory-convergence.mts`'s own `MAX_AUTO_WAIVER_RUN_LOOKUPS`: that
+  // constant is declared inside `collectFromGitHub`'s own function body --
+  // exactly the area kurone-kito/idd-skill#2912 (open now, claimed by a
+  // different session) is expected to rewrite for the same-repository
+  // bearer-evidence provenance gap. Keeping this bound independent avoids
+  // a rebase collision there; the two files must already agree on the
+  // same value by convention, not by import.
+  const MAX_PRE_MERGE_AUTO_WAIVER_RUN_LOOKUPS = 20;
+
+  // #2657/#2911: the same raw `helperRuntime.profile` config field
+  // `advisory-convergence.mts`'s own `collectFromGitHub` reads directly --
+  // `normalizePolicyConfig` does not carry `helperRuntime` through its
+  // normalized shape (that section is validated, not defaulted,
+  // elsewhere), and `IddConfig`'s index signature already types this
+  // access as `unknown` with no cast needed.
+  const rawHelperRuntime = iddConfig?.helperRuntime;
+  const helperRuntimeProfile =
+    rawHelperRuntime &&
+    typeof rawHelperRuntime === 'object' &&
+    typeof (rawHelperRuntime as { profile?: unknown }).profile === 'string'
+      ? (rawHelperRuntime as { profile: string }).profile
+      : undefined;
+  const repositoryFullName = owner && repo ? `${owner}/${repo}` : '';
+
+  // The load-bearing security boundary (kurone-kito/idd-skill#2911's
+  // decisive finding): fetched independently from THIS PR's own live
+  // diff, never from any comment body, so a forged marker can only ever
+  // affect a PR that already, genuinely touches the checker allowlist --
+  // same mitigation `autoWaiverValid` (advisory-convergence.mts) already
+  // relies on for the identical bearer-evidence gap. Reuses the
+  // ALREADY-FETCHED `changedFiles` above (no extra round-trip) plus a
+  // renamed-from-paths fetch, mirroring `collectFromGitHub`'s own merge
+  // of both sources exactly (a rename-shaped checker repair away from an
+  // allowlisted path must still be recognized).
+  const selfReferentialTriggerFiles = resolveSelfReferentialTriggerFiles(
+    helperRuntimeProfile,
+    repositoryFullName,
+  );
+  const selfReferentialRenamedFromPaths = port
+    .listChangeRequestRenamedFromPaths(args.prNumber)
+    .filter(Boolean);
+  const touchesSelfReferentialAllowlist = [
+    ...changedFiles,
+    ...selfReferentialRenamedFromPaths,
+  ].some((path) => selfReferentialTriggerFiles.includes(String(path)));
+
+  // Bounded scan for self-referential-bootstrap-auto candidate markers
+  // bound to this PR's own HEAD, mirroring `collectFromGitHub`'s own
+  // anti-flood tie-break exactly (earliest-first, capped): no selection
+  // order fully closes the flood problem, but this bounds worst-case API
+  // cost the same deliberately generous way, and
+  // `verifySelfReferentialBootstrapWaiverRun` below still requires
+  // independent Actions-run verification regardless of what this
+  // prefilter selects.
+  const autoWaiverRunIdCandidates: { runId: string; createdAt: string }[] = [];
+  const seenAutoWaiverRunIds = new Set<string>();
+  const prHeadShaLower = prHeadSha.toLowerCase();
+  for (const comment of normalizedComments) {
+    const body = comment.body;
+    if (!/^<!--\s*idd-external-check-waiver:/i.test(body)) continue;
+    const authorLogin = comment.author.login.trim().toLowerCase();
+    if (authorLogin !== 'github-actions[bot]') continue;
+    const parsed = parseExternalCheckWaiverComment(body, comment.createdAt);
+    // kurone-kito/idd-skill#2911: mirrors `collectFromGitHub`'s own
+    // prefilter conditions verbatim -- a canonical positive-integer
+    // run-id (never percent-decoded/sanitized attacker text reaching
+    // `getWorkflowRun`'s REST path unvalidated), an EXACT (never glob)
+    // checkSelector match, and this PR's own current HEAD -- before a
+    // candidate is ever eligible to spend part of the bounded lookup
+    // budget.
+    if (
+      parsed &&
+      parsed.reason === SELF_REFERENTIAL_BOOTSTRAP_AUTO_REASON &&
+      parsed.checkSelector === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR &&
+      parsed.runId &&
+      parseCanonicalIntegerOrNull(parsed.runId) !== null &&
+      !seenAutoWaiverRunIds.has(parsed.runId) &&
+      String(parsed.headSha ?? '')
+        .trim()
+        .toLowerCase() === prHeadShaLower
+    ) {
+      seenAutoWaiverRunIds.add(parsed.runId);
+      autoWaiverRunIdCandidates.push({
+        runId: parsed.runId,
+        createdAt: comment.createdAt,
+      });
+    }
+  }
+  const boundedAutoWaiverRunIds = autoWaiverRunIdCandidates
+    .sort((left, right) => left.createdAt.localeCompare(right.createdAt))
+    .slice(0, MAX_PRE_MERGE_AUTO_WAIVER_RUN_LOOKUPS)
+    .map((candidate) => candidate.runId);
+  const autoWaiverRunVerified: Record<string, boolean> = {};
+  for (const runId of boundedAutoWaiverRunIds) {
+    try {
+      const raw = port.getWorkflowRun(owner, repo, runId) as {
+        path?: string | null;
+        head_sha?: string | null;
+        head_repository?: { full_name?: string | null } | null;
+        event?: string | null;
+      };
+      autoWaiverRunVerified[runId] = verifySelfReferentialBootstrapWaiverRun(
+        {
+          path: raw?.path ?? null,
+          headSha: raw?.head_sha ?? null,
+          repositoryFullName: raw?.head_repository?.full_name ?? null,
+          event: raw?.event ?? null,
+        },
+        {
+          path: ADVISORY_CONVERGENCE_WORKFLOW_PATH,
+          headSha: prHeadSha,
+          repositoryFullName,
+        },
+      );
+    } catch {
+      // Fail closed per run id -- untrusted: a lookup failure (unknown
+      // run, transient API error) must never widen trust, and must never
+      // crash this whole evidence collector either. This is the
+      // deliberate fail-open-for-staleness direction documented on
+      // `buildPreMergeReadinessSummary`'s `staleSelfWaiver` computation:
+      // an unverified run suppresses the blocker rather than firing it.
+      autoWaiverRunVerified[runId] = false;
+    }
+  }
+
   const summary = buildPreMergeReadinessSummary(
     {
       prHeadSha,
@@ -864,6 +1007,8 @@ export function collectPreMergeReadiness(
       viewerAppSlug,
       configuredTrustedActors,
       collaboratorTrustEnabled,
+      touchesSelfReferentialAllowlist,
+      autoWaiverRunVerified,
     },
   );
 

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -849,12 +849,27 @@ export function collectPreMergeReadiness(
 
   // Bounded scan for self-referential-bootstrap-auto candidate markers
   // bound to this PR's own HEAD, mirroring `collectFromGitHub`'s own
-  // anti-flood tie-break exactly (earliest-first, capped): no selection
-  // order fully closes the flood problem, but this bounds worst-case API
-  // cost the same deliberately generous way, and
+  // anti-flood budget (20, capped) but NOT its earliest-first tie-break:
+  // no selection order fully closes the flood problem, and
   // `verifySelfReferentialBootstrapWaiverRun` below still requires
   // independent Actions-run verification regardless of what this
-  // prefilter selects.
+  // prefilter selects, but the two call sites correlate against
+  // different moments in time, so the same tie-break direction is wrong
+  // for this one. `collectFromGitHub` evaluates the marker for the
+  // checker's OWN in-flight run (implicitly "now"); this call site
+  // instead correlates against `passingCompletedAtMs` -- the ALREADY-
+  // SELECTED newest required-check instance's own `completedAt`, itself
+  // already the most recent of however many reruns exist for this HEAD
+  // (kurone-kito/idd-skill#2911, Codex review on PR #2915, P1): on a
+  // checker-touching PR that sits on one HEAD long enough to accumulate
+  // more than this 20-candidate budget's worth of bootstrap-auto
+  // markers, an earliest-first cap would keep only the OLDEST
+  // candidates -- exactly the ones LEAST likely to correlate with the
+  // most-recent-required-check-instance's `completedAt` -- starving
+  // `autoWaiverRunVerified` of the one marker that actually needs
+  // checking and letting the report incorrectly stay `ready`. Newest-
+  // first keeps the candidates most likely to cover that recent
+  // instance instead.
   const autoWaiverRunIdCandidates: { runId: string; createdAt: string }[] = [];
   const seenAutoWaiverRunIds = new Set<string>();
   const prHeadShaLower = prHeadSha.toLowerCase();
@@ -890,7 +905,7 @@ export function collectPreMergeReadiness(
     }
   }
   const boundedAutoWaiverRunIds = autoWaiverRunIdCandidates
-    .sort((left, right) => left.createdAt.localeCompare(right.createdAt))
+    .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
     .slice(0, MAX_PRE_MERGE_AUTO_WAIVER_RUN_LOOKUPS)
     .map((candidate) => candidate.runId);
   const autoWaiverRunVerified: Record<string, boolean> = {};

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -870,74 +870,93 @@ export function collectPreMergeReadiness(
   // checking and letting the report incorrectly stay `ready`. Newest-
   // first keeps the candidates most likely to cover that recent
   // instance instead.
-  const autoWaiverRunIdCandidates: { runId: string; createdAt: string }[] = [];
-  const seenAutoWaiverRunIds = new Set<string>();
-  const prHeadShaLower = prHeadSha.toLowerCase();
-  for (const comment of normalizedComments) {
-    const body = comment.body;
-    if (!/^<!--\s*idd-external-check-waiver:/i.test(body)) continue;
-    const authorLogin = comment.author.login.trim().toLowerCase();
-    if (authorLogin !== 'github-actions[bot]') continue;
-    const parsed = parseExternalCheckWaiverComment(body, comment.createdAt);
-    // kurone-kito/idd-skill#2911: mirrors `collectFromGitHub`'s own
-    // prefilter conditions verbatim -- a canonical positive-integer
-    // run-id (never percent-decoded/sanitized attacker text reaching
-    // `getWorkflowRun`'s REST path unvalidated), an EXACT (never glob)
-    // checkSelector match, and this PR's own current HEAD -- before a
-    // candidate is ever eligible to spend part of the bounded lookup
-    // budget.
-    if (
-      parsed &&
-      parsed.reason === SELF_REFERENTIAL_BOOTSTRAP_AUTO_REASON &&
-      parsed.checkSelector === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR &&
-      parsed.runId &&
-      parseCanonicalIntegerOrNull(parsed.runId) !== null &&
-      !seenAutoWaiverRunIds.has(parsed.runId) &&
-      String(parsed.headSha ?? '')
-        .trim()
-        .toLowerCase() === prHeadShaLower
-    ) {
-      seenAutoWaiverRunIds.add(parsed.runId);
-      autoWaiverRunIdCandidates.push({
-        runId: parsed.runId,
-        createdAt: comment.createdAt,
-      });
-    }
-  }
-  const boundedAutoWaiverRunIds = autoWaiverRunIdCandidates
-    .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
-    .slice(0, MAX_PRE_MERGE_AUTO_WAIVER_RUN_LOOKUPS)
-    .map((candidate) => candidate.runId);
   const autoWaiverRunVerified: Record<string, boolean> = {};
-  for (const runId of boundedAutoWaiverRunIds) {
-    try {
-      const raw = port.getWorkflowRun(owner, repo, runId) as {
-        path?: string | null;
-        head_sha?: string | null;
-        head_repository?: { full_name?: string | null } | null;
-        event?: string | null;
-      };
-      autoWaiverRunVerified[runId] = verifySelfReferentialBootstrapWaiverRun(
-        {
-          path: raw?.path ?? null,
-          headSha: raw?.head_sha ?? null,
-          repositoryFullName: raw?.head_repository?.full_name ?? null,
-          event: raw?.event ?? null,
-        },
-        {
-          path: ADVISORY_CONVERGENCE_WORKFLOW_PATH,
-          headSha: prHeadSha,
-          repositoryFullName,
-        },
-      );
-    } catch {
-      // Fail closed per run id -- untrusted: a lookup failure (unknown
-      // run, transient API error) must never widen trust, and must never
-      // crash this whole evidence collector either. This is the
-      // deliberate fail-open-for-staleness direction documented on
-      // `buildPreMergeReadinessSummary`'s `staleSelfWaiver` computation:
-      // an unverified run suppresses the blocker rather than firing it.
-      autoWaiverRunVerified[runId] = false;
+  // kurone-kito/idd-skill#2911 (Copilot review, PR #2915): the scan below
+  // and its up-to-20 `getWorkflowRun` lookups are pure overhead whenever
+  // `touchesSelfReferentialAllowlist` is false -- `buildPreMergeReadinessSummary`
+  // never even reaches this evidence in that case (its own `staleSelfWaiver`
+  // computation is unconditionally gated on the identical flag). Skipping
+  // the whole block here means an ordinary PR (the overwhelming majority,
+  // which never touches the checker allowlist at all) can never have a
+  // flood of bot-authored comments force wasted provider round-trips no
+  // matter how many it posts. This does not also gate on the mode-open/
+  // selector-waivable preconditions `buildPreMergeReadinessSummary` checks
+  // (those live behind private matching helpers in `protocol-helpers.mts`
+  // this file deliberately avoids importing, to keep this file's footprint
+  // minimal where kurone-kito/idd-skill#2912 is concurrently working) --
+  // the residual is bounded and harmless: at most 20 avoidable
+  // `getWorkflowRun` calls, only on the narrower set of PRs that already,
+  // genuinely touch the allowlist.
+  if (touchesSelfReferentialAllowlist) {
+    const autoWaiverRunIdCandidates: { runId: string; createdAt: string }[] =
+      [];
+    const seenAutoWaiverRunIds = new Set<string>();
+    const prHeadShaLower = prHeadSha.toLowerCase();
+    for (const comment of normalizedComments) {
+      const body = comment.body;
+      if (!/^<!--\s*idd-external-check-waiver:/i.test(body)) continue;
+      const authorLogin = comment.author.login.trim().toLowerCase();
+      if (authorLogin !== 'github-actions[bot]') continue;
+      const parsed = parseExternalCheckWaiverComment(body, comment.createdAt);
+      // kurone-kito/idd-skill#2911: mirrors `collectFromGitHub`'s own
+      // prefilter conditions verbatim -- a canonical positive-integer
+      // run-id (never percent-decoded/sanitized attacker text reaching
+      // `getWorkflowRun`'s REST path unvalidated), an EXACT (never glob)
+      // checkSelector match, and this PR's own current HEAD -- before a
+      // candidate is ever eligible to spend part of the bounded lookup
+      // budget.
+      if (
+        parsed &&
+        parsed.reason === SELF_REFERENTIAL_BOOTSTRAP_AUTO_REASON &&
+        parsed.checkSelector === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR &&
+        parsed.runId &&
+        parseCanonicalIntegerOrNull(parsed.runId) !== null &&
+        !seenAutoWaiverRunIds.has(parsed.runId) &&
+        String(parsed.headSha ?? '')
+          .trim()
+          .toLowerCase() === prHeadShaLower
+      ) {
+        seenAutoWaiverRunIds.add(parsed.runId);
+        autoWaiverRunIdCandidates.push({
+          runId: parsed.runId,
+          createdAt: comment.createdAt,
+        });
+      }
+    }
+    const boundedAutoWaiverRunIds = autoWaiverRunIdCandidates
+      .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
+      .slice(0, MAX_PRE_MERGE_AUTO_WAIVER_RUN_LOOKUPS)
+      .map((candidate) => candidate.runId);
+    for (const runId of boundedAutoWaiverRunIds) {
+      try {
+        const raw = port.getWorkflowRun(owner, repo, runId) as {
+          path?: string | null;
+          head_sha?: string | null;
+          head_repository?: { full_name?: string | null } | null;
+          event?: string | null;
+        };
+        autoWaiverRunVerified[runId] = verifySelfReferentialBootstrapWaiverRun(
+          {
+            path: raw?.path ?? null,
+            headSha: raw?.head_sha ?? null,
+            repositoryFullName: raw?.head_repository?.full_name ?? null,
+            event: raw?.event ?? null,
+          },
+          {
+            path: ADVISORY_CONVERGENCE_WORKFLOW_PATH,
+            headSha: prHeadSha,
+            repositoryFullName,
+          },
+        );
+      } catch {
+        // Fail closed per run id -- untrusted: a lookup failure (unknown
+        // run, transient API error) must never widen trust, and must
+        // never crash this whole evidence collector either. This is the
+        // deliberate fail-open-for-staleness direction documented on
+        // `buildPreMergeReadinessSummary`'s `staleSelfWaiver` computation:
+        // an unverified run suppresses the blocker rather than firing it.
+        autoWaiverRunVerified[runId] = false;
+      }
     }
   }
 

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -839,13 +839,49 @@ export function collectPreMergeReadiness(
     helperRuntimeProfile,
     repositoryFullName,
   );
-  const selfReferentialRenamedFromPaths = port
-    .listChangeRequestRenamedFromPaths(args.prNumber)
-    .filter(Boolean);
-  const touchesSelfReferentialAllowlist = [
-    ...changedFiles,
-    ...selfReferentialRenamedFromPaths,
-  ].some((path) => selfReferentialTriggerFiles.includes(String(path)));
+  const changedFilesTouchSelfReferentialAllowlist = changedFiles.some((path) =>
+    selfReferentialTriggerFiles.includes(String(path)),
+  );
+  // kurone-kito/idd-skill#2911 (Codex + CodeRabbit review, PR #2915): the
+  // renamed-from-paths lookup is a separate paginated `pulls/.../files`
+  // request that duplicates the `changedFiles` fetch above, and its
+  // result can only ever matter for a PR that (a) doesn't already prove
+  // the allowlist touch via `changedFiles` alone AND (b) carries at
+  // least one self-referential-bootstrap-auto marker candidate -- if
+  // neither the ordinary case (no marker at all) nor this case applies,
+  // `touchesSelfReferentialAllowlist`'s value can never affect the
+  // report either way, so skip the extra round-trip entirely. Cheap: the
+  // candidate scan below only re-uses `normalizedComments`, already
+  // fetched, no extra call. Wrapped in try/catch -- unlike every OTHER
+  // unguarded port call earlier in this collector, this one specifically
+  // sits behind an opt-in security gate that most PRs never need at all,
+  // so a transient failure here must not abort report generation for
+  // PRs the gate was never going to affect; fails to `[]` (never widens
+  // trust, matches `getWorkflowRun`'s own fail-closed-to-untrusted
+  // direction below).
+  const hasAnySelfReferentialMarkerCandidate = normalizedComments.some(
+    (comment) =>
+      /^<!--\s*idd-external-check-waiver:/i.test(comment.body) &&
+      comment.author.login.trim().toLowerCase() === 'github-actions[bot]',
+  );
+  let selfReferentialRenamedFromPaths: string[] = [];
+  if (
+    !changedFilesTouchSelfReferentialAllowlist &&
+    hasAnySelfReferentialMarkerCandidate
+  ) {
+    try {
+      selfReferentialRenamedFromPaths = port
+        .listChangeRequestRenamedFromPaths(args.prNumber)
+        .filter(Boolean);
+    } catch {
+      selfReferentialRenamedFromPaths = [];
+    }
+  }
+  const touchesSelfReferentialAllowlist =
+    changedFilesTouchSelfReferentialAllowlist ||
+    selfReferentialRenamedFromPaths.some((path) =>
+      selfReferentialTriggerFiles.includes(String(path)),
+    );
 
   // Bounded scan for self-referential-bootstrap-auto candidate markers
   // bound to this PR's own HEAD, mirroring `collectFromGitHub`'s own

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -8735,12 +8735,32 @@ export function buildPreMergeReadinessSummary(
     // absent `type` (the pre-#1483 data shape, including this fixture's
     // own base checker instance) still passes through unaffected, same
     // as `groupChecksByProducer`'s own no-conflicting-signal fallback.
+    // kurone-kito/idd-skill#2911 (Codex review, PR #2915, P1, fresh
+    // evidence against the type-only filter immediately above): a check
+    // is `type: 'check-run'` for ANY Actions workflow, not only the real
+    // checker -- a second, unrelated workflow file that happens to
+    // publish a check-run under the identical `idd-advisory-convergence`
+    // name would still pass the type filter alone. Declared independently
+    // here (mirroring `MAX_PRE_MERGE_AUTO_WAIVER_RUN_LOOKUPS`'s own
+    // rationale above) rather than importing a shared constant from
+    // `advisory-convergence.mts`, to avoid a rebase collision with
+    // #2912's concurrent work there; a dedicated test pins this literal
+    // against the workflow file's own `name:` field so the two can never
+    // silently drift apart. `workflowName` absent (`''`, the pre-#1483
+    // data shape most fixtures in this suite still use) still passes
+    // through unaffected, same as the type filter's own fallback --
+    // narrowing further only excludes a POSITIVELY different workflow
+    // identity, never an unlabeled one.
+    const ADVISORY_CONVERGENCE_WORKFLOW_DISPLAY_NAME =
+      'IDD advisory-convergence gate';
     const selfConvergenceProducerCandidates = selectLatestCheckPerName(
       selfConvergenceRawInstances,
     ).filter(
       (check) =>
         CHECK_PASS_EQUIVALENT_STATES.has(check.state) &&
-        (!check.type || check.type === 'check-run'),
+        (!check.type || check.type === 'check-run') &&
+        (!check.workflowName ||
+          check.workflowName === ADVISORY_CONVERGENCE_WORKFLOW_DISPLAY_NAME),
     );
     for (const latestSelfConvergenceCheck of selfConvergenceProducerCandidates) {
       const autoWaiverRunVerified = options.autoWaiverRunVerified ?? {};

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -393,6 +393,16 @@ export interface ExternalCheckWaiverEvidence {
      * `expired[].createdAt`'s doc comment above -- the identical
      * lower-bound need applies to a `wrongClaim`-classified marker. */
     createdAt: string;
+    /** kurone-kito/idd-skill#2911 (Codex review, PR #2915, P2): the
+     * marker's `expiresAt` field, verbatim -- `wrongClaim` classification
+     * happens BEFORE the expiry check in this function's own pipeline
+     * (see that check's own comment below), so a marker can be BOTH
+     * wrong-claim AND already-expired yet only ever reach the
+     * `wrongClaim` bucket, never `expired`. Without this field, a
+     * stale-self-waiver consumer has no way to exclude a wrong-claim
+     * marker that expired before the check it's being checked against
+     * ever completed -- see that consumer's own upper-bound check. */
+    expiresAt: string;
   }[];
   unauthorized: {
     authorLogin: string;
@@ -920,6 +930,7 @@ export function summarizeExternalCheckWaivers(
         reason: parsed.reason,
         runId: parsed.runId,
         createdAt: parsed.createdAt,
+        expiresAt: parsed.expiresAt,
       });
       continue;
     }
@@ -8862,6 +8873,19 @@ export function buildPreMergeReadinessSummary(
       // could not have justified that pass either, regardless of the
       // claim-installation comparison below. Same stale-leaning
       // treatment of an unparseable `createdAt`.
+      //
+      // kurone-kito/idd-skill#2911 (Codex review, PR #2915, P2): ALSO
+      // requires the upper bound (`expiresAt >= passingCompletedAtMs`),
+      // mirroring `staleExpiredEntry`'s own two-sided window check --
+      // without it, a marker that had ALREADY expired before the check
+      // even completed (a real scenario here specifically: this
+      // function's own `wrongClaim` classification runs BEFORE the
+      // expiry check, so a marker can be both wrong-claim AND
+      // already-expired yet only ever reach this bucket, never
+      // `expired`) gets treated as if it could have justified a LATER,
+      // genuinely unrelated pass, purely because the claim identity also
+      // happened to change again even later -- an unnecessary blocker
+      // with no real evidence behind it.
       const staleWrongClaimEntry =
         staleExpiredEntry || hasCoveringValidMarker
           ? undefined
@@ -8869,9 +8893,16 @@ export function buildPreMergeReadinessSummary(
               if (!isRunVerifiedSelfWaiverMarker(entry)) return false;
               if (passingCompletedAtMs === null) return true;
               const entryCreatedAtMs = Date.parse(entry.createdAt);
+              const entryExpiresAtMs = Date.parse(entry.expiresAt);
               if (
                 !Number.isNaN(entryCreatedAtMs) &&
                 entryCreatedAtMs > passingCompletedAtMs
+              ) {
+                return false;
+              }
+              if (
+                !Number.isNaN(entryExpiresAtMs) &&
+                entryExpiresAtMs < passingCompletedAtMs
               ) {
                 return false;
               }

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -362,6 +362,16 @@ export interface ExternalCheckWaiverEvidence {
      * still run the same run-bound trust verification on an EXPIRED
      * marker. */
     runId: string;
+    /** kurone-kito/idd-skill#2911 (Copilot review, PR #2915): the marker
+     * comment's own `createdAt` (server timestamp, never the marker's
+     * `created-at:` body field, mirroring how `parsed.createdAt` is
+     * already sourced elsewhere in this function) -- a stale-self-waiver
+     * consumer needs this as the LOWER bound of the marker's validity
+     * window (paired with `expiresAt` as the upper bound): a marker
+     * created AFTER a required check already completed could not
+     * possibly have justified that earlier pass, no matter how far in
+     * the future its `expiresAt` reaches. */
+    createdAt: string;
   }[];
   wrongHead: {
     authorLogin: string;
@@ -379,6 +389,10 @@ export interface ExternalCheckWaiverEvidence {
     /** kurone-kito/idd-skill#2911: see `expired[].runId`'s doc comment
      * above. */
     runId: string;
+    /** kurone-kito/idd-skill#2911 (Copilot review, PR #2915): see
+     * `expired[].createdAt`'s doc comment above -- the identical
+     * lower-bound need applies to a `wrongClaim`-classified marker. */
+    createdAt: string;
   }[];
   unauthorized: {
     authorLogin: string;
@@ -905,6 +919,7 @@ export function summarizeExternalCheckWaivers(
         waiverClaimId: parsed.claimId,
         reason: parsed.reason,
         runId: parsed.runId,
+        createdAt: parsed.createdAt,
       });
       continue;
     }
@@ -917,6 +932,7 @@ export function summarizeExternalCheckWaivers(
         expiresAt: parsed.expiresAt,
         reason: parsed.reason,
         runId: parsed.runId,
+        createdAt: parsed.createdAt,
       });
       continue;
     }
@@ -938,6 +954,7 @@ export function summarizeExternalCheckWaivers(
           expiresAt: parsed.expiresAt,
           reason: parsed.reason,
           runId: parsed.runId,
+          createdAt: parsed.createdAt,
         });
         continue;
       }
@@ -8705,12 +8722,24 @@ export function buildPreMergeReadinessSummary(
     ).filter((check) => CHECK_PASS_EQUIVALENT_STATES.has(check.state));
     for (const latestSelfConvergenceCheck of selfConvergenceProducerCandidates) {
       const autoWaiverRunVerified = options.autoWaiverRunVerified ?? {};
+      // kurone-kito/idd-skill#2911 (CodeRabbit + Copilot review, PR #2915,
+      // Major): `autoWaiverRunVerified` is keyed by `runId` alone. Without
+      // also requiring `checkSelector === staleSelfWaiverCheckSelector`
+      // here, a DIFFERENT-selector marker (this function's own
+      // `autoWaiverEvidence` is never filtered to one selector -- see its
+      // own call site above) that happens to reuse an already-verified
+      // `idd-advisory-convergence` run-id would be accepted as if it were
+      // evidence about THIS check, letting an unrelated check's waiver
+      // wrongly set `staleSelfWaiver` (`hasCoveringValidMarker` is already
+      // selector-scoped and cannot compensate for this gap on its own).
       const isRunVerifiedSelfWaiverMarker = (entry: {
         authorLogin: string;
+        checkSelector: string;
         reason: string;
         runId: string;
       }) =>
         entry.authorLogin === 'github-actions[bot]' &&
+        entry.checkSelector === staleSelfWaiverCheckSelector &&
         entry.reason === SELF_REFERENTIAL_BOOTSTRAP_AUTO_REASON &&
         entry.runId !== '' &&
         autoWaiverRunVerified[entry.runId] === true;
@@ -8760,23 +8789,50 @@ export function buildPreMergeReadinessSummary(
             passingCompletedAtMs <= expiresAtMs
           );
         });
+      // kurone-kito/idd-skill#2911 (Copilot review, PR #2915): checking
+      // only `expiresAt >= passingCompletedAtMs` (the upper bound) is not
+      // enough on its own -- a marker CREATED after the check already
+      // completed could not possibly have justified that earlier pass no
+      // matter how far its `expiresAt` reaches, so the LOWER bound
+      // (`createdAt <= passingCompletedAtMs`) must also hold before an
+      // entry counts as having plausibly covered the pass. An unparseable
+      // boundary on either side still counts (stale-leaning, matching this
+      // blocker's established fail-toward-flagging asymmetry) -- only a
+      // POSITIVE, parseable `createdAt` strictly after the pass excludes
+      // an entry.
       const staleExpiredEntry = hasCoveringValidMarker
         ? undefined
         : autoWaiverEvidence.expired.find((entry) => {
             if (!isRunVerifiedSelfWaiverMarker(entry)) return false;
             if (passingCompletedAtMs === null) return true;
             const entryExpiresAtMs = Date.parse(entry.expiresAt);
+            const entryCreatedAtMs = Date.parse(entry.createdAt);
             return (
-              Number.isNaN(entryExpiresAtMs) ||
-              entryExpiresAtMs >= passingCompletedAtMs
+              (Number.isNaN(entryExpiresAtMs) ||
+                entryExpiresAtMs >= passingCompletedAtMs) &&
+              (Number.isNaN(entryCreatedAtMs) ||
+                entryCreatedAtMs <= passingCompletedAtMs)
             );
           });
+      // kurone-kito/idd-skill#2911 (Copilot review, PR #2915): the
+      // identical lower-bound reasoning as `staleExpiredEntry` above --
+      // a `wrongClaim` marker created AFTER the check already completed
+      // could not have justified that pass either, regardless of the
+      // claim-installation comparison below. Same stale-leaning
+      // treatment of an unparseable `createdAt`.
       const staleWrongClaimEntry =
         staleExpiredEntry || hasCoveringValidMarker
           ? undefined
           : autoWaiverEvidence.wrongClaim.find((entry) => {
               if (!isRunVerifiedSelfWaiverMarker(entry)) return false;
               if (passingCompletedAtMs === null) return true;
+              const entryCreatedAtMs = Date.parse(entry.createdAt);
+              if (
+                !Number.isNaN(entryCreatedAtMs) &&
+                entryCreatedAtMs > passingCompletedAtMs
+              ) {
+                return false;
+              }
               if (!claimIdentityInstalledAt) return true;
               const installedAtMs = Date.parse(claimIdentityInstalledAt);
               return (

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -8717,9 +8717,31 @@ export function buildPreMergeReadinessSummary(
         workflowName: check.workflowName ?? null,
       }))
       .filter((check) => ci.requiredCheckNames.includes(check.name));
+    // kurone-kito/idd-skill#2911 (Codex review, PR #2915, P1, fresh
+    // evidence against THIS revision's own new per-producer loop): the
+    // producer grouping above intentionally keeps every distinct
+    // producer separate, but a non-Actions producer sharing this name
+    // (e.g. a legacy status context) can never legitimately be covered
+    // by a self-referential-bootstrap-auto marker in the first place --
+    // that marker only ever cites a workflow RUN
+    // (`verifySelfReferentialBootstrapWaiverRun` checks `path`/`event`
+    // against an Actions run), which a status-context producer has none
+    // of. Worse, such a producer typically has no parseable
+    // `completedAt`, which would otherwise hit this loop's stale-leaning
+    // `passingCompletedAtMs === null` branch below and flag a false
+    // positive even while the REAL convergence workflow's own instance
+    // is genuinely fresh. Exclude any producer whose `type` is populated
+    // and is not `'check-run'` before it ever becomes a candidate -- an
+    // absent `type` (the pre-#1483 data shape, including this fixture's
+    // own base checker instance) still passes through unaffected, same
+    // as `groupChecksByProducer`'s own no-conflicting-signal fallback.
     const selfConvergenceProducerCandidates = selectLatestCheckPerName(
       selfConvergenceRawInstances,
-    ).filter((check) => CHECK_PASS_EQUIVALENT_STATES.has(check.state));
+    ).filter(
+      (check) =>
+        CHECK_PASS_EQUIVALENT_STATES.has(check.state) &&
+        (!check.type || check.type === 'check-run'),
+    );
     for (const latestSelfConvergenceCheck of selfConvergenceProducerCandidates) {
       const autoWaiverRunVerified = options.autoWaiverRunVerified ?? {};
       // kurone-kito/idd-skill#2911 (CodeRabbit + Copilot review, PR #2915,

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -8724,6 +8724,11 @@ export function buildPreMergeReadinessSummary(
         name: String(check.name ?? ''),
         state: String(check.state ?? ''),
         completedAt: check.completedAt ?? null,
+        // kurone-kito/idd-skill#2911 (Codex review, PR #2915, P1): also
+        // carried through for the wrongClaim claim-installation
+        // comparison below, which anchors on this instead of
+        // `completedAt` -- see that comparison's own doc comment.
+        startedAt: check.startedAt ?? null,
         type: check.type ?? null,
         workflowName: check.workflowName ?? null,
       }))
@@ -8804,6 +8809,21 @@ export function buildPreMergeReadinessSummary(
       const passingCompletedAtMs = parseCompletedAt(
         latestSelfConvergenceCheck.completedAt,
       );
+      // kurone-kito/idd-skill#2911 (Codex review, PR #2915, P1): a
+      // long-running check job observes state (fetches comments/waiver
+      // evidence) starting near its OWN `startedAt`, not its later
+      // `completedAt` -- a claim handoff that lands strictly between
+      // those two moments means the run still evaluated the OLD claim's
+      // waiver even though its `completedAt` now reads after the
+      // handoff. Used only by the wrongClaim claim-installation
+      // comparison below (never the createdAt/expiresAt window checks,
+      // which are about the marker's own lifecycle relative to when the
+      // check's result was finalized, a different question). Falls back
+      // to `passingCompletedAtMs` when `startedAt` is missing/unparseable
+      // (legacy data shape) rather than weakening the comparison.
+      const passingStartedAtMs =
+        parseCompletedAt(latestSelfConvergenceCheck.startedAt) ??
+        passingCompletedAtMs;
       // kurone-kito/idd-skill#2911 (acceptance criterion 2, self-critique
       // against round 13's own commit message -- `git show 863c5249`
       // promised "correlation to the passing check's own completedAt OR
@@ -8908,9 +8928,17 @@ export function buildPreMergeReadinessSummary(
               }
               if (!claimIdentityInstalledAt) return true;
               const installedAtMs = Date.parse(claimIdentityInstalledAt);
+              // kurone-kito/idd-skill#2911 (Codex review, PR #2915, P1):
+              // anchors on `passingStartedAtMs`, not `passingCompletedAtMs`
+              // -- see that variable's own doc comment. A claim handoff
+              // landing strictly between the run's start and its
+              // completion still means the run's own evidence-fetch
+              // observed the OLD claim, so this must flag stale even
+              // though the check's `completedAt` now reads after the
+              // handoff.
               return (
                 Number.isNaN(installedAtMs) ||
-                passingCompletedAtMs < installedAtMs
+                (passingStartedAtMs ?? passingCompletedAtMs) < installedAtMs
               );
             });
       if (staleExpiredEntry) {

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -8841,6 +8841,32 @@ export function buildPreMergeReadinessSummary(
       // it only ever prevents THIS blocker from mis-firing on a pass that
       // a fresh marker already, genuinely covers; it can never clear a
       // blocker any OTHER evidence in this file raised.
+      //
+      // kurone-kito/idd-skill#2911 (design model, stated once here so a
+      // future review pass reads it instead of re-deriving it): the
+      // underlying question for ALL THREE finders below is interval
+      // overlap -- could this marker's own validity window,
+      // `[createdAt, expiresAt]`, have overlapped the run's observation
+      // window, `[startedAt, completedAt]`? That is
+      // `createdAt <= completedAt && expiresAt >= startedAt`. The LOWER
+      // bound stays anchored on `completedAt` (not `startedAt`)
+      // deliberately: the marker is posted BY the run itself, so its
+      // `createdAt` falls somewhere mid-run, between the run's own
+      // `startedAt` and `completedAt` -- anchoring the lower bound on
+      // `startedAt` instead would make a run's own marker unable to
+      // cover its own pass, breaking acceptance criterion 2 outright.
+      // The UPPER bound anchors on `startedAt` (via `passingStartedAtMs`,
+      // falling back to `passingCompletedAtMs` when unparseable): the run
+      // reads waiver evidence near its own start, so a marker that was
+      // still valid then, but expires before the run's slower
+      // `completedAt`, must not be misread as "expired before this pass"
+      // (Codex review, PR #2915, round 7, P2) -- the accepted residual is
+      // that a marker which expired early in the run, strictly before the
+      // run's own evidence-fetch instant (which this code cannot observe
+      // directly), still gets flagged and costs one avoidable rerun,
+      // never a false "not stale": the alternative of anchoring on
+      // `completedAt` instead risks the false negative Codex identified,
+      // which is the worse failure for a security-relevant blocker.
       const hasCoveringValidMarker =
         passingCompletedAtMs !== null &&
         autoWaiverEvidence.valid.some((entry) => {
@@ -8863,16 +8889,25 @@ export function buildPreMergeReadinessSummary(
           );
         });
       // kurone-kito/idd-skill#2911 (Copilot review, PR #2915): checking
-      // only `expiresAt >= passingCompletedAtMs` (the upper bound) is not
-      // enough on its own -- a marker CREATED after the check already
-      // completed could not possibly have justified that earlier pass no
-      // matter how far its `expiresAt` reaches, so the LOWER bound
+      // only `expiresAt >= ...` (the upper bound) is not enough on its
+      // own -- a marker CREATED after the check already completed could
+      // not possibly have justified that earlier pass no matter how far
+      // its `expiresAt` reaches, so the LOWER bound
       // (`createdAt <= passingCompletedAtMs`) must also hold before an
       // entry counts as having plausibly covered the pass. An unparseable
       // boundary on either side still counts (stale-leaning, matching this
       // blocker's established fail-toward-flagging asymmetry) -- only a
       // POSITIVE, parseable `createdAt` strictly after the pass excludes
       // an entry.
+      //
+      // kurone-kito/idd-skill#2911 (Codex review, PR #2915, round 7, P2):
+      // the UPPER bound anchors on `passingStartedAtMs` (falling back to
+      // `passingCompletedAtMs`), not `passingCompletedAtMs` directly --
+      // see the interval-overlap model documented above
+      // `hasCoveringValidMarker`. A marker that was still valid when the
+      // run observed it near its own start, but expires before the run's
+      // slower `completedAt`, must not be misread as having expired
+      // before the pass it actually covered.
       const staleExpiredEntry = hasCoveringValidMarker
         ? undefined
         : autoWaiverEvidence.expired.find((entry) => {
@@ -8880,9 +8915,11 @@ export function buildPreMergeReadinessSummary(
             if (passingCompletedAtMs === null) return true;
             const entryExpiresAtMs = Date.parse(entry.expiresAt);
             const entryCreatedAtMs = Date.parse(entry.createdAt);
+            const runObservationBoundMs =
+              passingStartedAtMs ?? passingCompletedAtMs;
             return (
               (Number.isNaN(entryExpiresAtMs) ||
-                entryExpiresAtMs >= passingCompletedAtMs) &&
+                entryExpiresAtMs >= runObservationBoundMs) &&
               (Number.isNaN(entryCreatedAtMs) ||
                 entryCreatedAtMs <= passingCompletedAtMs)
             );
@@ -8895,17 +8932,23 @@ export function buildPreMergeReadinessSummary(
       // treatment of an unparseable `createdAt`.
       //
       // kurone-kito/idd-skill#2911 (Codex review, PR #2915, P2): ALSO
-      // requires the upper bound (`expiresAt >= passingCompletedAtMs`),
-      // mirroring `staleExpiredEntry`'s own two-sided window check --
-      // without it, a marker that had ALREADY expired before the check
-      // even completed (a real scenario here specifically: this
-      // function's own `wrongClaim` classification runs BEFORE the
-      // expiry check, so a marker can be both wrong-claim AND
-      // already-expired yet only ever reach this bucket, never
-      // `expired`) gets treated as if it could have justified a LATER,
-      // genuinely unrelated pass, purely because the claim identity also
-      // happened to change again even later -- an unnecessary blocker
-      // with no real evidence behind it.
+      // requires the upper bound, mirroring `staleExpiredEntry`'s own
+      // two-sided window check -- without it, a marker that had ALREADY
+      // expired before the check even completed (a real scenario here
+      // specifically: this function's own `wrongClaim` classification
+      // runs BEFORE the expiry check, so a marker can be both
+      // wrong-claim AND already-expired yet only ever reach this bucket,
+      // never `expired`) gets treated as if it could have justified a
+      // LATER, genuinely unrelated pass, purely because the claim
+      // identity also happened to change again even later -- an
+      // unnecessary blocker with no real evidence behind it.
+      //
+      // kurone-kito/idd-skill#2911 (Codex review, PR #2915, round 7, P2):
+      // the upper-bound comparison anchors on `passingStartedAtMs`
+      // (falling back to `passingCompletedAtMs`), the same
+      // run-observation-bound reasoning as `staleExpiredEntry` above --
+      // see the interval-overlap model documented above
+      // `hasCoveringValidMarker`.
       const staleWrongClaimEntry =
         staleExpiredEntry || hasCoveringValidMarker
           ? undefined
@@ -8914,6 +8957,8 @@ export function buildPreMergeReadinessSummary(
               if (passingCompletedAtMs === null) return true;
               const entryCreatedAtMs = Date.parse(entry.createdAt);
               const entryExpiresAtMs = Date.parse(entry.expiresAt);
+              const runObservationBoundMs =
+                passingStartedAtMs ?? passingCompletedAtMs;
               if (
                 !Number.isNaN(entryCreatedAtMs) &&
                 entryCreatedAtMs > passingCompletedAtMs
@@ -8922,7 +8967,7 @@ export function buildPreMergeReadinessSummary(
               }
               if (
                 !Number.isNaN(entryExpiresAtMs) &&
-                entryExpiresAtMs < passingCompletedAtMs
+                entryExpiresAtMs < runObservationBoundMs
               ) {
                 return false;
               }
@@ -8936,9 +8981,19 @@ export function buildPreMergeReadinessSummary(
               // observed the OLD claim, so this must flag stale even
               // though the check's `completedAt` now reads after the
               // handoff.
+              //
+              // kurone-kito/idd-skill#2911 (Codex review, PR #2915,
+              // round 7, P1): uses `<=`, not `<` -- when the run's own
+              // observation bound and the claim-installation instant
+              // serialize to the EXACT same timestamp, there is no
+              // positive evidence the run's evidence-fetch actually
+              // happened after the handoff (a run can begin and read the
+              // old claim immediately before a handoff inside the same
+              // timestamp interval), so a tie must be treated as stale,
+              // not fresh.
               return (
                 Number.isNaN(installedAtMs) ||
-                (passingStartedAtMs ?? passingCompletedAtMs) < installedAtMs
+                runObservationBoundMs <= installedAtMs
               );
             });
       if (staleExpiredEntry) {

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -8668,19 +8668,42 @@ export function buildPreMergeReadinessSummary(
     staleSelfWaiverModeOpen &&
     staleSelfWaiverSelectorWaivable
   ) {
-    const selfConvergenceCheckInstances = ci.checks.filter(
-      (check) =>
-        check.required === true &&
+    // kurone-kito/idd-skill#2911 (Codex review on PR #2915, P1): the
+    // pre-fix version filtered `ci.checks` -- already reduced by
+    // `summarizeRequiredChecks` and stripped of its `type`/`workflowName`
+    // producer-identity fields -- and picked a single "latest" instance
+    // with `selectLatestCheckInstance` directly over that flattened list.
+    // When two distinct PRODUCERS (e.g. an Actions check-run and a legacy
+    // status context) share the `idd-advisory-convergence` name, that
+    // flattening could let a later, genuinely-passing instance from an
+    // UNRELATED producer mask an earlier instance from the checker's own
+    // producer that is still resting on a stale waiver, since only the
+    // single most-recent-across-all-producers instance was ever
+    // inspected. Group by producer instead, over the RAW `checks`
+    // parameter (which still carries `type`/`workflowName`, unlike
+    // `ci.checks`), using `selectLatestCheckPerName` -- the identical
+    // producer-identity grouping `classifyCiChecks`/
+    // `findDiscardedNonPassingSiblings` already establish for the same
+    // reason (#1483) -- then evaluate EACH producer's own latest instance
+    // independently below (loop, `break` on the first stale match), so a
+    // fresh pass from one producer can never hide a stale pass from
+    // another.
+    const selfConvergenceRawInstances = checks
+      .filter((check) =>
         matchCheckSelectorLocal(check.name, staleSelfWaiverCheckSelector),
-    );
-    const latestSelfConvergenceCheck =
-      selfConvergenceCheckInstances.length > 0
-        ? selectLatestCheckInstance(selfConvergenceCheckInstances)
-        : null;
-    if (
-      latestSelfConvergenceCheck &&
-      CHECK_PASS_EQUIVALENT_STATES.has(latestSelfConvergenceCheck.state)
-    ) {
+      )
+      .map((check) => ({
+        name: String(check.name ?? ''),
+        state: String(check.state ?? ''),
+        completedAt: check.completedAt ?? null,
+        type: check.type ?? null,
+        workflowName: check.workflowName ?? null,
+      }))
+      .filter((check) => ci.requiredCheckNames.includes(check.name));
+    const selfConvergenceProducerCandidates = selectLatestCheckPerName(
+      selfConvergenceRawInstances,
+    ).filter((check) => CHECK_PASS_EQUIVALENT_STATES.has(check.state));
+    for (const latestSelfConvergenceCheck of selfConvergenceProducerCandidates) {
       const autoWaiverRunVerified = options.autoWaiverRunVerified ?? {};
       const isRunVerifiedSelfWaiverMarker = (entry: {
         authorLogin: string;
@@ -8769,6 +8792,7 @@ export function buildPreMergeReadinessSummary(
           expiresAt: staleExpiredEntry.expiresAt,
           waiverClaimId: '',
         };
+        break;
       } else if (staleWrongClaimEntry) {
         staleSelfWaiver = {
           stale: true,
@@ -8777,6 +8801,7 @@ export function buildPreMergeReadinessSummary(
           expiresAt: '',
           waiverClaimId: staleWrongClaimEntry.waiverClaimId,
         };
+        break;
       }
     }
   }

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -345,7 +345,24 @@ export interface ExternalCheckWaiverEvidence {
      * of this function is unaffected by its presence. */
     runId: string;
   }[];
-  expired: { authorLogin: string; checkSelector: string; expiresAt: string }[];
+  expired: {
+    authorLogin: string;
+    checkSelector: string;
+    expiresAt: string;
+    /** kurone-kito/idd-skill#2911: the marker's `reason:` field,
+     * verbatim -- needed to identify a `self-referential-bootstrap-auto`
+     * marker even after it has expired (the `valid` bucket's own `reason`
+     * field, added for #2657, is unreachable once a marker expires out of
+     * that bucket). Every other caller of this function is unaffected by
+     * its presence. */
+    reason: string;
+    /** kurone-kito/idd-skill#2911: the marker's optional `run-id:` field,
+     * verbatim (`''` when absent) -- mirrors the `valid` bucket's own
+     * `runId` field (#2657), needed so a stale-self-waiver consumer can
+     * still run the same run-bound trust verification on an EXPIRED
+     * marker. */
+    runId: string;
+  }[];
   wrongHead: {
     authorLogin: string;
     checkSelector: string;
@@ -355,6 +372,13 @@ export interface ExternalCheckWaiverEvidence {
     authorLogin: string;
     checkSelector: string;
     waiverClaimId: string;
+    /** kurone-kito/idd-skill#2911: see `expired[].reason`'s doc comment
+     * above -- the identical need applies to a `wrongClaim`-classified
+     * marker, which likewise never reaches the `valid` bucket. */
+    reason: string;
+    /** kurone-kito/idd-skill#2911: see `expired[].runId`'s doc comment
+     * above. */
+    runId: string;
   }[];
   unauthorized: {
     authorLogin: string;
@@ -727,9 +751,10 @@ export function summarizeExternalCheckWaivers(
     // never merely `unauthorized`/`wrongHead`/etc., since the reason
     // itself disqualifies it regardless of any other field.
     //
-    // Exactly two call sites may set this `true` -- every other caller
-    // (this function's own ordinary-waiver callers, and
-    // `pre-merge-readiness.mts`) must leave it unset:
+    // Exactly three call sites may set this `true` -- every other caller
+    // (this function's own ordinary-waiver callers, including
+    // `buildPreMergeReadinessSummary`'s own PRIMARY `waiverEvidence` call
+    // below) must leave it unset:
     // 1. `advisory-convergence.mts`'s dedicated, isolated auto-waiver
     //    evidence call, whose `valid` classification directly feeds
     //    `autoWaiverValid` -- a GATE decision -- so it is paired with the
@@ -747,6 +772,27 @@ export function summarizeExternalCheckWaivers(
     //    decision that skips posting), so leaving it unset there costs
     //    nothing and keeps the exception as narrow as the decision it
     //    actually affects requires.
+    // 3. `buildPreMergeReadinessSummary`'s (this file's) own DEDICATED
+    //    `autoWaiverEvidence` call (kurone-kito/idd-skill#2911, replacing
+    //    the reverted kurone-kito/idd-skill#2657-era attempt at
+    //    commit 9ecc9954, which this issue's own findings list retired
+    //    across three further review rounds): read-only, feeding only a
+    //    stale-self-waiver merge BLOCKER -- it can add a blocker
+    //    `computePreMergeReadinessBlockers` would not otherwise report,
+    //    never satisfy one or make `ready` true, the opposite direction
+    //    from the gate-bypass risk this option otherwise guards against.
+    //    Trusts a marker as blocker evidence only after the SAME
+    //    run-id/event-type/HEAD/repository verification site 1 performs
+    //    (`verifySelfReferentialBootstrapWaiverRun`, reused verbatim from
+    //    `advisory-convergence.mts`) AND an independently-fetched
+    //    `touchesSelfReferentialAllowlist` precondition -- both computed
+    //    by the collector (`pre-merge-readiness.mts`) and threaded in as
+    //    `options.autoWaiverRunVerified`/`options.touchesSelfReferential-
+    //    Allowlist`, since a bearer-evidence-only citation of a real,
+    //    unrelated run (kurone-kito/idd-skill#2912's own residual gap)
+    //    would otherwise let a forged marker block an unrelated PR's
+    //    merge (the decisive Copilot finding that retired the original
+    //    attempt).
     allowSelfReferentialBootstrapAuto?: boolean;
   } = {},
 ): ExternalCheckWaiverEvidence {
@@ -857,6 +903,8 @@ export function summarizeExternalCheckWaivers(
         authorLogin,
         checkSelector: parsed.checkSelector,
         waiverClaimId: parsed.claimId,
+        reason: parsed.reason,
+        runId: parsed.runId,
       });
       continue;
     }
@@ -867,6 +915,8 @@ export function summarizeExternalCheckWaivers(
         authorLogin,
         checkSelector: parsed.checkSelector,
         expiresAt: parsed.expiresAt,
+        reason: parsed.reason,
+        runId: parsed.runId,
       });
       continue;
     }
@@ -886,6 +936,8 @@ export function summarizeExternalCheckWaivers(
           authorLogin,
           checkSelector: parsed.checkSelector,
           expiresAt: parsed.expiresAt,
+          reason: parsed.reason,
+          runId: parsed.runId,
         });
         continue;
       }
@@ -7179,6 +7231,20 @@ export function summarizeClaimValidation(
     ) => boolean;
     staleAgeMs?: number;
   } = {},
+  /**
+   * kurone-kito/idd-skill#2911: optional out-parameter this function
+   * mutates in place with `resolveActiveClaimWithForcedHandoffTrace`'s
+   * `activeSince` (the non-mutable claim-identity-transition anchor --
+   * see that interface's own doc comment for why `ClaimValidationSummary
+   * .activeClaim.createdAt` is unsuitable for this). Deliberately NOT a
+   * new field on `ClaimValidationSummary` itself: that type's shape is
+   * embedded in multiple schemas beyond `pre-merge-readiness.schema.json`
+   * (e.g. `discover-roadmap-union.schema.json`), so widening it would
+   * ripple into unrelated consumers. Every existing caller passes no 3rd
+   * argument and is completely unaffected; `buildPreMergeReadinessSummary`
+   * is the sole caller that supplies one today.
+   */
+  captureTraceInto?: { activeSince?: string },
 ): ClaimValidationSummary {
   const trustedMarkerLogins = new Set(
     normalizeTrustedMarkerLogins(options.trustedMarkerLogins ?? []),
@@ -7217,31 +7283,43 @@ export function summarizeClaimValidation(
   // for the same corrected-handoff state (resume `already_owned` vs. merge
   // `claimLost`) by design; both still funnel through the single
   // resolveActiveClaim resolver.
-  const activeClaim = resolveActiveClaim(claimEvents, {
-    isTrustedAuthor: trustedAuthorPredicate,
-    isForcedHandoffEnabled:
-      typeof options.isForcedHandoffEnabled === 'function'
-        ? options.isForcedHandoffEnabled
-        : buildForcedHandoffEnableGate({
-            forcedHandoffEnabled: options.forcedHandoffEnabled === true,
-            expectedLinkedPrReferences,
-            prFirstCommitAt: options.prFirstCommitAt ?? null,
-          }),
-    isAuthorizedForcedHandoff:
-      typeof options.isAuthorizedForcedHandoff === 'function'
-        ? options.isAuthorizedForcedHandoff
-        : (forcedBy: string) => {
-            if (authorizedForcedHandoffLogins.size === 0) {
-              return false;
-            }
-            return authorizedForcedHandoffLogins.has(
-              String(forcedBy ?? '')
-                .trim()
-                .toLowerCase(),
-            );
-          },
-    isStale: resolveStalePredicate(options.staleAgeMs),
-  });
+  // kurone-kito/idd-skill#2911: switched from the thin `resolveActiveClaim`
+  // wrapper to the full trace, so `captureTraceInto` (when the caller
+  // supplies it) can recover `activeSince` -- the same single-pass
+  // reduction, just no longer discarding the extra field. Every existing
+  // caller only ever read `.activeClaim` off `resolveActiveClaim`'s own
+  // return, so this is behavior-identical for that value.
+  const { activeClaim, activeSince } = resolveActiveClaimWithForcedHandoffTrace(
+    claimEvents,
+    {
+      isTrustedAuthor: trustedAuthorPredicate,
+      isForcedHandoffEnabled:
+        typeof options.isForcedHandoffEnabled === 'function'
+          ? options.isForcedHandoffEnabled
+          : buildForcedHandoffEnableGate({
+              forcedHandoffEnabled: options.forcedHandoffEnabled === true,
+              expectedLinkedPrReferences,
+              prFirstCommitAt: options.prFirstCommitAt ?? null,
+            }),
+      isAuthorizedForcedHandoff:
+        typeof options.isAuthorizedForcedHandoff === 'function'
+          ? options.isAuthorizedForcedHandoff
+          : (forcedBy: string) => {
+              if (authorizedForcedHandoffLogins.size === 0) {
+                return false;
+              }
+              return authorizedForcedHandoffLogins.has(
+                String(forcedBy ?? '')
+                  .trim()
+                  .toLowerCase(),
+              );
+            },
+      isStale: resolveStalePredicate(options.staleAgeMs),
+    },
+  );
+  if (captureTraceInto) {
+    captureTraceInto.activeSince = activeSince;
+  }
 
   const expectedNonce = String(options.expectedNonce ?? '').trim();
 
@@ -7650,6 +7728,43 @@ export function computePreMergeReadinessBlockers(
     blockers.push({ gate: 'ci', detail });
   }
 
+  // kurone-kito/idd-skill#2911: the OPPOSITE direction from the block
+  // above -- CI may currently report `idd-advisory-convergence` PASSING,
+  // but `buildPreMergeReadinessSummary`'s own `staleSelfWaiver` evidence
+  // (see its computation for the full rationale and the six findings this
+  // closes) may show that pass rests on a self-referential-bootstrap-auto
+  // waiver that has since gone stale, with no rerun since. Independent of
+  // (and not gated by) `isPreMergeCiAllPassing` above, since the whole
+  // point is to catch a check that currently LOOKS all-passing.
+  const staleSelfWaiver = preMergeAsRecord(report.staleSelfWaiver);
+  if (staleSelfWaiver.stale === true) {
+    const staleSelfWaiverCheckSelector = String(
+      staleSelfWaiver.checkSelector ?? '',
+    );
+    const staleReasonDetail =
+      staleSelfWaiver.reason === 'wrong-claim'
+        ? `was bound to claim "${String(
+            staleSelfWaiver.waiverClaimId ?? 'unknown',
+          )}", which the current claim identity (installed at "${
+            String(report.claimIdentityInstalledAt ?? '') || 'unknown'
+          }") no longer matches, with no rerun since`
+        : `expired at "${String(
+            staleSelfWaiver.expiresAt ?? 'unknown',
+          )}" with no rerun since`;
+    blockers.push({
+      gate: 'ci',
+      detail:
+        `"${staleSelfWaiverCheckSelector}" currently reports a passing ` +
+        `conclusion, but the self-referential-bootstrap-auto waiver ` +
+        `posted by github-actions[bot] that may have justified it ` +
+        `${staleReasonDetail} -- GitHub does not automatically ` +
+        're-evaluate a passing check when its supporting waiver comment ' +
+        `stops being valid. Rerun "${staleSelfWaiverCheckSelector}" for ` +
+        'the current HEAD before merging so it reflects the current, ' +
+        'unwaived state.',
+    });
+  }
+
   const reviewerStates = preMergeAsRecord(report.reviewerStates);
   if (!isPreMergeReviewSatisfied(reviewerStates)) {
     const selfApproval = preMergeAsRecord(reviewerStates.codeownerSelfApproval);
@@ -7993,6 +8108,30 @@ export function buildPreMergeReadinessSummary(
     // pre-#2046 behavior); `collectPreMergeReadiness` always sources the
     // policy value (default `disabled`).
     externalCheckWaiverMode?: string;
+    // kurone-kito/idd-skill#2911: caller-precomputed evidence for the
+    // `staleSelfWaiver` blocker above -- see that computation's own doc
+    // comment for the full rationale. Both fields default to the no-op/
+    // suppressed state, so every existing caller/fixture (which omits
+    // them) is unaffected; `collectPreMergeReadiness` is the sole caller
+    // that populates them.
+    //
+    // Independently fetched from THIS PR's own live diff (never from any
+    // comment body) -- whether it touches
+    // `resolveSelfReferentialTriggerFiles`'s allowlist. The load-bearing
+    // security boundary: without this, a forged self-referential-
+    // bootstrap-auto marker citing a real, unrelated run could block a
+    // completely unrelated PR's merge (see the decisive Copilot finding
+    // cited above).
+    touchesSelfReferentialAllowlist?: boolean;
+    // Keyed by the candidate marker's own `run-id:` field; `true` only
+    // when `verifySelfReferentialBootstrapWaiverRun` (reused verbatim from
+    // `advisory-convergence.mts`) confirmed that run id's own
+    // `GET .../actions/runs/{run-id}` lookup matches the expected
+    // workflow path, this PR's own HEAD SHA, this repository, and the
+    // `pull_request_target` event. A run id absent from this map (an
+    // unbounded/unlooked-up id, or a lookup that errored) is treated as
+    // unverified, never as verified.
+    autoWaiverRunVerified?: Record<string, boolean>;
     // Configured `claimTiming.staleAge` (#1310), parsed to milliseconds and
     // threaded to the write-gate claim resolver below so the F2/F3 merge gate
     // honors it instead of the hardcoded 24h `isStaleAt` default. Omitted by
@@ -8229,6 +8368,14 @@ export function buildPreMergeReadinessSummary(
       primaryBotLogin: options.primaryBotLogin,
     },
   );
+  // kurone-kito/idd-skill#2911: captures `resolveActiveClaimWithForcedHandoff
+  // Trace`'s `activeSince` (the non-mutable claim-identity-transition
+  // anchor `summarizeClaimValidation`'s own `captureTraceInto` parameter
+  // exposes) without widening `ClaimValidationSummary` -- see that
+  // parameter's own doc comment. Left `{}` (never populated) on the
+  // `claimless` branch below, matching that branch's own synthetic,
+  // not-applicable claim shape.
+  const claimTrace: { activeSince?: string } = {};
   const claim = options.claimless
     ? {
         expectedClaimId: 'none',
@@ -8245,19 +8392,28 @@ export function buildPreMergeReadinessSummary(
         claimLost: false,
         reason: 'not-applicable',
       }
-    : summarizeClaimValidation(claimEvents, {
-        trustedMarkerLogins,
-        forcedHandoffEnabled: options.forcedHandoffEnabled === true,
-        expectedLinkedPrs: options.expectedLinkedPrs ?? [],
-        prFirstCommitAt: options.prFirstCommitAt ?? null,
-        authorizedForcedHandoffLogins: options.authorizedForcedHandoffLogins,
-        isAuthorizedForcedHandoff: options.isAuthorizedForcedHandoff,
-        isForcedHandoffEnabled: options.isForcedHandoffEnabled,
-        expectedClaimId: options.expectedClaimId,
-        expectedAgentId: options.expectedAgentId,
-        expectedNonce: options.expectedNonce,
-        staleAgeMs: options.staleAgeMs,
-      });
+    : summarizeClaimValidation(
+        claimEvents,
+        {
+          trustedMarkerLogins,
+          forcedHandoffEnabled: options.forcedHandoffEnabled === true,
+          expectedLinkedPrs: options.expectedLinkedPrs ?? [],
+          prFirstCommitAt: options.prFirstCommitAt ?? null,
+          authorizedForcedHandoffLogins: options.authorizedForcedHandoffLogins,
+          isAuthorizedForcedHandoff: options.isAuthorizedForcedHandoff,
+          isForcedHandoffEnabled: options.isForcedHandoffEnabled,
+          expectedClaimId: options.expectedClaimId,
+          expectedAgentId: options.expectedAgentId,
+          expectedNonce: options.expectedNonce,
+          staleAgeMs: options.staleAgeMs,
+        },
+        claimTrace,
+      );
+  // kurone-kito/idd-skill#2911: `''` when no event ever produced an active
+  // claim (including the `claimless` branch above) -- every consumer of
+  // this field must treat that the same as "no anchor available" and fail
+  // closed (never treat an empty string as "installed at the epoch").
+  const claimIdentityInstalledAt = claimTrace.activeSince ?? '';
   const waivableCheckSelectors = options.waivableCheckSelectors ?? null;
   const waiverEvidence = summarizeExternalCheckWaivers(comments, {
     prHeadSha,
@@ -8268,6 +8424,26 @@ export function buildPreMergeReadinessSummary(
     waivableSelectors: waivableCheckSelectors,
     maxValidity: options.externalCheckWaiverMaxValidity ?? '',
     mode: options.externalCheckWaiverMode ?? '',
+  });
+  // kurone-kito/idd-skill#2911: a THIRD authorized `allowSelfReferential-
+  // BootstrapAuto` call site -- see that option's own doc comment in this
+  // file (`summarizeExternalCheckWaivers`) for the full list and why every
+  // other caller must leave it unset. Read-only, feeding only the
+  // `staleSelfWaiver` blocker evidence below; never satisfies a gate or
+  // makes `ready` true. `trustedMarkerLogins` extended with
+  // `github-actions[bot]` identically to `advisory-convergence.mts`'s own
+  // gate-decision call, so a self-referential-bootstrap-auto marker this
+  // repository's own posting job creates is visible to both.
+  const autoWaiverEvidence = summarizeExternalCheckWaivers(comments, {
+    prHeadSha,
+    activeClaimId: claim.activeClaim?.claimId ?? options.activeClaimId ?? '',
+    activeClaimSupersedes: claim.activeClaim?.supersedes ?? '',
+    trustedMarkerLogins: [...trustedMarkerLogins, 'github-actions[bot]'],
+    now,
+    waivableSelectors: waivableCheckSelectors,
+    maxValidity: options.externalCheckWaiverMaxValidity ?? '',
+    mode: options.externalCheckWaiverMode ?? '',
+    allowSelfReferentialBootstrapAuto: true,
   });
 
   // #1570: the caller-supplied terminal-unavailability verdict, reused below
@@ -8379,6 +8555,232 @@ export function buildPreMergeReadinessSummary(
         : null,
   });
 
+  // kurone-kito/idd-skill#2911: the OPPOSITE direction from the CI blocker
+  // below -- CI may currently report `idd-advisory-convergence` PASSING,
+  // but that pass may rest on a self-referential-bootstrap-auto marker
+  // that has since gone stale (expired, or claim-invalid across a genuine
+  // claim transition) with no rerun since. GitHub never reruns an
+  // already-successful check merely because its supporting comment stops
+  // being valid, so without this a PR could merge on a stale pass with no
+  // genuine advisory review (or fresh waiver) ever having covered it.
+  // Consumed by `computePreMergeReadinessBlockers` via
+  // `report.staleSelfWaiver` -- independent of, and never gated by,
+  // `isPreMergeCiAllPassing` there, since the whole point is to catch a
+  // check that currently LOOKS all-passing.
+  //
+  // This re-implements the blocker `9ecc9954`/`863c5249`/`337f4369`
+  // introduced and PR #2895's own review then retired across three more
+  // rounds (kurone-kito/idd-skill#2911's own "Findings" history), fixing
+  // every root cause in one pass rather than live-patching this call site
+  // again:
+  // - Deduplicated newest check instance (`selectLatestCheckInstance`),
+  //   not a raw `.find()` over the full (possibly multi-instance)
+  //   `ci.checks` list (round 15, Codex P1).
+  // - Scans BOTH `expired` and `wrongClaim` (round 14, Codex P1) --
+  //   `wrongClaim` never carries a comparable expiry, so it needs the
+  //   claim-identity-transition anchor below instead.
+  // - Correlates `wrongClaim` against `claimIdentityInstalledAt` (a
+  //   non-mutable claim-identity-transition anchor -- see that field's own
+  //   doc comment), never the mutable `claim.activeClaim.createdAt`
+  //   heartbeat clock (round 15, Codex P2).
+  // - Trusts a candidate marker only after `options.autoWaiverRunVerified`
+  //   confirms the SAME run-bound trust conditions
+  //   `verifySelfReferentialBootstrapWaiverRun` already applies (reused
+  //   verbatim, not reimplemented) AND `options.touchesSelfReferential-
+  //   Allowlist` independently confirms this PR's own diff touches the
+  //   checker allowlist (round 15, Copilot -- the decisive finding: a
+  //   same-repository `pull_request`-triggered workflow with
+  //   `issues: write` could otherwise cite a real, unrelated run (e.g.
+  //   this PR's own required-check instance of `idd-advisory-
+  //   convergence.yml`, which runs for EVERY PR regardless of allowlist
+  //   touch) to forge a marker that blocks a completely unrelated PR's
+  //   merge). Both booleans are precomputed by the collector
+  //   (`pre-merge-readiness.mts`), which does the actual `getWorkflowRun`/
+  //   changed-file I/O -- this function cannot perform it directly without
+  //   an import cycle back through `advisory-convergence.mts` (which
+  //   already imports FROM this file).
+  //
+  // Fail-closed/fail-open asymmetry, by design: an unverified run
+  // (`autoWaiverRunVerified[runId]` false/absent, including a transient
+  // `getWorkflowRun` failure) makes the candidate marker untrusted and
+  // therefore SUPPRESSES this blocker -- the safe direction for the
+  // decisive finding above (a forged-or-unresolvable citation must never
+  // become a merge-denial vector), even though it is the opposite of this
+  // file's usual fail-closed default elsewhere. `touchesSelfReferential-
+  // Allowlist` not `true` (including simply omitted by an older caller)
+  // suppresses the blocker unconditionally, for the identical reason.
+  //
+  // `autoWaiverEvidence` itself (computed just above, alongside the
+  // ordinary `waiverEvidence`) is deliberately NOT added to the returned
+  // `summary`: only this derived `staleSelfWaiver` verdict is schema-
+  // locked, so the raw per-marker bucket shape stays free to evolve
+  // (kurone-kito/idd-skill#2912's own bearer-evidence-vs-provenance work
+  // is a plausible future consumer) without forcing a fixture cascade
+  // across every `fixtures/pre-merge-readiness/*.json` file.
+  //
+  // Residual (documented, not fixed here): the run-id trust check above
+  // proves the cited run has the right shape, never that it actually
+  // posted the marker citing it (kurone-kito/idd-skill#2912 tracks
+  // closing that bearer-evidence gap -- see the identical residual note
+  // on `SELF_REFERENTIAL_WAIVER_TRIGGER_FILES` in advisory-convergence.mts,
+  // ~L277-303). `touchesSelfReferentialAllowlist` bounds the blast radius
+  // to PRs that already, genuinely touch the checker allowlist -- it does
+  // not fully close repeated same-repository forgery against ONE such PR
+  // (each round costs that PR one avoidable rerun, never a bypass).
+  const staleSelfWaiverCheckSelector =
+    DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR;
+  let staleSelfWaiver: {
+    stale: boolean;
+    checkSelector: string;
+    reason: 'expired' | 'wrong-claim' | null;
+    expiresAt: string;
+    waiverClaimId: string;
+  } = {
+    stale: false,
+    checkSelector: staleSelfWaiverCheckSelector,
+    reason: null,
+    expiresAt: '',
+    waiverClaimId: '',
+  };
+  // kurone-kito/idd-skill#2911 (Medium, self-critique against the merged
+  // #2657 gate decision): `summarizeExternalCheckWaivers` classifies a
+  // marker into `expired`/`wrongClaim` BEFORE its own `notConfigured`/
+  // `modeDisabled` checks ever run (both come later in that function's own
+  // pipeline), so those two buckets are populated regardless of
+  // `ciGate.externalCheckWaivers.mode`/`waivableSelectors` policy --
+  // unlike `valid`, which `autoWaiverValid` (advisory-convergence.mts) can
+  // only ever reach once mode/waivable ALREADY gated it. Gate this
+  // blocker on the identical precondition, so an adopter whose policy
+  // (the schema default: `mode: "disabled"`) could never have made this
+  // mechanism's waiver `valid` in the first place never sees a blocker
+  // from its `expired`/`wrongClaim` shadow either.
+  const staleSelfWaiverModeOpen =
+    (options.externalCheckWaiverMode ?? '') === '' ||
+    options.externalCheckWaiverMode === 'maintainer-authorized';
+  const staleSelfWaiverSelectorWaivable =
+    !Array.isArray(waivableCheckSelectors) ||
+    isCheckNameConfiguredWaivable(
+      staleSelfWaiverCheckSelector,
+      waivableCheckSelectors,
+    );
+  if (
+    options.touchesSelfReferentialAllowlist === true &&
+    staleSelfWaiverModeOpen &&
+    staleSelfWaiverSelectorWaivable
+  ) {
+    const selfConvergenceCheckInstances = ci.checks.filter(
+      (check) =>
+        check.required === true &&
+        matchCheckSelectorLocal(check.name, staleSelfWaiverCheckSelector),
+    );
+    const latestSelfConvergenceCheck =
+      selfConvergenceCheckInstances.length > 0
+        ? selectLatestCheckInstance(selfConvergenceCheckInstances)
+        : null;
+    if (
+      latestSelfConvergenceCheck &&
+      CHECK_PASS_EQUIVALENT_STATES.has(latestSelfConvergenceCheck.state)
+    ) {
+      const autoWaiverRunVerified = options.autoWaiverRunVerified ?? {};
+      const isRunVerifiedSelfWaiverMarker = (entry: {
+        authorLogin: string;
+        reason: string;
+        runId: string;
+      }) =>
+        entry.authorLogin === 'github-actions[bot]' &&
+        entry.reason === SELF_REFERENTIAL_BOOTSTRAP_AUTO_REASON &&
+        entry.runId !== '' &&
+        autoWaiverRunVerified[entry.runId] === true;
+      // A missing/unparseable `completedAt` on the SELECTED instance
+      // fails closed (treated as stale) here, same as the pre-#2911
+      // attempt: a real rerun always posts a parseable `completedAt`, so
+      // this only ever costs one extra, avoidable rerun on malformed
+      // evidence, never a false "not stale".
+      const passingCompletedAtMs = parseCompletedAt(
+        latestSelfConvergenceCheck.completedAt,
+      );
+      // kurone-kito/idd-skill#2911 (acceptance criterion 2, self-critique
+      // against round 13's own commit message -- `git show 863c5249`
+      // promised "correlation to the passing check's own completedAt OR
+      // to a newer valid marker" but its diff only ever implemented the
+      // first half): a candidate `expired`/`wrongClaim` marker proves
+      // nothing when a DIFFERENT, currently-valid, run-verified
+      // self-referential marker's own `[createdAt, expiresAt]` window
+      // already covers the moment the check last completed -- that is
+      // exactly "a fresh rerun under a new valid marker...has already
+      // superseded a stale marker." This is a time-window correlation
+      // over evidence this SAME call site's own `autoWaiverEvidence`
+      // already computed, not a use of `valid` to satisfy or relax the
+      // OVERALL gate (that direction stays exclusively `autoWaiverValid`'s,
+      // per `allowSelfReferentialBootstrapAuto`'s own ADD-only contract) --
+      // it only ever prevents THIS blocker from mis-firing on a pass that
+      // a fresh marker already, genuinely covers; it can never clear a
+      // blocker any OTHER evidence in this file raised.
+      const hasCoveringValidMarker =
+        passingCompletedAtMs !== null &&
+        autoWaiverEvidence.valid.some((entry) => {
+          if (
+            entry.authorLogin !== 'github-actions[bot]' ||
+            entry.reason !== SELF_REFERENTIAL_BOOTSTRAP_AUTO_REASON ||
+            entry.checkSelector !== staleSelfWaiverCheckSelector ||
+            entry.runId === '' ||
+            autoWaiverRunVerified[entry.runId] !== true
+          ) {
+            return false;
+          }
+          const createdAtMs = Date.parse(entry.createdAt);
+          const expiresAtMs = Date.parse(entry.expiresAt);
+          return (
+            !Number.isNaN(createdAtMs) &&
+            !Number.isNaN(expiresAtMs) &&
+            createdAtMs <= passingCompletedAtMs &&
+            passingCompletedAtMs <= expiresAtMs
+          );
+        });
+      const staleExpiredEntry = hasCoveringValidMarker
+        ? undefined
+        : autoWaiverEvidence.expired.find((entry) => {
+            if (!isRunVerifiedSelfWaiverMarker(entry)) return false;
+            if (passingCompletedAtMs === null) return true;
+            const entryExpiresAtMs = Date.parse(entry.expiresAt);
+            return (
+              Number.isNaN(entryExpiresAtMs) ||
+              entryExpiresAtMs >= passingCompletedAtMs
+            );
+          });
+      const staleWrongClaimEntry =
+        staleExpiredEntry || hasCoveringValidMarker
+          ? undefined
+          : autoWaiverEvidence.wrongClaim.find((entry) => {
+              if (!isRunVerifiedSelfWaiverMarker(entry)) return false;
+              if (passingCompletedAtMs === null) return true;
+              if (!claimIdentityInstalledAt) return true;
+              const installedAtMs = Date.parse(claimIdentityInstalledAt);
+              return (
+                Number.isNaN(installedAtMs) ||
+                passingCompletedAtMs < installedAtMs
+              );
+            });
+      if (staleExpiredEntry) {
+        staleSelfWaiver = {
+          stale: true,
+          checkSelector: staleSelfWaiverCheckSelector,
+          reason: 'expired',
+          expiresAt: staleExpiredEntry.expiresAt,
+          waiverClaimId: '',
+        };
+      } else if (staleWrongClaimEntry) {
+        staleSelfWaiver = {
+          stale: true,
+          checkSelector: staleSelfWaiverCheckSelector,
+          reason: 'wrong-claim',
+          expiresAt: '',
+          waiverClaimId: staleWrongClaimEntry.waiverClaimId,
+        };
+      }
+    }
+  }
+
   // #1570: reuse the SAME raw waiver evidence above (already validated for
   // selector/HEAD/claim/authority/expiry) to decide whether the caller-
   // supplied terminal-unavailability verdict is also validly waived, filtered
@@ -8487,6 +8889,16 @@ export function buildPreMergeReadinessSummary(
     // blocker detail or a resuming agent can cite the remaining
     // time-to-deadline without re-deriving it.
     advisoryConvergenceWaiverPrecondition,
+    // kurone-kito/idd-skill#2911: reported unconditionally (never omitted),
+    // matching this file's own convention for evidence fields
+    // `computePreMergeReadinessBlockers` consumes -- see `staleSelfWaiver`'s
+    // own computation above for the full contract. Deliberately outside
+    // `claim` (not `claim.activeClaimInstalledAt`): `ClaimValidationSummary`'s
+    // shape is embedded in schemas beyond this one (e.g.
+    // `discover-roadmap-union.schema.json`), so this stays a top-level,
+    // pre-merge-readiness-only field instead.
+    claimIdentityInstalledAt,
+    staleSelfWaiver,
     branchCurrency,
   };
 
@@ -8745,6 +9157,23 @@ export interface ActiveClaimResolution {
    * (e.g. only heartbeats followed the last transition).
    */
   appliedForcedHandoff: ParsedForcedHandoffMarker | null;
+  /**
+   * kurone-kito/idd-skill#2911: the GitHub `createdAt` of the event that
+   * most recently changed `activeClaim`'s `(agentId, claimId)` identity --
+   * a fresh claim, a stale takeover, or a forced handoff -- as opposed to
+   * `activeClaim.createdAt` itself, which `applyClaimEvent`'s heartbeat
+   * branch deliberately overwrites on every SAME-claim heartbeat (that
+   * field is the correct "stale clock" anchor for `idd-claim.instructions.md`'s
+   * staleness rule, but it is NOT a stable "this identity became active
+   * at" anchor -- a long-lived claim's `createdAt` keeps moving forward
+   * with every 12h heartbeat even though its identity never changes).
+   * `''` when no event ever produced a non-null active claim. A release
+   * with no later re-claim leaves this holding the release event's own
+   * `createdAt` (the "identity" transitioned to null then), which is
+   * harmless: callers that care about this field only ever consult it
+   * alongside a non-null `activeClaim`/`activeClaimPresent`.
+   */
+  activeSince: string;
 }
 
 /**
@@ -8774,6 +9203,7 @@ export function resolveActiveClaimWithForcedHandoffTrace(
 
   let active: ParsedClaimMarker | null = null;
   let appliedForcedHandoff: ParsedForcedHandoffMarker | null = null;
+  let activeSince = '';
   for (const event of orderedEvents) {
     const previous = active;
     const next = applyClaimEvent(previous, event, options);
@@ -8795,10 +9225,16 @@ export function resolveActiveClaimWithForcedHandoffTrace(
         candidate.newClaimId === next.claimId
           ? candidate
           : null;
+      // kurone-kito/idd-skill#2911: record the transition's own event
+      // timestamp -- see `ActiveClaimResolution.activeSince`'s doc comment
+      // for why this must be captured here (at the identity-changing step
+      // itself) rather than read back from `next.createdAt`, which a LATER
+      // same-claim heartbeat mutates in place.
+      activeSince = String(event.createdAt ?? '');
     }
     active = next;
   }
-  return { activeClaim: active, appliedForcedHandoff };
+  return { activeClaim: active, appliedForcedHandoff, activeSince };
 }
 
 export function resolveActiveClaim(

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -37,6 +37,7 @@ import {
   SAME_HEAD_REROLL_INELIGIBLE_REASON,
   SELF_REFERENTIAL_BOOTSTRAP_AUTO_REASON,
   SELF_REFERENTIAL_WAIVER_TRIGGER_FILES,
+  verifySelfReferentialBootstrapWaiverRun,
   viewerProbeGhOptions,
   writeAdvisoryConvergenceCliOutput,
 } from '../src/scripts/advisory-convergence.mts';
@@ -5557,3 +5558,46 @@ test('retryTransientGhFailure exhausts bounded attempts and rethrows the final e
   assert.equal(calls, 3);
   assert.equal(caught, lastError);
 });
+
+test(
+  'verifySelfReferentialBootstrapWaiverRun stays exported and behaves ' +
+    'identically for the cross-module caller added by ' +
+    'kurone-kito/idd-skill#2911 (pre-merge-readiness.mts reuses this ' +
+    'exact function rather than reimplementing it -- a rename or ' +
+    'signature change here would silently break that import without a ' +
+    'pin like this one)',
+  () => {
+    assert.equal(typeof verifySelfReferentialBootstrapWaiverRun, 'function');
+    const expected = {
+      path: ADVISORY_CONVERGENCE_WORKFLOW_PATH,
+      headSha: HEAD,
+      repositoryFullName: 'kurone-kito/idd-skill',
+    };
+    assert.equal(
+      verifySelfReferentialBootstrapWaiverRun(
+        {
+          path: ADVISORY_CONVERGENCE_WORKFLOW_PATH,
+          headSha: HEAD,
+          repositoryFullName: 'kurone-kito/idd-skill',
+          event: 'pull_request_target',
+        },
+        expected,
+      ),
+      true,
+    );
+    // A mismatched head SHA (the forged-citation shape #2911's decisive
+    // finding is about) must still fail closed through this same export.
+    assert.equal(
+      verifySelfReferentialBootstrapWaiverRun(
+        {
+          path: ADVISORY_CONVERGENCE_WORKFLOW_PATH,
+          headSha: OTHER_SHA,
+          repositoryFullName: 'kurone-kito/idd-skill',
+          event: 'pull_request_target',
+        },
+        expected,
+      ),
+      false,
+    );
+  },
+);

--- a/tests/pre-merge-readiness-collection-smoke.test.mts
+++ b/tests/pre-merge-readiness-collection-smoke.test.mts
@@ -1373,7 +1373,16 @@ function runSelfWaiverCollection(
               status: 'COMPLETED',
               conclusion: 'SUCCESS',
               completedAt: '2026-08-01T00:00:00Z',
-              workflowName: 'idd-advisory-convergence',
+              // kurone-kito/idd-skill#2911 (Codex review, PR #2915, P1):
+              // the REAL workflow display name
+              // (`.github/workflows/idd-advisory-convergence.yml`'s own
+              // `name:` field) -- matches the same literal
+              // `tests/advisory-wait.test.mts`/`tests/pre-merge-readiness.test.mts`
+              // already use, not the check-name selector, which is a
+              // different string. `buildPreMergeReadinessSummary`'s own
+              // `staleSelfWaiver` computation now filters on this exact
+              // value.
+              workflowName: 'IDD advisory-convergence gate',
             },
           ],
           mergeable: 'MERGEABLE',
@@ -1601,4 +1610,54 @@ test('collectPreMergeReadiness against a fake provider (kurone-kito/idd-skill#29
   };
   assert.equal(staleSelfWaiver.stale, true);
   assert.equal(staleSelfWaiver.reason, 'expired');
+});
+
+test('collectPreMergeReadiness against a fake provider (kurone-kito/idd-skill#2911, Copilot review on PR #2915): a run-id cited by more than one comment tracks the NEWEST createdAt among them, so a stale first occurrence can never push the candidate out of the bounded window on its own', () => {
+  // The target run-id posts its marker TWICE (e.g. a retry within the
+  // same run): once very early (would rank last under the pre-fix
+  // "keep first occurrence" behavior) and once very late (would rank
+  // first under the fix). 20 decoys sit strictly BETWEEN the two
+  // target timestamps -- exactly enough to crowd the target out of the
+  // top-20-newest window if its OLD timestamp were the one tracked.
+  const decoys = Array.from({ length: 20 }, (_, index) =>
+    selfWaiverMarkerCollectionComment({
+      id: index + 1,
+      expiresAt: '2026-07-30T12:00:00Z',
+      runId: String(2000 + index),
+      createdAt: `2026-07-30T${String(index + 1).padStart(2, '0')}:00:00Z`,
+    }),
+  );
+  const targetFirstOccurrence = selfWaiverMarkerCollectionComment({
+    id: 21,
+    expiresAt: '2026-08-01T00:05:00Z',
+    runId: '999',
+    createdAt: '2026-07-30T00:00:00Z',
+  });
+  const targetSecondOccurrence = selfWaiverMarkerCollectionComment({
+    id: 22,
+    expiresAt: '2026-08-01T00:05:00Z',
+    runId: '999',
+    createdAt: '2026-07-31T23:50:00Z',
+  });
+  const report = runSelfWaiverCollection({
+    comments: {
+      42: [targetFirstOccurrence, ...decoys, targetSecondOccurrence],
+    },
+    changedFiles: { 42: ['.github/idd/config.json'] },
+    workflowRuns: {
+      'o/r/999': {
+        path: '.github/workflows/idd-advisory-convergence.yml',
+        head_sha: SELF_WAIVER_PR_HEAD_SHA,
+        head_repository: { full_name: 'o/r' },
+        event: 'pull_request_target',
+      },
+      // No entries for the 20 decoy run-ids (2000-2019): if the bounded
+      // lookup ever selects one instead of the target run-id, the fake
+      // adapter throws and that decoy stays unverified -- harmless
+      // either way, keeping this test's only signal the target's own
+      // inclusion/exclusion.
+    },
+  });
+  const staleSelfWaiver = report.staleSelfWaiver as { stale: boolean };
+  assert.equal(staleSelfWaiver.stale, true);
 });

--- a/tests/pre-merge-readiness-collection-smoke.test.mts
+++ b/tests/pre-merge-readiness-collection-smoke.test.mts
@@ -1546,3 +1546,59 @@ test('collectPreMergeReadiness against a fake provider: a run-id citing a workfl
   const staleSelfWaiver = report.staleSelfWaiver as { stale: boolean };
   assert.equal(staleSelfWaiver.stale, false);
 });
+
+test('collectPreMergeReadiness against a fake provider (kurone-kito/idd-skill#2911, Codex review on PR #2915, P1): the bounded run-id lookup prioritizes the NEWEST marker candidates, so a flood of older decoys never crowds out the one marker that actually covers the passing check', () => {
+  // 20 older decoy markers -- enough to fully exhaust the 20-candidate
+  // lookup budget under the pre-fix earliest-first tie-break -- each
+  // posted, and expiring, long before the check's own `completedAt`
+  // (2026-08-01T00:00:00Z), so none of them could ever correlate with it
+  // even if verified. No `workflowRuns` entry is provided for any decoy:
+  // under the OLD earliest-first ordering these would be the ONLY
+  // candidates ever looked up (all 20 slots spent here), so the 21st,
+  // actually-relevant marker below would never even be looked up and this
+  // test would observe `stale: false` -- the exact bug the finding
+  // reports. Under the fix (newest-first), these decoys are the ones
+  // excluded instead.
+  const decoys = Array.from({ length: 20 }, (_, index) =>
+    selfWaiverMarkerCollectionComment({
+      id: index + 1,
+      expiresAt: '2026-07-30T12:00:00Z',
+      runId: String(1000 + index),
+      createdAt: `2026-07-30T00:${String(index).padStart(2, '0')}:00Z`,
+    }),
+  );
+  // The 21st, NEWEST marker -- genuinely covered the passing check at the
+  // time it completed (its `expiresAt` is after `completedAt`), but has
+  // since expired relative to `--now` (2026-08-01T00:10:00Z). This is the
+  // one marker the bounded lookup must not drop.
+  const target = selfWaiverMarkerCollectionComment({
+    id: 21,
+    expiresAt: '2026-08-01T00:05:00Z',
+    runId: '999',
+    createdAt: '2026-07-31T23:50:00Z',
+  });
+  const report = runSelfWaiverCollection({
+    comments: { 42: [...decoys, target] },
+    changedFiles: { 42: ['.github/idd/config.json'] },
+    workflowRuns: {
+      'o/r/999': {
+        path: '.github/workflows/idd-advisory-convergence.yml',
+        head_sha: SELF_WAIVER_PR_HEAD_SHA,
+        head_repository: { full_name: 'o/r' },
+        event: 'pull_request_target',
+      },
+      // Deliberately no entries for the 20 decoy run-ids (1000-1019): if
+      // the bounded lookup ever selects one of them instead of the
+      // target, the fake adapter throws and that decoy is simply
+      // unverified -- it can never manufacture a false `stale: true` on
+      // its own, keeping this test's only signal the target's own
+      // inclusion/exclusion.
+    },
+  });
+  const staleSelfWaiver = report.staleSelfWaiver as {
+    stale: boolean;
+    reason: string | null;
+  };
+  assert.equal(staleSelfWaiver.stale, true);
+  assert.equal(staleSelfWaiver.reason, 'expired');
+});

--- a/tests/pre-merge-readiness-collection-smoke.test.mts
+++ b/tests/pre-merge-readiness-collection-smoke.test.mts
@@ -7,6 +7,11 @@ import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import {
+  DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+  SELF_REFERENTIAL_BOOTSTRAP_AUTO_REASON,
+} from '../src/scripts/advisory-wait-policy.mts';
+import { renderExternalCheckWaiverComment } from '../src/scripts/marker-helpers.mts';
+import {
   collectPreMergeReadiness,
   normalizeClaimComment,
   normalizeComment,
@@ -1282,4 +1287,262 @@ test('collectPreMergeReadiness: secondaryQuietWindow still blocks for the full w
   );
   assert.equal(status.elapsed, false);
   assert.equal(status.remainingMinutes, 56);
+});
+
+// ---------------------------------------------------------------------------
+// kurone-kito/idd-skill#2911: stale-self-waiver merge blocker, exercised
+// through the REAL collector I/O path (comment scan -> bounded
+// getWorkflowRun lookups -> verifySelfReferentialBootstrapWaiverRun ->
+// buildPreMergeReadinessSummary), per the issue's own acceptance criterion
+// ("verified by a test using the fake provider adapter"). The pure
+// correlation/dedup/claim-anchor logic itself is covered directly in
+// tests/pre-merge-readiness.test.mts; these tests instead pin that the
+// collector's own comment-scan + getWorkflowRun wiring produces the inputs
+// that logic expects, and that a forged/unresolvable run citation is never
+// trusted.
+// ---------------------------------------------------------------------------
+
+const SELF_WAIVER_PR_HEAD_SHA = 'a'.repeat(40);
+
+function selfWaiverFakeProviderConfig(overrides: Record<string, unknown> = {}) {
+  return {
+    ciGate: {
+      externalCheckWaivers: { mode: 'maintainer-authorized' },
+      externalChecks: {
+        waivable: [
+          {
+            selector: DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+            matchMode: 'exact',
+          },
+        ],
+      },
+    },
+    ...overrides,
+  };
+}
+
+function selfWaiverMarkerCollectionComment(payload: {
+  id: number;
+  expiresAt: string;
+  runId: string;
+  createdAt: string;
+}) {
+  return {
+    id: payload.id,
+    body: renderExternalCheckWaiverComment({
+      agentId: 'idd-advisory-convergence-self-waiver',
+      claimId: 'none',
+      headSha: SELF_WAIVER_PR_HEAD_SHA,
+      checkSelector: DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+      reason: SELF_REFERENTIAL_BOOTSTRAP_AUTO_REASON,
+      expiresAt: payload.expiresAt,
+      runId: payload.runId,
+    }),
+    createdAt: payload.createdAt,
+    updatedAt: payload.createdAt,
+    authorLogin: 'github-actions[bot]',
+  };
+}
+
+function runSelfWaiverCollection(
+  fixtureOverrides: {
+    workflowRuns?: Record<string, unknown>;
+    changedFiles?: Record<number, string[]>;
+    comments?: Record<number, unknown[]>;
+  },
+  configOverrides: Record<string, unknown> = {},
+) {
+  const cwdRoot = mkdtempSync(
+    join(tmpdir(), 'idd-pre-merge-fake-self-waiver-'),
+  );
+  const originalCwd = process.cwd();
+  try {
+    process.chdir(cwdRoot);
+    const port = createFakeProviderAdapter({
+      changeRequestReadinessSnapshots: {
+        42: {
+          headSha: SELF_WAIVER_PR_HEAD_SHA,
+          baseRefName: 'main',
+          url: 'https://github.com/o/r/pull/42',
+          authorLogin: 'author-user',
+          reviewDecision: null,
+          statusCheckRollup: [
+            {
+              __typename: 'CheckRun',
+              name: DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+              status: 'COMPLETED',
+              conclusion: 'SUCCESS',
+              completedAt: '2026-08-01T00:00:00Z',
+              workflowName: 'idd-advisory-convergence',
+            },
+          ],
+          mergeable: 'MERGEABLE',
+          mergeStateStatus: 'CLEAN',
+          closingIssuesReferences: [],
+        },
+      },
+      branchRules: {
+        'o/r/main': [
+          {
+            type: 'required_status_checks',
+            parameters: {
+              required_status_checks: [
+                { context: DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR },
+              ],
+            },
+          },
+        ],
+      },
+      branchProtection: { 'o/r/main': {} },
+      reviewThreadsWithComments: { 42: [] },
+      reviewsWithHeadCommitDate: {
+        42: { reviews: [], headCommittedAt: '2026-07-31T23:00:00Z' },
+      },
+      comments: { 42: [], ...fixtureOverrides.comments },
+      changedFiles: { 42: [], ...fixtureOverrides.changedFiles },
+      workflowRuns: fixtureOverrides.workflowRuns ?? {},
+    } as never);
+
+    return collectPreMergeReadiness(
+      [
+        '--pr',
+        '42',
+        '--claimless',
+        '--owner',
+        'o',
+        '--repo',
+        'r',
+        '--now',
+        '2026-08-01T00:10:00Z',
+      ],
+      () => port,
+      () => selfWaiverFakeProviderConfig(configOverrides) as never,
+    );
+  } finally {
+    process.chdir(originalCwd);
+    rmSync(cwdRoot, { recursive: true, force: true });
+  }
+}
+
+test('collectPreMergeReadiness against a fake provider: a genuine, run-verified expired self-referential marker blocks a currently-passing idd-advisory-convergence check', () => {
+  const report = runSelfWaiverCollection({
+    comments: {
+      42: [
+        selfWaiverMarkerCollectionComment({
+          id: 1,
+          expiresAt: '2026-08-01T00:05:00Z',
+          runId: '999',
+          createdAt: '2026-07-31T23:00:00Z',
+        }),
+      ],
+    },
+    changedFiles: { 42: ['.github/idd/config.json'] },
+    workflowRuns: {
+      'o/r/999': {
+        path: '.github/workflows/idd-advisory-convergence.yml',
+        head_sha: SELF_WAIVER_PR_HEAD_SHA,
+        head_repository: { full_name: 'o/r' },
+        event: 'pull_request_target',
+      },
+    },
+  });
+  const staleSelfWaiver = report.staleSelfWaiver as { stale: boolean };
+  assert.equal(staleSelfWaiver.stale, true);
+  const blockers = report.blockers as { gate: string; detail: string }[];
+  assert.ok(
+    blockers.some(
+      (blocker) =>
+        blocker.gate === 'ci' &&
+        /self-referential-bootstrap-auto/.test(blocker.detail),
+    ),
+    `expected a self-referential-bootstrap-auto "ci" blocker, got: ${JSON.stringify(blockers)}`,
+  );
+});
+
+test('collectPreMergeReadiness against a fake provider: touchesSelfReferentialAllowlist false (this PR never touches the checker allowlist) suppresses the blocker even for an otherwise-verified expired marker -- closes the decisive round-15 forgery/DoS finding', () => {
+  const report = runSelfWaiverCollection({
+    comments: {
+      42: [
+        selfWaiverMarkerCollectionComment({
+          id: 1,
+          expiresAt: '2026-08-01T00:05:00Z',
+          runId: '999',
+          createdAt: '2026-07-31T23:00:00Z',
+        }),
+      ],
+    },
+    // No changedFiles entry for PR 42 -- it never touches the checker
+    // allowlist, so the blocker must never fire regardless of what the
+    // (here, genuinely run-verified) marker says.
+    changedFiles: {},
+    workflowRuns: {
+      'o/r/999': {
+        path: '.github/workflows/idd-advisory-convergence.yml',
+        head_sha: SELF_WAIVER_PR_HEAD_SHA,
+        head_repository: { full_name: 'o/r' },
+        event: 'pull_request_target',
+      },
+    },
+  });
+  const staleSelfWaiver = report.staleSelfWaiver as { stale: boolean };
+  assert.equal(staleSelfWaiver.stale, false);
+});
+
+test('collectPreMergeReadiness against a fake provider: a forged marker citing a real run with the wrong event/path/head/repository is never trusted, no blocker', () => {
+  const genuineRun = {
+    path: '.github/workflows/idd-advisory-convergence.yml',
+    head_sha: SELF_WAIVER_PR_HEAD_SHA,
+    head_repository: { full_name: 'o/r' },
+    event: 'pull_request_target',
+  };
+  const forgedVariants: Record<string, unknown>[] = [
+    { ...genuineRun, event: 'pull_request' },
+    { ...genuineRun, path: '.github/workflows/some-other-workflow.yml' },
+    { ...genuineRun, head_sha: 'b'.repeat(40) },
+    { ...genuineRun, head_repository: { full_name: 'attacker/fork' } },
+  ];
+  for (const [index, forgedRun] of forgedVariants.entries()) {
+    const runId = String(1000 + index);
+    const report = runSelfWaiverCollection({
+      comments: {
+        42: [
+          selfWaiverMarkerCollectionComment({
+            id: index + 1,
+            expiresAt: '2026-08-01T00:05:00Z',
+            runId,
+            createdAt: '2026-07-31T23:00:00Z',
+          }),
+        ],
+      },
+      changedFiles: { 42: ['.github/idd/config.json'] },
+      workflowRuns: { [`o/r/${runId}`]: forgedRun },
+    });
+    const staleSelfWaiver = report.staleSelfWaiver as { stale: boolean };
+    assert.equal(
+      staleSelfWaiver.stale,
+      false,
+      `forged variant ${index} (${JSON.stringify(forgedRun)}) must not trigger the blocker`,
+    );
+  }
+});
+
+test('collectPreMergeReadiness against a fake provider: a run-id citing a workflow run this repository has no record of (unresolvable lookup) is never trusted, no blocker', () => {
+  const report = runSelfWaiverCollection({
+    comments: {
+      42: [
+        selfWaiverMarkerCollectionComment({
+          id: 1,
+          expiresAt: '2026-08-01T00:05:00Z',
+          runId: '404404',
+          createdAt: '2026-07-31T23:00:00Z',
+        }),
+      ],
+    },
+    changedFiles: { 42: ['.github/idd/config.json'] },
+    // No workflowRuns entry for 404404 -- the fake adapter throws, matching
+    // the real GitHub adapter's own unresolvable-run behavior.
+    workflowRuns: {},
+  });
+  const staleSelfWaiver = report.staleSelfWaiver as { stale: boolean };
+  assert.equal(staleSelfWaiver.stale, false);
 });

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -10116,3 +10116,50 @@ test('#2911 (Copilot review, PR #2915): a marker CREATED after the check already
   );
   assert.equal(staleSelfWaiverOf(summary).stale, false);
 });
+
+test('#2911 (Codex review, PR #2915, P1, fresh evidence against the producer-grouping fix itself): a legacy status-context producer sharing the name never causes a false positive via the null-completedAt fail-closed branch, even while the real checker workflow is genuinely fresh', () => {
+  const base = withSelfWaiverCheckState(
+    selfWaiverInputBase(),
+    // The REAL convergence workflow's own instance: fresh, no waiver
+    // correlation needed at all -- no marker comment is added for it.
+    'SUCCESS',
+    '2026-05-11T23:55:00Z',
+  );
+  // An unrelated legacy status-context producer sharing the exact same
+  // name, with NO completedAt (typical of a status context) -- pre-fix,
+  // this producer's own candidacy hits the `passingCompletedAtMs ===
+  // null` fail-closed branch, which unconditionally matches ANY
+  // run-verified expired marker regardless of timing. This otherwise
+  // unrelated marker (posted long ago, with no bearing on the REAL
+  // workflow's fresh 23:55 pass) exists purely to give that branch
+  // something to match.
+  const checksWithStatusContextProducer = [
+    ...(base.checks ?? []),
+    {
+      name: DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+      state: 'SUCCESS',
+      completedAt: null,
+      type: 'status-context',
+      workflowName: '',
+    },
+  ];
+  const withStatusContextProducer = {
+    ...base,
+    checks: checksWithStatusContextProducer,
+  };
+  const marker = selfWaiverMarkerComment({
+    id: 'self-waiver-status-context-decoy',
+    claimId: 'claim-123',
+    expiresAt: '2026-05-11T20:00:00Z',
+    runId: '7171',
+    createdAt: '2026-05-11T19:00:00Z',
+  });
+  const summary = buildPreMergeReadinessSummary(
+    {
+      ...withStatusContextProducer,
+      comments: [...(withStatusContextProducer.comments ?? []), marker],
+    },
+    selfWaiverOptions({ autoWaiverRunVerified: { '7171': true } }),
+  );
+  assert.equal(staleSelfWaiverOf(summary).stale, false);
+});

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -10016,3 +10016,48 @@ test('#2911 claimless: an active-claim-bound wrongClaim marker fails closed to s
   assert.equal(staleSelfWaiverOf(summary).stale, true);
   assert.equal(staleSelfWaiverOf(summary).reason, 'wrong-claim');
 });
+
+test("#2911 (Codex review, PR #2915, P1): a fresher pass from a DIFFERENT producer never masks a stale pass from the checker workflow's own producer", () => {
+  const base = withSelfWaiverCheckState(
+    selfWaiverInputBase(),
+    'SUCCESS',
+    '2026-05-11T23:25:00Z',
+  );
+  // A second, same-NAME `idd-advisory-convergence` check instance from a
+  // distinct producer (a legacy status context, vs. the checker
+  // workflow's own Actions check-run, which carries no `type`/
+  // `workflowName` in this fixture's base shape) -- genuinely,
+  // independently SUCCESS, completed LATER, with no waiver correlation
+  // needed at all. Pre-fix, `selectLatestCheckInstance` picked a single
+  // "latest" instance across BOTH producers flattened together, so this
+  // fresher instance would have masked the checker's own stale pass
+  // below entirely (`stale` would incorrectly read `false`).
+  const checksWithDistinctProducer = [
+    ...(base.checks ?? []),
+    {
+      name: DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+      state: 'SUCCESS',
+      completedAt: '2026-05-11T23:50:00Z',
+      type: 'status-context',
+      workflowName: '',
+    },
+  ];
+  const withDistinctProducer = { ...base, checks: checksWithDistinctProducer };
+  const marker = selfWaiverMarkerComment({
+    id: 'self-waiver-expired-multi-producer',
+    claimId: 'claim-123',
+    expiresAt: '2026-05-11T23:30:00Z',
+    runId: '4343',
+    createdAt: '2026-05-11T23:10:00Z',
+  });
+  const summary = buildPreMergeReadinessSummary(
+    {
+      ...withDistinctProducer,
+      comments: [...(withDistinctProducer.comments ?? []), marker],
+    },
+    selfWaiverOptions({ autoWaiverRunVerified: { '4343': true } }),
+  );
+  assert.equal(staleSelfWaiverOf(summary).stale, true);
+  assert.equal(staleSelfWaiverOf(summary).reason, 'expired');
+  assert.equal(selfWaiverBlockers(summary).length, 1);
+});

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -2,10 +2,15 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
 
-import { SELF_REFERENTIAL_BOOTSTRAP_AUTO_REASON } from '../src/scripts/advisory-wait-policy.mts';
 import {
+  DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+  SELF_REFERENTIAL_BOOTSTRAP_AUTO_REASON,
+} from '../src/scripts/advisory-wait-policy.mts';
+import {
+  renderClaimedByMarker,
   renderExternalCheckWaiverComment,
   renderReviewReplyStamp,
+  renderUnclaimedByMarker,
 } from '../src/scripts/marker-helpers.mts';
 import {
   collectPreMergeReadiness,
@@ -9441,4 +9446,573 @@ test('#2272: an unrecognized developmentBranchTarget.status fails closed even wh
   );
   assert.ok(blocker);
   assert.match(blocker.detail, /unrecognized/);
+});
+
+// ---------------------------------------------------------------------------
+// kurone-kito/idd-skill#2911: stale-self-waiver merge blocker.
+//
+// Re-implements (properly, this time) the blocker PR #2895 added and then
+// reverted across three commits (9ecc9954/863c5249/337f4369) after three
+// more review rounds each found a new correctness/trust defect. Each test
+// below is named for the specific finding/constraint it pins so a future
+// edit that regresses one of them fails loudly and specifically, rather
+// than as an opaque diff against a hand-built fixture.
+// ---------------------------------------------------------------------------
+
+const SELF_WAIVER_HEAD_SHA = '1111111111111111111111111111111111111111';
+
+function selfWaiverInputBase(): PreMergeReadinessInput {
+  const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
+  return withAdvisoryConvergenceRequiredCheck(fixture);
+}
+
+function withSelfWaiverCheckState(
+  input: PreMergeReadinessInput,
+  state: string,
+  completedAt?: string,
+): PreMergeReadinessInput {
+  const checks = (input.checks ?? []).map((check) =>
+    check.name === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR
+      ? completedAt === undefined
+        ? { name: check.name, state }
+        : { ...check, state, completedAt }
+      : check,
+  );
+  return { ...input, checks };
+}
+
+function selfWaiverMarkerComment(payload: {
+  id: string;
+  claimId: string;
+  expiresAt: string;
+  runId: string;
+  createdAt: string;
+}) {
+  return {
+    id: payload.id,
+    author: { login: 'github-actions[bot]' },
+    body: renderExternalCheckWaiverComment({
+      agentId: 'idd-advisory-convergence-self-waiver',
+      claimId: payload.claimId,
+      headSha: SELF_WAIVER_HEAD_SHA,
+      checkSelector: DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+      reason: SELF_REFERENTIAL_BOOTSTRAP_AUTO_REASON,
+      expiresAt: payload.expiresAt,
+      runId: payload.runId,
+    }),
+    createdAt: payload.createdAt,
+    updatedAt: payload.createdAt,
+  };
+}
+
+function selfWaiverOptions(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
+  return {
+    ...fixture.options,
+    includeDispositionEvidence: true,
+    touchesSelfReferentialAllowlist: true,
+    ...overrides,
+  };
+}
+
+function selfWaiverBlockers(summary: unknown) {
+  return (
+    (summary as { blockers: unknown }).blockers as {
+      gate: string;
+      detail: string;
+    }[]
+  ).filter(
+    (blocker) =>
+      blocker.gate === 'ci' &&
+      /self-referential-bootstrap-auto/.test(blocker.detail),
+  );
+}
+
+function staleSelfWaiverOf(summary: unknown): {
+  stale: boolean;
+  checkSelector: string;
+  reason: 'expired' | 'wrong-claim' | null;
+  expiresAt: string;
+  waiverClaimId: string;
+} {
+  return (summary as { staleSelfWaiver: unknown })
+    .staleSelfWaiver as ReturnType<typeof staleSelfWaiverOf>;
+}
+
+function claimIdentityInstalledAtOf(summary: unknown): string {
+  return (summary as { claimIdentityInstalledAt: string })
+    .claimIdentityInstalledAt;
+}
+
+function activeClaimCreatedAtOf(summary: unknown): string {
+  return (summary as { claim: { activeClaim: { createdAt: string } } }).claim
+    .activeClaim.createdAt;
+}
+
+test('#2911 finding 1/round 12: an expired, run-verified self-referential marker blocks a currently-passing check with no rerun since', () => {
+  const base = withSelfWaiverCheckState(
+    selfWaiverInputBase(),
+    'SUCCESS',
+    '2026-05-11T23:25:00Z',
+  );
+  const marker = selfWaiverMarkerComment({
+    id: 'self-waiver-expired',
+    claimId: 'claim-123',
+    expiresAt: '2026-05-11T23:30:00Z',
+    runId: '4242',
+    createdAt: '2026-05-11T23:10:00Z',
+  });
+  const summary = buildPreMergeReadinessSummary(
+    { ...base, comments: [...(base.comments ?? []), marker] },
+    selfWaiverOptions({ autoWaiverRunVerified: { '4242': true } }),
+  );
+  assert.equal(staleSelfWaiverOf(summary).stale, true);
+  assert.equal(staleSelfWaiverOf(summary).reason, 'expired');
+  assert.equal(selfWaiverBlockers(summary).length, 1);
+  assert.deepEqual(
+    (summary as { blockers: unknown }).blockers,
+    computePreMergeReadinessBlockers(summary as Record<string, unknown>),
+  );
+});
+
+test('#2911 finding 2/round 13: a genuine rerun completing AFTER the expired marker clears the blocker', () => {
+  const base = withSelfWaiverCheckState(
+    selfWaiverInputBase(),
+    'SUCCESS',
+    '2026-05-11T23:45:00Z',
+  );
+  const marker = selfWaiverMarkerComment({
+    id: 'self-waiver-expired-then-rerun',
+    claimId: 'claim-123',
+    expiresAt: '2026-05-11T23:30:00Z',
+    runId: '4242',
+    createdAt: '2026-05-11T23:10:00Z',
+  });
+  const summary = buildPreMergeReadinessSummary(
+    { ...base, comments: [...(base.comments ?? []), marker] },
+    selfWaiverOptions({ autoWaiverRunVerified: { '4242': true } }),
+  );
+  assert.equal(staleSelfWaiverOf(summary).stale, false);
+  assert.equal(selfWaiverBlockers(summary).length, 0);
+});
+
+test('#2911 acceptance criterion 2 (round 13 commit promised, never implemented -- git show 863c5249): a fresh rerun covered by a DIFFERENT, currently-valid self-referential marker clears the blocker even though an older marker already expired', () => {
+  const base = withSelfWaiverCheckState(
+    selfWaiverInputBase(),
+    'SUCCESS',
+    '2026-05-11T23:20:00Z',
+  );
+  const staleMarker = selfWaiverMarkerComment({
+    id: 'self-waiver-stale',
+    claimId: 'claim-123',
+    expiresAt: '2026-05-11T23:30:00Z',
+    runId: '4242',
+    createdAt: '2026-05-11T22:00:00Z',
+  });
+  const coveringMarker = selfWaiverMarkerComment({
+    id: 'self-waiver-covering',
+    claimId: 'claim-123',
+    expiresAt: '2026-05-13T00:00:00Z',
+    runId: '5555',
+    createdAt: '2026-05-11T23:15:00Z',
+  });
+  const summary = buildPreMergeReadinessSummary(
+    {
+      ...base,
+      comments: [...(base.comments ?? []), staleMarker, coveringMarker],
+    },
+    selfWaiverOptions({
+      autoWaiverRunVerified: { '4242': true, '5555': true },
+    }),
+  );
+  assert.equal(staleSelfWaiverOf(summary).stale, false);
+  assert.equal(selfWaiverBlockers(summary).length, 0);
+});
+
+test('#2911 finding 3/round 14: a wrongClaim self-referential marker blocks when the check completed before the current claim identity was installed', () => {
+  const base = withSelfWaiverCheckState(
+    selfWaiverInputBase(),
+    'SUCCESS',
+    '2026-05-11T23:10:00Z',
+  );
+  const marker = selfWaiverMarkerComment({
+    id: 'self-waiver-wrong-claim-before',
+    claimId: 'some-other-claim',
+    expiresAt: '2026-05-13T00:00:00Z',
+    runId: '4242',
+    createdAt: '2026-05-11T23:00:00Z',
+  });
+  const summary = buildPreMergeReadinessSummary(
+    { ...base, comments: [...(base.comments ?? []), marker] },
+    selfWaiverOptions({ autoWaiverRunVerified: { '4242': true } }),
+  );
+  assert.equal(claimIdentityInstalledAtOf(summary), '2026-05-11T23:20:00Z');
+  assert.equal(staleSelfWaiverOf(summary).stale, true);
+  assert.equal(staleSelfWaiverOf(summary).reason, 'wrong-claim');
+  assert.equal(selfWaiverBlockers(summary).length, 1);
+});
+
+test('#2911 finding 3/round 14: the same wrongClaim marker does not block once the check completed after the current claim identity was installed', () => {
+  const base = withSelfWaiverCheckState(
+    selfWaiverInputBase(),
+    'SUCCESS',
+    '2026-05-11T23:25:00Z',
+  );
+  const marker = selfWaiverMarkerComment({
+    id: 'self-waiver-wrong-claim-after',
+    claimId: 'some-other-claim',
+    expiresAt: '2026-05-13T00:00:00Z',
+    runId: '4242',
+    createdAt: '2026-05-11T23:00:00Z',
+  });
+  const summary = buildPreMergeReadinessSummary(
+    { ...base, comments: [...(base.comments ?? []), marker] },
+    selfWaiverOptions({ autoWaiverRunVerified: { '4242': true } }),
+  );
+  assert.equal(staleSelfWaiverOf(summary).stale, false);
+  assert.equal(selfWaiverBlockers(summary).length, 0);
+});
+
+test('#2911 finding 4/round 15 (Codex P1): the deduplicated NEWEST check instance governs, not a raw first match over a multi-instance list', () => {
+  const inputWithHelper = selfWaiverInputBase();
+  const checks = [
+    // Older instance listed FIRST: if a naive .find()/first-match picked
+    // this one, its completedAt would land inside the stale marker's own
+    // window and wrongly block.
+    {
+      name: DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+      state: 'SUCCESS',
+      completedAt: '2026-05-11T23:20:00Z',
+    },
+    // Newer instance (a genuine rerun), deduplicated-selected as "latest":
+    // completed AFTER the stale marker's own expiry, so it must NOT block.
+    {
+      name: DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+      state: 'SUCCESS',
+      completedAt: '2026-05-11T23:50:00Z',
+    },
+    ...(inputWithHelper.checks ?? []).filter(
+      (check) => check.name !== DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+    ),
+  ];
+  const marker = selfWaiverMarkerComment({
+    id: 'self-waiver-dedup',
+    claimId: 'claim-123',
+    expiresAt: '2026-05-11T23:30:00Z',
+    runId: '4242',
+    createdAt: '2026-05-11T22:00:00Z',
+  });
+  const summary = buildPreMergeReadinessSummary(
+    {
+      ...inputWithHelper,
+      checks,
+      comments: [...(inputWithHelper.comments ?? []), marker],
+    },
+    selfWaiverOptions({ autoWaiverRunVerified: { '4242': true } }),
+  );
+  assert.equal(staleSelfWaiverOf(summary).stale, false);
+  assert.equal(selfWaiverBlockers(summary).length, 0);
+});
+
+test('#2911 dedup-rewrite asymmetry: a still-PENDING newest instance wins dedup over an older SUCCESS, so the pass-equivalent check never even runs', () => {
+  const inputWithHelper = selfWaiverInputBase();
+  const checks = [
+    {
+      name: DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+      state: 'SUCCESS',
+      completedAt: '2026-05-11T23:20:00Z',
+    },
+    {
+      name: DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+      state: 'PENDING',
+    },
+    ...(inputWithHelper.checks ?? []).filter(
+      (check) => check.name !== DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+    ),
+  ];
+  const marker = selfWaiverMarkerComment({
+    id: 'self-waiver-pending-dedup',
+    claimId: 'claim-123',
+    expiresAt: '2026-05-13T00:00:00Z',
+    runId: '4242',
+    createdAt: '2026-05-11T22:00:00Z',
+  });
+  const summary = buildPreMergeReadinessSummary(
+    {
+      ...inputWithHelper,
+      checks,
+      comments: [...(inputWithHelper.comments ?? []), marker],
+    },
+    selfWaiverOptions({ autoWaiverRunVerified: { '4242': true } }),
+  );
+  assert.equal(staleSelfWaiverOf(summary).stale, false);
+});
+
+test('#2911 dedup-rewrite asymmetry (documented, intentional): a SUCCESS selected instance with an unparseable completedAt still fails closed to stale', () => {
+  const base = withSelfWaiverCheckState(selfWaiverInputBase(), 'SUCCESS');
+  const marker = selfWaiverMarkerComment({
+    id: 'self-waiver-unparseable-completed-at',
+    claimId: 'claim-123',
+    expiresAt: '2026-05-11T23:30:00Z',
+    runId: '4242',
+    createdAt: '2026-05-11T22:00:00Z',
+  });
+  const summary = buildPreMergeReadinessSummary(
+    { ...base, comments: [...(base.comments ?? []), marker] },
+    selfWaiverOptions({ autoWaiverRunVerified: { '4242': true } }),
+  );
+  assert.equal(staleSelfWaiverOf(summary).stale, true);
+  assert.equal(staleSelfWaiverOf(summary).reason, 'expired');
+});
+
+test('#2911 finding 5/round 15 (Codex P2): a same-claim heartbeat after the rerun moves activeClaim.createdAt forward, but claimIdentityInstalledAt stays anchored on the original claim and never false-positives', () => {
+  const base = withSelfWaiverCheckState(
+    selfWaiverInputBase(),
+    'SUCCESS',
+    '2026-05-11T23:00:00Z',
+  );
+  const claimEvents = [
+    {
+      body: renderClaimedByMarker({
+        agentId: 'github-copilot-cli',
+        claimId: 'claim-123',
+        supersedes: 'none',
+        timestamp: '2026-05-11T22:00:00Z',
+        branch: 'issue/309-pre-merge-readiness',
+      }),
+      createdAt: '2026-05-11T22:00:00Z',
+      author: { login: 'kurone-kito' },
+    },
+    {
+      body: renderClaimedByMarker({
+        agentId: 'github-copilot-cli',
+        claimId: 'claim-123',
+        supersedes: 'none',
+        timestamp: '2026-05-11T23:50:00Z',
+        branch: 'issue/309-pre-merge-readiness',
+      }),
+      createdAt: '2026-05-11T23:50:00Z',
+      author: { login: 'kurone-kito' },
+    },
+  ];
+  const marker = selfWaiverMarkerComment({
+    id: 'self-waiver-heartbeat',
+    claimId: 'some-other-claim',
+    expiresAt: '2026-05-13T00:00:00Z',
+    runId: '4242',
+    createdAt: '2026-05-11T21:00:00Z',
+  });
+  const summary = buildPreMergeReadinessSummary(
+    {
+      ...base,
+      claimEvents,
+      comments: [...(base.comments ?? []), marker],
+    },
+    selfWaiverOptions({ autoWaiverRunVerified: { '4242': true } }),
+  );
+  // The mutable heartbeat clock moved to 23:50; the non-mutable transition
+  // anchor must stay at the original 22:00 claim.
+  assert.equal(activeClaimCreatedAtOf(summary), '2026-05-11T23:50:00Z');
+  assert.equal(claimIdentityInstalledAtOf(summary), '2026-05-11T22:00:00Z');
+  assert.equal(staleSelfWaiverOf(summary).stale, false);
+});
+
+test('#2911 claim-identity transition anchor: a release followed by a fresh re-claim moves claimIdentityInstalledAt to the re-claim, not the original claim or the release', () => {
+  const claimEvents = [
+    {
+      body: renderClaimedByMarker({
+        agentId: 'github-copilot-cli',
+        claimId: 'claim-123',
+        supersedes: 'none',
+        timestamp: '2026-05-11T20:00:00Z',
+        branch: 'issue/309-pre-merge-readiness',
+      }),
+      createdAt: '2026-05-11T20:00:00Z',
+      author: { login: 'kurone-kito' },
+    },
+    {
+      body: renderUnclaimedByMarker({
+        agentId: 'github-copilot-cli',
+        claimId: 'claim-123',
+        timestamp: '2026-05-11T21:00:00Z',
+      }),
+      createdAt: '2026-05-11T21:00:00Z',
+      author: { login: 'kurone-kito' },
+    },
+    {
+      body: renderClaimedByMarker({
+        agentId: 'github-copilot-cli-2',
+        claimId: 'claim-456',
+        supersedes: 'none',
+        timestamp: '2026-05-11T22:00:00Z',
+        branch: 'issue/309-pre-merge-readiness',
+      }),
+      createdAt: '2026-05-11T22:00:00Z',
+      author: { login: 'kurone-kito' },
+    },
+  ];
+  const base = selfWaiverInputBase();
+  const summary = buildPreMergeReadinessSummary(
+    { ...base, claimEvents },
+    selfWaiverOptions({
+      expectedClaimId: 'claim-456',
+      expectedAgentId: 'github-copilot-cli-2',
+    }),
+  );
+  assert.equal(claimIdentityInstalledAtOf(summary), '2026-05-11T22:00:00Z');
+});
+
+test('#2911 finding 6/round 15 (Copilot, decisive): touchesSelfReferentialAllowlist false suppresses the blocker even for an otherwise-stale, run-verified marker', () => {
+  const base = withSelfWaiverCheckState(
+    selfWaiverInputBase(),
+    'SUCCESS',
+    '2026-05-11T23:25:00Z',
+  );
+  const marker = selfWaiverMarkerComment({
+    id: 'self-waiver-no-allowlist-touch',
+    claimId: 'claim-123',
+    expiresAt: '2026-05-11T23:30:00Z',
+    runId: '4242',
+    createdAt: '2026-05-11T23:10:00Z',
+  });
+  const summary = buildPreMergeReadinessSummary(
+    { ...base, comments: [...(base.comments ?? []), marker] },
+    selfWaiverOptions({
+      touchesSelfReferentialAllowlist: false,
+      autoWaiverRunVerified: { '4242': true },
+    }),
+  );
+  assert.equal(staleSelfWaiverOf(summary).stale, false);
+  assert.equal(selfWaiverBlockers(summary).length, 0);
+});
+
+test('#2911 finding 6/round 15 (Copilot, decisive): an unverified run (forged or unresolvable citation) suppresses the blocker -- fail-open for staleness, the safe direction', () => {
+  const base = withSelfWaiverCheckState(
+    selfWaiverInputBase(),
+    'SUCCESS',
+    '2026-05-11T23:25:00Z',
+  );
+  const marker = selfWaiverMarkerComment({
+    id: 'self-waiver-unverified-run',
+    claimId: 'claim-123',
+    expiresAt: '2026-05-11T23:30:00Z',
+    runId: '4242',
+    createdAt: '2026-05-11T23:10:00Z',
+  });
+  const summaryFalse = buildPreMergeReadinessSummary(
+    { ...base, comments: [...(base.comments ?? []), marker] },
+    selfWaiverOptions({ autoWaiverRunVerified: { '4242': false } }),
+  );
+  assert.equal(staleSelfWaiverOf(summaryFalse).stale, false);
+
+  const summaryAbsent = buildPreMergeReadinessSummary(
+    { ...base, comments: [...(base.comments ?? []), marker] },
+    selfWaiverOptions({}),
+  );
+  assert.equal(staleSelfWaiverOf(summaryAbsent).stale, false);
+});
+
+test('#2911 (self-critique, mode/waivable gate): an otherwise-stale marker never blocks while ciGate.externalCheckWaivers.mode is not maintainer-authorized (the schema default)', () => {
+  const base = withSelfWaiverCheckState(
+    selfWaiverInputBase(),
+    'SUCCESS',
+    '2026-05-11T23:25:00Z',
+  );
+  const marker = selfWaiverMarkerComment({
+    id: 'self-waiver-mode-disabled',
+    claimId: 'claim-123',
+    expiresAt: '2026-05-11T23:30:00Z',
+    runId: '4242',
+    createdAt: '2026-05-11T23:10:00Z',
+  });
+  const summary = buildPreMergeReadinessSummary(
+    { ...base, comments: [...(base.comments ?? []), marker] },
+    selfWaiverOptions({
+      autoWaiverRunVerified: { '4242': true },
+      externalCheckWaiverMode: 'disabled',
+    }),
+  );
+  assert.equal(staleSelfWaiverOf(summary).stale, false);
+  assert.equal(selfWaiverBlockers(summary).length, 0);
+});
+
+test('#2911 (self-critique, mode/waivable gate): an otherwise-stale marker never blocks when the selector is not on the configured waivable-check surface', () => {
+  const base = withSelfWaiverCheckState(
+    selfWaiverInputBase(),
+    'SUCCESS',
+    '2026-05-11T23:25:00Z',
+  );
+  const marker = selfWaiverMarkerComment({
+    id: 'self-waiver-not-waivable',
+    claimId: 'claim-123',
+    expiresAt: '2026-05-11T23:30:00Z',
+    runId: '4242',
+    createdAt: '2026-05-11T23:10:00Z',
+  });
+  const summary = buildPreMergeReadinessSummary(
+    { ...base, comments: [...(base.comments ?? []), marker] },
+    selfWaiverOptions({
+      autoWaiverRunVerified: { '4242': true },
+      waivableCheckSelectors: [{ selector: 'lint', matchMode: 'exact' }],
+    }),
+  );
+  assert.equal(staleSelfWaiverOf(summary).stale, false);
+  assert.equal(selfWaiverBlockers(summary).length, 0);
+});
+
+test('#2911: an otherwise-stale marker blocks when mode is explicitly maintainer-authorized and the selector is configured waivable', () => {
+  const base = withSelfWaiverCheckState(
+    selfWaiverInputBase(),
+    'SUCCESS',
+    '2026-05-11T23:25:00Z',
+  );
+  const marker = selfWaiverMarkerComment({
+    id: 'self-waiver-mode-open',
+    claimId: 'claim-123',
+    expiresAt: '2026-05-11T23:30:00Z',
+    runId: '4242',
+    createdAt: '2026-05-11T23:10:00Z',
+  });
+  const summary = buildPreMergeReadinessSummary(
+    { ...base, comments: [...(base.comments ?? []), marker] },
+    selfWaiverOptions({
+      autoWaiverRunVerified: { '4242': true },
+      externalCheckWaiverMode: 'maintainer-authorized',
+      waivableCheckSelectors: [
+        {
+          selector: DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+          matchMode: 'exact',
+        },
+      ],
+    }),
+  );
+  assert.equal(staleSelfWaiverOf(summary).stale, true);
+  assert.equal(selfWaiverBlockers(summary).length, 1);
+});
+
+test('#2911 claimless: an active-claim-bound wrongClaim marker fails closed to stale when no claim identity ever resolves (claimIdentityInstalledAt is empty)', () => {
+  const base = withSelfWaiverCheckState(
+    selfWaiverInputBase(),
+    'SUCCESS',
+    '2026-05-11T23:25:00Z',
+  );
+  const marker = selfWaiverMarkerComment({
+    id: 'self-waiver-claimless',
+    claimId: 'some-claim',
+    expiresAt: '2026-05-13T00:00:00Z',
+    runId: '4242',
+    createdAt: '2026-05-11T23:10:00Z',
+  });
+  const summary = buildPreMergeReadinessSummary(
+    { ...base, claimEvents: [], comments: [...(base.comments ?? []), marker] },
+    selfWaiverOptions({
+      claimless: true,
+      autoWaiverRunVerified: { '4242': true },
+    }),
+  );
+  assert.equal(claimIdentityInstalledAtOf(summary), '');
+  assert.equal(staleSelfWaiverOf(summary).stale, true);
+  assert.equal(staleSelfWaiverOf(summary).reason, 'wrong-claim');
 });

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -10407,3 +10407,109 @@ test("#2911 (Codex review, PR #2915, P1): a claim handoff landing between the ru
   assert.equal(staleSelfWaiverOf(summary).stale, true);
   assert.equal(staleSelfWaiverOf(summary).reason, 'wrong-claim');
 });
+
+test('#2911 (Codex review, PR #2915, round 7, P1): a run started at the EXACT same instant a claim handoff installed is still wrong-claim-stale -- a tie is no evidence the run started after the handoff', () => {
+  const claimEvents = [
+    {
+      body: renderClaimedByMarker({
+        agentId: 'github-copilot-cli',
+        claimId: 'claim-123',
+        supersedes: 'none',
+        timestamp: '2026-05-11T20:00:00Z',
+        branch: 'issue/309-pre-merge-readiness',
+      }),
+      createdAt: '2026-05-11T20:00:00Z',
+      author: { login: 'kurone-kito' },
+    },
+    {
+      body: renderUnclaimedByMarker({
+        agentId: 'github-copilot-cli',
+        claimId: 'claim-123',
+        timestamp: '2026-05-11T21:00:00Z',
+      }),
+      createdAt: '2026-05-11T21:00:00Z',
+      author: { login: 'kurone-kito' },
+    },
+    {
+      body: renderClaimedByMarker({
+        agentId: 'github-copilot-cli-2',
+        claimId: 'claim-456',
+        supersedes: 'none',
+        timestamp: '2026-05-11T22:00:00Z',
+        branch: 'issue/309-pre-merge-readiness',
+      }),
+      createdAt: '2026-05-11T22:00:00Z',
+      author: { login: 'kurone-kito' },
+    },
+  ];
+  const fixture = selfWaiverInputBase();
+  const checks = (fixture.checks ?? []).map((check) =>
+    check.name === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR
+      ? {
+          ...check,
+          state: 'SUCCESS',
+          // startedAt serializes to the EXACT same instant claim-456
+          // installs -- there is no positive evidence the run's own
+          // evidence-fetch happened after the handoff rather than
+          // immediately before it in the same timestamp interval.
+          startedAt: '2026-05-11T22:00:00Z',
+          completedAt: '2026-05-11T22:30:00Z',
+        }
+      : check,
+  );
+  const base = { ...fixture, checks };
+  const marker = selfWaiverMarkerComment({
+    id: 'self-waiver-tied-handoff',
+    claimId: 'claim-123',
+    expiresAt: '2026-05-11T23:00:00Z',
+    runId: '5253',
+    createdAt: '2026-05-11T21:00:00Z',
+  });
+  const summary = buildPreMergeReadinessSummary(
+    { ...base, claimEvents, comments: [...(base.comments ?? []), marker] },
+    selfWaiverOptions({
+      expectedClaimId: 'claim-456',
+      expectedAgentId: 'github-copilot-cli-2',
+      autoWaiverRunVerified: { '5253': true },
+    }),
+  );
+  assert.equal(claimIdentityInstalledAtOf(summary), '2026-05-11T22:00:00Z');
+  assert.equal(staleSelfWaiverOf(summary).stale, true);
+  assert.equal(staleSelfWaiverOf(summary).reason, 'wrong-claim');
+});
+
+test("#2911 (Codex review, PR #2915, round 7, P2): a marker that expires mid-run, before the run's slower completedAt but after its own startedAt, still counts as having covered the pass it correlates to", () => {
+  const base = selfWaiverInputBase();
+  const checks = (base.checks ?? []).map((check) =>
+    check.name === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR
+      ? {
+          ...check,
+          state: 'SUCCESS',
+          // The run's own evidence-fetch happens near startedAt
+          // (21:00), while the marker below is still valid -- it only
+          // expires (21:30) before the run's slower completedAt
+          // (22:00). Anchoring the upper bound on completedAt alone
+          // would wrongly treat this as "expired before the pass" and
+          // suppress the blocker entirely.
+          startedAt: '2026-05-11T21:00:00Z',
+          completedAt: '2026-05-11T22:00:00Z',
+        }
+      : check,
+  );
+  // Same claim throughout (matches the fixture's default
+  // expectedClaimId/activeClaimId) so this marker is classified purely
+  // by expiry (the `expired` bucket), never `wrongClaim`.
+  const marker = selfWaiverMarkerComment({
+    id: 'self-waiver-expired-mid-run',
+    claimId: 'claim-123',
+    expiresAt: '2026-05-11T21:30:00Z',
+    runId: '5254',
+    createdAt: '2026-05-11T20:00:00Z',
+  });
+  const summary = buildPreMergeReadinessSummary(
+    { ...base, checks, comments: [...(base.comments ?? []), marker] },
+    selfWaiverOptions({ autoWaiverRunVerified: { '5254': true } }),
+  );
+  assert.equal(staleSelfWaiverOf(summary).stale, true);
+  assert.equal(staleSelfWaiverOf(summary).reason, 'expired');
+});

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -6272,6 +6272,49 @@ test('waiverEvidence with wrong-shape valid item fails schema validation', () =>
   );
 });
 
+test('waiverEvidence.expired/wrongClaim items validate with the actual runtime shape (kurone-kito/idd-skill#2911, Codex review, PR #2915, P1): pins reason/runId/createdAt against schema drift', () => {
+  // kurone-kito/idd-skill#2911 originally added `reason`/`runId` (and
+  // later `createdAt`) to `ExternalCheckWaiverEvidence`'s `expired`/
+  // `wrongClaim` item shape -- populated for EVERY marker that lands in
+  // those buckets, not only self-referential ones, so this is reachable
+  // through the ordinary, always-emitted `waiverEvidence` field (unlike
+  // `autoWaiverEvidence`, deliberately never emitted -- see that
+  // decision's own doc comment in protocol-helpers.mts). The schema's
+  // own `additionalProperties: false` on these item shapes previously
+  // drifted out of sync with a runtime field addition once already
+  // (`createdAt` shipped in the runtime type without a matching schema
+  // update) -- this test constructs the actual runtime item shape
+  // directly, rather than relying on any one evidence-routing scenario
+  // to happen to produce a non-empty bucket, so it stays a reliable
+  // regression guard regardless of which code path is exercised.
+  const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
+  const summary = buildPreMergeReadinessSummary(fixture.input, fixture.options);
+  const withExpiredItem = JSON.parse(JSON.stringify(summary));
+  withExpiredItem.waiverEvidence.expired = [
+    {
+      authorLogin: 'some-bot[bot]',
+      checkSelector: 'CodeRabbit',
+      expiresAt: '2026-05-11T23:30:00Z',
+      reason: 'maintainer-authorized',
+      runId: '',
+      createdAt: '2026-05-11T23:10:00Z',
+    },
+  ];
+  assert.deepEqual(validate(withExpiredItem, readinessSchema), []);
+  const withWrongClaimItem = JSON.parse(JSON.stringify(summary));
+  withWrongClaimItem.waiverEvidence.wrongClaim = [
+    {
+      authorLogin: 'some-bot[bot]',
+      checkSelector: 'CodeRabbit',
+      waiverClaimId: 'claim-999',
+      reason: 'maintainer-authorized',
+      runId: '',
+      createdAt: '2026-05-11T23:10:00Z',
+    },
+  ];
+  assert.deepEqual(validate(withWrongClaimItem, readinessSchema), []);
+});
+
 // ---------------------------------------------------------------------------
 // resolveActiveClaimForWriteGate (#1058): the write-side merge-gate revalidator
 // must recognize an operator-approved forced-handoff successor's claim while

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -6310,6 +6310,7 @@ test('waiverEvidence.expired/wrongClaim items validate with the actual runtime s
       reason: 'maintainer-authorized',
       runId: '',
       createdAt: '2026-05-11T23:10:00Z',
+      expiresAt: '2026-05-11T23:30:00Z',
     },
   ];
   assert.deepEqual(validate(withWrongClaimItem, readinessSchema), []);
@@ -10248,5 +10249,76 @@ test('#2911 (Codex review, PR #2915, P1, fresh evidence against the type-only fi
     },
     selfWaiverOptions({ autoWaiverRunVerified: { '8181': true } }),
   );
+  assert.equal(staleSelfWaiverOf(summary).stale, false);
+});
+
+test('#2911 (Codex review, PR #2915, P2): a wrongClaim marker that already expired BEFORE the check completed cannot retroactively justify that pass, even though the claim identity later changed again', () => {
+  // Same release -> re-claim shape as the claim-identity-transition-anchor
+  // test above: claim-123 claimed 20:00, released 21:00, claim-456
+  // claimed 22:00 -- so claimIdentityInstalledAt is 22:00, genuinely
+  // AFTER the check's own pass below (this is the load-bearing setup
+  // detail: without it, the wrongClaim branch never fires at all,
+  // pre-fix or post-fix, and this test would prove nothing).
+  const claimEvents = [
+    {
+      body: renderClaimedByMarker({
+        agentId: 'github-copilot-cli',
+        claimId: 'claim-123',
+        supersedes: 'none',
+        timestamp: '2026-05-11T20:00:00Z',
+        branch: 'issue/309-pre-merge-readiness',
+      }),
+      createdAt: '2026-05-11T20:00:00Z',
+      author: { login: 'kurone-kito' },
+    },
+    {
+      body: renderUnclaimedByMarker({
+        agentId: 'github-copilot-cli',
+        claimId: 'claim-123',
+        timestamp: '2026-05-11T21:00:00Z',
+      }),
+      createdAt: '2026-05-11T21:00:00Z',
+      author: { login: 'kurone-kito' },
+    },
+    {
+      body: renderClaimedByMarker({
+        agentId: 'github-copilot-cli-2',
+        claimId: 'claim-456',
+        supersedes: 'none',
+        timestamp: '2026-05-11T22:00:00Z',
+        branch: 'issue/309-pre-merge-readiness',
+      }),
+      createdAt: '2026-05-11T22:00:00Z',
+      author: { login: 'kurone-kito' },
+    },
+  ];
+  const base = withSelfWaiverCheckState(
+    selfWaiverInputBase(),
+    'SUCCESS',
+    // The check's own genuine pass -- AFTER the marker below already
+    // expired (19:30), but BEFORE claim-456 is installed (22:00).
+    '2026-05-11T20:30:00Z',
+  );
+  // Posted under claim-123 (the OLD claim), and already expired by
+  // 19:30 -- well before the 20:30 pass this test's marker must never
+  // be blamed for.
+  const marker = selfWaiverMarkerComment({
+    id: 'self-waiver-wrongclaim-already-expired',
+    claimId: 'claim-123',
+    expiresAt: '2026-05-11T19:30:00Z',
+    runId: '9191',
+    createdAt: '2026-05-11T19:00:00Z',
+  });
+  const summary = buildPreMergeReadinessSummary(
+    { ...base, claimEvents, comments: [...(base.comments ?? []), marker] },
+    selfWaiverOptions({
+      expectedClaimId: 'claim-456',
+      expectedAgentId: 'github-copilot-cli-2',
+      autoWaiverRunVerified: { '9191': true },
+    }),
+  );
+  // Sanity-check the load-bearing setup detail before asserting on the
+  // fix itself: claimIdentityInstalledAt genuinely postdates the pass.
+  assert.equal(claimIdentityInstalledAtOf(summary), '2026-05-11T22:00:00Z');
   assert.equal(staleSelfWaiverOf(summary).stale, false);
 });

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -10061,3 +10061,58 @@ test("#2911 (Codex review, PR #2915, P1): a fresher pass from a DIFFERENT produc
   assert.equal(staleSelfWaiverOf(summary).reason, 'expired');
   assert.equal(selfWaiverBlockers(summary).length, 1);
 });
+
+test('#2911 (CodeRabbit + Copilot review, PR #2915, Major): a DIFFERENT-selector marker that reuses an already-verified run-id is never trusted as evidence for idd-advisory-convergence', () => {
+  const base = withSelfWaiverCheckState(
+    selfWaiverInputBase(),
+    'SUCCESS',
+    '2026-05-11T23:25:00Z',
+  );
+  const foreignSelectorMarker = {
+    id: 'self-waiver-foreign-selector',
+    author: { login: 'github-actions[bot]' },
+    body: renderExternalCheckWaiverComment({
+      agentId: 'idd-advisory-convergence-self-waiver',
+      claimId: 'claim-123',
+      headSha: SELF_WAIVER_HEAD_SHA,
+      checkSelector: 'some-other-check',
+      reason: SELF_REFERENTIAL_BOOTSTRAP_AUTO_REASON,
+      expiresAt: '2026-05-11T23:30:00Z',
+      runId: '5151',
+    }),
+    createdAt: '2026-05-11T23:10:00Z',
+    updatedAt: '2026-05-11T23:10:00Z',
+  };
+  const summary = buildPreMergeReadinessSummary(
+    { ...base, comments: [...(base.comments ?? []), foreignSelectorMarker] },
+    // The run-id IS genuinely verified -- just for a marker that claims a
+    // different check selector. Reusing that verification for
+    // idd-advisory-convergence's own stale check would be the bug.
+    selfWaiverOptions({ autoWaiverRunVerified: { '5151': true } }),
+  );
+  assert.equal(staleSelfWaiverOf(summary).stale, false);
+});
+
+test('#2911 (Copilot review, PR #2915): a marker CREATED after the check already passed cannot retroactively justify that pass, even when its expiresAt is later', () => {
+  const base = withSelfWaiverCheckState(
+    selfWaiverInputBase(),
+    'SUCCESS',
+    '2026-05-11T23:25:00Z',
+  );
+  const marker = selfWaiverMarkerComment({
+    id: 'self-waiver-created-after-pass',
+    claimId: 'claim-123',
+    // expiresAt alone (naive upper-bound-only check) would satisfy the
+    // old logic -- it's after the check's own completedAt (23:25).
+    expiresAt: '2026-05-11T23:40:00Z',
+    runId: '6161',
+    // But this marker was CREATED after the check already passed, so it
+    // could never have justified that earlier pass.
+    createdAt: '2026-05-11T23:26:00Z',
+  });
+  const summary = buildPreMergeReadinessSummary(
+    { ...base, comments: [...(base.comments ?? []), marker] },
+    selfWaiverOptions({ autoWaiverRunVerified: { '6161': true } }),
+  );
+  assert.equal(staleSelfWaiverOf(summary).stale, false);
+});

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -10206,3 +10206,47 @@ test('#2911 (Codex review, PR #2915, P1, fresh evidence against the producer-gro
   );
   assert.equal(staleSelfWaiverOf(summary).stale, false);
 });
+
+test('#2911 (Codex review, PR #2915, P1, fresh evidence against the type-only filter): an unrelated Actions workflow publishing a check-run under the identical name never causes a false positive, even while the real checker workflow is genuinely fresh', () => {
+  const base = withSelfWaiverCheckState(
+    selfWaiverInputBase(),
+    // The REAL convergence workflow's own instance: fresh, no marker
+    // needed for it at all.
+    'SUCCESS',
+    '2026-05-11T23:55:00Z',
+  );
+  // A second, unrelated Actions workflow that happens to publish a
+  // check-run under the exact same `idd-advisory-convergence` name --
+  // type: 'check-run' alone (pre this fix) would let this producer
+  // through, and its own older instance can independently trigger a
+  // false `stale` regardless of the real checker's fresh state.
+  const checksWithDecoyWorkflowProducer = [
+    ...(base.checks ?? []),
+    {
+      name: DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+      state: 'SUCCESS',
+      completedAt: '2026-05-11T20:00:00Z',
+      type: 'check-run',
+      workflowName: 'Some Other Workflow',
+    },
+  ];
+  const withDecoyWorkflowProducer = {
+    ...base,
+    checks: checksWithDecoyWorkflowProducer,
+  };
+  const marker = selfWaiverMarkerComment({
+    id: 'self-waiver-decoy-workflow',
+    claimId: 'claim-123',
+    expiresAt: '2026-05-11T21:00:00Z',
+    runId: '8181',
+    createdAt: '2026-05-11T19:00:00Z',
+  });
+  const summary = buildPreMergeReadinessSummary(
+    {
+      ...withDecoyWorkflowProducer,
+      comments: [...(withDecoyWorkflowProducer.comments ?? []), marker],
+    },
+    selfWaiverOptions({ autoWaiverRunVerified: { '8181': true } }),
+  );
+  assert.equal(staleSelfWaiverOf(summary).stale, false);
+});

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -9519,7 +9519,18 @@ function withSelfWaiverCheckState(
     check.name === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR
       ? completedAt === undefined
         ? { name: check.name, state }
-        : { ...check, state, completedAt }
+        : // kurone-kito/idd-skill#2911 (Codex review, PR #2915, P1):
+          // also pins `startedAt` to `completedAt` here -- the base
+          // fixture's own `startedAt` (from
+          // `withAdvisoryConvergenceRequiredCheck`) is a fixed value
+          // unrelated to any given test's own `completedAt`, and once
+          // `passingStartedAtMs` became a real comparison anchor (see
+          // that variable's own doc comment), an unrelated leftover
+          // `startedAt` could silently change a test's outcome. Callers
+          // that need a genuinely distinct `startedAt`/`completedAt`
+          // pair (to exercise that exact race) build their own check
+          // object directly instead of using this helper.
+          { ...check, state, completedAt, startedAt: completedAt }
       : check,
   );
   return { ...input, checks };
@@ -10321,4 +10332,78 @@ test('#2911 (Codex review, PR #2915, P2): a wrongClaim marker that already expir
   // fix itself: claimIdentityInstalledAt genuinely postdates the pass.
   assert.equal(claimIdentityInstalledAtOf(summary), '2026-05-11T22:00:00Z');
   assert.equal(staleSelfWaiverOf(summary).stale, false);
+});
+
+test("#2911 (Codex review, PR #2915, P1): a claim handoff landing between the run's startedAt and completedAt still counts as wrong-claim-stale, even though completedAt alone reads after the handoff", () => {
+  // The run STARTS (and fetches its comment/waiver evidence) while
+  // claim-123 is still active, but doesn't COMPLETE until after
+  // claim-456 is installed -- the exact race this finding is about.
+  const claimEvents = [
+    {
+      body: renderClaimedByMarker({
+        agentId: 'github-copilot-cli',
+        claimId: 'claim-123',
+        supersedes: 'none',
+        timestamp: '2026-05-11T20:00:00Z',
+        branch: 'issue/309-pre-merge-readiness',
+      }),
+      createdAt: '2026-05-11T20:00:00Z',
+      author: { login: 'kurone-kito' },
+    },
+    {
+      body: renderUnclaimedByMarker({
+        agentId: 'github-copilot-cli',
+        claimId: 'claim-123',
+        timestamp: '2026-05-11T21:00:00Z',
+      }),
+      createdAt: '2026-05-11T21:00:00Z',
+      author: { login: 'kurone-kito' },
+    },
+    {
+      body: renderClaimedByMarker({
+        agentId: 'github-copilot-cli-2',
+        claimId: 'claim-456',
+        supersedes: 'none',
+        timestamp: '2026-05-11T22:00:00Z',
+        branch: 'issue/309-pre-merge-readiness',
+      }),
+      createdAt: '2026-05-11T22:00:00Z',
+      author: { login: 'kurone-kito' },
+    },
+  ];
+  const fixture = selfWaiverInputBase();
+  const checks = (fixture.checks ?? []).map((check) =>
+    check.name === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR
+      ? {
+          ...check,
+          state: 'SUCCESS',
+          // Started BEFORE the 22:00 handoff, completed AFTER it --
+          // `completedAt` alone would read as "fresh" (>= 22:00), but
+          // the run's own evidence-fetch happened under claim-123.
+          startedAt: '2026-05-11T21:30:00Z',
+          completedAt: '2026-05-11T22:30:00Z',
+        }
+      : check,
+  );
+  const base = { ...fixture, checks };
+  // Covers the 22:30 pass within its own window, so the createdAt/
+  // expiresAt bounds (unaffected by this fix) don't exclude it.
+  const marker = selfWaiverMarkerComment({
+    id: 'self-waiver-started-before-handoff',
+    claimId: 'claim-123',
+    expiresAt: '2026-05-11T23:00:00Z',
+    runId: '5252',
+    createdAt: '2026-05-11T21:00:00Z',
+  });
+  const summary = buildPreMergeReadinessSummary(
+    { ...base, claimEvents, comments: [...(base.comments ?? []), marker] },
+    selfWaiverOptions({
+      expectedClaimId: 'claim-456',
+      expectedAgentId: 'github-copilot-cli-2',
+      autoWaiverRunVerified: { '5252': true },
+    }),
+  );
+  assert.equal(claimIdentityInstalledAtOf(summary), '2026-05-11T22:00:00Z');
+  assert.equal(staleSelfWaiverOf(summary).stale, true);
+  assert.equal(staleSelfWaiverOf(summary).reason, 'wrong-claim');
 });

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -604,6 +604,8 @@ export const preMergeReadinessKeys = [
   'dispositionEvidence',
   'waiverEvidence',
   'advisoryConvergenceWaiverPrecondition',
+  'claimIdentityInstalledAt',
+  'staleSelfWaiver',
   'branchCurrency',
   'trustedMarkerActors',
   'trustedMarkerActorsSource',
@@ -1440,6 +1442,14 @@ const preMergeReadinessFixture = {
     deadlinePassed: false,
     terminalUnavailable: false,
     open: false,
+  },
+  claimIdentityInstalledAt: '2026-05-11T23:20:00Z',
+  staleSelfWaiver: {
+    stale: false,
+    checkSelector: 'idd-advisory-convergence',
+    reason: null,
+    expiresAt: '',
+    waiverClaimId: '',
   },
   branchCurrency: {
     mergeStateStatus: 'CLEAN',


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

A PR that edits the advisory-convergence checker itself can carry a
`self-referential-bootstrap-auto` waiver comment that
`github-actions[bot]` posts to escape the bootstrap chicken-and-egg
problem. That marker can go stale (expire, or become claim-invalid
across a genuine claim handoff) after the required
`idd-advisory-convergence` check has already posted a passing
conclusion it helped justify. GitHub never reruns an already-successful
check merely because its supporting comment stops being valid, so a
stale marker could let a PR merge on a pass that no longer reflects a
genuine advisory review or a fresh waiver.

This re-implements the merge-time blocker `9ecc9954`/`863c5249`/
`337f4369` introduced and PR #2895's review then retired across three
further rounds (this issue's own six "Findings"), fixing every root
cause in one pass instead of live-patching the call site again:

- Deduplicates the newest check instance (`selectLatestCheckInstance`)
  instead of a raw `.find()` over a possibly multi-instance check list.
- Scans both the `expired` and `wrongClaim` waiver buckets.
- Anchors the `wrongClaim` comparison to a new non-mutable
  `claimIdentityInstalledAt` field (captured once at the claim-identity
  transition), never the mutable `activeClaim.createdAt` heartbeat
  clock.
- For the decisive Copilot finding: only trusts a candidate marker
  after `verifySelfReferentialBootstrapWaiverRun` (exported and reused
  verbatim from `advisory-convergence.mts`, not reimplemented) confirms
  the cited run's shape, **and** the PR's own diff independently
  touches the checker allowlist. Without both checks, a
  same-repository `pull_request`-triggered workflow could cite an
  unrelated real run to forge a marker that blocks a completely
  unrelated PR's merge.

The new check reads this call site's own already-computed
`autoWaiverEvidence.valid` bucket only as a time-window correlation
against the passing check's `completedAt`, to avoid flagging a genuine
rerun that a fresh valid marker already covers (acceptance criterion
2). It never uses `valid` evidence to satisfy or relax the overall
gate — the ADD-only contract `allowSelfReferentialBootstrapAuto`'s
existing two call sites protect is about that direction, and this
third call site only ever adds a blocker. The whole computation is
gated on the same mode-open/selector-waivable preconditions the
existing `autoWaiverValid` path implicitly enjoys, so an adopter
running with `ciGate.externalCheckWaivers.mode: disabled` sees no new
blocker.

An unverified or unresolvable run, or a PR that doesn't touch the
allowlist, fails **open** (suppresses the blocker) rather than closed
— deliberately, since Finding 6's own fix direction is to remove a
merge-denial vector, the opposite of this codebase's usual fail-closed
default elsewhere.

## Linked issue

Closes #2911

## Follow-up issues (if any)

- [x] #2912 — the residual bearer-evidence-vs-provenance gap (a cited
  run's metadata proves shape, not that it actually posted the marker
  comment citing it), worked concurrently in the same two files.
- [x] #2919 — Copilot's round-8 finding that check-instance producer
  identity (`workflowName`) is a display-name match, not a
  workflow-path/event-bound one; rejected as a round-9 patch here
  (the fix is shared infrastructure spanning `groupChecksByProducer`
  and the collector, also used by the primary required-check gate) and
  tracked there instead, along with three further findings the same
  review pass suppressed.

## Background / rationale (if material)

`autoWaiverEvidence` itself is intentionally **not** added to the
emitted `pre-merge-readiness` report: only the derived
`staleSelfWaiver` verdict is schema-locked, keeping the raw per-marker
bucket shape free to evolve without a fixture cascade across every
`fixtures/pre-merge-readiness/*.json` file.

This branch keeps its footprint inside `advisory-convergence.mts` to
two minimal, non-body edits (exporting the existing
`verifySelfReferentialBootstrapWaiverRun` verification function, and a
call-site-count comment bump) specifically to minimize overlap with
#2912, which is being worked concurrently against the same two files
(`advisory-convergence.mts` / `protocol-helpers.mts`). `main` was
re-checked immediately before this PR's rebase and #2912 had not yet
merged, so no conflict was present at push time — worth a second look
in review if #2912 lands first.

**Review-fix history.** Automated review (Codex, CodeRabbit, Copilot)
found several genuine precision gaps in the initial implementation
across eight follow-up commits: producer-identity (and later,
workflow-identity) isolation for the check-instance selection so an
unrelated CI producer sharing the check name can never mask or forge
a verdict; a marker-selection tie-break correction (newest-first, not
earliest-first, since this call site correlates against the
already-selected check instance rather than "now"); a `checkSelector`
guard closing a cross-check evidence-reuse gap; two-sided
`[createdAt, expiresAt]` window checks on both the `expired` and
`wrongClaim` buckets (the schema was updated to match in the same or
a following commit each time); anchoring the claim-handoff comparison
on the check run's own `startedAt` rather than its later `completedAt`
(including the exact-tie case); and anchoring both buckets' upper
(expiry) window bound on that same run-observation bound instead of
`completedAt`, per the interval-overlap model now documented above
`hasCoveringValidMarker`. Each fix carries its own regression test,
confirmed to fail against the pre-fix code before the fix landed. A
further architectural finding (check-instance producer identity's
depth) was dispositioned as **Rejected** with a follow-up issue (#2919)
rather than patched further — see that issue and the linked review
thread for the full reasoning.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (6152 tests, 0 fail as of the latest push — run
  repeatedly across the review-fix history above, locally under heavy
  concurrent-session load, ~20s-245s instead of the usual ~20s; hosted
  CI is authoritative)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passed with 3 pre-existing,
  unrelated warnings)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed — this branch adds a new
  ADD-only merge blocker; it never relaxes or satisfies the gate, and
  is gated on the same mode/waivable-selector preconditions the
  existing auto-waiver path already respects.
- [x] Context budget impact reviewed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013MS7r6EVLb1kWoNKnr2PG6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pre-merge readiness now reports when claim identity was installed.
  * Added detection and validation of self-referential advisory-convergence waivers.
  * Readiness results now identify stale waivers and provide selector, reason, expiration, and claim details.
  * Expired and wrong-claim waiver evidence now retains reason and run information.

* **Bug Fixes**
  * Added blockers when passing convergence checks rely on expired or invalid waivers without a rerun.

* **Tests**
  * Expanded coverage for waiver validation, forged metadata, reruns, and stale-waiver scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
