### PR TITLE
fix(claim): serialize generated-tokens record writes to save nonces

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -2220,11 +2220,13 @@ close.
   do (`withGeneratedTokensWriteLock`, `src/scripts/claim-lock.mts`):
   atomically create a same-directory `<resolved-path>.writelock` guard
   file (exclusive create -- fails if it already exists), retrying
-  roughly every 5 ms for up to 5 seconds if it does. **Only once that
-  create call itself has actually succeeded** -- never before it, and
-  never merely because this invocation _attempted_ one -- arm a cleanup
-  handler (a shell `trap`, or the agent's own equivalent of a `finally`
-  block) that removes the guard **on every exit path from this point
+  roughly every 5 ms for up to 5 seconds if it does, **writing a fresh,
+  unique per-attempt token as the guard's own body** (a random value,
+  or `pid:timestamp:random` -- any scheme unique per attempt is fine).
+  **Only once that create call itself has actually succeeded** -- never
+  before it, and never merely because this invocation _attempted_ one --
+  arm a cleanup handler (a shell `trap`, or the agent's own equivalent of
+  a `finally` block) that runs on **every exit path from this point
   forward, success or failure alike**, then perform the write (or, for
   the backfill side, the read that captures the existing `nonce` and the
   write that follows it). Arming the handler any earlier (for example a
@@ -2235,26 +2237,45 @@ close.
   concurrent, holder's own guard** instead, reopening the exact ABA race
   #2922's CLI-side fix (`withGeneratedTokensWriteLock`'s own
   `openSync`/`writeSync`/`closeSync` ownership tracking) exists to close
