### PR TITLE
fix(idd-critique-telemetry-hook): deliver win32 stdin via a relay hop

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -137,7 +137,11 @@ jobs:
       # fix -- dropping the flag if the file-level hang no longer occurs
       # -- was confirmed live on native Windows 11: the full suite
       # (including every direct-await, real-detached-child test) now
-      # completes and exits naturally in ~28s with no flag, 40 passed / 1
-      # skipped (a POSIX-only fixture) / 0 failed / 0 hung.
+      # completes and exits naturally in ~28s with no flag, every test
+      # passing except the one POSIX-only fixture this suite always
+      # skips on win32 -- no hangs, no failures. Deliberately not
+      # pinning an exact pass count here: this suite's own test count
+      # keeps growing as later rounds add coverage, and a hard-coded
+      # number would drift stale again on the very next addition.
       - name: Run critique telemetry hook tests
         run: node --test tests/idd-critique-telemetry-hook.test.mts

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -124,21 +124,20 @@ jobs:
               process.exit(1);
             }
           '
-      # --test-force-exit (kurone-kito/idd-skill#2892, #2897 CI follow-up):
-      # this suite's direct-await tests spawn real detached win32 children,
-      # and at least one confirmed defect in that path (stuck stdin writes
-      # to a detached `cmd.exe`, tracked at kurone-kito/idd-skill#2910)
-      # leaves libuv handles the Node process never naturally drains,
-      # hanging `node --test` indefinitely on this runner even though every
-      # test itself has already completed and reported. This flag is
-      # Node's own documented mechanism for exactly that "tests are done
-      # but the process won't exit on its own" case; it does not change
-      # which tests run or their pass/fail outcome. Scoped to only this
-      # file/job rather than the shared `pre-push-validate` command
-      # (`.github/idd/config.json`): the same flag there would mask a
-      # future unrelated hang on any platform, and the added command-string
-      # bytes alone were enough to push the generated
-      # `idd-overview-core.instructions.md` doc over its enforced context-
-      # ceiling budget (#2897 CI follow-up, E10 critique pass).
+      # `--test-force-exit` (kurone-kito/idd-skill#2892, #2897 CI
+      # follow-up) used to be required here: this suite's direct-await
+      # tests spawn real detached win32 children, and a confirmed defect
+      # in that path (stuck stdin writes to a detached `cmd.exe`) left
+      # libuv handles the Node process never naturally drained, hanging
+      # `node --test` indefinitely on this runner even though every test
+      # itself had already completed and reported. kurone-kito/idd-skill
+      # #2910 fixed that underlying stdin-delivery defect (a win32-only
+      # relay hop replaces the direct `cmd.exe` spawn for the primary
+      # hook command), and this suite's own acceptance criterion for that
+      # fix -- dropping the flag if the file-level hang no longer occurs
+      # -- was confirmed live on native Windows 11: the full suite
+      # (including every direct-await, real-detached-child test) now
+      # completes and exits naturally in ~28s with no flag, 40 passed / 1
+      # skipped (a POSIX-only fixture) / 0 failed / 0 hung.
       - name: Run critique telemetry hook tests
-        run: node --test --test-force-exit tests/idd-critique-telemetry-hook.test.mts
+        run: node --test tests/idd-critique-telemetry-hook.test.mts

--- a/scripts/idd-critique-telemetry-hook.mjs
+++ b/scripts/idd-critique-telemetry-hook.mjs
@@ -97,8 +97,9 @@ const WIN32_RELAY_COMMAND_ENV =
   'IDD_CRITIQUE_TELEMETRY_HOOK_WIN32_RELAY_COMMAND';
 /**
  * win32-only relay script (kurone-kito/idd-skill#2910), run via
- * `spawnFn(process.execPath, ['-e', WIN32_RELAY_SCRIPT], {...})` in
- * {@link invokeCritiqueTelemetryHook} below -- mirrors this file's
+ * `spawnFn(process.execPath, ['--input-type=commonjs', '-e',
+ * WIN32_RELAY_SCRIPT], {...})` in {@link invokeCritiqueTelemetryHook}
+ * below -- mirrors this file's
  * existing precedent of inlining the watchdog's PowerShell script as a
  * string constant (see {@link spawnWatchdogWindows}). A single `${...}`
  * substitution (the env-var-name constant above) is all this template
@@ -408,12 +409,27 @@ export function invokeCritiqueTelemetryHook(command, payload, options) {
       // outright.
       child =
         platform === 'win32'
-          ? spawnFn(process.execPath, ['-e', WIN32_RELAY_SCRIPT], {
-              stdio: ['pipe', 'ignore', 'ignore'],
-              detached: true,
-              windowsHide: true,
-              env: { ...process.env, [WIN32_RELAY_COMMAND_ENV]: command },
-            })
+          ? spawnFn(
+              process.execPath,
+              // `--input-type=commonjs` (kurone-kito/idd-skill#2910
+              // review, Codex): explicit and load-bearing, not
+              // redundant with `-e`'s own CommonJS default. A caller
+              // whose own environment sets `NODE_OPTIONS=
+              // --input-type=module` -- inherited below via
+              // `...process.env` -- would otherwise make Node evaluate
+              // `WIN32_RELAY_SCRIPT` as ESM, where `require` is
+              // undefined and the relay throws before ever reading its
+              // stdin. Verified live: this flag overrides an
+              // inherited `--input-type=module` and is a no-op
+              // otherwise.
+              ['--input-type=commonjs', '-e', WIN32_RELAY_SCRIPT],
+              {
+                stdio: ['pipe', 'ignore', 'ignore'],
+                detached: true,
+                windowsHide: true,
+                env: { ...process.env, [WIN32_RELAY_COMMAND_ENV]: command },
+              },
+            )
           : spawnFn(command, {
               shell: true,
               stdio: ['pipe', 'ignore', 'ignore'],

--- a/scripts/idd-critique-telemetry-hook.mjs
+++ b/scripts/idd-critique-telemetry-hook.mjs
@@ -477,7 +477,26 @@ export function invokeCritiqueTelemetryHook(command, payload, options) {
         // WIN32_RELAY_SCRIPT's own doc comment for the full rationale
         // and why the original value still reaches the real target
         // command via a separate channel instead of being dropped.
-        const { NODE_OPTIONS: callerNodeOptions, ...relayEnv } = process.env;
+        //
+        // Case-insensitive key match (kurone-kito/idd-skill#2910 review,
+        // Copilot follow-up): Windows environment variable names are
+        // case-insensitive at the OS level, but a plain destructure
+        // (`const { NODE_OPTIONS, ...rest } = process.env`) only removes
+        // the exact-case key -- an inherited `Node_Options` or
+        // `node_options` entry (real-world precedent: Windows system
+        // variables like `ComSpec`/`Path` routinely keep non-canonical
+        // casing) would survive into `relayEnv` untouched and still let
+        // the relay load its preload code. Scan every key case-
+        // insensitively instead, keeping the last match's value (in
+        // practice at most one casing is ever actually set).
+        const relayEnv = { ...process.env };
+        let callerNodeOptions;
+        for (const key of Object.keys(relayEnv)) {
+          if (key.toUpperCase() === 'NODE_OPTIONS') {
+            callerNodeOptions = relayEnv[key];
+            delete relayEnv[key];
+          }
+        }
         child = spawnFn(
           process.execPath,
           // `--input-type=commonjs` (kurone-kito/idd-skill#2910 review,

--- a/scripts/idd-critique-telemetry-hook.mjs
+++ b/scripts/idd-critique-telemetry-hook.mjs
@@ -231,20 +231,39 @@ process.stdin.on('end', () => {
   // was tried first and rejected -- it broke every one of those stubs,
   // confirmed live).
   //
-  // In-place regex removal, not split/rejoin (kurone-kito/idd-skill#2910
+  // In-place regex removal within each unquoted segment, not a single
+  // whitespace-tokenizing split/rejoin (kurone-kito/idd-skill#2910
   // review, Copilot follow-up): an earlier version of this strip
-  // tokenized on whitespace and rejoined with single spaces, which is
-  // lossy for a quoted --require/--import value containing its own
-  // internal whitespace (for example a Windows path with a space in a
-  // directory name) -- rejoining would silently corrupt that path.
-  // Removing only the matched \`--input-type=<non-whitespace>\`
-  // substring (plus its own leading separator) leaves every other
-  // character of the original string, including any such quoting,
-  // completely untouched.
+  // tokenized the whole string on whitespace and rejoined with single
+  // spaces, which is lossy for a quoted --require/--import value
+  // containing its own internal whitespace (for example a Windows path
+  // with a space in a directory name) -- rejoining would silently
+  // corrupt that path. Removing only the matched
+  // \`--input-type=<non-whitespace>\` substring (plus its own leading
+  // separator) leaves every other character of the original string,
+  // including any such quoting, completely untouched.
+  //
+  // Quote-aware (kurone-kito/idd-skill#2910 review round 6, Copilot):
+  // the removal above is itself blind to quoting -- a legitimate quoted
+  // value that happens to contain the literal text \`--input-type=\`
+  // preceded by whitespace (for example a --require path whose own
+  // filename embeds that substring) would still be mangled, since a
+  // single whole-string regex has no notion of "inside a quoted span".
+  // Splitting first on double-quoted spans (keeping each one completely
+  // verbatim, including a backslash-escaped quote inside one, matching
+  // how Node's own NODE_OPTIONS parser treats \\" ) and applying the
+  // removal only to the unquoted segments between them closes that gap
+  // without reintroducing the whitespace-collapsing bug above --
+  // confirmed live: a --require value like
+  // \`"C:/dir/name --input-type=module.cjs"\` now survives unchanged.
   const forwardedNodeOptions = env['${WIN32_RELAY_NODE_OPTIONS_ENV}'] || '';
   delete env['${WIN32_RELAY_NODE_OPTIONS_ENV}'];
   const strippedNodeOptions = forwardedNodeOptions
-    .replace(/(^|\\s)--input-type=\\S+/g, '')
+    .split(/("(?:[^"\\\\]|\\\\.)*")/g)
+    .map((chunk, i) =>
+      i % 2 === 1 ? chunk : chunk.replace(/(^|\\s)--input-type=\\S+/g, ''),
+    )
+    .join('')
     .trim();
   if (strippedNodeOptions) {
     env.NODE_OPTIONS = strippedNodeOptions;
@@ -509,18 +528,43 @@ export function invokeCritiqueTelemetryHook(command, payload, options) {
         // the conditional spread below contributes nothing -- leaving
         // that stale value in `relayEnv` to reach the relay untouched,
         // which would then apply it to the inner spawn as if it were the
-        // real caller's NODE_OPTIONS. Delete both reserved keys
+        // real caller's NODE_OPTIONS. Deleting both reserved keys
         // unconditionally before the conditional re-add closes that gap;
         // `WIN32_RELAY_COMMAND_ENV` is always overwritten by the
         // unconditional entry below regardless, but is deleted here too
         // for symmetry and defense-in-depth.
+        //
+        // Folded into the same case-insensitive scan as NODE_OPTIONS
+        // (kurone-kito/idd-skill#2910 review round 6, Copilot + Codex,
+        // independently): an exact-case-only delete of the two reserved
+        // names above closes the gap only for their canonical spelling --
+        // Windows environment-variable names are case-insensitive at the
+        // OS level (the same reasoning the NODE_OPTIONS scan below already
+        // applies to itself), so a non-canonically-cased duplicate of
+        // either reserved name would still slip through without being
+        // scrubbed. In practice this specific gap is inert today, not a
+        // live leak: the
+        // relay's own lookup of these two names (WIN32_RELAY_SCRIPT's
+        // `env['...']` access) is itself exact-case, so a non-canonical
+        // duplicate reaching the relay is simply never read there either
+        // (confirmed live: a lower-cased reserved key added deliberately
+        // for this fix's own regression test still passed even before this
+        // change landed). Folding both names into one case-insensitive
+        // scan is still correct defense-in-depth against exactly that kind
+        // of exact-case assumption changing on either side in the future,
+        // and matches the NODE_OPTIONS scan's own reasoning rather than
+        // leaving these two names as a narrower, inconsistent special case.
         const relayEnv = { ...process.env };
-        delete relayEnv[WIN32_RELAY_COMMAND_ENV];
-        delete relayEnv[WIN32_RELAY_NODE_OPTIONS_ENV];
         let callerNodeOptions;
         for (const key of Object.keys(relayEnv)) {
-          if (key.toUpperCase() === 'NODE_OPTIONS') {
+          const upperKey = key.toUpperCase();
+          if (upperKey === 'NODE_OPTIONS') {
             callerNodeOptions = relayEnv[key];
+            delete relayEnv[key];
+          } else if (
+            upperKey === WIN32_RELAY_COMMAND_ENV ||
+            upperKey === WIN32_RELAY_NODE_OPTIONS_ENV
+          ) {
             delete relayEnv[key];
           }
         }

--- a/scripts/idd-critique-telemetry-hook.mjs
+++ b/scripts/idd-critique-telemetry-hook.mjs
@@ -96,24 +96,58 @@ const WATCHDOG_ARMED_TIMEOUT_MS = 3_000;
 const WIN32_RELAY_COMMAND_ENV =
   'IDD_CRITIQUE_TELEMETRY_HOOK_WIN32_RELAY_COMMAND';
 /**
+ * Environment-variable name used to forward the *caller's own*
+ * `NODE_OPTIONS` value to the win32 relay's inner (real target) spawn,
+ * without letting the relay's own `-e` invocation inherit it directly
+ * (kurone-kito/idd-skill#2910 review, Copilot). See
+ * {@link WIN32_RELAY_SCRIPT}'s own doc comment for the full rationale.
+ */
+const WIN32_RELAY_NODE_OPTIONS_ENV =
+  'IDD_CRITIQUE_TELEMETRY_HOOK_WIN32_RELAY_NODE_OPTIONS';
+/**
  * win32-only relay script (kurone-kito/idd-skill#2910), run via
  * `spawnFn(process.execPath, ['--input-type=commonjs', '-e',
  * WIN32_RELAY_SCRIPT], {...})` in {@link invokeCritiqueTelemetryHook}
  * below -- mirrors this file's
  * existing precedent of inlining the watchdog's PowerShell script as a
- * string constant (see {@link spawnWatchdogWindows}). A single `${...}`
- * substitution (the env-var-name constant above) is all this template
- * literal needs; the rest of the script body contains no literal `${`
- * sequence of its own, so there is no collision risk with the outer
- * `.mts` template-literal interpolation to guard against here, unlike
- * the watchdog's longer, multiply-interpolated PowerShell one-liner.
+ * string constant (see {@link spawnWatchdogWindows}). Two `${...}`
+ * substitutions (the two env-var-name constants above) are all this
+ * template literal needs; the rest of the script body contains no
+ * literal `${` sequence of its own, so there is no collision risk with
+ * the outer `.mts` template-literal interpolation to guard against here,
+ * unlike the watchdog's longer, multiply-interpolated PowerShell
+ * one-liner.
  *
- * Root cause (verified live on native Windows 11): `cmd.exe` (the
- * `shell: true` wrapper the primary spawn below uses on POSIX, and used
- * unconditionally on win32 too before this fix) never relays a piped
- * stdin payload to the further child it execs when `cmd.exe` itself
- * runs under Win32's `DETACHED_PROCESS` creation flag (what
- * `detached: true` maps to) -- confirmed at every payload size from 0B
+ * **The relay's own environment is sanitized of `NODE_OPTIONS`**
+ * (kurone-kito/idd-skill#2910 review, Copilot): the relay is itself a
+ * `node` process, so if it inherited the caller's raw `NODE_OPTIONS`
+ * directly, an inherited `--require`/`--import` would execute arbitrary
+ * preload code *inside the relay* before it ever forwards the payload --
+ * confirmed as a real mechanism, not merely hypothetical, by this
+ * repository's own win32 test stubs, which rely on exactly that
+ * `--require <preload>` pattern to inject their behavior (see
+ * `tests/test-utils.mts`'s `stubExecutable`). `invokeCritiqueTelemetryHook`
+ * below therefore does not pass the caller's own `NODE_OPTIONS` through
+ * to the relay's environment at all -- the relay's own process runs
+ * without any inherited `NODE_OPTIONS`, with `--input-type=commonjs`
+ * (kept as defense-in-depth even though the vector it originally guarded
+ * against, an inherited `--input-type=module`, is now also closed by
+ * this sanitization). The caller's *original* `NODE_OPTIONS` value still
+ * needs to reach the real target command two hops down -- POSIX and the
+ * pre-#2910 win32 path both let it through unchanged, and this fix must
+ * not narrow that existing contract -- so it travels through the
+ * separate {@link WIN32_RELAY_NODE_OPTIONS_ENV} channel instead, applied
+ * only to the inner spawn's own environment, never executed by the relay
+ * itself.
+ *
+ * Root cause (verified live on native Windows 11): on win32, `shell:
+ * true` wraps the primary spawn in `cmd.exe` (on POSIX the equivalent
+ * wrapper is `/bin/sh`, unaffected by any of this -- this whole defect
+ * and fix are win32-only). Before this fix, the primary spawn used that
+ * `cmd.exe` wrapper unconditionally on win32 too, and `cmd.exe` never
+ * relays a piped stdin payload to the further child it execs when
+ * `cmd.exe` itself runs under Win32's `DETACHED_PROCESS` creation flag
+ * (what `detached: true` maps to) -- confirmed at every payload size from 0B
  * to 500KB+, and for a non-Node consumer piped the same way, isolating
  * the fault to `cmd.exe`'s own stdin-relay plumbing under
  * `DETACHED_PROCESS` rather than anything Node/libuv- or payload-size-
@@ -182,6 +216,32 @@ process.stdin.on('end', () => {
   const payload = Buffer.concat(chunks);
   const env = { ...process.env };
   delete env['${WIN32_RELAY_COMMAND_ENV}'];
+  // The relay's OWN process never received the caller's raw NODE_OPTIONS
+  // (see WIN32_RELAY_SCRIPT's own doc comment) -- only this forwarded
+  // copy of it, specifically for the inner spawn below. Strip only
+  // whitespace-separated --input-type=... tokens (kurone-kito/idd-skill
+  // #2910 follow-up on the Codex review): Node rejects --input-type
+  // outright (ERR_INPUT_TYPE_NOT_ALLOWED) for any invocation that is not
+  // itself --eval/--print/stdin, which a configured command that happens
+  // to run \`node <file>\` (as this file's own win32 CI test fixtures do)
+  // would be -- while every other flag, notably this repository's own
+  // win32 test stubs' inherited --require <preload>, passes through
+  // unchanged (verified live: a --require alongside --input-type
+  // survives this strip and still runs; deleting NODE_OPTIONS wholesale
+  // here instead was tried first and rejected -- it broke every one of
+  // those stubs, confirmed live).
+  const forwardedNodeOptions = env['${WIN32_RELAY_NODE_OPTIONS_ENV}'] || '';
+  delete env['${WIN32_RELAY_NODE_OPTIONS_ENV}'];
+  const strippedNodeOptions = forwardedNodeOptions
+    .split(/\\s+/)
+    .filter(Boolean)
+    .filter((token) => !token.startsWith('--input-type='))
+    .join(' ');
+  if (strippedNodeOptions) {
+    env.NODE_OPTIONS = strippedNodeOptions;
+  } else {
+    delete env.NODE_OPTIONS;
+  }
   let child;
   try {
     child = spawn(command, {
@@ -407,35 +467,50 @@ export function invokeCritiqueTelemetryHook(command, payload, options) {
       // `killProcessGroup`'s win32 tree-kill below, which caps the whole
       // chain's lifetime at `timeoutMs` rather than preventing it
       // outright.
-      child =
-        platform === 'win32'
-          ? spawnFn(
-              process.execPath,
-              // `--input-type=commonjs` (kurone-kito/idd-skill#2910
-              // review, Codex): explicit and load-bearing, not
-              // redundant with `-e`'s own CommonJS default. A caller
-              // whose own environment sets `NODE_OPTIONS=
-              // --input-type=module` -- inherited below via
-              // `...process.env` -- would otherwise make Node evaluate
-              // `WIN32_RELAY_SCRIPT` as ESM, where `require` is
-              // undefined and the relay throws before ever reading its
-              // stdin. Verified live: this flag overrides an
-              // inherited `--input-type=module` and is a no-op
-              // otherwise.
-              ['--input-type=commonjs', '-e', WIN32_RELAY_SCRIPT],
-              {
-                stdio: ['pipe', 'ignore', 'ignore'],
-                detached: true,
-                windowsHide: true,
-                env: { ...process.env, [WIN32_RELAY_COMMAND_ENV]: command },
-              },
-            )
-          : spawnFn(command, {
-              shell: true,
-              stdio: ['pipe', 'ignore', 'ignore'],
-              detached: true,
-              windowsHide: true,
-            });
+      if (platform === 'win32') {
+        // Sanitize NODE_OPTIONS out of the relay's OWN environment
+        // (kurone-kito/idd-skill#2910 review, Copilot): the relay is
+        // itself a `node` process, so passing the caller's raw
+        // NODE_OPTIONS through to it would let an inherited
+        // `--require`/`--import` execute arbitrary preload code *inside
+        // the relay* before it ever forwards the payload -- see
+        // WIN32_RELAY_SCRIPT's own doc comment for the full rationale
+        // and why the original value still reaches the real target
+        // command via a separate channel instead of being dropped.
+        const { NODE_OPTIONS: callerNodeOptions, ...relayEnv } = process.env;
+        child = spawnFn(
+          process.execPath,
+          // `--input-type=commonjs` (kurone-kito/idd-skill#2910 review,
+          // Codex): defense-in-depth alongside the NODE_OPTIONS
+          // sanitization above -- not redundant with `-e`'s own
+          // CommonJS default, since a caller's inherited
+          // `NODE_OPTIONS=--input-type=module` would otherwise make
+          // Node evaluate `WIN32_RELAY_SCRIPT` as ESM, where `require`
+          // is undefined and the relay throws before ever reading its
+          // stdin. Verified live: this flag overrides an inherited
+          // `--input-type=module` and is a no-op otherwise.
+          ['--input-type=commonjs', '-e', WIN32_RELAY_SCRIPT],
+          {
+            stdio: ['pipe', 'ignore', 'ignore'],
+            detached: true,
+            windowsHide: true,
+            env: {
+              ...relayEnv,
+              [WIN32_RELAY_COMMAND_ENV]: command,
+              ...(callerNodeOptions
+                ? { [WIN32_RELAY_NODE_OPTIONS_ENV]: callerNodeOptions }
+                : {}),
+            },
+          },
+        );
+      } else {
+        child = spawnFn(command, {
+          shell: true,
+          stdio: ['pipe', 'ignore', 'ignore'],
+          detached: true,
+          windowsHide: true,
+        });
+      }
     } catch {
       settle(false);
       notifyDelivered();

--- a/scripts/idd-critique-telemetry-hook.mjs
+++ b/scripts/idd-critique-telemetry-hook.mjs
@@ -498,7 +498,25 @@ export function invokeCritiqueTelemetryHook(command, payload, options) {
         // the relay load its preload code. Scan every key case-
         // insensitively instead, keeping the last match's value (in
         // practice at most one casing is ever actually set).
+        //
+        // Scrub the reserved transport keys from `relayEnv` itself
+        // (kurone-kito/idd-skill#2910 review, Codex follow-up): `relayEnv`
+        // starts as a full copy of `process.env`, so if this hook's own
+        // process somehow already inherited a stale
+        // `WIN32_RELAY_NODE_OPTIONS_ENV` value (for example a leftover
+        // from a nested/prior invocation) while the caller's own
+        // NODE_OPTIONS was unset, `callerNodeOptions` stays undefined and
+        // the conditional spread below contributes nothing -- leaving
+        // that stale value in `relayEnv` to reach the relay untouched,
+        // which would then apply it to the inner spawn as if it were the
+        // real caller's NODE_OPTIONS. Delete both reserved keys
+        // unconditionally before the conditional re-add closes that gap;
+        // `WIN32_RELAY_COMMAND_ENV` is always overwritten by the
+        // unconditional entry below regardless, but is deleted here too
+        // for symmetry and defense-in-depth.
         const relayEnv = { ...process.env };
+        delete relayEnv[WIN32_RELAY_COMMAND_ENV];
+        delete relayEnv[WIN32_RELAY_NODE_OPTIONS_ENV];
         let callerNodeOptions;
         for (const key of Object.keys(relayEnv)) {
           if (key.toUpperCase() === 'NODE_OPTIONS') {

--- a/scripts/idd-critique-telemetry-hook.mjs
+++ b/scripts/idd-critique-telemetry-hook.mjs
@@ -81,6 +81,129 @@ const PAYLOAD_DELIVERY_TIMEOUT_MS = 1_000;
  * where a spawn confirms in low single-digit milliseconds.
  */
 const WATCHDOG_ARMED_TIMEOUT_MS = 3_000;
