### PR TITLE
feat(claim): backfill route for a generated-tokens record missing on a pre-existing claim

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -601,8 +601,8 @@ session's leftover lock resolves the same way. See
 mechanical detail.
 
 **Generated-tokens record.** Re-check with `--read-tokens` alongside
-`--acquire`; absent/malformed recovers via `--backfill-tokens`
-(`docs/idd-helper-scripts.md`).
+`--acquire`; absent/malformed recovers only via step 5
+(`idd-overview-core.instructions.md`).
 
 Then continue to `idd-work.instructions.md`.
 

--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -601,8 +601,8 @@ session's leftover lock resolves the same way. See
 mechanical detail.
 
 **Generated-tokens record.** Re-check with `--read-tokens` alongside
-`--acquire` before trusting a recalled `{claim-id}`. See
-`docs/idd-helper-scripts.md`.
+`--acquire`; absent/malformed recovers via `--backfill-tokens`
+(`docs/idd-helper-scripts.md`).
 
 Then continue to `idd-work.instructions.md`.
 

--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -202,15 +202,15 @@ When in scope, run:
    do not `add`, `commit`, or `push` from a worktree not on the claimed
    branch.
 5. Acquire the worktree-local claim lock immediately before the mutation,
-   using the profile-selected `claim-lock` helper (see
-   `docs/idd-helper-scripts.md`) with the current `{agent-id}` and
-   `{claim-id}`. Under the `instructions-only` profile, use the
-   helper-free fallback in `idd-work.instructions.md`, which uses the
-   same `idd-claim.lock` namespace. A `collision` is fail-closed: stop
-   unless the active claim revalidation authorizes an explicit takeover.
-   Also confirm `--read-tokens` finds this `{claim-id}` recorded
-   (`idd-claim.instructions.md`); absent or malformed fails closed the
-   same way.
+   using the profile-selected `claim-lock` helper
+   (`docs/idd-helper-scripts.md`) with `{agent-id}`/`{claim-id}`.
+   Under `instructions-only`, use `idd-work.instructions.md`'s
+   helper-free fallback (same `idd-claim.lock` namespace). A `collision`
+   fails closed unless claim revalidation authorizes an explicit
+   takeover. Also confirm `--read-tokens` finds this `{claim-id}`
+   recorded (`idd-claim.instructions.md`); absent/malformed fails closed
+   too, recoverable only via a matching `--check`, `--backfill-tokens`,
+   then retry (`docs/idd-helper-scripts.md`).
 
 **Recovery if a commit already landed on the wrong branch.** If this gate
 or `idd-doctor` finds a commit on the wrong branch, cherry-pick it onto

--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -208,9 +208,9 @@ When in scope, run:
    helper-free fallback. A `collision` fails closed unless claim
    revalidation authorizes an explicit takeover. Also confirm
    `--read-tokens` finds this `{claim-id}` recorded; absent/malformed
-   fails closed unless this acquire reported `reacquired: true` (never
-   fresh/takeover) -- only then `--check` -> `--backfill-tokens` ->
-   `--read-tokens` -> a final re-`--acquire` before mutating.
+   recovers only via `docs/idd-helper-scripts.md`'s gated backfill
+   sequence (each step must succeed before the next; `reacquired:
+   true` required at both ends) -- else fails closed.
 
 **Recovery if a commit already landed on the wrong branch.** If this gate
 or `idd-doctor` finds a commit on the wrong branch, cherry-pick it onto

--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -205,12 +205,12 @@ When in scope, run:
    using the profile-selected `claim-lock` helper
    (`docs/idd-helper-scripts.md`) with `{agent-id}`/`{claim-id}`.
    Under `instructions-only`, use `idd-work.instructions.md`'s
-   helper-free fallback (same `idd-claim.lock` namespace). A `collision`
-   fails closed unless claim revalidation authorizes an explicit
-   takeover. Also confirm `--read-tokens` finds this `{claim-id}`
-   recorded (`idd-claim.instructions.md`); absent/malformed fails closed
-   too, recoverable only via a matching `--check`, `--backfill-tokens`,
-   then retry (`docs/idd-helper-scripts.md`).
+   helper-free fallback. A `collision` fails closed unless claim
+   revalidation authorizes an explicit takeover. Also confirm
+   `--read-tokens` finds this `{claim-id}` recorded; absent/malformed
+   fails closed unless this acquire reported `reacquired: true` (never
+   fresh/takeover) -- only then `--check` -> `--backfill-tokens` ->
+   `--read-tokens` -> a final re-`--acquire` before mutating.
 
 **Recovery if a commit already landed on the wrong branch.** If this gate
 or `idd-doctor` finds a commit on the wrong branch, cherry-pick it onto

--- a/.github/instructions/lite/idd-claim-lite.instructions.md
+++ b/.github/instructions/lite/idd-claim-lite.instructions.md
@@ -434,7 +434,8 @@ node scripts/claim-lock.mjs --acquire --worktree <path> \
 
 Then, separately, run `--read-tokens --worktree <path> --claim-id
 <id>` and require `present: true` with no `malformed`; otherwise
