### PR TITLE
docs(advisory-convergence): document GHES upload-artifact limitation

### DIFF
--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -663,6 +663,7 @@ jobs:
           printf 'commentId=%s\nbodyDigest=%s\n' "$COMMENT_ID" "$BODY_DIGEST" \
             > "/tmp/idd-self-waiver-marker/idd-self-waiver-marker-${COMMENT_ID}-${BODY_DIGEST}"
       - name: Upload the posted marker's provenance artifact
+        # v4+ has no GHES Artifacts backend (GHES needs v3.2.2); see kurone-kito/idd-skill#2918 and idd-template/docs/onboarding/optional-host-setup.md.
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: steps.post-waiver.outputs.applied == 'true' && steps.post-waiver.outputs.comment-id != '' && steps.post-waiver.outputs.body-digest != ''
         with:

--- a/idd-template/.github/workflows/idd-advisory-convergence.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence.yml
@@ -815,7 +815,7 @@ jobs:
           printf 'commentId=%s\nbodyDigest=%s\n' "$COMMENT_ID" "$BODY_DIGEST" \
             > "/tmp/idd-self-waiver-marker/idd-self-waiver-marker-${COMMENT_ID}-${BODY_DIGEST}"
       - name: Upload the posted marker's provenance artifact
-        # v4+ has no GHES Artifacts backend (GHES needs v3.2.2); see kurone-kito/idd-skill#2918 and idd-template/docs/onboarding/optional-host-setup.md.
+        # v4+ has no GHES Artifacts backend (GHES needs v3.2.2); see kurone-kito/idd-skill#2918 and docs/onboarding/optional-host-setup.md.
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: steps.post-waiver.outputs.applied == 'true' && steps.post-waiver.outputs.comment-id != '' && steps.post-waiver.outputs.body-digest != ''
         with:

--- a/idd-template/.github/workflows/idd-advisory-convergence.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence.yml
@@ -815,6 +815,7 @@ jobs:
           printf 'commentId=%s\nbodyDigest=%s\n' "$COMMENT_ID" "$BODY_DIGEST" \
             > "/tmp/idd-self-waiver-marker/idd-self-waiver-marker-${COMMENT_ID}-${BODY_DIGEST}"
       - name: Upload the posted marker's provenance artifact
+        # v4+ has no GHES Artifacts backend (GHES needs v3.2.2); see kurone-kito/idd-skill#2918 and idd-template/docs/onboarding/optional-host-setup.md.
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: steps.post-waiver.outputs.applied == 'true' && steps.post-waiver.outputs.comment-id != '' && steps.post-waiver.outputs.body-digest != ''
         with:

--- a/idd-template/docs/onboarding/optional-host-setup.md
+++ b/idd-template/docs/onboarding/optional-host-setup.md
@@ -766,6 +766,25 @@ original, and the portable stub this template mirrors at
 `.github/workflows/idd-advisory-convergence.yml` in your own
 repository does not carry it.
 