+/**
+ * Environment-variable name used to hand the real target `command`
+ * string to the win32 relay script (see {@link WIN32_RELAY_SCRIPT})
+ * rather than passing it as an argv element. The relay is spawned with
+ * `shell: false`, so argv escaping is not actually a concern for Node's
+ * own spawn call -- the env-var route is chosen instead because it
+ * keeps the relay's own argv fixed (`['-e', WIN32_RELAY_SCRIPT]`)
+ * regardless of the configured command's own content, and avoids
+ * reasoning twice about how an arbitrary shell command string interacts
+ * with Node's Windows argv-quoting rules (the first time being
+ * `command`'s own later `shell: true` hop inside the relay itself).
+ */
+const WIN32_RELAY_COMMAND_ENV =
+  'IDD_CRITIQUE_TELEMETRY_HOOK_WIN32_RELAY_COMMAND';
+/**
+ * win32-only relay script (kurone-kito/idd-skill#2910), run via
+ * `spawnFn(process.execPath, ['-e', WIN32_RELAY_SCRIPT], {...})` in
+ * {@link invokeCritiqueTelemetryHook} below -- mirrors this file's
+ * existing precedent of inlining the watchdog's PowerShell script as a
+ * string constant (see {@link spawnWatchdogWindows}). A single `${...}`
+ * substitution (the env-var-name constant above) is all this template
+ * literal needs; the rest of the script body contains no literal `${`
+ * sequence of its own, so there is no collision risk with the outer
+ * `.mts` template-literal interpolation to guard against here, unlike
+ * the watchdog's longer, multiply-interpolated PowerShell one-liner.
+ *
+ * Root cause (verified live on native Windows 11): `cmd.exe` (the
+ * `shell: true` wrapper the primary spawn below uses on POSIX, and used
+ * unconditionally on win32 too before this fix) never relays a piped
+ * stdin payload to the further child it execs when `cmd.exe` itself
+ * runs under Win32's `DETACHED_PROCESS` creation flag (what
+ * `detached: true` maps to) -- confirmed at every payload size from 0B
+ * to 500KB+, and for a non-Node consumer piped the same way, isolating
+ * the fault to `cmd.exe`'s own stdin-relay plumbing under
+ * `DETACHED_PROCESS` rather than anything Node/libuv- or payload-size-
+ * specific. This is the same "`DETACHED_PROCESS` breaks a
+ * console-subsystem process's own I/O/message-pump initialization"
+ * pattern already root-caused for {@link spawnWatchdogWindows}'s own
+ * `powershell.exe` hop (kurone-kito/idd-skill#2892 / PR #2897),
+ * recurring for `cmd.exe`'s stdin relay instead of `powershell.exe`'s
+ * ConsoleHost startup.
+ *
+ * Fix shape: this script is itself spawned *directly* (`shell: false`)
+ * as a `node.exe` child under `detached: true` -- confirmed live to
+ * deliver a piped stdin payload correctly, at every size from 0B to
+ * 500KB+, once the caller waits for the stream to fully close before
+ * exiting (this file's `onPayloadDelivered` contract already does
+ * exactly that). It then reads its own stdin to completion, and only
+ * *then* re-spawns the real `command` through `shell: true` -- but,
+ * deliberately, NOT `detached` this time: this relay process itself is
+ * what now needs to survive the CLI's `process.exit()`, not the
+ * `cmd.exe` hop underneath it, so `cmd.exe` here is a normal
+ * (non-`DETACHED_PROCESS`) child and does not hit the stdin-relay
+ * defect above. The relay forwards the buffered payload to that
+ * child's stdin (with the relay-command env var above scrubbed from
+ * that inner spawn's own environment, so the configured `command`
+ * never sees an env var it didn't configure) and exits with the same
+ * code, preserving `invokeCritiqueTelemetryHook`'s existing
+ * `ok: code === 0` contract for its caller unchanged.
+ *
+ * `child.pid` (what this file's timeout/kill/watchdog logic already
+ * operates on generically -- see {@link killProcessGroup}) becomes
+ * this relay's pid on win32. Verified live: a
+ * `taskkill /PID <relay-pid> /T /F` (the existing
+ * {@link killProcessTreeWindows} call, unchanged) still reaches and
+ * kills the whole chain -- relay -> `cmd.exe` -> real target -- for
+ * both an already-settled chain and a genuinely hung target, so no
+ * change is needed to {@link killProcessGroup},
+ * {@link killProcessTreeWindows}, or either `spawnWatchdog*` function.
+ *
+ * Never throws from the relay's own perspective: a synchronous spawn
+ * failure or an async `'error'`/non-zero exit all resolve to
+ * `finish(1)` (a non-ok result for the caller), matching this file's
+ * "never throws" contract for the primary hook spawn. Like every other
+ * failure mode this file already absorbs silently (a bad command, a
+ * non-zero exit, a timeout), a defect in this script's own body would
+ * also fail silently in production (its `stdio` discards stderr) --
+ * an accepted extension of the existing contract, not a new risk;
+ * the same gap already exists for the inline PowerShell watchdog
+ * script below, with no unit-level syntax check for either. The tests
+ * this issue adds are the mitigation, run for real (not just
+ * argument-shape asserted) both locally, via the `platform: 'win32'`
+ * override tests below, and on native `windows-latest` CI.
+ */
+const WIN32_RELAY_SCRIPT = `
+const { spawn } = require('node:child_process');
+const command = process.env.${WIN32_RELAY_COMMAND_ENV};
+const chunks = [];
+let settled = false;
+const finish = (code) => {
+  if (settled) return;
+  settled = true;
+  process.exit(code);
+};
+process.stdin.on('data', (c) => chunks.push(c));
+process.stdin.on('error', () => finish(1));
+process.stdin.on('end', () => {
+  const payload = Buffer.concat(chunks);
+  const env = { ...process.env };
+  delete env['${WIN32_RELAY_COMMAND_ENV}'];
+  let child;
+  try {
+    child = spawn(command, {
+      shell: true,
+      stdio: ['pipe', 'ignore', 'ignore'],
+      windowsHide: true,
+      env,
+    });
+  } catch {
+    finish(1);
+    return;
+  }
+  child.on('error', () => finish(1));
+  child.on('exit', (code) => finish(code === null ? 1 : code));
+  child.stdin.on('error', () => {});
+  try {
+    child.stdin.write(payload);
+    child.stdin.end();
+  } catch {
+    // 'error'/'exit' handlers above still settle.
+  }
+});
+`;
 if (import.meta.main) {
   runCli();
 }