-  (#2922 review round 6, CodeRabbit). An agent that removes the guard
-  solely after a successful write and skips cleanup when that write
-  itself fails leaves the same orphaned-guard problem the CLI's own code
-  was separately reviewed for (#2922 review round 4, Copilot): every
-  later writer for this exact `{claim-id}` then waits the full 5 seconds
-  and fails closed until an operator manually removes it. The guard file's
-  own content is never read by anything -- its mere existence is the
-  whole coordination signal, so no atomic-visibility trick is needed for
-  it, unlike the lock file's own body. If the 5-second wait budget is
-  exhausted, stop fail-closed and report the guard path for manual
-  removal rather than writing anyway (an earlier revision of the CLI's
-  own lock self-reclaimed an aged guard automatically; three independent
-  reviewers found that unsafe -- see the doc comment on
-  `withGeneratedTokensWriteLock` for why fail-closed is the current
-  answer) -- a pre-existing guard this invocation did not itself create
-  is never removed on any path, success or failure. Skipping this
-  coordination reopens the exact race #2922 reported for the CLI path: a
-  concurrent writer's fresher `nonce` can be silently lost, including
-  between an `instructions-only` session and a helper-runtime session
-  sharing the same worktree.
+  (#2922 review round 6, CodeRabbit). The cleanup handler itself must be
+  **token-verified, not unconditional** (#2922 review round 11,
+  Copilot): re-read the guard and remove it only if it still holds the
+  exact token this attempt wrote, mirroring the CLI's own
+  `releaseGeneratedTokensWriteLockIfOwned` (and, before it,
+  `releaseCloneLock` in `src/scripts/clone-lock.mts`) -- an operator can
+  legitimately remove a guard by hand per the fail-closed timeout
+  guidance below while this invocation's own write is still genuinely in
+  flight, and a new writer can recreate it before this invocation's
+  cleanup runs; an unconditional removal there would delete that new
+  writer's guard instead of its own, letting two writers proceed at
+  once. Treat a guard that is simply already gone (removed by hand, or
+  already released) the same as a token mismatch -- nothing left for
+  this cleanup to remove, not an error. This narrows rather than
+  eliminates the race (verifying the token and removing the guard are
+  still two separate steps, not one atomic operation), which is an
+  accepted limitation shared with the CLI's own implementation -- see
+  the doc comment on `withGeneratedTokensWriteLock` in
+  `src/scripts/claim-lock.mts` for the full rationale. An agent that
+  removes the guard solely after a successful write and skips cleanup
+  when that write itself fails leaves the same orphaned-guard problem
+  the CLI's own code was separately reviewed for (#2922 review round 4,
+  Copilot): every later writer for this exact `{claim-id}` then waits
+  the full 5 seconds and fails closed until an operator manually removes
+  it. Unlike the record file's own body, the guard file's content is
+  read back by this same cleanup handler to verify ownership before
+  removing it -- no other, contending reader ever needs to inspect it,
+  so no atomic-visibility trick is needed beyond the exclusive create
+  itself. If the 5-second wait budget is exhausted, stop fail-closed and
+  report the guard path for manual removal rather than writing anyway
+  (an earlier revision of the CLI's own lock self-reclaimed an aged
+  guard automatically; three independent reviewers found that unsafe --
+  see the doc comment on `withGeneratedTokensWriteLock` for why
+  fail-closed is the current answer) -- a pre-existing guard this
+  invocation did not itself create is never removed on any path, success
+  or failure. Skipping this coordination reopens the exact race #2922
+  reported for the CLI path: a concurrent writer's fresher `nonce` can be
+  silently lost, including between an `instructions-only` session and a
+  helper-runtime session sharing the same worktree.
 - **`instructions-only` helper-free fallback, read side** (#2879 review,
   Codex P1 -- the mandatory `--read-tokens` check in the Claim
   revalidation gate has no helper-free path without this): resolve the

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -2212,17 +2212,27 @@ close.
   do (`withGeneratedTokensWriteLock`, `src/scripts/claim-lock.mts`):
   atomically create a same-directory `<resolved-path>.writelock` guard
   file (exclusive create -- fails if it already exists), retrying
-  roughly every 5 ms for up to 5 seconds if it does; only once that
-  create succeeds, perform the write (or, for the backfill side, the
-  read that captures the existing `nonce` and the write that follows
-  it); then remove the guard file **on every exit path, success or
-  failure alike** (a shell `trap`, or the agent's own equivalent of a
-  `finally` block) -- never only on success. An agent that removes the
-  guard solely after a successful write and skips cleanup when that
-  write itself fails leaves the same orphaned-guard problem the CLI's
-  own code was reviewed for (#2922 review round 4, Copilot): every later
-  writer for this exact `{claim-id}` then waits the full 5 seconds and
-  fails closed until an operator manually removes it. The guard file's
+  roughly every 5 ms for up to 5 seconds if it does. **Only once that
+  create call itself has actually succeeded** -- never before it, and
+  never merely because this invocation _attempted_ one -- arm a cleanup
+  handler (a shell `trap`, or the agent's own equivalent of a `finally`
+  block) that removes the guard **on every exit path from this point
+  forward, success or failure alike**, then perform the write (or, for
+  the backfill side, the read that captures the existing `nonce` and the
+  write that follows it). Arming the handler any earlier (for example a
+  `trap` set up before the create attempt) is not ownership-safe: a
+  failed create -- whether from `EEXIST` or from exhausting the 5-second
+  wait budget below -- proves nothing was created by this invocation, so
+  a handler armed that early would remove a **different, possibly
+  concurrent, holder's own guard** instead, reopening the exact ABA race
+  #2922's CLI-side fix (`withGeneratedTokensWriteLock`'s own
+  `openSync`/`writeSync`/`closeSync` ownership tracking) exists to close
+  (#2922 review round 6, CodeRabbit). An agent that removes the guard
+  solely after a successful write and skips cleanup when that write
+  itself fails leaves the same orphaned-guard problem the CLI's own code
+  was separately reviewed for (#2922 review round 4, Copilot): every
+  later writer for this exact `{claim-id}` then waits the full 5 seconds
+  and fails closed until an operator manually removes it. The guard file's
   own content is never read by anything -- its mere existence is the
   whole coordination signal, so no atomic-visibility trick is needed for
   it, unlike the lock file's own body. If the 5-second wait budget is

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -2204,6 +2204,30 @@ close.
   either, matching `recordGeneratedClaimTokens`'s own absolute
   invariant in `src/scripts/claim-lock.mts` (PR #2879 regression test;
   #2917 review, Copilot); stop fail-closed instead.
+- **`instructions-only` write-lock coordination** (#2922 -- applies to
+  this write side and to the backfill side below, which performs a
+  read-then-write of the same record): before writing, coordinate
+  against a concurrent writer for the same `{claim-id}` the way the
+  CLI's `recordGeneratedClaimTokens` and `backfillGeneratedClaimTokens`
+  do (`withGeneratedTokensWriteLock`, `src/scripts/claim-lock.mts`):
+  atomically create a same-directory `<resolved-path>.writelock` guard
+  file (exclusive create -- fails if it already exists), retrying
+  roughly every 5 ms for up to 5 seconds if it does; only once that
+  create succeeds, perform the write (or, for the backfill side, the
+  read that captures the existing `nonce` and the write that follows
+  it); then remove the guard file when done. The guard file's own
+  content is never read by anything -- its mere existence is the whole
+  coordination signal, so no atomic-visibility trick is needed for it,
+  unlike the lock file's own body. If the 5-second wait budget is
+  exhausted, stop fail-closed and report the guard path for manual
+  removal rather than writing anyway (an earlier revision of the CLI's
+  own lock self-reclaimed an aged guard automatically; three independent
+  reviewers found that unsafe -- see the doc comment on
+  `withGeneratedTokensWriteLock` for why fail-closed is the current
+  answer). Skipping this coordination reopens the exact race #2922
+  reported for the CLI path: a concurrent writer's fresher `nonce` can
+  be silently lost, including between an `instructions-only` session and
+  a helper-runtime session sharing the same worktree.
 - **`instructions-only` helper-free fallback, read side** (#2879 review,
   Codex P1 -- the mandatory `--read-tokens` check in the Claim
   revalidation gate has no helper-free path without this): resolve the
@@ -2229,9 +2253,11 @@ close.
   helper's own `racedCreate: true` marks exactly this case (#2917
   review, Codex). Only when it parses as well-formed and its `claimId`
   field equals the active `{claim-id}` exactly, apply the write-side
-  fallback above using the lock's own `agentId`, carrying forward an
-  existing well-formed record's own `nonce` when present, otherwise no
-  `nonce` (#2917 review, Copilot) -- except when the record's own
+  fallback above -- write-lock coordination included, wrapped around
+  this whole read-then-write, not just the write -- using the lock's
+  own `agentId`, carrying forward an existing well-formed record's own
+  `nonce` when present, otherwise no `nonce` (#2917 review, Copilot) --
+  except when the record's own
   resolved path is already occupied by a directory: leave it and its
   contents untouched and stop fail-closed instead, mirroring the CLI's
   own `record-blocked` status (`backfillGeneratedClaimTokens`,

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -2215,19 +2215,28 @@ close.
   roughly every 5 ms for up to 5 seconds if it does; only once that
   create succeeds, perform the write (or, for the backfill side, the
   read that captures the existing `nonce` and the write that follows
-  it); then remove the guard file when done. The guard file's own
-  content is never read by anything -- its mere existence is the whole
-  coordination signal, so no atomic-visibility trick is needed for it,
-  unlike the lock file's own body. If the 5-second wait budget is
+  it); then remove the guard file **on every exit path, success or
+  failure alike** (a shell `trap`, or the agent's own equivalent of a
+  `finally` block) -- never only on success. An agent that removes the
+  guard solely after a successful write and skips cleanup when that
+  write itself fails leaves the same orphaned-guard problem the CLI's
+  own code was reviewed for (#2922 review round 4, Copilot): every later
+  writer for this exact `{claim-id}` then waits the full 5 seconds and
+  fails closed until an operator manually removes it. The guard file's
+  own content is never read by anything -- its mere existence is the
+  whole coordination signal, so no atomic-visibility trick is needed for
+  it, unlike the lock file's own body. If the 5-second wait budget is
   exhausted, stop fail-closed and report the guard path for manual
   removal rather than writing anyway (an earlier revision of the CLI's
   own lock self-reclaimed an aged guard automatically; three independent
   reviewers found that unsafe -- see the doc comment on
   `withGeneratedTokensWriteLock` for why fail-closed is the current
-  answer). Skipping this coordination reopens the exact race #2922
-  reported for the CLI path: a concurrent writer's fresher `nonce` can
-  be silently lost, including between an `instructions-only` session and
-  a helper-runtime session sharing the same worktree.
+  answer) -- a pre-existing guard this invocation did not itself create
+  is never removed on any path, success or failure. Skipping this
+  coordination reopens the exact race #2922 reported for the CLI path: a
+  concurrent writer's fresher `nonce` can be silently lost, including
+  between an `instructions-only` session and a helper-runtime session
+  sharing the same worktree.
 - **`instructions-only` helper-free fallback, read side** (#2879 review,
   Codex P1 -- the mandatory `--read-tokens` check in the Claim
   revalidation gate has no helper-free path without this): resolve the

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -2196,14 +2196,22 @@ close.
   `{claim-id}`, UTF-8-encoded -- not the sanitized or truncated form,
   so a fallback and the CLI (or two fallback implementations) agree on
   the same path for the same claim-id (#2879 review, Codex P2). Write
-  `{ agentId, claimId, nonce?, recordedAt }`. No
-  exclusive-create semantics needed (unlike the lock): a plain atomic
-  replace is correct since this is idempotent evidence, not a
-  mutual-exclusion primitive -- except a directory already occupying
-  this exact path, which this fallback never replaces or deletes
-  either, matching `recordGeneratedClaimTokens`'s own absolute
-  invariant in `src/scripts/claim-lock.mts` (PR #2879 regression test;
-  #2917 review, Copilot); stop fail-closed instead.
+  `{ agentId, claimId, nonce?, recordedAt }`. No exclusive-create
+  semantics needed for **this record file itself** (unlike the lock
+  file): a plain atomic replace is correct here since the record is
+  idempotent evidence, not a mutual-exclusion primitive -- except a
+  directory already occupying this exact path, which this fallback
+  never replaces or deletes either, matching
+  `recordGeneratedClaimTokens`'s own absolute invariant in
+  `src/scripts/claim-lock.mts` (PR #2879 regression test; #2917 review,
+  Copilot); stop fail-closed instead. **This is scoped to the record
+  file's own replace step only** -- it does not exempt the coordination
+  below: the separate `.writelock` guard the next bullet introduces
+  _does_ need an exclusive create, every time, even though the record
+  replace it wraps does not (#2922 review round 8, Copilot). Skipping
+  the guard because "no exclusive-create semantics needed" was read as
+  covering this whole write reopens the exact nonce-clobber race #2922
+  reported.
 - **`instructions-only` write-lock coordination** (#2922 -- applies to
   this write side and to the backfill side below, which performs a
   read-then-write of the same record): before writing, coordinate

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -2220,11 +2220,13 @@ close.
   do (`withGeneratedTokensWriteLock`, `src/scripts/claim-lock.mts`):
   atomically create a same-directory `<resolved-path>.writelock` guard
   file (exclusive create -- fails if it already exists), retrying
-  roughly every 5 ms for up to 5 seconds if it does. **Only once that
-  create call itself has actually succeeded** -- never before it, and
-  never merely because this invocation _attempted_ one -- arm a cleanup
-  handler (a shell `trap`, or the agent's own equivalent of a `finally`
-  block) that removes the guard **on every exit path from this point
+  roughly every 5 ms for up to 5 seconds if it does, **writing a fresh,
+  unique per-attempt token as the guard's own body** (a random value,
+  or `pid:timestamp:random` -- any scheme unique per attempt is fine).
+  **Only once that create call itself has actually succeeded** -- never
+  before it, and never merely because this invocation _attempted_ one --
+  arm a cleanup handler (a shell `trap`, or the agent's own equivalent of
+  a `finally` block) that runs on **every exit path from this point
   forward, success or failure alike**, then perform the write (or, for
   the backfill side, the read that captures the existing `nonce` and the
   write that follows it). Arming the handler any earlier (for example a
@@ -2235,26 +2237,45 @@ close.
   concurrent, holder's own guard** instead, reopening the exact ABA race
   #2922's CLI-side fix (`withGeneratedTokensWriteLock`'s own
   `openSync`/`writeSync`/`closeSync` ownership tracking) exists to close
-  (#2922 review round 6, CodeRabbit). An agent that removes the guard
-  solely after a successful write and skips cleanup when that write
-  itself fails leaves the same orphaned-guard problem the CLI's own code
-  was separately reviewed for (#2922 review round 4, Copilot): every
-  later writer for this exact `{claim-id}` then waits the full 5 seconds
-  and fails closed until an operator manually removes it. The guard file's
-  own content is never read by anything -- its mere existence is the
-  whole coordination signal, so no atomic-visibility trick is needed for
-  it, unlike the lock file's own body. If the 5-second wait budget is
-  exhausted, stop fail-closed and report the guard path for manual
-  removal rather than writing anyway (an earlier revision of the CLI's
-  own lock self-reclaimed an aged guard automatically; three independent
-  reviewers found that unsafe -- see the doc comment on
-  `withGeneratedTokensWriteLock` for why fail-closed is the current
-  answer) -- a pre-existing guard this invocation did not itself create
-  is never removed on any path, success or failure. Skipping this
-  coordination reopens the exact race #2922 reported for the CLI path: a
-  concurrent writer's fresher `nonce` can be silently lost, including
-  between an `instructions-only` session and a helper-runtime session
-  sharing the same worktree.
+  (#2922 review round 6, CodeRabbit). The cleanup handler itself must be
+  **token-verified, not unconditional** (#2922 review round 11,
+  Copilot): re-read the guard and remove it only if it still holds the
+  exact token this attempt wrote, mirroring the CLI's own
+  `releaseGeneratedTokensWriteLockIfOwned` (and, before it,
+  `releaseCloneLock` in `src/scripts/clone-lock.mts`) -- an operator can
+  legitimately remove a guard by hand per the fail-closed timeout
+  guidance below while this invocation's own write is still genuinely in
+  flight, and a new writer can recreate it before this invocation's
+  cleanup runs; an unconditional removal there would delete that new
+  writer's guard instead of its own, letting two writers proceed at
+  once. Treat a guard that is simply already gone (removed by hand, or
+  already released) the same as a token mismatch -- nothing left for
+  this cleanup to remove, not an error. This narrows rather than
+  eliminates the race (verifying the token and removing the guard are
+  still two separate steps, not one atomic operation), which is an
+  accepted limitation shared with the CLI's own implementation -- see
+  the doc comment on `withGeneratedTokensWriteLock` in
+  `src/scripts/claim-lock.mts` for the full rationale. An agent that
+  removes the guard solely after a successful write and skips cleanup
+  when that write itself fails leaves the same orphaned-guard problem
+  the CLI's own code was separately reviewed for (#2922 review round 4,
+  Copilot): every later writer for this exact `{claim-id}` then waits
+  the full 5 seconds and fails closed until an operator manually removes
+  it. Unlike the record file's own body, the guard file's content is
+  read back by this same cleanup handler to verify ownership before
+  removing it -- no other, contending reader ever needs to inspect it,
+  so no atomic-visibility trick is needed beyond the exclusive create
+  itself. If the 5-second wait budget is exhausted, stop fail-closed and
+  report the guard path for manual removal rather than writing anyway
+  (an earlier revision of the CLI's own lock self-reclaimed an aged
+  guard automatically; three independent reviewers found that unsafe --
+  see the doc comment on `withGeneratedTokensWriteLock` for why
+  fail-closed is the current answer) -- a pre-existing guard this
+  invocation did not itself create is never removed on any path, success
+  or failure. Skipping this coordination reopens the exact race #2922
+  reported for the CLI path: a concurrent writer's fresher `nonce` can be
+  silently lost, including between an `instructions-only` session and a
+  helper-runtime session sharing the same worktree.
 - **`instructions-only` helper-free fallback, read side** (#2879 review,
   Codex P1 -- the mandatory `--read-tokens` check in the Claim
   revalidation gate has no helper-free path without this): resolve the

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -2212,17 +2212,27 @@ close.
   do (`withGeneratedTokensWriteLock`, `src/scripts/claim-lock.mts`):
   atomically create a same-directory `<resolved-path>.writelock` guard
   file (exclusive create -- fails if it already exists), retrying
-  roughly every 5 ms for up to 5 seconds if it does; only once that
-  create succeeds, perform the write (or, for the backfill side, the
-  read that captures the existing `nonce` and the write that follows
-  it); then remove the guard file **on every exit path, success or
-  failure alike** (a shell `trap`, or the agent's own equivalent of a
-  `finally` block) -- never only on success. An agent that removes the
-  guard solely after a successful write and skips cleanup when that
-  write itself fails leaves the same orphaned-guard problem the CLI's
-  own code was reviewed for (#2922 review round 4, Copilot): every later
-  writer for this exact `{claim-id}` then waits the full 5 seconds and
-  fails closed until an operator manually removes it. The guard file's
+  roughly every 5 ms for up to 5 seconds if it does. **Only once that
+  create call itself has actually succeeded** -- never before it, and
+  never merely because this invocation _attempted_ one -- arm a cleanup
+  handler (a shell `trap`, or the agent's own equivalent of a `finally`
+  block) that removes the guard **on every exit path from this point
+  forward, success or failure alike**, then perform the write (or, for
+  the backfill side, the read that captures the existing `nonce` and the
+  write that follows it). Arming the handler any earlier (for example a
+  `trap` set up before the create attempt) is not ownership-safe: a
+  failed create -- whether from `EEXIST` or from exhausting the 5-second
+  wait budget below -- proves nothing was created by this invocation, so
+  a handler armed that early would remove a **different, possibly
+  concurrent, holder's own guard** instead, reopening the exact ABA race
+  #2922's CLI-side fix (`withGeneratedTokensWriteLock`'s own
+  `openSync`/`writeSync`/`closeSync` ownership tracking) exists to close
+  (#2922 review round 6, CodeRabbit). An agent that removes the guard
+  solely after a successful write and skips cleanup when that write
+  itself fails leaves the same orphaned-guard problem the CLI's own code
+  was separately reviewed for (#2922 review round 4, Copilot): every
+  later writer for this exact `{claim-id}` then waits the full 5 seconds
+  and fails closed until an operator manually removes it. The guard file's
   own content is never read by anything -- its mere existence is the
   whole coordination signal, so no atomic-visibility trick is needed for
   it, unlike the lock file's own body. If the 5-second wait budget is

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -2204,6 +2204,30 @@ close.
   either, matching `recordGeneratedClaimTokens`'s own absolute
   invariant in `src/scripts/claim-lock.mts` (PR #2879 regression test;
   #2917 review, Copilot); stop fail-closed instead.
+- **`instructions-only` write-lock coordination** (#2922 -- applies to
+  this write side and to the backfill side below, which performs a
+  read-then-write of the same record): before writing, coordinate
+  against a concurrent writer for the same `{claim-id}` the way the
+  CLI's `recordGeneratedClaimTokens` and `backfillGeneratedClaimTokens`
+  do (`withGeneratedTokensWriteLock`, `src/scripts/claim-lock.mts`):
+  atomically create a same-directory `<resolved-path>.writelock` guard
+  file (exclusive create -- fails if it already exists), retrying
+  roughly every 5 ms for up to 5 seconds if it does; only once that
+  create succeeds, perform the write (or, for the backfill side, the
+  read that captures the existing `nonce` and the write that follows
+  it); then remove the guard file when done. The guard file's own
+  content is never read by anything -- its mere existence is the whole
+  coordination signal, so no atomic-visibility trick is needed for it,
+  unlike the lock file's own body. If the 5-second wait budget is
+  exhausted, stop fail-closed and report the guard path for manual
+  removal rather than writing anyway (an earlier revision of the CLI's
+  own lock self-reclaimed an aged guard automatically; three independent
+  reviewers found that unsafe -- see the doc comment on
+  `withGeneratedTokensWriteLock` for why fail-closed is the current
+  answer). Skipping this coordination reopens the exact race #2922
+  reported for the CLI path: a concurrent writer's fresher `nonce` can
+  be silently lost, including between an `instructions-only` session and
+  a helper-runtime session sharing the same worktree.
 - **`instructions-only` helper-free fallback, read side** (#2879 review,
   Codex P1 -- the mandatory `--read-tokens` check in the Claim
   revalidation gate has no helper-free path without this): resolve the
@@ -2229,9 +2253,11 @@ close.
   helper's own `racedCreate: true` marks exactly this case (#2917
   review, Codex). Only when it parses as well-formed and its `claimId`
   field equals the active `{claim-id}` exactly, apply the write-side
-  fallback above using the lock's own `agentId`, carrying forward an
-  existing well-formed record's own `nonce` when present, otherwise no
-  `nonce` (#2917 review, Copilot) -- except when the record's own
+  fallback above -- write-lock coordination included, wrapped around
+  this whole read-then-write, not just the write -- using the lock's
+  own `agentId`, carrying forward an existing well-formed record's own
+  `nonce` when present, otherwise no `nonce` (#2917 review, Copilot) --
+  except when the record's own
   resolved path is already occupied by a directory: leave it and its
   contents untouched and stop fail-closed instead, mirroring the CLI's
   own `record-blocked` status (`backfillGeneratedClaimTokens`,

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -2215,19 +2215,28 @@ close.
   roughly every 5 ms for up to 5 seconds if it does; only once that
   create succeeds, perform the write (or, for the backfill side, the
   read that captures the existing `nonce` and the write that follows
-  it); then remove the guard file when done. The guard file's own
-  content is never read by anything -- its mere existence is the whole
-  coordination signal, so no atomic-visibility trick is needed for it,
-  unlike the lock file's own body. If the 5-second wait budget is
+  it); then remove the guard file **on every exit path, success or
+  failure alike** (a shell `trap`, or the agent's own equivalent of a
+  `finally` block) -- never only on success. An agent that removes the
+  guard solely after a successful write and skips cleanup when that
+  write itself fails leaves the same orphaned-guard problem the CLI's
+  own code was reviewed for (#2922 review round 4, Copilot): every later
+  writer for this exact `{claim-id}` then waits the full 5 seconds and
+  fails closed until an operator manually removes it. The guard file's
+  own content is never read by anything -- its mere existence is the
+  whole coordination signal, so no atomic-visibility trick is needed for
+  it, unlike the lock file's own body. If the 5-second wait budget is
   exhausted, stop fail-closed and report the guard path for manual
   removal rather than writing anyway (an earlier revision of the CLI's
   own lock self-reclaimed an aged guard automatically; three independent
   reviewers found that unsafe -- see the doc comment on
   `withGeneratedTokensWriteLock` for why fail-closed is the current
-  answer). Skipping this coordination reopens the exact race #2922
-  reported for the CLI path: a concurrent writer's fresher `nonce` can
-  be silently lost, including between an `instructions-only` session and
-  a helper-runtime session sharing the same worktree.
+  answer) -- a pre-existing guard this invocation did not itself create
+  is never removed on any path, success or failure. Skipping this
+  coordination reopens the exact race #2922 reported for the CLI path: a
+  concurrent writer's fresher `nonce` can be silently lost, including
+  between an `instructions-only` session and a helper-runtime session
+  sharing the same worktree.
 - **`instructions-only` helper-free fallback, read side** (#2879 review,
   Codex P1 -- the mandatory `--read-tokens` check in the Claim
   revalidation gate has no helper-free path without this): resolve the

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -2196,14 +2196,22 @@ close.
   `{claim-id}`, UTF-8-encoded -- not the sanitized or truncated form,
   so a fallback and the CLI (or two fallback implementations) agree on
   the same path for the same claim-id (#2879 review, Codex P2). Write
-  `{ agentId, claimId, nonce?, recordedAt }`. No
-  exclusive-create semantics needed (unlike the lock): a plain atomic
-  replace is correct since this is idempotent evidence, not a
-  mutual-exclusion primitive -- except a directory already occupying
-  this exact path, which this fallback never replaces or deletes
-  either, matching `recordGeneratedClaimTokens`'s own absolute
-  invariant in `src/scripts/claim-lock.mts` (PR #2879 regression test;
-  #2917 review, Copilot); stop fail-closed instead.
+  `{ agentId, claimId, nonce?, recordedAt }`. No exclusive-create
+  semantics needed for **this record file itself** (unlike the lock
+  file): a plain atomic replace is correct here since the record is
+  idempotent evidence, not a mutual-exclusion primitive -- except a
+  directory already occupying this exact path, which this fallback
+  never replaces or deletes either, matching
+  `recordGeneratedClaimTokens`'s own absolute invariant in
+  `src/scripts/claim-lock.mts` (PR #2879 regression test; #2917 review,
+  Copilot); stop fail-closed instead. **This is scoped to the record
+  file's own replace step only** -- it does not exempt the coordination
+  below: the separate `.writelock` guard the next bullet introduces
+  _does_ need an exclusive create, every time, even though the record
+  replace it wraps does not (#2922 review round 8, Copilot). Skipping
+  the guard because "no exclusive-create semantics needed" was read as
+  covering this whole write reopens the exact nonce-clobber race #2922
+  reported.
 - **`instructions-only` write-lock coordination** (#2922 -- applies to
   this write side and to the backfill side below, which performs a
   read-then-write of the same record): before writing, coordinate

--- a/scripts/claim-lock.mjs
+++ b/scripts/claim-lock.mjs
@@ -634,6 +634,22 @@ function resolveGeneratedTokensWriteLockPath(recordPath) {
  * never a write landing invisibly *inside* backfill's own read-then-write
  * window).
  *
+ * **Scope: writers only, not a general readers/writers lock** (#2922
+ * review, Copilot). A standalone {@link readGeneratedClaimTokens} /
+ * {@link readGeneratedTokensAtPath} call made *outside* another write's own
+ * `critical` callback is never guarded by this lock -- only the two
+ * call sites that mutate the record (this file's own `recordGeneratedClaimTokens`
+ * and `backfillGeneratedClaimTokens`) participate. On Windows,
+ * {@link atomicReplaceFile}'s existing-file branch removes the old target
+ * before renaming the replacement in (see that function's own doc
+ * comment, and `overwriteLockAtomically`'s identical, pre-existing gap
+ * for the claim lock file above), so an unguarded concurrent read can in
+ * principle observe a transient `absent` during any write to this record,
+ * with or without this lock. That gap predates this lock and is
+ * unrelated to the nonce-clobber race it closes; guarding reads too (or
+ * changing the read contract to rule out a transient `absent`) is a
+ * separate, broader design question out of scope for #2922.
+ *
  * `critical` must call only the unlocked write primitive
  * ({@link writeGeneratedClaimTokensRecord}), never the locked
  * {@link recordGeneratedClaimTokens} wrapper -- this guard is not
@@ -683,19 +699,30 @@ function withGeneratedTokensWriteLock(recordPath, critical) {
       sleepSyncMs(GENERATED_TOKENS_WRITE_LOCK_RETRY_INTERVAL_MS);
     }
   }
+  let result;
   try {
-    return critical();
-  } finally {
-    // Best-effort cleanup only: a failure here never masks a real error
-    // from `critical()`, and a leaked guard file only costs the next
-    // caller a bounded wait before this same failure mode applies to them
-    // too, per the fail-closed rationale above.
+    result = critical();
+  } catch (error) {
+    // Best-effort cleanup on a `critical()` failure only: a cleanup
+    // failure here must never mask the real error the caller needs to
+    // see, so it is swallowed -- a leaked guard file in this branch only
+    // costs the next caller a bounded wait before this same fail-closed
+    // behavior applies to them too.
     try {
       unlinkSync(lockPath);
     } catch {
       // ignore
     }
+    throw error;
   }
+  // `critical()` succeeded: do NOT swallow a release failure here (#2922
+  // review, Codex). Reporting success while silently leaving the guard
+  // behind would give the caller no signal that anything needs recovery
+  // -- every subsequent write for this claim-id would otherwise just
+  // silently wait out a full timeout before failing, with nothing
+  // pointing at the actual cause.
+  unlinkSync(lockPath);
+  return result;
 }
 /**
  * Read-only inspection of the generated-tokens record for `claimId` at

--- a/scripts/claim-lock.mjs
+++ b/scripts/claim-lock.mjs
@@ -695,10 +695,43 @@ function resolveGeneratedTokensWriteLockPath(recordPath) {
  * the thrown error's own recovery instructions, rather than an automatic
  * reclaim this codebase cannot yet prove safe without a real
  * compare-and-swap or ownership-token primitive.
+ *
+ * Both releases below (the `critical()`-failure cleanup and the
+ * `critical()`-success release) are **token-verified**, not a bare
+ * `unlinkSync(lockPath)` (#2922 review round 10, Copilot): each acquisition
+ * writes a fresh random token into the guard body, and release re-reads the
+ * guard and only unlinks it when that same token is still present. This
+ * mirrors this repository's own existing precedent for exactly this
+ * problem -- `releaseCloneLock` in `clone-lock.mts` -- which likewise
+ * refuses to remove a lock file whose recorded `token` no longer matches
+ * the releasing handle's own. Without this check, a guard manually removed
+ * by an operator (per the timeout error's own recovery instructions) while
+ * the original holder's `critical()` is still genuinely running could be
+ * recreated by a new writer before the original holder's release runs;
+ * that release would then delete the *new* writer's guard instead of a
+ * guard it actually owns, letting two writers believe they hold exclusive
+ * access at once -- the same class of hazard already solved on the
+ * acquire side (see the `openSync`/`writeSync`/`closeSync` ownership
+ * comment above), now closed on the release side too.
+ *
+ * This narrows the guard-recreation window rather than eliminating it:
+ * the same kind of race could still, in principle, land *between* the
+ * token read and the `unlinkSync` call the check guards, because no
+ * `wx`-only filesystem primitive gives a true atomic compare-and-delete.
+ * Closing that residual sliver would need a real compare-and-swap or
+ * `flock(2)`-style primitive this module deliberately avoids taking on
+ * (see the header comment). It is accepted as a known limitation: it only
+ * matters when a live holder's own guard is manually removed while that
+ * holder's `critical()` is still running -- a precondition violation of
+ * the timeout error's own recovery instructions -- and #2922's Acceptance
+ * Criteria only ever covers nonce-preservation under normal concurrent
+ * operation, not safety after an operator has manually intervened on a
+ * guard that turns out not to have been actually orphaned.
  */
 function withGeneratedTokensWriteLock(recordPath, critical) {
   const lockPath = resolveGeneratedTokensWriteLockPath(recordPath);
   const deadline = Date.now() + GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS;
+  const token = randomGeneratedTokensWriteLockToken();
   for (;;) {
     let fd;
     try {
@@ -725,11 +758,15 @@ function withGeneratedTokensWriteLock(recordPath, critical) {
     // is its sole, syscall-proven owner from this point on, so a failure
     // finishing the write below is always safe to clean up.
     try {
-      writeSync(fd, String(process.pid));
+      writeSync(fd, token);
     } catch (error) {
       // `writeSync` failing leaves `fd` genuinely still open (a write
       // failure does not close the descriptor), so this is the correct,
-      // and only, place to close it for this branch.
+      // and only, place to close it for this branch. A bare `unlinkSync`
+      // (not the token-verified {@link releaseGeneratedTokensWriteLockIfOwned})
+      // is safe here: `critical()` has not run yet, so no wall-clock window
+      // has opened in which an operator could have manually removed this
+      // still-fresh guard for a different reason to recreate it.
       try {
         closeSync(fd);
       } catch {
@@ -752,6 +789,8 @@ function withGeneratedTokensWriteLock(recordPath, critical) {
       // exact descriptor number for something else (for example another
       // thread's own `open()`), so a second close attempt on it here
       // could silently disrupt unrelated I/O elsewhere in the process.
+      // A bare `unlinkSync` remains safe for the same reason as the
+      // `writeSync` failure branch above: `critical()` has not run yet.
       try {
         unlinkSync(lockPath);
       } catch {
@@ -775,9 +814,11 @@ function withGeneratedTokensWriteLock(recordPath, critical) {
     // would otherwise have no way to learn a guard was left behind until
     // a later, unrelated caller independently discovers it via its own
     // timeout -- minutes or more later, and by a completely different
-    // caller than the one whose failure actually caused it.
+    // caller than the one whose failure actually caused it. Token-verified
+    // (#2922 review round 10, Copilot): see the function-level doc comment
+    // above for why this must not be a bare `unlinkSync`.
     try {
-      unlinkSync(lockPath);
+      releaseGeneratedTokensWriteLockIfOwned(lockPath, token);
     } catch (cleanupError) {
       const combined = new Error(
         `${error.message} (additionally failed to remove the ` +
@@ -794,9 +835,39 @@ function withGeneratedTokensWriteLock(recordPath, critical) {
   // behind would give the caller no signal that anything needs recovery
   // -- every subsequent write for this claim-id would otherwise just
   // silently wait out a full timeout before failing, with nothing
-  // pointing at the actual cause.
-  unlinkSync(lockPath);
+  // pointing at the actual cause. Token-verified (#2922 review round 10,
+  // Copilot): see the function-level doc comment above.
+  releaseGeneratedTokensWriteLockIfOwned(lockPath, token);
   return result;
+}
+/** Generate a fresh, effectively-unique token for one lock acquisition. */
+function randomGeneratedTokensWriteLockToken() {
+  return `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+/**
+ * Release the generated-tokens write-lock guard at `lockPath` only if it
+ * still holds `token` -- the token this same acquisition wrote when it
+ * created the guard (see {@link withGeneratedTokensWriteLock}'s doc
+ * comment for the full ABA rationale and its residual-race caveat). A
+ * missing guard (already released, or never observed) and a guard whose
+ * token no longer matches (recreated by a different owner) are both
+ * treated as "nothing this call may remove" and silently return, mirroring
+ * `releaseCloneLock`'s own token-mismatch handling in `clone-lock.mts`.
+ */
+function releaseGeneratedTokensWriteLockIfOwned(lockPath, token) {
+  let body;
+  try {
+    body = readFileSync(lockPath, 'utf8');
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return;
+    }
+    throw error;
+  }
+  if (body !== token) {
+    return;
+  }
+  unlinkSync(lockPath);
 }
 /**
  * Read-only inspection of the generated-tokens record for `claimId` at

--- a/scripts/claim-lock.mjs
+++ b/scripts/claim-lock.mjs
@@ -765,15 +765,27 @@ function withGeneratedTokensWriteLock(recordPath, critical) {
   try {
     result = critical();
   } catch (error) {
-    // Best-effort cleanup on a `critical()` failure only: a cleanup
-    // failure here must never mask the real error the caller needs to
-    // see, so it is swallowed -- a leaked guard file in this branch only
-    // costs the next caller a bounded wait before this same fail-closed
-    // behavior applies to them too.
+    // Best-effort cleanup on a `critical()` failure: a cleanup failure
+    // here must never *replace* the real error the caller needs to see,
+    // so on a clean cleanup this rethrows `error` verbatim -- a leaked
+    // guard file then only costs the next caller a bounded wait before
+    // this same fail-closed behavior applies to them too. But when the
+    // cleanup *also* fails, report both instead of silently swallowing
+    // the second failure (#2922 review round 9, Copilot): the caller
+    // would otherwise have no way to learn a guard was left behind until
+    // a later, unrelated caller independently discovers it via its own
+    // timeout -- minutes or more later, and by a completely different
+    // caller than the one whose failure actually caused it.
     try {
       unlinkSync(lockPath);
-    } catch {
-      // ignore
+    } catch (cleanupError) {
+      const combined = new Error(
+        `${error.message} (additionally failed to remove the ` +
+          `generated-tokens write lock guard at ${lockPath} during ` +
+          `cleanup: ${cleanupError.message})`,
+      );
+      combined.cause = error;
+      throw combined;
     }
     throw error;
   }

--- a/scripts/claim-lock.mjs
+++ b/scripts/claim-lock.mjs
@@ -658,12 +658,17 @@ function resolveGeneratedTokensWriteLockPath(recordPath) {
  * {@link recordGeneratedClaimTokens} wrapper -- this guard is not
  * re-entrant, and nesting would deadlock a caller against itself.
  *
- * The guard file's own *content* is never read back by anything -- unlike
- * the claim lock's `linkSync`-based fresh-create fix (#2920), which exists
+ * No *contending* reader ever needs to inspect the guard file's content
+ * before the creator finishes writing and closes it -- unlike the claim
+ * lock's `linkSync`-based fresh-create fix (#2920), which exists
  * specifically so a *third-party reader* never observes a torn body -- so a
  * plain `wx`-flag exclusive create is sufficient here: POSIX and Windows
  * both make `O_CREAT | O_EXCL` (`CREATE_NEW`) atomic for existence alone,
- * with no partial-content window to close.
+ * with no partial-content window to close. (This creator's *own* later
+ * release does read the body back, to verify the token it wrote at create
+ * time is still present -- see {@link releaseGeneratedTokensWriteLockIfOwned}
+ * -- #2922 review round 11, Copilot; only a torn-body window relevant to a
+ * different reader is what this paragraph rules out.)
  *
  * The create step uses {@link openSync}/{@link writeSync}/{@link closeSync}
  * directly, rather than a single {@link writeFileSync} call, specifically to
@@ -852,7 +857,13 @@ function randomGeneratedTokensWriteLockToken() {
  * missing guard (already released, or never observed) and a guard whose
  * token no longer matches (recreated by a different owner) are both
  * treated as "nothing this call may remove" and silently return, mirroring
- * `releaseCloneLock`'s own token-mismatch handling in `clone-lock.mts`.
+ * `releaseCloneLock`'s own token-mismatch handling in `clone-lock.mts`. The
+ * guard can also disappear *after* this function's own token read confirms
+ * ownership but *before* its `unlinkSync` call below runs -- swallow that
+ * `ENOENT` the same way (#2922 review round 11, Copilot), matching
+ * `releaseCloneLock`'s identical handling at `clone-lock.mts:329-333`:
+ * a guard that is simply already gone by the time of the unlink is still
+ * "nothing left for this call to remove," not a failure to report.
  */
 function releaseGeneratedTokensWriteLockIfOwned(lockPath, token) {
   let body;
@@ -867,7 +878,13 @@ function releaseGeneratedTokensWriteLockIfOwned(lockPath, token) {
   if (body !== token) {
     return;
   }
-  unlinkSync(lockPath);
+  try {
+    unlinkSync(lockPath);
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
 }
 /**
  * Read-only inspection of the generated-tokens record for `claimId` at

--- a/scripts/claim-lock.mjs
+++ b/scripts/claim-lock.mjs
@@ -114,6 +114,32 @@
 // a GitHub round-trip, matching `--acquire`'s own same-machine, no-network
 // design.
 //
+// Generated-tokens write lock (#2922): `--backfill-tokens` preserves an
+// existing record's own `nonce` by reading it, then writing the backfilled
+// record back with that captured value -- a read-modify-write with nothing
+// serializing it against a concurrent plain `--record-tokens --nonce` call
+// (the activation-nonce minting flow's own second write) landing in
+// between. Because every write to this file was previously a plain
+// `atomicReplaceFile` replace, not a compare-and-swap, that interleaving
+// could silently clobber a fresher nonce with the stale value the backfill
+// captured moments earlier. Both call sites now share one
+// `withGeneratedTokensWriteLock` critical section, keyed by the record's
+// own path: a same-directory `.writelock` guard file created via a plain
+// `wx`-flag exclusive create (existence alone needs no atomic-visibility
+// trick, unlike the claim lock body `linkSync` closes for #2920 above --
+// nothing ever reads this guard file's content). This makes the two writers
+// fully mutually exclusive rather than merely narrowing the window: a
+// concurrent write either completes entirely before the backfill's read
+// (and is correctly preserved) or entirely after its write (a normal,
+// non-lossy last-writer-wins overwrite), never in between. A guard file
+// orphaned by a killed process (rather than released via a normal
+// `finally`) self-heals after one bounded wait: the critical section it
+// guards is always a handful of synchronous `fs` calls with no `await` in
+// between, so a guard old enough to have outlived one full wait budget is
+// reclaimed as stale (by file modification time) and removed, exactly
+// once per call, rather than blocking every future write against that
+// claim-id forever.
+//
 // Scope of the ownership proof (#2879 review, Codex P1): a `present: true`
 // `--read-tokens` result proves "a `--record-tokens` call for this exact
 // claim-id landed at this path" -- it does not cryptographically bind that
@@ -153,6 +179,17 @@ import { parseCliArgs } from './cli-args.mjs';
 const CLAIM_LOCK_FILE_NAME = 'idd-claim.lock';
 const GENERATED_TOKENS_FILE_PREFIX = 'idd-generated-tokens';
 const MAX_RETRY_ATTEMPTS = 5;
+/**
+ * Bounded wait budget for the generated-tokens record's own write-lock
+ * (#2922, see {@link withGeneratedTokensWriteLock}). Every critical section
+ * it guards is a handful of synchronous, non-blocking-I/O `fs` calls with
+ * no `await` in between, so genuine contention is expected to resolve in
+ * microseconds; a caller still waiting past this budget has almost
+ * certainly hit a guard file orphaned by a killed process rather than a
+ * live holder, so it fails loudly instead of hanging forever.
+ */
+const GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS = 5_000;
+const GENERATED_TOKENS_WRITE_LOCK_RETRY_INTERVAL_MS = 5;
 /**
  * Cap on the sanitized-claim-id portion of a generated-tokens filename
  * (see {@link sanitizeClaimIdForFilename}). A claim-id is an opaque
@@ -557,6 +594,132 @@ function isGeneratedTokensBody(value) {
   );
 }
 /**
+ * Block the calling thread for `ms` milliseconds. Node's main thread (unlike
+ * a browser UI thread) permits a blocking `Atomics.wait`, so a private,
+ * never-`notify`'d `SharedArrayBuffer` slot works as a plain synchronous
+ * sleep -- there is no cross-process or cross-thread signalling involved,
+ * only a timer, matching this CLI's fully synchronous execution model.
+ */
+function sleepSyncMs(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+/** Resolve the write-lock guard path for the generated-tokens record at `recordPath`. */
+function resolveGeneratedTokensWriteLockPath(recordPath) {
+  return `${recordPath}.writelock`;
+}
+/**
+ * Serialize every critical section that reads and/or writes the
+ * generated-tokens record at `recordPath` against every other one for that
+ * same path (#2922). Closes the race where {@link backfillGeneratedClaimTokens}
+ * captures an existing record's `nonce` via {@link readGeneratedClaimTokens},
+ * then a concurrent plain write -- the activation-nonce minting flow's own
+ * `--record-tokens --nonce` call, via {@link recordGeneratedClaimTokens} --
+ * lands in between, and backfill's own subsequent write (a plain
+ * {@link atomicReplaceFile} replace, not a compare-and-swap) silently
+ * clobbers that fresher nonce with the stale value it captured moments
+ * earlier. Both call sites resolve to the same lock path for the same
+ * `(cwd, claimId)` pair (they share {@link resolveGeneratedTokensPath}), so
+ * true mutual exclusion holds between them: a plain write either completes
+ * entirely before backfill's read (and backfill observes it, preserving its
+ * nonce correctly) or entirely after backfill's write (and simply
+ * overwrites, which is the expected, non-lossy last-writer-wins outcome --
+ * never a write landing invisibly *inside* backfill's own read-then-write
+ * window).
+ *
+ * `critical` must call only the unlocked write primitive
+ * ({@link writeGeneratedClaimTokensRecord}), never the locked
+ * {@link recordGeneratedClaimTokens} wrapper -- this guard is not
+ * re-entrant, and nesting would deadlock a caller against itself.
+ *
+ * The guard file's own *content* is never read back by anything -- unlike
+ * the claim lock's `linkSync`-based fresh-create fix (#2920), which exists
+ * specifically so a *third-party reader* never observes a torn body -- so a
+ * plain `wx`-flag exclusive create is sufficient here: POSIX and Windows
+ * both make `O_CREAT | O_EXCL` (`CREATE_NEW`) atomic for existence alone,
+ * with no partial-content window to close. See
+ * {@link GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS} for the bounded-retry
+ * rationale, and {@link isStaleGeneratedTokensWriteLock} for the one-shot
+ * orphan-reclaim path a caller falls into after that budget is exhausted.
+ */
+function withGeneratedTokensWriteLock(recordPath, critical) {
+  const lockPath = resolveGeneratedTokensWriteLockPath(recordPath);
+  let deadline = Date.now() + GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS;
+  let staleReclaimAttempted = false;
+  for (;;) {
+    try {
+      writeFileSync(lockPath, String(process.pid), { flag: 'wx' });
+      break;
+    } catch (error) {
+      if (error.code !== 'EEXIST') {
+        throw error;
+      }
+      if (Date.now() < deadline) {
+        sleepSyncMs(GENERATED_TOKENS_WRITE_LOCK_RETRY_INTERVAL_MS);
+        continue;
+      }
+      // The wait budget is exhausted. Reclaim an orphaned guard exactly
+      // once per call before giving up: every critical section this lock
+      // guards is a handful of synchronous, non-blocking-I/O `fs` calls
+      // with no `await` in between, so a guard old enough to have outlived
+      // one full wait budget was almost certainly abandoned by a killed
+      // process, not a live holder still working.
+      if (!staleReclaimAttempted && isStaleGeneratedTokensWriteLock(lockPath)) {
+        staleReclaimAttempted = true;
+        try {
+          unlinkSync(lockPath);
+        } catch {
+          // A concurrent reclaimer may have already removed it (or a
+          // legitimate holder already released it) -- either way, the
+          // create attempt below decides what happens next.
+        }
+        deadline = Date.now() + GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS;
+        continue;
+      }
+      throw new Error(
+        `Timed out waiting for the generated-tokens write lock at ${lockPath}; ` +
+          `a crashed holder may have left it behind. If this persists, ` +
+          `remove ${lockPath} to recover.`,
+      );
+    }
+  }
+  try {
+    return critical();
+  } finally {
+    // Best-effort cleanup only: a failure here never masks a real error
+    // from `critical()`, and a leaked guard file only costs the next
+    // caller one bounded wait before the stale-reclaim path above removes
+    // it for them.
+    try {
+      unlinkSync(lockPath);
+    } catch {
+      // ignore
+    }
+  }
+}
+/**
+ * Whether the write-lock guard file at `lockPath` has aged past one full
+ * {@link GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS} budget, per its own file
+ * modification time -- the sole signal {@link withGeneratedTokensWriteLock}
+ * uses to tell an orphaned guard (left behind by a process killed between
+ * acquiring it and reaching its own `finally` release) from a still-live
+ * holder. This is a safe basis specifically because every critical section
+ * this lock guards is synchronous with no `await` in between: a genuine
+ * holder writes the guard and releases it again within microseconds, so a
+ * guard old enough to have already outlived one full wait budget could
+ * never be a live holder still working, only an orphan. `false` on any
+ * read failure (absent, or otherwise unreadable) -- not something this
+ * call can safely reclaim as stale; the caller's own next create attempt
+ * resolves the state either way.
+ */
+function isStaleGeneratedTokensWriteLock(lockPath) {
+  try {
+    const ageMs = Date.now() - statSync(lockPath).mtimeMs;
+    return ageMs >= GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS;
+  } catch {
+    return false;
+  }
+}
+/**
  * Read-only inspection of the generated-tokens record for `claimId` at
  * `cwd`'s own private git-admin directory. Never creates, mutates, or
  * deletes anything.
@@ -593,13 +756,19 @@ export function readGeneratedClaimTokens(cwd, claimId) {
 /**
  * Write (create or idempotently replace) the generated-tokens record for
  * `claimId` at `cwd`'s own private git-admin directory. Unlike the lock
- * file, this has no collision/`--takeover` concept: the record is
- * per-claim-id evidence, not a mutual-exclusion primitive, so re-invoking
- * (once in the primary worktree at A5 claim time with `{agentId,
- * claimId}`, again with `{agentId, claimId, nonce}` right before the
- * activation-nonce marker posts, and again in the new sibling worktree at
- * B1) is always a safe, expected, idempotent overwrite of the same path.
+ * file, this exposes no collision/`--takeover` concept of its own: the
+ * record is per-claim-id evidence, not a caller-visible mutual-exclusion
+ * primitive, so re-invoking (once in the primary worktree at A5 claim time
+ * with `{agentId, claimId}`, again with `{agentId, claimId, nonce}` right
+ * before the activation-nonce marker posts, and again in the new sibling
+ * worktree at B1) is always a safe, expected, idempotent overwrite of the
+ * same path. Internally, every write (and {@link backfillGeneratedClaimTokens}'s
+ * own read-then-write) is now serialized through
+ * {@link withGeneratedTokensWriteLock} (#2922) so a concurrent writer's
+ * nonce can never be silently lost -- that locking is this function's own
+ * implementation detail, not a contract callers need to coordinate with.
  *
+
  * Never replaces a directory occupying the resolved path (regression,
  * #2879 review): a matching `idd-claim.lock` authenticates the claim
  * lock, not the token record's own path, and this filename's hash
@@ -612,6 +781,20 @@ export function readGeneratedClaimTokens(cwd, claimId) {
  */
 export function recordGeneratedClaimTokens(cwd, fields) {
   const path = resolveGeneratedTokensPath(cwd, fields.claimId);
+  withGeneratedTokensWriteLock(path, () => {
+    writeGeneratedClaimTokensRecord(path, fields);
+  });
+  return { path };
+}
+/**
+ * Unlocked write primitive shared by {@link recordGeneratedClaimTokens} and
+ * {@link backfillGeneratedClaimTokens} (#2922). Never call this directly
+ * from outside {@link withGeneratedTokensWriteLock}'s `critical` callback --
+ * it performs no locking of its own, by design, so both callers can share
+ * one lock acquisition around their own (possibly read-then-write) critical
+ * section without deadlocking against a non-re-entrant guard.
+ */
+function writeGeneratedClaimTokensRecord(path, fields) {
   const body = {
     agentId: fields.agentId,
     claimId: fields.claimId,
@@ -619,7 +802,6 @@ export function recordGeneratedClaimTokens(cwd, fields) {
     recordedAt: new Date().toISOString(),
   };
   atomicReplaceFile(path, JSON.stringify(body));
-  return { path };
 }
 /**
  * Recovery route (#2884) for a worktree whose generated-tokens record
@@ -649,7 +831,7 @@ export function recordGeneratedClaimTokens(cwd, fields) {
  *   documented gated sequence stops here with no further action needed.
  * - Present lock whose `claimId` matches, and no directory blocks the
  *   record path → writes the generated-tokens record via
- *   {@link recordGeneratedClaimTokens}, using the lock's own `agentId`
+ *   {@link writeGeneratedClaimTokensRecord}, using the lock's own `agentId`
  *   and no `nonce` (matching a fresh pre-nonce `--record-tokens` call) →
  *   `backfilled`. If a well-formed record for this exact `claimId`
  *   already exists (outside the documented recovery route, which only ever
@@ -657,15 +839,19 @@ export function recordGeneratedClaimTokens(cwd, fields) {
  *   meaning no well-formed record exists yet -- so this is a defensive
  *   guard against a caller invoking this function directly against
  *   caller-discipline), its own `nonce` is preserved rather than silently
- *   erased: {@link recordGeneratedClaimTokens} replaces the whole record,
- *   so writing with no `nonce` unconditionally would otherwise drop an
- *   existing one (#2917 review, Copilot).
+ *   erased: {@link writeGeneratedClaimTokensRecord} replaces the whole
+ *   record, so writing with no `nonce` unconditionally would otherwise
+ *   drop an existing one (#2917 review, Copilot). The read that discovers
+ *   this existing nonce and the write that preserves it now share one
+ *   {@link withGeneratedTokensWriteLock} critical section (#2922), so a
+ *   concurrent writer's own fresher nonce can never land invisibly between
+ *   them.
  *
  * Performs no GitHub round-trip on any path, matching `--acquire`'s own
  * same-machine, no-network design. Re-invoking after a successful backfill
  * always reports `backfilled` again -- a safe, idempotent overwrite via
- * `recordGeneratedClaimTokens`'s own existing idempotency contract, not a
- * separate `already-present` status.
+ * `writeGeneratedClaimTokensRecord`'s own existing idempotency contract, not
+ * a separate `already-present` status.
  */
 export function backfillGeneratedClaimTokens(worktree, claimId) {
   const lockPath = resolveClaimLockPath(worktree);
@@ -680,29 +866,48 @@ export function backfillGeneratedClaimTokens(worktree, claimId) {
   if (read.lock.claimId !== claimId) {
     return { status: 'lock-mismatch', lockPath, path, holder: read.lock };
   }
-  // A directory at the record's own path is never authorized to be
-  // replaced here -- see the function-level doc comment above and
-  // recordGeneratedClaimTokens's own doc comment.
-  try {
-    if (statSync(path).isDirectory()) {
-      return { status: 'record-blocked', lockPath, path };
+  // The directory check, the nonce-preserving read, and the write below all
+  // run inside one write-lock critical section (#2922): without it, a
+  // concurrent plain `recordGeneratedClaimTokens` write (e.g. the
+  // activation-nonce minting flow's own `--record-tokens --nonce` call)
+  // could land between the read and the write, and this function's own
+  // subsequent write -- built from the nonce it captured moments earlier --
+  // would silently clobber that fresher nonce. See
+  // {@link withGeneratedTokensWriteLock} for the full rationale; its
+  // `critical` callback here calls only the unlocked
+  // {@link writeGeneratedClaimTokensRecord} primitive, never the locked
+  // {@link recordGeneratedClaimTokens} wrapper, to avoid deadlocking against
+  // this same non-re-entrant guard.
+  return withGeneratedTokensWriteLock(path, () => {
+    // A directory at the record's own path is never authorized to be
+    // replaced here -- see the function-level doc comment above and
+    // recordGeneratedClaimTokens's own doc comment.
+    try {
+      if (statSync(path).isDirectory()) {
+        return { status: 'record-blocked', lockPath, path };
+      }
+    } catch {
+      // Absent, or an unreadable non-directory path: fall through and let
+      // writeGeneratedClaimTokensRecord's own atomic-write handle it the
+      // same way it always has.
     }
-  } catch {
-    // Absent, or an unreadable non-directory path: fall through and let
-    // recordGeneratedClaimTokens's own atomic-write handle it the same
-    // way it always has.
-  }
-  // Preserve an existing well-formed record's own nonce, if any -- see the
-  // function-level doc comment above.
-  const existing = readGeneratedClaimTokens(worktree, claimId);
-  const nonce =
-    existing.status === 'present' ? existing.record.nonce : undefined;
-  recordGeneratedClaimTokens(worktree, {
-    agentId: read.lock.agentId,
-    claimId,
-    ...(nonce === undefined ? {} : { nonce }),
+    // Preserve an existing well-formed record's own nonce, if any -- see
+    // the function-level doc comment above.
+    const existing = readGeneratedClaimTokens(worktree, claimId);
+    const nonce =
+      existing.status === 'present' ? existing.record.nonce : undefined;
+    writeGeneratedClaimTokensRecord(path, {
+      agentId: read.lock.agentId,
+      claimId,
+      ...(nonce === undefined ? {} : { nonce }),
+    });
+    return {
+      status: 'backfilled',
+      lockPath,
+      path,
+      agentId: read.lock.agentId,
+    };
   });
-  return { status: 'backfilled', lockPath, path, agentId: read.lock.agentId };
 }
 function parseArgs(argv) {
   const { values, help } = parseCliArgs(argv, CLAIM_LOCK_FLAG_SPEC);

--- a/scripts/claim-lock.mjs
+++ b/scripts/claim-lock.mjs
@@ -763,7 +763,24 @@ function withGeneratedTokensWriteLock(recordPath, critical) {
     // is its sole, syscall-proven owner from this point on, so a failure
     // finishing the write below is always safe to clean up.
     try {
-      writeSync(fd, token);
+      // A single `writeSync(fd, token)` call is not guaranteed to write
+      // every byte -- `write(2)` (and thus `writeSync`) may legitimately
+      // return fewer bytes than requested without throwing (#2922 review
+      // round 12, Codex and Copilot independently). A truncated guard
+      // body would then never match `token` again: release's own
+      // token-comparison in {@link releaseGeneratedTokensWriteLockIfOwned}
+      // would treat it as "not mine" and leave the guard behind forever,
+      // even though this call's own write, and the caller's `critical()`,
+      // both otherwise succeed -- every later writer for this claim-id
+      // then waits the full timeout and fails closed until an operator
+      // manually removes it. Loop on the buffer form until every byte is
+      // written, the same pattern Node's own `writeFileSync` uses
+      // internally for exactly this reason.
+      const buffer = Buffer.from(token, 'utf8');
+      let written = 0;
+      while (written < buffer.length) {
+        written += writeSync(fd, buffer, written, buffer.length - written);
+      }
     } catch (error) {
       // `writeSync` failing leaves `fd` genuinely still open (a write
       // failure does not close the descriptor), so this is the correct,

--- a/scripts/claim-lock.mjs
+++ b/scripts/claim-lock.mjs
@@ -726,13 +726,32 @@ function withGeneratedTokensWriteLock(recordPath, critical) {
     // finishing the write below is always safe to clean up.
     try {
       writeSync(fd, String(process.pid));
-      closeSync(fd);
     } catch (error) {
+      // `writeSync` failing leaves `fd` genuinely still open (a write
+      // failure does not close the descriptor), so this is the correct,
+      // and only, place to close it for this branch.
       try {
         closeSync(fd);
       } catch {
-        // Already closed, or otherwise invalid -- ignore.
+        // ignore
       }
+      try {
+        unlinkSync(lockPath);
+      } catch {
+        // Best-effort: never mask the real error above.
+      }
+      throw error;
+    }
+    try {
+      closeSync(fd);
+    } catch (error) {
+      // Do NOT retry `closeSync(fd)` here (#2922 review round 8,
+      // Codex): POSIX close() semantics mean the descriptor is no longer
+      // ours to touch once this call has been made, whether or not it
+      // reported an error -- the kernel may already have recycled that
+      // exact descriptor number for something else (for example another
+      // thread's own `open()`), so a second close attempt on it here
+      // could silently disrupt unrelated I/O elsewhere in the process.
       try {
         unlinkSync(lockPath);
       } catch {

--- a/scripts/claim-lock.mjs
+++ b/scripts/claim-lock.mjs
@@ -733,6 +733,30 @@ function resolveGeneratedTokensWriteLockPath(recordPath) {
  * operation, not safety after an operator has manually intervened on a
  * guard that turns out not to have been actually orphaned.
  */
+/**
+ * Combine an original failure with a cleanup failure that happened while
+ * handling it, so neither is silently lost (#2922 review round 9,
+ * Copilot; extended round 12, Codex, to the acquire-phase cleanup
+ * branches below, which had the same gap this originally closed only for
+ * the `critical()`-failure path). Without this, a caller who sees only
+ * `originalError` has no way to learn a guard was also left behind at
+ * `lockPath` until a later, unrelated caller independently discovers it
+ * via its own timeout -- minutes or more later, and attributed to the
+ * wrong operation.
+ */
+function combineGeneratedTokensWriteLockCleanupFailure(
+  originalError,
+  cleanupError,
+  lockPath,
+) {
+  const combined = new Error(
+    `${originalError.message} (additionally failed to remove ` +
+      `the generated-tokens write lock guard at ${lockPath} during ` +
+      `cleanup: ${cleanupError.message})`,
+  );
+  combined.cause = originalError;
+  return combined;
+}
 function withGeneratedTokensWriteLock(recordPath, critical) {
   const lockPath = resolveGeneratedTokensWriteLockPath(recordPath);
   const deadline = Date.now() + GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS;
@@ -794,10 +818,20 @@ function withGeneratedTokensWriteLock(recordPath, critical) {
       } catch {
         // ignore
       }
+      // Report a cleanup-unlink failure alongside the real error rather
+      // than silently swallowing it (#2922 review round 12, Codex):
+      // otherwise a guard left behind here (for example because Windows
+      // still considers the descriptor open) blocks every later writer
+      // for this claim-id until an operator manually removes it, with
+      // nothing in the thrown error pointing at that guard path.
       try {
         unlinkSync(lockPath);
-      } catch {
-        // Best-effort: never mask the real error above.
+      } catch (cleanupError) {
+        throw combineGeneratedTokensWriteLockCleanupFailure(
+          error,
+          cleanupError,
+          lockPath,
+        );
       }
       throw error;
     }
@@ -813,10 +847,20 @@ function withGeneratedTokensWriteLock(recordPath, critical) {
       // could silently disrupt unrelated I/O elsewhere in the process.
       // A bare `unlinkSync` remains safe for the same reason as the
       // `writeSync` failure branch above: `critical()` has not run yet.
+      // Report a cleanup-unlink failure alongside the real error, same
+      // as that branch (#2922 review round 12, Codex) -- this is the
+      // exact scenario the review cited: `closeSync` fails (for example
+      // Windows still considers the guard open) and the cleanup unlink
+      // also fails, so the guard can remain and block every later writer
+      // while the caller is never shown its path.
       try {
         unlinkSync(lockPath);
-      } catch {
-        // Best-effort: never mask the real error above.
+      } catch (cleanupError) {
+        throw combineGeneratedTokensWriteLockCleanupFailure(
+          error,
+          cleanupError,
+          lockPath,
+        );
       }
       throw error;
     }
@@ -842,13 +886,11 @@ function withGeneratedTokensWriteLock(recordPath, critical) {
     try {
       releaseGeneratedTokensWriteLockIfOwned(lockPath, token);
     } catch (cleanupError) {
-      const combined = new Error(
-        `${error.message} (additionally failed to remove the ` +
-          `generated-tokens write lock guard at ${lockPath} during ` +
-          `cleanup: ${cleanupError.message})`,
+      throw combineGeneratedTokensWriteLockCleanupFailure(
+        error,
+        cleanupError,
+        lockPath,
       );
-      combined.cause = error;
-      throw combined;
     }
     throw error;
   }

--- a/scripts/claim-lock.mjs
+++ b/scripts/claim-lock.mjs
@@ -686,6 +686,24 @@ function withGeneratedTokensWriteLock(recordPath, critical) {
       break;
     } catch (error) {
       if (error.code !== 'EEXIST') {
+        // Not a collision with an existing guard: `wx`'s own open+write+
+        // close sequence can still leave a file at `lockPath` even though
+        // this call itself threw (#2922 review round 4, Copilot) -- for
+        // example `ENOSPC` failing the write after `O_CREAT | O_EXCL`
+        // already made the (empty or partial) file visible. Unlike the
+        // stale-guard reclaim removed above, cleaning up here carries no
+        // ABA risk: excluding `EEXIST` means this exact call -- never a
+        // prior or concurrent holder -- is the only possible owner of
+        // whatever now exists at `lockPath`, so removing it is always
+        // safe. Best-effort: a cleanup failure must never mask the real
+        // error the caller needs to see (and is also the safe outcome
+        // when nothing was actually created, e.g. the directory itself
+        // was unwritable).
+        try {
+          unlinkSync(lockPath);
+        } catch {
+          // ignore
+        }
         throw error;
       }
       if (Date.now() >= deadline) {

--- a/scripts/claim-lock.mjs
+++ b/scripts/claim-lock.mjs
@@ -133,12 +133,19 @@
 // (and is correctly preserved) or entirely after its write (a normal,
 // non-lossy last-writer-wins overwrite), never in between. A guard file
 // orphaned by a killed process (rather than released via a normal
-// `finally`) self-heals after one bounded wait: the critical section it
-// guards is always a handful of synchronous `fs` calls with no `await` in
-// between, so a guard old enough to have outlived one full wait budget is
-// reclaimed as stale (by file modification time) and removed, exactly
-// once per call, rather than blocking every future write against that
-// claim-id forever.
+// `finally`) fails every future write against that claim-id closed with a
+// clear recovery message rather than silently reclaiming itself: an
+// earlier revision self-reclaimed a guard old enough (by file modification
+// time) to have outlived one full wait budget, but three independent
+// reviewers (Codex, Copilot, CodeRabbit) flagged that as its own ABA race
+// -- two callers can both classify the same guard as stale, and the
+// second's unconditional unlink can delete the first reclaimer's fresh
+// replacement (or a still-live holder's own guard), letting both enter
+// the critical section at once and reintroducing the exact clobber this
+// lock exists to prevent. Closing that safely needs a real
+// compare-and-swap or ownership-token primitive this file does not yet
+// have, so failing closed -- explicit operator cleanup required -- is the
+// safer default for now.
 //
 // Scope of the ownership proof (#2879 review, Codex P1): a `present: true`
 // `--read-tokens` result proves "a `--record-tokens` call for this exact
@@ -182,11 +189,12 @@ const MAX_RETRY_ATTEMPTS = 5;
 /**
  * Bounded wait budget for the generated-tokens record's own write-lock
  * (#2922, see {@link withGeneratedTokensWriteLock}). Every critical section
- * it guards is a handful of synchronous, non-blocking-I/O `fs` calls with
- * no `await` in between, so genuine contention is expected to resolve in
- * microseconds; a caller still waiting past this budget has almost
- * certainly hit a guard file orphaned by a killed process rather than a
- * live holder, so it fails loudly instead of hanging forever.
+ * it guards is a handful of synchronous `fs` calls (real disk I/O, not
+ * microseconds-scale, but with no `await` and no external process spawn in
+ * between) -- genuine contention is expected to resolve well under this
+ * budget; a caller still waiting past it has almost certainly hit a guard
+ * file orphaned by a killed process rather than a live holder, so it
+ * fails loudly instead of hanging forever.
  */
 const GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS = 5_000;
 const GENERATED_TOKENS_WRITE_LOCK_RETRY_INTERVAL_MS = 5;
@@ -636,15 +644,26 @@ function resolveGeneratedTokensWriteLockPath(recordPath) {
  * specifically so a *third-party reader* never observes a torn body -- so a
  * plain `wx`-flag exclusive create is sufficient here: POSIX and Windows
  * both make `O_CREAT | O_EXCL` (`CREATE_NEW`) atomic for existence alone,
- * with no partial-content window to close. See
- * {@link GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS} for the bounded-retry
- * rationale, and {@link isStaleGeneratedTokensWriteLock} for the one-shot
- * orphan-reclaim path a caller falls into after that budget is exhausted.
+ * with no partial-content window to close.
+ *
+ * Fails closed after {@link GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS} rather
+ * than self-reclaiming an aged guard (#2922 review -- Codex, Copilot, and
+ * CodeRabbit each independently flagged a since-removed timeout-then-unlink
+ * reclaim path as an ABA race: two callers can both classify the same
+ * guard as stale, and an unconditional `unlinkSync` by the second can
+ * delete the first reclaimer's freshly created replacement -- or a still
+ * genuinely live holder's own guard -- letting two callers enter this
+ * critical section at once, reintroducing the exact clobber this lock
+ * exists to prevent). An orphaned guard (left behind by a process killed
+ * between acquiring it and reaching its own `finally` release) therefore
+ * requires explicit operator cleanup -- removing the reported path -- per
+ * the thrown error's own recovery instructions, rather than an automatic
+ * reclaim this codebase cannot yet prove safe without a real
+ * compare-and-swap or ownership-token primitive.
  */
 function withGeneratedTokensWriteLock(recordPath, critical) {
   const lockPath = resolveGeneratedTokensWriteLockPath(recordPath);
-  let deadline = Date.now() + GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS;
-  let staleReclaimAttempted = false;
+  const deadline = Date.now() + GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS;
   for (;;) {
     try {
       writeFileSync(lockPath, String(process.pid), { flag: 'wx' });
@@ -653,33 +672,15 @@ function withGeneratedTokensWriteLock(recordPath, critical) {
       if (error.code !== 'EEXIST') {
         throw error;
       }
-      if (Date.now() < deadline) {
-        sleepSyncMs(GENERATED_TOKENS_WRITE_LOCK_RETRY_INTERVAL_MS);
-        continue;
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `Timed out waiting for the generated-tokens write lock at ${lockPath}; ` +
+            `a crashed holder may have left it behind. Remove ${lockPath} ` +
+            `to recover (only safe once you have confirmed no live process ` +
+            `still holds it).`,
+        );
       }
-      // The wait budget is exhausted. Reclaim an orphaned guard exactly
-      // once per call before giving up: every critical section this lock
-      // guards is a handful of synchronous, non-blocking-I/O `fs` calls
-      // with no `await` in between, so a guard old enough to have outlived
-      // one full wait budget was almost certainly abandoned by a killed
-      // process, not a live holder still working.
-      if (!staleReclaimAttempted && isStaleGeneratedTokensWriteLock(lockPath)) {
-        staleReclaimAttempted = true;
-        try {
-          unlinkSync(lockPath);
-        } catch {
-          // A concurrent reclaimer may have already removed it (or a
-          // legitimate holder already released it) -- either way, the
-          // create attempt below decides what happens next.
-        }
-        deadline = Date.now() + GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS;
-        continue;
-      }
-      throw new Error(
-        `Timed out waiting for the generated-tokens write lock at ${lockPath}; ` +
-          `a crashed holder may have left it behind. If this persists, ` +
-          `remove ${lockPath} to recover.`,
-      );
+      sleepSyncMs(GENERATED_TOKENS_WRITE_LOCK_RETRY_INTERVAL_MS);
     }
   }
   try {
@@ -687,8 +688,8 @@ function withGeneratedTokensWriteLock(recordPath, critical) {
   } finally {
     // Best-effort cleanup only: a failure here never masks a real error
     // from `critical()`, and a leaked guard file only costs the next
-    // caller one bounded wait before the stale-reclaim path above removes
-    // it for them.
+    // caller a bounded wait before this same failure mode applies to them
+    // too, per the fail-closed rationale above.
     try {
       unlinkSync(lockPath);
     } catch {
@@ -697,35 +698,30 @@ function withGeneratedTokensWriteLock(recordPath, critical) {
   }
 }
 /**
- * Whether the write-lock guard file at `lockPath` has aged past one full
- * {@link GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS} budget, per its own file
- * modification time -- the sole signal {@link withGeneratedTokensWriteLock}
- * uses to tell an orphaned guard (left behind by a process killed between
- * acquiring it and reaching its own `finally` release) from a still-live
- * holder. This is a safe basis specifically because every critical section
- * this lock guards is synchronous with no `await` in between: a genuine
- * holder writes the guard and releases it again within microseconds, so a
- * guard old enough to have already outlived one full wait budget could
- * never be a live holder still working, only an orphan. `false` on any
- * read failure (absent, or otherwise unreadable) -- not something this
- * call can safely reclaim as stale; the caller's own next create attempt
- * resolves the state either way.
- */
-function isStaleGeneratedTokensWriteLock(lockPath) {
-  try {
-    const ageMs = Date.now() - statSync(lockPath).mtimeMs;
-    return ageMs >= GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS;
-  } catch {
-    return false;
-  }
-}
-/**
  * Read-only inspection of the generated-tokens record for `claimId` at
  * `cwd`'s own private git-admin directory. Never creates, mutates, or
  * deletes anything.
  */
 export function readGeneratedClaimTokens(cwd, claimId) {
-  const path = resolveGeneratedTokensPath(cwd, claimId);
+  return readGeneratedTokensAtPath(
+    resolveGeneratedTokensPath(cwd, claimId),
+    claimId,
+  );
+}
+/**
+ * Path-based counterpart of {@link readGeneratedClaimTokens}, for a caller
+ * that has already resolved the record's path and must not re-resolve it
+ * (#2922 review, CodeRabbit): `resolveGeneratedTokensPath` shells out to
+ * `git rev-parse` via {@link resolveWorktreeAdminDir}, a synchronous child
+ * process spawn that can easily cost tens of milliseconds -- re-running it
+ * from inside a {@link withGeneratedTokensWriteLock} critical section would
+ * needlessly stretch that critical section with work the lock's bounded
+ * wait budget doesn't need to account for at all.
+ * {@link backfillGeneratedClaimTokens} uses this directly with its own
+ * already-resolved `path`, never the
+ * public `cwd`-based function above, once inside that lock.
+ */
+function readGeneratedTokensAtPath(path, claimId) {
   let raw;
   try {
     raw = readFileSync(path, 'utf8');
@@ -892,8 +888,11 @@ export function backfillGeneratedClaimTokens(worktree, claimId) {
       // same way it always has.
     }
     // Preserve an existing well-formed record's own nonce, if any -- see
-    // the function-level doc comment above.
-    const existing = readGeneratedClaimTokens(worktree, claimId);
+    // the function-level doc comment above. Uses the already-resolved
+    // `path`, not the public cwd-based `readGeneratedClaimTokens` (#2922
+    // review, CodeRabbit): that would re-run `resolveGeneratedTokensPath`'s
+    // synchronous `git rev-parse` spawn from inside this critical section.
+    const existing = readGeneratedTokensAtPath(path, claimId);
     const nonce =
       existing.status === 'present' ? existing.record.nonce : undefined;
     writeGeneratedClaimTokensRecord(path, {

--- a/scripts/claim-lock.mjs
+++ b/scripts/claim-lock.mjs
@@ -172,13 +172,16 @@
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import {
+  closeSync,
   linkSync,
+  openSync,
   readFileSync,
   renameSync,
   rmSync,
   statSync,
   unlinkSync,
   writeFileSync,
+  writeSync,
 } from 'node:fs';
 import { join } from 'node:path';
 import { parseCliArgs } from './cli-args.mjs';
@@ -662,6 +665,22 @@ function resolveGeneratedTokensWriteLockPath(recordPath) {
  * both make `O_CREAT | O_EXCL` (`CREATE_NEW`) atomic for existence alone,
  * with no partial-content window to close.
  *
+ * The create step uses {@link openSync}/{@link writeSync}/{@link closeSync}
+ * directly, rather than a single {@link writeFileSync} call, specifically to
+ * track ownership precisely (#2922 review round 5, Copilot): only a
+ * *successful* `openSync(path, 'wx')` proves this call exclusively created
+ * `lockPath` and is its sole owner from that instant on, so only a failure
+ * *after* that point (finishing the write, or closing the descriptor) is
+ * safe to clean up with an unlink. A failure *at* `openSync` itself (for
+ * example `EMFILE`/`ENFILE`, transient descriptor exhaustion) proves the
+ * opposite -- nothing was created by this call -- so nothing is touched;
+ * unlinking there could delete a different, possibly concurrent, holder's
+ * genuine guard, landing right back in the same ABA-race territory as the
+ * stale-guard reclaim already removed below. An earlier revision used the
+ * single-call `writeFileSync(path, ..., { flag: 'wx' })` form and cleaned
+ * up on *any* non-`EEXIST` error, which could not tell these two cases
+ * apart.
+ *
  * Fails closed after {@link GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS} rather
  * than self-reclaiming an aged guard (#2922 review -- Codex, Copilot, and
  * CodeRabbit each independently flagged a since-removed timeout-then-unlink
@@ -681,29 +700,14 @@ function withGeneratedTokensWriteLock(recordPath, critical) {
   const lockPath = resolveGeneratedTokensWriteLockPath(recordPath);
   const deadline = Date.now() + GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS;
   for (;;) {
+    let fd;
     try {
-      writeFileSync(lockPath, String(process.pid), { flag: 'wx' });
-      break;
+      fd = openSync(lockPath, 'wx');
     } catch (error) {
       if (error.code !== 'EEXIST') {
-        // Not a collision with an existing guard: `wx`'s own open+write+
-        // close sequence can still leave a file at `lockPath` even though
-        // this call itself threw (#2922 review round 4, Copilot) -- for
-        // example `ENOSPC` failing the write after `O_CREAT | O_EXCL`
-        // already made the (empty or partial) file visible. Unlike the
-        // stale-guard reclaim removed above, cleaning up here carries no
-        // ABA risk: excluding `EEXIST` means this exact call -- never a
-        // prior or concurrent holder -- is the only possible owner of
-        // whatever now exists at `lockPath`, so removing it is always
-        // safe. Best-effort: a cleanup failure must never mask the real
-        // error the caller needs to see (and is also the safe outcome
-        // when nothing was actually created, e.g. the directory itself
-        // was unwritable).
-        try {
-          unlinkSync(lockPath);
-        } catch {
-          // ignore
-        }
+        // `openSync` itself never returned a descriptor, so this call
+        // never became the guard's owner -- see the function-level doc
+        // comment above for why nothing here is safe to touch.
         throw error;
       }
       if (Date.now() >= deadline) {
@@ -715,7 +719,28 @@ function withGeneratedTokensWriteLock(recordPath, critical) {
         );
       }
       sleepSyncMs(GENERATED_TOKENS_WRITE_LOCK_RETRY_INTERVAL_MS);
+      continue;
     }
+    // `openSync` succeeded: this call exclusively created `lockPath` and
+    // is its sole, syscall-proven owner from this point on, so a failure
+    // finishing the write below is always safe to clean up.
+    try {
+      writeSync(fd, String(process.pid));
+      closeSync(fd);
+    } catch (error) {
+      try {
+        closeSync(fd);
+      } catch {
+        // Already closed, or otherwise invalid -- ignore.
+      }
+      try {
+        unlinkSync(lockPath);
+      } catch {
+        // Best-effort: never mask the real error above.
+      }
+      throw error;
+    }
+    break;
   }
   let result;
   try {

--- a/src/scripts/claim-lock.mts
+++ b/src/scripts/claim-lock.mts
@@ -115,6 +115,32 @@
 // a GitHub round-trip, matching `--acquire`'s own same-machine, no-network
 // design.
 //
+// Generated-tokens write lock (#2922): `--backfill-tokens` preserves an
+// existing record's own `nonce` by reading it, then writing the backfilled
+// record back with that captured value -- a read-modify-write with nothing
+// serializing it against a concurrent plain `--record-tokens --nonce` call
+// (the activation-nonce minting flow's own second write) landing in
+// between. Because every write to this file was previously a plain
+// `atomicReplaceFile` replace, not a compare-and-swap, that interleaving
+// could silently clobber a fresher nonce with the stale value the backfill
+// captured moments earlier. Both call sites now share one
+// `withGeneratedTokensWriteLock` critical section, keyed by the record's
+// own path: a same-directory `.writelock` guard file created via a plain
+// `wx`-flag exclusive create (existence alone needs no atomic-visibility
+// trick, unlike the claim lock body `linkSync` closes for #2920 above --
+// nothing ever reads this guard file's content). This makes the two writers
+// fully mutually exclusive rather than merely narrowing the window: a
+// concurrent write either completes entirely before the backfill's read
+// (and is correctly preserved) or entirely after its write (a normal,
+// non-lossy last-writer-wins overwrite), never in between. A guard file
+// orphaned by a killed process (rather than released via a normal
+// `finally`) self-heals after one bounded wait: the critical section it
+// guards is always a handful of synchronous `fs` calls with no `await` in
+// between, so a guard old enough to have outlived one full wait budget is
+// reclaimed as stale (by file modification time) and removed, exactly
+// once per call, rather than blocking every future write against that
+// claim-id forever.
+//
 // Scope of the ownership proof (#2879 review, Codex P1): a `present: true`
 // `--read-tokens` result proves "a `--record-tokens` call for this exact
 // claim-id landed at this path" -- it does not cryptographically bind that
@@ -166,6 +192,17 @@ interface ClaimLockBody {
 const CLAIM_LOCK_FILE_NAME = 'idd-claim.lock';
 const GENERATED_TOKENS_FILE_PREFIX = 'idd-generated-tokens';
 const MAX_RETRY_ATTEMPTS = 5;
+/**
+ * Bounded wait budget for the generated-tokens record's own write-lock
+ * (#2922, see {@link withGeneratedTokensWriteLock}). Every critical section
+ * it guards is a handful of synchronous, non-blocking-I/O `fs` calls with
+ * no `await` in between, so genuine contention is expected to resolve in
+ * microseconds; a caller still waiting past this budget has almost
+ * certainly hit a guard file orphaned by a killed process rather than a
+ * live holder, so it fails loudly instead of hanging forever.
+ */
+const GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS = 5_000;
+const GENERATED_TOKENS_WRITE_LOCK_RETRY_INTERVAL_MS = 5;
 /**
  * Cap on the sanitized-claim-id portion of a generated-tokens filename
  * (see {@link sanitizeClaimIdForFilename}). A claim-id is an opaque
@@ -686,6 +723,139 @@ export type GeneratedTokensReadResult =
   | { status: 'present'; path: string; record: GeneratedTokensBody };
 
 /**
+ * Block the calling thread for `ms` milliseconds. Node's main thread (unlike
+ * a browser UI thread) permits a blocking `Atomics.wait`, so a private,
+ * never-`notify`'d `SharedArrayBuffer` slot works as a plain synchronous
+ * sleep -- there is no cross-process or cross-thread signalling involved,
+ * only a timer, matching this CLI's fully synchronous execution model.
+ */
+function sleepSyncMs(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/** Resolve the write-lock guard path for the generated-tokens record at `recordPath`. */
+function resolveGeneratedTokensWriteLockPath(recordPath: string): string {
+  return `${recordPath}.writelock`;
+}
+
+/**
+ * Serialize every critical section that reads and/or writes the
+ * generated-tokens record at `recordPath` against every other one for that
+ * same path (#2922). Closes the race where {@link backfillGeneratedClaimTokens}
+ * captures an existing record's `nonce` via {@link readGeneratedClaimTokens},
+ * then a concurrent plain write -- the activation-nonce minting flow's own
+ * `--record-tokens --nonce` call, via {@link recordGeneratedClaimTokens} --
+ * lands in between, and backfill's own subsequent write (a plain
+ * {@link atomicReplaceFile} replace, not a compare-and-swap) silently
+ * clobbers that fresher nonce with the stale value it captured moments
+ * earlier. Both call sites resolve to the same lock path for the same
+ * `(cwd, claimId)` pair (they share {@link resolveGeneratedTokensPath}), so
+ * true mutual exclusion holds between them: a plain write either completes
+ * entirely before backfill's read (and backfill observes it, preserving its
+ * nonce correctly) or entirely after backfill's write (and simply
+ * overwrites, which is the expected, non-lossy last-writer-wins outcome --
+ * never a write landing invisibly *inside* backfill's own read-then-write
+ * window).
+ *
+ * `critical` must call only the unlocked write primitive
+ * ({@link writeGeneratedClaimTokensRecord}), never the locked
+ * {@link recordGeneratedClaimTokens} wrapper -- this guard is not
+ * re-entrant, and nesting would deadlock a caller against itself.
+ *
+ * The guard file's own *content* is never read back by anything -- unlike
+ * the claim lock's `linkSync`-based fresh-create fix (#2920), which exists
+ * specifically so a *third-party reader* never observes a torn body -- so a
+ * plain `wx`-flag exclusive create is sufficient here: POSIX and Windows
+ * both make `O_CREAT | O_EXCL` (`CREATE_NEW`) atomic for existence alone,
+ * with no partial-content window to close. See
+ * {@link GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS} for the bounded-retry
+ * rationale, and {@link isStaleGeneratedTokensWriteLock} for the one-shot
+ * orphan-reclaim path a caller falls into after that budget is exhausted.
+ */
+function withGeneratedTokensWriteLock<T>(
+  recordPath: string,
+  critical: () => T,
+): T {
+  const lockPath = resolveGeneratedTokensWriteLockPath(recordPath);
+  let deadline = Date.now() + GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS;
+  let staleReclaimAttempted = false;
+  for (;;) {
+    try {
+      writeFileSync(lockPath, String(process.pid), { flag: 'wx' });
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
+        throw error;
+      }
+      if (Date.now() < deadline) {
+        sleepSyncMs(GENERATED_TOKENS_WRITE_LOCK_RETRY_INTERVAL_MS);
+        continue;
+      }
+      // The wait budget is exhausted. Reclaim an orphaned guard exactly
+      // once per call before giving up: every critical section this lock
+      // guards is a handful of synchronous, non-blocking-I/O `fs` calls
+      // with no `await` in between, so a guard old enough to have outlived
+      // one full wait budget was almost certainly abandoned by a killed
+      // process, not a live holder still working.
+      if (!staleReclaimAttempted && isStaleGeneratedTokensWriteLock(lockPath)) {
+        staleReclaimAttempted = true;
+        try {
+          unlinkSync(lockPath);
+        } catch {
+          // A concurrent reclaimer may have already removed it (or a
+          // legitimate holder already released it) -- either way, the
+          // create attempt below decides what happens next.
+        }
+        deadline = Date.now() + GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS;
+        continue;
+      }
+      throw new Error(
+        `Timed out waiting for the generated-tokens write lock at ${lockPath}; ` +
+          `a crashed holder may have left it behind. If this persists, ` +
+          `remove ${lockPath} to recover.`,
+      );
+    }
+  }
+  try {
+    return critical();
+  } finally {
+    // Best-effort cleanup only: a failure here never masks a real error
+    // from `critical()`, and a leaked guard file only costs the next
+    // caller one bounded wait before the stale-reclaim path above removes
+    // it for them.
+    try {
+      unlinkSync(lockPath);
+    } catch {
+      // ignore
+    }
+  }
+}
+
+/**
+ * Whether the write-lock guard file at `lockPath` has aged past one full
+ * {@link GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS} budget, per its own file
+ * modification time -- the sole signal {@link withGeneratedTokensWriteLock}
+ * uses to tell an orphaned guard (left behind by a process killed between
+ * acquiring it and reaching its own `finally` release) from a still-live
+ * holder. This is a safe basis specifically because every critical section
+ * this lock guards is synchronous with no `await` in between: a genuine
+ * holder writes the guard and releases it again within microseconds, so a
+ * guard old enough to have already outlived one full wait budget could
+ * never be a live holder still working, only an orphan. `false` on any
+ * read failure (absent, or otherwise unreadable) -- not something this
+ * call can safely reclaim as stale; the caller's own next create attempt
+ * resolves the state either way.
+ */
+function isStaleGeneratedTokensWriteLock(lockPath: string): boolean {
+  try {
+    const ageMs = Date.now() - statSync(lockPath).mtimeMs;
+    return ageMs >= GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Read-only inspection of the generated-tokens record for `claimId` at
  * `cwd`'s own private git-admin directory. Never creates, mutates, or
  * deletes anything.
@@ -726,13 +896,19 @@ export function readGeneratedClaimTokens(
 /**
  * Write (create or idempotently replace) the generated-tokens record for
  * `claimId` at `cwd`'s own private git-admin directory. Unlike the lock
- * file, this has no collision/`--takeover` concept: the record is
- * per-claim-id evidence, not a mutual-exclusion primitive, so re-invoking
- * (once in the primary worktree at A5 claim time with `{agentId,
- * claimId}`, again with `{agentId, claimId, nonce}` right before the
- * activation-nonce marker posts, and again in the new sibling worktree at
- * B1) is always a safe, expected, idempotent overwrite of the same path.
+ * file, this exposes no collision/`--takeover` concept of its own: the
+ * record is per-claim-id evidence, not a caller-visible mutual-exclusion
+ * primitive, so re-invoking (once in the primary worktree at A5 claim time
+ * with `{agentId, claimId}`, again with `{agentId, claimId, nonce}` right
+ * before the activation-nonce marker posts, and again in the new sibling
+ * worktree at B1) is always a safe, expected, idempotent overwrite of the
+ * same path. Internally, every write (and {@link backfillGeneratedClaimTokens}'s
+ * own read-then-write) is now serialized through
+ * {@link withGeneratedTokensWriteLock} (#2922) so a concurrent writer's
+ * nonce can never be silently lost -- that locking is this function's own
+ * implementation detail, not a contract callers need to coordinate with.
  *
+
  * Never replaces a directory occupying the resolved path (regression,
  * #2879 review): a matching `idd-claim.lock` authenticates the claim
  * lock, not the token record's own path, and this filename's hash
@@ -748,6 +924,24 @@ export function recordGeneratedClaimTokens(
   fields: { agentId: string; claimId: string; nonce?: string },
 ): { path: string } {
   const path = resolveGeneratedTokensPath(cwd, fields.claimId);
+  withGeneratedTokensWriteLock(path, () => {
+    writeGeneratedClaimTokensRecord(path, fields);
+  });
+  return { path };
+}
+
+/**
+ * Unlocked write primitive shared by {@link recordGeneratedClaimTokens} and
+ * {@link backfillGeneratedClaimTokens} (#2922). Never call this directly
+ * from outside {@link withGeneratedTokensWriteLock}'s `critical` callback --
+ * it performs no locking of its own, by design, so both callers can share
+ * one lock acquisition around their own (possibly read-then-write) critical
+ * section without deadlocking against a non-re-entrant guard.
+ */
+function writeGeneratedClaimTokensRecord(
+  path: string,
+  fields: { agentId: string; claimId: string; nonce?: string },
+): void {
   const body: GeneratedTokensBody = {
     agentId: fields.agentId,
     claimId: fields.claimId,
@@ -755,7 +949,6 @@ export function recordGeneratedClaimTokens(
     recordedAt: new Date().toISOString(),
   };
   atomicReplaceFile(path, JSON.stringify(body));
-  return { path };
 }
 
 /**
@@ -811,7 +1004,7 @@ export interface BackfillTokensOutcome {
  *   documented gated sequence stops here with no further action needed.
  * - Present lock whose `claimId` matches, and no directory blocks the
  *   record path → writes the generated-tokens record via
- *   {@link recordGeneratedClaimTokens}, using the lock's own `agentId`
+ *   {@link writeGeneratedClaimTokensRecord}, using the lock's own `agentId`
  *   and no `nonce` (matching a fresh pre-nonce `--record-tokens` call) →
  *   `backfilled`. If a well-formed record for this exact `claimId`
  *   already exists (outside the documented recovery route, which only ever
@@ -819,15 +1012,19 @@ export interface BackfillTokensOutcome {
  *   meaning no well-formed record exists yet -- so this is a defensive
  *   guard against a caller invoking this function directly against
  *   caller-discipline), its own `nonce` is preserved rather than silently
- *   erased: {@link recordGeneratedClaimTokens} replaces the whole record,
- *   so writing with no `nonce` unconditionally would otherwise drop an
- *   existing one (#2917 review, Copilot).
+ *   erased: {@link writeGeneratedClaimTokensRecord} replaces the whole
+ *   record, so writing with no `nonce` unconditionally would otherwise
+ *   drop an existing one (#2917 review, Copilot). The read that discovers
+ *   this existing nonce and the write that preserves it now share one
+ *   {@link withGeneratedTokensWriteLock} critical section (#2922), so a
+ *   concurrent writer's own fresher nonce can never land invisibly between
+ *   them.
  *
  * Performs no GitHub round-trip on any path, matching `--acquire`'s own
  * same-machine, no-network design. Re-invoking after a successful backfill
  * always reports `backfilled` again -- a safe, idempotent overwrite via
- * `recordGeneratedClaimTokens`'s own existing idempotency contract, not a
- * separate `already-present` status.
+ * `writeGeneratedClaimTokensRecord`'s own existing idempotency contract, not
+ * a separate `already-present` status.
  */
 export function backfillGeneratedClaimTokens(
   worktree: string,
@@ -847,31 +1044,50 @@ export function backfillGeneratedClaimTokens(
     return { status: 'lock-mismatch', lockPath, path, holder: read.lock };
   }
 
-  // A directory at the record's own path is never authorized to be
-  // replaced here -- see the function-level doc comment above and
-  // recordGeneratedClaimTokens's own doc comment.
-  try {
-    if (statSync(path).isDirectory()) {
-      return { status: 'record-blocked', lockPath, path };
+  // The directory check, the nonce-preserving read, and the write below all
+  // run inside one write-lock critical section (#2922): without it, a
+  // concurrent plain `recordGeneratedClaimTokens` write (e.g. the
+  // activation-nonce minting flow's own `--record-tokens --nonce` call)
+  // could land between the read and the write, and this function's own
+  // subsequent write -- built from the nonce it captured moments earlier --
+  // would silently clobber that fresher nonce. See
+  // {@link withGeneratedTokensWriteLock} for the full rationale; its
+  // `critical` callback here calls only the unlocked
+  // {@link writeGeneratedClaimTokensRecord} primitive, never the locked
+  // {@link recordGeneratedClaimTokens} wrapper, to avoid deadlocking against
+  // this same non-re-entrant guard.
+  return withGeneratedTokensWriteLock(path, () => {
+    // A directory at the record's own path is never authorized to be
+    // replaced here -- see the function-level doc comment above and
+    // recordGeneratedClaimTokens's own doc comment.
+    try {
+      if (statSync(path).isDirectory()) {
+        return { status: 'record-blocked', lockPath, path };
+      }
+    } catch {
+      // Absent, or an unreadable non-directory path: fall through and let
+      // writeGeneratedClaimTokensRecord's own atomic-write handle it the
+      // same way it always has.
     }
-  } catch {
-    // Absent, or an unreadable non-directory path: fall through and let
-    // recordGeneratedClaimTokens's own atomic-write handle it the same
-    // way it always has.
-  }
 
-  // Preserve an existing well-formed record's own nonce, if any -- see the
-  // function-level doc comment above.
-  const existing = readGeneratedClaimTokens(worktree, claimId);
-  const nonce =
-    existing.status === 'present' ? existing.record.nonce : undefined;
+    // Preserve an existing well-formed record's own nonce, if any -- see
+    // the function-level doc comment above.
+    const existing = readGeneratedClaimTokens(worktree, claimId);
+    const nonce =
+      existing.status === 'present' ? existing.record.nonce : undefined;
 
-  recordGeneratedClaimTokens(worktree, {
-    agentId: read.lock.agentId,
-    claimId,
-    ...(nonce === undefined ? {} : { nonce }),
+    writeGeneratedClaimTokensRecord(path, {
+      agentId: read.lock.agentId,
+      claimId,
+      ...(nonce === undefined ? {} : { nonce }),
+    });
+    return {
+      status: 'backfilled',
+      lockPath,
+      path,
+      agentId: read.lock.agentId,
+    };
   });
-  return { status: 'backfilled', lockPath, path, agentId: read.lock.agentId };
 }
 
 interface ParsedArgs {

--- a/src/scripts/claim-lock.mts
+++ b/src/scripts/claim-lock.mts
@@ -820,6 +820,24 @@ function withGeneratedTokensWriteLock<T>(
       break;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
+        // Not a collision with an existing guard: `wx`'s own open+write+
+        // close sequence can still leave a file at `lockPath` even though
+        // this call itself threw (#2922 review round 4, Copilot) -- for
+        // example `ENOSPC` failing the write after `O_CREAT | O_EXCL`
+        // already made the (empty or partial) file visible. Unlike the
+        // stale-guard reclaim removed above, cleaning up here carries no
+        // ABA risk: excluding `EEXIST` means this exact call -- never a
+        // prior or concurrent holder -- is the only possible owner of
+        // whatever now exists at `lockPath`, so removing it is always
+        // safe. Best-effort: a cleanup failure must never mask the real
+        // error the caller needs to see (and is also the safe outcome
+        // when nothing was actually created, e.g. the directory itself
+        // was unwritable).
+        try {
+          unlinkSync(lockPath);
+        } catch {
+          // ignore
+        }
         throw error;
       }
       if (Date.now() >= deadline) {

--- a/src/scripts/claim-lock.mts
+++ b/src/scripts/claim-lock.mts
@@ -174,13 +174,16 @@
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import {
+  closeSync,
   linkSync,
+  openSync,
   readFileSync,
   renameSync,
   rmSync,
   statSync,
   unlinkSync,
   writeFileSync,
+  writeSync,
 } from 'node:fs';
 import { join } from 'node:path';
 import { parseCliArgs } from './cli-args.mts';
@@ -793,6 +796,22 @@ function resolveGeneratedTokensWriteLockPath(recordPath: string): string {
  * both make `O_CREAT | O_EXCL` (`CREATE_NEW`) atomic for existence alone,
  * with no partial-content window to close.
  *
+ * The create step uses {@link openSync}/{@link writeSync}/{@link closeSync}
+ * directly, rather than a single {@link writeFileSync} call, specifically to
+ * track ownership precisely (#2922 review round 5, Copilot): only a
+ * *successful* `openSync(path, 'wx')` proves this call exclusively created
+ * `lockPath` and is its sole owner from that instant on, so only a failure
+ * *after* that point (finishing the write, or closing the descriptor) is
+ * safe to clean up with an unlink. A failure *at* `openSync` itself (for
+ * example `EMFILE`/`ENFILE`, transient descriptor exhaustion) proves the
+ * opposite -- nothing was created by this call -- so nothing is touched;
+ * unlinking there could delete a different, possibly concurrent, holder's
+ * genuine guard, landing right back in the same ABA-race territory as the
+ * stale-guard reclaim already removed below. An earlier revision used the
+ * single-call `writeFileSync(path, ..., { flag: 'wx' })` form and cleaned
+ * up on *any* non-`EEXIST` error, which could not tell these two cases
+ * apart.
+ *
  * Fails closed after {@link GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS} rather
  * than self-reclaiming an aged guard (#2922 review -- Codex, Copilot, and
  * CodeRabbit each independently flagged a since-removed timeout-then-unlink
@@ -815,29 +834,14 @@ function withGeneratedTokensWriteLock<T>(
   const lockPath = resolveGeneratedTokensWriteLockPath(recordPath);
   const deadline = Date.now() + GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS;
   for (;;) {
+    let fd: number;
     try {
-      writeFileSync(lockPath, String(process.pid), { flag: 'wx' });
-      break;
+      fd = openSync(lockPath, 'wx');
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
-        // Not a collision with an existing guard: `wx`'s own open+write+
-        // close sequence can still leave a file at `lockPath` even though
-        // this call itself threw (#2922 review round 4, Copilot) -- for
-        // example `ENOSPC` failing the write after `O_CREAT | O_EXCL`
-        // already made the (empty or partial) file visible. Unlike the
-        // stale-guard reclaim removed above, cleaning up here carries no
-        // ABA risk: excluding `EEXIST` means this exact call -- never a
-        // prior or concurrent holder -- is the only possible owner of
-        // whatever now exists at `lockPath`, so removing it is always
-        // safe. Best-effort: a cleanup failure must never mask the real
-        // error the caller needs to see (and is also the safe outcome
-        // when nothing was actually created, e.g. the directory itself
-        // was unwritable).
-        try {
-          unlinkSync(lockPath);
-        } catch {
-          // ignore
-        }
+        // `openSync` itself never returned a descriptor, so this call
+        // never became the guard's owner -- see the function-level doc
+        // comment above for why nothing here is safe to touch.
         throw error;
       }
       if (Date.now() >= deadline) {
@@ -849,7 +853,28 @@ function withGeneratedTokensWriteLock<T>(
         );
       }
       sleepSyncMs(GENERATED_TOKENS_WRITE_LOCK_RETRY_INTERVAL_MS);
+      continue;
     }
+    // `openSync` succeeded: this call exclusively created `lockPath` and
+    // is its sole, syscall-proven owner from this point on, so a failure
+    // finishing the write below is always safe to clean up.
+    try {
+      writeSync(fd, String(process.pid));
+      closeSync(fd);
+    } catch (error) {
+      try {
+        closeSync(fd);
+      } catch {
+        // Already closed, or otherwise invalid -- ignore.
+      }
+      try {
+        unlinkSync(lockPath);
+      } catch {
+        // Best-effort: never mask the real error above.
+      }
+      throw error;
+    }
+    break;
   }
   let result: T;
   try {

--- a/src/scripts/claim-lock.mts
+++ b/src/scripts/claim-lock.mts
@@ -134,12 +134,19 @@
 // (and is correctly preserved) or entirely after its write (a normal,
 // non-lossy last-writer-wins overwrite), never in between. A guard file
 // orphaned by a killed process (rather than released via a normal
-// `finally`) self-heals after one bounded wait: the critical section it
-// guards is always a handful of synchronous `fs` calls with no `await` in
-// between, so a guard old enough to have outlived one full wait budget is
-// reclaimed as stale (by file modification time) and removed, exactly
-// once per call, rather than blocking every future write against that
-// claim-id forever.
+// `finally`) fails every future write against that claim-id closed with a
+// clear recovery message rather than silently reclaiming itself: an
+// earlier revision self-reclaimed a guard old enough (by file modification
+// time) to have outlived one full wait budget, but three independent
+// reviewers (Codex, Copilot, CodeRabbit) flagged that as its own ABA race
+// -- two callers can both classify the same guard as stale, and the
+// second's unconditional unlink can delete the first reclaimer's fresh
+// replacement (or a still-live holder's own guard), letting both enter
+// the critical section at once and reintroducing the exact clobber this
+// lock exists to prevent. Closing that safely needs a real
+// compare-and-swap or ownership-token primitive this file does not yet
+// have, so failing closed -- explicit operator cleanup required -- is the
+// safer default for now.
 //
 // Scope of the ownership proof (#2879 review, Codex P1): a `present: true`
 // `--read-tokens` result proves "a `--record-tokens` call for this exact
@@ -195,11 +202,12 @@ const MAX_RETRY_ATTEMPTS = 5;
 /**
  * Bounded wait budget for the generated-tokens record's own write-lock
  * (#2922, see {@link withGeneratedTokensWriteLock}). Every critical section
- * it guards is a handful of synchronous, non-blocking-I/O `fs` calls with
- * no `await` in between, so genuine contention is expected to resolve in
- * microseconds; a caller still waiting past this budget has almost
- * certainly hit a guard file orphaned by a killed process rather than a
- * live holder, so it fails loudly instead of hanging forever.
+ * it guards is a handful of synchronous `fs` calls (real disk I/O, not
+ * microseconds-scale, but with no `await` and no external process spawn in
+ * between) -- genuine contention is expected to resolve well under this
+ * budget; a caller still waiting past it has almost certainly hit a guard
+ * file orphaned by a killed process rather than a live holder, so it
+ * fails loudly instead of hanging forever.
  */
 const GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS = 5_000;
 const GENERATED_TOKENS_WRITE_LOCK_RETRY_INTERVAL_MS = 5;
@@ -767,18 +775,29 @@ function resolveGeneratedTokensWriteLockPath(recordPath: string): string {
  * specifically so a *third-party reader* never observes a torn body -- so a
  * plain `wx`-flag exclusive create is sufficient here: POSIX and Windows
  * both make `O_CREAT | O_EXCL` (`CREATE_NEW`) atomic for existence alone,
- * with no partial-content window to close. See
- * {@link GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS} for the bounded-retry
- * rationale, and {@link isStaleGeneratedTokensWriteLock} for the one-shot
- * orphan-reclaim path a caller falls into after that budget is exhausted.
+ * with no partial-content window to close.
+ *
+ * Fails closed after {@link GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS} rather
+ * than self-reclaiming an aged guard (#2922 review -- Codex, Copilot, and
+ * CodeRabbit each independently flagged a since-removed timeout-then-unlink
+ * reclaim path as an ABA race: two callers can both classify the same
+ * guard as stale, and an unconditional `unlinkSync` by the second can
+ * delete the first reclaimer's freshly created replacement -- or a still
+ * genuinely live holder's own guard -- letting two callers enter this
+ * critical section at once, reintroducing the exact clobber this lock
+ * exists to prevent). An orphaned guard (left behind by a process killed
+ * between acquiring it and reaching its own `finally` release) therefore
+ * requires explicit operator cleanup -- removing the reported path -- per
+ * the thrown error's own recovery instructions, rather than an automatic
+ * reclaim this codebase cannot yet prove safe without a real
+ * compare-and-swap or ownership-token primitive.
  */
 function withGeneratedTokensWriteLock<T>(
   recordPath: string,
   critical: () => T,
 ): T {
   const lockPath = resolveGeneratedTokensWriteLockPath(recordPath);
-  let deadline = Date.now() + GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS;
-  let staleReclaimAttempted = false;
+  const deadline = Date.now() + GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS;
   for (;;) {
     try {
       writeFileSync(lockPath, String(process.pid), { flag: 'wx' });
@@ -787,33 +806,15 @@ function withGeneratedTokensWriteLock<T>(
       if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
         throw error;
       }
-      if (Date.now() < deadline) {
-        sleepSyncMs(GENERATED_TOKENS_WRITE_LOCK_RETRY_INTERVAL_MS);
-        continue;
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `Timed out waiting for the generated-tokens write lock at ${lockPath}; ` +
+            `a crashed holder may have left it behind. Remove ${lockPath} ` +
+            `to recover (only safe once you have confirmed no live process ` +
+            `still holds it).`,
+        );
       }
-      // The wait budget is exhausted. Reclaim an orphaned guard exactly
-      // once per call before giving up: every critical section this lock
-      // guards is a handful of synchronous, non-blocking-I/O `fs` calls
-      // with no `await` in between, so a guard old enough to have outlived
-      // one full wait budget was almost certainly abandoned by a killed
-      // process, not a live holder still working.
-      if (!staleReclaimAttempted && isStaleGeneratedTokensWriteLock(lockPath)) {
-        staleReclaimAttempted = true;
-        try {
-          unlinkSync(lockPath);
-        } catch {
-          // A concurrent reclaimer may have already removed it (or a
-          // legitimate holder already released it) -- either way, the
-          // create attempt below decides what happens next.
-        }
-        deadline = Date.now() + GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS;
-        continue;
-      }
-      throw new Error(
-        `Timed out waiting for the generated-tokens write lock at ${lockPath}; ` +
-          `a crashed holder may have left it behind. If this persists, ` +
-          `remove ${lockPath} to recover.`,
-      );
+      sleepSyncMs(GENERATED_TOKENS_WRITE_LOCK_RETRY_INTERVAL_MS);
     }
   }
   try {
@@ -821,37 +822,13 @@ function withGeneratedTokensWriteLock<T>(
   } finally {
     // Best-effort cleanup only: a failure here never masks a real error
     // from `critical()`, and a leaked guard file only costs the next
-    // caller one bounded wait before the stale-reclaim path above removes
-    // it for them.
+    // caller a bounded wait before this same failure mode applies to them
+    // too, per the fail-closed rationale above.
     try {
       unlinkSync(lockPath);
     } catch {
       // ignore
     }
-  }
-}
-
-/**
- * Whether the write-lock guard file at `lockPath` has aged past one full
- * {@link GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS} budget, per its own file
- * modification time -- the sole signal {@link withGeneratedTokensWriteLock}
- * uses to tell an orphaned guard (left behind by a process killed between
- * acquiring it and reaching its own `finally` release) from a still-live
- * holder. This is a safe basis specifically because every critical section
- * this lock guards is synchronous with no `await` in between: a genuine
- * holder writes the guard and releases it again within microseconds, so a
- * guard old enough to have already outlived one full wait budget could
- * never be a live holder still working, only an orphan. `false` on any
- * read failure (absent, or otherwise unreadable) -- not something this
- * call can safely reclaim as stale; the caller's own next create attempt
- * resolves the state either way.
- */
-function isStaleGeneratedTokensWriteLock(lockPath: string): boolean {
-  try {
-    const ageMs = Date.now() - statSync(lockPath).mtimeMs;
-    return ageMs >= GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS;
-  } catch {
-    return false;
   }
 }
 
@@ -864,7 +841,29 @@ export function readGeneratedClaimTokens(
   cwd: string,
   claimId: string,
 ): GeneratedTokensReadResult {
-  const path = resolveGeneratedTokensPath(cwd, claimId);
+  return readGeneratedTokensAtPath(
+    resolveGeneratedTokensPath(cwd, claimId),
+    claimId,
+  );
+}
+
+/**
+ * Path-based counterpart of {@link readGeneratedClaimTokens}, for a caller
+ * that has already resolved the record's path and must not re-resolve it
+ * (#2922 review, CodeRabbit): `resolveGeneratedTokensPath` shells out to
+ * `git rev-parse` via {@link resolveWorktreeAdminDir}, a synchronous child
+ * process spawn that can easily cost tens of milliseconds -- re-running it
+ * from inside a {@link withGeneratedTokensWriteLock} critical section would
+ * needlessly stretch that critical section with work the lock's bounded
+ * wait budget doesn't need to account for at all.
+ * {@link backfillGeneratedClaimTokens} uses this directly with its own
+ * already-resolved `path`, never the
+ * public `cwd`-based function above, once inside that lock.
+ */
+function readGeneratedTokensAtPath(
+  path: string,
+  claimId: string,
+): GeneratedTokensReadResult {
   let raw: string;
   try {
     raw = readFileSync(path, 'utf8');
@@ -1071,8 +1070,11 @@ export function backfillGeneratedClaimTokens(
     }
 
     // Preserve an existing well-formed record's own nonce, if any -- see
-    // the function-level doc comment above.
-    const existing = readGeneratedClaimTokens(worktree, claimId);
+    // the function-level doc comment above. Uses the already-resolved
+    // `path`, not the public cwd-based `readGeneratedClaimTokens` (#2922
+    // review, CodeRabbit): that would re-run `resolveGeneratedTokensPath`'s
+    // synchronous `git rev-parse` spawn from inside this critical section.
+    const existing = readGeneratedTokensAtPath(path, claimId);
     const nonce =
       existing.status === 'present' ? existing.record.nonce : undefined;
 

--- a/src/scripts/claim-lock.mts
+++ b/src/scripts/claim-lock.mts
@@ -789,12 +789,17 @@ function resolveGeneratedTokensWriteLockPath(recordPath: string): string {
  * {@link recordGeneratedClaimTokens} wrapper -- this guard is not
  * re-entrant, and nesting would deadlock a caller against itself.
  *
- * The guard file's own *content* is never read back by anything -- unlike
- * the claim lock's `linkSync`-based fresh-create fix (#2920), which exists
+ * No *contending* reader ever needs to inspect the guard file's content
+ * before the creator finishes writing and closes it -- unlike the claim
+ * lock's `linkSync`-based fresh-create fix (#2920), which exists
  * specifically so a *third-party reader* never observes a torn body -- so a
  * plain `wx`-flag exclusive create is sufficient here: POSIX and Windows
  * both make `O_CREAT | O_EXCL` (`CREATE_NEW`) atomic for existence alone,
- * with no partial-content window to close.
+ * with no partial-content window to close. (This creator's *own* later
+ * release does read the body back, to verify the token it wrote at create
+ * time is still present -- see {@link releaseGeneratedTokensWriteLockIfOwned}
+ * -- #2922 review round 11, Copilot; only a torn-body window relevant to a
+ * different reader is what this paragraph rules out.)
  *
  * The create step uses {@link openSync}/{@link writeSync}/{@link closeSync}
  * directly, rather than a single {@link writeFileSync} call, specifically to
@@ -988,7 +993,13 @@ function randomGeneratedTokensWriteLockToken(): string {
  * missing guard (already released, or never observed) and a guard whose
  * token no longer matches (recreated by a different owner) are both
  * treated as "nothing this call may remove" and silently return, mirroring
- * `releaseCloneLock`'s own token-mismatch handling in `clone-lock.mts`.
+ * `releaseCloneLock`'s own token-mismatch handling in `clone-lock.mts`. The
+ * guard can also disappear *after* this function's own token read confirms
+ * ownership but *before* its `unlinkSync` call below runs -- swallow that
+ * `ENOENT` the same way (#2922 review round 11, Copilot), matching
+ * `releaseCloneLock`'s identical handling at `clone-lock.mts:329-333`:
+ * a guard that is simply already gone by the time of the unlink is still
+ * "nothing left for this call to remove," not a failure to report.
  */
 function releaseGeneratedTokensWriteLockIfOwned(
   lockPath: string,
@@ -1006,7 +1017,13 @@ function releaseGeneratedTokensWriteLockIfOwned(
   if (body !== token) {
     return;
   }
-  unlinkSync(lockPath);
+  try {
+    unlinkSync(lockPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
+  }
 }
 
 /**

--- a/src/scripts/claim-lock.mts
+++ b/src/scripts/claim-lock.mts
@@ -864,6 +864,31 @@ function resolveGeneratedTokensWriteLockPath(recordPath: string): string {
  * operation, not safety after an operator has manually intervened on a
  * guard that turns out not to have been actually orphaned.
  */
+/**
+ * Combine an original failure with a cleanup failure that happened while
+ * handling it, so neither is silently lost (#2922 review round 9,
+ * Copilot; extended round 12, Codex, to the acquire-phase cleanup
+ * branches below, which had the same gap this originally closed only for
+ * the `critical()`-failure path). Without this, a caller who sees only
+ * `originalError` has no way to learn a guard was also left behind at
+ * `lockPath` until a later, unrelated caller independently discovers it
+ * via its own timeout -- minutes or more later, and attributed to the
+ * wrong operation.
+ */
+function combineGeneratedTokensWriteLockCleanupFailure(
+  originalError: unknown,
+  cleanupError: unknown,
+  lockPath: string,
+): Error {
+  const combined = new Error(
+    `${(originalError as Error).message} (additionally failed to remove ` +
+      `the generated-tokens write lock guard at ${lockPath} during ` +
+      `cleanup: ${(cleanupError as Error).message})`,
+  );
+  (combined as Error & { cause?: unknown }).cause = originalError;
+  return combined;
+}
+
 function withGeneratedTokensWriteLock<T>(
   recordPath: string,
   critical: () => T,
@@ -928,10 +953,20 @@ function withGeneratedTokensWriteLock<T>(
       } catch {
         // ignore
       }
+      // Report a cleanup-unlink failure alongside the real error rather
+      // than silently swallowing it (#2922 review round 12, Codex):
+      // otherwise a guard left behind here (for example because Windows
+      // still considers the descriptor open) blocks every later writer
+      // for this claim-id until an operator manually removes it, with
+      // nothing in the thrown error pointing at that guard path.
       try {
         unlinkSync(lockPath);
-      } catch {
-        // Best-effort: never mask the real error above.
+      } catch (cleanupError) {
+        throw combineGeneratedTokensWriteLockCleanupFailure(
+          error,
+          cleanupError,
+          lockPath,
+        );
       }
       throw error;
     }
@@ -947,10 +982,20 @@ function withGeneratedTokensWriteLock<T>(
       // could silently disrupt unrelated I/O elsewhere in the process.
       // A bare `unlinkSync` remains safe for the same reason as the
       // `writeSync` failure branch above: `critical()` has not run yet.
+      // Report a cleanup-unlink failure alongside the real error, same
+      // as that branch (#2922 review round 12, Codex) -- this is the
+      // exact scenario the review cited: `closeSync` fails (for example
+      // Windows still considers the guard open) and the cleanup unlink
+      // also fails, so the guard can remain and block every later writer
+      // while the caller is never shown its path.
       try {
         unlinkSync(lockPath);
-      } catch {
-        // Best-effort: never mask the real error above.
+      } catch (cleanupError) {
+        throw combineGeneratedTokensWriteLockCleanupFailure(
+          error,
+          cleanupError,
+          lockPath,
+        );
       }
       throw error;
     }
@@ -976,13 +1021,11 @@ function withGeneratedTokensWriteLock<T>(
     try {
       releaseGeneratedTokensWriteLockIfOwned(lockPath, token);
     } catch (cleanupError) {
-      const combined = new Error(
-        `${(error as Error).message} (additionally failed to remove the ` +
-          `generated-tokens write lock guard at ${lockPath} during ` +
-          `cleanup: ${(cleanupError as Error).message})`,
+      throw combineGeneratedTokensWriteLockCleanupFailure(
+        error,
+        cleanupError,
+        lockPath,
       );
-      (combined as Error & { cause?: unknown }).cause = error;
-      throw combined;
     }
     throw error;
   }

--- a/src/scripts/claim-lock.mts
+++ b/src/scripts/claim-lock.mts
@@ -826,6 +826,38 @@ function resolveGeneratedTokensWriteLockPath(recordPath: string): string {
  * the thrown error's own recovery instructions, rather than an automatic
  * reclaim this codebase cannot yet prove safe without a real
  * compare-and-swap or ownership-token primitive.
+ *
+ * Both releases below (the `critical()`-failure cleanup and the
+ * `critical()`-success release) are **token-verified**, not a bare
+ * `unlinkSync(lockPath)` (#2922 review round 10, Copilot): each acquisition
+ * writes a fresh random token into the guard body, and release re-reads the
+ * guard and only unlinks it when that same token is still present. This
+ * mirrors this repository's own existing precedent for exactly this
+ * problem -- `releaseCloneLock` in `clone-lock.mts` -- which likewise
+ * refuses to remove a lock file whose recorded `token` no longer matches
+ * the releasing handle's own. Without this check, a guard manually removed
+ * by an operator (per the timeout error's own recovery instructions) while
+ * the original holder's `critical()` is still genuinely running could be
+ * recreated by a new writer before the original holder's release runs;
+ * that release would then delete the *new* writer's guard instead of a
+ * guard it actually owns, letting two writers believe they hold exclusive
+ * access at once -- the same class of hazard already solved on the
+ * acquire side (see the `openSync`/`writeSync`/`closeSync` ownership
+ * comment above), now closed on the release side too.
+ *
+ * This narrows the guard-recreation window rather than eliminating it:
+ * the same kind of race could still, in principle, land *between* the
+ * token read and the `unlinkSync` call the check guards, because no
+ * `wx`-only filesystem primitive gives a true atomic compare-and-delete.
+ * Closing that residual sliver would need a real compare-and-swap or
+ * `flock(2)`-style primitive this module deliberately avoids taking on
+ * (see the header comment). It is accepted as a known limitation: it only
+ * matters when a live holder's own guard is manually removed while that
+ * holder's `critical()` is still running -- a precondition violation of
+ * the timeout error's own recovery instructions -- and #2922's Acceptance
+ * Criteria only ever covers nonce-preservation under normal concurrent
+ * operation, not safety after an operator has manually intervened on a
+ * guard that turns out not to have been actually orphaned.
  */
 function withGeneratedTokensWriteLock<T>(
   recordPath: string,
@@ -833,6 +865,7 @@ function withGeneratedTokensWriteLock<T>(
 ): T {
   const lockPath = resolveGeneratedTokensWriteLockPath(recordPath);
   const deadline = Date.now() + GENERATED_TOKENS_WRITE_LOCK_TIMEOUT_MS;
+  const token = randomGeneratedTokensWriteLockToken();
   for (;;) {
     let fd: number;
     try {
@@ -859,11 +892,15 @@ function withGeneratedTokensWriteLock<T>(
     // is its sole, syscall-proven owner from this point on, so a failure
     // finishing the write below is always safe to clean up.
     try {
-      writeSync(fd, String(process.pid));
+      writeSync(fd, token);
     } catch (error) {
       // `writeSync` failing leaves `fd` genuinely still open (a write
       // failure does not close the descriptor), so this is the correct,
-      // and only, place to close it for this branch.
+      // and only, place to close it for this branch. A bare `unlinkSync`
+      // (not the token-verified {@link releaseGeneratedTokensWriteLockIfOwned})
+      // is safe here: `critical()` has not run yet, so no wall-clock window
+      // has opened in which an operator could have manually removed this
+      // still-fresh guard for a different reason to recreate it.
       try {
         closeSync(fd);
       } catch {
@@ -886,6 +923,8 @@ function withGeneratedTokensWriteLock<T>(
       // exact descriptor number for something else (for example another
       // thread's own `open()`), so a second close attempt on it here
       // could silently disrupt unrelated I/O elsewhere in the process.
+      // A bare `unlinkSync` remains safe for the same reason as the
+      // `writeSync` failure branch above: `critical()` has not run yet.
       try {
         unlinkSync(lockPath);
       } catch {
@@ -909,9 +948,11 @@ function withGeneratedTokensWriteLock<T>(
     // would otherwise have no way to learn a guard was left behind until
     // a later, unrelated caller independently discovers it via its own
     // timeout -- minutes or more later, and by a completely different
-    // caller than the one whose failure actually caused it.
+    // caller than the one whose failure actually caused it. Token-verified
+    // (#2922 review round 10, Copilot): see the function-level doc comment
+    // above for why this must not be a bare `unlinkSync`.
     try {
-      unlinkSync(lockPath);
+      releaseGeneratedTokensWriteLockIfOwned(lockPath, token);
     } catch (cleanupError) {
       const combined = new Error(
         `${(error as Error).message} (additionally failed to remove the ` +
@@ -928,9 +969,44 @@ function withGeneratedTokensWriteLock<T>(
   // behind would give the caller no signal that anything needs recovery
   // -- every subsequent write for this claim-id would otherwise just
   // silently wait out a full timeout before failing, with nothing
-  // pointing at the actual cause.
-  unlinkSync(lockPath);
+  // pointing at the actual cause. Token-verified (#2922 review round 10,
+  // Copilot): see the function-level doc comment above.
+  releaseGeneratedTokensWriteLockIfOwned(lockPath, token);
   return result;
+}
+
+/** Generate a fresh, effectively-unique token for one lock acquisition. */
+function randomGeneratedTokensWriteLockToken(): string {
+  return `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+/**
+ * Release the generated-tokens write-lock guard at `lockPath` only if it
+ * still holds `token` -- the token this same acquisition wrote when it
+ * created the guard (see {@link withGeneratedTokensWriteLock}'s doc
+ * comment for the full ABA rationale and its residual-race caveat). A
+ * missing guard (already released, or never observed) and a guard whose
+ * token no longer matches (recreated by a different owner) are both
+ * treated as "nothing this call may remove" and silently return, mirroring
+ * `releaseCloneLock`'s own token-mismatch handling in `clone-lock.mts`.
+ */
+function releaseGeneratedTokensWriteLockIfOwned(
+  lockPath: string,
+  token: string,
+): void {
+  let body: string;
+  try {
+    body = readFileSync(lockPath, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return;
+    }
+    throw error;
+  }
+  if (body !== token) {
+    return;
+  }
+  unlinkSync(lockPath);
 }
 
 /**

--- a/src/scripts/claim-lock.mts
+++ b/src/scripts/claim-lock.mts
@@ -899,15 +899,27 @@ function withGeneratedTokensWriteLock<T>(
   try {
     result = critical();
   } catch (error) {
-    // Best-effort cleanup on a `critical()` failure only: a cleanup
-    // failure here must never mask the real error the caller needs to
-    // see, so it is swallowed -- a leaked guard file in this branch only
-    // costs the next caller a bounded wait before this same fail-closed
-    // behavior applies to them too.
+    // Best-effort cleanup on a `critical()` failure: a cleanup failure
+    // here must never *replace* the real error the caller needs to see,
+    // so on a clean cleanup this rethrows `error` verbatim -- a leaked
+    // guard file then only costs the next caller a bounded wait before
+    // this same fail-closed behavior applies to them too. But when the
+    // cleanup *also* fails, report both instead of silently swallowing
+    // the second failure (#2922 review round 9, Copilot): the caller
+    // would otherwise have no way to learn a guard was left behind until
+    // a later, unrelated caller independently discovers it via its own
+    // timeout -- minutes or more later, and by a completely different
+    // caller than the one whose failure actually caused it.
     try {
       unlinkSync(lockPath);
-    } catch {
-      // ignore
+    } catch (cleanupError) {
+      const combined = new Error(
+        `${(error as Error).message} (additionally failed to remove the ` +
+          `generated-tokens write lock guard at ${lockPath} during ` +
+          `cleanup: ${(cleanupError as Error).message})`,
+      );
+      (combined as Error & { cause?: unknown }).cause = error;
+      throw combined;
     }
     throw error;
   }

--- a/src/scripts/claim-lock.mts
+++ b/src/scripts/claim-lock.mts
@@ -897,7 +897,24 @@ function withGeneratedTokensWriteLock<T>(
     // is its sole, syscall-proven owner from this point on, so a failure
     // finishing the write below is always safe to clean up.
     try {
-      writeSync(fd, token);
+      // A single `writeSync(fd, token)` call is not guaranteed to write
+      // every byte -- `write(2)` (and thus `writeSync`) may legitimately
+      // return fewer bytes than requested without throwing (#2922 review
+      // round 12, Codex and Copilot independently). A truncated guard
+      // body would then never match `token` again: release's own
+      // token-comparison in {@link releaseGeneratedTokensWriteLockIfOwned}
+      // would treat it as "not mine" and leave the guard behind forever,
+      // even though this call's own write, and the caller's `critical()`,
+      // both otherwise succeed -- every later writer for this claim-id
+      // then waits the full timeout and fails closed until an operator
+      // manually removes it. Loop on the buffer form until every byte is
+      // written, the same pattern Node's own `writeFileSync` uses
+      // internally for exactly this reason.
+      const buffer = Buffer.from(token, 'utf8');
+      let written = 0;
+      while (written < buffer.length) {
+        written += writeSync(fd, buffer, written, buffer.length - written);
+      }
     } catch (error) {
       // `writeSync` failing leaves `fd` genuinely still open (a write
       // failure does not close the descriptor), so this is the correct,

--- a/src/scripts/claim-lock.mts
+++ b/src/scripts/claim-lock.mts
@@ -860,13 +860,32 @@ function withGeneratedTokensWriteLock<T>(
     // finishing the write below is always safe to clean up.
     try {
       writeSync(fd, String(process.pid));
-      closeSync(fd);
     } catch (error) {
+      // `writeSync` failing leaves `fd` genuinely still open (a write
+      // failure does not close the descriptor), so this is the correct,
+      // and only, place to close it for this branch.
       try {
         closeSync(fd);
       } catch {
-        // Already closed, or otherwise invalid -- ignore.
+        // ignore
       }
+      try {
+        unlinkSync(lockPath);
+      } catch {
+        // Best-effort: never mask the real error above.
+      }
+      throw error;
+    }
+    try {
+      closeSync(fd);
+    } catch (error) {
+      // Do NOT retry `closeSync(fd)` here (#2922 review round 8,
+      // Codex): POSIX close() semantics mean the descriptor is no longer
+      // ours to touch once this call has been made, whether or not it
+      // reported an error -- the kernel may already have recycled that
+      // exact descriptor number for something else (for example another
+      // thread's own `open()`), so a second close attempt on it here
+      // could silently disrupt unrelated I/O elsewhere in the process.
       try {
         unlinkSync(lockPath);
       } catch {

--- a/src/scripts/claim-lock.mts
+++ b/src/scripts/claim-lock.mts
@@ -765,6 +765,22 @@ function resolveGeneratedTokensWriteLockPath(recordPath: string): string {
  * never a write landing invisibly *inside* backfill's own read-then-write
  * window).
  *
+ * **Scope: writers only, not a general readers/writers lock** (#2922
+ * review, Copilot). A standalone {@link readGeneratedClaimTokens} /
+ * {@link readGeneratedTokensAtPath} call made *outside* another write's own
+ * `critical` callback is never guarded by this lock -- only the two
+ * call sites that mutate the record (this file's own `recordGeneratedClaimTokens`
+ * and `backfillGeneratedClaimTokens`) participate. On Windows,
+ * {@link atomicReplaceFile}'s existing-file branch removes the old target
+ * before renaming the replacement in (see that function's own doc
+ * comment, and `overwriteLockAtomically`'s identical, pre-existing gap
+ * for the claim lock file above), so an unguarded concurrent read can in
+ * principle observe a transient `absent` during any write to this record,
+ * with or without this lock. That gap predates this lock and is
+ * unrelated to the nonce-clobber race it closes; guarding reads too (or
+ * changing the read contract to rule out a transient `absent`) is a
+ * separate, broader design question out of scope for #2922.
+ *
  * `critical` must call only the unlocked write primitive
  * ({@link writeGeneratedClaimTokensRecord}), never the locked
  * {@link recordGeneratedClaimTokens} wrapper -- this guard is not
@@ -817,19 +833,30 @@ function withGeneratedTokensWriteLock<T>(
       sleepSyncMs(GENERATED_TOKENS_WRITE_LOCK_RETRY_INTERVAL_MS);
     }
   }
+  let result: T;
   try {
-    return critical();
-  } finally {
-    // Best-effort cleanup only: a failure here never masks a real error
-    // from `critical()`, and a leaked guard file only costs the next
-    // caller a bounded wait before this same failure mode applies to them
-    // too, per the fail-closed rationale above.
+    result = critical();
+  } catch (error) {
+    // Best-effort cleanup on a `critical()` failure only: a cleanup
+    // failure here must never mask the real error the caller needs to
+    // see, so it is swallowed -- a leaked guard file in this branch only
+    // costs the next caller a bounded wait before this same fail-closed
+    // behavior applies to them too.
     try {
       unlinkSync(lockPath);
     } catch {
       // ignore
     }
+    throw error;
   }
+  // `critical()` succeeded: do NOT swallow a release failure here (#2922
+  // review, Codex). Reporting success while silently leaving the guard
+  // behind would give the caller no signal that anything needs recovery
+  // -- every subsequent write for this claim-id would otherwise just
+  // silently wait out a full timeout before failing, with nothing
+  // pointing at the actual cause.
+  unlinkSync(lockPath);
+  return result;
 }
 
 /**

--- a/tests/claim-lock.test.mts
+++ b/tests/claim-lock.test.mts
@@ -1876,6 +1876,67 @@ test("write-lock: a guard recreated by a different owner while critical() is sti
   }
 });
 
+test('write-lock: a guard that vanishes between the release-time token read and the unlink is a silent no-op, not a thrown ENOENT (#2922 review round 11, Copilot)', () => {
+  // The token-verified release reads the guard, confirms the token still
+  // matches, then unlinks it -- two separate steps, not one atomic
+  // operation. If the guard disappears in the gap between them (an
+  // operator's manual removal landing in that exact narrow window, or any
+  // other legitimate reason -- the guard is simply already gone), the
+  // release must still treat that as "nothing left to remove," per this
+  // helper's own documented no-op contract, matching `releaseCloneLock`'s
+  // identical `ENOENT`-swallowing behavior on its own unlink in
+  // clone-lock.mts. Before this fix, the bare `unlinkSync` after the
+  // token-match check threw `ENOENT` uncaught, incorrectly surfacing a
+  // successful write as a failure.
+  const fixture = setupLinkedWorktree();
+  const fs = require('node:fs');
+  const originalReadFileSync = fs.readFileSync;
+  let intercepted = false;
+  try {
+    const claimId = 'claim-vanish-2922';
+    const recordPath = resolveGeneratedTokensPath(fixture.worktree, claimId);
+    const guardPath = `${recordPath}.writelock`;
+
+    fs.readFileSync = (...args: Parameters<typeof originalReadFileSync>) => {
+      const result = originalReadFileSync(...args);
+      if (!intercepted && args[0] === guardPath && typeof result === 'string') {
+        intercepted = true;
+        // Simulate the guard vanishing right after this release's own
+        // token-match read confirmed ownership, but before its own
+        // unlinkSync call (immediately below, in production code) runs.
+        fs.unlinkSync(guardPath);
+      }
+      return result;
+    };
+    require('node:module').syncBuiltinESMExports();
+
+    // Must not throw: a guard already gone by the time of the unlink is
+    // still a successful release, not a reportable failure.
+    assert.doesNotThrow(() => {
+      recordGeneratedClaimTokens(fixture.worktree, {
+        agentId: 'agent-a',
+        claimId,
+        nonce: 'n1',
+      });
+    });
+
+    assert.equal(
+      intercepted,
+      true,
+      'expected the readFileSync interception to fire during release',
+    );
+    // The record write itself completed normally, and the guard stays
+    // gone (nothing recreated it in this scenario).
+    const read = readGeneratedClaimTokens(fixture.worktree, claimId);
+    assert.equal(read.status, 'present');
+    assert.equal(existsSync(guardPath), false);
+  } finally {
+    fs.readFileSync = originalReadFileSync;
+    require('node:module').syncBuiltinESMExports();
+    teardown(fixture);
+  }
+});
+
 test('backfill-tokens: reports record-blocked instead of deleting a directory at the generated-tokens path (PR #2917 review, Codex P2 then Copilot)', () => {
   const fixture = setupLinkedWorktree();
   try {

--- a/tests/claim-lock.test.mts
+++ b/tests/claim-lock.test.mts
@@ -8,6 +8,7 @@ import {
   readFileSync,
   rmSync,
   statSync,
+  utimesSync,
   writeFileSync,
 } from 'node:fs';
 import { availableParallelism, devNull, tmpdir } from 'node:os';
@@ -1462,6 +1463,283 @@ test("backfill-tokens: preserves an existing well-formed record's own nonce rath
     assert.equal(read.status, 'present');
     assert.equal(read.status === 'present' && read.record.agentId, 'agent-a');
     assert.equal(read.status === 'present' && read.record.nonce, 'nonce-a');
+  } finally {
+    teardown(fixture);
+  }
+});
+
+// Worker-thread payloads for the concurrent-write regression test below
+// (#2922). Unlike `RACE_WORKER_CODE`/`RACE_READER_CODE` above -- which must
+// *statistically* widen a microseconds-wide race window because #2920's
+// fix is a single atomic syscall with nothing to synchronize against --
+// this race is fully deterministic to reproduce: `withGeneratedTokensWriteLock`
+// gives the test a real, observable synchronization point (the reader
+// worker's own paused `readFileSync`) to drive from, so no fs-interception
+// widening trick is needed, only the same worker_threads + Atomics
+// ready/release-barrier idiom already established above.
+//
+// `READER_WORKER_CODE` calls `backfillGeneratedClaimTokens` itself, but
+// intercepts `fs.readFileSync` (propagated into the compiled CLI module's
+// ESM import via `node:module`'s `syncBuiltinESMExports`, the same
+// mechanism `RACE_WORKER_CODE` above uses) so that specifically its own
+// read of the generated-tokens record path -- not the unrelated
+// `idd-claim.lock` read that happens earlier in the same call -- captures
+// the pre-race body, signals the main thread that it is paused
+// mid-critical-section (holding the write-lock guard the whole time), and
+// blocks until released.
+const READER_WORKER_CODE = `
+  const { workerData, parentPort } = require('node:worker_threads');
+  const fs = require('node:fs');
+  const { worktree, claimId, recordPath, sab, cliUrl } = workerData;
+  const ints = new Int32Array(sab);
+  const originalReadFileSync = fs.readFileSync;
+  fs.readFileSync = (path, opts) => {
+    const result = originalReadFileSync(path, opts);
+    if (path === recordPath) {
+      // Signal "paused mid read-modify-write, still holding the guard
+      // file" and block until the main thread releases it.
+      Atomics.store(ints, 0, 1);
+      Atomics.notify(ints, 0);
+      Atomics.wait(ints, 1, 0);
+    }
+    return result;
+  };
+  require('node:module').syncBuiltinESMExports();
+  import(cliUrl).then(({ backfillGeneratedClaimTokens }) => {
+    const outcome = backfillGeneratedClaimTokens(worktree, claimId);
+    parentPort.postMessage(outcome);
+  });
+`;
+
+// \`WRITER_WORKER_CODE\` is the concurrent plain writer -- the
+// activation-nonce minting flow's own \`--record-tokens --nonce\` call in
+// production terms. It is launched only after the main thread has already
+// confirmed the reader is paused (see the test body), so its own attempt
+// to enter \`withGeneratedTokensWriteLock\` is guaranteed to observe the
+// guard file already held. It signals \`ints[2]\` immediately after its own
+// \`import()\` resolves and right before calling \`recordGeneratedClaimTokens\`,
+// so the main thread's "is the writer genuinely blocked" race window (see
+// the test body) starts only once the writer has actually reached its own
+// lock-acquire attempt -- otherwise a slow cold-start \`import()\` (module
+// bootstrap, first dynamic import of the compiled CLI module) could eat
+// into that window and make the assertion vacuously pass on a loaded host,
+// matching how the pre-existing race test above pays for its own
+// dedicated warm-up round.
+const WRITER_WORKER_CODE = `
+  const { workerData, parentPort } = require('node:worker_threads');
+  const { worktree, agentId, claimId, nonce, sab, cliUrl } = workerData;
+  const ints = new Int32Array(sab);
+  import(cliUrl).then(({ recordGeneratedClaimTokens }) => {
+    Atomics.store(ints, 2, 1);
+    Atomics.notify(ints, 2);
+    const outcome = recordGeneratedClaimTokens(worktree, {
+      agentId,
+      claimId,
+      nonce,
+    });
+    parentPort.postMessage(outcome);
+  });
+`;
+
+test('backfill-tokens: a nonce written by a concurrent recordGeneratedClaimTokens call during the read-modify-write window is never silently overwritten or lost (#2922)', async () => {
+  // Deterministic reproduction of the exact race #2922 describes:
+  // `backfillGeneratedClaimTokens` reads an existing record's `nonce`
+  // (capturing "old-nonce") to preserve it, then a concurrent
+  // `recordGeneratedClaimTokens` call writes a fresher "new-nonce" for the
+  // very same claim-id, then the backfill's own write finally lands.
+  // Pre-fix (plain `atomicReplaceFile`, no synchronization at all), the
+  // concurrent writer's call is never blocked, so it always completes
+  // during the reader's pause and the reader's subsequent write
+  // unconditionally clobbers it back to "old-nonce" -- exactly the bug
+  // report. Post-fix, both calls share one `withGeneratedTokensWriteLock`
+  // critical section keyed by the record's own path, so the writer's call
+  // cannot even begin its own write until the reader's full
+  // read-modify-write finishes and releases the guard -- provably, not
+  // merely statistically, since this test positively asserts the writer's
+  // promise has not yet settled while the reader still holds the pause.
+  const fixture = setupLinkedWorktree();
+  try {
+    const claimId = 'claim-2922';
+    const recordPath = resolveGeneratedTokensPath(fixture.worktree, claimId);
+
+    // The claim lock `backfillGeneratedClaimTokens` reads to authorize
+    // itself and to source the agentId it writes with.
+    const acquired = acquireClaimLock(
+      fixture.worktree,
+      'agent-reader',
+      claimId,
+      false,
+    );
+    assert.equal(acquired.mode, 'acquired');
+
+    // Seed a pre-existing well-formed record so the reader's read captures
+    // a real nonce to (attempt to) preserve, matching the "record already
+    // exists" defensive path the sibling test above also exercises.
+    recordGeneratedClaimTokens(fixture.worktree, {
+      agentId: 'agent-reader',
+      claimId,
+      nonce: 'old-nonce',
+    });
+
+    const cliUrl = pathToFileURL(CLI_PATH).href;
+    const sab = new SharedArrayBuffer(12);
+    const ints = new Int32Array(sab);
+    // ints[0]: reader-paused flag; ints[1]: release flag; ints[2]:
+    // writer-ready-to-attempt-its-own-write flag.
+    Atomics.store(ints, 0, 0);
+    Atomics.store(ints, 1, 0);
+    Atomics.store(ints, 2, 0);
+
+    const reader = new Worker(READER_WORKER_CODE, {
+      eval: true,
+      workerData: {
+        worktree: fixture.worktree,
+        claimId,
+        recordPath,
+        sab,
+        cliUrl,
+      },
+    });
+    const readerDone = new Promise((resolve, reject) => {
+      reader.on('message', resolve);
+      reader.on('error', reject);
+    });
+    try {
+      // Wait for the reader to signal it has read the existing record and
+      // is now paused, still holding the write-lock guard file.
+      const pausedDeadline = Date.now() + 10_000;
+      while (Atomics.load(ints, 0) === 0 && Date.now() < pausedDeadline) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      assert.equal(
+        Atomics.load(ints, 0),
+        1,
+        'expected the reader worker to reach its paused read within the deadline',
+      );
+
+      const writer = new Worker(WRITER_WORKER_CODE, {
+        eval: true,
+        workerData: {
+          worktree: fixture.worktree,
+          agentId: 'agent-writer',
+          claimId,
+          nonce: 'new-nonce',
+          sab,
+          cliUrl,
+        },
+      });
+      const writerDone = new Promise((resolve, reject) => {
+        writer.on('message', resolve);
+        writer.on('error', reject);
+      });
+      try {
+        // Wait for the writer's own `import()` to resolve and for it to
+        // reach its own lock-acquire attempt before starting the race
+        // window below -- otherwise a slow cold-start import could eat
+        // into that window and make the next assertion vacuously pass.
+        const writerReadyDeadline = Date.now() + 10_000;
+        while (
+          Atomics.load(ints, 2) === 0 &&
+          Date.now() < writerReadyDeadline
+        ) {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+        }
+        assert.equal(
+          Atomics.load(ints, 2),
+          1,
+          'expected the writer worker to reach its own lock-acquire attempt within the deadline',
+        );
+
+        // Positive proof of mutual exclusion, not an assumption: the
+        // writer's own `withGeneratedTokensWriteLock` acquire must still
+        // be blocked (EEXIST-retrying) while the reader holds the guard,
+        // so its promise must not have settled yet.
+        const settledEarly = await Promise.race([
+          writerDone.then(() => true),
+          new Promise((resolve) => setTimeout(() => resolve(false), 250)),
+        ]);
+        assert.equal(
+          settledEarly,
+          false,
+          'expected the concurrent recordGeneratedClaimTokens call to stay blocked on the write-lock guard while the reader is mid-critical-section',
+        );
+
+        // Release the reader; it finishes its own (now-redundant) write
+        // with the stale "old-nonce" it captured, then releases the guard,
+        // finally letting the writer's blocked call proceed.
+        Atomics.store(ints, 1, 1);
+        Atomics.notify(ints, 1);
+
+        const [readerOutcome, writerOutcome] = (await Promise.all([
+          readerDone,
+          writerDone,
+        ])) as [{ status: string }, { path: string }];
+        assert.equal(readerOutcome.status, 'backfilled');
+        assert.ok(writerOutcome.path);
+      } finally {
+        await writer.terminate();
+      }
+    } finally {
+      await reader.terminate();
+    }
+
+    // The writer's later, fully-serialized write must be the final state --
+    // never silently reverted to the reader's stale capture.
+    const finalRead = readGeneratedClaimTokens(fixture.worktree, claimId);
+    assert.equal(finalRead.status, 'present');
+    assert.equal(
+      finalRead.status === 'present' && finalRead.record.nonce,
+      'new-nonce',
+      `expected the concurrently-written nonce to survive, got: ${JSON.stringify(finalRead)}`,
+    );
+    assert.equal(
+      finalRead.status === 'present' && finalRead.record.agentId,
+      'agent-writer',
+    );
+  } finally {
+    teardown(fixture);
+  }
+});
+
+test('write-lock: an orphaned generated-tokens guard file (left behind by a killed process, not released) self-heals instead of blocking writes forever (#2922)', async () => {
+  // A guard file old enough to have already outlived one full wait budget
+  // can never be a live holder -- every critical section it guards is
+  // synchronous with no `await` in between -- so it must be reclaimed as
+  // stale rather than wedging every future write against this claim-id.
+  // This exercises the real wait budget end to end (no test-only seam
+  // shortens it, matching this suite's existing preference for testing
+  // production code exactly as it runs), so it costs several real seconds
+  // of wall-clock time -- a single test, not a loop, kept to one instance
+  // deliberately for that reason.
+  const fixture = setupLinkedWorktree();
+  try {
+    const claimId = 'claim-orphan-2922';
+    const recordPath = resolveGeneratedTokensPath(fixture.worktree, claimId);
+    const guardPath = `${recordPath}.writelock`;
+
+    // Simulate a process that acquired the guard and was killed before its
+    // own `finally` ever ran: the guard file exists, but its modification
+    // time is already well past the wait budget.
+    writeFileSync(guardPath, '999999');
+    const longAgo = new Date(Date.now() - 10 * 60 * 1000);
+    utimesSync(guardPath, longAgo, longAgo);
+
+    const outcome = recordGeneratedClaimTokens(fixture.worktree, {
+      agentId: 'agent-a',
+      claimId,
+      nonce: 'nonce-after-reclaim',
+    });
+    assert.equal(outcome.path, recordPath);
+
+    const read = readGeneratedClaimTokens(fixture.worktree, claimId);
+    assert.equal(read.status, 'present');
+    assert.equal(
+      read.status === 'present' && read.record.nonce,
+      'nonce-after-reclaim',
+    );
+    // The write's own `finally` releases the guard it reclaimed and
+    // re-created, so nothing is left behind for the next caller.
+    assert.equal(existsSync(guardPath), false);
   } finally {
     teardown(fixture);
   }

--- a/tests/claim-lock.test.mts
+++ b/tests/claim-lock.test.mts
@@ -1998,6 +1998,82 @@ test('write-lock: a short (partial) writeSync while writing the guard token is r
   }
 });
 
+test('write-lock: a closeSync failure whose own cleanup unlink also fails reports both, not just the descriptor-close error (#2922 review round 12, Codex)', () => {
+  // Mirrors the exact scenario the review described: closeSync(fd) fails
+  // during acquisition (for example, Windows still considers the guard
+  // open), and the cleanup unlinkSync that follows also fails. Before
+  // this fix, the nested catch discarded the cleanup failure and rethrew
+  // only the descriptor-close error, so a caller had no way to learn the
+  // guard was also left behind -- every later writer for this claim-id
+  // would then silently wait the full timeout and fail closed with
+  // nothing pointing at the actual orphaned-guard cause.
+  const fixture = setupLinkedWorktree();
+  const fs = require('node:fs');
+  const originalCloseSync = fs.closeSync;
+  const originalUnlinkSync = fs.unlinkSync;
+  let closeIntercepted = false;
+  let unlinkIntercepted = false;
+  try {
+    const claimId = 'claim-close-and-unlink-fail-2922';
+    const recordPath = resolveGeneratedTokensPath(fixture.worktree, claimId);
+    const guardPath = `${recordPath}.writelock`;
+
+    fs.closeSync = (...args: Parameters<typeof originalCloseSync>) => {
+      if (!closeIntercepted) {
+        closeIntercepted = true;
+        // Still actually close the real descriptor so the test fixture
+        // itself does not leak an open fd, then report failure the way
+        // a real close failure would.
+        originalCloseSync(...args);
+        throw new Error('simulated closeSync failure (e.g. EBUSY)');
+      }
+      return originalCloseSync(...args);
+    };
+    fs.unlinkSync = (...args: Parameters<typeof originalUnlinkSync>) => {
+      if (!unlinkIntercepted && args[0] === guardPath) {
+        unlinkIntercepted = true;
+        throw new Error('simulated cleanup unlinkSync failure');
+      }
+      return originalUnlinkSync(...args);
+    };
+    require('node:module').syncBuiltinESMExports();
+
+    assert.throws(
+      () => {
+        recordGeneratedClaimTokens(fixture.worktree, {
+          agentId: 'agent-a',
+          claimId,
+          nonce: 'n1',
+        });
+      },
+      (error: unknown) =>
+        error instanceof Error &&
+        error.message.includes('simulated closeSync failure') &&
+        error.message.includes('simulated cleanup unlinkSync failure') &&
+        error.message.includes(guardPath) &&
+        (error as Error & { cause?: unknown }).cause instanceof Error,
+      'expected a combined error naming both failures and the guard path',
+    );
+
+    assert.equal(closeIntercepted, true);
+    assert.equal(unlinkIntercepted, true);
+  } finally {
+    fs.closeSync = originalCloseSync;
+    fs.unlinkSync = originalUnlinkSync;
+    require('node:module').syncBuiltinESMExports();
+    // The simulated failures leave the guard behind for real (the
+    // interception only reported failure -- see above -- it never
+    // actually removed the file), so clean it up before the fixture's
+    // own teardown to avoid leaking it.
+    const recordPath = resolveGeneratedTokensPath(
+      fixture.worktree,
+      'claim-close-and-unlink-fail-2922',
+    );
+    rmSync(`${recordPath}.writelock`, { force: true });
+    teardown(fixture);
+  }
+});
+
 test('backfill-tokens: reports record-blocked instead of deleting a directory at the generated-tokens path (PR #2917 review, Codex P2 then Copilot)', () => {
   const fixture = setupLinkedWorktree();
   try {

--- a/tests/claim-lock.test.mts
+++ b/tests/claim-lock.test.mts
@@ -1517,24 +1517,30 @@ const READER_WORKER_CODE = `
 // to enter \`withGeneratedTokensWriteLock\` is guaranteed to observe the
 // guard file already held.
 //
-// It signals \`ints[2]\` from inside a test-side \`fs.writeFileSync\`
-// interception (the same propagate-via-\`syncBuiltinESMExports\` technique
-// \`READER_WORKER_CODE\` and the pre-existing race test above both use),
-// the instant its own lock-acquire attempt -- the \`.writelock\`-suffixed,
-// \`{ flag: 'wx' }\` exclusive-create call inside
-// \`withGeneratedTokensWriteLock\` -- actually happens, not merely after its
-// \`import()\` resolves. An earlier revision signaled right after \`import()\`
-// instead, immediately before calling \`recordGeneratedClaimTokens\`; #2922
-// review (Copilot, a suppressed/lower-confidence finding) correctly noted
-// that a worker can still be preempted by the scheduler in the gap between
-// that signal and its first actual lock-acquire attempt, so the main
-// thread's "is the writer genuinely blocked" race window (see the test
-// body) could in
-// principle start slightly before the writer had attempted anything at
-// all. Signaling from inside the intercepted call itself closes that gap
-// completely: the signal and the attempt are now the same synchronous
-// statement, with no scheduling point in between for the writer thread to
-// be preempted at.
+// It signals \`ints[2]\` from a \`finally\` wrapped tightly around a
+// test-side \`fs.writeFileSync\` interception (the same
+// propagate-via-\`syncBuiltinESMExports\` technique \`READER_WORKER_CODE\`
+// and the pre-existing race test above both use) of its own lock-acquire
+// attempt -- the \`.writelock\`-suffixed, \`{ flag: 'wx' }\` exclusive-create
+// call inside \`withGeneratedTokensWriteLock\`. This went through two
+// rounds of #2922 review tightening, each closing a smaller residual gap
+// than the last:
+// 1. An earlier revision signaled right after \`import()\` resolved,
+//    immediately before calling \`recordGeneratedClaimTokens\`. Copilot
+//    (a suppressed/lower-confidence finding) noted a worker could still
+//    be preempted between that signal and its first actual lock-acquire
+//    attempt, so the main thread's race-window check could in principle
+//    start before the writer had attempted anything.
+// 2. The fix moved the signal inside the \`fs.writeFileSync\` interception,
+//    but *before* delegating to the real \`writeFileSync\` call -- closing
+//    most of the gap, but leaving one statement (the delegation itself)
+//    between signal and attempt. A further #2922 review round (Copilot,
+//    again suppressed) caught this remaining sliver.
+// 3. Signaling from a \`finally\` around the real \`writeFileSync\` call
+//    instead closes the gap completely: the signal now fires only once
+//    the attempt has genuinely completed (an \`EEXIST\` throw or a
+//    successful create), with no scheduling point of its own between the
+//    attempt and the signal.
 const WRITER_WORKER_CODE = `
   const { workerData, parentPort } = require('node:worker_threads');
   const fs = require('node:fs');
@@ -1542,16 +1548,25 @@ const WRITER_WORKER_CODE = `
   const ints = new Int32Array(sab);
   const originalWriteFileSync = fs.writeFileSync;
   fs.writeFileSync = (path, data, opts) => {
-    if (
-      typeof path === 'string' &&
-      path.endsWith('.writelock') &&
-      opts &&
-      opts.flag === 'wx'
-    ) {
+    const isGuardCreateAttempt =
+      typeof path === 'string' && path.endsWith('.writelock') && opts && opts.flag === 'wx';
+    if (!isGuardCreateAttempt) {
+      return originalWriteFileSync(path, data, opts);
+    }
+    // Signal from a \`finally\` around the *actual* syscall attempt (#2922
+    // review round 3, Copilot), not before it: signaling first still left
+    // a gap -- between the signal and \`originalWriteFileSync\` actually
+    // running -- where a preempted worker could let the main thread's
+    // race-window check pass before the writer had touched the guard at
+    // all. A \`finally\` here fires only once the attempt has genuinely
+    // completed (EEXIST throw or successful create), with no scheduling
+    // point of its own in between.
+    try {
+      return originalWriteFileSync(path, data, opts);
+    } finally {
       Atomics.store(ints, 2, 1);
       Atomics.notify(ints, 2);
     }
-    return originalWriteFileSync(path, data, opts);
   };
   require('node:module').syncBuiltinESMExports();
   import(cliUrl).then(({ recordGeneratedClaimTokens }) => {
@@ -1719,6 +1734,53 @@ test('backfill-tokens: a nonce written by a concurrent recordGeneratedClaimToken
       finalRead.status === 'present' && finalRead.record.agentId,
       'agent-writer',
     );
+  } finally {
+    teardown(fixture);
+  }
+});
+
+test('write-lock: an existing guard file blocks a write until the timeout, then fails closed without writing the record or touching the guard (#2922 review round 3, Copilot)', () => {
+  // Coverage the reviewer flagged as missing: the regression test above
+  // only exercises successful contention (a guard released partway
+  // through the wait). This test exercises the *other* documented
+  // outcome -- a guard that is never released -- confirming
+  // `withGeneratedTokensWriteLock` genuinely fails closed rather than
+  // silently reclaiming it or writing anyway, so a future change that
+  // reintroduces an unsafe reclaim (or drops the timeout check entirely)
+  // would break this test. Costs the real ~5s wait budget (no test-only
+  // seam shortens it, matching this suite's existing preference for
+  // testing production code exactly as it runs) -- a single test, not a
+  // loop, deliberately for that reason.
+  const fixture = setupLinkedWorktree();
+  try {
+    const claimId = 'claim-timeout-2922';
+    const recordPath = resolveGeneratedTokensPath(fixture.worktree, claimId);
+    const guardPath = `${recordPath}.writelock`;
+    // Simulate a guard some other holder still owns (orphaned or
+    // genuinely live -- this function cannot tell the difference, and
+    // must fail closed either way).
+    writeFileSync(guardPath, 'held-by-another-process');
+
+    assert.throws(
+      () => {
+        recordGeneratedClaimTokens(fixture.worktree, {
+          agentId: 'agent-a',
+          claimId,
+          nonce: 'should-never-be-written',
+        });
+      },
+      (error: unknown) =>
+        error instanceof Error && error.message.includes(guardPath),
+      'expected a timeout error naming the guard path for manual recovery',
+    );
+
+    // Fails closed, not silently: the record itself was never written.
+    const read = readGeneratedClaimTokens(fixture.worktree, claimId);
+    assert.equal(read.status, 'absent');
+    // The guard is left exactly as found -- this function never removes
+    // a guard it did not itself create.
+    assert.equal(existsSync(guardPath), true);
+    assert.equal(readFileSync(guardPath, 'utf8'), 'held-by-another-process');
   } finally {
     teardown(fixture);
   }

--- a/tests/claim-lock.test.mts
+++ b/tests/claim-lock.test.mts
@@ -1518,11 +1518,11 @@ const READER_WORKER_CODE = `
 // guard file already held.
 //
 // It signals \`ints[2]\` from a \`finally\` wrapped tightly around a
-// test-side \`fs.writeFileSync\` interception (the same
+// test-side \`fs.openSync\` interception (the same
 // propagate-via-\`syncBuiltinESMExports\` technique \`READER_WORKER_CODE\`
 // and the pre-existing race test above both use) of its own lock-acquire
-// attempt -- the \`.writelock\`-suffixed, \`{ flag: 'wx' }\` exclusive-create
-// call inside \`withGeneratedTokensWriteLock\`. This went through two
+// attempt -- the \`.writelock\`-suffixed, \`'wx'\`-flag exclusive-create call
+// inside \`withGeneratedTokensWriteLock\`. This went through several
 // rounds of #2922 review tightening, each closing a smaller residual gap
 // than the last:
 // 1. An earlier revision signaled right after \`import()\` resolved,
@@ -1531,38 +1531,47 @@ const READER_WORKER_CODE = `
 //    be preempted between that signal and its first actual lock-acquire
 //    attempt, so the main thread's race-window check could in principle
 //    start before the writer had attempted anything.
-// 2. The fix moved the signal inside the \`fs.writeFileSync\` interception,
-//    but *before* delegating to the real \`writeFileSync\` call -- closing
-//    most of the gap, but leaving one statement (the delegation itself)
-//    between signal and attempt. A further #2922 review round (Copilot,
-//    again suppressed) caught this remaining sliver.
-// 3. Signaling from a \`finally\` around the real \`writeFileSync\` call
-//    instead closes the gap completely: the signal now fires only once
-//    the attempt has genuinely completed (an \`EEXIST\` throw or a
-//    successful create), with no scheduling point of its own between the
-//    attempt and the signal.
+// 2. The fix moved the signal inside an \`fs.writeFileSync\` interception
+//    (production's exclusive-create call at the time), but *before*
+//    delegating to the real call -- closing most of the gap, but leaving
+//    one statement (the delegation itself) between signal and attempt. A
+//    further #2922 review round (Copilot, again suppressed) caught this
+//    remaining sliver.
+// 3. Signaling from a \`finally\` around the real call instead closed the
+//    gap completely: the signal fires only once the attempt has
+//    genuinely completed (an \`EEXIST\` throw or a successful create),
+//    with no scheduling point of its own between the attempt and the
+//    signal.
+// 4. A later #2922 review round (Copilot) flagged that the *production*
+//    exclusive-create itself was not ownership-safe on a non-\`EEXIST\`
+//    failure, so \`withGeneratedTokensWriteLock\` switched from a single
+//    \`fs.writeFileSync(path, ..., { flag: 'wx' })\` call to
+//    \`fs.openSync(path, 'wx')\` (own doc comment has the full rationale)
+//    -- this interception moved with it, from \`fs.writeFileSync\` to
+//    \`fs.openSync\`, to keep testing the exclusive-create call production
+//    code actually makes.
 const WRITER_WORKER_CODE = `
   const { workerData, parentPort } = require('node:worker_threads');
   const fs = require('node:fs');
   const { worktree, agentId, claimId, nonce, sab, cliUrl } = workerData;
   const ints = new Int32Array(sab);
-  const originalWriteFileSync = fs.writeFileSync;
-  fs.writeFileSync = (path, data, opts) => {
+  const originalOpenSync = fs.openSync;
+  fs.openSync = (path, flags, mode) => {
     const isGuardCreateAttempt =
-      typeof path === 'string' && path.endsWith('.writelock') && opts && opts.flag === 'wx';
+      typeof path === 'string' && path.endsWith('.writelock') && flags === 'wx';
     if (!isGuardCreateAttempt) {
-      return originalWriteFileSync(path, data, opts);
+      return originalOpenSync(path, flags, mode);
     }
     // Signal from a \`finally\` around the *actual* syscall attempt (#2922
     // review round 3, Copilot), not before it: signaling first still left
-    // a gap -- between the signal and \`originalWriteFileSync\` actually
+    // a gap -- between the signal and \`originalOpenSync\` actually
     // running -- where a preempted worker could let the main thread's
     // race-window check pass before the writer had touched the guard at
     // all. A \`finally\` here fires only once the attempt has genuinely
     // completed (EEXIST throw or successful create), with no scheduling
     // point of its own in between.
     try {
-      return originalWriteFileSync(path, data, opts);
+      return originalOpenSync(path, flags, mode);
     } finally {
       Atomics.store(ints, 2, 1);
       Atomics.notify(ints, 2);

--- a/tests/claim-lock.test.mts
+++ b/tests/claim-lock.test.mts
@@ -8,7 +8,6 @@ import {
   readFileSync,
   rmSync,
   statSync,
-  utimesSync,
   writeFileSync,
 } from 'node:fs';
 import { availableParallelism, devNull, tmpdir } from 'node:os';
@@ -1516,22 +1515,46 @@ const READER_WORKER_CODE = `
 // production terms. It is launched only after the main thread has already
 // confirmed the reader is paused (see the test body), so its own attempt
 // to enter \`withGeneratedTokensWriteLock\` is guaranteed to observe the
-// guard file already held. It signals \`ints[2]\` immediately after its own
-// \`import()\` resolves and right before calling \`recordGeneratedClaimTokens\`,
-// so the main thread's "is the writer genuinely blocked" race window (see
-// the test body) starts only once the writer has actually reached its own
-// lock-acquire attempt -- otherwise a slow cold-start \`import()\` (module
-// bootstrap, first dynamic import of the compiled CLI module) could eat
-// into that window and make the assertion vacuously pass on a loaded host,
-// matching how the pre-existing race test above pays for its own
-// dedicated warm-up round.
+// guard file already held.
+//
+// It signals \`ints[2]\` from inside a test-side \`fs.writeFileSync\`
+// interception (the same propagate-via-\`syncBuiltinESMExports\` technique
+// \`READER_WORKER_CODE\` and the pre-existing race test above both use),
+// the instant its own lock-acquire attempt -- the \`.writelock\`-suffixed,
+// \`{ flag: 'wx' }\` exclusive-create call inside
+// \`withGeneratedTokensWriteLock\` -- actually happens, not merely after its
+// \`import()\` resolves. An earlier revision signaled right after \`import()\`
+// instead, immediately before calling \`recordGeneratedClaimTokens\`; #2922
+// review (Copilot, a suppressed/lower-confidence finding) correctly noted
+// that a worker can still be preempted by the scheduler in the gap between
+// that signal and its first actual lock-acquire attempt, so the main
+// thread's "is the writer genuinely blocked" race window (see the test
+// body) could in
+// principle start slightly before the writer had attempted anything at
+// all. Signaling from inside the intercepted call itself closes that gap
+// completely: the signal and the attempt are now the same synchronous
+// statement, with no scheduling point in between for the writer thread to
+// be preempted at.
 const WRITER_WORKER_CODE = `
   const { workerData, parentPort } = require('node:worker_threads');
+  const fs = require('node:fs');
   const { worktree, agentId, claimId, nonce, sab, cliUrl } = workerData;
   const ints = new Int32Array(sab);
+  const originalWriteFileSync = fs.writeFileSync;
+  fs.writeFileSync = (path, data, opts) => {
+    if (
+      typeof path === 'string' &&
+      path.endsWith('.writelock') &&
+      opts &&
+      opts.flag === 'wx'
+    ) {
+      Atomics.store(ints, 2, 1);
+      Atomics.notify(ints, 2);
+    }
+    return originalWriteFileSync(path, data, opts);
+  };
+  require('node:module').syncBuiltinESMExports();
   import(cliUrl).then(({ recordGeneratedClaimTokens }) => {
-    Atomics.store(ints, 2, 1);
-    Atomics.notify(ints, 2);
     const outcome = recordGeneratedClaimTokens(worktree, {
       agentId,
       claimId,
@@ -1696,50 +1719,6 @@ test('backfill-tokens: a nonce written by a concurrent recordGeneratedClaimToken
       finalRead.status === 'present' && finalRead.record.agentId,
       'agent-writer',
     );
-  } finally {
-    teardown(fixture);
-  }
-});
-
-test('write-lock: an orphaned generated-tokens guard file (left behind by a killed process, not released) self-heals instead of blocking writes forever (#2922)', async () => {
-  // A guard file old enough to have already outlived one full wait budget
-  // can never be a live holder -- every critical section it guards is
-  // synchronous with no `await` in between -- so it must be reclaimed as
-  // stale rather than wedging every future write against this claim-id.
-  // This exercises the real wait budget end to end (no test-only seam
-  // shortens it, matching this suite's existing preference for testing
-  // production code exactly as it runs), so it costs several real seconds
-  // of wall-clock time -- a single test, not a loop, kept to one instance
-  // deliberately for that reason.
-  const fixture = setupLinkedWorktree();
-  try {
-    const claimId = 'claim-orphan-2922';
-    const recordPath = resolveGeneratedTokensPath(fixture.worktree, claimId);
-    const guardPath = `${recordPath}.writelock`;
-
-    // Simulate a process that acquired the guard and was killed before its
-    // own `finally` ever ran: the guard file exists, but its modification
-    // time is already well past the wait budget.
-    writeFileSync(guardPath, '999999');
-    const longAgo = new Date(Date.now() - 10 * 60 * 1000);
-    utimesSync(guardPath, longAgo, longAgo);
-
-    const outcome = recordGeneratedClaimTokens(fixture.worktree, {
-      agentId: 'agent-a',
-      claimId,
-      nonce: 'nonce-after-reclaim',
-    });
-    assert.equal(outcome.path, recordPath);
-
-    const read = readGeneratedClaimTokens(fixture.worktree, claimId);
-    assert.equal(read.status, 'present');
-    assert.equal(
-      read.status === 'present' && read.record.nonce,
-      'nonce-after-reclaim',
-    );
-    // The write's own `finally` releases the guard it reclaimed and
-    // re-created, so nothing is left behind for the next caller.
-    assert.equal(existsSync(guardPath), false);
   } finally {
     teardown(fixture);
   }

--- a/tests/claim-lock.test.mts
+++ b/tests/claim-lock.test.mts
@@ -1937,6 +1937,67 @@ test('write-lock: a guard that vanishes between the release-time token read and 
   }
 });
 
+test('write-lock: a short (partial) writeSync while writing the guard token is retried until the full token is written (#2922 review round 12, Codex and Copilot)', () => {
+  // write(2) -- and thus writeSync -- may legitimately return fewer bytes
+  // than requested without throwing. Before this fix, a single
+  // writeSync(fd, token) call trusted it wrote the whole token; a
+  // truncated body would then never match the in-memory token again, so
+  // release's own comparison would treat the guard as "not mine" and
+  // leave it behind forever even though the write and critical() both
+  // otherwise succeeded. Simulates exactly that short return value and
+  // confirms the retry loop still lands the full token, so release still
+  // matches and cleans the guard up normally.
+  const fixture = setupLinkedWorktree();
+  const fs = require('node:fs');
+  const originalWriteSync = fs.writeSync;
+  let shortWriteInjected = false;
+  try {
+    const claimId = 'claim-short-write-2922';
+    const recordPath = resolveGeneratedTokensPath(fixture.worktree, claimId);
+    const guardPath = `${recordPath}.writelock`;
+
+    fs.writeSync = (...args: Parameters<typeof originalWriteSync>) => {
+      const [fd, data, offset, length] = args as unknown as [
+        number,
+        Buffer,
+        number,
+        number,
+      ];
+      if (!shortWriteInjected && Buffer.isBuffer(data) && length > 1) {
+        shortWriteInjected = true;
+        // Simulate write(2) legitimately writing only the first byte of
+        // this call's request.
+        return originalWriteSync(fd, data, offset, 1);
+      }
+      return originalWriteSync(...args);
+    };
+    require('node:module').syncBuiltinESMExports();
+
+    assert.doesNotThrow(() => {
+      recordGeneratedClaimTokens(fixture.worktree, {
+        agentId: 'agent-a',
+        claimId,
+        nonce: 'n1',
+      });
+    });
+
+    assert.equal(
+      shortWriteInjected,
+      true,
+      'expected the short-write interception to fire',
+    );
+    const read = readGeneratedClaimTokens(fixture.worktree, claimId);
+    assert.equal(read.status, 'present');
+    // The guard must be fully released, not left orphaned by a
+    // truncated token that no longer matches on release.
+    assert.equal(existsSync(guardPath), false);
+  } finally {
+    fs.writeSync = originalWriteSync;
+    require('node:module').syncBuiltinESMExports();
+    teardown(fixture);
+  }
+});
+
 test('backfill-tokens: reports record-blocked instead of deleting a directory at the generated-tokens path (PR #2917 review, Codex P2 then Copilot)', () => {
   const fixture = setupLinkedWorktree();
   try {

--- a/tests/claim-lock.test.mts
+++ b/tests/claim-lock.test.mts
@@ -10,6 +10,7 @@ import {
   statSync,
   writeFileSync,
 } from 'node:fs';
+import { createRequire } from 'node:module';
 import { availableParallelism, devNull, tmpdir } from 'node:os';
 import { basename, join, sep } from 'node:path';
 import { test } from 'node:test';
@@ -27,6 +28,12 @@ import {
   resolveGeneratedTokensPath,
 } from '../src/scripts/claim-lock.mts';
 
+// Used only by the token-verified-release test below, to reach the CJS
+// side of the `node:fs` builtin for the same `syncBuiltinESMExports`
+// propagation technique the worker-thread payloads in this file already
+// use -- see that test's own comment for why a main-thread (not
+// worker-thread) patch is sufficient here.
+const require = createRequire(import.meta.url);
 const execFileAsync = promisify(execFile);
 const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
 const CLI_PATH = join(REPO_ROOT, 'scripts/claim-lock.mjs');
@@ -1791,6 +1798,80 @@ test('write-lock: an existing guard file blocks a write until the timeout, then 
     assert.equal(existsSync(guardPath), true);
     assert.equal(readFileSync(guardPath, 'utf8'), 'held-by-another-process');
   } finally {
+    teardown(fixture);
+  }
+});
+
+test("write-lock: a guard recreated by a different owner while critical() is still running is never deleted by the original holder's own release (#2922 review round 10, Copilot)", () => {
+  // Reproduces the ABA hazard the round-10 review flagged on the release
+  // side (the acquire side already has an equivalent test above, and its
+  // own fix predates this one): if a guard this call created is manually
+  // removed and immediately recreated by a different writer *while this
+  // call's own `critical()` is still genuinely running*, an unconditional
+  // `unlinkSync` on release would delete the replacement owner's guard
+  // instead of its own -- letting two writers believe they hold exclusive
+  // access at once. This runs entirely on the main thread (no
+  // worker_threads/Atomics needed, unlike the concurrent-write regression
+  // test above): the whole scenario is deterministically reproducible by
+  // intercepting the one `renameSync` call `critical()` itself makes
+  // (`atomicReplaceFile`'s rename into place) and performing the
+  // simulated "manual remove + recreate by someone else" synchronously
+  // inside that interception, before letting the real rename proceed --
+  // no separate thread or timing race is needed to land it inside the
+  // critical section. The patch reaches the compiled TypeScript source's
+  // own `node:fs` import via `syncBuiltinESMExports`, the same propagation
+  // mechanism the worker-thread payloads elsewhere in this file use for a
+  // CJS-side patch to reach an ESM named import.
+  const fixture = setupLinkedWorktree();
+  const fs = require('node:fs');
+  const originalRenameSync = fs.renameSync;
+  let intercepted = false;
+  const REPLACEMENT_GUARD_BODY = 'replacement-owner-token';
+  try {
+    const claimId = 'claim-aba-release-2922';
+    const recordPath = resolveGeneratedTokensPath(fixture.worktree, claimId);
+    const guardPath = `${recordPath}.writelock`;
+
+    fs.renameSync = (...args: Parameters<typeof originalRenameSync>) => {
+      if (!intercepted && args[1] === recordPath) {
+        intercepted = true;
+        // Simulate an operator manually removing the guard per the
+        // timeout error's own recovery instructions (mistakenly, since
+        // this holder is not actually dead -- its critical() is right
+        // here, still running), immediately followed by a different
+        // writer winning the exclusive-create race and installing its
+        // own guard before this call's own release runs.
+        fs.unlinkSync(guardPath);
+        fs.writeFileSync(guardPath, REPLACEMENT_GUARD_BODY, { flag: 'wx' });
+      }
+      return originalRenameSync(...args);
+    };
+    require('node:module').syncBuiltinESMExports();
+
+    // Must not throw: a content mismatch on release is a silent no-op
+    // (mirroring `releaseCloneLock`'s own token-mismatch handling in
+    // clone-lock.mts), never a thrown error surfaced to this caller.
+    recordGeneratedClaimTokens(fixture.worktree, {
+      agentId: 'agent-a',
+      claimId,
+      nonce: 'n1',
+    });
+
+    assert.equal(
+      intercepted,
+      true,
+      'expected the renameSync interception to fire during critical()',
+    );
+    // The record write itself completed normally...
+    const read = readGeneratedClaimTokens(fixture.worktree, claimId);
+    assert.equal(read.status, 'present');
+    // ...but the replacement owner's guard must survive this call's own
+    // release: an unconditional unlinkSync would have deleted it.
+    assert.equal(existsSync(guardPath), true);
+    assert.equal(readFileSync(guardPath, 'utf8'), REPLACEMENT_GUARD_BODY);
+  } finally {
+    fs.renameSync = originalRenameSync;
+    require('node:module').syncBuiltinESMExports();
     teardown(fixture);
   }
 });


### PR DESCRIPTION
# Summary

`backfillGeneratedClaimTokens` preserves an existing generated-tokens
record's own `nonce` by reading it, then writing the backfilled record
back with that captured value. Nothing serialized that read-then-write
against a concurrent plain `--record-tokens --nonce` call (the
activation-nonce minting flow's own second write for the same
claim-id), and every write to this file was a plain `atomicReplaceFile`
replace, not a compare-and-swap — so the interleaving could silently
clobber a fresher nonce with the stale value backfill captured moments
earlier (flagged by CodeRabbit against PR #2917).

This PR serializes both mutating call sites for the generated-tokens
record — `recordGeneratedClaimTokens`'s own write, and
`backfillGeneratedClaimTokens`'s nonce-preserving read-then-write —
through one `withGeneratedTokensWriteLock` critical section per
claim-id, guarded by a same-directory `<record>.writelock` file
created via a plain `wx`-flag exclusive create (existence alone needs
no atomic-visibility trick, unlike the claim lock body's own `linkSync`
fix for #2920, since nothing ever reads this guard file's content).
**Scope: writers only, not a general readers/writers lock** — a
standalone `readGeneratedClaimTokens` call made outside a write's own
critical section stays lock-free by design (see the doc comment on
`withGeneratedTokensWriteLock`); on Windows in particular, such a read
can in principle still observe a transient `absent` during any write to
this record, a narrower, pre-existing gap unrelated to the nonce-loss
race this PR closes. Both `recordGeneratedClaimTokens` and
`backfillGeneratedClaimTokens` now share the same lock keyed by the
record's own path, so a concurrent write either completes entirely
before backfill's read (and is correctly preserved) or entirely after
backfill's write (an expected, non-lossy last-writer-wins overwrite) —
never invisibly in between. If the wait budget is exhausted (a guard
orphaned by a killed
process, or genuine contention), the caller fails closed with a clear
message naming the guard path for manual recovery, rather than
attempting an automatic reclaim — an earlier revision of this PR did
attempt automatic mtime-based reclaim, but three independent reviewers
(Codex, Copilot, CodeRabbit) identified it as its own ABA race (two
callers could both classify the same guard as stale, and the second's
unconditional unlink could delete the first's fresh replacement or a
still-live holder's own guard), so it was removed in favor of the
fail-closed behavior, matching this repository's own established
precedent for the same failure mode (#2389's clone-scoped lock).

Both guard releases (the `critical()`-failure cleanup and the
`critical()`-success path) are now **token-verified** rather than a
bare `unlinkSync`, mirroring this repository's own existing
`releaseCloneLock` precedent in `clone-lock.mts`: each acquisition
writes a fresh random token into the guard body, and release re-reads
the guard first, only unlinking when that same token is still present.
This closes the same class of ABA hazard already solved on the acquire
side, now on the release side too — a guard manually removed while its
original holder's `critical()` is still genuinely running could
otherwise be recreated by a new writer before the original holder's own
release ran, deleting the new writer's guard instead of its own. This
narrows, rather than eliminates, that race (verify-then-unlink is still
read-then-act — no `wx`-only filesystem primitive gives an atomic
compare-and-delete); the residual sliver is documented in the function's
own doc comment as an accepted limitation tied to a precondition
violation of the timeout error's own manual-recovery instructions, out
of scope for this issue's own Acceptance Criteria.

Added a deterministic `node:worker_threads` + `Atomics` regression test
that reproduces the exact race (verified locally to fail against the
prior unlocked code before the fix was restored) and positively proves
mutual exclusion — including that a concurrent writer's own lock-acquire
attempt genuinely stays blocked while the reader holds the guard, not
merely a wall-clock timing coincidence. A second, same-thread regression
test reproduces the release-side ABA scenario above by intercepting
`critical()`'s own `renameSync` call, and was likewise confirmed to fail
against the prior bare-`unlinkSync` code.

The `instructions-only` fallback protocol documented for adopters
without helper runtime (the distributed default profile) never
described this write-lock coordination, so a session following that
fallback — or a mixed helper/fallback deployment sharing a worktree —
could still lose a nonce the same way; the canonical
`idd-template/docs/idd-helper-scripts.md` source now documents the same
coordination, and the `docs/idd-helper-scripts.md` mirror is resynced.

Later review rounds hardened the release path itself: a stale doc claim
that the guard's content was "never read back by anything" was
corrected once release started reading it for token verification; the
release-time `unlinkSync` now tolerates the guard already being gone
between its own token-match read and the unlink (matching
`releaseCloneLock`'s identical `ENOENT` handling), instead of throwing
and misreporting a successful write as a failure; the guard-token write
itself now loops until every byte lands, since a single `writeSync`
call is not guaranteed to write the whole token in one call and a
truncated body would never match on release; and a cleanup-unlink
failure during the two earlier acquire-phase failure branches is now
reported alongside its cause (a gap in the same combine-both-errors
fix an earlier round applied only to the `critical()`-failure path),
via a small shared helper. Two further review findings in this same
area were **rejected** rather than fixed further, as documented, disposed
findings recorded here rather than filed as separate issues: extending
token-verified release to the two acquire-phase failure branches
themselves (the guard is still solely owned at that point — both
branches run in the same synchronous, non-yielding sequence immediately
after the exclusive create succeeds, with no realistic window for
external interference before their own cleanup runs a few instructions
later, unlike the release-side case where `critical()` genuinely has
room to run for a while), and mirroring the CLI's full write-robustness
protocol (short-write retry plus combined-error cleanup) into the
`instructions-only` fallback doc in exhaustive prose (an open-ended
specification exercise disproportionate to a documentation reference,
and not required by this issue's own Acceptance Criteria).

**Process note**: this session implemented the fix before posting the
B2 plan comment on the issue, so it disclosed that reordering there
rather than silently skipping the step —
[issue #2922](https://github.com/kurone-kito/idd-skill/issues/2922#issuecomment-5638265014).

## Linked issue

Closes #2922

## Follow-up issues (if any)

No new tracked issues filed. Two review findings were dispositioned as
known, accepted limitations rather than fixed (see Summary for the
reasoning behind each) — recorded here per this repo's scope-fence
convention rather than as separate issues:

- [x] Acquire-phase failure-branch cleanup (`writeSync`/`closeSync`
      failing right after a successful guard create) stays a bare
      `unlinkSync`, not token-verified — the window in which an
      external actor could interfere is not reachable given this
      function's synchronous execution model, unlike the release-side
      case token verification protects.
- [x] The `instructions-only` fallback doc does not mirror the CLI's
      full short-write-retry-plus-combined-error-cleanup protocol —
      out of scope for a documentation reference targeting arbitrary
      shell/agent implementations.

## Background / rationale (if material)

- The write-lock guard is a distinct file from both the record itself
  and the pre-existing `idd-claim.lock`, so it never interferes with
  either's own collision/directory-guard semantics (the `record-blocked`
  directory-guard path from PR #2879/#2917 is untouched by this diff).
- No `linkSync`/hard-link dependency is introduced — the guard only
  needs existence-based exclusivity (`O_CREAT | O_EXCL` / `CREATE_NEW`),
  which is already relied on elsewhere in this file across platforms.
- `backfillGeneratedClaimTokens`'s critical section now reads the
  record via a path-based reader using its own already-resolved path,
  rather than re-resolving it through `git rev-parse` while holding the
  write-lock guard (CodeRabbit review) — that spawn is a genuine,
  if usually small, cost that has no reason to run inside the lock.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`npx biome check`, `npx dprint check`,
      `npx markdownlint-cli2` — clean; only pre-existing, unrelated
      warnings elsewhere in the repo)
- [x] `pnpm test` (`node --test tests/*.test.mts` — 6216 passed, 3
      pre-existing skips, 0 failures)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (clean — the template source and its
      mirror stay in sync)
- [x] `node scripts/idd-doctor.mjs` (passed; only pre-existing,
      unrelated warnings)

Also ran `pnpm run build:check` (generated `scripts/claim-lock.mjs`
matches the committed source), `node scripts/audit-code-span-wrap.mjs`,
and `node scripts/token-cost-report.mjs --check` (no drift).

**Windows CI note**: the first push's "Windows platform tests" job
failed once, in `tests/idd-critique-telemetry-hook.test.mts` (a win32
process-kill-watchdog timing test this diff never touches). Confirmed
pre-existing: an unrelated PR (`issue/2919-...`) hit the identical
failing assertion in the same test a few hours earlier on the same
workflow. Rerun once per this repo's `ciWait.rerunPolicy`.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none — this changes a claim-lock
      helper script's internal locking plus its documented fallback
      protocol, not merge policy or gates)
- [x] Context budget impact reviewed (no
      `.github/instructions/` file touched; the touched template file
      is a `docs/` reference doc, not a phase-file instruction bundle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164z9Kt7Ww95fre2JqidEBE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved concurrent generated-token writes by ensuring only the lock owner can release its guard.
  - Prevented an earlier operation from removing a replacement guard during release.
  - Lock cleanup now preserves the original operation error while reporting additional cleanup failures.
  - Missing guards during cleanup are handled safely, and timeout behavior remains fail-closed.
  - Backfill operations coordinate the complete read-and-write sequence to preserve nonce updates.

- **Documentation**
  - Clarified write coordination, ownership verification, timeout behavior, and cleanup requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