+**The self-waiver provenance artifact is unavailable on GHES.** The
+`idd-advisory-convergence-self-waiver` job's "Upload the posted
+marker's provenance artifact" step pins `actions/upload-artifact` v4+
+(currently `v7.0.1`), which needs the newer Artifacts service backend
+that GitHub Enterprise Server does not support; GHES instead needs the
+`v3.2.2` (or `v3.2.2-node20`) release, itself deprecated on
+github.com. Because the
+self-waiver mechanism fails closed, this never lets a forged waiver
+through on GHES — the upload step simply fails, or produces no
+artifact — but it does mean the self-referential-bootstrap-auto
+mechanism can never actually complete on a GHES-hosted adopter,
+degrading every genuine attempt to "no auto-waiver" and leaving only
+the maintainer-authorized waiver path for every such PR (found by a
+Codex review of kurone-kito/idd-skill#2914 during the
+kurone-kito/idd-skill#2912 fix cycle, 2026-09-11). See
+kurone-kito/idd-skill#2918 for the open tradeoff and the rationale for
+keeping the pinned version rather than adding a runner-detection
+branch.
+
 ## Optional — mark the vendored helper bundle `linguist-vendored`
 
 This step applies **only to the `vendored-node` profile** (the only

--- a/idd-template/docs/onboarding/optional-host-setup.md
+++ b/idd-template/docs/onboarding/optional-host-setup.md
@@ -781,9 +781,9 @@ degrading every genuine attempt to "no auto-waiver" and leaving only
 the maintainer-authorized waiver path for every such PR (found by a
 Codex review of kurone-kito/idd-skill#2914 during the
 kurone-kito/idd-skill#2912 fix cycle, 2026-09-11). See
-kurone-kito/idd-skill#2918 for the open tradeoff and the rationale for
-keeping the pinned version rather than adding a runner-detection
-branch.
+kurone-kito/idd-skill#2918 for the full tradeoff discussion and the
+rationale for keeping the pinned version rather than adding a
+runner-detection branch.
 
 ## Optional — mark the vendored helper bundle `linguist-vendored`
 


### PR DESCRIPTION
# Summary

Documents a known GHES (GitHub Enterprise Server) limitation for
`idd-advisory-convergence-self-waiver`'s "Upload the posted marker's
provenance artifact" step: it pins `actions/upload-artifact@v7.0.1`,
which requires the newer Artifacts service backend that GHES does not
support. GHES needs the deprecated (on github.com) `v3.2.2` (or
`v3.2.2-node20`) release instead. Per the maintainer's recorded
Groom-hearing decision on the issue, this is documentation-only: the
pinned action version and workflow behavior are unchanged on both
hosts, no runner-detection branch is added.

Changes:

- `idd-template/docs/onboarding/optional-host-setup.md`: new
  bold-lead-in paragraph at the end of the "Optional — host
  idd-advisory-convergence as a required-check CI workflow" section
  documenting the limitation, its fail-closed consequence (never a
  forged waiver validates on GHES — only availability degrades to "no
  auto-waiver"), and a pointer to this issue.
- `.github/workflows/idd-advisory-convergence.yml` and
  `idd-template/.github/workflows/idd-advisory-convergence.yml`: one
  single-line comment added directly above each pinned `uses:
  actions/upload-artifact@... # v7.0.1` line, citing this issue and
  the doc paragraph as a breadcrumb for a future migration effort.
  The two comments point at different doc paths by design (fixed in
  `fa5effac` after Copilot's review caught it, see below): the source
  repository's own copy cites
  `idd-template/docs/onboarding/optional-host-setup.md`, since that's
  where the file genuinely lives here; the `idd-template/` copy cites
  `docs/onboarding/optional-host-setup.md` instead, since
  `template-distribution.md` strips the `idd-template/` prefix when
  this file reaches an adopter's own repository.

`git diff` on both workflow files shows comment-only additions — no
pin, `if:`, or `with:` change.

## Linked issue

Closes #2918

## Follow-up issues (if any)

- [ ] `idd-advisory-convergence-self-waiver`'s
      self-referential-bootstrap-auto step failed on this PR (this PR's
      own diff touches the checker's trigger-file allowlist, so it
      fired) with `gh: Resource not accessible by integration (HTTP
      403)` posting the waiver comment — run 34599387997, job
      103262709055. Not blocking (non-required check; the
      maintainer-authorized waiver path still covers this PR), but
      worth a maintainer look at the job's `issues: write` permission
      grant if the self-bootstrap path should work going forward.

## Background / rationale (if material)

Found by a Codex review of #2914 during the #2912 fix cycle. The
maintainer's Groom-hearing decision (recorded on the issue) chose
documentation over a runner-detection branch because this repository
does not itself run on GHES, so a runner-detection branch's behavior
on a real GHES runner could never be exercised by this repository's
own CI — an unverifiable "trust the branch logic for an untested
host" gap that fails this project's clear-verification bar for
autopilot work.

**Plan-ordering note**: the B2 plan comment was posted essentially
together with the file edits rather than strictly plan-before-edit;
flagged on the issue per B3's self-check. No content changed as a
result — a critique pass reviewed the draft plan before the post, and
its one accepted suggestion (folding in the issue's own
`v3.2.2-node20` alternative) is reflected in the diff.

**Local `node --test` note**: an early local run was interrupted while
diagnosing unrelated Bash-tool output latency under heavy concurrent
session load on this host (confirmed via `pgrep`/rate-limit checks,
not a defect); a subsequent clean run completed successfully (6190
pass, 0 fail, 3 skipped — all three are pre-existing `win32`-only
subtests that skip by design on this Linux host, unrelated to this
diff, which changed no test files). Hosted CI's own test run is
authoritative regardless, per this repo's
local-flakiness-under-concurrent-load guidance.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013MS7r6EVLb1kWoNKnr2PG6





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented GitHub Enterprise Server compatibility requirements for artifact uploads.
  - Clarified that self-waiver provenance artifacts are unavailable on GHES.
  - Explained that automatic self-waivers fail closed on GHES, leaving maintainer-authorized waivers as the available option.
  - Added references to the relevant artifact version constraints and issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->