@@ -242,48 +365,61 @@ export function invokeCritiqueTelemetryHook(command, payload, options) {
     };
     let child;
     try {
-      child = spawnFn(command, {
-        shell: true,
-        stdio: ['pipe', 'ignore', 'ignore'],
-        // `detached: true` (not `child.unref()`) only: this puts the child
-        // in its own session so it survives a signal sent to this
-        // process's group (e.g. the invoking shell's own job-control
-        // teardown), without unref'ing it. Deliberately NOT calling
-        // `child.unref()` here -- that would remove the *only* thing
-        // keeping the event loop alive long enough for the (also unref'd)
-        // timeout timer below to ever fire for a caller that legitimately
-        // awaits this promise (every test in this file does; a future
-        // non-CLI embedder might too) -- with both unref'd, nothing forces
-        // the loop to keep running, so the promise could stay pending
-        // forever once nothing else in the process needs the loop. The
-        // CLI's own `--invoke` mode (below) doesn't need this ref/unref
-        // distinction at all: it never awaits this promise, and
-        // `process.exit()` terminates unconditionally regardless of any
-        // pending handle's ref status.
-        detached: true,
-        // windowsHide (kurone-kito/idd-skill#2892; no-op on POSIX): maps to
-        // Win32's CREATE_NO_WINDOW creation flag *and* STARTUPINFO's
-        // wShowWindow=SW_HIDE. Verified against libuv's own win/process.c
-        // and Microsoft's Process Creation Flags documentation: the
-        // CREATE_NO_WINDOW half is a documented no-op here specifically --
-        // MSDN states it "is ignored if ... used with either
-        // CREATE_NEW_CONSOLE or DETACHED_PROCESS", and `detached: true`
-        // above is what sets DETACHED_PROCESS (required so this child
-        // survives `--invoke`'s `process.exit()`; cannot be dropped). The
-        // wShowWindow=SW_HIDE half is set unconditionally in STARTUPINFO
-        // regardless of DETACHED_PROCESS, and `cmd.exe` (the `shell: true`
-        // wrapper on win32) DOES propagate that show-state hint to the
-        // further child it execs for `command` -- verified live on native
-        // Windows 11 (kurone-kito/idd-skill#2892 review follow-up): a
-        // real, unmocked spawn through this exact path shows
-        // `MainWindowHandle == 0` (Get-Process) for both a quick-exiting
-        // and a hung-then-killed target, for the whole process tree this
-        // creates. The bound, reliable mitigation for a window that
-        // somehow still appears despite this is `killProcessGroup`'s
-        // win32 tree-kill below, which caps its lifetime at `timeoutMs`
-        // rather than preventing it outright.
-        windowsHide: true,
-      });
+      // `detached: true` (not `child.unref()`) only, on both branches
+      // below: this puts the child in its own session so it survives a
+      // signal sent to this process's group (e.g. the invoking shell's
+      // own job-control teardown), without unref'ing it. Deliberately
+      // NOT calling `child.unref()` here -- that would remove the *only*
+      // thing keeping the event loop alive long enough for the (also
+      // unref'd) timeout timer below to ever fire for a caller that
+      // legitimately awaits this promise (every test in this file does;
+      // a future non-CLI embedder might too) -- with both unref'd,
+      // nothing forces the loop to keep running, so the promise could
+      // stay pending forever once nothing else in the process needs the
+      // loop. The CLI's own `--invoke` mode (below) doesn't need this
+      // ref/unref distinction at all: it never awaits this promise, and
+      // `process.exit()` terminates unconditionally regardless of any
+      // pending handle's ref status.
+      //
+      // windowsHide (kurone-kito/idd-skill#2892; no-op on POSIX): maps to
+      // Win32's CREATE_NO_WINDOW creation flag *and* STARTUPINFO's
+      // wShowWindow=SW_HIDE. Verified against libuv's own win/process.c
+      // and Microsoft's Process Creation Flags documentation: the
+      // CREATE_NO_WINDOW half is a documented no-op specifically when
+      // combined with DETACHED_PROCESS (what `detached: true` sets) --
+      // MSDN states it "is ignored if ... used with either
+      // CREATE_NEW_CONSOLE or DETACHED_PROCESS". On the win32 branch
+      // below, that leaves `windowsHide` on the outer (detached) relay
+      // spawn a documented no-op for the same reason `spawnWatchdogWindows`'s
+      // own detached spawn is -- the relay is a plain `node.exe` process
+      // with no console to begin with under DETACHED_PROCESS, so there is
+      // nothing to hide there regardless. The relay's *own* inner spawn of
+      // the real `command` (see `WIN32_RELAY_SCRIPT` below) is NOT
+      // detached, so CREATE_NO_WINDOW is not overridden there and reliably
+      // suppresses that `cmd.exe` hop's own console window directly --
+      // verified live on native Windows 11 (kurone-kito/idd-skill#2892
+      // review follow-up, re-confirmed for kurone-kito/idd-skill#2910's
+      // relay shape): `MainWindowHandle == 0` (Get-Process) for both a
+      // quick-exiting and a hung-then-killed target, for the whole
+      // process tree this creates. The bound, reliable mitigation for a
+      // window that somehow still appears despite this is
+      // `killProcessGroup`'s win32 tree-kill below, which caps the whole
+      // chain's lifetime at `timeoutMs` rather than preventing it
+      // outright.
+      child =
+        platform === 'win32'
+          ? spawnFn(process.execPath, ['-e', WIN32_RELAY_SCRIPT], {
+              stdio: ['pipe', 'ignore', 'ignore'],
+              detached: true,
+              windowsHide: true,
+              env: { ...process.env, [WIN32_RELAY_COMMAND_ENV]: command },
+            })
+          : spawnFn(command, {
+              shell: true,
+              stdio: ['pipe', 'ignore', 'ignore'],
+              detached: true,
+              windowsHide: true,
+            });
     } catch {
       settle(false);
       notifyDelivered();
@@ -421,13 +557,20 @@ export function invokeCritiqueTelemetryHook(command, payload, options) {
  * POSIX process-group semantics). On win32, a negative pid is meaningless
  * to `process.kill` -- there is no POSIX-style process-group signal to
  * send -- so this instead delegates to {@link killProcessTreeWindows}, a
- * real process-*tree* kill via `taskkill /T` (kurone-kito/idd-skill#2892):
- * `shell: true` makes `child` the `cmd.exe` wrapper, and the actual
- * invoked command is a *further* child of that wrapper, never reachable by
- * terminating the wrapper alone -- which is exactly what this file's
- * previous Windows fallback (`child.kill('SIGKILL')` below) only ever did,
- * leaving that further child (and its own auto-allocated console window)
- * orphaned. Never throws.
+ * real process-*tree* kill via `taskkill /T` (kurone-kito/idd-skill#2892).
+ * On win32, `child` is the primary spawn's own top-level process:
+ * `cmd.exe` (the `shell: true` wrapper) directly, on POSIX and, before
+ * kurone-kito/idd-skill#2910, on win32 too; since that fix, the win32
+ * `child` is instead the relay process (see `WIN32_RELAY_SCRIPT`), which
+ * itself wraps `cmd.exe` as its own child one level further down. Either
+ * way, the actual invoked command sits one or more levels beneath `child`,
+ * never reachable by terminating `child` alone -- which is exactly what
+ * this file's previous Windows fallback (`child.kill('SIGKILL')` below)
+ * only ever did, leaving that further descendant (and its own
+ * auto-allocated console window) orphaned. `taskkill /T`'s tree-kill
+ * reaches the whole subtree regardless of its depth beneath `child`, so
+ * this function needs no depth-specific knowledge of which shape `child`
+ * is. Never throws.
  *
  * Also used by {@link cancelWatchdog} to disarm the watchdog's own process
  * (itself `detached: true` -- see {@link spawnWatchdogPosix} /

--- a/scripts/idd-critique-telemetry-hook.mjs
+++ b/scripts/idd-critique-telemetry-hook.mjs
@@ -219,24 +219,33 @@ process.stdin.on('end', () => {
   // The relay's OWN process never received the caller's raw NODE_OPTIONS
   // (see WIN32_RELAY_SCRIPT's own doc comment) -- only this forwarded
   // copy of it, specifically for the inner spawn below. Strip only
-  // whitespace-separated --input-type=... tokens (kurone-kito/idd-skill
-  // #2910 follow-up on the Codex review): Node rejects --input-type
-  // outright (ERR_INPUT_TYPE_NOT_ALLOWED) for any invocation that is not
-  // itself --eval/--print/stdin, which a configured command that happens
-  // to run \`node <file>\` (as this file's own win32 CI test fixtures do)
-  // would be -- while every other flag, notably this repository's own
-  // win32 test stubs' inherited --require <preload>, passes through
-  // unchanged (verified live: a --require alongside --input-type
-  // survives this strip and still runs; deleting NODE_OPTIONS wholesale
-  // here instead was tried first and rejected -- it broke every one of
-  // those stubs, confirmed live).
+  // --input-type=... tokens (kurone-kito/idd-skill#2910 follow-up on the
+  // Codex review): Node rejects --input-type outright
+  // (ERR_INPUT_TYPE_NOT_ALLOWED) for any invocation that is not itself
+  // --eval/--print/stdin, which a configured command that happens to run
+  // \`node <file>\` (as this file's own win32 CI test fixtures do) would
+  // be -- while every other flag, notably this repository's own win32
+  // test stubs' inherited --require <preload>, passes through unchanged
+  // (verified live: a --require alongside --input-type survives this
+  // strip and still runs; deleting NODE_OPTIONS wholesale here instead
+  // was tried first and rejected -- it broke every one of those stubs,
+  // confirmed live).
+  //
+  // In-place regex removal, not split/rejoin (kurone-kito/idd-skill#2910
+  // review, Copilot follow-up): an earlier version of this strip
+  // tokenized on whitespace and rejoined with single spaces, which is
+  // lossy for a quoted --require/--import value containing its own
+  // internal whitespace (for example a Windows path with a space in a
+  // directory name) -- rejoining would silently corrupt that path.
+  // Removing only the matched \`--input-type=<non-whitespace>\`
+  // substring (plus its own leading separator) leaves every other
+  // character of the original string, including any such quoting,
+  // completely untouched.
   const forwardedNodeOptions = env['${WIN32_RELAY_NODE_OPTIONS_ENV}'] || '';
   delete env['${WIN32_RELAY_NODE_OPTIONS_ENV}'];
   const strippedNodeOptions = forwardedNodeOptions
-    .split(/\\s+/)
-    .filter(Boolean)
-    .filter((token) => !token.startsWith('--input-type='))
-    .join(' ');
+    .replace(/(^|\\s)--input-type=\\S+/g, '')
+    .trim();
   if (strippedNodeOptions) {
     env.NODE_OPTIONS = strippedNodeOptions;
   } else {

--- a/src/scripts/idd-critique-telemetry-hook.mts
+++ b/src/scripts/idd-critique-telemetry-hook.mts
@@ -229,24 +229,33 @@ process.stdin.on('end', () => {
   // The relay's OWN process never received the caller's raw NODE_OPTIONS
   // (see WIN32_RELAY_SCRIPT's own doc comment) -- only this forwarded
   // copy of it, specifically for the inner spawn below. Strip only
-  // whitespace-separated --input-type=... tokens (kurone-kito/idd-skill
-  // #2910 follow-up on the Codex review): Node rejects --input-type
-  // outright (ERR_INPUT_TYPE_NOT_ALLOWED) for any invocation that is not
-  // itself --eval/--print/stdin, which a configured command that happens
-  // to run \`node <file>\` (as this file's own win32 CI test fixtures do)
-  // would be -- while every other flag, notably this repository's own
-  // win32 test stubs' inherited --require <preload>, passes through
-  // unchanged (verified live: a --require alongside --input-type
-  // survives this strip and still runs; deleting NODE_OPTIONS wholesale
-  // here instead was tried first and rejected -- it broke every one of
-  // those stubs, confirmed live).
+  // --input-type=... tokens (kurone-kito/idd-skill#2910 follow-up on the
+  // Codex review): Node rejects --input-type outright
+  // (ERR_INPUT_TYPE_NOT_ALLOWED) for any invocation that is not itself
+  // --eval/--print/stdin, which a configured command that happens to run
+  // \`node <file>\` (as this file's own win32 CI test fixtures do) would
+  // be -- while every other flag, notably this repository's own win32
+  // test stubs' inherited --require <preload>, passes through unchanged
+  // (verified live: a --require alongside --input-type survives this
+  // strip and still runs; deleting NODE_OPTIONS wholesale here instead
+  // was tried first and rejected -- it broke every one of those stubs,
+  // confirmed live).
+  //
+  // In-place regex removal, not split/rejoin (kurone-kito/idd-skill#2910
+  // review, Copilot follow-up): an earlier version of this strip
+  // tokenized on whitespace and rejoined with single spaces, which is
+  // lossy for a quoted --require/--import value containing its own
+  // internal whitespace (for example a Windows path with a space in a
+  // directory name) -- rejoining would silently corrupt that path.
+  // Removing only the matched \`--input-type=<non-whitespace>\`
+  // substring (plus its own leading separator) leaves every other
+  // character of the original string, including any such quoting,
+  // completely untouched.
   const forwardedNodeOptions = env['${WIN32_RELAY_NODE_OPTIONS_ENV}'] || '';
   delete env['${WIN32_RELAY_NODE_OPTIONS_ENV}'];
   const strippedNodeOptions = forwardedNodeOptions
-    .split(/\\s+/)
-    .filter(Boolean)
-    .filter((token) => !token.startsWith('--input-type='))
-    .join(' ');
+    .replace(/(^|\\s)--input-type=\\S+/g, '')
+    .trim();
   if (strippedNodeOptions) {
     env.NODE_OPTIONS = strippedNodeOptions;
   } else {

--- a/src/scripts/idd-critique-telemetry-hook.mts
+++ b/src/scripts/idd-critique-telemetry-hook.mts
@@ -105,24 +105,59 @@ const WIN32_RELAY_COMMAND_ENV =
   'IDD_CRITIQUE_TELEMETRY_HOOK_WIN32_RELAY_COMMAND';
 
 /**
+ * Environment-variable name used to forward the *caller's own*
+ * `NODE_OPTIONS` value to the win32 relay's inner (real target) spawn,
+ * without letting the relay's own `-e` invocation inherit it directly
+ * (kurone-kito/idd-skill#2910 review, Copilot). See
+ * {@link WIN32_RELAY_SCRIPT}'s own doc comment for the full rationale.
+ */
+const WIN32_RELAY_NODE_OPTIONS_ENV =
+  'IDD_CRITIQUE_TELEMETRY_HOOK_WIN32_RELAY_NODE_OPTIONS';
+
+/**
  * win32-only relay script (kurone-kito/idd-skill#2910), run via
  * `spawnFn(process.execPath, ['--input-type=commonjs', '-e',
  * WIN32_RELAY_SCRIPT], {...})` in {@link invokeCritiqueTelemetryHook}
  * below -- mirrors this file's
  * existing precedent of inlining the watchdog's PowerShell script as a
- * string constant (see {@link spawnWatchdogWindows}). A single `${...}`
- * substitution (the env-var-name constant above) is all this template
- * literal needs; the rest of the script body contains no literal `${`
- * sequence of its own, so there is no collision risk with the outer
- * `.mts` template-literal interpolation to guard against here, unlike
- * the watchdog's longer, multiply-interpolated PowerShell one-liner.
+ * string constant (see {@link spawnWatchdogWindows}). Two `${...}`
+ * substitutions (the two env-var-name constants above) are all this
+ * template literal needs; the rest of the script body contains no
+ * literal `${` sequence of its own, so there is no collision risk with
+ * the outer `.mts` template-literal interpolation to guard against here,
+ * unlike the watchdog's longer, multiply-interpolated PowerShell
+ * one-liner.
  *
- * Root cause (verified live on native Windows 11): `cmd.exe` (the
- * `shell: true` wrapper the primary spawn below uses on POSIX, and used
- * unconditionally on win32 too before this fix) never relays a piped
- * stdin payload to the further child it execs when `cmd.exe` itself
- * runs under Win32's `DETACHED_PROCESS` creation flag (what
- * `detached: true` maps to) -- confirmed at every payload size from 0B
+ * **The relay's own environment is sanitized of `NODE_OPTIONS`**
+ * (kurone-kito/idd-skill#2910 review, Copilot): the relay is itself a
+ * `node` process, so if it inherited the caller's raw `NODE_OPTIONS`
+ * directly, an inherited `--require`/`--import` would execute arbitrary
+ * preload code *inside the relay* before it ever forwards the payload --
+ * confirmed as a real mechanism, not merely hypothetical, by this
+ * repository's own win32 test stubs, which rely on exactly that
+ * `--require <preload>` pattern to inject their behavior (see
+ * `tests/test-utils.mts`'s `stubExecutable`). `invokeCritiqueTelemetryHook`
+ * below therefore does not pass the caller's own `NODE_OPTIONS` through
+ * to the relay's environment at all -- the relay's own process runs
+ * without any inherited `NODE_OPTIONS`, with `--input-type=commonjs`
+ * (kept as defense-in-depth even though the vector it originally guarded
+ * against, an inherited `--input-type=module`, is now also closed by
+ * this sanitization). The caller's *original* `NODE_OPTIONS` value still
+ * needs to reach the real target command two hops down -- POSIX and the
+ * pre-#2910 win32 path both let it through unchanged, and this fix must
+ * not narrow that existing contract -- so it travels through the
+ * separate {@link WIN32_RELAY_NODE_OPTIONS_ENV} channel instead, applied
+ * only to the inner spawn's own environment, never executed by the relay
+ * itself.
+ *
+ * Root cause (verified live on native Windows 11): on win32, `shell:
+ * true` wraps the primary spawn in `cmd.exe` (on POSIX the equivalent
+ * wrapper is `/bin/sh`, unaffected by any of this -- this whole defect
+ * and fix are win32-only). Before this fix, the primary spawn used that
+ * `cmd.exe` wrapper unconditionally on win32 too, and `cmd.exe` never
+ * relays a piped stdin payload to the further child it execs when
+ * `cmd.exe` itself runs under Win32's `DETACHED_PROCESS` creation flag
+ * (what `detached: true` maps to) -- confirmed at every payload size from 0B
  * to 500KB+, and for a non-Node consumer piped the same way, isolating
  * the fault to `cmd.exe`'s own stdin-relay plumbing under
  * `DETACHED_PROCESS` rather than anything Node/libuv- or payload-size-
@@ -191,6 +226,32 @@ process.stdin.on('end', () => {
   const payload = Buffer.concat(chunks);
   const env = { ...process.env };
   delete env['${WIN32_RELAY_COMMAND_ENV}'];
+  // The relay's OWN process never received the caller's raw NODE_OPTIONS
+  // (see WIN32_RELAY_SCRIPT's own doc comment) -- only this forwarded
+  // copy of it, specifically for the inner spawn below. Strip only
+  // whitespace-separated --input-type=... tokens (kurone-kito/idd-skill
+  // #2910 follow-up on the Codex review): Node rejects --input-type
+  // outright (ERR_INPUT_TYPE_NOT_ALLOWED) for any invocation that is not
+  // itself --eval/--print/stdin, which a configured command that happens
+  // to run \`node <file>\` (as this file's own win32 CI test fixtures do)
+  // would be -- while every other flag, notably this repository's own
+  // win32 test stubs' inherited --require <preload>, passes through
+  // unchanged (verified live: a --require alongside --input-type
+  // survives this strip and still runs; deleting NODE_OPTIONS wholesale
+  // here instead was tried first and rejected -- it broke every one of
+  // those stubs, confirmed live).
+  const forwardedNodeOptions = env['${WIN32_RELAY_NODE_OPTIONS_ENV}'] || '';
+  delete env['${WIN32_RELAY_NODE_OPTIONS_ENV}'];
+  const strippedNodeOptions = forwardedNodeOptions
+    .split(/\\s+/)
+    .filter(Boolean)
+    .filter((token) => !token.startsWith('--input-type='))
+    .join(' ');
+  if (strippedNodeOptions) {
+    env.NODE_OPTIONS = strippedNodeOptions;
+  } else {
+    delete env.NODE_OPTIONS;
+  }
   let child;
   try {
     child = spawn(command, {
@@ -421,12 +482,17 @@ export interface InvokeCritiqueTelemetryHookOptions {
   onWatchdogArmed?: () => void;
   /**
    * Injectable for tests, mirroring {@link spawnFn}: overrides
-   * `process.platform` for this invocation's win32-vs-POSIX kill/watchdog
-   * branching (kurone-kito/idd-skill#2892) so the exact `taskkill`/
-   * `powershell.exe` argument construction can be asserted
-   * deterministically from a non-Windows CI runner, the same way a fake
-   * `spawnFn` is already used to assert the POSIX watchdog's arguments.
-   * Defaults to the real `process.platform`.
+   * `process.platform` for this invocation's win32-vs-POSIX branching.
+   * Originally scoped to kill/watchdog selection only
+   * (kurone-kito/idd-skill#2892) so the exact `taskkill`/`powershell.exe`
+   * argument construction can be asserted deterministically from a
+   * non-Windows CI runner, the same way a fake `spawnFn` is already used
+   * to assert the POSIX watchdog's arguments; kurone-kito/idd-skill#2910
+   * extended it to also select the *primary* spawn shape (the win32
+   * relay vs. the direct POSIX `shell: true` spawn), so an override now
+   * exercises `WIN32_RELAY_SCRIPT` for real (via `node -e`, not mocked)
+   * from any host, not only the kill/watchdog argument shapes. Defaults
+   * to the real `process.platform`.
    */
   platform?: NodeJS.Platform;
 }
@@ -558,35 +624,50 @@ export function invokeCritiqueTelemetryHook(
       // `killProcessGroup`'s win32 tree-kill below, which caps the whole
       // chain's lifetime at `timeoutMs` rather than preventing it
       // outright.
-      child =
-        platform === 'win32'
-          ? spawnFn(
-              process.execPath,
-              // `--input-type=commonjs` (kurone-kito/idd-skill#2910
-              // review, Codex): explicit and load-bearing, not
-              // redundant with `-e`'s own CommonJS default. A caller
-              // whose own environment sets `NODE_OPTIONS=
-              // --input-type=module` -- inherited below via
-              // `...process.env` -- would otherwise make Node evaluate
-              // `WIN32_RELAY_SCRIPT` as ESM, where `require` is
-              // undefined and the relay throws before ever reading its
-              // stdin. Verified live: this flag overrides an
-              // inherited `--input-type=module` and is a no-op
-              // otherwise.
-              ['--input-type=commonjs', '-e', WIN32_RELAY_SCRIPT],
-              {
-                stdio: ['pipe', 'ignore', 'ignore'],
-                detached: true,
-                windowsHide: true,
-                env: { ...process.env, [WIN32_RELAY_COMMAND_ENV]: command },
-              },
-            )
-          : spawnFn(command, {
-              shell: true,
-              stdio: ['pipe', 'ignore', 'ignore'],
-              detached: true,
-              windowsHide: true,
-            });
+      if (platform === 'win32') {
+        // Sanitize NODE_OPTIONS out of the relay's OWN environment
+        // (kurone-kito/idd-skill#2910 review, Copilot): the relay is
+        // itself a `node` process, so passing the caller's raw
+        // NODE_OPTIONS through to it would let an inherited
+        // `--require`/`--import` execute arbitrary preload code *inside
+        // the relay* before it ever forwards the payload -- see
+        // WIN32_RELAY_SCRIPT's own doc comment for the full rationale
+        // and why the original value still reaches the real target
+        // command via a separate channel instead of being dropped.
+        const { NODE_OPTIONS: callerNodeOptions, ...relayEnv } = process.env;
+        child = spawnFn(
+          process.execPath,
+          // `--input-type=commonjs` (kurone-kito/idd-skill#2910 review,
+          // Codex): defense-in-depth alongside the NODE_OPTIONS
+          // sanitization above -- not redundant with `-e`'s own
+          // CommonJS default, since a caller's inherited
+          // `NODE_OPTIONS=--input-type=module` would otherwise make
+          // Node evaluate `WIN32_RELAY_SCRIPT` as ESM, where `require`
+          // is undefined and the relay throws before ever reading its
+          // stdin. Verified live: this flag overrides an inherited
+          // `--input-type=module` and is a no-op otherwise.
+          ['--input-type=commonjs', '-e', WIN32_RELAY_SCRIPT],
+          {
+            stdio: ['pipe', 'ignore', 'ignore'],
+            detached: true,
+            windowsHide: true,
+            env: {
+              ...relayEnv,
+              [WIN32_RELAY_COMMAND_ENV]: command,
+              ...(callerNodeOptions
+                ? { [WIN32_RELAY_NODE_OPTIONS_ENV]: callerNodeOptions }
+                : {}),
+            },
+          },
+        );
+      } else {
+        child = spawnFn(command, {
+          shell: true,
+          stdio: ['pipe', 'ignore', 'ignore'],
+          detached: true,
+          windowsHide: true,
+        });
+      }
     } catch {
       settle(false);
       notifyDelivered();

--- a/src/scripts/idd-critique-telemetry-hook.mts
+++ b/src/scripts/idd-critique-telemetry-hook.mts
@@ -106,8 +106,9 @@ const WIN32_RELAY_COMMAND_ENV =
 
 /**
  * win32-only relay script (kurone-kito/idd-skill#2910), run via
- * `spawnFn(process.execPath, ['-e', WIN32_RELAY_SCRIPT], {...})` in
- * {@link invokeCritiqueTelemetryHook} below -- mirrors this file's
+ * `spawnFn(process.execPath, ['--input-type=commonjs', '-e',
+ * WIN32_RELAY_SCRIPT], {...})` in {@link invokeCritiqueTelemetryHook}
+ * below -- mirrors this file's
  * existing precedent of inlining the watchdog's PowerShell script as a
  * string constant (see {@link spawnWatchdogWindows}). A single `${...}`
  * substitution (the env-var-name constant above) is all this template
@@ -559,12 +560,27 @@ export function invokeCritiqueTelemetryHook(
       // outright.
       child =
         platform === 'win32'
-          ? spawnFn(process.execPath, ['-e', WIN32_RELAY_SCRIPT], {
-              stdio: ['pipe', 'ignore', 'ignore'],
-              detached: true,
-              windowsHide: true,
-              env: { ...process.env, [WIN32_RELAY_COMMAND_ENV]: command },
-            })
+          ? spawnFn(
+              process.execPath,
+              // `--input-type=commonjs` (kurone-kito/idd-skill#2910
+              // review, Codex): explicit and load-bearing, not
+              // redundant with `-e`'s own CommonJS default. A caller
+              // whose own environment sets `NODE_OPTIONS=
+              // --input-type=module` -- inherited below via
+              // `...process.env` -- would otherwise make Node evaluate
+              // `WIN32_RELAY_SCRIPT` as ESM, where `require` is
+              // undefined and the relay throws before ever reading its
+              // stdin. Verified live: this flag overrides an
+              // inherited `--input-type=module` and is a no-op
+              // otherwise.
+              ['--input-type=commonjs', '-e', WIN32_RELAY_SCRIPT],
+              {
+                stdio: ['pipe', 'ignore', 'ignore'],
+                detached: true,
+                windowsHide: true,
+                env: { ...process.env, [WIN32_RELAY_COMMAND_ENV]: command },
+              },
+            )
           : spawnFn(command, {
               shell: true,
               stdio: ['pipe', 'ignore', 'ignore'],

--- a/src/scripts/idd-critique-telemetry-hook.mts
+++ b/src/scripts/idd-critique-telemetry-hook.mts
@@ -241,20 +241,39 @@ process.stdin.on('end', () => {
   // was tried first and rejected -- it broke every one of those stubs,
   // confirmed live).
   //
-  // In-place regex removal, not split/rejoin (kurone-kito/idd-skill#2910
+  // In-place regex removal within each unquoted segment, not a single
+  // whitespace-tokenizing split/rejoin (kurone-kito/idd-skill#2910
   // review, Copilot follow-up): an earlier version of this strip
-  // tokenized on whitespace and rejoined with single spaces, which is
-  // lossy for a quoted --require/--import value containing its own
-  // internal whitespace (for example a Windows path with a space in a
-  // directory name) -- rejoining would silently corrupt that path.
-  // Removing only the matched \`--input-type=<non-whitespace>\`
-  // substring (plus its own leading separator) leaves every other
-  // character of the original string, including any such quoting,
-  // completely untouched.
+  // tokenized the whole string on whitespace and rejoined with single
+  // spaces, which is lossy for a quoted --require/--import value
+  // containing its own internal whitespace (for example a Windows path
+  // with a space in a directory name) -- rejoining would silently
+  // corrupt that path. Removing only the matched
+  // \`--input-type=<non-whitespace>\` substring (plus its own leading
+  // separator) leaves every other character of the original string,
+  // including any such quoting, completely untouched.
+  //
+  // Quote-aware (kurone-kito/idd-skill#2910 review round 6, Copilot):
+  // the removal above is itself blind to quoting -- a legitimate quoted
+  // value that happens to contain the literal text \`--input-type=\`
+  // preceded by whitespace (for example a --require path whose own
+  // filename embeds that substring) would still be mangled, since a
+  // single whole-string regex has no notion of "inside a quoted span".
+  // Splitting first on double-quoted spans (keeping each one completely
+  // verbatim, including a backslash-escaped quote inside one, matching
+  // how Node's own NODE_OPTIONS parser treats \\" ) and applying the
+  // removal only to the unquoted segments between them closes that gap
+  // without reintroducing the whitespace-collapsing bug above --
+  // confirmed live: a --require value like
+  // \`"C:/dir/name --input-type=module.cjs"\` now survives unchanged.
   const forwardedNodeOptions = env['${WIN32_RELAY_NODE_OPTIONS_ENV}'] || '';
   delete env['${WIN32_RELAY_NODE_OPTIONS_ENV}'];
   const strippedNodeOptions = forwardedNodeOptions
-    .replace(/(^|\\s)--input-type=\\S+/g, '')
+    .split(/("(?:[^"\\\\]|\\\\.)*")/g)
+    .map((chunk, i) =>
+      i % 2 === 1 ? chunk : chunk.replace(/(^|\\s)--input-type=\\S+/g, ''),
+    )
+    .join('')
     .trim();
   if (strippedNodeOptions) {
     env.NODE_OPTIONS = strippedNodeOptions;
@@ -666,18 +685,43 @@ export function invokeCritiqueTelemetryHook(
         // the conditional spread below contributes nothing -- leaving
         // that stale value in `relayEnv` to reach the relay untouched,
         // which would then apply it to the inner spawn as if it were the
-        // real caller's NODE_OPTIONS. Delete both reserved keys
+        // real caller's NODE_OPTIONS. Deleting both reserved keys
         // unconditionally before the conditional re-add closes that gap;
         // `WIN32_RELAY_COMMAND_ENV` is always overwritten by the
         // unconditional entry below regardless, but is deleted here too
         // for symmetry and defense-in-depth.
+        //
+        // Folded into the same case-insensitive scan as NODE_OPTIONS
+        // (kurone-kito/idd-skill#2910 review round 6, Copilot + Codex,
+        // independently): an exact-case-only delete of the two reserved
+        // names above closes the gap only for their canonical spelling --
+        // Windows environment-variable names are case-insensitive at the
+        // OS level (the same reasoning the NODE_OPTIONS scan below already
+        // applies to itself), so a non-canonically-cased duplicate of
+        // either reserved name would still slip through without being
+        // scrubbed. In practice this specific gap is inert today, not a
+        // live leak: the
+        // relay's own lookup of these two names (WIN32_RELAY_SCRIPT's
+        // `env['...']` access) is itself exact-case, so a non-canonical
+        // duplicate reaching the relay is simply never read there either
+        // (confirmed live: a lower-cased reserved key added deliberately
+        // for this fix's own regression test still passed even before this
+        // change landed). Folding both names into one case-insensitive
+        // scan is still correct defense-in-depth against exactly that kind
+        // of exact-case assumption changing on either side in the future,
+        // and matches the NODE_OPTIONS scan's own reasoning rather than
+        // leaving these two names as a narrower, inconsistent special case.
         const relayEnv: NodeJS.ProcessEnv = { ...process.env };
-        delete relayEnv[WIN32_RELAY_COMMAND_ENV];
-        delete relayEnv[WIN32_RELAY_NODE_OPTIONS_ENV];
         let callerNodeOptions: string | undefined;
         for (const key of Object.keys(relayEnv)) {
-          if (key.toUpperCase() === 'NODE_OPTIONS') {
+          const upperKey = key.toUpperCase();
+          if (upperKey === 'NODE_OPTIONS') {
             callerNodeOptions = relayEnv[key];
+            delete relayEnv[key];
+          } else if (
+            upperKey === WIN32_RELAY_COMMAND_ENV ||
+            upperKey === WIN32_RELAY_NODE_OPTIONS_ENV
+          ) {
             delete relayEnv[key];
           }
         }

--- a/src/scripts/idd-critique-telemetry-hook.mts
+++ b/src/scripts/idd-critique-telemetry-hook.mts
@@ -655,7 +655,25 @@ export function invokeCritiqueTelemetryHook(
         // the relay load its preload code. Scan every key case-
         // insensitively instead, keeping the last match's value (in
         // practice at most one casing is ever actually set).
+        //
+        // Scrub the reserved transport keys from `relayEnv` itself
+        // (kurone-kito/idd-skill#2910 review, Codex follow-up): `relayEnv`
+        // starts as a full copy of `process.env`, so if this hook's own
+        // process somehow already inherited a stale
+        // `WIN32_RELAY_NODE_OPTIONS_ENV` value (for example a leftover
+        // from a nested/prior invocation) while the caller's own
+        // NODE_OPTIONS was unset, `callerNodeOptions` stays undefined and
+        // the conditional spread below contributes nothing -- leaving
+        // that stale value in `relayEnv` to reach the relay untouched,
+        // which would then apply it to the inner spawn as if it were the
+        // real caller's NODE_OPTIONS. Delete both reserved keys
+        // unconditionally before the conditional re-add closes that gap;
+        // `WIN32_RELAY_COMMAND_ENV` is always overwritten by the
+        // unconditional entry below regardless, but is deleted here too
+        // for symmetry and defense-in-depth.
         const relayEnv: NodeJS.ProcessEnv = { ...process.env };
+        delete relayEnv[WIN32_RELAY_COMMAND_ENV];
+        delete relayEnv[WIN32_RELAY_NODE_OPTIONS_ENV];
         let callerNodeOptions: string | undefined;
         for (const key of Object.keys(relayEnv)) {
           if (key.toUpperCase() === 'NODE_OPTIONS') {

--- a/src/scripts/idd-critique-telemetry-hook.mts
+++ b/src/scripts/idd-critique-telemetry-hook.mts
@@ -89,6 +89,131 @@ const PAYLOAD_DELIVERY_TIMEOUT_MS = 1_000;
  */
 const WATCHDOG_ARMED_TIMEOUT_MS = 3_000;
 
+/**
+ * Environment-variable name used to hand the real target `command`
+ * string to the win32 relay script (see {@link WIN32_RELAY_SCRIPT})
+ * rather than passing it as an argv element. The relay is spawned with
+ * `shell: false`, so argv escaping is not actually a concern for Node's
+ * own spawn call -- the env-var route is chosen instead because it
+ * keeps the relay's own argv fixed (`['-e', WIN32_RELAY_SCRIPT]`)
+ * regardless of the configured command's own content, and avoids
+ * reasoning twice about how an arbitrary shell command string interacts
+ * with Node's Windows argv-quoting rules (the first time being
+ * `command`'s own later `shell: true` hop inside the relay itself).
+ */
+const WIN32_RELAY_COMMAND_ENV =
+  'IDD_CRITIQUE_TELEMETRY_HOOK_WIN32_RELAY_COMMAND';
+
+/**
+ * win32-only relay script (kurone-kito/idd-skill#2910), run via
+ * `spawnFn(process.execPath, ['-e', WIN32_RELAY_SCRIPT], {...})` in
+ * {@link invokeCritiqueTelemetryHook} below -- mirrors this file's
+ * existing precedent of inlining the watchdog's PowerShell script as a
+ * string constant (see {@link spawnWatchdogWindows}). A single `${...}`
+ * substitution (the env-var-name constant above) is all this template
+ * literal needs; the rest of the script body contains no literal `${`
+ * sequence of its own, so there is no collision risk with the outer
+ * `.mts` template-literal interpolation to guard against here, unlike
+ * the watchdog's longer, multiply-interpolated PowerShell one-liner.
+ *
+ * Root cause (verified live on native Windows 11): `cmd.exe` (the
+ * `shell: true` wrapper the primary spawn below uses on POSIX, and used
+ * unconditionally on win32 too before this fix) never relays a piped
+ * stdin payload to the further child it execs when `cmd.exe` itself
+ * runs under Win32's `DETACHED_PROCESS` creation flag (what
+ * `detached: true` maps to) -- confirmed at every payload size from 0B
+ * to 500KB+, and for a non-Node consumer piped the same way, isolating
+ * the fault to `cmd.exe`'s own stdin-relay plumbing under
+ * `DETACHED_PROCESS` rather than anything Node/libuv- or payload-size-
+ * specific. This is the same "`DETACHED_PROCESS` breaks a
+ * console-subsystem process's own I/O/message-pump initialization"
+ * pattern already root-caused for {@link spawnWatchdogWindows}'s own
+ * `powershell.exe` hop (kurone-kito/idd-skill#2892 / PR #2897),
+ * recurring for `cmd.exe`'s stdin relay instead of `powershell.exe`'s
+ * ConsoleHost startup.
+ *
+ * Fix shape: this script is itself spawned *directly* (`shell: false`)
+ * as a `node.exe` child under `detached: true` -- confirmed live to
+ * deliver a piped stdin payload correctly, at every size from 0B to
+ * 500KB+, once the caller waits for the stream to fully close before
+ * exiting (this file's `onPayloadDelivered` contract already does
+ * exactly that). It then reads its own stdin to completion, and only
+ * *then* re-spawns the real `command` through `shell: true` -- but,
+ * deliberately, NOT `detached` this time: this relay process itself is
+ * what now needs to survive the CLI's `process.exit()`, not the
+ * `cmd.exe` hop underneath it, so `cmd.exe` here is a normal
+ * (non-`DETACHED_PROCESS`) child and does not hit the stdin-relay
+ * defect above. The relay forwards the buffered payload to that
+ * child's stdin (with the relay-command env var above scrubbed from
+ * that inner spawn's own environment, so the configured `command`
+ * never sees an env var it didn't configure) and exits with the same
+ * code, preserving `invokeCritiqueTelemetryHook`'s existing
+ * `ok: code === 0` contract for its caller unchanged.
+ *
+ * `child.pid` (what this file's timeout/kill/watchdog logic already
+ * operates on generically -- see {@link killProcessGroup}) becomes
+ * this relay's pid on win32. Verified live: a
+ * `taskkill /PID <relay-pid> /T /F` (the existing
+ * {@link killProcessTreeWindows} call, unchanged) still reaches and
+ * kills the whole chain -- relay -> `cmd.exe` -> real target -- for
+ * both an already-settled chain and a genuinely hung target, so no
+ * change is needed to {@link killProcessGroup},
+ * {@link killProcessTreeWindows}, or either `spawnWatchdog*` function.
+ *
+ * Never throws from the relay's own perspective: a synchronous spawn
+ * failure or an async `'error'`/non-zero exit all resolve to
+ * `finish(1)` (a non-ok result for the caller), matching this file's
+ * "never throws" contract for the primary hook spawn. Like every other
+ * failure mode this file already absorbs silently (a bad command, a
+ * non-zero exit, a timeout), a defect in this script's own body would
+ * also fail silently in production (its `stdio` discards stderr) --
+ * an accepted extension of the existing contract, not a new risk;
+ * the same gap already exists for the inline PowerShell watchdog
+ * script below, with no unit-level syntax check for either. The tests
+ * this issue adds are the mitigation, run for real (not just
+ * argument-shape asserted) both locally, via the `platform: 'win32'`
+ * override tests below, and on native `windows-latest` CI.
+ */
+const WIN32_RELAY_SCRIPT = `
+const { spawn } = require('node:child_process');
+const command = process.env.${WIN32_RELAY_COMMAND_ENV};
+const chunks = [];
+let settled = false;
+const finish = (code) => {
+  if (settled) return;
+  settled = true;
+  process.exit(code);
+};
+process.stdin.on('data', (c) => chunks.push(c));
+process.stdin.on('error', () => finish(1));
+process.stdin.on('end', () => {
+  const payload = Buffer.concat(chunks);
+  const env = { ...process.env };
+  delete env['${WIN32_RELAY_COMMAND_ENV}'];
+  let child;
+  try {
+    child = spawn(command, {
+      shell: true,
+      stdio: ['pipe', 'ignore', 'ignore'],
+      windowsHide: true,
+      env,
+    });
+  } catch {
+    finish(1);
+    return;
+  }
+  child.on('error', () => finish(1));
+  child.on('exit', (code) => finish(code === null ? 1 : code));
+  child.stdin.on('error', () => {});
+  try {
+    child.stdin.write(payload);
+    child.stdin.end();
+  } catch {
+    // 'error'/'exit' handlers above still settle.
+  }
+});
+`;
+
 if (import.meta.main) {
   runCli();
 }
@@ -243,15 +368,22 @@ export interface InvokeCritiqueTelemetryHookOptions {
   /** Injectable for tests; defaults to `node:child_process`'s `spawn`. */
   spawnFn?: typeof spawn;
   /**
-   * Called once (at most) as soon as `payload` has been fully handed off to
-   * the child's stdin -- on the stdin stream's `'close'` (fires once the
-   * underlying pipe is closed, whether that followed a clean `'finish'` or
-   * an error) or on a spawn/child `'error'` that means no delivery will
-   * ever happen. Lets a fire-and-forget caller (the CLI's `--invoke`, via
-   * `runInvoke` below) wait for the payload to actually reach the child's
-   * pipe without waiting for the hook *process* to settle (#2685 review,
+   * Called once (at most) as soon as `payload` has been fully **written
+   * to** the child's stdin -- on the stdin stream's `'close'` (fires once
+   * the underlying pipe is closed, whether that followed a clean
+   * `'finish'` or an error) or on a spawn/child `'error'` that means no
+   * delivery will ever happen. This signals the write side flushed into
+   * the OS pipe, not that the child has necessarily read the bytes yet.
+   * Lets a fire-and-forget caller (the CLI's `--invoke`, via `runInvoke`
+   * below) wait for the payload to actually reach the child's pipe
+   * without waiting for the hook *process* to settle (#2685 review,
    * CodeRabbit: `process.exit(0)` racing an in-flight stdin write could
-   * otherwise truncate the JSON the hook receives).
+   * otherwise truncate the JSON the hook receives). On win32
+   * (kurone-kito/idd-skill#2910), `child` is the relay process (see
+   * `WIN32_RELAY_SCRIPT`), so this signal specifically means the payload
+   * reached the *relay*, not yet the real target command one hop further
+   * down -- consistent with this option's existing "reached the child's
+   * pipe", not "the hook finished", contract.
    */
   onPayloadDelivered?: () => void;
   /**
@@ -384,48 +516,61 @@ export function invokeCritiqueTelemetryHook(
 
     let child: ChildProcess;
     try {
-      child = spawnFn(command, {
-        shell: true,
-        stdio: ['pipe', 'ignore', 'ignore'],
-        // `detached: true` (not `child.unref()`) only: this puts the child
-        // in its own session so it survives a signal sent to this
-        // process's group (e.g. the invoking shell's own job-control
-        // teardown), without unref'ing it. Deliberately NOT calling
-        // `child.unref()` here -- that would remove the *only* thing
-        // keeping the event loop alive long enough for the (also unref'd)
-        // timeout timer below to ever fire for a caller that legitimately
-        // awaits this promise (every test in this file does; a future
-        // non-CLI embedder might too) -- with both unref'd, nothing forces
-        // the loop to keep running, so the promise could stay pending
-        // forever once nothing else in the process needs the loop. The
-        // CLI's own `--invoke` mode (below) doesn't need this ref/unref
-        // distinction at all: it never awaits this promise, and
-        // `process.exit()` terminates unconditionally regardless of any
-        // pending handle's ref status.
-        detached: true,
-        // windowsHide (kurone-kito/idd-skill#2892; no-op on POSIX): maps to
-        // Win32's CREATE_NO_WINDOW creation flag *and* STARTUPINFO's
-        // wShowWindow=SW_HIDE. Verified against libuv's own win/process.c
-        // and Microsoft's Process Creation Flags documentation: the
-        // CREATE_NO_WINDOW half is a documented no-op here specifically --
-        // MSDN states it "is ignored if ... used with either
-        // CREATE_NEW_CONSOLE or DETACHED_PROCESS", and `detached: true`
-        // above is what sets DETACHED_PROCESS (required so this child
-        // survives `--invoke`'s `process.exit()`; cannot be dropped). The
-        // wShowWindow=SW_HIDE half is set unconditionally in STARTUPINFO
-        // regardless of DETACHED_PROCESS, and `cmd.exe` (the `shell: true`
-        // wrapper on win32) DOES propagate that show-state hint to the
-        // further child it execs for `command` -- verified live on native
-        // Windows 11 (kurone-kito/idd-skill#2892 review follow-up): a
-        // real, unmocked spawn through this exact path shows
-        // `MainWindowHandle == 0` (Get-Process) for both a quick-exiting
-        // and a hung-then-killed target, for the whole process tree this
-        // creates. The bound, reliable mitigation for a window that
-        // somehow still appears despite this is `killProcessGroup`'s
-        // win32 tree-kill below, which caps its lifetime at `timeoutMs`
-        // rather than preventing it outright.
-        windowsHide: true,
-      });
+      // `detached: true` (not `child.unref()`) only, on both branches
+      // below: this puts the child in its own session so it survives a
+      // signal sent to this process's group (e.g. the invoking shell's
+      // own job-control teardown), without unref'ing it. Deliberately
+      // NOT calling `child.unref()` here -- that would remove the *only*
+      // thing keeping the event loop alive long enough for the (also
+      // unref'd) timeout timer below to ever fire for a caller that
+      // legitimately awaits this promise (every test in this file does;
+      // a future non-CLI embedder might too) -- with both unref'd,
+      // nothing forces the loop to keep running, so the promise could
+      // stay pending forever once nothing else in the process needs the
+      // loop. The CLI's own `--invoke` mode (below) doesn't need this
+      // ref/unref distinction at all: it never awaits this promise, and
+      // `process.exit()` terminates unconditionally regardless of any
+      // pending handle's ref status.
+      //
+      // windowsHide (kurone-kito/idd-skill#2892; no-op on POSIX): maps to
+      // Win32's CREATE_NO_WINDOW creation flag *and* STARTUPINFO's
+      // wShowWindow=SW_HIDE. Verified against libuv's own win/process.c
+      // and Microsoft's Process Creation Flags documentation: the
+      // CREATE_NO_WINDOW half is a documented no-op specifically when
+      // combined with DETACHED_PROCESS (what `detached: true` sets) --
+      // MSDN states it "is ignored if ... used with either
+      // CREATE_NEW_CONSOLE or DETACHED_PROCESS". On the win32 branch
+      // below, that leaves `windowsHide` on the outer (detached) relay
+      // spawn a documented no-op for the same reason `spawnWatchdogWindows`'s
+      // own detached spawn is -- the relay is a plain `node.exe` process
+      // with no console to begin with under DETACHED_PROCESS, so there is
+      // nothing to hide there regardless. The relay's *own* inner spawn of
+      // the real `command` (see `WIN32_RELAY_SCRIPT` below) is NOT
+      // detached, so CREATE_NO_WINDOW is not overridden there and reliably
+      // suppresses that `cmd.exe` hop's own console window directly --
+      // verified live on native Windows 11 (kurone-kito/idd-skill#2892
+      // review follow-up, re-confirmed for kurone-kito/idd-skill#2910's
+      // relay shape): `MainWindowHandle == 0` (Get-Process) for both a
+      // quick-exiting and a hung-then-killed target, for the whole
+      // process tree this creates. The bound, reliable mitigation for a
+      // window that somehow still appears despite this is
+      // `killProcessGroup`'s win32 tree-kill below, which caps the whole
+      // chain's lifetime at `timeoutMs` rather than preventing it
+      // outright.
+      child =
+        platform === 'win32'
+          ? spawnFn(process.execPath, ['-e', WIN32_RELAY_SCRIPT], {
+              stdio: ['pipe', 'ignore', 'ignore'],
+              detached: true,
+              windowsHide: true,
+              env: { ...process.env, [WIN32_RELAY_COMMAND_ENV]: command },
+            })
+          : spawnFn(command, {
+              shell: true,
+              stdio: ['pipe', 'ignore', 'ignore'],
+              detached: true,
+              windowsHide: true,
+            });
     } catch {
       settle(false);
       notifyDelivered();
@@ -568,13 +713,20 @@ export function invokeCritiqueTelemetryHook(
  * POSIX process-group semantics). On win32, a negative pid is meaningless
  * to `process.kill` -- there is no POSIX-style process-group signal to
  * send -- so this instead delegates to {@link killProcessTreeWindows}, a
- * real process-*tree* kill via `taskkill /T` (kurone-kito/idd-skill#2892):
- * `shell: true` makes `child` the `cmd.exe` wrapper, and the actual
- * invoked command is a *further* child of that wrapper, never reachable by
- * terminating the wrapper alone -- which is exactly what this file's
- * previous Windows fallback (`child.kill('SIGKILL')` below) only ever did,
- * leaving that further child (and its own auto-allocated console window)
- * orphaned. Never throws.
+ * real process-*tree* kill via `taskkill /T` (kurone-kito/idd-skill#2892).
+ * On win32, `child` is the primary spawn's own top-level process:
+ * `cmd.exe` (the `shell: true` wrapper) directly, on POSIX and, before
+ * kurone-kito/idd-skill#2910, on win32 too; since that fix, the win32
+ * `child` is instead the relay process (see `WIN32_RELAY_SCRIPT`), which
+ * itself wraps `cmd.exe` as its own child one level further down. Either
+ * way, the actual invoked command sits one or more levels beneath `child`,
+ * never reachable by terminating `child` alone -- which is exactly what
+ * this file's previous Windows fallback (`child.kill('SIGKILL')` below)
+ * only ever did, leaving that further descendant (and its own
+ * auto-allocated console window) orphaned. `taskkill /T`'s tree-kill
+ * reaches the whole subtree regardless of its depth beneath `child`, so
+ * this function needs no depth-specific knowledge of which shape `child`
+ * is. Never throws.
  *
  * Also used by {@link cancelWatchdog} to disarm the watchdog's own process
  * (itself `detached: true` -- see {@link spawnWatchdogPosix} /

--- a/src/scripts/idd-critique-telemetry-hook.mts
+++ b/src/scripts/idd-critique-telemetry-hook.mts
@@ -634,7 +634,26 @@ export function invokeCritiqueTelemetryHook(
         // WIN32_RELAY_SCRIPT's own doc comment for the full rationale
         // and why the original value still reaches the real target
         // command via a separate channel instead of being dropped.
-        const { NODE_OPTIONS: callerNodeOptions, ...relayEnv } = process.env;
+        //
+        // Case-insensitive key match (kurone-kito/idd-skill#2910 review,
+        // Copilot follow-up): Windows environment variable names are
+        // case-insensitive at the OS level, but a plain destructure
+        // (`const { NODE_OPTIONS, ...rest } = process.env`) only removes
+        // the exact-case key -- an inherited `Node_Options` or
+        // `node_options` entry (real-world precedent: Windows system
+        // variables like `ComSpec`/`Path` routinely keep non-canonical
+        // casing) would survive into `relayEnv` untouched and still let
+        // the relay load its preload code. Scan every key case-
+        // insensitively instead, keeping the last match's value (in
+        // practice at most one casing is ever actually set).
+        const relayEnv: NodeJS.ProcessEnv = { ...process.env };
+        let callerNodeOptions: string | undefined;
+        for (const key of Object.keys(relayEnv)) {
+          if (key.toUpperCase() === 'NODE_OPTIONS') {
+            callerNodeOptions = relayEnv[key];
+            delete relayEnv[key];
+          }
+        }
         child = spawnFn(
           process.execPath,
           // `--input-type=commonjs` (kurone-kito/idd-skill#2910 review,

--- a/tests/idd-critique-telemetry-hook.test.mts
+++ b/tests/idd-critique-telemetry-hook.test.mts
@@ -699,7 +699,12 @@ test('invokeCritiqueTelemetryHook spawns a win32 process-tree kill (taskkill /PI
     let taskkillOptions: Record<string, unknown> | undefined;
     const spawnFn: typeof spawn = ((...args: Parameters<typeof spawn>) => {
       const child = spawn(...args);
-      if (args[0] === stayAliveCommand('idd-telemetry-hook-hang-win32')) {
+      // kurone-kito/idd-skill#2910: on win32 the primary spawn is the
+      // relay (`process.execPath` with `-e`), not the raw command string
+      // -- `process.execPath` is the one value unique to that call among
+      // everything else this spawnFn sees (the watchdog and `taskkill`
+      // calls both pass a string as args[0]).
+      if (args[0] === process.execPath) {
         primaryChild = child;
       }
       if (args[0] === 'taskkill') {
@@ -836,6 +841,14 @@ test('invokeCritiqueTelemetryHook win32 backup watchdog actually kills a real hu
     'idd-telemetry-hook-watchdog-real-kill',
     'setInterval(() => {}, 1000);\n',
   );
+  // kurone-kito/idd-skill#2910: on win32 the primary spawn is the relay
+  // (`process.execPath` with `-e`), so `hookPid` below is the relay's
+  // own pid, not the innermost stub script's pid -- exactly what
+  // killProcessGroup/killProcessTreeWindows operate on in production.
+  // The watchdog's `taskkill /PID <relay-pid> /T /F` still has to reach
+  // through the relay's own `cmd.exe` hop to the real stub script to
+  // terminate it, so checking whether the relay's pid is still alive
+  // below still proves the watchdog's tree-kill actually worked.
   let hookPid: number | undefined;
   try {
     const spawnFn: typeof spawn = ((...args: Parameters<typeof spawn>) => {
@@ -845,10 +858,7 @@ test('invokeCritiqueTelemetryHook win32 backup watchdog actually kills a real hu
         return fake;
       }
       const child = spawn(...args);
-      if (
-        typeof args[0] === 'string' &&
-        args[0].includes('idd-telemetry-hook-watchdog-real-kill')
-      ) {
+      if (args[0] === process.execPath) {
         hookPid = child.pid;
       }
       return child;
@@ -858,7 +868,7 @@ test('invokeCritiqueTelemetryHook win32 backup watchdog actually kills a real hu
       samplePayload(),
       { timeoutMs: 1_000, spawnFn },
     );
-    assert.ok(hookPid, 'expected the hung hook to have a real pid');
+    assert.ok(hookPid, 'expected the relay to have a real pid');
     // Give the watchdog's own 1-second sleep plus its taskkill call room
     // to complete -- generous but bounded, matching this file's other
     // real-timing assertions.
@@ -960,13 +970,13 @@ test('invokeCritiqueTelemetryHook does not create a visible console window on wi
     await quickPromise;
 
     // Half 2: a command that hangs and is killed on timeout.
+    // kurone-kito/idd-skill#2910: on win32 the primary spawn is the relay
+    // (`process.execPath` with `-e`), so `hangPid` below (used only for
+    // this test's own cleanup, not an assertion) is the relay's pid.
     let hangPid: number | undefined;
     const spawnFn: typeof spawn = ((...args: Parameters<typeof spawn>) => {
       const child = spawn(...args);
-      if (
-        typeof args[0] === 'string' &&
-        args[0].includes('idd-telemetry-hook-window-check-hang')
-      ) {
+      if (args[0] === process.execPath) {
         hangPid = child.pid;
       }
       return child;
@@ -1023,7 +1033,10 @@ test('invokeCritiqueTelemetryHook falls back to killing just the wrapper when th
         throw new Error('synthetic taskkill spawn failure');
       }
       const child = spawn(...args);
-      if (args[0] === stayAliveCommand('idd-telemetry-hook-hang-win32-throw')) {
+      // kurone-kito/idd-skill#2910: see the win32 taskkill-on-timeout
+      // test above for why `process.execPath` (not the raw command
+      // string) now uniquely identifies the primary spawn on win32.
+      if (args[0] === process.execPath) {
         primaryChild = child;
       }
       return child;
@@ -1124,10 +1137,10 @@ test('invokeCritiqueTelemetryHook falls back to killing just the wrapper when th
         return fakeKiller;
       }
       const child = spawn(...args);
-      if (
-        args[0] ===
-        stayAliveCommand('idd-telemetry-hook-hang-win32-async-throw')
-      ) {
+      // kurone-kito/idd-skill#2910: see the win32 taskkill-on-timeout
+      // test above for why `process.execPath` (not the raw command
+      // string) now uniquely identifies the primary spawn on win32.
+      if (args[0] === process.execPath) {
         primaryChild = child;
       }
       return child;
@@ -1557,20 +1570,15 @@ test('CLI --invoke does not wait for a hanging resolved hook up to its default 5
   }
 });
 
-test('CLI --invoke waits for a large payload to fully reach the hook before exiting (#2685 review, CodeRabbit)', {
-  // win32 (kurone-kito/idd-skill#2910 follow-up): the production spawn
-  // shape this test exercises -- `shell: true` + `detached: true` + piped
-  // stdin -- never delivers ANY stdin payload to the target command on
-  // native Windows, not just large ones. Confirmed via a size sweep from
-  // 0B to 500KB: every non-empty size fails identically (the grandchild's
-  // stdin never emits 'data' or 'end'), and a native (non-Node) consumer
-  // piped through the same shape is equally affected, isolating the fault
-  // to `cmd.exe`'s own stdin relay under Win32's DETACHED_PROCESS creation
-  // flag rather than anything Node/libuv- or payload-size-specific. This
-  // is a pre-existing defect (predates PR #2897) with no known fix yet --
-  // see #2910 for the full reproduction matrix and candidate designs.
-  skip: process.platform === 'win32',
-}, async () => {
+test('CLI --invoke waits for a large payload to fully reach the hook before exiting (#2685 review, CodeRabbit)', async () => {
+  // win32 (kurone-kito/idd-skill#2910): this test used to be skipped on
+  // win32 -- the production spawn shape it exercises, `shell: true` +
+  // `detached: true` + piped stdin, never delivered ANY stdin payload to
+  // the target command on native Windows, at any size. #2910's fix
+  // (a `shell: false` `node.exe` relay hop on win32 only, see
+  // `WIN32_RELAY_SCRIPT`) resolves the underlying defect, so this test
+  // now runs for real on every platform, exercising the fixed,
+  // unmocked `invokeCritiqueTelemetryHook` spawn path end to end.
   // Regression fixture: `runInvoke` used to fire `invokeCritiqueTelemetryHook`
   // and call `process.exit(0)` right after, without waiting for the stdin
   // write to the hook's pipe to actually finish -- fine for a small
@@ -1630,6 +1638,63 @@ process.stdin.on('end', () => {
       received,
       expected,
       'expected the hook to receive the full, untruncated payload',
+    );
+  } finally {
+    restore();
+  }
+});
+
+test('CLI --invoke waits for a small payload to fully reach the hook before exiting on win32 (kurone-kito/idd-skill#2910)', {
+  // The large-payload test above already covers win32 for a payload well
+  // over the OS pipe buffer; #2910's own reproduction found the defect
+  // was size-independent (0B and every size up to 500KB+ all failed
+  // identically), so this test closes the acceptance criterion's other
+  // explicit half -- a small (well under 1KB), single-write payload --
+  // on real win32 specifically, where the relay hop actually matters.
+  // POSIX needs no separate small-payload win32 case since it never took
+  // the relay path to begin with.
+  skip: process.platform !== 'win32',
+}, async () => {
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-critique-telemetry-hook-cli-invoke-small-payload-'),
+  );
+  const receivedPath = join(sandbox, 'received.json');
+  const restore = stubExecutable(
+    'idd-telemetry-hook-capture-stdin-small',
+    `const fs = require('fs');
+const chunks = [];
+process.stdin.on('data', (c) => chunks.push(c));
+process.stdin.on('end', () => {
+  fs.writeFileSync(${JSON.stringify(receivedPath)}, Buffer.concat(chunks));
+  process.exit(0);
+});
+`,
+  );
+  try {
+    const policyPath = join(sandbox, 'config.json');
+    writeFileSync(
+      policyPath,
+      JSON.stringify({
+        critiqueLoop: {
+          telemetryHook: {
+            command: stayAliveCommand('idd-telemetry-hook-capture-stdin-small'),
+          },
+        },
+      }),
+    );
+    const expected = JSON.stringify(samplePayload());
+    const { stdout } = runCli(
+      ['--policy', policyPath, '--invoke'],
+      undefined,
+      expected,
+    );
+    assert.equal(stdout, '');
+
+    const received = await waitForNonEmptyFile(receivedPath, 5_000);
+    assert.equal(
+      received,
+      expected,
+      'expected the hook to receive the full, untruncated small payload',
     );
   } finally {
     restore();

--- a/tests/idd-critique-telemetry-hook.test.mts
+++ b/tests/idd-critique-telemetry-hook.test.mts
@@ -783,6 +783,62 @@ process.stdin.on('end', () => {
   }
 });
 
+test('invokeCritiqueTelemetryHook forwards a compound (a && b) command through the win32 relay when platform is overridden to win32 (kurone-kito/idd-skill#2910 review, Copilot)', async () => {
+  // Issue #2910's own "Proposed change" section requires this fix to
+  // "keep the existing command config contract (an arbitrary shell
+  // command string, including a && b-style compound commands) working
+  // the same way it does on POSIX today, since shell: true exists
+  // specifically to support that". The win32-relay-success test above
+  // only exercises a single executable; this test closes that gap with
+  // a genuine `a && b` compound command, forwarded through the relay's
+  // own inner `shell: true` hop unchanged. The first stub deliberately
+  // does not read stdin (exits synchronously and unconditionally, so it
+  // needs no `stayAliveCommand` positional argument per that helper's
+  // own doc comment), so the full payload reaches the second stub
+  // untouched -- proving the relay does not mangle or truncate the
+  // command string across the `&&` boundary.
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-critique-telemetry-hook-win32-relay-compound-'),
+  );
+  const receivedPath = join(sandbox, 'received.json');
+  const restoreFirst = stubExecutable(
+    'idd-telemetry-hook-win32-relay-compound-first',
+    'process.exit(0);\n',
+  );
+  const restoreSecond = stubExecutable(
+    'idd-telemetry-hook-win32-relay-compound-second',
+    `const fs = require('fs');
+const chunks = [];
+process.stdin.on('data', (c) => chunks.push(c));
+process.stdin.on('end', () => {
+  fs.writeFileSync(${JSON.stringify(receivedPath)}, Buffer.concat(chunks));
+  process.exit(0);
+});
+`,
+  );
+  try {
+    const command =
+      'idd-telemetry-hook-win32-relay-compound-first && ' +
+      stayAliveCommand('idd-telemetry-hook-win32-relay-compound-second');
+    const payload = samplePayload();
+    const result = await invokeCritiqueTelemetryHook(command, payload, {
+      timeoutMs: 5_000,
+      platform: 'win32',
+    });
+    assert.deepEqual(result, { attempted: true, ok: true });
+    const received = await waitForNonEmptyFile(receivedPath, 5_000);
+    assert.equal(
+      received,
+      JSON.stringify(payload),
+      'expected the second half of the compound command to receive the full, untruncated payload',
+    );
+  } finally {
+    // LIFO order, matching this file's other multi-stub tests.
+    restoreSecond();
+    restoreFirst();
+  }
+});
+
 test('invokeCritiqueTelemetryHook spawns a win32 process-tree kill (taskkill /PID <pid> /T /F) on timeout when platform is overridden to win32', async () => {
   const restore = stubExecutable(
     'idd-telemetry-hook-hang-win32',

--- a/tests/idd-critique-telemetry-hook.test.mts
+++ b/tests/idd-critique-telemetry-hook.test.mts
@@ -678,15 +678,24 @@ test('invokeCritiqueTelemetryHook kills a backgrounded descendant on timeout, no
 // These two tests give deterministic, non-CI coverage of the *argument
 // construction* for the win32 kill path from any OS, using the injectable
 // `platform` option the same way `spawnFn` is already injected for
-// testability -- overriding `platform` only changes which of
-// `killProcessGroup`/`spawnWatchdog`'s own branches this code takes; it
-// does not change which real shell the still-real `shell: true` spawn
-// below is interpreted by (that is always whatever the host OS actually
-// provides). The `windows-latest` CI job (added alongside this file) is
-// the actual behavioral verification gate on every push; the argument-shape
-// tests below have also since been cross-checked live on native Windows 11
-// during the #2897 CI follow-up (kurone-kito/idd-skill#2892), not only
-// inferred from a non-Windows implementation environment.
+// testability. Originally (kurone-kito/idd-skill#2892), overriding
+// `platform` only changed which of `killProcessGroup`/`spawnWatchdog`'s
+// own branches the code took, never which real shell the primary
+// `shell: true` spawn was interpreted by (always whatever the host OS
+// actually provides). kurone-kito/idd-skill#2910 extended `platform` to
+// also select the *primary* spawn shape: on any host, an override to
+// `'win32'` now routes that primary spawn through the real
+// `WIN32_RELAY_SCRIPT` (via `node -e`, not mocked), which itself still
+// invokes the host's own real shell for the actual target command one
+// hop further in -- so the win32-specific relay logic gets real,
+// non-CI-only coverage too, not just the kill/watchdog argument shapes
+// this section's own two tests below were originally written for. The
+// `windows-latest` CI job (added alongside this file) remains the actual
+// behavioral verification gate on every push; the argument-shape tests
+// below have also since been cross-checked live on native Windows 11
+// during the #2897 CI follow-up (kurone-kito/idd-skill#2892) and the
+// #2910 relay work, not only inferred from a non-Windows implementation
+// environment.
 
 test('invokeCritiqueTelemetryHook delivers the payload and resolves ok:true through the win32 relay when platform is overridden to win32 (kurone-kito/idd-skill#2910)', async () => {
   // Complements the win32 hang/kill-path tests below (which all exercise
@@ -740,11 +749,17 @@ test('invokeCritiqueTelemetryHook win32 relay survives an inherited NODE_OPTIONS
   // not defined in ES module scope`) before this test was written. The
   // fix passes an explicit `--input-type=commonjs` flag, which overrides
   // an inherited `--input-type=module`.
-  const originalNodeOptions = process.env.NODE_OPTIONS;
   const sandbox = mkdtempSync(
     join(tmpdir(), 'idd-critique-telemetry-hook-win32-relay-node-options-'),
   );
   const receivedPath = join(sandbox, 'received.json');
+  // stubExecutable's own win32 branch already sets process.env.NODE_OPTIONS
+  // (to inject its own `--require <preload>`) as part of the call below --
+  // append to THAT current value, not to whatever NODE_OPTIONS held before
+  // this call. Appending to a pre-stub snapshot instead would silently
+  // discard the stub's own `--require` and break the stub mechanism
+  // itself (confirmed live on native Windows: doing it that way made 10
+  // unrelated win32 tests fail alongside this one, not just this one).
   const restore = stubExecutable(
     'idd-telemetry-hook-win32-relay-node-options',
     `const fs = require('fs');
@@ -756,9 +771,10 @@ process.stdin.on('end', () => {
 });
 `,
   );
+  const nodeOptionsAfterStub = process.env.NODE_OPTIONS;
   try {
-    process.env.NODE_OPTIONS = originalNodeOptions
-      ? `${originalNodeOptions} --input-type=module`
+    process.env.NODE_OPTIONS = nodeOptionsAfterStub
+      ? `${nodeOptionsAfterStub} --input-type=module`
       : '--input-type=module';
     const payload = samplePayload();
     const result = await invokeCritiqueTelemetryHook(
@@ -774,10 +790,15 @@ process.stdin.on('end', () => {
       'expected the relay to still deliver the payload despite an inherited --input-type=module',
     );
   } finally {
-    if (originalNodeOptions === undefined) {
+    // Restore to the stub's own NODE_OPTIONS value (pre --input-type
+    // append) before restore() unwinds the stub itself -- restore()
+    // resets to its own pre-stub snapshot regardless, so this step is
+    // only needed if a future edit adds code between here and restore()
+    // that reads process.env.NODE_OPTIONS.
+    if (nodeOptionsAfterStub === undefined) {
       delete process.env.NODE_OPTIONS;
     } else {
-      process.env.NODE_OPTIONS = originalNodeOptions;
+      process.env.NODE_OPTIONS = nodeOptionsAfterStub;
     }
     restore();
   }

--- a/tests/idd-critique-telemetry-hook.test.mts
+++ b/tests/idd-critique-telemetry-hook.test.mts
@@ -993,6 +993,98 @@ process.stdin.on('end', () => {
   }
 });
 
+test('invokeCritiqueTelemetryHook win32 relay clears a stale inherited reserved NODE_OPTIONS-channel value before spawning (kurone-kito/idd-skill#2910 review, Codex follow-up)', async () => {
+  // The reserved IDD_CRITIQUE_TELEMETRY_HOOK_WIN32_RELAY_NODE_OPTIONS
+  // channel exists purely as transport from the primary process to the
+  // relay's own inner spawn (see WIN32_RELAY_SCRIPT's own doc comment) --
+  // it is never meant to already be present as an ambient variable on
+  // this hook's own process. But if it somehow is (for example leaked
+  // from a nested or prior invocation of this same hook), the primary
+  // spawn's relayEnv -- a full copy of process.env -- inherits it too;
+  // when the real caller's own NODE_OPTIONS happens to be unset,
+  // callerNodeOptions comes back undefined, so the conditional re-add
+  // contributes nothing and nothing else explicitly clears the stale
+  // value out of relayEnv before it reaches the relay. Simulate that leak
+  // directly with an intentionally-broken --require target on the stale
+  // channel: if it reaches the real target's NODE_OPTIONS without being
+  // scrubbed first, the target process fails to even start and the
+  // payload never arrives; with the channel properly cleared, the target
+  // starts clean and receives the payload normally.
+  //
+  // Not `stubExecutable` (confirmed live on native Windows): its own win32
+  // branch unconditionally sets `process.env.NODE_OPTIONS` itself, to make
+  // its exe-copy-plus-preload redirect trick work at all -- deleting
+  // NODE_OPTIONS the way this test needs to would break that redirect and
+  // fail the test regardless of whether the fix under test is applied,
+  // which is exactly what happened when this test was first written
+  // against `stubExecutable`. Building the target directly as `node
+  // <scriptPath>` sidesteps NODE_OPTIONS entirely for the target's own
+  // startup, leaving this test free to control it purely to exercise the
+  // reserved-channel leak.
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-critique-telemetry-hook-win32-relay-stale-channel-'),
+  );
+  const receivedPath = join(sandbox, 'received.json');
+  const targetScriptPath = join(sandbox, 'target.cjs');
+  writeFileSync(
+    targetScriptPath,
+    `const fs = require('fs');
+const chunks = [];
+process.stdin.on('data', (c) => chunks.push(c));
+process.stdin.on('end', () => {
+  fs.writeFileSync(${JSON.stringify(receivedPath)}, Buffer.concat(chunks));
+  process.exit(0);
+});
+`,
+  );
+  // Two simple quoted paths, no nested quoting or embedded newlines --
+  // deliberately avoids `-e "<script>"` here (unlike this file's other
+  // directly-built commands), since that would need the whole multi-line
+  // script JSON-escaped into one already-quoted command string, which
+  // `cmd.exe`'s own quote parsing (the real win32 shell behind `shell:
+  // true`) does not handle the same way a POSIX shell does.
+  const command = `${JSON.stringify(process.execPath)} ${JSON.stringify(targetScriptPath)}`;
+  const hadNodeOptions = Object.hasOwn(process.env, 'NODE_OPTIONS');
+  const previousNodeOptions = process.env.NODE_OPTIONS;
+  const hadStaleChannelValue = Object.hasOwn(
+    process.env,
+    'IDD_CRITIQUE_TELEMETRY_HOOK_WIN32_RELAY_NODE_OPTIONS',
+  );
+  const previousStaleChannelValue =
+    process.env.IDD_CRITIQUE_TELEMETRY_HOOK_WIN32_RELAY_NODE_OPTIONS;
+  try {
+    // NODE_OPTIONS itself must stay unset so callerNodeOptions comes back
+    // undefined and the conditional re-add cannot mask the bug under test.
+    delete process.env.NODE_OPTIONS;
+    process.env.IDD_CRITIQUE_TELEMETRY_HOOK_WIN32_RELAY_NODE_OPTIONS =
+      '--require /idd-2910-nonexistent-stale-channel-preload.cjs';
+    const payload = samplePayload();
+    const result = await invokeCritiqueTelemetryHook(command, payload, {
+      timeoutMs: 5_000,
+      platform: 'win32',
+    });
+    assert.deepEqual(result, { attempted: true, ok: true });
+    const received = await waitForNonEmptyFile(receivedPath, 5_000);
+    assert.equal(
+      received,
+      JSON.stringify(payload),
+      'expected the target to start clean and receive the full payload, with the stale reserved channel value scrubbed rather than leaked through as its NODE_OPTIONS',
+    );
+  } finally {
+    if (hadStaleChannelValue) {
+      process.env.IDD_CRITIQUE_TELEMETRY_HOOK_WIN32_RELAY_NODE_OPTIONS =
+        previousStaleChannelValue;
+    } else {
+      delete process.env.IDD_CRITIQUE_TELEMETRY_HOOK_WIN32_RELAY_NODE_OPTIONS;
+    }
+    if (hadNodeOptions) {
+      process.env.NODE_OPTIONS = previousNodeOptions;
+    } else {
+      delete process.env.NODE_OPTIONS;
+    }
+  }
+});
+
 test('invokeCritiqueTelemetryHook forwards a compound (a && b) command through the win32 relay when platform is overridden to win32 (kurone-kito/idd-skill#2910 review, Copilot)', async () => {
   // Issue #2910's own "Proposed change" section requires this fix to
   // "keep the existing command config contract (an arbitrary shell

--- a/tests/idd-critique-telemetry-hook.test.mts
+++ b/tests/idd-critique-telemetry-hook.test.mts
@@ -688,6 +688,48 @@ test('invokeCritiqueTelemetryHook kills a backgrounded descendant on timeout, no
 // during the #2897 CI follow-up (kurone-kito/idd-skill#2892), not only
 // inferred from a non-Windows implementation environment.
 
+test('invokeCritiqueTelemetryHook delivers the payload and resolves ok:true through the win32 relay when platform is overridden to win32 (kurone-kito/idd-skill#2910)', async () => {
+  // Complements the win32 hang/kill-path tests below (which all exercise
+  // `ok:false` outcomes) with the relay's own success path: a quick-exiting
+  // target, byte-exact payload delivery, and `ok:true`/exit-code-0
+  // forwarding through the relay -- `platform: 'win32'` routes this call
+  // through the real `WIN32_RELAY_SCRIPT` (via `node -e`, not mocked) even
+  // on this non-Windows test host, the same real-code-path coverage this
+  // file's other `platform: 'win32'`-override tests already rely on.
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-critique-telemetry-hook-win32-relay-success-'),
+  );
+  const receivedPath = join(sandbox, 'received.json');
+  const restore = stubExecutable(
+    'idd-telemetry-hook-win32-relay-success',
+    `const fs = require('fs');
+const chunks = [];
+process.stdin.on('data', (c) => chunks.push(c));
+process.stdin.on('end', () => {
+  fs.writeFileSync(${JSON.stringify(receivedPath)}, Buffer.concat(chunks));
+  process.exit(0);
+});
+`,
+  );
+  try {
+    const payload = samplePayload();
+    const result = await invokeCritiqueTelemetryHook(
+      stayAliveCommand('idd-telemetry-hook-win32-relay-success'),
+      payload,
+      { timeoutMs: 5_000, platform: 'win32' },
+    );
+    assert.deepEqual(result, { attempted: true, ok: true });
+    const received = await waitForNonEmptyFile(receivedPath, 5_000);
+    assert.equal(
+      received,
+      JSON.stringify(payload),
+      'expected the relay to forward the full, untruncated payload to the real target',
+    );
+  } finally {
+    restore();
+  }
+});
+
 test('invokeCritiqueTelemetryHook spawns a win32 process-tree kill (taskkill /PID <pid> /T /F) on timeout when platform is overridden to win32', async () => {
   const restore = stubExecutable(
     'idd-telemetry-hook-hang-win32',

--- a/tests/idd-critique-telemetry-hook.test.mts
+++ b/tests/idd-critique-telemetry-hook.test.mts
@@ -1085,6 +1085,148 @@ process.stdin.on('end', () => {
   }
 });
 
+test('invokeCritiqueTelemetryHook win32 relay preserves a quoted --require path whose own filename embeds "--input-type=" text (kurone-kito/idd-skill#2910 review round 6, Copilot + Codex)', async () => {
+  // The --input-type strip (see WIN32_RELAY_SCRIPT's own doc comment) used
+  // to be one whole-string regex with no notion of "inside a quoted
+  // span" -- so a *legitimate* quoted --require value that happens to
+  // contain the literal text "--input-type=" preceded by whitespace (for
+  // example a filename that itself embeds that substring, a real if
+  // unusual shape) would be mistaken for a genuine top-level option and
+  // stripped, truncating the quoted path and breaking the target's own
+  // --require. Deliberately construct the preload's *filename* to embed
+  // that exact substring, reproducing the review's own repro
+  // (`"C:/dir/name --input-type=module.cjs"`) rather than a synthetic
+  // stand-in.
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-critique-telemetry-hook-win32-relay-quoted-token-'),
+  );
+  const targetPreloadSentinel = join(sandbox, 'target-preload-loaded.txt');
+  const preloadPath = join(sandbox, 'preload --input-type=module.cjs');
+  writeFileSync(
+    preloadPath,
+    `require('fs').writeFileSync(${JSON.stringify(targetPreloadSentinel)}, 'loaded');\n`,
+  );
+  const receivedPath = join(sandbox, 'received.json');
+  const restore = stubExecutable(
+    'idd-telemetry-hook-win32-relay-quoted-token-target',
+    `const fs = require('fs');
+const chunks = [];
+process.stdin.on('data', (c) => chunks.push(c));
+process.stdin.on('end', () => {
+  fs.writeFileSync(${JSON.stringify(receivedPath)}, Buffer.concat(chunks));
+  process.exit(0);
+});
+`,
+  );
+  const nodeOptionsAfterStub = process.env.NODE_OPTIONS;
+  try {
+    // Quoted and forward-slashed for the same reasons as this file's
+    // other --require-path tests above (tmpdir() can contain a space;
+    // a quoted native Windows backslash path loses its backslashes).
+    const quotedPreloadPath = `"${preloadPath.replaceAll('\\', '/')}"`;
+    process.env.NODE_OPTIONS = nodeOptionsAfterStub
+      ? `${nodeOptionsAfterStub} --require ${quotedPreloadPath}`
+      : `--require ${quotedPreloadPath}`;
+    const payload = samplePayload();
+    const result = await invokeCritiqueTelemetryHook(
+      stayAliveCommand('idd-telemetry-hook-win32-relay-quoted-token-target'),
+      payload,
+      { timeoutMs: 5_000, platform: 'win32' },
+    );
+    assert.deepEqual(result, { attempted: true, ok: true });
+    const received = await waitForNonEmptyFile(receivedPath, 5_000);
+    assert.equal(
+      received,
+      JSON.stringify(payload),
+      'expected the target to receive the full payload',
+    );
+    assert.equal(
+      existsSync(targetPreloadSentinel),
+      true,
+      'expected the target to have loaded the --require preload despite its own filename embedding "--input-type="',
+    );
+  } finally {
+    if (nodeOptionsAfterStub === undefined) {
+      delete process.env.NODE_OPTIONS;
+    } else {
+      process.env.NODE_OPTIONS = nodeOptionsAfterStub;
+    }
+    restore();
+  }
+});
+
+test('invokeCritiqueTelemetryHook win32 relay scrubs a non-canonically-cased reserved NODE_OPTIONS-channel key too (kurone-kito/idd-skill#2910 review round 6, Copilot + Codex)', async () => {
+  // Defense-in-depth, not a currently observable leak (no-fabrication
+  // note): the relay's own lookup of these two reserved names
+  // (WIN32_RELAY_SCRIPT's `env['...']` access) is itself exact-case, so a
+  // non-canonically-cased duplicate reaching the relay would already be
+  // inert there today -- confirmed live, this test's own poisoned
+  // lower-cased key produces the same ok:true outcome whether or not the
+  // primary-spawn scrub below runs. What this test actually verifies is
+  // narrower and still worth pinning: the poisoned key itself must not
+  // appear in the env object the primary spawn hands to the relay at
+  // all, closing the gap before it could ever matter (for example if the
+  // relay's own lookup were ever changed to be case-insensitive too,
+  // matching the NODE_OPTIONS scan it already sits next to).
+  const restore = stubExecutable(
+    'idd-telemetry-hook-win32-relay-mixed-case-reserved',
+    'process.exit(0);\n',
+  );
+  let capturedEnv: NodeJS.ProcessEnv | undefined;
+  const spawnFn: typeof spawn = ((...args: Parameters<typeof spawn>) => {
+    const child = spawn(...args);
+    // Same discriminator as this file's other win32 argument-shape tests:
+    // the primary spawn is uniquely identified by process.execPath as
+    // args[0] on win32 (the relay itself), unlike the target/taskkill
+    // calls this spawnFn also sees.
+    if (args[0] === process.execPath) {
+      capturedEnv = (args[2] as { env?: NodeJS.ProcessEnv }).env;
+    }
+    return child;
+  }) as typeof spawn;
+  const poisonKey = 'idd_critique_telemetry_hook_win32_relay_node_options';
+  const poisonValue = '--require /idd-2910-poison-reserved-channel.cjs';
+  const hadPoisonKey = Object.hasOwn(process.env, poisonKey);
+  const previousPoisonValue = (process.env as Record<string, string>)[
+    poisonKey
+  ];
+  try {
+    (process.env as Record<string, string>)[poisonKey] = poisonValue;
+    const result = await invokeCritiqueTelemetryHook(
+      stayAliveCommand('idd-telemetry-hook-win32-relay-mixed-case-reserved'),
+      samplePayload(),
+      { timeoutMs: 5_000, spawnFn, platform: 'win32' },
+    );
+    assert.deepEqual(result, { attempted: true, ok: true });
+    assert.ok(
+      capturedEnv,
+      'expected the primary win32 spawn to have been observed',
+    );
+    // Local const, not the outer `let` (TypeScript's control-flow
+    // narrowing from the `assert.ok` above does not persist into the
+    // filter callback closure below).
+    const observedEnv = capturedEnv;
+    const leaked = Object.keys(observedEnv).filter(
+      (key) =>
+        key.toUpperCase() ===
+          'IDD_CRITIQUE_TELEMETRY_HOOK_WIN32_RELAY_NODE_OPTIONS' &&
+        observedEnv[key] === poisonValue,
+    );
+    assert.deepEqual(
+      leaked,
+      [],
+      `expected the poisoned non-canonically-cased reserved key to be scrubbed from the relay's env, found: ${JSON.stringify(leaked)}`,
+    );
+  } finally {
+    if (hadPoisonKey) {
+      (process.env as Record<string, string>)[poisonKey] = previousPoisonValue;
+    } else {
+      delete (process.env as Record<string, string>)[poisonKey];
+    }
+    restore();
+  }
+});
+
 test('invokeCritiqueTelemetryHook forwards a compound (a && b) command through the win32 relay when platform is overridden to win32 (kurone-kito/idd-skill#2910 review, Copilot)', async () => {
   // Issue #2910's own "Proposed change" section requires this fix to
   // "keep the existing command config contract (an arbitrary shell

--- a/tests/idd-critique-telemetry-hook.test.mts
+++ b/tests/idd-critique-telemetry-hook.test.mts
@@ -1,7 +1,13 @@
 import assert from 'node:assert/strict';
 import { execFileSync, spawn, spawnSync } from 'node:child_process';
 import { EventEmitter } from 'node:events';
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
@@ -795,6 +801,78 @@ process.stdin.on('end', () => {
     // resets to its own pre-stub snapshot regardless, so this step is
     // only needed if a future edit adds code between here and restore()
     // that reads process.env.NODE_OPTIONS.
+    if (nodeOptionsAfterStub === undefined) {
+      delete process.env.NODE_OPTIONS;
+    } else {
+      process.env.NODE_OPTIONS = nodeOptionsAfterStub;
+    }
+    restore();
+  }
+});
+
+test('invokeCritiqueTelemetryHook win32 relay never executes an inherited NODE_OPTIONS preload itself, though the real target still can (kurone-kito/idd-skill#2910 review, Copilot)', async () => {
+  // The `--input-type=commonjs` flag and the NODE_OPTIONS-sanitization
+  // fix above are meant to stop an inherited `--require`/`--import` from
+  // running arbitrary preload code *inside the relay itself* -- but
+  // neither of the other two NODE_OPTIONS tests in this file actually
+  // proves that: the test above only exercises `--input-type=module`,
+  // which the relay's own explicit `--input-type=commonjs` flag already
+  // neutralizes on its own, with or without the sanitization fix. This
+  // test uses a real `--require` preload instead, and distinguishes "did
+  // the relay's own process load it" from "did the real target's
+  // process load it" (expected -- the original NODE_OPTIONS, minus
+  // --input-type, is deliberately still forwarded there) by having the
+  // preload check for the relay-command env var that only the relay's
+  // own process ever has set.
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-critique-telemetry-hook-win32-relay-preload-'),
+  );
+  const relayPoisonedSentinel = join(sandbox, 'relay-poisoned.txt');
+  const preloadPath = join(sandbox, 'preload.cjs');
+  writeFileSync(
+    preloadPath,
+    `const fs = require('fs');
+if (process.env.IDD_CRITIQUE_TELEMETRY_HOOK_WIN32_RELAY_COMMAND) {
+  fs.writeFileSync(${JSON.stringify(relayPoisonedSentinel)}, 'relay loaded the inherited preload');
+}
+`,
+  );
+  const receivedPath = join(sandbox, 'received.json');
+  const restore = stubExecutable(
+    'idd-telemetry-hook-win32-relay-preload-target',
+    `const fs = require('fs');
+const chunks = [];
+process.stdin.on('data', (c) => chunks.push(c));
+process.stdin.on('end', () => {
+  fs.writeFileSync(${JSON.stringify(receivedPath)}, Buffer.concat(chunks));
+  process.exit(0);
+});
+`,
+  );
+  const nodeOptionsAfterStub = process.env.NODE_OPTIONS;
+  try {
+    process.env.NODE_OPTIONS = nodeOptionsAfterStub
+      ? `${nodeOptionsAfterStub} --require ${preloadPath}`
+      : `--require ${preloadPath}`;
+    const payload = samplePayload();
+    const result = await invokeCritiqueTelemetryHook(
+      stayAliveCommand('idd-telemetry-hook-win32-relay-preload-target'),
+      payload,
+      { timeoutMs: 5_000, platform: 'win32' },
+    );
+    assert.equal(
+      existsSync(relayPoisonedSentinel),
+      false,
+      'expected the relay itself to never load the inherited --require preload',
+    );
+    assert.deepEqual(result, { attempted: true, ok: true });
+    const received = await waitForNonEmptyFile(receivedPath, 5_000);
+    assert.equal(
+      received,
+      JSON.stringify(payload),
+      'expected the target to still receive the full payload with the preload forwarded',
+    );
+  } finally {
     if (nodeOptionsAfterStub === undefined) {
       delete process.env.NODE_OPTIONS;
     } else {

--- a/tests/idd-critique-telemetry-hook.test.mts
+++ b/tests/idd-critique-telemetry-hook.test.mts
@@ -851,9 +851,24 @@ process.stdin.on('end', () => {
   );
   const nodeOptionsAfterStub = process.env.NODE_OPTIONS;
   try {
+    // Quoted, and forward-slashed on win32 (kurone-kito/idd-skill#2910
+    // review, Copilot): tmpdir() can contain a space (a real, if
+    // uncommon, path shape on some hosts), and Node's NODE_OPTIONS
+    // parser splits on unquoted whitespace, so an unquoted path there
+    // would silently fail to load and this test would stop exercising
+    // what it claims to. Quoting alone is not enough on win32, though
+    // (empirically verified): inside a quoted NODE_OPTIONS token, Node
+    // treats a backslash as an escape character, so a quoted native
+    // Windows path (`C:\tmp\...`) loses every backslash and fails to
+    // resolve -- confirmed live: `--require "C:\tmp\...\preload.cjs"`
+    // throws `MODULE_NOT_FOUND` for the mangled path
+    // `C:tmp...preload.cjs`. `stubExecutable`'s own `--require` flag
+    // (`tests/test-utils.mts`) already works around exactly this by
+    // converting to forward slashes before quoting -- do the same here.
+    const quotedPreloadPath = `"${preloadPath.replaceAll('\\', '/')}"`;
     process.env.NODE_OPTIONS = nodeOptionsAfterStub
-      ? `${nodeOptionsAfterStub} --require ${preloadPath}`
-      : `--require ${preloadPath}`;
+      ? `${nodeOptionsAfterStub} --require ${quotedPreloadPath}`
+      : `--require ${quotedPreloadPath}`;
     const payload = samplePayload();
     const result = await invokeCritiqueTelemetryHook(
       stayAliveCommand('idd-telemetry-hook-win32-relay-preload-target'),
@@ -877,6 +892,102 @@ process.stdin.on('end', () => {
       delete process.env.NODE_OPTIONS;
     } else {
       process.env.NODE_OPTIONS = nodeOptionsAfterStub;
+    }
+    restore();
+  }
+});
+
+test('invokeCritiqueTelemetryHook win32 relay strips a non-canonically-cased Node_Options key too (kurone-kito/idd-skill#2910 review, Copilot)', async () => {
+  // Every other NODE_OPTIONS test in this file sets the canonical-case
+  // key, which would already pass even with the earlier exact-case-only
+  // `const { NODE_OPTIONS, ...relayEnv } = process.env` destructure --
+  // none of them actually exercises the case-insensitive scrub itself.
+  // Windows environment-variable names are case-insensitive at the OS
+  // level but a plain JS object key is not, so a caller whose own
+  // environment carries a differently-cased entry (real-world
+  // precedent: Windows system variables like ComSpec/Path routinely
+  // keep non-canonical casing) needs the scrub to still catch it.
+  // `process.env` is a plain object on every platform (this test's own
+  // manual assignment below simulates that shape directly, regardless
+  // of what the real OS would produce), so setting a mixed-case key
+  // here exercises the exact same code path a genuine Windows
+  // non-canonical entry would.
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-critique-telemetry-hook-win32-relay-mixed-case-'),
+  );
+  const relayPoisonedSentinel = join(sandbox, 'relay-poisoned.txt');
+  const preloadPath = join(sandbox, 'preload.cjs');
+  writeFileSync(
+    preloadPath,
+    `const fs = require('fs');
+if (process.env.IDD_CRITIQUE_TELEMETRY_HOOK_WIN32_RELAY_COMMAND) {
+  fs.writeFileSync(${JSON.stringify(relayPoisonedSentinel)}, 'relay loaded the inherited preload');
+}
+`,
+  );
+  const receivedPath = join(sandbox, 'received.json');
+  const restore = stubExecutable(
+    'idd-telemetry-hook-win32-relay-mixed-case-target',
+    `const fs = require('fs');
+const chunks = [];
+process.stdin.on('data', (c) => chunks.push(c));
+process.stdin.on('end', () => {
+  fs.writeFileSync(${JSON.stringify(receivedPath)}, Buffer.concat(chunks));
+  process.exit(0);
+});
+`,
+  );
+  // stubExecutable's win32 branch already set the *canonical-case*
+  // process.env.NODE_OPTIONS (to inject its own --require <preload>).
+  // Move that content onto the non-canonically-cased key below instead
+  // of adding a second, separate key alongside it: a real Windows
+  // environment has exactly one such variable, just possibly spelled
+  // non-canonically -- simultaneously having both NODE_OPTIONS and
+  // Node_Options present is not a realistic shape, and this fix's own
+  // key-iteration order would nondeterministically clobber one value
+  // with the other (confirmed live: an earlier version of this test did
+  // exactly that and silently dropped the stub's own --require,
+  // breaking the stub mechanism itself, not the fix under test).
+  const nodeOptionsAfterStub = process.env.NODE_OPTIONS;
+  const hadMixedCaseKey = Object.hasOwn(process.env, 'Node_Options');
+  const previousMixedCaseValue = process.env.Node_Options;
+  try {
+    delete process.env.NODE_OPTIONS;
+    // Deliberately the *non*-canonical casing -- the sanitization fix
+    // under test matches keys case-insensitively via
+    // `key.toUpperCase() === 'NODE_OPTIONS'`, so this specific spelling
+    // exercises that comparison rather than an exact-match shortcut.
+    // Forward-slashed before quoting -- see the sibling preload test
+    // above for why a quoted native Windows backslash path fails to
+    // resolve on win32 (Node strips backslashes as escapes inside a
+    // quoted NODE_OPTIONS token).
+    const myPreloadRequire = `--require "${preloadPath.replaceAll('\\', '/')}"`;
+    process.env.Node_Options = nodeOptionsAfterStub
+      ? `${nodeOptionsAfterStub} ${myPreloadRequire}`
+      : myPreloadRequire;
+    const payload = samplePayload();
+    const result = await invokeCritiqueTelemetryHook(
+      stayAliveCommand('idd-telemetry-hook-win32-relay-mixed-case-target'),
+      payload,
+      { timeoutMs: 5_000, platform: 'win32' },
+    );
+    assert.equal(
+      existsSync(relayPoisonedSentinel),
+      false,
+      'expected the relay itself to never load a preload inherited via a non-canonically-cased NODE_OPTIONS key',
+    );
+    assert.deepEqual(result, { attempted: true, ok: true });
+    const received = await waitForNonEmptyFile(receivedPath, 5_000);
+    assert.equal(
+      received,
+      JSON.stringify(payload),
+      'expected the target to still receive the full payload with the preload forwarded',
+    );
+  } finally {
+    if (hadMixedCaseKey) {
+      process.env.Node_Options = previousMixedCaseValue;
+    } else {
+      delete process.env.Node_Options;
     }
     restore();
   }

--- a/tests/idd-critique-telemetry-hook.test.mts
+++ b/tests/idd-critique-telemetry-hook.test.mts
@@ -730,6 +730,59 @@ process.stdin.on('end', () => {
   }
 });
 
+test('invokeCritiqueTelemetryHook win32 relay survives an inherited NODE_OPTIONS=--input-type=module (kurone-kito/idd-skill#2910 review, Codex)', async () => {
+  // A caller whose own environment sets NODE_OPTIONS=--input-type=module
+  // -- inherited by the relay spawn via `env: {...process.env, ...}` --
+  // would otherwise make Node evaluate WIN32_RELAY_SCRIPT as ESM, where
+  // `require` is undefined and the relay throws before ever reading its
+  // stdin: verified locally (`NODE_OPTIONS=--input-type=module node -e
+  // "require('node:child_process')"` throws `ReferenceError: require is
+  // not defined in ES module scope`) before this test was written. The
+  // fix passes an explicit `--input-type=commonjs` flag, which overrides
+  // an inherited `--input-type=module`.
+  const originalNodeOptions = process.env.NODE_OPTIONS;
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-critique-telemetry-hook-win32-relay-node-options-'),
+  );
+  const receivedPath = join(sandbox, 'received.json');
+  const restore = stubExecutable(
+    'idd-telemetry-hook-win32-relay-node-options',
+    `const fs = require('fs');
+const chunks = [];
+process.stdin.on('data', (c) => chunks.push(c));
+process.stdin.on('end', () => {
+  fs.writeFileSync(${JSON.stringify(receivedPath)}, Buffer.concat(chunks));
+  process.exit(0);
+});
+`,
+  );
+  try {
+    process.env.NODE_OPTIONS = originalNodeOptions
+      ? `${originalNodeOptions} --input-type=module`
+      : '--input-type=module';
+    const payload = samplePayload();
+    const result = await invokeCritiqueTelemetryHook(
+      stayAliveCommand('idd-telemetry-hook-win32-relay-node-options'),
+      payload,
+      { timeoutMs: 5_000, platform: 'win32' },
+    );
+    assert.deepEqual(result, { attempted: true, ok: true });
+    const received = await waitForNonEmptyFile(receivedPath, 5_000);
+    assert.equal(
+      received,
+      JSON.stringify(payload),
+      'expected the relay to still deliver the payload despite an inherited --input-type=module',
+    );
+  } finally {
+    if (originalNodeOptions === undefined) {
+      delete process.env.NODE_OPTIONS;
+    } else {
+      process.env.NODE_OPTIONS = originalNodeOptions;
+    }
+    restore();
+  }
+});
+
 test('invokeCritiqueTelemetryHook spawns a win32 process-tree kill (taskkill /PID <pid> /T /F) on timeout when platform is overridden to win32', async () => {
   const restore = stubExecutable(
     'idd-telemetry-hook-hang-win32',


### PR DESCRIPTION
# Summary

On native Windows, `invokeCritiqueTelemetryHook`'s fire-and-forget spawn
(`shell: true` + `detached: true` + piped stdin) never delivered any
stdin payload to the target `critiqueLoop.telemetryHook.command`, at any
payload size from 0B to 500KB+ — confirmed with a live native-Windows
reproduction (WSL2 interop, real `node.exe`, outside CI) before writing
any fix. `cmd.exe` running under Win32's `DETACHED_PROCESS` creation flag
(what `detached: true` maps to) cannot relay piped stdin to the further
child it execs; `detached: true` itself is required so the hook survives
the CLI's own `process.exit()`, so no combination of the existing options
had a working shape left for win32 stdin delivery.

Fix: on win32 only, the primary spawn now routes through a small relay —
a direct (`shell: false`) `node.exe` child spawned under `detached: true`
(confirmed live to deliver piped stdin correctly at every size once the
caller waits for the stream to close, which this file's
`onPayloadDelivered` contract already does), which itself reads stdin to
completion and only then re-spawns the real command through
`shell: true` — but **not** detached, since only the relay itself needs
to survive `process.exit()`. The real command travels through a
dedicated environment variable rather than argv (no Windows
argv-escaping question), deleted from the inner spawn's own environment
after use. `child.pid` — what the existing timeout/kill/watchdog logic
already operates on generically — becomes the relay's pid on win32; a
live `taskkill /PID <relay-pid> /T /F` still reaches and kills the whole
relay → `cmd.exe` → target chain (verified live, including a genuinely
hung target), so `killProcessGroup`, `killProcessTreeWindows`, and both
`spawnWatchdog*` functions need no behavioral change — only doc-comment
updates where they went stale. POSIX behavior is byte-identical to
before. The relay's own environment is also sanitized of the *caller's*
`NODE_OPTIONS` (see review round 2 below) so an inherited
`--require`/`--import` cannot run arbitrary preload code inside the
relay itself; the caller's original value still reaches the real target
command unchanged, through its own dedicated forwarding channel.

Several existing tests whose stubbed `spawnFn` identified "the primary
hook spawn" by matching the raw command string against `args[0]` are
updated to match `process.execPath` instead — the one value now unique
to the relay call on win32 (the watchdog and `taskkill` spawns both pass
a string as `args[0]`, never `process.execPath`). The previously
win32-skipped large-payload delivery test now runs for real on every
platform, and new tests close the small-payload, compound-command
(`a && b`), and inherited-`NODE_OPTIONS` gaps in size/shape coverage.
The `lint-windows` CI job's own `--test-force-exit` flag is also
dropped: it was needed for a pre-existing file-level `node --test` hang
partly attributed to this same delivery defect, and the full suite
(including every direct-await, real-detached-child test) was confirmed
live on native Windows 11 to complete and exit naturally in ~28s without
it.

This went through a B2 planning critique pass before implementation (a
separate review agent caught a real gap: 5 affected tests, not 2 as
first drafted — 2 of which are real-Windows-only tests that would have
silently degraded rather than failed on CI — plus a stale doc comment
and two design decisions to make explicit), a C1 self-review pass on
the landed diff, and six live reviewer rounds (Codex ×4, Copilot ×4) —
see Background below for all six, including two false starts this
session's own native-Windows re-verification caught before they ever
reached CI.

## Linked issue

Closes #2910

## Follow-up issues (if any)

- [ ] Copilot's review flagged that the relay's inner spawn finishes on
  the shell child's `'exit'` event rather than waiting for its stdio
  streams to fully `'close'`, so a compound command that backgrounds a
  longer-lived descendant (inheriting stdin) could in principle lose
  queued bytes or leave that descendant outside the relay pid the
  watchdog/tree-kill tracks. Rejected for this PR (see Background) as
  matching pre-existing POSIX behavior and outside this issue's own
  scope statement, but noted here as a candidate for a future
  follow-up if a real backgrounded-descendant use case ever surfaces.

## Background / rationale (if material)

**Review round 1 (Codex, HEAD `a7637a7a`).** Found a genuine bug: a
caller whose own environment sets `NODE_OPTIONS=--input-type=module` —
inherited by the relay spawn — makes Node evaluate the relay's `-e`
script as ESM, where `require` is undefined, turning `ok: true` into
`ok: false`. Verified locally (reproduced the failure, then confirmed
an explicit `--input-type=commonjs` flag fixes it) and fixed in
`559161c0`, with a regression test.

**Review round 2 (Copilot, HEAD `559161c0`/`d26e4a1c`).** Four findings:

- The win32-relay success-path test only passed a single executable,
  not a compound (`a && b`) command — but issue #2910's own "Proposed
  change" section explicitly requires the fix to keep compound-command
  support working the same way it does on POSIX today. Accepted and
  fixed in `d26e4a1c` with a dedicated compound-command test.
- The `'exit'`-vs-`'close'`/backgrounded-descendant concern above.
  Rejected (see the follow-up item above for the full reasoning).
- **A real bug this session's own AC4 re-verification had already
  caught independently**: deleting the caller's `NODE_OPTIONS` wholesale
  for the relay's inner spawn (an earlier, since-replaced version of
  this fix) broke this repository's own win32 test stubs, whose
  `--require <preload>` mechanism depends on it, *and* broke any real
  target command that runs `node <file>` under an inherited
  `--input-type=...`. Confirmed live on native Windows 11 before
  Copilot's review even ran (11 unrelated tests failed). Fixed by
  stripping only `--input-type=...` tokens instead of the whole
  variable, landed in `12b0caae`.
- **The deeper structural issue Copilot's review found on top of that
  fix**: since the relay is itself a `node` process, passing the
  caller's *raw* `NODE_OPTIONS` through to the relay's own spawn (needed
  to forward it onward) let an inherited `--require`/`--import` execute
  arbitrary preload code inside the relay before it ever forwards the
  payload. Accepted and fixed in `12b0caae`: the relay's own environment
  no longer receives `NODE_OPTIONS` at all; the caller's original value
  travels to the inner spawn only, through a dedicated forwarding
  channel.

**Review round 3 (Copilot, HEAD `559161c0`/`d26e4a1c`, two embedded
findings with no threads of their own):**

- The relay-command and `NODE_OPTIONS`-forwarding transport uses two
  internally-reserved, project-prefixed environment variable names
  (`IDD_CRITIQUE_TELEMETRY_HOOK_WIN32_RELAY_COMMAND` /
  `..._NODE_OPTIONS`). Copilot noted that a caller whose own environment
  happened to already define one of these exact names would have that
  value overwritten. Rejected: the names are deliberately long and
  namespaced specifically to make real-world collision implausible, and
  a restore-if-pre-existing mechanism would not fully close the gap
  anyway, since the relay's own spawn already overwrites the value
  before any inner-spawn cleanup step could run.
- Passing the command (and now also the forwarded `NODE_OPTIONS`)
  through the environment introduces Windows' environment-block size
  limit (~32K), which the schema does not bound. Rejected: the old
  `shell: true` command-line path had a comparable order-of-magnitude
  limit of its own (~32K for `CreateProcess`'s command line), a failure
  here degrades gracefully to `{ ok: false }` — this fire-and-forget
  hook's own documented contract already accepts silent failure for any
  spawn failure — and real `critiqueLoop.telemetryHook.command` values
  are short notification triggers by design, not data payloads.

Both round-3 rejections are acknowledged via a `review-ack:` marker
(current HEAD) rather than a reply-and-resolve, since neither has a
thread of its own — see `idd-review-triage.instructions.md`'s
`review-ack:` paragraph.

**Review round 4 (Codex + Copilot, HEAD `12b0caae`).** Three findings:

- Codex: the `NODE_OPTIONS` case-insensitivity gap above was
  independently caught by this session's own native-Windows
  verification workflow before Copilot's earlier round-2 suppressed
  finding on the same topic was ever read — same root cause, same fix,
  landed together in `c1ea4eee`.
- Copilot: neither existing `NODE_OPTIONS` test actually proved the
  round-2 security fix (relay sanitization) works, since the only test
  using it exercises `--input-type=module`, already neutralized by the
  relay's own explicit `--input-type=commonjs` flag regardless of the
  sanitization fix. Accepted and fixed in `c1ea4eee` with a dedicated
  test using a real `--require` preload that distinguishes "did the
  relay's own process load it" from "did the real target's process load
  it" (expected).
- Copilot: stripping `--input-type=...` from the value forwarded to the
  *real target* (not just the relay) changes the existing environment
  contract for a target command that legitimately relies on an inherited
  `--input-type=module`. Rejected: an operator who needs that for their
  own command can pass it directly on the command string instead (e.g.
  `node --input-type=module --eval "..."`), unaffected by anything this
  fix does on either platform; relying on an *inherited* value for one
  specific command's own module-type semantics is already a fragile,
  discouraged pattern; and, concretely, that same inherited value already
  crashes today on POSIX (`ERR_INPUT_TYPE_NOT_ALLOWED`) for the far more
  common file/module-load target shape — this repository's own win32
  test stubs included, confirmed by a live native-Windows CI failure
  before this fix ever landed.

**Review round 5 (Codex, HEAD `c1ea4eee`).** Two findings:

- The round-4 `--input-type` strip tokenized the whole string on
  whitespace and rejoined with single spaces, which is lossy for a
  quoted `--require`/`--import` value with its own internal whitespace
  (e.g. a Windows path with a space in a directory name) — rejoining
  would silently corrupt it. Accepted and fixed in `c7e89697`: in-place
  regex removal of only the matched `--input-type=<token>` substring,
  leaving every other character (including such quoting) untouched.
- If the caller's own `NODE_OPTIONS` is unset while the reserved
  `IDD_CRITIQUE_TELEMETRY_HOOK_WIN32_RELAY_NODE_OPTIONS` transport key
  already happens to hold a stale value (e.g. leaked from a nested/prior
  invocation), the primary spawn's conditional re-add contributes
  nothing and that stale value reaches the relay unscrubbed, which then
  applies it to the real target as if it were genuine. Accepted and
  fixed in `7f66c4b3`: both reserved transport keys are now deleted from
  the relay's env unconditionally before the conditional re-add.

**Review round 6 (Copilot + Codex, HEAD `c7e89697`).** Three findings:

- Copilot + Codex (independently, two separate examples): the round-5
  `--input-type` strip is itself quote-blind — a legitimate quoted
  `--require`/`--import` value that happens to contain the literal text
  `--input-type=` preceded by whitespace (e.g. a filename embedding that
  substring) is still mistaken for a real top-level option and stripped,
  truncating the quoted path. Accepted and fixed in `7d6af7a6`: the
  string is split on double-quoted spans first (each kept completely
  verbatim, including a backslash-escaped quote inside one), and the
  existing removal now applies only within the unquoted segments between
  them.
- Copilot + Codex (independently): the round-5 reserved-key delete is
  exact-case only, while Windows environment-variable names are
  case-insensitive at the OS level (the same reasoning already applied
  to `NODE_OPTIONS` itself). Accepted and fixed in `7d6af7a6`: both
  reserved names are now folded into the same case-insensitive scan
  `NODE_OPTIONS` already uses. Honest characterization (no-fabrication
  note): this is defense-in-depth, not a currently live leak — the
  relay's own lookup of these two names is itself exact-case, so a
  non-canonical duplicate reaching it was already inert either way,
  confirmed live by running the regression test both before and after
  the fix.
- Codex: re-raised the round-4 "eval-based hooks losing `--input-type`"
  argument in a new form (`node -e`/`-p`/stdin-based configured hooks
  deliberately relying on an inherited
  `NODE_OPTIONS=--input-type=module`). Rejected, citing the round-4
  reasoning directly: an operator who needs that can pass it on their
  own command string instead, unaffected by this fix on either platform;
  relying on an inherited value for one command's own module-type
  semantics is already fragile; and the same inherited value already
  hard-crashes the far more common `node <file>`-shaped target with
  `ERR_INPUT_TYPE_NOT_ALLOWED`.

Both round-5 fixes and the two accepted round-6 findings are covered by
dedicated regression tests, each verified live to fail on the pre-fix
code (and only that one test) and pass clean on the fix, on both this
file's own Linux suite and native Windows.

`lint-windows` (`windows-latest`) is not a required branch-protection
check for this repository (per PR #2897's own precedent) — its
pass/fail on this PR's HEAD is read and reported here before merge, not
assumed from local testing alone.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdQ5SPdFLaDGus5PNdBUhw