-stop. See `docs/idd-helper-scripts.md`.
+`--check` match -> `--backfill-tokens` -> retry, else stop
+(`docs/idd-helper-scripts.md`).
 
 A matching `{claim-id}` re-acquires as a read-only check. A different
 `{claim-id}` is always a collision — re-run pre-check (c) (`--claim-id`

--- a/.github/instructions/lite/idd-claim-lite.instructions.md
+++ b/.github/instructions/lite/idd-claim-lite.instructions.md
@@ -432,10 +432,10 @@ node scripts/claim-lock.mjs --acquire --worktree <path> \
   --agent-id <agent-id> --claim-id <claim-id>
 ```
 
-Then, separately, run `--read-tokens --worktree <path> --claim-id
-<id>` and require `present: true` with no `malformed`; otherwise
-`--check` match -> `--backfill-tokens` -> retry, else stop
-(`docs/idd-helper-scripts.md`).
+Then run `--read-tokens --worktree <path> --claim-id <id>` and
+require `present: true` with no `malformed`; otherwise, only if this
+re-acquired (never fresh/takeover): `--check` -> `--backfill-tokens`
+-> retry -> re-acquire, else stop.
 
 A matching `{claim-id}` re-acquires as a read-only check. A different
 `{claim-id}` is always a collision — re-run pre-check (c) (`--claim-id`
@@ -452,8 +452,7 @@ first, then `--fresh-claim-gate` if not `already_owned`):
 - `already-claimed` naming a **different** id: a live competitor holds
   it — stop, the claim was lost.
 
-No release step: `git worktree remove` at F4 deletes the lock with the
-worktree.
+No release step (F4 `git worktree remove` deletes it).
 
 Then continue to `idd-work-lite.instructions.md` — except on
 `instructions-only`, where that file declines the profile in its own

--- a/.github/instructions/lite/idd-claim-lite.instructions.md
+++ b/.github/instructions/lite/idd-claim-lite.instructions.md
@@ -433,9 +433,9 @@ node scripts/claim-lock.mjs --acquire --worktree <path> \
 ```
 
 Then run `--read-tokens --worktree <path> --claim-id <id>` and
-require `present: true` with no `malformed`; otherwise, only if this
-re-acquired (never fresh/takeover): `--check` -> `--backfill-tokens`
--> retry -> re-acquire, else stop.
+require `present: true` with no `malformed`; otherwise recover per
+`docs/idd-helper-scripts.md` (gated: each step succeeds,
+`reacquired: true` both ends), else stop.
 
 A matching `{claim-id}` re-acquires as a read-only check. A different
 `{claim-id}` is always a collision — re-run pre-check (c) (`--claim-id`

--- a/.github/instructions/lite/idd-merge-handoff-lite.instructions.md
+++ b/.github/instructions/lite/idd-merge-handoff-lite.instructions.md
@@ -41,10 +41,9 @@ Before posting the handoff comment, confirm all of the following:
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
    `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
-   and require `present: true` with no `malformed`; otherwise, only on
-   a matching re-acquire (never a fresh create or takeover), run
-   `--check` -> `--backfill-tokens` -> retry -> re-acquire before
-   mutating -- else stop (`docs/idd-helper-scripts.md`).
+   and require `present: true` with no `malformed`; otherwise recover
+   per `docs/idd-helper-scripts.md` (gated: each step succeeds,
+   `reacquired: true` both ends), else stop.
 4. If any check fails, stop.
 
 ## F2.5 — Draft and post the handoff comment

--- a/.github/instructions/lite/idd-merge-handoff-lite.instructions.md
+++ b/.github/instructions/lite/idd-merge-handoff-lite.instructions.md
@@ -41,7 +41,9 @@ Before posting the handoff comment, confirm all of the following:
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
    `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
-   and require `present: true` with no `malformed`; otherwise stop.
+   and require `present: true` with no `malformed`; otherwise run
+   `--check`, and on a match run `--backfill-tokens` then retry -- else
+   stop (`docs/idd-helper-scripts.md`).
 4. If any check fails, stop.
 
 ## F2.5 — Draft and post the handoff comment

--- a/.github/instructions/lite/idd-merge-handoff-lite.instructions.md
+++ b/.github/instructions/lite/idd-merge-handoff-lite.instructions.md
@@ -41,9 +41,10 @@ Before posting the handoff comment, confirm all of the following:
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
    `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
-   and require `present: true` with no `malformed`; otherwise run
-   `--check`, and on a match run `--backfill-tokens` then retry -- else
-   stop (`docs/idd-helper-scripts.md`).
+   and require `present: true` with no `malformed`; otherwise, only on
+   a matching re-acquire (never a fresh create or takeover), run
+   `--check` -> `--backfill-tokens` -> retry -> re-acquire before
+   mutating -- else stop (`docs/idd-helper-scripts.md`).
 4. If any check fails, stop.
 
 ## F2.5 — Draft and post the handoff comment

--- a/.github/instructions/lite/idd-pr-submit-lite.instructions.md
+++ b/.github/instructions/lite/idd-pr-submit-lite.instructions.md
@@ -86,9 +86,10 @@ following:
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
    `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
-   and require `present: true` with no `malformed`; otherwise run
-   `--check`, and on a match run `--backfill-tokens` then retry -- else
-   stop (`docs/idd-helper-scripts.md`).
+   and require `present: true` with no `malformed`; otherwise, only on
+   a matching re-acquire (never a fresh create or takeover), run
+   `--check` -> `--backfill-tokens` -> retry -> re-acquire before
+   mutating -- else stop (`docs/idd-helper-scripts.md`).
 6. If any check fails, stop.
 
 ## D1 — Sync main before first push

--- a/.github/instructions/lite/idd-pr-submit-lite.instructions.md
+++ b/.github/instructions/lite/idd-pr-submit-lite.instructions.md
@@ -86,10 +86,9 @@ following:
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
    `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
-   and require `present: true` with no `malformed`; otherwise, only on
-   a matching re-acquire (never a fresh create or takeover), run
-   `--check` -> `--backfill-tokens` -> retry -> re-acquire before
-   mutating -- else stop (`docs/idd-helper-scripts.md`).
+   and require `present: true` with no `malformed`; otherwise recover
+   per `docs/idd-helper-scripts.md` (gated: each step succeeds,
+   `reacquired: true` both ends), else stop.
 6. If any check fails, stop.
 
 ## D1 — Sync main before first push

--- a/.github/instructions/lite/idd-pr-submit-lite.instructions.md
+++ b/.github/instructions/lite/idd-pr-submit-lite.instructions.md
@@ -86,7 +86,9 @@ following:
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
    `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
-   and require `present: true` with no `malformed`; otherwise stop.
+   and require `present: true` with no `malformed`; otherwise run
+   `--check`, and on a match run `--backfill-tokens` then retry -- else
+   stop (`docs/idd-helper-scripts.md`).
 6. If any check fails, stop.
 
 ## D1 — Sync main before first push

--- a/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -87,10 +87,9 @@ other GitHub side effect, confirm all of the following:
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
    `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
-   and require `present: true` with no `malformed`; otherwise, only on
-   a matching re-acquire (never a fresh create or takeover), run
-   `--check` -> `--backfill-tokens` -> retry -> re-acquire before
-   mutating -- else stop (`docs/idd-helper-scripts.md`).
+   and require `present: true` with no `malformed`; otherwise recover
+   per `docs/idd-helper-scripts.md` (gated: each step succeeds,
+   `reacquired: true` both ends), else stop.
 6. If any check fails, stop.
 
 ## E9 — Fix accepted issues

--- a/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -87,9 +87,10 @@ other GitHub side effect, confirm all of the following:
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
    `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
-   and require `present: true` with no `malformed`; otherwise run
-   `--check`, and on a match run `--backfill-tokens` then retry -- else
-   stop (`docs/idd-helper-scripts.md`).
+   and require `present: true` with no `malformed`; otherwise, only on
+   a matching re-acquire (never a fresh create or takeover), run
+   `--check` -> `--backfill-tokens` -> retry -> re-acquire before
+   mutating -- else stop (`docs/idd-helper-scripts.md`).
 6. If any check fails, stop.
 
 ## E9 — Fix accepted issues

--- a/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -87,7 +87,9 @@ other GitHub side effect, confirm all of the following:
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
    `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
-   and require `present: true` with no `malformed`; otherwise stop.
+   and require `present: true` with no `malformed`; otherwise run
+   `--check`, and on a match run `--backfill-tokens` then retry -- else
+   stop (`docs/idd-helper-scripts.md`).
 6. If any check fails, stop.
 
 ## E9 — Fix accepted issues

--- a/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
@@ -62,9 +62,10 @@ GitHub side effect, confirm all of the following:
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
    `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
-   and require `present: true` with no `malformed`; otherwise run
-   `--check`, and on a match run `--backfill-tokens` then retry -- else
-   stop (`docs/idd-helper-scripts.md`).
+   and require `present: true` with no `malformed`; otherwise, only on
+   a matching re-acquire (never a fresh create or takeover), run
+   `--check` -> `--backfill-tokens` -> retry -> re-acquire before
+   mutating -- else stop (`docs/idd-helper-scripts.md`).
 6. If any check fails, stop.
 
 ## E1 — Fetch review items into ReviewItems_snapshot

--- a/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
@@ -62,7 +62,9 @@ GitHub side effect, confirm all of the following:
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
    `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
-   and require `present: true` with no `malformed`; otherwise stop.
+   and require `present: true` with no `malformed`; otherwise run
+   `--check`, and on a match run `--backfill-tokens` then retry -- else
+   stop (`docs/idd-helper-scripts.md`).
 6. If any check fails, stop.
 
 ## E1 — Fetch review items into ReviewItems_snapshot

--- a/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
@@ -62,10 +62,9 @@ GitHub side effect, confirm all of the following:
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
    `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
-   and require `present: true` with no `malformed`; otherwise, only on
-   a matching re-acquire (never a fresh create or takeover), run
-   `--check` -> `--backfill-tokens` -> retry -> re-acquire before
-   mutating -- else stop (`docs/idd-helper-scripts.md`).
+   and require `present: true` with no `malformed`; otherwise recover
+   per `docs/idd-helper-scripts.md` (gated: each step succeeds,
+   `reacquired: true` both ends), else stop.
 6. If any check fails, stop.
 
 ## E1 — Fetch review items into ReviewItems_snapshot

--- a/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/.github/instructions/lite/idd-work-lite.instructions.md
@@ -56,7 +56,9 @@ request, or other GitHub side effect, confirm all of the following:
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
    `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
-   and require `present: true` with no `malformed`; otherwise stop.
+   and require `present: true` with no `malformed`; otherwise run
+   `--check`, and on a match run `--backfill-tokens` then retry -- else
+   stop (`docs/idd-helper-scripts.md`).
 6. If any check fails, stop.
 
 ## B1 — Create worktree

--- a/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/.github/instructions/lite/idd-work-lite.instructions.md
@@ -56,9 +56,10 @@ request, or other GitHub side effect, confirm all of the following:
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
    `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
-   and require `present: true` with no `malformed`; otherwise run
-   `--check`, and on a match run `--backfill-tokens` then retry -- else
-   stop (`docs/idd-helper-scripts.md`).
+   and require `present: true` with no `malformed`; otherwise, only on
+   a matching re-acquire (never a fresh create or takeover), run
+   `--check` -> `--backfill-tokens` -> retry -> re-acquire before
+   mutating -- else stop (`docs/idd-helper-scripts.md`).
 6. If any check fails, stop.
 
 ## B1 — Create worktree

--- a/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/.github/instructions/lite/idd-work-lite.instructions.md
@@ -56,10 +56,9 @@ request, or other GitHub side effect, confirm all of the following:
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
    `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
-   and require `present: true` with no `malformed`; otherwise, only on
-   a matching re-acquire (never a fresh create or takeover), run
-   `--check` -> `--backfill-tokens` -> retry -> re-acquire before
-   mutating -- else stop (`docs/idd-helper-scripts.md`).
+   and require `present: true` with no `malformed`; otherwise recover
+   per `docs/idd-helper-scripts.md` (gated: each step succeeds,
+   `reacquired: true` both ends), else stop.
 6. If any check fails, stop.
 
 ## B1 — Create worktree

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1920,8 +1920,10 @@ close.
   [`idd-claim.instructions.md`'s Worktree-local lock file section](../.github/instructions/idd-claim.instructions.md#worktree-local-lock-file-same-machine-collision).
 - Source repo / vendored-node commands:
   `node scripts/claim-lock.mjs --record-tokens --worktree <path>
-  --agent-id <id> --claim-id <id> [--nonce <nonce>]`
-  and `node scripts/claim-lock.mjs --read-tokens --worktree <path>
+  --agent-id <id> --claim-id <id> [--nonce <nonce>]`,
+  `node scripts/claim-lock.mjs --read-tokens --worktree <path>
+  --claim-id <id>`, and
+  `node scripts/claim-lock.mjs --backfill-tokens --worktree <path>
   --claim-id <id>`
 - Package-manager / ephemeral-npx command: use the same profile-selected
   `idd:claim-lock` command as the lock above; the literal invocations are:
@@ -1933,6 +1935,9 @@ close.
 
   npx --yes --package <helper-package-spec> \
     idd-claim-lock --read-tokens --worktree <path> --claim-id <id>
+
+  npx --yes --package <helper-package-spec> \
+    idd-claim-lock --backfill-tokens --worktree <path> --claim-id <id>
   ```
 
 - **When to call `--record-tokens`**: once at A5 claim time, right after
@@ -1970,6 +1975,31 @@ close.
   at); `present: false` means this claim-id was never recorded. Treat
   `malformed` the same as absent for an ownership check — never trust a
   claim-id this record does not affirmatively confirm.
+- **When to call `--backfill-tokens`** (#2884): the recovery route the
+  Claim revalidation gate's step 5 documents for an absent or malformed
+  `--read-tokens` result -- a worktree whose B1 predates this
+  generated-tokens-record feature (a rollout gap: PR #2879 review, Codex
+  P1) never gets a record written, so `--read-tokens` fails closed
+  forever with no recovery otherwise. Reads the existing `idd-claim.lock`
+  file at `<path>` (the same resolution `--check` uses) and writes only
+  when it is present and its own `claimId` matches the given
+  `--claim-id` exactly, using the lock's own `agentId` and no `--nonce`
+  (matching a fresh pre-nonce `--record-tokens` call): reports
+  `backfilled`. An absent lock reports `lock-absent`; an unparseable or
+  otherwise unreadable lock (for example a directory at the lock path)
+  reports `lock-malformed`; a lock present for a different `claimId`
+  reports `lock-mismatch` (naming the actual holder) -- all three write
+  nothing. Exits `0` for `backfilled` and `2` for the three failure
+  statuses, mirroring `--acquire`'s own collision exit-code contract so a
+  caller can chain `--backfill-tokens && --read-tokens`. Performs no
+  GitHub round-trip, matching `--acquire`'s own same-machine, no-network
+  design -- the caller is responsible for having already independently
+  confirmed the live claim-id via GitHub before ever reaching this
+  recovery step; this command only ever reconciles local worktree state,
+  never adjudicates claim ownership itself. Re-invoking after a
+  successful backfill is always a safe, idempotent overwrite (reports
+  `backfilled` again), matching `--record-tokens`'s own idempotency
+  contract -- there is no separate `already-present` status.
 - No explicit release verb, no cleanup across takeovers: like the lock
   file, the record lives inside the worktree's own private git-admin
   directory, so `git worktree remove` at F4 deletes it together with the
@@ -2016,6 +2046,17 @@ close.
   `present: true, malformed: true`; only a well-formed record whose
   `claimId` field matches is plain `present: true`. Treat `malformed`
   the same as absent for the ownership check -- fail closed on both.
+- **`instructions-only` helper-free fallback, backfill side** (#2884 --
+  the same class of gap PR #2879's Codex P1 review flagged for
+  `--read-tokens` above: a mandatory gate-recovery step needs a
+  helper-free path too, and `instructions-only` is the distributed
+  default profile): resolve the worktree-local lock file the same way as
+  the lock section above and parse it the same way `--check` does. Only
+  when it parses as well-formed and its `claimId` field equals the
+  active `{claim-id}` exactly, apply the write-side fallback above using
+  the lock's own `agentId` and no `nonce`. An absent lock, a lock that
+  fails to parse, or a lock whose `claimId` differs all leave the
+  existing fail-closed stop unchanged -- write nothing.
 
 ### Clone-scoped lock
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -2007,13 +2007,29 @@ close.
   successful backfill is always a safe, idempotent overwrite (reports
   `backfilled` again), matching `--record-tokens`'s own idempotency
   contract -- there is no separate `already-present` status. The Claim
-  revalidation gate (step 5, `idd-overview-core.instructions.md`) only
-  reaches this route when its own initial `--acquire` reported
-  `reacquired: true` -- a fresh `acquired` (lock just created) or
-  `forcedTakeover: true` is never legitimate backfill evidence -- and
-  re-runs `--acquire` once more immediately before the mutation,
-  closing the window this recovery sequence opens (#2917 review,
-  Copilot).
+  revalidation gate (step 5, `idd-overview-core.instructions.md`, and
+  the equivalent step in every lite guard) only reaches this route
+  when its own initial `--acquire` reported `reacquired: true` -- a
+  fresh `acquired` (lock just created) or `forcedTakeover: true` is
+  never legitimate backfill evidence. From there, **each step gates
+  the next** -- proceed to the next step only on the exact result
+  shown, and stop fail-closed on any other result:
+  1. `--check` reports the lock `present`, holder matching
+     `{claim-id}`.
+  2. `--backfill-tokens` reports `backfilled`.
+  3. The retried `--read-tokens` reports `present: true` (no
+     `malformed`).
+  4. A final `--acquire`, run again immediately before the mutation,
+     reports `reacquired: true` -- not a fresh `acquired`, which
+     would mean the lock vanished mid-recovery (for example a
+     concurrent takeover) and this step would otherwise create a new
+     one and let the mutation proceed with no real token evidence.
+
+  This closes two gaps a review round each found real: the window
+  between the initial acquire and the mutation that a concurrent
+  takeover could exploit, and a literal reading of the sequence as an
+  unconditional run-these-in-order list rather than a chain each
+  link of which must actually succeed (#2917 review, Copilot).
 - No explicit release verb, no cleanup across takeovers: like the lock
   file, the record lives inside the worktree's own private git-admin
   directory, so `git worktree remove` at F4 deletes it together with the

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1984,7 +1984,14 @@ close.
   file at `<path>` (the same resolution `--check` uses) and writes only
   when it is present and its own `claimId` matches the given
   `--claim-id` exactly, using the lock's own `agentId` and no `--nonce`
-  (matching a fresh pre-nonce `--record-tokens` call): reports
+  (matching a fresh pre-nonce `--record-tokens` call) unless a
+  well-formed record for this `--claim-id` is already present, in which
+  case its own `nonce` is preserved rather than silently erased (the
+  documented recovery route only ever reaches this command when
+  `--read-tokens` reported absent/malformed -- meaning no well-formed
+  record exists yet -- but the CLI itself does not enforce that
+  precondition, so it guards against a direct out-of-band invocation
+  too, #2917 review): reports
   `backfilled`. An absent lock reports `lock-absent`; an unparseable or
   otherwise unreadable lock (for example a directory at the lock path)
   reports `lock-malformed`; a lock present for a different `claimId`

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1977,6 +1977,14 @@ close.
   A `holder`
   snapshot of the previous occupant is reported on **both** a plain
   `collision` and an authorized takeover, not only on takeover.
+- `reacquired: true` also carries an optional `racedCreate: true` flag
+  (#2917 review, Codex): set when this exact
+  invocation's own first read found the lock absent and its own
+  exclusive-create attempt then lost a race to a concurrent same-`claim-id`
+  creator, so the eventual match came from a later retry, not the
+  invocation's first look. A caller trusting `reacquired: true` as
+  evidence the lock predates this call (as the backfill-tokens recovery
+  route does) must also require `racedCreate` to be absent/`false`.
 - The `--acquire` CLI exits `0` only for `acquired` and exits `2` for
   `collision`, so a hook can safely chain installation or another mutation
   with `&&`; `--check` remains read-only and exits `0` for a reported state.
@@ -2091,9 +2099,14 @@ close.
   `backfilled`. An absent lock reports `lock-absent`; an unparseable or
   otherwise unreadable lock (for example a directory at the lock path)
   reports `lock-malformed`; a lock present for a different `claimId`
-  reports `lock-mismatch` (naming the actual holder) -- all three write
-  nothing. Exits `0` for `backfilled` and `2` for the three failure
-  statuses, mirroring `--acquire`'s own collision exit-code contract so a
+  reports `lock-mismatch` (naming the actual holder); a matching lock
+  whose own record path is a directory reports `record-blocked` instead
+  of deleting it -- the lock only authenticates the lock, not this
+  separate path, and the path's hash suffix is not collision-proof, so
+  lock authority alone never authorizes replacing it (#2917 review,
+  Copilot) -- all four write nothing. Exits `0` for `backfilled` and `2`
+  for the four failure statuses, mirroring `--acquire`'s own collision
+  exit-code contract so a
   caller can chain `--backfill-tokens && --read-tokens`. Performs no
   GitHub round-trip, matching `--acquire`'s own same-machine, no-network
   design -- the caller is responsible for having already independently
@@ -2104,28 +2117,45 @@ close.
   `backfilled` again), matching `--record-tokens`'s own idempotency
   contract -- there is no separate `already-present` status. The Claim
   revalidation gate (step 5, `idd-overview-core.instructions.md`, and
-  the equivalent step in every lite guard) only reaches this route
-  when its own initial `--acquire` reported `reacquired: true` -- a
-  fresh `acquired` (lock just created) or `forcedTakeover: true` is
-  never legitimate backfill evidence. From there, **each step gates
-  the next** -- proceed to the next step only on the exact result
-  shown, and stop fail-closed on any other result:
+  the equivalent step in every lite guard) reaches this route only
+  through a chain in which **each step gates the next** -- proceed to
+  the next step only on the exact result shown, and stop fail-closed on
+  any other result:
+  0. The gate's own initial `--acquire` reports `reacquired: true` with
+  no `racedCreate` -- a fresh `acquired` (lock just created),
+  `forcedTakeover: true`, or `reacquired: true` with `racedCreate:
+     true` (this call itself raced a concurrent creator for the same
+  claim-id, so the match is not proof the lock predates this gate
+  pass) are never legitimate backfill evidence.
   1. `--check` reports the lock `present`, holder matching
      `{claim-id}`.
   2. `--backfill-tokens` reports `backfilled`.
   3. The retried `--read-tokens` reports `present: true` (no
      `malformed`).
   4. A final `--acquire`, run again immediately before the mutation,
-     reports `reacquired: true` -- not a fresh `acquired`, which
-     would mean the lock vanished mid-recovery (for example a
+     reports `reacquired: true` with no `racedCreate` -- the same
+     requirement as step 0, applied again because a fresh `acquired`
+     here would mean the lock vanished mid-recovery (for example a
      concurrent takeover) and this step would otherwise create a new
      one and let the mutation proceed with no real token evidence.
 
-  This closes two gaps a review round each found real: the window
+  This closes gaps three review rounds each found real: the window
   between the initial acquire and the mutation that a concurrent
-  takeover could exploit, and a literal reading of the sequence as an
-  unconditional run-these-in-order list rather than a chain each
-  link of which must actually succeed (#2917 review, Copilot).
+  takeover could exploit; a literal reading of the sequence as an
+  unconditional run-these-in-order list rather than a chain each link
+  of which must actually succeed; and `reacquired: true` alone being
+  trusted as proof of pre-existence when a same-claim-id race can
+  produce it for a lock that is in fact only microseconds old
+  (`acquireClaimLock`'s own `EEXIST`-retry loop,
+  `src/scripts/claim-lock.mts`) (#2917 review, Codex and Copilot).
+  Residual, named rather than hidden: a _third_ process arriving after
+  such a race has already settled sees `reacquired: true` with no
+  `racedCreate` on its own first read, the same way it would for a
+  lock that is genuinely years old -- this mechanism only ever detects
+  a race this specific call itself observed, never a lock's true age;
+  the Claim revalidation gate's own GitHub-verified claim check (steps
+  1-4 before this one) is the actual authority this is defense in
+  depth for, not a replacement for it.
 - No explicit release verb, no cleanup across takeovers: like the lock
   file, the record lives inside the worktree's own private git-admin
   directory, so `git worktree remove` at F4 deletes it together with the

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -2001,17 +2001,26 @@ close.
   `git worktree remove` at F4 deletes it together with the worktree
 - **`instructions-only` helper-free fallback** (no helper runtime
   available): resolve the private admin directory with
-  `git -C <worktree> rev-parse --absolute-git-dir`, then atomically
-  create an `idd-claim.lock` file there with an exclusive file-create
-  API (`open(..., O_CREAT|O_EXCL)` on POSIX, or the PowerShell
+  `git -C <worktree> rev-parse --absolute-git-dir`, then read the
+  `idd-claim.lock` path first, before writing anything. Present,
+  well-formed, and its holder matches (`agentId`, `claimId`) →
+  re-acquired without writing — this call's own first read found the
+  lock already there, mirroring the helper's `reacquired: true` with no
+  `racedCreate`. Absent → create it with an exclusive file-create API
+  (`open(..., O_CREAT|O_EXCL)` on POSIX, or the PowerShell
   `FileMode.CreateNew` equivalent), writing the same JSON holder shape
-  (`agentId`, `claimId`, `acquiredAt`). A path that already exists is a
-  collision; a matching holder may re-acquire, and a missing,
-  malformed, or unreadable holder is also a collision. Never delete or
-  override a different holder — enable a helper runtime for an
-  authorized takeover instead. Both profiles share the `idd-claim.lock`
-  namespace, so a helper-runtime session and an instructions-only
-  session see the same lock.
+  (`agentId`, `claimId`, `acquiredAt`). If that create then fails
+  because the path now exists (`EEXIST`), a concurrent same-claim-id
+  writer landed between the read and the create; re-read to confirm the
+  holder matches, but treat this outcome as a race, not as evidence the
+  lock predates this call — never equal it to a lock this same read
+  already found present (the helper's `racedCreate: true`, #2917
+  review, Codex). A path that already exists with a non-matching,
+  missing, malformed, or unreadable holder is a collision either way.
+  Never delete or override a different holder — enable a helper runtime
+  for an authorized takeover instead. Both profiles share the
+  `idd-claim.lock` namespace, so a helper-runtime session and an
+  instructions-only session see the same lock.
 
 ### Worktree-local generated-tokens record
 
@@ -2190,7 +2199,11 @@ close.
   `{ agentId, claimId, nonce?, recordedAt }`. No
   exclusive-create semantics needed (unlike the lock): a plain atomic
   replace is correct since this is idempotent evidence, not a
-  mutual-exclusion primitive.
+  mutual-exclusion primitive -- except a directory already occupying
+  this exact path, which this fallback never replaces or deletes
+  either, matching `recordGeneratedClaimTokens`'s own absolute
+  invariant in `src/scripts/claim-lock.mts` (PR #2879 regression test;
+  #2917 review, Copilot); stop fail-closed instead.
 - **`instructions-only` helper-free fallback, read side** (#2879 review,
   Codex P1 -- the mandatory `--read-tokens` check in the Claim
   revalidation gate has no helper-free path without this): resolve the
@@ -2208,17 +2221,27 @@ close.
   helper-free path too, and `instructions-only` is the distributed
   default profile): resolve the worktree-local lock file the same way as
   the lock section above and parse it the same way `--check` does --
-  but only when that lock already existed before this gate's own
-  acquire step (the exclusive create above failed `EEXIST` with a
-  matching holder, never a lock this same attempt just created, #2917
-  review). Only when it parses as well-formed and its `claimId` field
-  equals the active `{claim-id}` exactly, apply the write-side fallback
-  above using the lock's own `agentId`, carrying forward an existing
-  well-formed record's own `nonce` when present, otherwise no `nonce`
-  (#2917 review, Copilot). An absent lock, a lock that fails to parse,
-  a lock whose `claimId` differs, or a lock this same attempt just
-  created all leave the existing fail-closed stop unchanged -- write
-  nothing.
+  but only when your own _first read_ in the acquire step above already
+  found the lock present and matching, never when it was absent there
+  and your own exclusive-create then failed `EEXIST`. That failure means
+  a concurrent same-claim-id writer landed between your read and your
+  create -- a race, not evidence the lock predates this gate pass; the
+  helper's own `racedCreate: true` marks exactly this case (#2917
+  review, Codex). Only when it parses as well-formed and its `claimId`
+  field equals the active `{claim-id}` exactly, apply the write-side
+  fallback above using the lock's own `agentId`, carrying forward an
+  existing well-formed record's own `nonce` when present, otherwise no
+  `nonce` (#2917 review, Copilot) -- except when the record's own
+  resolved path is already occupied by a directory: leave it and its
+  contents untouched and stop fail-closed instead, mirroring the CLI's
+  own `record-blocked` status (`backfillGeneratedClaimTokens`,
+  `src/scripts/claim-lock.mts`) -- a matching lock authenticates the
+  lock, not that separate path, and the path's hash suffix is not
+  collision-proof, so lock authority alone never authorizes replacing it
+  (#2917 review, Copilot). An absent lock, a lock that fails to parse, a
+  lock whose `claimId` differs, or a lock your own first read did not
+  already find present and matching all leave the existing fail-closed
+  stop unchanged -- write nothing.
 
 ### Clone-scoped lock
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -2006,7 +2006,14 @@ close.
   never adjudicates claim ownership itself. Re-invoking after a
   successful backfill is always a safe, idempotent overwrite (reports
   `backfilled` again), matching `--record-tokens`'s own idempotency
-  contract -- there is no separate `already-present` status.
+  contract -- there is no separate `already-present` status. The Claim
+  revalidation gate (step 5, `idd-overview-core.instructions.md`) only
+  reaches this route when its own initial `--acquire` reported
+  `reacquired: true` -- a fresh `acquired` (lock just created) or
+  `forcedTakeover: true` is never legitimate backfill evidence -- and
+  re-runs `--acquire` once more immediately before the mutation,
+  closing the window this recovery sequence opens (#2917 review,
+  Copilot).
 - No explicit release verb, no cleanup across takeovers: like the lock
   file, the record lives inside the worktree's own private git-admin
   directory, so `git worktree remove` at F4 deletes it together with the
@@ -2058,12 +2065,18 @@ close.
   `--read-tokens` above: a mandatory gate-recovery step needs a
   helper-free path too, and `instructions-only` is the distributed
   default profile): resolve the worktree-local lock file the same way as
-  the lock section above and parse it the same way `--check` does. Only
-  when it parses as well-formed and its `claimId` field equals the
-  active `{claim-id}` exactly, apply the write-side fallback above using
-  the lock's own `agentId` and no `nonce`. An absent lock, a lock that
-  fails to parse, or a lock whose `claimId` differs all leave the
-  existing fail-closed stop unchanged -- write nothing.
+  the lock section above and parse it the same way `--check` does --
+  but only when that lock already existed before this gate's own
+  acquire step (the exclusive create above failed `EEXIST` with a
+  matching holder, never a lock this same attempt just created, #2917
+  review). Only when it parses as well-formed and its `claimId` field
+  equals the active `{claim-id}` exactly, apply the write-side fallback
+  above using the lock's own `agentId`, carrying forward an existing
+  well-formed record's own `nonce` when present, otherwise no `nonce`
+  (#2917 review, Copilot). An absent lock, a lock that fails to parse,
+  a lock whose `claimId` differs, or a lock this same attempt just
+  created all leave the existing fail-closed stop unchanged -- write
+  nothing.
 
 ### Clone-scoped lock
 

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -596,8 +596,8 @@ session's leftover lock resolves the same way. See
 mechanical detail.
 
 **Generated-tokens record.** Re-check with `--read-tokens` alongside
-`--acquire` before trusting a recalled `{claim-id}`. See
-`docs/idd-helper-scripts.md`.
+`--acquire`; absent/malformed recovers via `--backfill-tokens`
+(`docs/idd-helper-scripts.md`).
 
 Then continue to `idd-work.instructions.md`.
 

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -596,8 +596,8 @@ session's leftover lock resolves the same way. See
 mechanical detail.
 
 **Generated-tokens record.** Re-check with `--read-tokens` alongside
-`--acquire`; absent/malformed recovers via `--backfill-tokens`
-(`docs/idd-helper-scripts.md`).
+`--acquire`; absent/malformed recovers only via step 5
+(`idd-overview-core.instructions.md`).
 
 Then continue to `idd-work.instructions.md`.
 

--- a/idd-template/.github/instructions/idd-overview-core.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-core.instructions.md
@@ -203,9 +203,9 @@ When in scope, run:
    helper-free fallback. A `collision` fails closed unless claim
    revalidation authorizes an explicit takeover. Also confirm
    `--read-tokens` finds this `{claim-id}` recorded; absent/malformed
-   fails closed unless this acquire reported `reacquired: true` (never
-   fresh/takeover) -- only then `--check` -> `--backfill-tokens` ->
-   `--read-tokens` -> a final re-`--acquire` before mutating.
+   recovers only via `docs/idd-helper-scripts.md`'s gated backfill
+   sequence (each step must succeed before the next; `reacquired:
+   true` required at both ends) -- else fails closed.
 
 **Recovery if a commit already landed on the wrong branch.** If this gate
 or `idd-doctor` finds a commit on the wrong branch, cherry-pick it onto

--- a/idd-template/.github/instructions/idd-overview-core.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-core.instructions.md
@@ -200,12 +200,12 @@ When in scope, run:
    using the profile-selected `claim-lock` helper
    (`docs/idd-helper-scripts.md`) with `{agent-id}`/`{claim-id}`.
    Under `instructions-only`, use `idd-work.instructions.md`'s
-   helper-free fallback (same `idd-claim.lock` namespace). A `collision`
-   fails closed unless claim revalidation authorizes an explicit
-   takeover. Also confirm `--read-tokens` finds this `{claim-id}`
-   recorded (`idd-claim.instructions.md`); absent/malformed fails closed
-   too, recoverable only via a matching `--check`, `--backfill-tokens`,
-   then retry (`docs/idd-helper-scripts.md`).
+   helper-free fallback. A `collision` fails closed unless claim
+   revalidation authorizes an explicit takeover. Also confirm
+   `--read-tokens` finds this `{claim-id}` recorded; absent/malformed
+   fails closed unless this acquire reported `reacquired: true` (never
+   fresh/takeover) -- only then `--check` -> `--backfill-tokens` ->
+   `--read-tokens` -> a final re-`--acquire` before mutating.
 
 **Recovery if a commit already landed on the wrong branch.** If this gate
 or `idd-doctor` finds a commit on the wrong branch, cherry-pick it onto

--- a/idd-template/.github/instructions/idd-overview-core.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-core.instructions.md
@@ -197,15 +197,15 @@ When in scope, run:
    do not `add`, `commit`, or `push` from a worktree not on the claimed
    branch.
 5. Acquire the worktree-local claim lock immediately before the mutation,
-   using the profile-selected `claim-lock` helper (see
-   `docs/idd-helper-scripts.md`) with the current `{agent-id}` and
-   `{claim-id}`. Under the `instructions-only` profile, use the
-   helper-free fallback in `idd-work.instructions.md`, which uses the
-   same `idd-claim.lock` namespace. A `collision` is fail-closed: stop
-   unless the active claim revalidation authorizes an explicit takeover.
-   Also confirm `--read-tokens` finds this `{claim-id}` recorded
-   (`idd-claim.instructions.md`); absent or malformed fails closed the
-   same way.
+   using the profile-selected `claim-lock` helper
+   (`docs/idd-helper-scripts.md`) with `{agent-id}`/`{claim-id}`.
+   Under `instructions-only`, use `idd-work.instructions.md`'s
+   helper-free fallback (same `idd-claim.lock` namespace). A `collision`
+   fails closed unless claim revalidation authorizes an explicit
+   takeover. Also confirm `--read-tokens` finds this `{claim-id}`
+   recorded (`idd-claim.instructions.md`); absent/malformed fails closed
+   too, recoverable only via a matching `--check`, `--backfill-tokens`,
+   then retry (`docs/idd-helper-scripts.md`).
 
 **Recovery if a commit already landed on the wrong branch.** If this gate
 or `idd-doctor` finds a commit on the wrong branch, cherry-pick it onto

--- a/idd-template/.github/instructions/lite/idd-claim-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-claim-lite.instructions.md
@@ -429,7 +429,8 @@ node scripts/claim-lock.mjs --acquire --worktree <path> \
 
 Then, separately, run `--read-tokens --worktree <path> --claim-id
 <id>` and require `present: true` with no `malformed`; otherwise
-stop. See `docs/idd-helper-scripts.md`.
+`--check` match -> `--backfill-tokens` -> retry, else stop
+(`docs/idd-helper-scripts.md`).
 
 A matching `{claim-id}` re-acquires as a read-only check. A different
 `{claim-id}` is always a collision — re-run pre-check (c) (`--claim-id`

--- a/idd-template/.github/instructions/lite/idd-claim-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-claim-lite.instructions.md
@@ -427,10 +427,10 @@ node scripts/claim-lock.mjs --acquire --worktree <path> \
   --agent-id <agent-id> --claim-id <claim-id>
 ```
 
-Then, separately, run `--read-tokens --worktree <path> --claim-id
-<id>` and require `present: true` with no `malformed`; otherwise
-`--check` match -> `--backfill-tokens` -> retry, else stop
-(`docs/idd-helper-scripts.md`).
+Then run `--read-tokens --worktree <path> --claim-id <id>` and
+require `present: true` with no `malformed`; otherwise, only if this
+re-acquired (never fresh/takeover): `--check` -> `--backfill-tokens`
+-> retry -> re-acquire, else stop.
 
 A matching `{claim-id}` re-acquires as a read-only check. A different
 `{claim-id}` is always a collision — re-run pre-check (c) (`--claim-id`
@@ -447,8 +447,7 @@ first, then `--fresh-claim-gate` if not `already_owned`):
 - `already-claimed` naming a **different** id: a live competitor holds
   it — stop, the claim was lost.
 
-No release step: `git worktree remove` at F4 deletes the lock with the
-worktree.
+No release step (F4 `git worktree remove` deletes it).
 
 Then continue to `idd-work-lite.instructions.md` — except on
 `instructions-only`, where that file declines the profile in its own

--- a/idd-template/.github/instructions/lite/idd-claim-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-claim-lite.instructions.md
@@ -428,9 +428,9 @@ node scripts/claim-lock.mjs --acquire --worktree <path> \
 ```
 
 Then run `--read-tokens --worktree <path> --claim-id <id>` and
-require `present: true` with no `malformed`; otherwise, only if this
-re-acquired (never fresh/takeover): `--check` -> `--backfill-tokens`
--> retry -> re-acquire, else stop.
+require `present: true` with no `malformed`; otherwise recover per
+`docs/idd-helper-scripts.md` (gated: each step succeeds,
+`reacquired: true` both ends), else stop.
 
 A matching `{claim-id}` re-acquires as a read-only check. A different
 `{claim-id}` is always a collision — re-run pre-check (c) (`--claim-id`

--- a/idd-template/.github/instructions/lite/idd-merge-handoff-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-merge-handoff-lite.instructions.md
@@ -36,10 +36,9 @@ Before posting the handoff comment, confirm all of the following:
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
    `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
-   and require `present: true` with no `malformed`; otherwise, only on
-   a matching re-acquire (never a fresh create or takeover), run
-   `--check` -> `--backfill-tokens` -> retry -> re-acquire before
-   mutating -- else stop (`docs/idd-helper-scripts.md`).
+   and require `present: true` with no `malformed`; otherwise recover
+   per `docs/idd-helper-scripts.md` (gated: each step succeeds,
+   `reacquired: true` both ends), else stop.
 4. If any check fails, stop.
 
 ## F2.5 — Draft and post the handoff comment

--- a/idd-template/.github/instructions/lite/idd-merge-handoff-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-merge-handoff-lite.instructions.md
@@ -36,7 +36,9 @@ Before posting the handoff comment, confirm all of the following:
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
    `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
-   and require `present: true` with no `malformed`; otherwise stop.
+   and require `present: true` with no `malformed`; otherwise run
+   `--check`, and on a match run `--backfill-tokens` then retry -- else
+   stop (`docs/idd-helper-scripts.md`).
 4. If any check fails, stop.
 
 ## F2.5 — Draft and post the handoff comment

--- a/idd-template/.github/instructions/lite/idd-merge-handoff-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-merge-handoff-lite.instructions.md
@@ -36,9 +36,10 @@ Before posting the handoff comment, confirm all of the following:
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
    `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
-   and require `present: true` with no `malformed`; otherwise run
-   `--check`, and on a match run `--backfill-tokens` then retry -- else
-   stop (`docs/idd-helper-scripts.md`).
+   and require `present: true` with no `malformed`; otherwise, only on
+   a matching re-acquire (never a fresh create or takeover), run
+   `--check` -> `--backfill-tokens` -> retry -> re-acquire before
+   mutating -- else stop (`docs/idd-helper-scripts.md`).
 4. If any check fails, stop.
 
 ## F2.5 — Draft and post the handoff comment

--- a/idd-template/.github/instructions/lite/idd-pr-submit-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-pr-submit-lite.instructions.md
@@ -81,7 +81,9 @@ following:
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
    `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
-   and require `present: true` with no `malformed`; otherwise stop.
+   and require `present: true` with no `malformed`; otherwise run
+   `--check`, and on a match run `--backfill-tokens` then retry -- else
+   stop (`docs/idd-helper-scripts.md`).
 6. If any check fails, stop.
 
 ## D1 — Sync main before first push

--- a/idd-template/.github/instructions/lite/idd-pr-submit-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-pr-submit-lite.instructions.md
@@ -81,10 +81,9 @@ following:
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
    `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
-   and require `present: true` with no `malformed`; otherwise, only on
-   a matching re-acquire (never a fresh create or takeover), run
-   `--check` -> `--backfill-tokens` -> retry -> re-acquire before
-   mutating -- else stop (`docs/idd-helper-scripts.md`).
+   and require `present: true` with no `malformed`; otherwise recover
+   per `docs/idd-helper-scripts.md` (gated: each step succeeds,
+   `reacquired: true` both ends), else stop.
 6. If any check fails, stop.
 
 ## D1 — Sync main before first push

--- a/idd-template/.github/instructions/lite/idd-pr-submit-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-pr-submit-lite.instructions.md
@@ -81,9 +81,10 @@ following:
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
    `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
-   and require `present: true` with no `malformed`; otherwise run
-   `--check`, and on a match run `--backfill-tokens` then retry -- else
-   stop (`docs/idd-helper-scripts.md`).
+   and require `present: true` with no `malformed`; otherwise, only on
+   a matching re-acquire (never a fresh create or takeover), run
+   `--check` -> `--backfill-tokens` -> retry -> re-acquire before
+   mutating -- else stop (`docs/idd-helper-scripts.md`).
 6. If any check fails, stop.
 
 ## D1 — Sync main before first push

--- a/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -82,7 +82,9 @@ other GitHub side effect, confirm all of the following:
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
    `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
-   and require `present: true` with no `malformed`; otherwise stop.
+   and require `present: true` with no `malformed`; otherwise run
+   `--check`, and on a match run `--backfill-tokens` then retry -- else
+   stop (`docs/idd-helper-scripts.md`).
 6. If any check fails, stop.
 
 ## E9 — Fix accepted issues

--- a/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -82,9 +82,10 @@ other GitHub side effect, confirm all of the following:
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
    `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
-   and require `present: true` with no `malformed`; otherwise run
-   `--check`, and on a match run `--backfill-tokens` then retry -- else
-   stop (`docs/idd-helper-scripts.md`).
+   and require `present: true` with no `malformed`; otherwise, only on
+   a matching re-acquire (never a fresh create or takeover), run
+   `--check` -> `--backfill-tokens` -> retry -> re-acquire before
+   mutating -- else stop (`docs/idd-helper-scripts.md`).
 6. If any check fails, stop.
 
 ## E9 — Fix accepted issues

--- a/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -82,10 +82,9 @@ other GitHub side effect, confirm all of the following:
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
    `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
-   and require `present: true` with no `malformed`; otherwise, only on
-   a matching re-acquire (never a fresh create or takeover), run
-   `--check` -> `--backfill-tokens` -> retry -> re-acquire before
-   mutating -- else stop (`docs/idd-helper-scripts.md`).
+   and require `present: true` with no `malformed`; otherwise recover
+   per `docs/idd-helper-scripts.md` (gated: each step succeeds,
+   `reacquired: true` both ends), else stop.
 6. If any check fails, stop.
 
 ## E9 — Fix accepted issues

--- a/idd-template/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
@@ -57,10 +57,9 @@ GitHub side effect, confirm all of the following:
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
    `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
-   and require `present: true` with no `malformed`; otherwise, only on
-   a matching re-acquire (never a fresh create or takeover), run
-   `--check` -> `--backfill-tokens` -> retry -> re-acquire before
-   mutating -- else stop (`docs/idd-helper-scripts.md`).
+   and require `present: true` with no `malformed`; otherwise recover
+   per `docs/idd-helper-scripts.md` (gated: each step succeeds,
+   `reacquired: true` both ends), else stop.
 6. If any check fails, stop.
 
 ## E1 — Fetch review items into ReviewItems_snapshot

--- a/idd-template/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
@@ -57,7 +57,9 @@ GitHub side effect, confirm all of the following:
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
    `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
-   and require `present: true` with no `malformed`; otherwise stop.
+   and require `present: true` with no `malformed`; otherwise run
+   `--check`, and on a match run `--backfill-tokens` then retry -- else
+   stop (`docs/idd-helper-scripts.md`).
 6. If any check fails, stop.
 
 ## E1 — Fetch review items into ReviewItems_snapshot

--- a/idd-template/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
@@ -57,9 +57,10 @@ GitHub side effect, confirm all of the following:
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
    `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
-   and require `present: true` with no `malformed`; otherwise run
-   `--check`, and on a match run `--backfill-tokens` then retry -- else
-   stop (`docs/idd-helper-scripts.md`).
+   and require `present: true` with no `malformed`; otherwise, only on
+   a matching re-acquire (never a fresh create or takeover), run
+   `--check` -> `--backfill-tokens` -> retry -> re-acquire before
+   mutating -- else stop (`docs/idd-helper-scripts.md`).
 6. If any check fails, stop.
 
 ## E1 — Fetch review items into ReviewItems_snapshot

--- a/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
@@ -51,10 +51,9 @@ request, or other GitHub side effect, confirm all of the following:
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
    `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
-   and require `present: true` with no `malformed`; otherwise, only on
-   a matching re-acquire (never a fresh create or takeover), run
-   `--check` -> `--backfill-tokens` -> retry -> re-acquire before
-   mutating -- else stop (`docs/idd-helper-scripts.md`).
+   and require `present: true` with no `malformed`; otherwise recover
+   per `docs/idd-helper-scripts.md` (gated: each step succeeds,
+   `reacquired: true` both ends), else stop.
 6. If any check fails, stop.
 
 ## B1 — Create worktree

--- a/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
@@ -51,7 +51,9 @@ request, or other GitHub side effect, confirm all of the following:
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
    `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
-   and require `present: true` with no `malformed`; otherwise stop.
+   and require `present: true` with no `malformed`; otherwise run
+   `--check`, and on a match run `--backfill-tokens` then retry -- else
+   stop (`docs/idd-helper-scripts.md`).
 6. If any check fails, stop.
 
 ## B1 — Create worktree

--- a/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
@@ -51,9 +51,10 @@ request, or other GitHub side effect, confirm all of the following:
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed. Then, separately, run
    `--read-tokens --worktree <this-worktree-path> --claim-id <id>`
-   and require `present: true` with no `malformed`; otherwise run
-   `--check`, and on a match run `--backfill-tokens` then retry -- else
-   stop (`docs/idd-helper-scripts.md`).
+   and require `present: true` with no `malformed`; otherwise, only on
+   a matching re-acquire (never a fresh create or takeover), run
+   `--check` -> `--backfill-tokens` -> retry -> re-acquire before
+   mutating -- else stop (`docs/idd-helper-scripts.md`).
 6. If any check fails, stop.
 
 ## B1 — Create worktree

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1920,8 +1920,10 @@ close.
   [`idd-claim.instructions.md`'s Worktree-local lock file section](../.github/instructions/idd-claim.instructions.md#worktree-local-lock-file-same-machine-collision).
 - Source repo / vendored-node commands:
   `node scripts/claim-lock.mjs --record-tokens --worktree <path>
-  --agent-id <id> --claim-id <id> [--nonce <nonce>]`
-  and `node scripts/claim-lock.mjs --read-tokens --worktree <path>
+  --agent-id <id> --claim-id <id> [--nonce <nonce>]`,
+  `node scripts/claim-lock.mjs --read-tokens --worktree <path>
+  --claim-id <id>`, and
+  `node scripts/claim-lock.mjs --backfill-tokens --worktree <path>
   --claim-id <id>`
 - Package-manager / ephemeral-npx command: use the same profile-selected
   `idd:claim-lock` command as the lock above; the literal invocations are:
@@ -1933,6 +1935,9 @@ close.
 
   npx --yes --package <helper-package-spec> \
     idd-claim-lock --read-tokens --worktree <path> --claim-id <id>
+
+  npx --yes --package <helper-package-spec> \
+    idd-claim-lock --backfill-tokens --worktree <path> --claim-id <id>
   ```
 
 - **When to call `--record-tokens`**: once at A5 claim time, right after
@@ -1970,6 +1975,31 @@ close.
   at); `present: false` means this claim-id was never recorded. Treat
   `malformed` the same as absent for an ownership check — never trust a
   claim-id this record does not affirmatively confirm.
+- **When to call `--backfill-tokens`** (#2884): the recovery route the
+  Claim revalidation gate's step 5 documents for an absent or malformed
+  `--read-tokens` result -- a worktree whose B1 predates this
+  generated-tokens-record feature (a rollout gap: PR #2879 review, Codex
+  P1) never gets a record written, so `--read-tokens` fails closed
+  forever with no recovery otherwise. Reads the existing `idd-claim.lock`
+  file at `<path>` (the same resolution `--check` uses) and writes only
+  when it is present and its own `claimId` matches the given
+  `--claim-id` exactly, using the lock's own `agentId` and no `--nonce`
+  (matching a fresh pre-nonce `--record-tokens` call): reports
+  `backfilled`. An absent lock reports `lock-absent`; an unparseable or
+  otherwise unreadable lock (for example a directory at the lock path)
+  reports `lock-malformed`; a lock present for a different `claimId`
+  reports `lock-mismatch` (naming the actual holder) -- all three write
+  nothing. Exits `0` for `backfilled` and `2` for the three failure
+  statuses, mirroring `--acquire`'s own collision exit-code contract so a
+  caller can chain `--backfill-tokens && --read-tokens`. Performs no
+  GitHub round-trip, matching `--acquire`'s own same-machine, no-network
+  design -- the caller is responsible for having already independently
+  confirmed the live claim-id via GitHub before ever reaching this
+  recovery step; this command only ever reconciles local worktree state,
+  never adjudicates claim ownership itself. Re-invoking after a
+  successful backfill is always a safe, idempotent overwrite (reports
+  `backfilled` again), matching `--record-tokens`'s own idempotency
+  contract -- there is no separate `already-present` status.
 - No explicit release verb, no cleanup across takeovers: like the lock
   file, the record lives inside the worktree's own private git-admin
   directory, so `git worktree remove` at F4 deletes it together with the
@@ -2016,6 +2046,17 @@ close.
   `present: true, malformed: true`; only a well-formed record whose
   `claimId` field matches is plain `present: true`. Treat `malformed`
   the same as absent for the ownership check -- fail closed on both.
+- **`instructions-only` helper-free fallback, backfill side** (#2884 --
+  the same class of gap PR #2879's Codex P1 review flagged for
+  `--read-tokens` above: a mandatory gate-recovery step needs a
+  helper-free path too, and `instructions-only` is the distributed
+  default profile): resolve the worktree-local lock file the same way as
+  the lock section above and parse it the same way `--check` does. Only
+  when it parses as well-formed and its `claimId` field equals the
+  active `{claim-id}` exactly, apply the write-side fallback above using
+  the lock's own `agentId` and no `nonce`. An absent lock, a lock that
+  fails to parse, or a lock whose `claimId` differs all leave the
+  existing fail-closed stop unchanged -- write nothing.
 
 ### Clone-scoped lock
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -2007,13 +2007,29 @@ close.
   successful backfill is always a safe, idempotent overwrite (reports
   `backfilled` again), matching `--record-tokens`'s own idempotency
   contract -- there is no separate `already-present` status. The Claim
-  revalidation gate (step 5, `idd-overview-core.instructions.md`) only
-  reaches this route when its own initial `--acquire` reported
-  `reacquired: true` -- a fresh `acquired` (lock just created) or
-  `forcedTakeover: true` is never legitimate backfill evidence -- and
-  re-runs `--acquire` once more immediately before the mutation,
-  closing the window this recovery sequence opens (#2917 review,
-  Copilot).
+  revalidation gate (step 5, `idd-overview-core.instructions.md`, and
+  the equivalent step in every lite guard) only reaches this route
+  when its own initial `--acquire` reported `reacquired: true` -- a
+  fresh `acquired` (lock just created) or `forcedTakeover: true` is
+  never legitimate backfill evidence. From there, **each step gates
+  the next** -- proceed to the next step only on the exact result
+  shown, and stop fail-closed on any other result:
+  1. `--check` reports the lock `present`, holder matching
+     `{claim-id}`.
+  2. `--backfill-tokens` reports `backfilled`.
+  3. The retried `--read-tokens` reports `present: true` (no
+     `malformed`).
+  4. A final `--acquire`, run again immediately before the mutation,
+     reports `reacquired: true` -- not a fresh `acquired`, which
+     would mean the lock vanished mid-recovery (for example a
+     concurrent takeover) and this step would otherwise create a new
+     one and let the mutation proceed with no real token evidence.
+
+  This closes two gaps a review round each found real: the window
+  between the initial acquire and the mutation that a concurrent
+  takeover could exploit, and a literal reading of the sequence as an
+  unconditional run-these-in-order list rather than a chain each
+  link of which must actually succeed (#2917 review, Copilot).
 - No explicit release verb, no cleanup across takeovers: like the lock
   file, the record lives inside the worktree's own private git-admin
   directory, so `git worktree remove` at F4 deletes it together with the

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1984,7 +1984,14 @@ close.
   file at `<path>` (the same resolution `--check` uses) and writes only
   when it is present and its own `claimId` matches the given
   `--claim-id` exactly, using the lock's own `agentId` and no `--nonce`
-  (matching a fresh pre-nonce `--record-tokens` call): reports
+  (matching a fresh pre-nonce `--record-tokens` call) unless a
+  well-formed record for this `--claim-id` is already present, in which
+  case its own `nonce` is preserved rather than silently erased (the
+  documented recovery route only ever reaches this command when
+  `--read-tokens` reported absent/malformed -- meaning no well-formed
+  record exists yet -- but the CLI itself does not enforce that
+  precondition, so it guards against a direct out-of-band invocation
+  too, #2917 review): reports
   `backfilled`. An absent lock reports `lock-absent`; an unparseable or
   otherwise unreadable lock (for example a directory at the lock path)
   reports `lock-malformed`; a lock present for a different `claimId`

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1977,6 +1977,14 @@ close.
   A `holder`
   snapshot of the previous occupant is reported on **both** a plain
   `collision` and an authorized takeover, not only on takeover.
+- `reacquired: true` also carries an optional `racedCreate: true` flag
+  (#2917 review, Codex): set when this exact
+  invocation's own first read found the lock absent and its own
+  exclusive-create attempt then lost a race to a concurrent same-`claim-id`
+  creator, so the eventual match came from a later retry, not the
+  invocation's first look. A caller trusting `reacquired: true` as
+  evidence the lock predates this call (as the backfill-tokens recovery
+  route does) must also require `racedCreate` to be absent/`false`.
 - The `--acquire` CLI exits `0` only for `acquired` and exits `2` for
   `collision`, so a hook can safely chain installation or another mutation
   with `&&`; `--check` remains read-only and exits `0` for a reported state.
@@ -2091,9 +2099,14 @@ close.
   `backfilled`. An absent lock reports `lock-absent`; an unparseable or
   otherwise unreadable lock (for example a directory at the lock path)
   reports `lock-malformed`; a lock present for a different `claimId`
-  reports `lock-mismatch` (naming the actual holder) -- all three write
-  nothing. Exits `0` for `backfilled` and `2` for the three failure
-  statuses, mirroring `--acquire`'s own collision exit-code contract so a
+  reports `lock-mismatch` (naming the actual holder); a matching lock
+  whose own record path is a directory reports `record-blocked` instead
+  of deleting it -- the lock only authenticates the lock, not this
+  separate path, and the path's hash suffix is not collision-proof, so
+  lock authority alone never authorizes replacing it (#2917 review,
+  Copilot) -- all four write nothing. Exits `0` for `backfilled` and `2`
+  for the four failure statuses, mirroring `--acquire`'s own collision
+  exit-code contract so a
   caller can chain `--backfill-tokens && --read-tokens`. Performs no
   GitHub round-trip, matching `--acquire`'s own same-machine, no-network
   design -- the caller is responsible for having already independently
@@ -2104,28 +2117,45 @@ close.
   `backfilled` again), matching `--record-tokens`'s own idempotency
   contract -- there is no separate `already-present` status. The Claim
   revalidation gate (step 5, `idd-overview-core.instructions.md`, and
-  the equivalent step in every lite guard) only reaches this route
-  when its own initial `--acquire` reported `reacquired: true` -- a
-  fresh `acquired` (lock just created) or `forcedTakeover: true` is
-  never legitimate backfill evidence. From there, **each step gates
-  the next** -- proceed to the next step only on the exact result
-  shown, and stop fail-closed on any other result:
+  the equivalent step in every lite guard) reaches this route only
+  through a chain in which **each step gates the next** -- proceed to
+  the next step only on the exact result shown, and stop fail-closed on
+  any other result:
+  0. The gate's own initial `--acquire` reports `reacquired: true` with
+  no `racedCreate` -- a fresh `acquired` (lock just created),
+  `forcedTakeover: true`, or `reacquired: true` with `racedCreate:
+     true` (this call itself raced a concurrent creator for the same
+  claim-id, so the match is not proof the lock predates this gate
+  pass) are never legitimate backfill evidence.
   1. `--check` reports the lock `present`, holder matching
      `{claim-id}`.
   2. `--backfill-tokens` reports `backfilled`.
   3. The retried `--read-tokens` reports `present: true` (no
      `malformed`).
   4. A final `--acquire`, run again immediately before the mutation,
-     reports `reacquired: true` -- not a fresh `acquired`, which
-     would mean the lock vanished mid-recovery (for example a
+     reports `reacquired: true` with no `racedCreate` -- the same
+     requirement as step 0, applied again because a fresh `acquired`
+     here would mean the lock vanished mid-recovery (for example a
      concurrent takeover) and this step would otherwise create a new
      one and let the mutation proceed with no real token evidence.
 
-  This closes two gaps a review round each found real: the window
+  This closes gaps three review rounds each found real: the window
   between the initial acquire and the mutation that a concurrent
-  takeover could exploit, and a literal reading of the sequence as an
-  unconditional run-these-in-order list rather than a chain each
-  link of which must actually succeed (#2917 review, Copilot).
+  takeover could exploit; a literal reading of the sequence as an
+  unconditional run-these-in-order list rather than a chain each link
+  of which must actually succeed; and `reacquired: true` alone being
+  trusted as proof of pre-existence when a same-claim-id race can
+  produce it for a lock that is in fact only microseconds old
+  (`acquireClaimLock`'s own `EEXIST`-retry loop,
+  `src/scripts/claim-lock.mts`) (#2917 review, Codex and Copilot).
+  Residual, named rather than hidden: a _third_ process arriving after
+  such a race has already settled sees `reacquired: true` with no
+  `racedCreate` on its own first read, the same way it would for a
+  lock that is genuinely years old -- this mechanism only ever detects
+  a race this specific call itself observed, never a lock's true age;
+  the Claim revalidation gate's own GitHub-verified claim check (steps
+  1-4 before this one) is the actual authority this is defense in
+  depth for, not a replacement for it.
 - No explicit release verb, no cleanup across takeovers: like the lock
   file, the record lives inside the worktree's own private git-admin
   directory, so `git worktree remove` at F4 deletes it together with the

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -2001,17 +2001,26 @@ close.
   `git worktree remove` at F4 deletes it together with the worktree
 - **`instructions-only` helper-free fallback** (no helper runtime
   available): resolve the private admin directory with
-  `git -C <worktree> rev-parse --absolute-git-dir`, then atomically
-  create an `idd-claim.lock` file there with an exclusive file-create
-  API (`open(..., O_CREAT|O_EXCL)` on POSIX, or the PowerShell
+  `git -C <worktree> rev-parse --absolute-git-dir`, then read the
+  `idd-claim.lock` path first, before writing anything. Present,
+  well-formed, and its holder matches (`agentId`, `claimId`) →
+  re-acquired without writing — this call's own first read found the
+  lock already there, mirroring the helper's `reacquired: true` with no
+  `racedCreate`. Absent → create it with an exclusive file-create API
+  (`open(..., O_CREAT|O_EXCL)` on POSIX, or the PowerShell
   `FileMode.CreateNew` equivalent), writing the same JSON holder shape
-  (`agentId`, `claimId`, `acquiredAt`). A path that already exists is a
-  collision; a matching holder may re-acquire, and a missing,
-  malformed, or unreadable holder is also a collision. Never delete or
-  override a different holder — enable a helper runtime for an
-  authorized takeover instead. Both profiles share the `idd-claim.lock`
-  namespace, so a helper-runtime session and an instructions-only
-  session see the same lock.
+  (`agentId`, `claimId`, `acquiredAt`). If that create then fails
+  because the path now exists (`EEXIST`), a concurrent same-claim-id
+  writer landed between the read and the create; re-read to confirm the
+  holder matches, but treat this outcome as a race, not as evidence the
+  lock predates this call — never equal it to a lock this same read
+  already found present (the helper's `racedCreate: true`, #2917
+  review, Codex). A path that already exists with a non-matching,
+  missing, malformed, or unreadable holder is a collision either way.
+  Never delete or override a different holder — enable a helper runtime
+  for an authorized takeover instead. Both profiles share the
+  `idd-claim.lock` namespace, so a helper-runtime session and an
+  instructions-only session see the same lock.
 
 ### Worktree-local generated-tokens record
 
@@ -2190,7 +2199,11 @@ close.
   `{ agentId, claimId, nonce?, recordedAt }`. No
   exclusive-create semantics needed (unlike the lock): a plain atomic
   replace is correct since this is idempotent evidence, not a
-  mutual-exclusion primitive.
+  mutual-exclusion primitive -- except a directory already occupying
+  this exact path, which this fallback never replaces or deletes
+  either, matching `recordGeneratedClaimTokens`'s own absolute
+  invariant in `src/scripts/claim-lock.mts` (PR #2879 regression test;
+  #2917 review, Copilot); stop fail-closed instead.
 - **`instructions-only` helper-free fallback, read side** (#2879 review,
   Codex P1 -- the mandatory `--read-tokens` check in the Claim
   revalidation gate has no helper-free path without this): resolve the
@@ -2208,17 +2221,27 @@ close.
   helper-free path too, and `instructions-only` is the distributed
   default profile): resolve the worktree-local lock file the same way as
   the lock section above and parse it the same way `--check` does --
-  but only when that lock already existed before this gate's own
-  acquire step (the exclusive create above failed `EEXIST` with a
-  matching holder, never a lock this same attempt just created, #2917
-  review). Only when it parses as well-formed and its `claimId` field
-  equals the active `{claim-id}` exactly, apply the write-side fallback
-  above using the lock's own `agentId`, carrying forward an existing
-  well-formed record's own `nonce` when present, otherwise no `nonce`
-  (#2917 review, Copilot). An absent lock, a lock that fails to parse,
-  a lock whose `claimId` differs, or a lock this same attempt just
-  created all leave the existing fail-closed stop unchanged -- write
-  nothing.
+  but only when your own _first read_ in the acquire step above already
+  found the lock present and matching, never when it was absent there
+  and your own exclusive-create then failed `EEXIST`. That failure means
+  a concurrent same-claim-id writer landed between your read and your
+  create -- a race, not evidence the lock predates this gate pass; the
+  helper's own `racedCreate: true` marks exactly this case (#2917
+  review, Codex). Only when it parses as well-formed and its `claimId`
+  field equals the active `{claim-id}` exactly, apply the write-side
+  fallback above using the lock's own `agentId`, carrying forward an
+  existing well-formed record's own `nonce` when present, otherwise no
+  `nonce` (#2917 review, Copilot) -- except when the record's own
+  resolved path is already occupied by a directory: leave it and its
+  contents untouched and stop fail-closed instead, mirroring the CLI's
+  own `record-blocked` status (`backfillGeneratedClaimTokens`,
+  `src/scripts/claim-lock.mts`) -- a matching lock authenticates the
+  lock, not that separate path, and the path's hash suffix is not
+  collision-proof, so lock authority alone never authorizes replacing it
+  (#2917 review, Copilot). An absent lock, a lock that fails to parse, a
+  lock whose `claimId` differs, or a lock your own first read did not
+  already find present and matching all leave the existing fail-closed
+  stop unchanged -- write nothing.
 
 ### Clone-scoped lock
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -2006,7 +2006,14 @@ close.
   never adjudicates claim ownership itself. Re-invoking after a
   successful backfill is always a safe, idempotent overwrite (reports
   `backfilled` again), matching `--record-tokens`'s own idempotency
-  contract -- there is no separate `already-present` status.
+  contract -- there is no separate `already-present` status. The Claim
+  revalidation gate (step 5, `idd-overview-core.instructions.md`) only
+  reaches this route when its own initial `--acquire` reported
+  `reacquired: true` -- a fresh `acquired` (lock just created) or
+  `forcedTakeover: true` is never legitimate backfill evidence -- and
+  re-runs `--acquire` once more immediately before the mutation,
+  closing the window this recovery sequence opens (#2917 review,
+  Copilot).
 - No explicit release verb, no cleanup across takeovers: like the lock
   file, the record lives inside the worktree's own private git-admin
   directory, so `git worktree remove` at F4 deletes it together with the
@@ -2058,12 +2065,18 @@ close.
   `--read-tokens` above: a mandatory gate-recovery step needs a
   helper-free path too, and `instructions-only` is the distributed
   default profile): resolve the worktree-local lock file the same way as
-  the lock section above and parse it the same way `--check` does. Only
-  when it parses as well-formed and its `claimId` field equals the
-  active `{claim-id}` exactly, apply the write-side fallback above using
-  the lock's own `agentId` and no `nonce`. An absent lock, a lock that
-  fails to parse, or a lock whose `claimId` differs all leave the
-  existing fail-closed stop unchanged -- write nothing.
+  the lock section above and parse it the same way `--check` does --
+  but only when that lock already existed before this gate's own
+  acquire step (the exclusive create above failed `EEXIST` with a
+  matching holder, never a lock this same attempt just created, #2917
+  review). Only when it parses as well-formed and its `claimId` field
+  equals the active `{claim-id}` exactly, apply the write-side fallback
+  above using the lock's own `agentId`, carrying forward an existing
+  well-formed record's own `nonce` when present, otherwise no `nonce`
+  (#2917 review, Copilot). An absent lock, a lock that fails to parse,
+  a lock whose `claimId` differs, or a lock this same attempt just
+  created all leave the existing fail-closed stop unchanged -- write
+  nothing.
 
 ### Clone-scoped lock
 

--- a/scripts/claim-lock.mjs
+++ b/scripts/claim-lock.mjs
@@ -561,7 +561,15 @@ export function recordGeneratedClaimTokens(cwd, fields) {
  * - Present lock whose `claimId` matches → writes the generated-tokens
  *   record via {@link recordGeneratedClaimTokens}, using the lock's own
  *   `agentId` and no `nonce` (matching a fresh pre-nonce `--record-tokens`
- *   call) → `backfilled`.
+ *   call) → `backfilled`. If a well-formed record for this exact `claimId`
+ *   already exists (outside the documented recovery route, which only ever
+ *   reaches this function when `--read-tokens` reported absent/malformed --
+ *   meaning no well-formed record exists yet -- so this is a defensive
+ *   guard against a caller invoking this function directly against
+ *   caller-discipline), its own `nonce` is preserved rather than silently
+ *   erased: {@link recordGeneratedClaimTokens} replaces the whole record,
+ *   so writing with no `nonce` unconditionally would otherwise drop an
+ *   existing one (#2917 review, Copilot).
  *
  * Performs no GitHub round-trip on any path, matching `--acquire`'s own
  * same-machine, no-network design. Re-invoking after a successful backfill
@@ -582,9 +590,15 @@ export function backfillGeneratedClaimTokens(worktree, claimId) {
   if (read.lock.claimId !== claimId) {
     return { status: 'lock-mismatch', lockPath, path, holder: read.lock };
   }
+  // Preserve an existing well-formed record's own nonce, if any -- see the
+  // function-level doc comment above.
+  const existing = readGeneratedClaimTokens(worktree, claimId);
+  const nonce =
+    existing.status === 'present' ? existing.record.nonce : undefined;
   recordGeneratedClaimTokens(worktree, {
     agentId: read.lock.agentId,
     claimId,
+    ...(nonce === undefined ? {} : { nonce }),
   });
   return { status: 'backfilled', lockPath, path, agentId: read.lock.agentId };
 }
@@ -745,8 +759,10 @@ does not affirmatively confirm.
 generated-tokens record was never created because its B1 worktree
 predates the record feature: it reads the existing \`idd-claim.lock\` file
 and, only when present with a --claim-id that matches exactly, writes the
-generated-tokens record using the lock's own recorded agent-id (no
---nonce). An absent lock reports \`lock-absent\`, an unparseable or
+generated-tokens record using the lock's own recorded agent-id, with no
+--nonce unless an existing well-formed record for this --claim-id already
+carries one, which is preserved rather than erased. An absent lock reports
+\`lock-absent\`, an unparseable or
 unreadable lock reports \`lock-malformed\`, and a lock recorded for a
 different claim-id reports \`lock-mismatch\` (naming the actual holder) --
 all three write nothing. A successful write reports \`backfilled\` and

--- a/scripts/claim-lock.mjs
+++ b/scripts/claim-lock.mjs
@@ -76,6 +76,27 @@
 // generated, rather than one merely recalled from (possibly compacted)
 // conversation context.
 //
+// Backfill recovery route (#2884): an adopter who upgrades their
+// `idd-template/` copy to gain the generated-tokens-record feature while a
+// claim already has its B1 worktree (created before this feature existed)
+// never reruns the claim-posting sequence or B1, so no generated-tokens
+// record is ever created in that worktree -- every subsequent
+// `--read-tokens` check then fails closed forever, even though the
+// session still legitimately owns the claim (PR #2879 review, Codex P1).
+// `--backfill-tokens` closes that gap by trusting the worktree's own
+// `idd-claim.lock` file instead of a live GitHub round-trip: that lock
+// already carries the legitimate `agentId` for exactly this scenario, and
+// is mechanically verifiable on disk rather than relying on the current
+// session's own (possibly compacted) recollection. It writes only when
+// the lock is present and its own `claimId` matches the caller's
+// `--claim-id` exactly; an absent, malformed, or mismatched lock all fail
+// closed with a distinct status and write nothing. The caller -- the
+// Claim revalidation gate's documented recovery route -- is responsible
+// for having already independently confirmed the live claim-id via
+// GitHub before ever reaching this step; this command itself never makes
+// a GitHub round-trip, matching `--acquire`'s own same-machine, no-network
+// design.
+//
 // Scope of the ownership proof (#2879 review, Codex P1): a `present: true`
 // `--read-tokens` result proves "a `--record-tokens` call for this exact
 // claim-id landed at this path" -- it does not cryptographically bind that
@@ -132,6 +153,7 @@ const CLAIM_LOCK_FLAG_SPEC = {
   '--check': { type: 'boolean' },
   '--record-tokens': { type: 'boolean' },
   '--read-tokens': { type: 'boolean' },
+  '--backfill-tokens': { type: 'boolean' },
   '--worktree': { type: 'string' },
   '--agent-id': { type: 'string' },
   '--claim-id': { type: 'string' },
@@ -520,6 +542,52 @@ export function recordGeneratedClaimTokens(cwd, fields) {
   atomicReplaceFile(path, JSON.stringify(body));
   return { path };
 }
+/**
+ * Recovery route (#2884) for a worktree whose generated-tokens record
+ * (#2719) was never created because its B1 worktree predates that
+ * feature: reconstruct it from the worktree's own `idd-claim.lock` file,
+ * which already carries the legitimate `agentId` for exactly this
+ * rollout-gap scenario (PR #2879 review, Codex P1) -- see the header
+ * comment's "Backfill recovery route" paragraph for the full rationale.
+ *
+ * Fails closed -- writes nothing -- unless the lock is present and its
+ * own `claimId` matches `claimId` exactly:
+ *
+ * - Absent lock → `lock-absent`.
+ * - Malformed lock (unparseable, or an unreadable path such as a
+ *   directory) → `lock-malformed`.
+ * - Present lock recorded for a different `claimId` → `lock-mismatch`
+ *   (with `holder` naming the actual lock holder, never silently trusted).
+ * - Present lock whose `claimId` matches → writes the generated-tokens
+ *   record via {@link recordGeneratedClaimTokens}, using the lock's own
+ *   `agentId` and no `nonce` (matching a fresh pre-nonce `--record-tokens`
+ *   call) → `backfilled`.
+ *
+ * Performs no GitHub round-trip on any path, matching `--acquire`'s own
+ * same-machine, no-network design. Re-invoking after a successful backfill
+ * always reports `backfilled` again -- a safe, idempotent overwrite via
+ * `recordGeneratedClaimTokens`'s own existing idempotency contract, not a
+ * separate `already-present` status.
+ */
+export function backfillGeneratedClaimTokens(worktree, claimId) {
+  const lockPath = resolveClaimLockPath(worktree);
+  const path = resolveGeneratedTokensPath(worktree, claimId);
+  const read = readLock(lockPath);
+  if (read.status === 'absent') {
+    return { status: 'lock-absent', lockPath, path };
+  }
+  if (read.status === 'malformed') {
+    return { status: 'lock-malformed', lockPath, path };
+  }
+  if (read.lock.claimId !== claimId) {
+    return { status: 'lock-mismatch', lockPath, path, holder: read.lock };
+  }
+  recordGeneratedClaimTokens(worktree, {
+    agentId: read.lock.agentId,
+    claimId,
+  });
+  return { status: 'backfilled', lockPath, path, agentId: read.lock.agentId };
+}
 function parseArgs(argv) {
   const { values, help } = parseCliArgs(argv, CLAIM_LOCK_FLAG_SPEC);
   return {
@@ -527,6 +595,7 @@ function parseArgs(argv) {
     check: Boolean(values.check),
     recordTokens: Boolean(values['record-tokens']),
     readTokens: Boolean(values['read-tokens']),
+    backfillTokens: Boolean(values['backfill-tokens']),
     worktree: typeof values.worktree === 'string' ? values.worktree : null,
     agentId: typeof values['agent-id'] === 'string' ? values['agent-id'] : null,
     claimId: typeof values['claim-id'] === 'string' ? values['claim-id'] : null,
@@ -535,11 +604,15 @@ function parseArgs(argv) {
     help,
   };
 }
-/** Exactly one of the four mode flags, for the `runCli` mode-selection error. */
+/** Exactly one of the five mode flags, for the `runCli` mode-selection error. */
 function selectedModeCount(args) {
-  return [args.acquire, args.check, args.recordTokens, args.readTokens].filter(
-    Boolean,
-  ).length;
+  return [
+    args.acquire,
+    args.check,
+    args.recordTokens,
+    args.readTokens,
+    args.backfillTokens,
+  ].filter(Boolean).length;
 }
 function runCli() {
   const args = parseArgs(process.argv.slice(2));
@@ -549,7 +622,7 @@ function runCli() {
   }
   if (selectedModeCount(args) !== 1) {
     throw new Error(
-      'exactly one of --acquire, --check, --record-tokens, or --read-tokens is required',
+      'exactly one of --acquire, --check, --record-tokens, --read-tokens, or --backfill-tokens is required',
     );
   }
   if (args.worktree === null) {
@@ -588,6 +661,17 @@ function runCli() {
     process.stdout.write(`${JSON.stringify(outcome)}\n`);
     return;
   }
+  if (args.backfillTokens) {
+    if (args.claimId === null) {
+      throw new Error('--claim-id is required for --backfill-tokens');
+    }
+    const outcome = backfillGeneratedClaimTokens(args.worktree, args.claimId);
+    process.stdout.write(`${JSON.stringify(outcome)}\n`);
+    if (outcome.status !== 'backfilled') {
+      process.exitCode = 2;
+    }
+    return;
+  }
   if (args.agentId === null) {
     throw new Error('--agent-id is required for --acquire');
   }
@@ -611,6 +695,7 @@ function printHelp() {
   node scripts/claim-lock.mjs --check --worktree <path>
   node scripts/claim-lock.mjs --record-tokens --worktree <path> --agent-id <id> --claim-id <id> [--nonce <nonce>]
   node scripts/claim-lock.mjs --read-tokens --worktree <path> --claim-id <id>
+  node scripts/claim-lock.mjs --backfill-tokens --worktree <path> --claim-id <id>
 
 Worktree-local lock file: a same-machine fast path that complements the
 cross-machine activation-nonce claim check. Resolves the lock file inside
@@ -655,5 +740,23 @@ recorded (or was recorded under a different claim-id, which resolves to a
 different path). Both \`malformed\` and absent must be treated the same
 way by a caller checking ownership: never trust a claim-id this record
 does not affirmatively confirm.
+
+--backfill-tokens is the recovery route for a worktree whose
+generated-tokens record was never created because its B1 worktree
+predates the record feature: it reads the existing \`idd-claim.lock\` file
+and, only when present with a --claim-id that matches exactly, writes the
+generated-tokens record using the lock's own recorded agent-id (no
+--nonce). An absent lock reports \`lock-absent\`, an unparseable or
+unreadable lock reports \`lock-malformed\`, and a lock recorded for a
+different claim-id reports \`lock-mismatch\` (naming the actual holder) --
+all three write nothing. A successful write reports \`backfilled\` and
+exits 0; the three failure statuses exit 2, mirroring --acquire's own
+collision exit-code contract so a caller can chain
+\`--backfill-tokens && --read-tokens\`. Like --acquire, this performs no
+GitHub round-trip -- the caller must have already independently confirmed
+the live claim-id via GitHub before reaching this recovery step.
+Re-invoking after a successful backfill is always a safe, idempotent
+overwrite (reports \`backfilled\` again), matching --record-tokens's own
+idempotency contract.
 `);
 }

--- a/scripts/claim-lock.mjs
+++ b/scripts/claim-lock.mjs
@@ -530,8 +530,21 @@ export function readGeneratedClaimTokens(cwd, claimId) {
  * claimId}`, again with `{agentId, claimId, nonce}` right before the
  * activation-nonce marker posts, and again in the new sibling worktree at
  * B1) is always a safe, expected, idempotent overwrite of the same path.
+ *
+ * `replaceDirectory` defaults to `false` here -- a plain `--record-tokens`
+ * call must never silently delete a directory occupying the resolved path
+ * (regression, #2879 review) -- mirroring {@link overwriteLockAtomically}'s
+ * own narrower authorized-only grant for the lock file. Only
+ * {@link backfillGeneratedClaimTokens} passes `true`: it has already
+ * confirmed the worktree's own `idd-claim.lock` matches `claimId` before
+ * ever reaching this write, which is the same kind of local authorization
+ * `overwriteLockAtomically`'s authorized-takeover caller has, and without
+ * it the write this function performs for exactly the
+ * `malformed`-because-directory case would throw an uncaught `EISDIR`
+ * instead of reporting the documented `backfilled` outcome (#2917 review,
+ * Codex P2).
  */
-export function recordGeneratedClaimTokens(cwd, fields) {
+export function recordGeneratedClaimTokens(cwd, fields, options = {}) {
   const path = resolveGeneratedTokensPath(cwd, fields.claimId);
   const body = {
     agentId: fields.agentId,
@@ -539,7 +552,9 @@ export function recordGeneratedClaimTokens(cwd, fields) {
     ...(fields.nonce === undefined ? {} : { nonce: fields.nonce }),
     recordedAt: new Date().toISOString(),
   };
-  atomicReplaceFile(path, JSON.stringify(body));
+  atomicReplaceFile(path, JSON.stringify(body), {
+    replaceDirectory: options.replaceDirectory ?? false,
+  });
   return { path };
 }
 /**
@@ -595,11 +610,20 @@ export function backfillGeneratedClaimTokens(worktree, claimId) {
   const existing = readGeneratedClaimTokens(worktree, claimId);
   const nonce =
     existing.status === 'present' ? existing.record.nonce : undefined;
-  recordGeneratedClaimTokens(worktree, {
-    agentId: read.lock.agentId,
-    claimId,
-    ...(nonce === undefined ? {} : { nonce }),
-  });
+  recordGeneratedClaimTokens(
+    worktree,
+    {
+      agentId: read.lock.agentId,
+      claimId,
+      ...(nonce === undefined ? {} : { nonce }),
+    },
+    // Authorized here (unlike a plain --record-tokens call, #2879 review):
+    // the lock read above already confirmed a matching claimId, so a
+    // directory at this exact sanitized, hash-suffixed path is tampering,
+    // not a legitimate concurrent claim -- see the doc comment on
+    // recordGeneratedClaimTokens.
+    { replaceDirectory: true },
+  );
   return { status: 'backfilled', lockPath, path, agentId: read.lock.agentId };
 }
 function parseArgs(argv) {

--- a/scripts/claim-lock.mjs
+++ b/scripts/claim-lock.mjs
@@ -394,13 +394,28 @@ function overwriteLockAtomically(path, agentId, claimId) {
  * independently re-verify live claim state (e.g.
  * `resume-claim-routing.mjs --fresh-claim-gate`) before retrying with
  * `takeover: true`.
+ *
+ * `reacquired: true` from this function's very first read (before this
+ * call has attempted any write of its own) means the lock definitely
+ * predates this call. Every other path that produces `reacquired: true`
+ * -- a later loop iteration, or either post-retry fallback below -- is
+ * reached only after this call's own first read found the lock *absent*
+ * and its own create attempt then hit `EEXIST`, meaning some concurrent
+ * writer created the matching lock while this call was still running.
+ * That is a genuine race this call itself observed, not evidence the
+ * lock is old, so those paths also set `racedCreate: true` -- a caller
+ * treating `reacquired: true` as proof of pre-existence (the
+ * `--backfill-tokens` recovery route does) must require `racedCreate` to
+ * be absent too (#2917 review, Codex).
  */
 export function acquireClaimLock(worktree, agentId, claimId, takeover) {
   const path = resolveClaimLockPath(worktree);
   for (let attempt = 0; attempt < MAX_RETRY_ATTEMPTS; attempt += 1) {
     const read = readLock(path);
     if (read.status === 'present' && read.lock.claimId === claimId) {
-      return { mode: 'acquired', path, reacquired: true };
+      return attempt === 0
+        ? { mode: 'acquired', path, reacquired: true }
+        : { mode: 'acquired', path, reacquired: true, racedCreate: true };
     }
     if (read.status === 'absent') {
       try {
@@ -411,7 +426,10 @@ export function acquireClaimLock(worktree, agentId, claimId, takeover) {
           throw error;
         }
         // Raced with a concurrent fresh acquire between the read above and
-        // this create; loop around to re-read and re-decide.
+        // this create; loop around to re-read and re-decide. Any
+        // `reacquired: true` this call reports from here on is no longer
+        // from its own first look, so it also carries `racedCreate: true`
+        // (see the function-level doc comment above).
         continue;
       }
     }
@@ -430,10 +448,13 @@ export function acquireClaimLock(worktree, agentId, claimId, takeover) {
   // Re-read once after the final EEXIST so a well-formed winner is reported
   // to the caller instead of being returned as an unexplained collision. If
   // the winner disappeared before this read, make one last create attempt so
-  // a transiently absent lock is not reported as a false collision.
+  // a transiently absent lock is not reported as a false collision. Every
+  // return below is reached only after this call's own first read already
+  // found the lock absent (that is how the loop above was entered at all),
+  // so every `reacquired: true` from here on carries `racedCreate: true`.
   const finalRead = readLock(path);
   if (finalRead.status === 'present' && finalRead.lock.claimId === claimId) {
-    return { mode: 'acquired', path, reacquired: true };
+    return { mode: 'acquired', path, reacquired: true, racedCreate: true };
   }
   if (finalRead.status === 'absent') {
     try {
@@ -448,7 +469,7 @@ export function acquireClaimLock(worktree, agentId, claimId, takeover) {
         racedRead.status === 'present' &&
         racedRead.lock.claimId === claimId
       ) {
-        return { mode: 'acquired', path, reacquired: true };
+        return { mode: 'acquired', path, reacquired: true, racedCreate: true };
       }
       return {
         mode: 'collision',
@@ -531,20 +552,17 @@ export function readGeneratedClaimTokens(cwd, claimId) {
  * activation-nonce marker posts, and again in the new sibling worktree at
  * B1) is always a safe, expected, idempotent overwrite of the same path.
  *
- * `replaceDirectory` defaults to `false` here -- a plain `--record-tokens`
- * call must never silently delete a directory occupying the resolved path
- * (regression, #2879 review) -- mirroring {@link overwriteLockAtomically}'s
- * own narrower authorized-only grant for the lock file. Only
- * {@link backfillGeneratedClaimTokens} passes `true`: it has already
- * confirmed the worktree's own `idd-claim.lock` matches `claimId` before
- * ever reaching this write, which is the same kind of local authorization
- * `overwriteLockAtomically`'s authorized-takeover caller has, and without
- * it the write this function performs for exactly the
- * `malformed`-because-directory case would throw an uncaught `EISDIR`
- * instead of reporting the documented `backfilled` outcome (#2917 review,
- * Codex P2).
+ * Never replaces a directory occupying the resolved path (regression,
+ * #2879 review): a matching `idd-claim.lock` authenticates the claim
+ * lock, not the token record's own path, and this filename's hash
+ * suffix is not collision-proof, so lock authority alone does not prove
+ * a directory here is disposable -- unlike `overwriteLockAtomically`'s
+ * narrower, GitHub-reverified-takeover-gated grant for the lock file
+ * itself (#2917 review, Copilot). {@link backfillGeneratedClaimTokens}
+ * reports a distinct `record-blocked` status for exactly this case
+ * instead of calling this function at all.
  */
-export function recordGeneratedClaimTokens(cwd, fields, options = {}) {
+export function recordGeneratedClaimTokens(cwd, fields) {
   const path = resolveGeneratedTokensPath(cwd, fields.claimId);
   const body = {
     agentId: fields.agentId,
@@ -552,9 +570,7 @@ export function recordGeneratedClaimTokens(cwd, fields, options = {}) {
     ...(fields.nonce === undefined ? {} : { nonce: fields.nonce }),
     recordedAt: new Date().toISOString(),
   };
-  atomicReplaceFile(path, JSON.stringify(body), {
-    replaceDirectory: options.replaceDirectory ?? false,
-  });
+  atomicReplaceFile(path, JSON.stringify(body));
   return { path };
 }
 /**
@@ -573,10 +589,21 @@ export function recordGeneratedClaimTokens(cwd, fields, options = {}) {
  *   directory) → `lock-malformed`.
  * - Present lock recorded for a different `claimId` → `lock-mismatch`
  *   (with `holder` naming the actual lock holder, never silently trusted).
- * - Present lock whose `claimId` matches → writes the generated-tokens
- *   record via {@link recordGeneratedClaimTokens}, using the lock's own
- *   `agentId` and no `nonce` (matching a fresh pre-nonce `--record-tokens`
- *   call) → `backfilled`. If a well-formed record for this exact `claimId`
+ * - Present lock whose `claimId` matches, but a directory already
+ *   occupies the generated-tokens record's own path → `record-blocked`.
+ *   A matching lock authenticates the *lock*, not this separate path, and
+ *   the path's hash suffix is not collision-proof, so lock authority
+ *   alone does not prove a directory here is disposable -- this stays
+ *   fail-closed rather than deleting it, unlike the lock file's own
+ *   GitHub-reverified-takeover-gated directory replacement (#2917
+ *   review, Copilot). `--read-tokens` already reports this same
+ *   directory-at-path case as `malformed`, so a caller following the
+ *   documented gated sequence stops here with no further action needed.
+ * - Present lock whose `claimId` matches, and no directory blocks the
+ *   record path → writes the generated-tokens record via
+ *   {@link recordGeneratedClaimTokens}, using the lock's own `agentId`
+ *   and no `nonce` (matching a fresh pre-nonce `--record-tokens` call) →
+ *   `backfilled`. If a well-formed record for this exact `claimId`
  *   already exists (outside the documented recovery route, which only ever
  *   reaches this function when `--read-tokens` reported absent/malformed --
  *   meaning no well-formed record exists yet -- so this is a defensive
@@ -605,25 +632,28 @@ export function backfillGeneratedClaimTokens(worktree, claimId) {
   if (read.lock.claimId !== claimId) {
     return { status: 'lock-mismatch', lockPath, path, holder: read.lock };
   }
+  // A directory at the record's own path is never authorized to be
+  // replaced here -- see the function-level doc comment above and
+  // recordGeneratedClaimTokens's own doc comment.
+  try {
+    if (statSync(path).isDirectory()) {
+      return { status: 'record-blocked', lockPath, path };
+    }
+  } catch {
+    // Absent, or an unreadable non-directory path: fall through and let
+    // recordGeneratedClaimTokens's own atomic-write handle it the same
+    // way it always has.
+  }
   // Preserve an existing well-formed record's own nonce, if any -- see the
   // function-level doc comment above.
   const existing = readGeneratedClaimTokens(worktree, claimId);
   const nonce =
     existing.status === 'present' ? existing.record.nonce : undefined;
-  recordGeneratedClaimTokens(
-    worktree,
-    {
-      agentId: read.lock.agentId,
-      claimId,
-      ...(nonce === undefined ? {} : { nonce }),
-    },
-    // Authorized here (unlike a plain --record-tokens call, #2879 review):
-    // the lock read above already confirmed a matching claimId, so a
-    // directory at this exact sanitized, hash-suffixed path is tampering,
-    // not a legitimate concurrent claim -- see the doc comment on
-    // recordGeneratedClaimTokens.
-    { replaceDirectory: true },
-  );
+  recordGeneratedClaimTokens(worktree, {
+    agentId: read.lock.agentId,
+    claimId,
+    ...(nonce === undefined ? {} : { nonce }),
+  });
   return { status: 'backfilled', lockPath, path, agentId: read.lock.agentId };
 }
 function parseArgs(argv) {
@@ -787,10 +817,13 @@ generated-tokens record using the lock's own recorded agent-id, with no
 --nonce unless an existing well-formed record for this --claim-id already
 carries one, which is preserved rather than erased. An absent lock reports
 \`lock-absent\`, an unparseable or
-unreadable lock reports \`lock-malformed\`, and a lock recorded for a
-different claim-id reports \`lock-mismatch\` (naming the actual holder) --
-all three write nothing. A successful write reports \`backfilled\` and
-exits 0; the three failure statuses exit 2, mirroring --acquire's own
+unreadable lock reports \`lock-malformed\`, a lock recorded for a
+different claim-id reports \`lock-mismatch\` (naming the actual holder),
+and a matching lock whose own record path is blocked by a directory
+reports \`record-blocked\` (a matching lock authenticates the lock, not
+that separate path, so this stays fail-closed rather than deleting it)
+-- all four write nothing. A successful write reports \`backfilled\` and
+exits 0; the four failure statuses exit 2, mirroring --acquire's own
 collision exit-code contract so a caller can chain
 \`--backfill-tokens && --read-tokens\`. Like --acquire, this performs no
 GitHub round-trip -- the caller must have already independently confirmed

--- a/src/scripts/claim-lock.mts
+++ b/src/scripts/claim-lock.mts
@@ -432,11 +432,21 @@ function overwriteLockAtomically(
   });
 }
 
-/** Outcome shape returned by {@link acquireClaimLock}. */
+/**
+ * Outcome shape returned by {@link acquireClaimLock}. `racedCreate` is
+ * only ever set alongside `reacquired: true`: it means this exact
+ * invocation's own first read found the lock absent, and its own
+ * exclusive-create attempt then lost a race to a concurrent same-`claim-id`
+ * creator (#2917 review, Codex) -- so the eventual match
+ * came from a later retry, not this invocation's first look, and is not
+ * proof the lock predates this call. See {@link acquireClaimLock}'s doc
+ * comment for the full rationale.
+ */
 export interface AcquireLockOutcome {
   mode: 'acquired' | 'collision';
   path: string;
   reacquired?: boolean;
+  racedCreate?: boolean;
   forcedTakeover?: boolean;
   holder?: ClaimLockBody;
 }
@@ -454,6 +464,19 @@ export interface AcquireLockOutcome {
  * independently re-verify live claim state (e.g.
  * `resume-claim-routing.mjs --fresh-claim-gate`) before retrying with
  * `takeover: true`.
+ *
+ * `reacquired: true` from this function's very first read (before this
+ * call has attempted any write of its own) means the lock definitely
+ * predates this call. Every other path that produces `reacquired: true`
+ * -- a later loop iteration, or either post-retry fallback below -- is
+ * reached only after this call's own first read found the lock *absent*
+ * and its own create attempt then hit `EEXIST`, meaning some concurrent
+ * writer created the matching lock while this call was still running.
+ * That is a genuine race this call itself observed, not evidence the
+ * lock is old, so those paths also set `racedCreate: true` -- a caller
+ * treating `reacquired: true` as proof of pre-existence (the
+ * `--backfill-tokens` recovery route does) must require `racedCreate` to
+ * be absent too (#2917 review, Codex).
  */
 export function acquireClaimLock(
   worktree: string,
@@ -467,7 +490,9 @@ export function acquireClaimLock(
     const read = readLock(path);
 
     if (read.status === 'present' && read.lock.claimId === claimId) {
-      return { mode: 'acquired', path, reacquired: true };
+      return attempt === 0
+        ? { mode: 'acquired', path, reacquired: true }
+        : { mode: 'acquired', path, reacquired: true, racedCreate: true };
     }
 
     if (read.status === 'absent') {
@@ -479,7 +504,10 @@ export function acquireClaimLock(
           throw error;
         }
         // Raced with a concurrent fresh acquire between the read above and
-        // this create; loop around to re-read and re-decide.
+        // this create; loop around to re-read and re-decide. Any
+        // `reacquired: true` this call reports from here on is no longer
+        // from its own first look, so it also carries `racedCreate: true`
+        // (see the function-level doc comment above).
         continue;
       }
     }
@@ -500,10 +528,13 @@ export function acquireClaimLock(
   // Re-read once after the final EEXIST so a well-formed winner is reported
   // to the caller instead of being returned as an unexplained collision. If
   // the winner disappeared before this read, make one last create attempt so
-  // a transiently absent lock is not reported as a false collision.
+  // a transiently absent lock is not reported as a false collision. Every
+  // return below is reached only after this call's own first read already
+  // found the lock absent (that is how the loop above was entered at all),
+  // so every `reacquired: true` from here on carries `racedCreate: true`.
   const finalRead = readLock(path);
   if (finalRead.status === 'present' && finalRead.lock.claimId === claimId) {
-    return { mode: 'acquired', path, reacquired: true };
+    return { mode: 'acquired', path, reacquired: true, racedCreate: true };
   }
   if (finalRead.status === 'absent') {
     try {
@@ -518,7 +549,7 @@ export function acquireClaimLock(
         racedRead.status === 'present' &&
         racedRead.lock.claimId === claimId
       ) {
-        return { mode: 'acquired', path, reacquired: true };
+        return { mode: 'acquired', path, reacquired: true, racedCreate: true };
       }
       return {
         mode: 'collision',
@@ -649,23 +680,19 @@ export function readGeneratedClaimTokens(
  * activation-nonce marker posts, and again in the new sibling worktree at
  * B1) is always a safe, expected, idempotent overwrite of the same path.
  *
- * `replaceDirectory` defaults to `false` here -- a plain `--record-tokens`
- * call must never silently delete a directory occupying the resolved path
- * (regression, #2879 review) -- mirroring {@link overwriteLockAtomically}'s
- * own narrower authorized-only grant for the lock file. Only
- * {@link backfillGeneratedClaimTokens} passes `true`: it has already
- * confirmed the worktree's own `idd-claim.lock` matches `claimId` before
- * ever reaching this write, which is the same kind of local authorization
- * `overwriteLockAtomically`'s authorized-takeover caller has, and without
- * it the write this function performs for exactly the
- * `malformed`-because-directory case would throw an uncaught `EISDIR`
- * instead of reporting the documented `backfilled` outcome (#2917 review,
- * Codex P2).
+ * Never replaces a directory occupying the resolved path (regression,
+ * #2879 review): a matching `idd-claim.lock` authenticates the claim
+ * lock, not the token record's own path, and this filename's hash
+ * suffix is not collision-proof, so lock authority alone does not prove
+ * a directory here is disposable -- unlike `overwriteLockAtomically`'s
+ * narrower, GitHub-reverified-takeover-gated grant for the lock file
+ * itself (#2917 review, Copilot). {@link backfillGeneratedClaimTokens}
+ * reports a distinct `record-blocked` status for exactly this case
+ * instead of calling this function at all.
  */
 export function recordGeneratedClaimTokens(
   cwd: string,
   fields: { agentId: string; claimId: string; nonce?: string },
-  options: { replaceDirectory?: boolean } = {},
 ): { path: string } {
   const path = resolveGeneratedTokensPath(cwd, fields.claimId);
   const body: GeneratedTokensBody = {
@@ -674,9 +701,7 @@ export function recordGeneratedClaimTokens(
     ...(fields.nonce === undefined ? {} : { nonce: fields.nonce }),
     recordedAt: new Date().toISOString(),
   };
-  atomicReplaceFile(path, JSON.stringify(body), {
-    replaceDirectory: options.replaceDirectory ?? false,
-  });
+  atomicReplaceFile(path, JSON.stringify(body));
   return { path };
 }
 
@@ -693,7 +718,12 @@ export function recordGeneratedClaimTokens(
  * `backfilled`, naming the lock-sourced agent-id that was written.
  */
 export interface BackfillTokensOutcome {
-  status: 'backfilled' | 'lock-absent' | 'lock-malformed' | 'lock-mismatch';
+  status:
+    | 'backfilled'
+    | 'lock-absent'
+    | 'lock-malformed'
+    | 'lock-mismatch'
+    | 'record-blocked';
   lockPath: string;
   path: string;
   agentId?: string;
@@ -716,10 +746,21 @@ export interface BackfillTokensOutcome {
  *   directory) → `lock-malformed`.
  * - Present lock recorded for a different `claimId` → `lock-mismatch`
  *   (with `holder` naming the actual lock holder, never silently trusted).
- * - Present lock whose `claimId` matches → writes the generated-tokens
- *   record via {@link recordGeneratedClaimTokens}, using the lock's own
- *   `agentId` and no `nonce` (matching a fresh pre-nonce `--record-tokens`
- *   call) → `backfilled`. If a well-formed record for this exact `claimId`
+ * - Present lock whose `claimId` matches, but a directory already
+ *   occupies the generated-tokens record's own path → `record-blocked`.
+ *   A matching lock authenticates the *lock*, not this separate path, and
+ *   the path's hash suffix is not collision-proof, so lock authority
+ *   alone does not prove a directory here is disposable -- this stays
+ *   fail-closed rather than deleting it, unlike the lock file's own
+ *   GitHub-reverified-takeover-gated directory replacement (#2917
+ *   review, Copilot). `--read-tokens` already reports this same
+ *   directory-at-path case as `malformed`, so a caller following the
+ *   documented gated sequence stops here with no further action needed.
+ * - Present lock whose `claimId` matches, and no directory blocks the
+ *   record path → writes the generated-tokens record via
+ *   {@link recordGeneratedClaimTokens}, using the lock's own `agentId`
+ *   and no `nonce` (matching a fresh pre-nonce `--record-tokens` call) →
+ *   `backfilled`. If a well-formed record for this exact `claimId`
  *   already exists (outside the documented recovery route, which only ever
  *   reaches this function when `--read-tokens` reported absent/malformed --
  *   meaning no well-formed record exists yet -- so this is a defensive
@@ -753,26 +794,30 @@ export function backfillGeneratedClaimTokens(
     return { status: 'lock-mismatch', lockPath, path, holder: read.lock };
   }
 
+  // A directory at the record's own path is never authorized to be
+  // replaced here -- see the function-level doc comment above and
+  // recordGeneratedClaimTokens's own doc comment.
+  try {
+    if (statSync(path).isDirectory()) {
+      return { status: 'record-blocked', lockPath, path };
+    }
+  } catch {
+    // Absent, or an unreadable non-directory path: fall through and let
+    // recordGeneratedClaimTokens's own atomic-write handle it the same
+    // way it always has.
+  }
+
   // Preserve an existing well-formed record's own nonce, if any -- see the
   // function-level doc comment above.
   const existing = readGeneratedClaimTokens(worktree, claimId);
   const nonce =
     existing.status === 'present' ? existing.record.nonce : undefined;
 
-  recordGeneratedClaimTokens(
-    worktree,
-    {
-      agentId: read.lock.agentId,
-      claimId,
-      ...(nonce === undefined ? {} : { nonce }),
-    },
-    // Authorized here (unlike a plain --record-tokens call, #2879 review):
-    // the lock read above already confirmed a matching claimId, so a
-    // directory at this exact sanitized, hash-suffixed path is tampering,
-    // not a legitimate concurrent claim -- see the doc comment on
-    // recordGeneratedClaimTokens.
-    { replaceDirectory: true },
-  );
+  recordGeneratedClaimTokens(worktree, {
+    agentId: read.lock.agentId,
+    claimId,
+    ...(nonce === undefined ? {} : { nonce }),
+  });
   return { status: 'backfilled', lockPath, path, agentId: read.lock.agentId };
 }
 
@@ -965,10 +1010,13 @@ generated-tokens record using the lock's own recorded agent-id, with no
 --nonce unless an existing well-formed record for this --claim-id already
 carries one, which is preserved rather than erased. An absent lock reports
 \`lock-absent\`, an unparseable or
-unreadable lock reports \`lock-malformed\`, and a lock recorded for a
-different claim-id reports \`lock-mismatch\` (naming the actual holder) --
-all three write nothing. A successful write reports \`backfilled\` and
-exits 0; the three failure statuses exit 2, mirroring --acquire's own
+unreadable lock reports \`lock-malformed\`, a lock recorded for a
+different claim-id reports \`lock-mismatch\` (naming the actual holder),
+and a matching lock whose own record path is blocked by a directory
+reports \`record-blocked\` (a matching lock authenticates the lock, not
+that separate path, so this stays fail-closed rather than deleting it)
+-- all four write nothing. A successful write reports \`backfilled\` and
+exits 0; the four failure statuses exit 2, mirroring --acquire's own
 collision exit-code contract so a caller can chain
 \`--backfill-tokens && --read-tokens\`. Like --acquire, this performs no
 GitHub round-trip -- the caller must have already independently confirmed

--- a/src/scripts/claim-lock.mts
+++ b/src/scripts/claim-lock.mts
@@ -703,7 +703,15 @@ export interface BackfillTokensOutcome {
  * - Present lock whose `claimId` matches → writes the generated-tokens
  *   record via {@link recordGeneratedClaimTokens}, using the lock's own
  *   `agentId` and no `nonce` (matching a fresh pre-nonce `--record-tokens`
- *   call) → `backfilled`.
+ *   call) → `backfilled`. If a well-formed record for this exact `claimId`
+ *   already exists (outside the documented recovery route, which only ever
+ *   reaches this function when `--read-tokens` reported absent/malformed --
+ *   meaning no well-formed record exists yet -- so this is a defensive
+ *   guard against a caller invoking this function directly against
+ *   caller-discipline), its own `nonce` is preserved rather than silently
+ *   erased: {@link recordGeneratedClaimTokens} replaces the whole record,
+ *   so writing with no `nonce` unconditionally would otherwise drop an
+ *   existing one (#2917 review, Copilot).
  *
  * Performs no GitHub round-trip on any path, matching `--acquire`'s own
  * same-machine, no-network design. Re-invoking after a successful backfill
@@ -729,9 +737,16 @@ export function backfillGeneratedClaimTokens(
     return { status: 'lock-mismatch', lockPath, path, holder: read.lock };
   }
 
+  // Preserve an existing well-formed record's own nonce, if any -- see the
+  // function-level doc comment above.
+  const existing = readGeneratedClaimTokens(worktree, claimId);
+  const nonce =
+    existing.status === 'present' ? existing.record.nonce : undefined;
+
   recordGeneratedClaimTokens(worktree, {
     agentId: read.lock.agentId,
     claimId,
+    ...(nonce === undefined ? {} : { nonce }),
   });
   return { status: 'backfilled', lockPath, path, agentId: read.lock.agentId };
 }
@@ -921,8 +936,10 @@ does not affirmatively confirm.
 generated-tokens record was never created because its B1 worktree
 predates the record feature: it reads the existing \`idd-claim.lock\` file
 and, only when present with a --claim-id that matches exactly, writes the
-generated-tokens record using the lock's own recorded agent-id (no
---nonce). An absent lock reports \`lock-absent\`, an unparseable or
+generated-tokens record using the lock's own recorded agent-id, with no
+--nonce unless an existing well-formed record for this --claim-id already
+carries one, which is preserved rather than erased. An absent lock reports
+\`lock-absent\`, an unparseable or
 unreadable lock reports \`lock-malformed\`, and a lock recorded for a
 different claim-id reports \`lock-mismatch\` (naming the actual holder) --
 all three write nothing. A successful write reports \`backfilled\` and

--- a/src/scripts/claim-lock.mts
+++ b/src/scripts/claim-lock.mts
@@ -77,6 +77,27 @@
 // generated, rather than one merely recalled from (possibly compacted)
 // conversation context.
 //
+// Backfill recovery route (#2884): an adopter who upgrades their
+// `idd-template/` copy to gain the generated-tokens-record feature while a
+// claim already has its B1 worktree (created before this feature existed)
+// never reruns the claim-posting sequence or B1, so no generated-tokens
+// record is ever created in that worktree -- every subsequent
+// `--read-tokens` check then fails closed forever, even though the
+// session still legitimately owns the claim (PR #2879 review, Codex P1).
+// `--backfill-tokens` closes that gap by trusting the worktree's own
+// `idd-claim.lock` file instead of a live GitHub round-trip: that lock
+// already carries the legitimate `agentId` for exactly this scenario, and
+// is mechanically verifiable on disk rather than relying on the current
+// session's own (possibly compacted) recollection. It writes only when
+// the lock is present and its own `claimId` matches the caller's
+// `--claim-id` exactly; an absent, malformed, or mismatched lock all fail
+// closed with a distinct status and write nothing. The caller -- the
+// Claim revalidation gate's documented recovery route -- is responsible
+// for having already independently confirmed the live claim-id via
+// GitHub before ever reaching this step; this command itself never makes
+// a GitHub round-trip, matching `--acquire`'s own same-machine, no-network
+// design.
+//
 // Scope of the ownership proof (#2879 review, Codex P1): a `present: true`
 // `--read-tokens` result proves "a `--record-tokens` call for this exact
 // claim-id landed at this path" -- it does not cryptographically bind that
@@ -146,6 +167,7 @@ const CLAIM_LOCK_FLAG_SPEC = {
   '--check': { type: 'boolean' },
   '--record-tokens': { type: 'boolean' },
   '--read-tokens': { type: 'boolean' },
+  '--backfill-tokens': { type: 'boolean' },
   '--worktree': { type: 'string' },
   '--agent-id': { type: 'string' },
   '--claim-id': { type: 'string' },
@@ -642,11 +664,84 @@ export function recordGeneratedClaimTokens(
   return { path };
 }
 
+/**
+ * Outcome shape returned by {@link backfillGeneratedClaimTokens}. `path` is
+ * the generated-tokens record's own path, reported on every status
+ * (mirroring {@link GeneratedTokensReadResult}'s convention of reporting
+ * `path` even when absent/malformed) since it is resolved from `worktree`
+ * and `claimId` alone, independent of whether the lock read succeeded.
+ * `lockPath` is the separate `idd-claim.lock` path this command reads to
+ * decide. `holder` is populated only for `lock-mismatch`, naming the
+ * lock's actual (different) claim -- mirroring {@link AcquireLockOutcome}'s
+ * own `holder` field on a collision. `agentId` is populated only for
+ * `backfilled`, naming the lock-sourced agent-id that was written.
+ */
+export interface BackfillTokensOutcome {
+  status: 'backfilled' | 'lock-absent' | 'lock-malformed' | 'lock-mismatch';
+  lockPath: string;
+  path: string;
+  agentId?: string;
+  holder?: ClaimLockBody;
+}
+
+/**
+ * Recovery route (#2884) for a worktree whose generated-tokens record
+ * (#2719) was never created because its B1 worktree predates that
+ * feature: reconstruct it from the worktree's own `idd-claim.lock` file,
+ * which already carries the legitimate `agentId` for exactly this
+ * rollout-gap scenario (PR #2879 review, Codex P1) -- see the header
+ * comment's "Backfill recovery route" paragraph for the full rationale.
+ *
+ * Fails closed -- writes nothing -- unless the lock is present and its
+ * own `claimId` matches `claimId` exactly:
+ *
+ * - Absent lock → `lock-absent`.
+ * - Malformed lock (unparseable, or an unreadable path such as a
+ *   directory) → `lock-malformed`.
+ * - Present lock recorded for a different `claimId` → `lock-mismatch`
+ *   (with `holder` naming the actual lock holder, never silently trusted).
+ * - Present lock whose `claimId` matches → writes the generated-tokens
+ *   record via {@link recordGeneratedClaimTokens}, using the lock's own
+ *   `agentId` and no `nonce` (matching a fresh pre-nonce `--record-tokens`
+ *   call) → `backfilled`.
+ *
+ * Performs no GitHub round-trip on any path, matching `--acquire`'s own
+ * same-machine, no-network design. Re-invoking after a successful backfill
+ * always reports `backfilled` again -- a safe, idempotent overwrite via
+ * `recordGeneratedClaimTokens`'s own existing idempotency contract, not a
+ * separate `already-present` status.
+ */
+export function backfillGeneratedClaimTokens(
+  worktree: string,
+  claimId: string,
+): BackfillTokensOutcome {
+  const lockPath = resolveClaimLockPath(worktree);
+  const path = resolveGeneratedTokensPath(worktree, claimId);
+  const read = readLock(lockPath);
+
+  if (read.status === 'absent') {
+    return { status: 'lock-absent', lockPath, path };
+  }
+  if (read.status === 'malformed') {
+    return { status: 'lock-malformed', lockPath, path };
+  }
+  if (read.lock.claimId !== claimId) {
+    return { status: 'lock-mismatch', lockPath, path, holder: read.lock };
+  }
+
+  recordGeneratedClaimTokens(worktree, {
+    agentId: read.lock.agentId,
+    claimId,
+  });
+  return { status: 'backfilled', lockPath, path, agentId: read.lock.agentId };
+}
+
 interface ParsedArgs {
   acquire: boolean;
   check: boolean;
   recordTokens: boolean;
   readTokens: boolean;
+  backfillTokens: boolean;
   worktree: string | null;
   agentId: string | null;
   claimId: string | null;
@@ -662,6 +757,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     check: Boolean(values.check),
     recordTokens: Boolean(values['record-tokens']),
     readTokens: Boolean(values['read-tokens']),
+    backfillTokens: Boolean(values['backfill-tokens']),
     worktree: typeof values.worktree === 'string' ? values.worktree : null,
     agentId:
       typeof values['agent-id'] === 'string'
@@ -677,11 +773,15 @@ function parseArgs(argv: string[]): ParsedArgs {
   };
 }
 
-/** Exactly one of the four mode flags, for the `runCli` mode-selection error. */
+/** Exactly one of the five mode flags, for the `runCli` mode-selection error. */
 function selectedModeCount(args: ParsedArgs): number {
-  return [args.acquire, args.check, args.recordTokens, args.readTokens].filter(
-    Boolean,
-  ).length;
+  return [
+    args.acquire,
+    args.check,
+    args.recordTokens,
+    args.readTokens,
+    args.backfillTokens,
+  ].filter(Boolean).length;
 }
 
 function runCli(): void {
@@ -692,7 +792,7 @@ function runCli(): void {
   }
   if (selectedModeCount(args) !== 1) {
     throw new Error(
-      'exactly one of --acquire, --check, --record-tokens, or --read-tokens is required',
+      'exactly one of --acquire, --check, --record-tokens, --read-tokens, or --backfill-tokens is required',
     );
   }
   if (args.worktree === null) {
@@ -735,6 +835,18 @@ function runCli(): void {
     return;
   }
 
+  if (args.backfillTokens) {
+    if (args.claimId === null) {
+      throw new Error('--claim-id is required for --backfill-tokens');
+    }
+    const outcome = backfillGeneratedClaimTokens(args.worktree, args.claimId);
+    process.stdout.write(`${JSON.stringify(outcome)}\n`);
+    if (outcome.status !== 'backfilled') {
+      process.exitCode = 2;
+    }
+    return;
+  }
+
   if (args.agentId === null) {
     throw new Error('--agent-id is required for --acquire');
   }
@@ -759,6 +871,7 @@ function printHelp(): void {
   node scripts/claim-lock.mjs --check --worktree <path>
   node scripts/claim-lock.mjs --record-tokens --worktree <path> --agent-id <id> --claim-id <id> [--nonce <nonce>]
   node scripts/claim-lock.mjs --read-tokens --worktree <path> --claim-id <id>
+  node scripts/claim-lock.mjs --backfill-tokens --worktree <path> --claim-id <id>
 
 Worktree-local lock file: a same-machine fast path that complements the
 cross-machine activation-nonce claim check. Resolves the lock file inside
@@ -803,5 +916,23 @@ recorded (or was recorded under a different claim-id, which resolves to a
 different path). Both \`malformed\` and absent must be treated the same
 way by a caller checking ownership: never trust a claim-id this record
 does not affirmatively confirm.
+
+--backfill-tokens is the recovery route for a worktree whose
+generated-tokens record was never created because its B1 worktree
+predates the record feature: it reads the existing \`idd-claim.lock\` file
+and, only when present with a --claim-id that matches exactly, writes the
+generated-tokens record using the lock's own recorded agent-id (no
+--nonce). An absent lock reports \`lock-absent\`, an unparseable or
+unreadable lock reports \`lock-malformed\`, and a lock recorded for a
+different claim-id reports \`lock-mismatch\` (naming the actual holder) --
+all three write nothing. A successful write reports \`backfilled\` and
+exits 0; the three failure statuses exit 2, mirroring --acquire's own
+collision exit-code contract so a caller can chain
+\`--backfill-tokens && --read-tokens\`. Like --acquire, this performs no
+GitHub round-trip -- the caller must have already independently confirmed
+the live claim-id via GitHub before reaching this recovery step.
+Re-invoking after a successful backfill is always a safe, idempotent
+overwrite (reports \`backfilled\` again), matching --record-tokens's own
+idempotency contract.
 `);
 }

--- a/src/scripts/claim-lock.mts
+++ b/src/scripts/claim-lock.mts
@@ -648,10 +648,24 @@ export function readGeneratedClaimTokens(
  * claimId}`, again with `{agentId, claimId, nonce}` right before the
  * activation-nonce marker posts, and again in the new sibling worktree at
  * B1) is always a safe, expected, idempotent overwrite of the same path.
+ *
+ * `replaceDirectory` defaults to `false` here -- a plain `--record-tokens`
+ * call must never silently delete a directory occupying the resolved path
+ * (regression, #2879 review) -- mirroring {@link overwriteLockAtomically}'s
+ * own narrower authorized-only grant for the lock file. Only
+ * {@link backfillGeneratedClaimTokens} passes `true`: it has already
+ * confirmed the worktree's own `idd-claim.lock` matches `claimId` before
+ * ever reaching this write, which is the same kind of local authorization
+ * `overwriteLockAtomically`'s authorized-takeover caller has, and without
+ * it the write this function performs for exactly the
+ * `malformed`-because-directory case would throw an uncaught `EISDIR`
+ * instead of reporting the documented `backfilled` outcome (#2917 review,
+ * Codex P2).
  */
 export function recordGeneratedClaimTokens(
   cwd: string,
   fields: { agentId: string; claimId: string; nonce?: string },
+  options: { replaceDirectory?: boolean } = {},
 ): { path: string } {
   const path = resolveGeneratedTokensPath(cwd, fields.claimId);
   const body: GeneratedTokensBody = {
@@ -660,7 +674,9 @@ export function recordGeneratedClaimTokens(
     ...(fields.nonce === undefined ? {} : { nonce: fields.nonce }),
     recordedAt: new Date().toISOString(),
   };
-  atomicReplaceFile(path, JSON.stringify(body));
+  atomicReplaceFile(path, JSON.stringify(body), {
+    replaceDirectory: options.replaceDirectory ?? false,
+  });
   return { path };
 }
 
@@ -743,11 +759,20 @@ export function backfillGeneratedClaimTokens(
   const nonce =
     existing.status === 'present' ? existing.record.nonce : undefined;
 
-  recordGeneratedClaimTokens(worktree, {
-    agentId: read.lock.agentId,
-    claimId,
-    ...(nonce === undefined ? {} : { nonce }),
-  });
+  recordGeneratedClaimTokens(
+    worktree,
+    {
+      agentId: read.lock.agentId,
+      claimId,
+      ...(nonce === undefined ? {} : { nonce }),
+    },
+    // Authorized here (unlike a plain --record-tokens call, #2879 review):
+    // the lock read above already confirmed a matching claimId, so a
+    // directory at this exact sanitized, hash-suffixed path is tampering,
+    // not a legitimate concurrent claim -- see the doc comment on
+    // recordGeneratedClaimTokens.
+    { replaceDirectory: true },
+  );
   return { status: 'backfilled', lockPath, path, agentId: read.lock.agentId };
 }
 

--- a/tests/claim-lock.test.mts
+++ b/tests/claim-lock.test.mts
@@ -946,6 +946,41 @@ test('backfill-tokens: re-running after a successful backfill is idempotent — 
   }
 });
 
+test("backfill-tokens: preserves an existing well-formed record's own nonce rather than erasing it (PR #2917 review, Copilot)", () => {
+  const fixture = setupLinkedWorktree();
+  try {
+    const acquired = acquireClaimLock(
+      fixture.worktree,
+      'agent-a',
+      'claim-a',
+      false,
+    );
+    assert.equal(acquired.mode, 'acquired');
+
+    // A nonce-bearing record already exists for this exact claim-id --
+    // outside the documented recovery route (which only ever reaches
+    // --backfill-tokens when --read-tokens reports absent/malformed, i.e.
+    // no well-formed record exists yet), but the CLI itself does not
+    // enforce that precondition, so a direct out-of-band invocation must
+    // not silently erase the nonce.
+    recordGeneratedClaimTokens(fixture.worktree, {
+      agentId: 'agent-a',
+      claimId: 'claim-a',
+      nonce: 'nonce-a',
+    });
+
+    const outcome = backfillGeneratedClaimTokens(fixture.worktree, 'claim-a');
+    assert.equal(outcome.status, 'backfilled');
+
+    const read = readGeneratedClaimTokens(fixture.worktree, 'claim-a');
+    assert.equal(read.status, 'present');
+    assert.equal(read.status === 'present' && read.record.agentId, 'agent-a');
+    assert.equal(read.status === 'present' && read.record.nonce, 'nonce-a');
+  } finally {
+    teardown(fixture);
+  }
+});
+
 test('CLI: --backfill-tokens writes on a matching lock and exits 0, and exits non-zero with no write on a mismatched claim-id', async () => {
   const fixture = setupLinkedWorktree();
   try {

--- a/tests/claim-lock.test.mts
+++ b/tests/claim-lock.test.mts
@@ -18,6 +18,7 @@ import { promisify } from 'node:util';
 
 import {
   acquireClaimLock,
+  backfillGeneratedClaimTokens,
   checkClaimLock,
   readGeneratedClaimTokens,
   recordGeneratedClaimTokens,
@@ -817,6 +818,195 @@ test('CLI: --record-tokens then --read-tokens round trip via the compiled CLI', 
     const readMalformedOutcome = JSON.parse(readMalformedResult.stdout);
     assert.equal(readMalformedOutcome.present, true);
     assert.equal(readMalformedOutcome.malformed, true);
+  } finally {
+    teardown(fixture);
+  }
+});
+
+// Backfill-tokens recovery route tests (#2884).
+
+test('backfill-tokens: backfilled — a present, matching lock writes the generated-tokens record using the lock agent-id, with no nonce', () => {
+  const fixture = setupLinkedWorktree();
+  try {
+    const acquired = acquireClaimLock(
+      fixture.worktree,
+      'agent-a',
+      'claim-a',
+      false,
+    );
+    assert.equal(acquired.mode, 'acquired');
+
+    const outcome = backfillGeneratedClaimTokens(fixture.worktree, 'claim-a');
+    assert.equal(outcome.status, 'backfilled');
+    assert.equal(outcome.agentId, 'agent-a');
+
+    const read = readGeneratedClaimTokens(fixture.worktree, 'claim-a');
+    assert.equal(read.status, 'present');
+    assert.equal(read.status === 'present' && read.record.agentId, 'agent-a');
+    assert.equal(read.status === 'present' && read.record.claimId, 'claim-a');
+    assert.equal(read.status === 'present' && read.record.nonce, undefined);
+  } finally {
+    teardown(fixture);
+  }
+});
+
+test('backfill-tokens: lock-absent — no lock file exists, writes nothing', () => {
+  const fixture = setupLinkedWorktree();
+  try {
+    const outcome = backfillGeneratedClaimTokens(fixture.worktree, 'claim-a');
+    assert.equal(outcome.status, 'lock-absent');
+    assert.equal(outcome.holder, undefined);
+
+    const read = readGeneratedClaimTokens(fixture.worktree, 'claim-a');
+    assert.equal(read.status, 'absent');
+  } finally {
+    teardown(fixture);
+  }
+});
+
+test('backfill-tokens: lock-malformed — an unparseable lock body writes nothing', () => {
+  const fixture = setupLinkedWorktree();
+  try {
+    const lockPath = resolveClaimLockPath(fixture.worktree);
+    writeFileSync(lockPath, 'not json at all {{{');
+
+    const outcome = backfillGeneratedClaimTokens(fixture.worktree, 'claim-a');
+    assert.equal(outcome.status, 'lock-malformed');
+    assert.equal(outcome.holder, undefined);
+
+    const read = readGeneratedClaimTokens(fixture.worktree, 'claim-a');
+    assert.equal(read.status, 'absent');
+  } finally {
+    teardown(fixture);
+  }
+});
+
+test('backfill-tokens: lock-malformed — a directory at the lock path writes nothing (same unreadable-path case as --check/--acquire)', () => {
+  const fixture = setupLinkedWorktree();
+  try {
+    const lockPath = resolveClaimLockPath(fixture.worktree);
+    mkdirSync(lockPath);
+
+    const outcome = backfillGeneratedClaimTokens(fixture.worktree, 'claim-a');
+    assert.equal(outcome.status, 'lock-malformed');
+
+    const read = readGeneratedClaimTokens(fixture.worktree, 'claim-a');
+    assert.equal(read.status, 'absent');
+  } finally {
+    teardown(fixture);
+  }
+});
+
+test('backfill-tokens: lock-mismatch — a lock present for a different claim-id writes nothing and reports the actual holder', () => {
+  const fixture = setupLinkedWorktree();
+  try {
+    const acquired = acquireClaimLock(
+      fixture.worktree,
+      'agent-a',
+      'claim-a',
+      false,
+    );
+    assert.equal(acquired.mode, 'acquired');
+
+    const outcome = backfillGeneratedClaimTokens(fixture.worktree, 'claim-b');
+    assert.equal(outcome.status, 'lock-mismatch');
+    assert.equal(outcome.holder?.agentId, 'agent-a');
+    assert.equal(outcome.holder?.claimId, 'claim-a');
+
+    const read = readGeneratedClaimTokens(fixture.worktree, 'claim-b');
+    assert.equal(read.status, 'absent');
+  } finally {
+    teardown(fixture);
+  }
+});
+
+test('backfill-tokens: re-running after a successful backfill is idempotent — reports backfilled again without corrupting the record', () => {
+  const fixture = setupLinkedWorktree();
+  try {
+    const acquired = acquireClaimLock(
+      fixture.worktree,
+      'agent-a',
+      'claim-a',
+      false,
+    );
+    assert.equal(acquired.mode, 'acquired');
+
+    const first = backfillGeneratedClaimTokens(fixture.worktree, 'claim-a');
+    assert.equal(first.status, 'backfilled');
+
+    const second = backfillGeneratedClaimTokens(fixture.worktree, 'claim-a');
+    assert.equal(second.status, 'backfilled');
+
+    const read = readGeneratedClaimTokens(fixture.worktree, 'claim-a');
+    assert.equal(read.status, 'present');
+    assert.equal(read.status === 'present' && read.record.agentId, 'agent-a');
+    assert.equal(read.status === 'present' && read.record.claimId, 'claim-a');
+  } finally {
+    teardown(fixture);
+  }
+});
+
+test('CLI: --backfill-tokens writes on a matching lock and exits 0, and exits non-zero with no write on a mismatched claim-id', async () => {
+  const fixture = setupLinkedWorktree();
+  try {
+    const acquired = acquireClaimLock(
+      fixture.worktree,
+      'agent-a',
+      'claim-a',
+      false,
+    );
+    assert.equal(acquired.mode, 'acquired');
+
+    const backfillResult = await execFileAsync(process.execPath, [
+      CLI_PATH,
+      '--backfill-tokens',
+      '--worktree',
+      fixture.worktree,
+      '--claim-id',
+      'claim-a',
+    ]);
+    const backfillOutcome = JSON.parse(backfillResult.stdout);
+    assert.equal(backfillOutcome.status, 'backfilled');
+    assert.equal(backfillOutcome.agentId, 'agent-a');
+
+    const readResult = await execFileAsync(process.execPath, [
+      CLI_PATH,
+      '--read-tokens',
+      '--worktree',
+      fixture.worktree,
+      '--claim-id',
+      'claim-a',
+    ]);
+    const readOutcome = JSON.parse(readResult.stdout);
+    assert.equal(readOutcome.present, true);
+    assert.equal(readOutcome.record.agentId, 'agent-a');
+
+    await assert.rejects(
+      execFileAsync(process.execPath, [
+        CLI_PATH,
+        '--backfill-tokens',
+        '--worktree',
+        fixture.worktree,
+        '--claim-id',
+        'claim-b',
+      ]),
+      (error: NodeJS.ErrnoException & { stdout?: string }) => {
+        assert.equal(error.code, 2);
+        assert.equal(JSON.parse(error.stdout ?? '').status, 'lock-mismatch');
+        return true;
+      },
+    );
+
+    // A different claim-id's record was never written by the failed call.
+    const readOtherResult = await execFileAsync(process.execPath, [
+      CLI_PATH,
+      '--read-tokens',
+      '--worktree',
+      fixture.worktree,
+      '--claim-id',
+      'claim-b',
+    ]);
+    assert.equal(JSON.parse(readOtherResult.stdout).present, false);
   } finally {
     teardown(fixture);
   }

--- a/tests/claim-lock.test.mts
+++ b/tests/claim-lock.test.mts
@@ -981,6 +981,43 @@ test("backfill-tokens: preserves an existing well-formed record's own nonce rath
   }
 });
 
+test('backfill-tokens: self-heals a stray directory at the generated-tokens path instead of throwing (PR #2917 review, Codex P2)', () => {
+  const fixture = setupLinkedWorktree();
+  try {
+    const acquired = acquireClaimLock(
+      fixture.worktree,
+      'agent-a',
+      'claim-a',
+      false,
+    );
+    assert.equal(acquired.mode, 'acquired');
+
+    // Simulate the malformed-token-path-is-a-directory case
+    // `readGeneratedClaimTokens` already reports as `malformed` (read side):
+    // before this fix, the matching write side threw instead of replacing
+    // it, so the documented recovery route this exact `malformed` result
+    // sends a caller to would crash rather than report a clean outcome.
+    const tokensPath = readGeneratedClaimTokens(
+      fixture.worktree,
+      'claim-a',
+    ).path;
+    mkdirSync(tokensPath, { recursive: true });
+    assert.equal(
+      readGeneratedClaimTokens(fixture.worktree, 'claim-a').status,
+      'malformed',
+    );
+
+    const outcome = backfillGeneratedClaimTokens(fixture.worktree, 'claim-a');
+    assert.equal(outcome.status, 'backfilled');
+
+    const read = readGeneratedClaimTokens(fixture.worktree, 'claim-a');
+    assert.equal(read.status, 'present');
+    assert.equal(read.status === 'present' && read.record.agentId, 'agent-a');
+  } finally {
+    teardown(fixture);
+  }
+});
+
 test('CLI: --backfill-tokens writes on a matching lock and exits 0, and exits non-zero with no write on a mismatched claim-id', async () => {
   const fixture = setupLinkedWorktree();
   try {

--- a/tests/claim-lock.test.mts
+++ b/tests/claim-lock.test.mts
@@ -13,8 +13,9 @@ import {
 import { devNull, tmpdir } from 'node:os';
 import { basename, join, sep } from 'node:path';
 import { test } from 'node:test';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
+import { Worker } from 'node:worker_threads';
 
 import {
   acquireClaimLock,
@@ -504,6 +505,190 @@ test('acquire: N concurrent forced-takeovers never corrupt the lock — every wr
   }
 });
 
+// Worker-thread payload for the race test below. `eval`-loaded per
+// round rather than a separate fixture file, per this suite's existing
+// preference for self-contained tests. Deliberately imports the
+// *compiled* CLI module (matching the execFileAsync CLI tests
+// elsewhere in this file), not the .mts source, since this string is
+// handed to Worker's own module loader rather than this file's own
+// TypeScript-aware one.
+const RACE_WORKER_CODE = `
+  const { workerData, parentPort } = require('node:worker_threads');
+  const { worktree, sab, cliUrl } = workerData;
+  const ints = new Int32Array(sab);
+  import(cliUrl).then(({ acquireClaimLock }) => {
+    // Signal ready, then block until the main thread releases every
+    // worker in this round at (as close to) the same instant.
+    Atomics.add(ints, 0, 1);
+    Atomics.wait(ints, 1, 0);
+    const outcome = acquireClaimLock(worktree, 'agent-a', 'claim-a', false);
+    parentPort.postMessage(outcome);
+  });
+`;
+
+test('acquire: a same-claim-id race against an absent lock can raise racedCreate, and never fabricates a holder on the pre-existing torn-read gap (PR #2917 review, Codex; torn-read gap tracked in kurone-kito/idd-skill#2920)', async (t) => {
+  // Statistical health check across several rounds, not a proof, like the
+  // concurrent-takeovers test above -- but using worker_threads with an
+  // Atomics ready-count barrier instead of subprocess spawning. The
+  // exclusive-create race window is microseconds wide; process-spawn
+  // overhead (milliseconds) reliably swamps it, so a subprocess batch
+  // (like the takeover test above) essentially never reproduces this
+  // specific race in practice. In-process worker threads sharing one
+  // Node process avoid that overhead and do, on hosts with enough cores
+  // -- see kurone-kito/idd-skill#2920 for the measurements this is based
+  // on and the pre-existing gap the torn-read branch below documents.
+  //
+  // Structural invariants that must hold on every round regardless of
+  // whether a race actually manifests on this host:
+  // - every outcome's mode is 'acquired' or 'collision'
+  // - exactly one outcome is a true fresh create (mode:'acquired', no
+  //   `reacquired`) -- O_EXCL create is atomic at the OS level
+  // - every `racedCreate:true` co-occurs with `reacquired:true`
+  // - every `collision` outcome carries no `holder` -- this batch's own
+  //   lock starts absent and every acquire uses the same claim-id, so a
+  //   genuine different-claim-id collision is impossible here; a
+  //   `collision` can only be the pre-existing torn-read gap (#2920), and
+  //   a `holder` appearing on one would mean a *different*, more serious
+  //   bug than the one this comment documents
+  // - the final lock body still names the single fresh creator
+  //
+  // Whether `racedCreate:true` is actually observed varies with host CPU
+  // count and scheduler noise, so it is soft-checked via a diagnostic
+  // across multiple rounds rather than a hard per-run assertion -- this
+  // test must not fail merely because a given CI runner has few cores.
+  const fixture = setupLinkedWorktree();
+  try {
+    const cliUrl = pathToFileURL(CLI_PATH).href;
+    const lockPath = resolveClaimLockPath(fixture.worktree);
+    const ROUNDS = 5;
+    const CONCURRENT_ACQUIRES = 60;
+    let anyRacedCreate = false;
+    let anyTornReadCollision = false;
+
+    for (let round = 0; round < ROUNDS; round += 1) {
+      rmSync(lockPath, { force: true });
+
+      const sab = new SharedArrayBuffer(8);
+      const ints = new Int32Array(sab);
+      // ints[0]: ready count; ints[1]: go flag.
+      Atomics.store(ints, 0, 0);
+      Atomics.store(ints, 1, 0);
+
+      const workers = Array.from({ length: CONCURRENT_ACQUIRES }, () => {
+        const worker = new Worker(RACE_WORKER_CODE, {
+          eval: true,
+          workerData: { worktree: fixture.worktree, sab, cliUrl },
+        });
+        return new Promise((resolve, reject) => {
+          worker.on('message', (outcome) => {
+            resolve(outcome);
+            void worker.terminate();
+          });
+          worker.on('error', reject);
+        });
+      });
+
+      // Poll until every worker in this round has imported the module
+      // and reached its own Atomics.wait, then release them together.
+      const deadline = Date.now() + 10_000;
+      while (
+        Atomics.load(ints, 0) < CONCURRENT_ACQUIRES &&
+        Date.now() < deadline
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      Atomics.store(ints, 1, 1);
+      Atomics.notify(ints, 1);
+
+      const outcomes = (await Promise.all(workers)) as Array<{
+        mode: string;
+        reacquired?: boolean;
+        racedCreate?: boolean;
+        holder?: unknown;
+      }>;
+
+      for (const outcome of outcomes) {
+        assert.ok(
+          outcome.mode === 'acquired' || outcome.mode === 'collision',
+          `unexpected mode, got: ${JSON.stringify(outcome)}`,
+        );
+        if (outcome.racedCreate === true) {
+          assert.equal(
+            outcome.reacquired,
+            true,
+            `racedCreate:true without reacquired:true, got: ${JSON.stringify(outcome)}`,
+          );
+          anyRacedCreate = true;
+        }
+        if (outcome.mode === 'collision') {
+          assert.equal(
+            outcome.holder,
+            undefined,
+            `expected a same-claim-id collision in this batch to be the torn-read gap (no holder), got: ${JSON.stringify(outcome)}`,
+          );
+          anyTornReadCollision = true;
+        }
+      }
+
+      const freshCreates = outcomes.filter(
+        (outcome) => outcome.mode === 'acquired' && outcome.reacquired !== true,
+      );
+      assert.equal(
+        freshCreates.length,
+        1,
+        `expected exactly one true fresh create in round ${round}, got: ${JSON.stringify(outcomes)}`,
+      );
+
+      const finalBody = JSON.parse(readFileSync(lockPath, 'utf8'));
+      assert.equal(finalBody.claimId, 'claim-a');
+      assert.equal(finalBody.agentId, 'agent-a');
+    }
+
+    t.diagnostic(
+      anyRacedCreate
+        ? `observed racedCreate:true across ${ROUNDS} round(s)`
+        : `no racedCreate:true observed across ${ROUNDS} round(s) on this host -- the positive path is verified by construction (acquireClaimLock's three reacquired-from-a-retry return sites), not exercised deterministically here`,
+    );
+    t.diagnostic(
+      anyTornReadCollision
+        ? `observed the pre-existing torn-read collision gap (kurone-kito/idd-skill#2920) across ${ROUNDS} round(s)`
+        : `no torn-read collision observed across ${ROUNDS} round(s) on this host`,
+    );
+  } finally {
+    teardown(fixture);
+  }
+});
+
+test('acquire: a genuinely pre-existing matching lock reacquires with no racedCreate', () => {
+  const fixture = setupLinkedWorktree();
+  try {
+    const first = acquireClaimLock(
+      fixture.worktree,
+      'agent-a',
+      'claim-a',
+      false,
+    );
+    assert.equal(first.mode, 'acquired');
+    assert.equal(first.reacquired, undefined);
+    assert.equal(first.racedCreate, undefined);
+
+    // A later, separate call against the now-settled, already-present
+    // lock -- the ordinary single-session "before every mutation"
+    // re-check -- must read as unambiguously pre-existing.
+    const second = acquireClaimLock(
+      fixture.worktree,
+      'agent-a',
+      'claim-a',
+      false,
+    );
+    assert.equal(second.mode, 'acquired');
+    assert.equal(second.reacquired, true);
+    assert.equal(second.racedCreate, undefined);
+  } finally {
+    teardown(fixture);
+  }
+});
+
 // Generated-tokens record tests (#2719).
 
 test('generated-tokens: record/read round trip reports the recorded fields', () => {
@@ -981,7 +1166,7 @@ test("backfill-tokens: preserves an existing well-formed record's own nonce rath
   }
 });
 
-test('backfill-tokens: self-heals a stray directory at the generated-tokens path instead of throwing (PR #2917 review, Codex P2)', () => {
+test('backfill-tokens: reports record-blocked instead of deleting a directory at the generated-tokens path (PR #2917 review, Codex P2 then Copilot)', () => {
   const fixture = setupLinkedWorktree();
   try {
     const acquired = acquireClaimLock(
@@ -993,26 +1178,36 @@ test('backfill-tokens: self-heals a stray directory at the generated-tokens path
     assert.equal(acquired.mode, 'acquired');
 
     // Simulate the malformed-token-path-is-a-directory case
-    // `readGeneratedClaimTokens` already reports as `malformed` (read side):
-    // before this fix, the matching write side threw instead of replacing
-    // it, so the documented recovery route this exact `malformed` result
-    // sends a caller to would crash rather than report a clean outcome.
+    // `readGeneratedClaimTokens` already reports as `malformed` (read side).
+    // An earlier fix here made the write side self-heal by deleting the
+    // directory, but a matching `idd-claim.lock` only authenticates the
+    // *lock*, not this separate path, and the path's hash suffix is not
+    // collision-proof -- so a stray/colliding directory's contents must
+    // survive, the same invariant the #2879-review regression test below
+    // already establishes for a plain --record-tokens call.
     const tokensPath = readGeneratedClaimTokens(
       fixture.worktree,
       'claim-a',
     ).path;
     mkdirSync(tokensPath, { recursive: true });
+    writeFileSync(join(tokensPath, 'unrelated-file.txt'), 'do not delete me');
     assert.equal(
       readGeneratedClaimTokens(fixture.worktree, 'claim-a').status,
       'malformed',
     );
 
     const outcome = backfillGeneratedClaimTokens(fixture.worktree, 'claim-a');
-    assert.equal(outcome.status, 'backfilled');
+    assert.equal(outcome.status, 'record-blocked');
 
-    const read = readGeneratedClaimTokens(fixture.worktree, 'claim-a');
-    assert.equal(read.status, 'present');
-    assert.equal(read.status === 'present' && read.record.agentId, 'agent-a');
+    assert.equal(statSync(tokensPath).isDirectory(), true);
+    assert.equal(
+      readFileSync(join(tokensPath, 'unrelated-file.txt'), 'utf8'),
+      'do not delete me',
+    );
+    assert.equal(
+      readGeneratedClaimTokens(fixture.worktree, 'claim-a').status,
+      'malformed',
+    );
   } finally {
     teardown(fixture);
   }

--- a/tests/claim-lock.test.mts
+++ b/tests/claim-lock.test.mts
@@ -10,7 +10,7 @@ import {
   statSync,
   writeFileSync,
 } from 'node:fs';
-import { devNull, tmpdir } from 'node:os';
+import { availableParallelism, devNull, tmpdir } from 'node:os';
 import { basename, join, sep } from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -526,9 +526,23 @@ const RACE_WORKER_CODE = `
   });
 `;
 
-test('acquire: a same-claim-id race against an absent lock can raise racedCreate, and never fabricates a holder on the pre-existing torn-read gap (PR #2917 review, Codex; torn-read gap tracked in kurone-kito/idd-skill#2920)', async (t) => {
-  // Statistical health check across several rounds, not a proof, like the
-  // concurrent-takeovers test above -- but using worker_threads with an
+// Kept deliberately small: a full worker_threads race harness costs real
+// wall-clock time in CI (measured ~57s at ROUNDS=5, CONCURRENT_ACQUIRES=60
+// on a constrained runner -- PR #2917 review, Codex P2), and the constants
+// below are a proportionality call, not a precision one -- the test's job
+// is verifying hard structural invariants that must hold whenever the race
+// manifests, not maximizing the chance it manifests on any given run. See
+// the test body below for why a deterministic (non-probabilistic)
+// reproduction was rejected instead of tuned down.
+const RACE_TEST_ROUNDS = 2;
+const RACE_TEST_WORKERS_PER_ROUND = Math.min(
+  16,
+  Math.max(8, availableParallelism() * 2),
+);
+
+test('acquire: structural invariants hold under a same-claim-id race against an absent lock (PR #2917 review, Codex; racedCreate observation is a diagnostic, torn-read gap tracked in kurone-kito/idd-skill#2920)', async (t) => {
+  // Statistical health check across a couple of rounds, not a proof, like
+  // the concurrent-takeovers test above -- but using worker_threads with an
   // Atomics ready-count barrier instead of subprocess spawning. The
   // exclusive-create race window is microseconds wide; process-spawn
   // overhead (milliseconds) reliably swamps it, so a subprocess batch
@@ -537,6 +551,21 @@ test('acquire: a same-claim-id race against an absent lock can raise racedCreate
   // Node process avoid that overhead and do, on hosts with enough cores
   // -- see kurone-kito/idd-skill#2920 for the measurements this is based
   // on and the pre-existing gap the torn-read branch below documents.
+  //
+  // A deterministic reproduction (a test-only injection hook forcing the
+  // race window open) was considered and rejected: it would add a
+  // production-code seam whose only consumer is this one test -- its own
+  // reviewable surface, and out of proportion to the field it verifies.
+  // `acquireClaimLock`'s three `reacquired`-from-a-retry return sites
+  // (the source of `racedCreate: true`) are verified by direct code
+  // reading instead, and separately by the deterministic
+  // "genuinely pre-existing matching lock" test below, which exercises the
+  // *no-race* path exactly. This test's positive `racedCreate`/torn-read
+  // observations stay a diagnostic, not a hard assertion, precisely
+  // because a regression that stopped setting `racedCreate` entirely could
+  // still pass a run that never happens to observe the race -- the
+  // structural invariants asserted below are what this test actually
+  // guards on every run, race-observed or not.
   //
   // Structural invariants that must hold on every round regardless of
   // whether a race actually manifests on this host:
@@ -560,8 +589,8 @@ test('acquire: a same-claim-id race against an absent lock can raise racedCreate
   try {
     const cliUrl = pathToFileURL(CLI_PATH).href;
     const lockPath = resolveClaimLockPath(fixture.worktree);
-    const ROUNDS = 5;
-    const CONCURRENT_ACQUIRES = 60;
+    const ROUNDS = RACE_TEST_ROUNDS;
+    const CONCURRENT_ACQUIRES = RACE_TEST_WORKERS_PER_ROUND;
     let anyRacedCreate = false;
     let anyTornReadCollision = false;
 
@@ -574,16 +603,15 @@ test('acquire: a same-claim-id race against an absent lock can raise racedCreate
       Atomics.store(ints, 0, 0);
       Atomics.store(ints, 1, 0);
 
+      const workerRefs: Worker[] = [];
       const workers = Array.from({ length: CONCURRENT_ACQUIRES }, () => {
         const worker = new Worker(RACE_WORKER_CODE, {
           eval: true,
           workerData: { worktree: fixture.worktree, sab, cliUrl },
         });
+        workerRefs.push(worker);
         return new Promise((resolve, reject) => {
-          worker.on('message', (outcome) => {
-            resolve(outcome);
-            void worker.terminate();
-          });
+          worker.on('message', resolve);
           worker.on('error', reject);
         });
       });
@@ -606,6 +634,11 @@ test('acquire: a same-claim-id race against an absent lock can raise racedCreate
         racedCreate?: boolean;
         holder?: unknown;
       }>;
+      // Terminate only after every worker has already posted its
+      // outcome and settled, so tearing one thread down can never
+      // race another round's still-in-flight worker in this same
+      // batch (PR #2917 review, Codex P2).
+      await Promise.all(workerRefs.map((worker) => worker.terminate()));
 
       for (const outcome of outcomes) {
         assert.ok(


### PR DESCRIPTION
# Summary

Adds a `--backfill-tokens --worktree <path> --claim-id <id>` recovery
subcommand to `claim-lock.mts` for a worktree whose generated-tokens
record (#2719) was never created because its B1 worktree predates
that feature -- the rollout gap PR #2879's review (Codex P1) found,
where `--read-tokens` fails closed forever with no recovery route.
The new subcommand reads the worktree's existing `idd-claim.lock`
file and, only when present with a matching `claimId`, writes the
generated-tokens record using the lock's own `agentId` (no nonce);
an absent, malformed, or mismatched lock all fail closed with a
distinct status and write nothing. Covered by one unit test per
status, an idempotent-rerun test, and a CLI round-trip test.

Documents the new recovery route in `idd-overview-core.instructions.md`'s
Claim revalidation gate (step 5: `--check` -> `--backfill-tokens` ->
retry, fail-closed stop unchanged otherwise) and in
`docs/idd-helper-scripts.md` next to the existing
`--record-tokens`/`--read-tokens` entries, including an
`instructions-only` helper-free fallback bullet -- the same class of
gap PR #2879's Codex P1 review flagged for `--read-tokens`, since
`instructions-only` is the distributed default profile.

## Linked issue

Closes #2884

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

**Scope expansion beyond the issue's listed candidate files**: the
five helper-enabled "lite" instruction variants
(`idd-work-lite`/`idd-review-snapshot-lite`/`idd-pr-submit-lite`/
`idd-merge-handoff-lite`/`idd-review-fix-lite`) independently restate
this exact same fail-closed `--read-tokens` check with no recovery
route, and each file's own header declares it must stay in semantic
parity with its standard-tier counterpart ("any mismatch ... is a bug
in this file"). Shipping the fix only in the standard-tier
`idd-overview-core.instructions.md` would leave the identical
rollout gap live for the weak-model lite profile, so a short recovery
pointer (`--check` -> `--backfill-tokens` -> retry) was added to each
of the five lite files as well. `instructions-only` is out of scope
for the lite files by their own contract ("if `instructions-only`,
use the standard file instead"), so no helper-free fallback text was
needed there.

**Byte-budget constraint on the doc wording**: this repository
enforces a per-bundle context-ceiling byte budget
(`node scripts/audit-docs.mjs --check`, 98% of a fixed limit per
`audit/sync-manifest.json`'s `bundleBudgets`). `idd-overview-core`'s
own bundle was already at ~97.9% utilization before this change, and
two lite bundles (`pr-submit-lite`, `review-snapshot-lite`) were at
~97%, so the added recovery-route text in all six files is
deliberately terse, including a small compression of adjacent
pre-existing step-5 wording in `idd-overview-core.instructions.md` to
stay under the ceiling. `node scripts/audit-docs.mjs --check` passes
with every touched bundle still under 98%.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`npx biome check`, `npx dprint check`,
      `npx markdownlint-cli2`)
- [x] `pnpm test` (`node --test tests/*.test.mts`, 6124 passed / 2
      pre-existing skips)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (verified via `sync-docs.mjs --apply`
      producing no further diff, plus `audit-docs.mjs --check`'s own
      mirror-consistency check)
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDJpTELrY2SnjHW9m5Aw7i



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added gated recovery for missing or malformed lock-token records.
  - Recovery now verifies successful acquisition and reacquisition before proceeding.
  - Added clear handling for concurrent acquisition races and blocked token-record paths.

- **Bug Fixes**
  - Prevented unsafe recovery when locks or token data are invalid, ambiguous, or incomplete.
  - Preserved existing nonce data and protected directories from replacement.

- **Documentation**
  - Clarified recovery procedures, validation requirements, waiver evidence, failure statuses, and exit behavior.

- **Tests**
  - Added coverage for acquisition races, recovery safeguards, directory protection, and token integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->