### PR TITLE
fix(claim): close torn-read false collision in acquireClaimLock

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Run workshop integrity check
         run: node scripts/verify-workshop-integrity.mjs --format table
   lint-windows:
-    name: Critique telemetry hook (Windows)
+    name: Windows platform tests
     runs-on: windows-latest
     # Regression coverage for kurone-kito/idd-skill#2892: only
     # idd-critique-telemetry-hook.mts combines `shell: true` with
@@ -145,3 +145,36 @@ jobs:
       # number would drift stale again on the very next addition.
       - name: Run critique telemetry hook tests
         run: node --test tests/idd-critique-telemetry-hook.test.mts
+      # `acquireClaimLock`'s fresh-create path (#2920) deliberately
+      # depends on `linkSync` returning `EEXIST` for an existing
+      # destination -- true on POSIX, but Windows uses a different
+      # syscall (`CreateHardLinkW`) under the hood, and #2920's own
+      # acceptance criterion #2 requires that behavior verified on this
+      # platform explicitly, not assumed by POSIX analogy (Copilot
+      # review, PR #2923: this job previously never ran any part of
+      # `tests/claim-lock.test.mts`, leaving that criterion unexercised
+      # in CI). Run a narrow subset rather than the whole file: this
+      # suite also has POSIX-only fixtures (e.g. permission-bit tests
+      # via `chmodSync`, meaningless on Windows' ACL model) that were
+      # never vetted for this runner, and this job was deliberately
+      # narrowed after the #2892/#2910 hangs above -- widening it
+      # wholesale reintroduces that risk for coverage this fix does not
+      # need. The three selected tests are exactly the ones that
+      # exercise `createLockFileExclusively`'s `linkSync` path: a plain
+      # fresh acquire (create succeeds), the worker-thread race test
+      # (concurrent create -- exactly one exclusive winner, every loser
+      # observes `EEXIST` and reacquires), and the pre-existing-lock
+      # reacquire (confirms the *no-create* fast path stays untouched).
+      - name: Run claim-lock Windows-relevant tests
+        # The pattern is deliberately ASCII-only (no em dash), unlike the
+        # test titles themselves: this `run:` step has no `shell: bash`
+        # override, so it executes as PowerShell on this runner, and a
+        # non-ASCII argument's encoding through PowerShell-to-node argv
+        # on Windows is untested here -- safer to match on a unique
+        # substring that avoids the question entirely.
+        run: >-
+          node --test --test-name-pattern
+          "fresh acquire succeeds with no prior lock|structural invariants
+          hold under a same-claim-id race|genuinely pre-existing matching
+          lock reacquires with no racedCreate"
+          tests/claim-lock.test.mts

--- a/scripts/claim-lock.mjs
+++ b/scripts/claim-lock.mjs
@@ -37,6 +37,23 @@
 // path is the other recovery exception: an authorized takeover removes that
 // exact directory before installing the replacement.
 //
+// Fresh-create atomicity (#2920): the very first `--acquire` against an
+// absent lock also writes to the lock path, via `createLockFileExclusively`
+// below -- a same-directory temp-write + `linkSync` (atomic, EEXIST-exclusive
+// hard link), never a direct `writeFileSync(path, ..., { flag: 'wx' })`. A
+// direct `wx` create leaves a window between the file becoming visible at
+// `path` (open+create) and its content finishing (write) where a concurrent
+// `readLock` can observe a torn/partial body and misclassify it as
+// `malformed` -- producing a false `collision` result even when the same
+// `claimId` is about to win the race. Writing the full body to a temp file
+// first (fully written and closed before it is ever linked in) and then
+// atomically hard-linking it into place closes that window structurally: a
+// concurrent reader can only ever observe "absent" or a fully-formed body at
+// `path`, never a partial one. `linkSync` is create-only (no replace
+// semantics), so unlike the takeover path's `renameSync` fallback above, it
+// needs no Windows-specific recovery branch -- `CreateHardLinkW` fails
+// cleanly with `EEXIST` there too when the destination already exists.
+//
 // This lock intentionally does not try to perfectly serialize two
 // concurrent authorized takeovers of the same worktree -- that is a much
 // narrower race than the collision above, and the claim revalidation gate
@@ -122,6 +139,7 @@
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import {
+  linkSync,
   readFileSync,
   renameSync,
   rmSync,
@@ -382,6 +400,49 @@ function overwriteLockAtomically(path, agentId, claimId) {
   });
 }
 /**
+ * Create the lock file at `path` atomically, only when nothing exists there
+ * yet (#2920). Writes the full lock body to a same-directory temp file first
+ * -- fully written and closed before it is ever linked in -- then
+ * `linkSync`s that temp file into `path`. `linkSync` is both atomic and
+ * `EEXIST`-exclusive: a losing concurrent caller gets a clean `EEXIST`, never
+ * a chance to observe partial content at `path` mid-write, unlike a direct
+ * `writeFileSync(path, ..., { flag: 'wx' })` (open+create, then a separate
+ * write). Returns `'created'` on success or `'exists'` on a losing race
+ * (`EEXIST`); any other error rethrows -- deliberately, rather than falling
+ * back to the direct `wx` write this function replaces: a worktree's private
+ * git-admin directory lives on the same filesystem as the rest of the git
+ * repository, so the mainstream, hard-link-capable filesystems this
+ * repository already depends on elsewhere (ext4, APFS, NTFS) cover the
+ * supported case. A filesystem that rejects `linkSync` entirely (no
+ * hard-link support) fails this call loudly instead of silently
+ * reintroducing the exact torn-read race this function exists to close.
+ */
+function createLockFileExclusively(path, agentId, claimId) {
+  const tmpPath = `${path}.tmp-${process.pid}-${Math.random().toString(36).slice(2)}`;
+  writeFileSync(tmpPath, renderLockBody(agentId, claimId), { flag: 'wx' });
+  try {
+    linkSync(tmpPath, path);
+    return 'created';
+  } catch (error) {
+    if (error.code === 'EEXIST') {
+      return 'exists';
+    }
+    throw error;
+  } finally {
+    // Unlike `atomicReplaceFile`'s finally (where a successful `renameSync`
+    // already moved `tmpPath` away, making this a no-op ENOENT), a
+    // successful `linkSync` here leaves `tmpPath` in place as a second,
+    // now-redundant hard link to the same content -- this unlink is what
+    // actually removes it. Best-effort: a cleanup failure here never masks
+    // a real create/link error, and a leaked temp file is harmless.
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      // ignore
+    }
+  }
+}
+/**
  * Acquire (or idempotently re-acquire) the worktree-local claim lock.
  * Safe to call before every mutation, not just once at worktree creation.
  *
@@ -418,20 +479,15 @@ export function acquireClaimLock(worktree, agentId, claimId, takeover) {
         : { mode: 'acquired', path, reacquired: true, racedCreate: true };
     }
     if (read.status === 'absent') {
-      try {
-        writeFileSync(path, renderLockBody(agentId, claimId), { flag: 'wx' });
+      if (createLockFileExclusively(path, agentId, claimId) === 'created') {
         return { mode: 'acquired', path };
-      } catch (error) {
-        if (error.code !== 'EEXIST') {
-          throw error;
-        }
-        // Raced with a concurrent fresh acquire between the read above and
-        // this create; loop around to re-read and re-decide. Any
-        // `reacquired: true` this call reports from here on is no longer
-        // from its own first look, so it also carries `racedCreate: true`
-        // (see the function-level doc comment above).
-        continue;
       }
+      // Raced with a concurrent fresh acquire between the read above and
+      // this create; loop around to re-read and re-decide. Any
+      // `reacquired: true` this call reports from here on is no longer
+      // from its own first look, so it also carries `racedCreate: true`
+      // (see the function-level doc comment above).
+      continue;
     }
     // Either a different claim-id, or a malformed body whose holder can't
     // be determined safely: always a same-machine collision either way.
@@ -457,26 +513,18 @@ export function acquireClaimLock(worktree, agentId, claimId, takeover) {
     return { mode: 'acquired', path, reacquired: true, racedCreate: true };
   }
   if (finalRead.status === 'absent') {
-    try {
-      writeFileSync(path, renderLockBody(agentId, claimId), { flag: 'wx' });
+    if (createLockFileExclusively(path, agentId, claimId) === 'created') {
       return { mode: 'acquired', path };
-    } catch (error) {
-      if (error.code !== 'EEXIST') {
-        throw error;
-      }
-      const racedRead = readLock(path);
-      if (
-        racedRead.status === 'present' &&
-        racedRead.lock.claimId === claimId
-      ) {
-        return { mode: 'acquired', path, reacquired: true, racedCreate: true };
-      }
-      return {
-        mode: 'collision',
-        path,
-        holder: racedRead.status === 'present' ? racedRead.lock : undefined,
-      };
     }
+    const racedRead = readLock(path);
+    if (racedRead.status === 'present' && racedRead.lock.claimId === claimId) {
+      return { mode: 'acquired', path, reacquired: true, racedCreate: true };
+    }
+    return {
+      mode: 'collision',
+      path,
+      holder: racedRead.status === 'present' ? racedRead.lock : undefined,
+    };
   }
   return {
     mode: 'collision',

--- a/src/scripts/claim-lock.mts
+++ b/src/scripts/claim-lock.mts
@@ -38,6 +38,23 @@
 // path is the other recovery exception: an authorized takeover removes that
 // exact directory before installing the replacement.
 //
+// Fresh-create atomicity (#2920): the very first `--acquire` against an
+// absent lock also writes to the lock path, via `createLockFileExclusively`
+// below -- a same-directory temp-write + `linkSync` (atomic, EEXIST-exclusive
+// hard link), never a direct `writeFileSync(path, ..., { flag: 'wx' })`. A
+// direct `wx` create leaves a window between the file becoming visible at
+// `path` (open+create) and its content finishing (write) where a concurrent
+// `readLock` can observe a torn/partial body and misclassify it as
+// `malformed` -- producing a false `collision` result even when the same
+// `claimId` is about to win the race. Writing the full body to a temp file
+// first (fully written and closed before it is ever linked in) and then
+// atomically hard-linking it into place closes that window structurally: a
+// concurrent reader can only ever observe "absent" or a fully-formed body at
+// `path`, never a partial one. `linkSync` is create-only (no replace
+// semantics), so unlike the takeover path's `renameSync` fallback above, it
+// needs no Windows-specific recovery branch -- `CreateHardLinkW` fails
+// cleanly with `EEXIST` there too when the destination already exists.
+//
 // This lock intentionally does not try to perfectly serialize two
 // concurrent authorized takeovers of the same worktree -- that is a much
 // narrower race than the collision above, and the claim revalidation gate
@@ -124,6 +141,7 @@
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import {
+  linkSync,
   readFileSync,
   renameSync,
   rmSync,
@@ -433,6 +451,54 @@ function overwriteLockAtomically(
 }
 
 /**
+ * Create the lock file at `path` atomically, only when nothing exists there
+ * yet (#2920). Writes the full lock body to a same-directory temp file first
+ * -- fully written and closed before it is ever linked in -- then
+ * `linkSync`s that temp file into `path`. `linkSync` is both atomic and
+ * `EEXIST`-exclusive: a losing concurrent caller gets a clean `EEXIST`, never
+ * a chance to observe partial content at `path` mid-write, unlike a direct
+ * `writeFileSync(path, ..., { flag: 'wx' })` (open+create, then a separate
+ * write). Returns `'created'` on success or `'exists'` on a losing race
+ * (`EEXIST`); any other error rethrows -- deliberately, rather than falling
+ * back to the direct `wx` write this function replaces: a worktree's private
+ * git-admin directory lives on the same filesystem as the rest of the git
+ * repository, so the mainstream, hard-link-capable filesystems this
+ * repository already depends on elsewhere (ext4, APFS, NTFS) cover the
+ * supported case. A filesystem that rejects `linkSync` entirely (no
+ * hard-link support) fails this call loudly instead of silently
+ * reintroducing the exact torn-read race this function exists to close.
+ */
+function createLockFileExclusively(
+  path: string,
+  agentId: string,
+  claimId: string,
+): 'created' | 'exists' {
+  const tmpPath = `${path}.tmp-${process.pid}-${Math.random().toString(36).slice(2)}`;
+  writeFileSync(tmpPath, renderLockBody(agentId, claimId), { flag: 'wx' });
+  try {
+    linkSync(tmpPath, path);
+    return 'created';
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+      return 'exists';
+    }
+    throw error;
+  } finally {
+    // Unlike `atomicReplaceFile`'s finally (where a successful `renameSync`
+    // already moved `tmpPath` away, making this a no-op ENOENT), a
+    // successful `linkSync` here leaves `tmpPath` in place as a second,
+    // now-redundant hard link to the same content -- this unlink is what
+    // actually removes it. Best-effort: a cleanup failure here never masks
+    // a real create/link error, and a leaked temp file is harmless.
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      // ignore
+    }
+  }
+}
+
+/**
  * Outcome shape returned by {@link acquireClaimLock}. `racedCreate` is
  * only ever set alongside `reacquired: true`: it means this exact
  * invocation's own first read found the lock absent, and its own
@@ -496,20 +562,15 @@ export function acquireClaimLock(
     }
 
     if (read.status === 'absent') {
-      try {
-        writeFileSync(path, renderLockBody(agentId, claimId), { flag: 'wx' });
+      if (createLockFileExclusively(path, agentId, claimId) === 'created') {
         return { mode: 'acquired', path };
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
-          throw error;
-        }
-        // Raced with a concurrent fresh acquire between the read above and
-        // this create; loop around to re-read and re-decide. Any
-        // `reacquired: true` this call reports from here on is no longer
-        // from its own first look, so it also carries `racedCreate: true`
-        // (see the function-level doc comment above).
-        continue;
       }
+      // Raced with a concurrent fresh acquire between the read above and
+      // this create; loop around to re-read and re-decide. Any
+      // `reacquired: true` this call reports from here on is no longer
+      // from its own first look, so it also carries `racedCreate: true`
+      // (see the function-level doc comment above).
+      continue;
     }
 
     // Either a different claim-id, or a malformed body whose holder can't
@@ -537,26 +598,18 @@ export function acquireClaimLock(
     return { mode: 'acquired', path, reacquired: true, racedCreate: true };
   }
   if (finalRead.status === 'absent') {
-    try {
-      writeFileSync(path, renderLockBody(agentId, claimId), { flag: 'wx' });
+    if (createLockFileExclusively(path, agentId, claimId) === 'created') {
       return { mode: 'acquired', path };
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
-        throw error;
-      }
-      const racedRead = readLock(path);
-      if (
-        racedRead.status === 'present' &&
-        racedRead.lock.claimId === claimId
-      ) {
-        return { mode: 'acquired', path, reacquired: true, racedCreate: true };
-      }
-      return {
-        mode: 'collision',
-        path,
-        holder: racedRead.status === 'present' ? racedRead.lock : undefined,
-      };
     }
+    const racedRead = readLock(path);
+    if (racedRead.status === 'present' && racedRead.lock.claimId === claimId) {
+      return { mode: 'acquired', path, reacquired: true, racedCreate: true };
+    }
+    return {
+      mode: 'collision',
+      path,
+      holder: racedRead.status === 'present' ? racedRead.lock : undefined,
+    };
   }
   return {
     mode: 'collision',

--- a/tests/claim-lock.test.mts
+++ b/tests/claim-lock.test.mts
@@ -526,6 +526,77 @@ const RACE_WORKER_CODE = `
   });
 `;
 
+// Reader-thread payload for the same race test: a pure `readFileSync`
+// spinner with no `acquireClaimLock` call and therefore no internal
+// `execFileSync('git', ...)` spawn (PR #2923 review, Copilot). The
+// acquirer race window is microseconds wide, and process-spawn overhead
+// inside `acquireClaimLock` itself can serialize the acquirer workers
+// past it on some hosts (observed: 0/7 reproductions at up to N=150
+// acquirer-only workers on a 24-core sandbox host) -- an outcome-shape
+// assertion alone could therefore miss a regression on such a host. This
+// reader busy-loops `readFileSync` on the same lock path from the same
+// release barrier, with no spawn overhead of its own, so it can sample
+// many times inside the same microsecond-scale window and catch a
+// regression to a non-atomic fresh-create directly: any read that
+// succeeds but is not a complete, well-formed lock body is a torn read
+// the atomic `linkSync` fresh-create path (#2920) must make impossible.
+const RACE_READER_CODE = `
+  const { workerData, parentPort } = require('node:worker_threads');
+  const { readFileSync } = require('node:fs');
+  const { lockPath, sab } = workerData;
+  const ints = new Int32Array(sab);
+  Atomics.add(ints, 0, 1);
+  Atomics.wait(ints, 1, 0);
+  const badReads = [];
+  let readCount = 0;
+  let nonEnoentReadCount = 0;
+  const deadline = Date.now() + 5000;
+  while (Atomics.load(ints, 2) === 0 && Date.now() < deadline) {
+    readCount += 1;
+    let body;
+    try {
+      body = readFileSync(lockPath, 'utf8');
+    } catch (error) {
+      if (error && error.code === 'ENOENT') {
+        continue;
+      }
+      badReads.push({
+        kind: 'read-error',
+        code: error && error.code,
+        message: String(error && error.message),
+      });
+      continue;
+    }
+    if (nonEnoentReadCount === 0) {
+      // Report this reader's first non-ENOENT read so the main thread
+      // can wait for every reader to have genuinely sampled the file
+      // at least once before signaling stop (CodeRabbit review, PR
+      // #2923) -- otherwise a reader the scheduler never got around to
+      // before the acquirer race settled could report zero reads and
+      // silently contribute no coverage on that run.
+      Atomics.add(ints, 3, 1);
+    }
+    nonEnoentReadCount += 1;
+    if (body.length === 0) {
+      badReads.push({ kind: 'empty' });
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(body);
+      if (
+        !parsed ||
+        typeof parsed.claimId !== 'string' ||
+        typeof parsed.agentId !== 'string'
+      ) {
+        badReads.push({ kind: 'malformed-shape', body });
+      }
+    } catch {
+      badReads.push({ kind: 'parse-error', body });
+    }
+  }
+  parentPort.postMessage({ badReads, readCount, nonEnoentReadCount });
+`;
+
 // Kept deliberately small: a full worker_threads race harness costs real
 // wall-clock time in CI (measured ~57s at ROUNDS=5, CONCURRENT_ACQUIRES=60
 // on a constrained runner -- PR #2917 review, Codex P2), and the constants
@@ -533,12 +604,17 @@ const RACE_WORKER_CODE = `
 // is verifying hard structural invariants that must hold whenever the race
 // manifests, not maximizing the chance it manifests on any given run. See
 // the test body below for why a deterministic (non-probabilistic)
-// reproduction was rejected instead of tuned down.
+// reproduction was rejected in favor of a spawn-free reader instead.
 const RACE_TEST_ROUNDS = 2;
 const RACE_TEST_WORKERS_PER_ROUND = Math.min(
   16,
   Math.max(8, availableParallelism() * 2),
 );
+// Small and fixed rather than scaled with CONCURRENT_ACQUIRES: readers
+// pay no per-worker git-spawn cost, so a handful spinning for the whole
+// release window already samples the race far more densely than adding
+// more acquirers would.
+const RACE_TEST_READERS_PER_ROUND = 4;
 
 test('acquire: structural invariants hold under a same-claim-id race against an absent lock, including the closed torn-read collision gap (PR #2917 review, Codex; gap closed by #2920)', async (t) => {
   // Statistical health check across a couple of rounds, not a proof, like
@@ -554,9 +630,20 @@ test('acquire: structural invariants hold under a same-claim-id race against an 
   // race window open) was considered and rejected: it would add a
   // production-code seam whose only consumer is this one test -- its own
   // reviewable surface, and out of proportion to the field it verifies.
+  // Instead, dedicated spawn-free reader workers (`RACE_READER_CODE`)
+  // busy-loop `readFileSync` on the lock path from the same release
+  // barrier as the acquirers: with no git-spawn overhead of their own,
+  // they sample the microsecond-scale window far more densely than the
+  // acquirer race itself needs to land on it, and a hard assertion below
+  // requires every read they observe to be either absent (`ENOENT`) or a
+  // complete, well-formed lock body -- never torn. This directly catches
+  // a regression to a non-atomic fresh-create even on a host (or CI
+  // runner) where the acquirer-only race happens not to collide (PR
+  // #2923 review, Copilot -- the outcome-shape assertions alone do not
+  // reliably exercise the race per #2920's own acceptance criterion).
   // `acquireClaimLock`'s three `reacquired`-from-a-retry return sites
   // (the source of `racedCreate: true`) are verified by direct code
-  // reading instead, and separately by the deterministic
+  // reading, and separately by the deterministic
   // "genuinely pre-existing matching lock" test below, which exercises the
   // *no-race* path exactly. This test's positive `racedCreate`
   // observation stays a diagnostic, not a hard assertion, precisely
@@ -574,6 +661,10 @@ test('acquire: structural invariants hold under a same-claim-id race against an 
   //   claim-id, so a genuine different-claim-id collision was never
   //   possible in this scenario either -- any `collision` outcome now
   //   means a regression, not an accepted pre-existing gap
+  // - every reader's spin-loop over the same window never observes a
+  //   torn (empty, partial, or malformed) lock body -- reliably exercised
+  //   regardless of whether the acquirer-only race additionally collides
+  //   on this host
   // - exactly one outcome is a true fresh create (mode:'acquired', no
   //   `reacquired`) -- the atomic create is exclusive at the OS level
   // - every `racedCreate:true` co-occurs with `reacquired:true`
@@ -589,35 +680,56 @@ test('acquire: structural invariants hold under a same-claim-id race against an 
     const lockPath = resolveClaimLockPath(fixture.worktree);
     const ROUNDS = RACE_TEST_ROUNDS;
     const CONCURRENT_ACQUIRES = RACE_TEST_WORKERS_PER_ROUND;
+    const READERS = RACE_TEST_READERS_PER_ROUND;
     let anyRacedCreate = false;
+    let totalReads = 0;
+    let totalNonEnoentReads = 0;
 
     for (let round = 0; round < ROUNDS; round += 1) {
       rmSync(lockPath, { force: true });
 
-      const sab = new SharedArrayBuffer(8);
+      const sab = new SharedArrayBuffer(16);
       const ints = new Int32Array(sab);
-      // ints[0]: ready count; ints[1]: go flag.
+      // ints[0]: ready count; ints[1]: go flag; ints[2]: reader-stop
+      // flag; ints[3]: count of readers that have had at least one
+      // non-ENOENT read.
       Atomics.store(ints, 0, 0);
       Atomics.store(ints, 1, 0);
+      Atomics.store(ints, 2, 0);
+      Atomics.store(ints, 3, 0);
 
-      const workerRefs: Worker[] = [];
-      const workers = Array.from({ length: CONCURRENT_ACQUIRES }, () => {
+      const acquirerRefs: Worker[] = [];
+      const acquirers = Array.from({ length: CONCURRENT_ACQUIRES }, () => {
         const worker = new Worker(RACE_WORKER_CODE, {
           eval: true,
           workerData: { worktree: fixture.worktree, sab, cliUrl },
         });
-        workerRefs.push(worker);
+        acquirerRefs.push(worker);
         return new Promise((resolve, reject) => {
           worker.on('message', resolve);
           worker.on('error', reject);
         });
       });
 
-      // Poll until every worker in this round has imported the module
-      // and reached its own Atomics.wait, then release them together.
+      const readerRefs: Worker[] = [];
+      const readers = Array.from({ length: READERS }, () => {
+        const worker = new Worker(RACE_READER_CODE, {
+          eval: true,
+          workerData: { lockPath, sab },
+        });
+        readerRefs.push(worker);
+        return new Promise((resolve, reject) => {
+          worker.on('message', resolve);
+          worker.on('error', reject);
+        });
+      });
+
+      // Poll until every worker in this round -- acquirers and readers
+      // alike -- has reached its own Atomics.wait, then release them
+      // together.
       const deadline = Date.now() + 10_000;
       while (
-        Atomics.load(ints, 0) < CONCURRENT_ACQUIRES &&
+        Atomics.load(ints, 0) < CONCURRENT_ACQUIRES + READERS &&
         Date.now() < deadline
       ) {
         await new Promise((resolve) => setTimeout(resolve, 5));
@@ -625,17 +737,47 @@ test('acquire: structural invariants hold under a same-claim-id race against an 
       Atomics.store(ints, 1, 1);
       Atomics.notify(ints, 1);
 
-      const outcomes = (await Promise.all(workers)) as Array<{
+      const outcomes = (await Promise.all(acquirers)) as Array<{
         mode: string;
         reacquired?: boolean;
         racedCreate?: boolean;
         holder?: unknown;
       }>;
-      // Terminate only after every worker has already posted its
-      // outcome and settled, so tearing one thread down can never
-      // race another round's still-in-flight worker in this same
-      // batch (PR #2917 review, Codex P2).
-      await Promise.all(workerRefs.map((worker) => worker.terminate()));
+      // Every acquirer has settled and the winning lock body is already
+      // final on disk, so wait for every reader to have observed at
+      // least one non-ENOENT read before signaling stop (CodeRabbit
+      // review, PR #2923) -- otherwise a reader the scheduler never got
+      // around to during the race window could report zero reads and
+      // silently contribute no coverage on that run. The file is stably
+      // present at this point, so this wait is expected to resolve
+      // almost immediately; a real timeout means a reader never ran at
+      // all, worth failing loudly on rather than passing silently.
+      const readersSeenDeadline = Date.now() + 2_000;
+      while (
+        Atomics.load(ints, 3) < READERS &&
+        Date.now() < readersSeenDeadline
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      assert.equal(
+        Atomics.load(ints, 3),
+        READERS,
+        `expected all ${READERS} reader(s) to observe at least one non-ENOENT read in round ${round} before stopping; only ${Atomics.load(ints, 3)} did -- a reader may never have been scheduled`,
+      );
+      // Tell the readers to stop spinning and collect their reports.
+      Atomics.store(ints, 2, 1);
+      const readerReports = (await Promise.all(readers)) as Array<{
+        badReads: Array<{ kind: string }>;
+        readCount: number;
+        nonEnoentReadCount: number;
+      }>;
+      // Terminate only after every worker (acquirers and readers) has
+      // already posted its outcome and settled, so tearing one thread
+      // down can never race another round's still-in-flight worker in
+      // this same batch (PR #2917 review, Codex P2).
+      await Promise.all(
+        [...acquirerRefs, ...readerRefs].map((worker) => worker.terminate()),
+      );
 
       for (const outcome of outcomes) {
         assert.equal(
@@ -651,6 +793,16 @@ test('acquire: structural invariants hold under a same-claim-id race against an 
           );
           anyRacedCreate = true;
         }
+      }
+
+      for (const report of readerReports) {
+        assert.deepEqual(
+          report.badReads,
+          [],
+          `reader observed a torn/malformed lock-file read in round ${round} (regression to a non-atomic fresh-create, #2920): ${JSON.stringify(report.badReads)}`,
+        );
+        totalReads += report.readCount;
+        totalNonEnoentReads += report.nonEnoentReadCount;
       }
 
       const freshCreates = outcomes.filter(
@@ -671,6 +823,9 @@ test('acquire: structural invariants hold under a same-claim-id race against an 
       anyRacedCreate
         ? `observed racedCreate:true across ${ROUNDS} round(s)`
         : `no racedCreate:true observed across ${ROUNDS} round(s) on this host -- the positive path is verified by construction (acquireClaimLock's three reacquired-from-a-retry return sites), not exercised deterministically here`,
+    );
+    t.diagnostic(
+      `readers performed ${totalReads} read attempt(s) (${totalNonEnoentReads} non-ENOENT) across ${ROUNDS} round(s); zero torn/malformed reads observed`,
     );
   } finally {
     teardown(fixture);

--- a/tests/claim-lock.test.mts
+++ b/tests/claim-lock.test.mts
@@ -514,8 +514,47 @@ test('acquire: N concurrent forced-takeovers never corrupt the lock — every wr
 // TypeScript-aware one.
 const RACE_WORKER_CODE = `
   const { workerData, parentPort } = require('node:worker_threads');
+  const fs = require('node:fs');
   const { worktree, sab, cliUrl } = workerData;
   const ints = new Int32Array(sab);
+  // Deterministically widen the fresh-create race window (PR #2923
+  // review, Copilot -- a scheduler could otherwise run every acquirer
+  // to completion before any reader gets a timeslice, so the readers
+  // only prove they saw the stable final file, not the write itself).
+  // Intercept any exclusive-create write ({ flag: 'wx' }) this
+  // worker's own acquireClaimLock call makes, and yield the CPU for a
+  // bounded pause between the file becoming visible (open) and its
+  // content finishing (write) -- long enough that a busy-spinning
+  // reader on another OS thread is virtually guaranteed to be
+  // scheduled during it, on any host including a constrained CI
+  // runner. This turns "readers probably sample the window" into
+  // "readers provably do," entirely test-side: the patch lives only
+  // in this worker's own module registry, propagated from the CJS
+  // \`fs\` export object to the compiled CLI module's ESM named
+  // import of the same function via node:module's
+  // syncBuiltinESMExports (a documented Node mechanism for exactly
+  // this). A production-code injection hook was considered instead
+  // and rejected as its own reviewable surface for a single test; this
+  // needs none.
+  const originalWriteFileSync = fs.writeFileSync;
+  fs.writeFileSync = (path, data, opts) => {
+    if (!opts || opts.flag !== 'wx') {
+      return originalWriteFileSync(path, data, opts);
+    }
+    const fd = fs.openSync(path, 'wx');
+    Atomics.add(ints, 4, 1);
+    try {
+      // ints[5] is never written elsewhere, so this always times out --
+      // a bounded, scheduler-yielding pause, not a real wait for a
+      // signal.
+      Atomics.wait(ints, 5, 0, 20);
+    } finally {
+      Atomics.sub(ints, 4, 1);
+    }
+    fs.writeSync(fd, data);
+    fs.closeSync(fd);
+  };
+  require('node:module').syncBuiltinESMExports();
   import(cliUrl).then(({ acquireClaimLock }) => {
     // Signal ready, then block until the main thread releases every
     // worker in this round at (as close to) the same instant.
@@ -529,17 +568,23 @@ const RACE_WORKER_CODE = `
 // Reader-thread payload for the same race test: a pure `readFileSync`
 // spinner with no `acquireClaimLock` call and therefore no internal
 // `execFileSync('git', ...)` spawn (PR #2923 review, Copilot). The
-// acquirer race window is microseconds wide, and process-spawn overhead
-// inside `acquireClaimLock` itself can serialize the acquirer workers
-// past it on some hosts (observed: 0/7 reproductions at up to N=150
-// acquirer-only workers on a 24-core sandbox host) -- an outcome-shape
-// assertion alone could therefore miss a regression on such a host. This
-// reader busy-loops `readFileSync` on the same lock path from the same
-// release barrier, with no spawn overhead of its own, so it can sample
-// many times inside the same microsecond-scale window and catch a
+// acquirer race window would otherwise be microseconds wide, and
+// process-spawn overhead inside `acquireClaimLock` itself can serialize
+// the acquirer workers past it on some hosts (observed: 0/7
+// reproductions at up to N=150 acquirer-only workers on a 24-core
+// sandbox host) -- an outcome-shape assertion alone could therefore
+// miss a regression on such a host. This reader busy-loops
+// `readFileSync` on the same lock path from the same release barrier,
+// with no spawn overhead of its own, so it can sample many times inside
+// the widened window (see `RACE_WORKER_CODE` above) and catch a
 // regression to a non-atomic fresh-create directly: any read that
 // succeeds but is not a complete, well-formed lock body is a torn read
 // the atomic `linkSync` fresh-create path (#2920) must make impossible.
+// The shape check mirrors `readLock`'s own validator
+// (`src/scripts/claim-lock.mts`), including `acquiredAt`, not just
+// `claimId`/`agentId` (CodeRabbit + Copilot review, PR #2923) -- a body
+// missing only that field would otherwise pass this check while
+// production code classifies it malformed.
 const RACE_READER_CODE = `
   const { workerData, parentPort } = require('node:worker_threads');
   const { readFileSync } = require('node:fs');
@@ -550,9 +595,22 @@ const RACE_READER_CODE = `
   const badReads = [];
   let readCount = 0;
   let nonEnoentReadCount = 0;
-  const deadline = Date.now() + 5000;
+  let readsDuringWindow = 0;
+  // Must exceed the main thread's release-barrier budget (10s) plus its
+  // reader-coverage wait (2s), so the stop flag -- not this fallback --
+  // is what normally ends the loop; this is only a last-resort backstop
+  // against a hung round (CodeRabbit review, PR #2923).
+  const deadline = Date.now() + 20_000;
   while (Atomics.load(ints, 2) === 0 && Date.now() < deadline) {
     readCount += 1;
+    // ints[4] > 0 means some acquirer is currently paused between
+    // opening its exclusive-create file and finishing its content
+    // write (see RACE_WORKER_CODE) -- count every read attempted in
+    // that window, regardless of outcome, as evidence this reader was
+    // actually scheduled during it rather than only after it closed.
+    if (Atomics.load(ints, 4) > 0) {
+      readsDuringWindow += 1;
+    }
     let body;
     try {
       body = readFileSync(lockPath, 'utf8');
@@ -586,7 +644,8 @@ const RACE_READER_CODE = `
       if (
         !parsed ||
         typeof parsed.claimId !== 'string' ||
-        typeof parsed.agentId !== 'string'
+        typeof parsed.agentId !== 'string' ||
+        typeof parsed.acquiredAt !== 'string'
       ) {
         badReads.push({ kind: 'malformed-shape', body });
       }
@@ -594,7 +653,12 @@ const RACE_READER_CODE = `
       badReads.push({ kind: 'parse-error', body });
     }
   }
-  parentPort.postMessage({ badReads, readCount, nonEnoentReadCount });
+  parentPort.postMessage({
+    badReads,
+    readCount,
+    nonEnoentReadCount,
+    readsDuringWindow,
+  });
 `;
 
 // Kept deliberately small: a full worker_threads race harness costs real
@@ -603,8 +667,10 @@ const RACE_READER_CODE = `
 // below are a proportionality call, not a precision one -- the test's job
 // is verifying hard structural invariants that must hold whenever the race
 // manifests, not maximizing the chance it manifests on any given run. See
-// the test body below for why a deterministic (non-probabilistic)
-// reproduction was rejected in favor of a spawn-free reader instead.
+// the test body below for why a *production*-code deterministic-reproduction
+// hook was rejected in favor of a spawn-free reader plus a test-side `fs`
+// interposition in the acquirer worker (`RACE_WORKER_CODE`) that
+// deterministically widens the race window instead.
 const RACE_TEST_ROUNDS = 2;
 const RACE_TEST_WORKERS_PER_ROUND = Math.min(
   16,
@@ -626,21 +692,35 @@ test('acquire: structural invariants hold under a same-claim-id race against an 
   // specific race in practice. In-process worker threads sharing one
   // Node process avoid that overhead and do, on hosts with enough cores.
   //
-  // A deterministic reproduction (a test-only injection hook forcing the
-  // race window open) was considered and rejected: it would add a
-  // production-code seam whose only consumer is this one test -- its own
-  // reviewable surface, and out of proportion to the field it verifies.
-  // Instead, dedicated spawn-free reader workers (`RACE_READER_CODE`)
-  // busy-loop `readFileSync` on the lock path from the same release
-  // barrier as the acquirers: with no git-spawn overhead of their own,
-  // they sample the microsecond-scale window far more densely than the
-  // acquirer race itself needs to land on it, and a hard assertion below
-  // requires every read they observe to be either absent (`ENOENT`) or a
-  // complete, well-formed lock body -- never torn. This directly catches
-  // a regression to a non-atomic fresh-create even on a host (or CI
-  // runner) where the acquirer-only race happens not to collide (PR
-  // #2923 review, Copilot -- the outcome-shape assertions alone do not
-  // reliably exercise the race per #2920's own acceptance criterion).
+  // A *production*-code injection hook forcing the race window open was
+  // considered and rejected: it would add a production seam whose only
+  // consumer is this one test -- its own reviewable surface, and out of
+  // proportion to the field it verifies. Instead, two test-side
+  // mechanisms combine to make the race deterministic without touching
+  // production code:
+  // - `RACE_WORKER_CODE` (the acquirer payload) intercepts its own
+  //   worker's exclusive-create write ({ flag: 'wx' }) via a CJS-side
+  //   `fs.writeFileSync` patch synced into the compiled CLI module's ESM
+  //   import (`node:module`'s `syncBuiltinESMExports`), and yields the
+  //   CPU for a bounded pause between the file becoming visible and its
+  //   content finishing -- widening a window that would otherwise be
+  //   microseconds wide into one busy-spinning readers on other OS
+  //   threads are virtually guaranteed to be scheduled during, on any
+  //   host including a constrained CI runner.
+  // - `RACE_READER_CODE` (the reader payload) busy-loops `readFileSync`
+  //   on the lock path from the same release barrier as the acquirers,
+  //   with no git-spawn overhead of its own, and a hard assertion below
+  //   requires every read it observes to be either absent (`ENOENT`) or
+  //   a complete, well-formed lock body -- never torn -- plus a separate
+  //   hard assertion that at least one read across all readers actually
+  //   landed inside the widened window each round, so the mechanism's
+  //   own liveness is verified rather than assumed.
+  // Together these directly catch a regression to a non-atomic
+  // fresh-create deterministically, not merely with high probability (PR
+  // #2923 review, Copilot -- outcome-shape assertions alone do not
+  // reliably exercise the race, and a reader that only ever observes the
+  // settled post-write file does not either, per #2920's own acceptance
+  // criterion).
   // `acquireClaimLock`'s three `reacquired`-from-a-retry return sites
   // (the source of `racedCreate: true`) are verified by direct code
   // reading, and separately by the deterministic
@@ -662,9 +742,12 @@ test('acquire: structural invariants hold under a same-claim-id race against an 
   //   possible in this scenario either -- any `collision` outcome now
   //   means a regression, not an accepted pre-existing gap
   // - every reader's spin-loop over the same window never observes a
-  //   torn (empty, partial, or malformed) lock body -- reliably exercised
-  //   regardless of whether the acquirer-only race additionally collides
-  //   on this host
+  //   torn (empty, partial, or malformed) lock body -- deterministically
+  //   exercised via the widened window above, regardless of whether the
+  //   acquirer-only race additionally collides on this host
+  // - at least one reader read lands inside the widened window each
+  //   round -- proof the interception/yield mechanism itself is live,
+  //   not merely assumed to be
   // - exactly one outcome is a true fresh create (mode:'acquired', no
   //   `reacquired`) -- the atomic create is exclusive at the OS level
   // - every `racedCreate:true` co-occurs with `reacquired:true`
@@ -684,19 +767,41 @@ test('acquire: structural invariants hold under a same-claim-id race against an 
     let anyRacedCreate = false;
     let totalReads = 0;
     let totalNonEnoentReads = 0;
+    let totalReadsDuringWindow = 0;
 
-    for (let round = 0; round < ROUNDS; round += 1) {
+    // Round -1 is an unasserted warm-up, not part of ROUNDS. A fresh
+    // process's very first worker_threads batch pays one-time costs
+    // (V8 isolate/module bootstrap, first-ever dynamic `import()` of the
+    // compiled CLI module, first-ever `git` spawn) that can stretch an
+    // acquirer's own pre-pause work well past the intended 20ms window,
+    // observed directly: round "0" without this warm-up sometimes showed
+    // 0 reader reads landing inside the window even though acquirers did
+    // reach and execute it, purely because the round finished before a
+    // still-warming-up reader's busy-loop or the still-warming-up
+    // acquirers' pauses ever overlapped in wall-clock time. Every
+    // measured round after the first one reliably shows the window
+    // covering most of that round's reads (tens of thousands observed
+    // locally), so one throwaway round absorbs the one-time cost instead
+    // of the assertions having to tolerate it.
+    for (let round = -1; round < ROUNDS; round += 1) {
+      const isWarmup = round === -1;
       rmSync(lockPath, { force: true });
 
-      const sab = new SharedArrayBuffer(16);
+      const sab = new SharedArrayBuffer(32);
       const ints = new Int32Array(sab);
       // ints[0]: ready count; ints[1]: go flag; ints[2]: reader-stop
       // flag; ints[3]: count of readers that have had at least one
-      // non-ENOENT read.
+      // non-ENOENT read; ints[4]: count of acquirers currently paused
+      // between opening their exclusive-create file and finishing its
+      // content write (RACE_WORKER_CODE's deterministic window); ints[5]
+      // is a dedicated always-zero Atomics.wait target used only to
+      // yield the CPU for that pause, never written elsewhere.
       Atomics.store(ints, 0, 0);
       Atomics.store(ints, 1, 0);
       Atomics.store(ints, 2, 0);
       Atomics.store(ints, 3, 0);
+      Atomics.store(ints, 4, 0);
+      Atomics.store(ints, 5, 0);
 
       const acquirerRefs: Worker[] = [];
       const acquirers = Array.from({ length: CONCURRENT_ACQUIRES }, () => {
@@ -743,34 +848,46 @@ test('acquire: structural invariants hold under a same-claim-id race against an 
         racedCreate?: boolean;
         holder?: unknown;
       }>;
-      // Every acquirer has settled and the winning lock body is already
-      // final on disk, so wait for every reader to have observed at
-      // least one non-ENOENT read before signaling stop (CodeRabbit
-      // review, PR #2923) -- otherwise a reader the scheduler never got
-      // around to during the race window could report zero reads and
-      // silently contribute no coverage on that run. The file is stably
-      // present at this point, so this wait is expected to resolve
-      // almost immediately; a real timeout means a reader never ran at
-      // all, worth failing loudly on rather than passing silently.
-      const readersSeenDeadline = Date.now() + 2_000;
-      while (
-        Atomics.load(ints, 3) < READERS &&
-        Date.now() < readersSeenDeadline
-      ) {
-        await new Promise((resolve) => setTimeout(resolve, 5));
-      }
-      assert.equal(
-        Atomics.load(ints, 3),
-        READERS,
-        `expected all ${READERS} reader(s) to observe at least one non-ENOENT read in round ${round} before stopping; only ${Atomics.load(ints, 3)} did -- a reader may never have been scheduled`,
-      );
-      // Tell the readers to stop spinning and collect their reports.
-      Atomics.store(ints, 2, 1);
-      const readerReports = (await Promise.all(readers)) as Array<{
+      let readerReports: Array<{
         badReads: Array<{ kind: string }>;
         readCount: number;
         nonEnoentReadCount: number;
+        readsDuringWindow: number;
       }>;
+      if (isWarmup) {
+        // Skip the reader-coverage wait during warm-up -- its own
+        // purpose is priming the JIT/worker-creation machinery, not
+        // proving coverage, and would be subject to the exact same
+        // cold-start variance this round exists to absorb.
+        Atomics.store(ints, 2, 1);
+        readerReports = (await Promise.all(readers)) as typeof readerReports;
+      } else {
+        // Every acquirer has settled and the winning lock body is
+        // already final on disk, so wait for every reader to have
+        // observed at least one non-ENOENT read before signaling stop
+        // (CodeRabbit review, PR #2923) -- otherwise a reader the
+        // scheduler never got around to during the race window could
+        // report zero reads and silently contribute no coverage on
+        // this run. The file is stably present at this point, so this
+        // wait is expected to resolve almost immediately; a real
+        // timeout means a reader never ran at all, worth failing
+        // loudly on rather than passing silently.
+        const readersSeenDeadline = Date.now() + 2_000;
+        while (
+          Atomics.load(ints, 3) < READERS &&
+          Date.now() < readersSeenDeadline
+        ) {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+        }
+        assert.equal(
+          Atomics.load(ints, 3),
+          READERS,
+          `expected all ${READERS} reader(s) to observe at least one non-ENOENT read in round ${round} before stopping; only ${Atomics.load(ints, 3)} did -- a reader may never have been scheduled`,
+        );
+        // Tell the readers to stop spinning and collect their reports.
+        Atomics.store(ints, 2, 1);
+        readerReports = (await Promise.all(readers)) as typeof readerReports;
+      }
       // Terminate only after every worker (acquirers and readers) has
       // already posted its outcome and settled, so tearing one thread
       // down can never race another round's still-in-flight worker in
@@ -778,6 +895,10 @@ test('acquire: structural invariants hold under a same-claim-id race against an 
       await Promise.all(
         [...acquirerRefs, ...readerRefs].map((worker) => worker.terminate()),
       );
+
+      if (isWarmup) {
+        continue;
+      }
 
       for (const outcome of outcomes) {
         assert.equal(
@@ -795,6 +916,7 @@ test('acquire: structural invariants hold under a same-claim-id race against an 
         }
       }
 
+      let roundReadsDuringWindow = 0;
       for (const report of readerReports) {
         assert.deepEqual(
           report.badReads,
@@ -803,7 +925,13 @@ test('acquire: structural invariants hold under a same-claim-id race against an 
         );
         totalReads += report.readCount;
         totalNonEnoentReads += report.nonEnoentReadCount;
+        roundReadsDuringWindow += report.readsDuringWindow;
       }
+      totalReadsDuringWindow += roundReadsDuringWindow;
+      assert.ok(
+        roundReadsDuringWindow > 0,
+        `expected at least one reader read to land inside the widened exclusive-create window in round ${round} -- got 0, meaning the deterministic-window mechanism itself did not fire or no reader was scheduled during it (PR #2923 review, Copilot)`,
+      );
 
       const freshCreates = outcomes.filter(
         (outcome) => outcome.mode === 'acquired' && outcome.reacquired !== true,
@@ -825,7 +953,7 @@ test('acquire: structural invariants hold under a same-claim-id race against an 
         : `no racedCreate:true observed across ${ROUNDS} round(s) on this host -- the positive path is verified by construction (acquireClaimLock's three reacquired-from-a-retry return sites), not exercised deterministically here`,
     );
     t.diagnostic(
-      `readers performed ${totalReads} read attempt(s) (${totalNonEnoentReads} non-ENOENT) across ${ROUNDS} round(s); zero torn/malformed reads observed`,
+      `readers performed ${totalReads} read attempt(s) (${totalNonEnoentReads} non-ENOENT, ${totalReadsDuringWindow} inside the widened exclusive-create window) across ${ROUNDS} round(s); zero torn/malformed reads observed`,
     );
   } finally {
     teardown(fixture);

--- a/tests/claim-lock.test.mts
+++ b/tests/claim-lock.test.mts
@@ -540,7 +540,7 @@ const RACE_TEST_WORKERS_PER_ROUND = Math.min(
   Math.max(8, availableParallelism() * 2),
 );
 
-test('acquire: structural invariants hold under a same-claim-id race against an absent lock (PR #2917 review, Codex; racedCreate observation is a diagnostic, torn-read gap tracked in kurone-kito/idd-skill#2920)', async (t) => {
+test('acquire: structural invariants hold under a same-claim-id race against an absent lock, including the closed torn-read collision gap (PR #2917 review, Codex; gap closed by #2920)', async (t) => {
   // Statistical health check across a couple of rounds, not a proof, like
   // the concurrent-takeovers test above -- but using worker_threads with an
   // Atomics ready-count barrier instead of subprocess spawning. The
@@ -548,9 +548,7 @@ test('acquire: structural invariants hold under a same-claim-id race against an 
   // overhead (milliseconds) reliably swamps it, so a subprocess batch
   // (like the takeover test above) essentially never reproduces this
   // specific race in practice. In-process worker threads sharing one
-  // Node process avoid that overhead and do, on hosts with enough cores
-  // -- see kurone-kito/idd-skill#2920 for the measurements this is based
-  // on and the pre-existing gap the torn-read branch below documents.
+  // Node process avoid that overhead and do, on hosts with enough cores.
   //
   // A deterministic reproduction (a test-only injection hook forcing the
   // race window open) was considered and rejected: it would add a
@@ -560,25 +558,25 @@ test('acquire: structural invariants hold under a same-claim-id race against an 
   // (the source of `racedCreate: true`) are verified by direct code
   // reading instead, and separately by the deterministic
   // "genuinely pre-existing matching lock" test below, which exercises the
-  // *no-race* path exactly. This test's positive `racedCreate`/torn-read
-  // observations stay a diagnostic, not a hard assertion, precisely
+  // *no-race* path exactly. This test's positive `racedCreate`
+  // observation stays a diagnostic, not a hard assertion, precisely
   // because a regression that stopped setting `racedCreate` entirely could
-  // still pass a run that never happens to observe the race -- the
-  // structural invariants asserted below are what this test actually
-  // guards on every run, race-observed or not.
+  // still pass a run that never happens to observe the race.
   //
   // Structural invariants that must hold on every round regardless of
   // whether a race actually manifests on this host:
-  // - every outcome's mode is 'acquired' or 'collision'
+  // - every outcome's mode is 'acquired' -- **never** 'collision': #2920
+  //   closed the fresh-create path's torn-read window (a same-directory
+  //   temp-write + atomic `linkSync` instead of a direct
+  //   `writeFileSync(path, ..., { flag: 'wx' })`), so a same-claim-id race
+  //   against an absent lock can no longer produce a false collision here;
+  //   this batch's own lock starts absent and every acquire uses the same
+  //   claim-id, so a genuine different-claim-id collision was never
+  //   possible in this scenario either -- any `collision` outcome now
+  //   means a regression, not an accepted pre-existing gap
   // - exactly one outcome is a true fresh create (mode:'acquired', no
-  //   `reacquired`) -- O_EXCL create is atomic at the OS level
+  //   `reacquired`) -- the atomic create is exclusive at the OS level
   // - every `racedCreate:true` co-occurs with `reacquired:true`
-  // - every `collision` outcome carries no `holder` -- this batch's own
-  //   lock starts absent and every acquire uses the same claim-id, so a
-  //   genuine different-claim-id collision is impossible here; a
-  //   `collision` can only be the pre-existing torn-read gap (#2920), and
-  //   a `holder` appearing on one would mean a *different*, more serious
-  //   bug than the one this comment documents
   // - the final lock body still names the single fresh creator
   //
   // Whether `racedCreate:true` is actually observed varies with host CPU
@@ -592,7 +590,6 @@ test('acquire: structural invariants hold under a same-claim-id race against an 
     const ROUNDS = RACE_TEST_ROUNDS;
     const CONCURRENT_ACQUIRES = RACE_TEST_WORKERS_PER_ROUND;
     let anyRacedCreate = false;
-    let anyTornReadCollision = false;
 
     for (let round = 0; round < ROUNDS; round += 1) {
       rmSync(lockPath, { force: true });
@@ -641,9 +638,10 @@ test('acquire: structural invariants hold under a same-claim-id race against an 
       await Promise.all(workerRefs.map((worker) => worker.terminate()));
 
       for (const outcome of outcomes) {
-        assert.ok(
-          outcome.mode === 'acquired' || outcome.mode === 'collision',
-          `unexpected mode, got: ${JSON.stringify(outcome)}`,
+        assert.equal(
+          outcome.mode,
+          'acquired',
+          `expected every same-claim-id racer to acquire (never collision, #2920) -- got: ${JSON.stringify(outcome)}`,
         );
         if (outcome.racedCreate === true) {
           assert.equal(
@@ -652,14 +650,6 @@ test('acquire: structural invariants hold under a same-claim-id race against an 
             `racedCreate:true without reacquired:true, got: ${JSON.stringify(outcome)}`,
           );
           anyRacedCreate = true;
-        }
-        if (outcome.mode === 'collision') {
-          assert.equal(
-            outcome.holder,
-            undefined,
-            `expected a same-claim-id collision in this batch to be the torn-read gap (no holder), got: ${JSON.stringify(outcome)}`,
-          );
-          anyTornReadCollision = true;
         }
       }
 
@@ -681,11 +671,6 @@ test('acquire: structural invariants hold under a same-claim-id race against an 
       anyRacedCreate
         ? `observed racedCreate:true across ${ROUNDS} round(s)`
         : `no racedCreate:true observed across ${ROUNDS} round(s) on this host -- the positive path is verified by construction (acquireClaimLock's three reacquired-from-a-retry return sites), not exercised deterministically here`,
-    );
-    t.diagnostic(
-      anyTornReadCollision
-        ? `observed the pre-existing torn-read collision gap (kurone-kito/idd-skill#2920) across ${ROUNDS} round(s)`
-        : `no torn-read collision observed across ${ROUNDS} round(s) on this host`,
     );
   } finally {
     teardown(fixture);


### PR DESCRIPTION
# Summary

Closes `acquireClaimLock`'s fresh-create torn-read gap: a concurrent
`--acquire` call racing the *same* `claim-id` against an absent lock
could previously read the lock file mid-write and misclassify it as
malformed, returning a spurious `collision` even though that same
claim-id was about to win the race.

## Linked issue

Closes #2920

## Follow-up issues (if any)

- [ ] none filed directly (per this repo's rule against calling
  `gh issue create` from an executing session) -- recommended for a
  future authoring pass: the `instructions-only` helper-free fallback
  documented in `docs/idd-helper-scripts.md` (and its `idd-template/`
  mirror) still creates `idd-claim.lock` via a non-atomic
  `open(O_CREAT|O_EXCL)`-then-write sequence sharing the same lock
  namespace as the now-atomic helper-runtime path. A helper-runtime
  session (atomic, post-#2920) racing an `instructions-only` session
  (still non-atomic), or two `instructions-only` sessions racing each
  other, can still hit the same class of false collision this issue
  closes for the helper-runtime path. Out of scope here since it is an
  agent-facing procedure change needing its own review, not named in
  this issue's acceptance criteria.

## Background / rationale (if material)

`acquireClaimLock`'s fresh-create path created the lock file directly
with `writeFileSync(path, ..., { flag: 'wx' })` -- an `open`+`create`
that makes the file visible at `path` before its content-write
completes. A concurrent reader in that narrow window could observe a
torn/partial body and classify it `malformed`, which
`acquireClaimLock`'s existing malformed-handling treats as "always a
same-machine collision either way" -- even when the same `claim-id`
actually owns (or is about to own) the lock.

The fix adds `createLockFileExclusively`: write the full lock body to
a same-directory temp file first (fully written and closed before it
is ever linked in), then `linkSync` that temp file into place.
`linkSync` is both atomic and `EEXIST`-exclusive, so a losing
concurrent caller gets a clean `EEXIST` and never observes partial
content -- closing the window structurally rather than relying on
write size staying small enough to be "usually" atomic. Both
fresh-create call sites in `acquireClaimLock` (the initial loop
iteration and the post-retry-exhaustion fallback) now go through this
helper. `linkSync` is create-only (no replace semantics), so unlike
the existing takeover path's `renameSync` fallback, it needs no
Windows-specific recovery branch. This repository's own Windows CI job
now exercises that path directly (added below, following a Copilot
review on this PR that the job previously ran no part of
`tests/claim-lock.test.mts` at all, per #2920's acceptance criterion
#2) rather than relying on POSIX-analogy assumption about
`CreateHardLinkW`'s `EEXIST` behavior.

This PR rebases past `#2917` (merged while this branch was in
progress), which added `racedCreate` tracking to the same two
fresh-create call sites and its own worker-thread race test that
*tolerated* this exact torn-read collision as a documented,
pre-existing gap. That test is strengthened here to assert the
invariant this fix now guarantees: `mode: 'collision'` can no longer
occur for a same-claim-id race against an absent lock -- a regression
there is now a hard failure instead of an accepted diagnostic.

**Making the race test reliable, across three review rounds on this
PR**: this session's own first draft race test (against a temporary
revert of only the `.mts`/`.mjs` fix) did not reproduce the collision
across 7 runs at up to N=150 workers on this sandbox's 24-core host,
despite the issue's own investigation reporting ~50% reproduction at
N=80 on a comparable host -- most likely because `acquireClaimLock`'s
internal `execFileSync('git', ...)` spawn jitter swamps the
microsecond-scale race window regardless of thread count on this
particular host/filesystem. Copilot review correctly flagged that an
outcome-shape assertion alone therefore does not reliably exercise the
race per #2920's own acceptance criterion. The test now closes that
gap with two mechanisms, both entirely test-side (no production-code
seam): dedicated spawn-free reader workers busy-loop `readFileSync` on
the lock path and hard-assert every read is either absent or a
complete, well-formed body (never torn); and the acquirer worker
deterministically widens the race window itself, by intercepting its
own `writeFileSync(..., { flag: 'wx' })` call and yielding the CPU for
a bounded pause between the file opening and its content finishing (a
test-side `fs` interposition propagated into the compiled CLI module's
ESM import via `node:module`'s `syncBuiltinESMExports`), with a hard
assertion that at least one reader read actually lands inside that
window every round. Verified in both directions after each change:
5-6 consecutive runs failed the relevant assertion against a temporary
revert of only the production fix; 10 consecutive full-suite runs
passed against the fix. Separately, `linkSync`'s atomicity and
`EEXIST`-exclusivity were also verified directly (a losing `linkSync`
against an existing regular file, and separately against an existing
directory, both fail cleanly with `EEXIST` and leave the target
untouched), and the control-flow change was traced by hand against
`MAX_RETRY_ATTEMPTS`.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (biome, dprint, markdownlint, cspell -- all pass; 8
  pre-existing warnings in unrelated files, not from this diff)
- [x] `pnpm test` (`node --test tests/*.test.mts`, full suite green)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (no `idd-template/` docs touched by
  this change)
- [x] `node scripts/idd-doctor.mjs` (passed at both the initial
  post-rebase HEAD and the current HEAD, same 3 pre-existing
  environment warnings each time, unrelated to this diff)
- [x] Windows-relevant `linkSync`/`EEXIST` behavior (#2920 acceptance
  criterion #2) -- not locally runnable on this sandbox's Linux host;
  verified by the new "Windows platform tests" CI job step instead,
  which exercises exactly that path on `windows-latest`

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none -- no change to merge policy
  or gates)
- [x] Context budget impact reviewed (none -- no instruction files
  changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198btW2nnuoe3EDk2TGC38L
