### PR TITLE
fix(protocol-helpers): recognize a fourth CodeRabbit ack shape

### DIFF
--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1473,8 +1473,19 @@ const CODERABBIT_ACK_OPENING_RE = new RegExp(
 //     prose would also still misclassify, for the same reason.
 const CODERABBIT_ACK_STRONG_CLOSURE_RE =
   /✅\s*Review thread resolved\.|I couldn't resolve this review thread on the repository platform/i;
+// Widened to add `almost`/`nearly` (Copilot review, #2927, round 4): a
+// proximity adverb -- "close to, but short of, complete" -- is the same
+// hedged/non-committal degree semantic this enumeration already covers
+// ("partially", "mostly", "largely"), just a different lexical subclass
+// (proximity rather than partiality). "`@user`, thanks. The fix almost
+// matches the requested behavior.\n\n🐇 ✅" states an explicitly
+// INCOMPLETE fix -- the same class of risk guard 5's own reasoning
+// already established for this whole enumeration -- and previously
+// passed the pre-"matches" lookbehind unnoticed, wired into this shared
+// constant so both the third and fourth shapes benefit without
+// duplication.
 const CODERABBIT_ACK_HEDGE_WORDS_SOURCE =
-  'partially|partly|somewhat|mostly|largely|barely|slightly|arguably|in\\s+part|to\\s+some\\s+extent|not\\s+(?:fully|entirely|completely|really)';
+  'partially|partly|somewhat|mostly|largely|barely|slightly|arguably|almost|nearly|in\\s+part|to\\s+some\\s+extent|not\\s+(?:fully|entirely|completely|really)';
 // Sibling enumeration to the degree-adverb list above, for the SAME
 // hedged/non-committal semantic class but the ADJECTIVE part of speech
 // (self-critique, E2 pass on this PR, PR #2868): the adverb list above

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1337,6 +1337,16 @@ const CODERABBIT_ACK_OPENING_RE = new RegExp(
 // across three rounds of Codex/Copilot review on this same PR (#2858,
 // PR #2868) -- never apply to the two strong, structurally-safe forms:
 //
+// #2927: a FOURTH shape, weaker-in-kind the same way -- "The fix
+// matches the requested behavior." rather than "addresses the ...
+// concern/finding" -- documented separately, below the lead-in
+// whitelist, as `CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE`, tested
+// only after this third form's own regex fails to match (see
+// `isKnownAdvisoryAckTemplate` below). Mentioned here only as an index
+// pointer so this comment block's forward references stay coherent;
+// its own reasoning lives with its own regex, not duplicated into this
+// third form's guard history below.
+//
 // Guard history below reflects the CURRENT implementation as of round 7
 // (Codex/CodeRabbit review on PR #2868) -- Copilot's round-8 review
 // flagged an earlier revision of this comment block for still describing
@@ -1370,8 +1380,9 @@ const CODERABBIT_ACK_OPENING_RE = new RegExp(
 //    Codex): the closure sentence must end in a period immediately
 //    followed by the complete recognized boilerplate shape (see
 //    `CODERABBIT_ACK_CLOSURE_TAIL_SOURCE` below), not merely start with
-//    one of its markers. Every sampled reply (all 20: the original 18
-//    plus these 2) carries real trailing boilerplate, so requiring it
+//    one of its markers. Every sampled reply (all 21: the original 18,
+//    these 2, plus #2927's own sample below) carries real trailing
+//    boilerplate, so requiring it
 //    unconditionally costs no real match; this also rejects a single-
 //    sentence reply with nothing following it at all, such as "`@user`,
 //    confirmed. This partially addresses the concern." with no footer --
@@ -1622,7 +1633,16 @@ const CODERABBIT_ACK_CONJUNCTION_WORDS_SOURCE = 'for|and|nor|but|or|yet|so';
 // sandwiched between the two as if it were all one details block's
 // content. The per-character negative lookahead forbids consuming past
 // the first "</details>" at all, so no such backtrack is possible.
-const CODERABBIT_ACK_CLOSURE_SIGNOFF_SOURCE = '🐇(?:\\s*✓)?';
+// Widened to also accept the ✅ (U+2705, "white heavy check mark")
+// emoji alongside the existing ✓ (U+2713, "check mark") (#2927): the
+// fourth ack shape's real observed sample, documented below
+// `CODERABBIT_ACK_CLOSURE_LEADIN_RE`, signs off with "🐇 ✅" rather
+// than "🐇 ✓" (confirmed byte-exact via the REST comments API, no
+// variation selector). Purely additive -- the ✓ alternative, and every
+// existing regression sample that uses it, still matches unchanged, so
+// this costs nothing against the unchanged-regression requirement
+// (AC2, #2927).
+const CODERABBIT_ACK_CLOSURE_SIGNOFF_SOURCE = '🐇(?:\\s*(?:✓|✅))?';
 const CODERABBIT_ACK_CLOSURE_DETAILS_SOURCE =
   '---\\s*<details>(?:(?!<\\/details>)[\\s\\S])*<\\/details>';
 const CODERABBIT_ACK_CLOSURE_DISCLAIMER_SOURCE =
@@ -1856,6 +1876,116 @@ const CODERABBIT_ACK_CLOSURE_LEADIN_RE = new RegExp(
     ')\\s+$',
   'i',
 );
+// #2927: a FOURTH ack shape, observed on kurone-kito/idd-skill#2921's
+// review thread `discussion_r3989223825`
+// (<https://github.com/kurone-kito/idd-skill/pull/2921#discussion_r3989223825>),
+// fetched byte-exact via the pulls/comments REST API (the same
+// byte-exact-fixture discipline #2858's own comment above already
+// established for its two samples):
+//
+//   `@kurone-kito`, thanks. The fix matches the requested behavior. The
+//   default fixture now uses the permissive zero-parseable-run-ID path.
+//
+//   🐇 ✅
+//
+//   _You are interacting with an AI system._
+//
+//   <!-- This is an auto-generated reply by CodeRabbit -->
+//
+// Same root cause as the third shape above: this thread was already
+// resolved independently (by this repository's own
+// resolve-review-thread.mjs) before CodeRabbit replied, so it had no
+// resolve-attempt of its own to report -- neither
+// `CODERABBIT_ACK_STRONG_CLOSURE_RE` nor
+// `CODERABBIT_ACK_ADDRESSES_CLOSURE_RE` match it: no "Review thread
+// resolved" trailer, and its verb phrase is "matches the requested
+// behavior" rather than "addresses the ... concern/finding".
+//
+// Structurally SIMPLER than the third shape in one respect: "matches
+// the requested behavior" is a fixed, closed phrase with no internal
+// noun-phrase gap to police, unlike "addresses the [1-3 modifier
+// tokens] concern/finding". Guards 1, 2, 4, and 10 above exist only to
+// bound that internal gap, so none of them apply here -- a contrastive
+// insertion such as "matches a different requested behavior" (AC3,
+// #2927's own contrastive example) simply fails to match the fixed
+// phrase at all, rather than needing its own guard.
+//
+// What DOES transfer, for the identical reason guards 5/8/9 exist on
+// the third shape: AC3 (#2927) requires "This partially matches...",
+// "This never matches...", and "This supposedly matches..." to still
+// read as withheld/uncertain, not confirmed. The same closed hedge/
+// negation/epistemic enumerations are reused via an identical negative
+// lookbehind immediately before "matches". A hedge/negation/epistemic
+// word hiding in the LEAD-IN noun phrase instead ("The temporary fix
+// matches...") is already excluded for free by reusing
+// `CODERABBIT_ACK_CLOSURE_LEADIN_RE` unchanged below (guard 7's own
+// exclusions apply there) -- the real sample's lead-in, "The fix",
+// already fits that regex's existing "the" + one-word alternative with
+// no changes needed.
+//
+// New wrinkle this shape introduces: the real sample above has ONE
+// more free-text sentence ("The default fixture now uses...") between
+// the closure verb phrase and the boilerplate tail. The third shape's
+// guard 3 requires the boilerplate immediately after its closure
+// sentence, with no bare trailing content allowed at all; reusing that
+// requirement unchanged here would reject the real sample and fail AC1
+// (#2927). The trailing sentence is therefore permitted, but bounded
+// with the SAME token-capped, positive-shape grammar guard 1 uses for
+// the third shape's internal gap -- not a free `[^.!?]` skip, which
+// this file's own history (guard 2's comment above) already found
+// insufficient once:
+//   - at most 10 space-separated `[\w-]+` tokens total (the real
+//     sample's trailing sentence needs 9: "The default fixture now
+//     uses the permissive zero-parseable-run-ID path"; one token of
+//     headroom, the same ratio guard 1 uses for its own cap);
+//   - the FIRST token must be one of the same closed determiner/
+//     pronoun set the lead-in whitelist already uses (`this`/`that`/
+//     `it`/`the`) -- free against the real sample (its trailing
+//     sentence starts with "The"), and rejects the most natural
+//     new-feedback openers ("Still", "Note", "Please", "However",
+//     "One");
+//   - every token (including the first) is excluded from the same
+//     closed hedge/negation/epistemic/conjunction enumerations already
+//     used throughout this file;
+//   - no comma, semicolon, apostrophe, or sentence terminator may
+//     appear anywhere inside it: `[\w-]+` tokens separated only by
+//     `\s+` cannot cross any of those characters, so a second, joined
+//     clause ("...behavior. The fix, however, breaks other tests.")
+//     breaks the token chain and the whole optional group fails to
+//     match, falling through to requiring the boilerplate immediately
+//     after "behavior." instead (guard 3's original requirement,
+//     unchanged as the fallback);
+//   - exactly one trailing `.` immediately followed by the same
+//     boilerplate tail is mandatory whenever the group is present at
+//     all -- a SECOND free sentence between this one and the tail is
+//     not reachable within the token cap without crossing a sentence
+//     terminator, which breaks the token chain the same way.
+//
+// Residual risk, stated rather than papered over, the same standard as
+// every guard above: within the 10-token cap, the determiner-first-
+// token requirement, and the closed-class exclusions, a syntactically
+// clean, unhedged sentence with no excluded vocabulary -- e.g. "The
+// null-check still remains unresolved in the other branch." (9 tokens,
+// starts with "The", no hedge/negation/epistemic/conjunction word) --
+// would still be accepted as the permitted trailing sentence and
+// misclassify. This is narrower than the round-6 bypass guard 3 closed
+// for the third shape (that gap was an unbounded `---\n\n`-delimited
+// prose span; this one is capped at 10 clean tokens with a restricted
+// opener), but it is not eliminated -- the same "no sampled reply has
+// used this position to hide substantive feedback" standard as
+// residual gap (a) above. A future sample demonstrating this bypass is
+// a design question for a follow-up issue, the same escalation path
+// residual gap (a) already uses -- not something to chase further
+// here.
+const CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE = new RegExp(
+  `(?<!\\b(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE})\\s+)` +
+    '\\bmatches\\s+the\\s+requested\\s+behavior\\b\\.\\s*' +
+    '(?:\\b(?:this|that|it|the)\\b' +
+    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE}|${CODERABBIT_ACK_CONJUNCTION_WORDS_SOURCE})\\b)[\\w-]+){0,9}` +
+    '\\.\\s*)?' +
+    CODERABBIT_ACK_CLOSURE_TAIL_SOURCE,
+  'i',
+);
 function isKnownAdvisoryAckTemplate(comment) {
   const authorLogin = String(comment.author?.login ?? '');
   const body = String(comment.body ?? '');
@@ -1869,19 +1999,30 @@ function isKnownAdvisoryAckTemplate(comment) {
   // The two strong forms (CodeRabbit's own resolve-attempt decision) are
   // checked on the whole body with no further guard -- see the comment
   // above `CODERABBIT_ACK_STRONG_CLOSURE_RE` for why the weaker third
-  // form's guards (locality, sentence-boundary, hedge-adverb, opening-
-  // to-closure lead-in whitelist) must never apply here, even when
-  // unrelated hedge-shaped wording happens to appear elsewhere in the
-  // same reply (e.g. a Learnings-used block).
+  // and fourth forms' guards (locality, sentence-boundary, hedge-adverb,
+  // opening-to-closure lead-in whitelist) must never apply here, even
+  // when unrelated hedge-shaped wording happens to appear elsewhere in
+  // the same reply (e.g. a Learnings-used block).
   if (CODERABBIT_ACK_STRONG_CLOSURE_RE.test(body)) {
     return true;
   }
-  const addressesMatch = CODERABBIT_ACK_ADDRESSES_CLOSURE_RE.exec(body);
-  if (!addressesMatch) {
+  // The third (#2858) and fourth (#2927) forms are tried in the order
+  // they were introduced; the first one whose closure regex matches
+  // wins, and its own opening-to-closure gap is checked against the
+  // SAME shared lead-in whitelist below (both forms' real observed
+  // lead-ins already fit it unchanged). No real sample matches both
+  // regexes at once, so this ordering has no observed effect on the
+  // result -- it is deterministic either way, matching the "checked
+  // only after [the earlier form] fail[s]" comment above
+  // `CODERABBIT_ACK_ADDRESSES_CLOSURE_RE`.
+  const weakClosureMatch =
+    CODERABBIT_ACK_ADDRESSES_CLOSURE_RE.exec(body) ??
+    CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE.exec(body);
+  if (!weakClosureMatch) {
     return false;
   }
   const openingEnd = openingMatch.index + openingMatch[0].length;
-  const gapToClosure = body.slice(openingEnd, addressesMatch.index);
+  const gapToClosure = body.slice(openingEnd, weakClosureMatch.index);
   return CODERABBIT_ACK_CLOSURE_LEADIN_RE.test(gapToClosure);
 }
 // Codex usage / quota exhaustion for code reviews. Token-anchored on all

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1929,97 +1929,50 @@ const CODERABBIT_ACK_CLOSURE_LEADIN_RE = new RegExp(
 // guard 3 requires the boilerplate immediately after its closure
 // sentence, with no bare trailing content allowed at all; reusing that
 // requirement unchanged here would reject the real sample and fail AC1
-// (#2927). The trailing sentence is therefore permitted, but bounded
-// with the SAME token-capped, positive-shape grammar guard 1 uses for
-// the third shape's internal gap -- not a free `[^.!?]` skip, which
-// this file's own history (guard 2's comment above) already found
-// insufficient once:
-//   - at most 10 space-separated `[\w-]+` tokens total (the real
-//     sample's trailing sentence needs 9: "The default fixture now
-//     uses the permissive zero-parseable-run-ID path"; one token of
-//     headroom, the same ratio guard 1 uses for its own cap);
-//   - the FIRST token must be one of the same closed determiner/
-//     pronoun set the lead-in whitelist already uses (`this`/`that`/
-//     `it`/`the`) -- free against the real sample (its trailing
-//     sentence starts with "The"), and rejects the most natural
-//     new-feedback openers ("Still", "Note", "Please", "However",
-//     "One");
-//   - every token (including the first) is excluded from the same
-//     closed hedge/negation/epistemic/conjunction enumerations already
-//     used throughout this file, PLUS the third shape's own trigger
-//     verb (see `CODERABBIT_ACK_MATCHES_TRAILING_EXCLUDED_VERB_SOURCE`
-//     below);
-//   - no comma, semicolon, apostrophe, or sentence terminator may
-//     appear anywhere inside it: `[\w-]+` tokens separated only by
-//     `\s+` cannot cross any of those characters, so a second, joined
-//     clause ("...behavior. The fix, however, breaks other tests.")
-//     breaks the token chain and the whole optional group fails to
-//     match, falling through to requiring the boilerplate immediately
-//     after "behavior." instead (guard 3's original requirement,
-//     unchanged as the fallback);
-//   - exactly one trailing `.` immediately followed by the same
-//     boilerplate tail is mandatory whenever the group is present at
-//     all -- a SECOND free sentence between this one and the tail is
-//     not reachable within the token cap without crossing a sentence
-//     terminator, which breaks the token chain the same way.
+// (#2927).
 //
-// Copilot review (#2927) found a genuine interaction bug this trailing
-// sentence's grammar makes possible: "The fix matches the requested
-// behavior. The default fixture addresses the security concern.\n\n🐇
-// ✅" -- the trailing sentence, unrestricted, happily absorbs
-// "addresses the security concern." as innocuous filler, but that exact
-// substring is ALSO a structurally valid `CODERABBIT_ACK_ADDRESSES_
-// CLOSURE_RE` match (genuine boilerplate immediately follows it). Two
-// problems compounded: (1) `isKnownAdvisoryAckTemplate` tried the third
-// shape first and committed to its structural match even though that
-// match's OWN lead-in (spanning the whole preceding "matches the
-// requested behavior" sentence) then failed the whitelist, never
-// falling through to try this fourth shape's own, separately valid,
-// match -- fixed below by trying each form independently instead of
-// short-circuiting; (2) even with that fixed, a reply combining BOTH
-// shapes' closure vocabulary in one body is exactly the ambiguous case
-// this file's fail-closed philosophy exists for -- it makes two
-// separate, sequential outcome claims, not a single benign courtesy
-// summary. Rather than accept it once the control-flow bug is fixed,
-// `CODERABBIT_ACK_MATCHES_TRAILING_EXCLUDED_VERB_SOURCE` below excludes
-// the third shape's own trigger verb from this trailing sentence's
-// tokens too, so this exact combination is REJECTED for a principled,
-// closed-class reason (ambiguous cross-shape vocabulary) rather than
-// silently accepted as "purely descriptive" filler.
+// A first attempt permitted this trailing sentence via a token-capped,
+// positive-shape grammar (10 `[\w-]+` tokens, closed-class-excluded,
+// determiner-first-token restricted) -- the same STYLE as guard 1's
+// internal "addresses the ... concern" gap. Copilot review (#2927)
+// correctly rejected this as still too permissive: the grammar's own
+// documented residual risk -- a syntactically clean, unhedged,
+// determiner-led sentence with no excluded vocabulary, e.g. "The
+// null-check still remains unresolved in the other branch." (9 tokens,
+// "The" opener, no excluded word) -- structurally satisfies ANY such
+// bounded-but-general grammar while stating a genuine new blocker, and
+// would suppress the merge gate exactly the way this file's fail-closed
+// philosophy exists to prevent. Unlike gap (a) above (contrastive
+// adjectives inside an already-narrow noun-phrase slot, genuinely
+// irreducible without recreating the open-ended "new concern"
+// blocklist), an open determiner-led sentence is not a narrow residual
+// edge -- it is most of the risk surface a "positive-shape grammar"
+// was supposed to close in the first place. The SAME review also found
+// this permissive grammar could absorb the third shape's own "addresses
+// the ... concern/finding" vocabulary as innocuous filler, which could
+// then interact badly with `isKnownAdvisoryAckTemplate`'s own
+// closure-form selection (see that function's own comment for the
+// control-flow half of that fix).
 //
-// Residual risk, stated rather than papered over, the same standard as
-// every guard above: within the 10-token cap, the determiner-first-
-// token requirement, and the closed-class exclusions (including the
-// address-verb exclusion above), a syntactically clean, unhedged
-// sentence with no excluded vocabulary -- e.g. "The null-check still
-// remains unresolved in the other branch." (9 tokens, starts with
-// "The", no hedge/negation/epistemic/conjunction/address-verb word) --
-// would still be accepted as the permitted trailing sentence and
-// misclassify. This is narrower than the round-6 bypass guard 3 closed
-// for the third shape (that gap was an unbounded `---\n\n`-delimited
-// prose span; this one is capped at 10 clean tokens with a restricted
-// opener and now two excluded vocabulary families), but it is not
-// eliminated -- the same "no sampled reply has used this position to
-// hide substantive feedback" standard as residual gap (a) above. A
-// future sample demonstrating this bypass is a design question for a
-// follow-up issue, the same escalation path residual gap (a) already
-// uses -- not something to chase further here.
-//
-// The third shape's own trigger verb ("addresses"), excluded from this
-// trailing sentence's tokens for the reason above (Copilot review,
-// #2927). `CODERABBIT_ACK_ADDRESSES_CLOSURE_RE` only ever matches the
-// literal token "addresses" (not "address"/"addressed"/"addressing"),
-// but the closed word-family is excluded rather than only that one
-// inflection, for the same defense-in-depth reasoning this file applies
-// to its other closed enumerations.
-const CODERABBIT_ACK_MATCHES_TRAILING_EXCLUDED_VERB_SOURCE =
-  'address(?:es|ed|ing)?';
+// With only ONE real observed sample and no broader pattern to derive a
+// general grammar FROM, the trailing sentence is instead permitted only
+// as an EXACT literal match of that one sample's own continuation text
+// -- the same resolution guard 6's lead-in whitelist already applies
+// (enumerate the exact observed shape(s), fail closed on everything
+// else, widen later only when a new real sample demonstrates a genuine
+// second shape) -- rather than a grammar general enough to also accept
+// prose no sample has ever produced. This has no residual risk in this
+// slot at all (a fixed string cannot admit arbitrary new content), and
+// incidentally also closes the cross-shape-vocabulary concern above for
+// free: the literal sample text contains neither "addresses" nor
+// "concern"/"finding".
+const CODERABBIT_ACK_MATCHES_TRAILING_OBSERVED_SENTENCE_SOURCE = escapeRegExp(
+  'The default fixture now uses the permissive zero-parseable-run-ID path.',
+);
 const CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE = new RegExp(
   `(?<!\\b(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE})\\s+)` +
     '\\bmatches\\s+the\\s+requested\\s+behavior\\b\\.\\s*' +
-    '(?:\\b(?:this|that|it|the)\\b' +
-    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE}|${CODERABBIT_ACK_CONJUNCTION_WORDS_SOURCE}|${CODERABBIT_ACK_MATCHES_TRAILING_EXCLUDED_VERB_SOURCE})\\b)[\\w-]+){0,9}` +
-    '\\.\\s*)?' +
+    `(?:${CODERABBIT_ACK_MATCHES_TRAILING_OBSERVED_SENTENCE_SOURCE}\\s*)?` +
     CODERABBIT_ACK_CLOSURE_TAIL_SOURCE,
   'i',
 );
@@ -2055,8 +2008,8 @@ function isKnownAdvisoryAckTemplate(comment) {
   // function to `false` without ever trying this fourth shape's own,
   // separately valid, match. See the doc comment above
   // `CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE` for the full example
-  // and why the trailing-sentence grammar there is ALSO tightened
-  // rather than relying on this loop fix alone.
+  // and why its trailing-sentence slot is ALSO narrowed to an exact
+  // literal match rather than relying on this loop fix alone.
   const openingEnd = openingMatch.index + openingMatch[0].length;
   for (const closureRe of [
     CODERABBIT_ACK_ADDRESSES_CLOSURE_RE,

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1340,9 +1340,14 @@ const CODERABBIT_ACK_OPENING_RE = new RegExp(
 // #2927: a FOURTH shape, weaker-in-kind the same way -- "The fix
 // matches the requested behavior." rather than "addresses the ...
 // concern/finding" -- documented separately, below the lead-in
-// whitelist, as `CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE`, tested
-// only after this third form's own regex fails to match (see
-// `isKnownAdvisoryAckTemplate` below). Mentioned here only as an index
+// whitelist, as `CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE`, tried
+// after this third form in `isKnownAdvisoryAckTemplate` below --
+// including when this third form's own regex DOES structurally match
+// but that match's own lead-in then fails, not only when this third
+// form's regex fails to match at all (Copilot review, #2927, round 2,
+// on an earlier revision of this sentence that understated it). Each
+// form is checked against its own lead-in independently; see that
+// function's own comment for why. Mentioned here only as an index
 // pointer so this comment block's forward references stay coherent;
 // its own reasoning lives with its own regex, not duplicated into this
 // third form's guard history below.
@@ -1915,13 +1920,33 @@ const CODERABBIT_ACK_CLOSURE_LEADIN_RE = new RegExp(
 // "This never matches...", and "This supposedly matches..." to still
 // read as withheld/uncertain, not confirmed. The same closed hedge/
 // negation/epistemic enumerations are reused via an identical negative
-// lookbehind immediately before "matches". A hedge/negation/epistemic
-// word hiding in the LEAD-IN noun phrase instead ("The temporary fix
-// matches...") is already excluded for free by reusing
-// `CODERABBIT_ACK_CLOSURE_LEADIN_RE` unchanged below (guard 7's own
-// exclusions apply there) -- the real sample's lead-in, "The fix",
-// already fits that regex's existing "the" + one-word alternative with
-// no changes needed.
+// lookbehind immediately before "matches".
+//
+// A first attempt reused `CODERABBIT_ACK_CLOSURE_LEADIN_RE` unchanged
+// for the opening-to-closure gap, on the theory that the real sample's
+// lead-in, "The fix", already fits that regex's existing "the" + one-
+// word alternative. Copilot review (#2927, round 2) found this reuse
+// carries over a pre-existing gap in that shared regex's OWN "the ..."
+// branch: it excludes hedge/negation/epistemic words (guard 7) but not
+// CONTRASTIVE adjectives, the same residual gap (a) documented above
+// `CODERABBIT_ACK_STRONG_CLOSURE_RE` for the third shape's internal
+// gap. "`@user`, thanks. The wrong fix matches the requested
+// behavior.\n\n🐇 ✅" passes that branch ("the" + "wrong" + "fix", two
+// words, within budget) even though "wrong fix" plausibly signals a
+// substantive problem. For the third shape this gap was accepted as
+// residual risk (no sampled reply has used it); reusing the same
+// broad "the" + 1-2 arbitrary words shape here would import that same
+// risk into a SECOND caller with no sample-based justification of its
+// own. With only ONE real sample and no evidence this shape needs
+// anything broader than the exact phrase actually observed,
+// `CODERABBIT_ACK_MATCHES_LEADIN_RE` below gives this fourth shape its
+// OWN, much narrower lead-in check instead of reusing the shared one:
+// a bare pronoun (`this`/`that`/`it`, the same closed, modifier-free
+// words the shared regex also uses, so no NEW gap there) or the exact
+// literal phrase "the fix" -- not "the" plus any word. This closes the
+// contrastive-adjective gap completely for this shape ("the wrong
+// fix" no longer matches "the fix" literally) without touching the
+// shared regex or the third shape's own established behavior.
 //
 // New wrinkle this shape introduces: the real sample above has ONE
 // more free-text sentence ("The default fixture now uses...") between
@@ -1976,6 +2001,16 @@ const CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE = new RegExp(
     CODERABBIT_ACK_CLOSURE_TAIL_SOURCE,
   'i',
 );
+// This fourth shape's own opening-to-closure lead-in check (Copilot
+// review, #2927, round 2) -- deliberately NOT `CODERABBIT_ACK_CLOSURE_
+// LEADIN_RE`; see the doc comment above `CODERABBIT_ACK_MATCHES_
+// BEHAVIOR_CLOSURE_RE` for why reusing that shared regex's broader
+// "the" + 1-2 arbitrary words branch would import its known
+// contrastive-adjective gap into a second caller with no sample-based
+// justification. A bare pronoun or the exact literal phrase "the fix"
+// -- the only lead-in actually observed -- and nothing else.
+const CODERABBIT_ACK_MATCHES_LEADIN_RE =
+  /^[.!]\s+(?:this|that|it|the\s+fix)\s+$/i;
 function isKnownAdvisoryAckTemplate(comment) {
   const authorLogin = String(comment.author?.login ?? '');
   const body = String(comment.body ?? '');
@@ -1997,30 +2032,42 @@ function isKnownAdvisoryAckTemplate(comment) {
     return true;
   }
   // The third (#2858) and fourth (#2927) forms are tried in the order
-  // they were introduced, each independently: a structural match whose
-  // own opening-to-closure gap fails the shared lead-in whitelist below
-  // does NOT disqualify a later form from also being tried, since that
-  // whitelist is a per-match check, not a whole-body verdict. Committing
-  // to the first structural match regardless of its own lead-in outcome
-  // was a real bug (Copilot review, #2927): an unrelated
-  // `CODERABBIT_ACK_ADDRESSES_CLOSURE_RE` match elsewhere in the body,
-  // with its own lead-in failing, used to short-circuit this whole
-  // function to `false` without ever trying this fourth shape's own,
-  // separately valid, match. See the doc comment above
-  // `CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE` for the full example
-  // and why its trailing-sentence slot is ALSO narrowed to an exact
-  // literal match rather than relying on this loop fix alone.
+  // they were introduced, each independently and each against its OWN
+  // lead-in check (the third shape's shared `CODERABBIT_ACK_CLOSURE_
+  // LEADIN_RE`; the fourth shape's own, narrower `CODERABBIT_ACK_
+  // MATCHES_LEADIN_RE` -- see that constant's doc comment for why it is
+  // not the shared one). A structural match whose own lead-in fails
+  // does NOT disqualify a later form from also being tried, since a
+  // lead-in check is a per-match verdict, not a whole-body one.
+  // Committing to the first structural match regardless of its own
+  // lead-in outcome was a real bug (Copilot review, #2927, round 1): an
+  // unrelated `CODERABBIT_ACK_ADDRESSES_CLOSURE_RE` match elsewhere in
+  // the body, with its own lead-in failing, used to short-circuit this
+  // whole function to `false` without ever trying this fourth shape's
+  // own, separately valid, match -- not only when the third shape's
+  // regex fails to match at all, contrary to an earlier revision of the
+  // index comment above `CODERABBIT_ACK_STRONG_CLOSURE_RE` (Copilot
+  // review, #2927, round 2). See the doc comment above `CODERABBIT_ACK_
+  // MATCHES_BEHAVIOR_CLOSURE_RE` for why its trailing-sentence slot is
+  // ALSO narrowed to an exact literal match rather than relying on this
+  // loop fix alone.
   const openingEnd = openingMatch.index + openingMatch[0].length;
-  for (const closureRe of [
-    CODERABBIT_ACK_ADDRESSES_CLOSURE_RE,
-    CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE,
+  for (const { closureRe, leadinRe } of [
+    {
+      closureRe: CODERABBIT_ACK_ADDRESSES_CLOSURE_RE,
+      leadinRe: CODERABBIT_ACK_CLOSURE_LEADIN_RE,
+    },
+    {
+      closureRe: CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE,
+      leadinRe: CODERABBIT_ACK_MATCHES_LEADIN_RE,
+    },
   ]) {
     const closureMatch = closureRe.exec(body);
     if (!closureMatch) {
       continue;
     }
     const gapToClosure = body.slice(openingEnd, closureMatch.index);
-    if (CODERABBIT_ACK_CLOSURE_LEADIN_RE.test(gapToClosure)) {
+    if (leadinRe.test(gapToClosure)) {
       return true;
     }
   }

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1946,7 +1946,9 @@ const CODERABBIT_ACK_CLOSURE_LEADIN_RE = new RegExp(
 //     "One");
 //   - every token (including the first) is excluded from the same
 //     closed hedge/negation/epistemic/conjunction enumerations already
-//     used throughout this file;
+//     used throughout this file, PLUS the third shape's own trigger
+//     verb (see `CODERABBIT_ACK_MATCHES_TRAILING_EXCLUDED_VERB_SOURCE`
+//     below);
 //   - no comma, semicolon, apostrophe, or sentence terminator may
 //     appear anywhere inside it: `[\w-]+` tokens separated only by
 //     `\s+` cannot cross any of those characters, so a second, joined
@@ -1961,27 +1963,62 @@ const CODERABBIT_ACK_CLOSURE_LEADIN_RE = new RegExp(
 //     not reachable within the token cap without crossing a sentence
 //     terminator, which breaks the token chain the same way.
 //
+// Copilot review (#2927) found a genuine interaction bug this trailing
+// sentence's grammar makes possible: "The fix matches the requested
+// behavior. The default fixture addresses the security concern.\n\n🐇
+// ✅" -- the trailing sentence, unrestricted, happily absorbs
+// "addresses the security concern." as innocuous filler, but that exact
+// substring is ALSO a structurally valid `CODERABBIT_ACK_ADDRESSES_
+// CLOSURE_RE` match (genuine boilerplate immediately follows it). Two
+// problems compounded: (1) `isKnownAdvisoryAckTemplate` tried the third
+// shape first and committed to its structural match even though that
+// match's OWN lead-in (spanning the whole preceding "matches the
+// requested behavior" sentence) then failed the whitelist, never
+// falling through to try this fourth shape's own, separately valid,
+// match -- fixed below by trying each form independently instead of
+// short-circuiting; (2) even with that fixed, a reply combining BOTH
+// shapes' closure vocabulary in one body is exactly the ambiguous case
+// this file's fail-closed philosophy exists for -- it makes two
+// separate, sequential outcome claims, not a single benign courtesy
+// summary. Rather than accept it once the control-flow bug is fixed,
+// `CODERABBIT_ACK_MATCHES_TRAILING_EXCLUDED_VERB_SOURCE` below excludes
+// the third shape's own trigger verb from this trailing sentence's
+// tokens too, so this exact combination is REJECTED for a principled,
+// closed-class reason (ambiguous cross-shape vocabulary) rather than
+// silently accepted as "purely descriptive" filler.
+//
 // Residual risk, stated rather than papered over, the same standard as
 // every guard above: within the 10-token cap, the determiner-first-
-// token requirement, and the closed-class exclusions, a syntactically
-// clean, unhedged sentence with no excluded vocabulary -- e.g. "The
-// null-check still remains unresolved in the other branch." (9 tokens,
-// starts with "The", no hedge/negation/epistemic/conjunction word) --
+// token requirement, and the closed-class exclusions (including the
+// address-verb exclusion above), a syntactically clean, unhedged
+// sentence with no excluded vocabulary -- e.g. "The null-check still
+// remains unresolved in the other branch." (9 tokens, starts with
+// "The", no hedge/negation/epistemic/conjunction/address-verb word) --
 // would still be accepted as the permitted trailing sentence and
 // misclassify. This is narrower than the round-6 bypass guard 3 closed
 // for the third shape (that gap was an unbounded `---\n\n`-delimited
 // prose span; this one is capped at 10 clean tokens with a restricted
-// opener), but it is not eliminated -- the same "no sampled reply has
-// used this position to hide substantive feedback" standard as
-// residual gap (a) above. A future sample demonstrating this bypass is
-// a design question for a follow-up issue, the same escalation path
-// residual gap (a) already uses -- not something to chase further
-// here.
+// opener and now two excluded vocabulary families), but it is not
+// eliminated -- the same "no sampled reply has used this position to
+// hide substantive feedback" standard as residual gap (a) above. A
+// future sample demonstrating this bypass is a design question for a
+// follow-up issue, the same escalation path residual gap (a) already
+// uses -- not something to chase further here.
+//
+// The third shape's own trigger verb ("addresses"), excluded from this
+// trailing sentence's tokens for the reason above (Copilot review,
+// #2927). `CODERABBIT_ACK_ADDRESSES_CLOSURE_RE` only ever matches the
+// literal token "addresses" (not "address"/"addressed"/"addressing"),
+// but the closed word-family is excluded rather than only that one
+// inflection, for the same defense-in-depth reasoning this file applies
+// to its other closed enumerations.
+const CODERABBIT_ACK_MATCHES_TRAILING_EXCLUDED_VERB_SOURCE =
+  'address(?:es|ed|ing)?';
 const CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE = new RegExp(
   `(?<!\\b(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE})\\s+)` +
     '\\bmatches\\s+the\\s+requested\\s+behavior\\b\\.\\s*' +
     '(?:\\b(?:this|that|it|the)\\b' +
-    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE}|${CODERABBIT_ACK_CONJUNCTION_WORDS_SOURCE})\\b)[\\w-]+){0,9}` +
+    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE}|${CODERABBIT_ACK_CONJUNCTION_WORDS_SOURCE}|${CODERABBIT_ACK_MATCHES_TRAILING_EXCLUDED_VERB_SOURCE})\\b)[\\w-]+){0,9}` +
     '\\.\\s*)?' +
     CODERABBIT_ACK_CLOSURE_TAIL_SOURCE,
   'i',
@@ -2007,23 +2044,34 @@ function isKnownAdvisoryAckTemplate(comment) {
     return true;
   }
   // The third (#2858) and fourth (#2927) forms are tried in the order
-  // they were introduced; the first one whose closure regex matches
-  // wins, and its own opening-to-closure gap is checked against the
-  // SAME shared lead-in whitelist below (both forms' real observed
-  // lead-ins already fit it unchanged). No real sample matches both
-  // regexes at once, so this ordering has no observed effect on the
-  // result -- it is deterministic either way, matching the "checked
-  // only after [the earlier form] fail[s]" comment above
-  // `CODERABBIT_ACK_ADDRESSES_CLOSURE_RE`.
-  const weakClosureMatch =
-    CODERABBIT_ACK_ADDRESSES_CLOSURE_RE.exec(body) ??
-    CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE.exec(body);
-  if (!weakClosureMatch) {
-    return false;
-  }
+  // they were introduced, each independently: a structural match whose
+  // own opening-to-closure gap fails the shared lead-in whitelist below
+  // does NOT disqualify a later form from also being tried, since that
+  // whitelist is a per-match check, not a whole-body verdict. Committing
+  // to the first structural match regardless of its own lead-in outcome
+  // was a real bug (Copilot review, #2927): an unrelated
+  // `CODERABBIT_ACK_ADDRESSES_CLOSURE_RE` match elsewhere in the body,
+  // with its own lead-in failing, used to short-circuit this whole
+  // function to `false` without ever trying this fourth shape's own,
+  // separately valid, match. See the doc comment above
+  // `CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE` for the full example
+  // and why the trailing-sentence grammar there is ALSO tightened
+  // rather than relying on this loop fix alone.
   const openingEnd = openingMatch.index + openingMatch[0].length;
-  const gapToClosure = body.slice(openingEnd, weakClosureMatch.index);
-  return CODERABBIT_ACK_CLOSURE_LEADIN_RE.test(gapToClosure);
+  for (const closureRe of [
+    CODERABBIT_ACK_ADDRESSES_CLOSURE_RE,
+    CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE,
+  ]) {
+    const closureMatch = closureRe.exec(body);
+    if (!closureMatch) {
+      continue;
+    }
+    const gapToClosure = body.slice(openingEnd, closureMatch.index);
+    if (CODERABBIT_ACK_CLOSURE_LEADIN_RE.test(gapToClosure)) {
+      return true;
+    }
+  }
+  return false;
 }
 // Codex usage / quota exhaustion for code reviews. Token-anchored on all
 // three of "Codex usage limit(s)", a reach/exceed/hit-family verb, and "for

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2859,7 +2859,9 @@ const CODERABBIT_ACK_CLOSURE_LEADIN_RE = new RegExp(
 //     "One");
 //   - every token (including the first) is excluded from the same
 //     closed hedge/negation/epistemic/conjunction enumerations already
-//     used throughout this file;
+//     used throughout this file, PLUS the third shape's own trigger
+//     verb (see `CODERABBIT_ACK_MATCHES_TRAILING_EXCLUDED_VERB_SOURCE`
+//     below);
 //   - no comma, semicolon, apostrophe, or sentence terminator may
 //     appear anywhere inside it: `[\w-]+` tokens separated only by
 //     `\s+` cannot cross any of those characters, so a second, joined
@@ -2874,27 +2876,62 @@ const CODERABBIT_ACK_CLOSURE_LEADIN_RE = new RegExp(
 //     not reachable within the token cap without crossing a sentence
 //     terminator, which breaks the token chain the same way.
 //
+// Copilot review (#2927) found a genuine interaction bug this trailing
+// sentence's grammar makes possible: "The fix matches the requested
+// behavior. The default fixture addresses the security concern.\n\n🐇
+// ✅" -- the trailing sentence, unrestricted, happily absorbs
+// "addresses the security concern." as innocuous filler, but that exact
+// substring is ALSO a structurally valid `CODERABBIT_ACK_ADDRESSES_
+// CLOSURE_RE` match (genuine boilerplate immediately follows it). Two
+// problems compounded: (1) `isKnownAdvisoryAckTemplate` tried the third
+// shape first and committed to its structural match even though that
+// match's OWN lead-in (spanning the whole preceding "matches the
+// requested behavior" sentence) then failed the whitelist, never
+// falling through to try this fourth shape's own, separately valid,
+// match -- fixed below by trying each form independently instead of
+// short-circuiting; (2) even with that fixed, a reply combining BOTH
+// shapes' closure vocabulary in one body is exactly the ambiguous case
+// this file's fail-closed philosophy exists for -- it makes two
+// separate, sequential outcome claims, not a single benign courtesy
+// summary. Rather than accept it once the control-flow bug is fixed,
+// `CODERABBIT_ACK_MATCHES_TRAILING_EXCLUDED_VERB_SOURCE` below excludes
+// the third shape's own trigger verb from this trailing sentence's
+// tokens too, so this exact combination is REJECTED for a principled,
+// closed-class reason (ambiguous cross-shape vocabulary) rather than
+// silently accepted as "purely descriptive" filler.
+//
 // Residual risk, stated rather than papered over, the same standard as
 // every guard above: within the 10-token cap, the determiner-first-
-// token requirement, and the closed-class exclusions, a syntactically
-// clean, unhedged sentence with no excluded vocabulary -- e.g. "The
-// null-check still remains unresolved in the other branch." (9 tokens,
-// starts with "The", no hedge/negation/epistemic/conjunction word) --
+// token requirement, and the closed-class exclusions (including the
+// address-verb exclusion above), a syntactically clean, unhedged
+// sentence with no excluded vocabulary -- e.g. "The null-check still
+// remains unresolved in the other branch." (9 tokens, starts with
+// "The", no hedge/negation/epistemic/conjunction/address-verb word) --
 // would still be accepted as the permitted trailing sentence and
 // misclassify. This is narrower than the round-6 bypass guard 3 closed
 // for the third shape (that gap was an unbounded `---\n\n`-delimited
 // prose span; this one is capped at 10 clean tokens with a restricted
-// opener), but it is not eliminated -- the same "no sampled reply has
-// used this position to hide substantive feedback" standard as
-// residual gap (a) above. A future sample demonstrating this bypass is
-// a design question for a follow-up issue, the same escalation path
-// residual gap (a) already uses -- not something to chase further
-// here.
+// opener and now two excluded vocabulary families), but it is not
+// eliminated -- the same "no sampled reply has used this position to
+// hide substantive feedback" standard as residual gap (a) above. A
+// future sample demonstrating this bypass is a design question for a
+// follow-up issue, the same escalation path residual gap (a) already
+// uses -- not something to chase further here.
+//
+// The third shape's own trigger verb ("addresses"), excluded from this
+// trailing sentence's tokens for the reason above (Copilot review,
+// #2927). `CODERABBIT_ACK_ADDRESSES_CLOSURE_RE` only ever matches the
+// literal token "addresses" (not "address"/"addressed"/"addressing"),
+// but the closed word-family is excluded rather than only that one
+// inflection, for the same defense-in-depth reasoning this file applies
+// to its other closed enumerations.
+const CODERABBIT_ACK_MATCHES_TRAILING_EXCLUDED_VERB_SOURCE =
+  'address(?:es|ed|ing)?';
 const CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE = new RegExp(
   `(?<!\\b(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE})\\s+)` +
     '\\bmatches\\s+the\\s+requested\\s+behavior\\b\\.\\s*' +
     '(?:\\b(?:this|that|it|the)\\b' +
-    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE}|${CODERABBIT_ACK_CONJUNCTION_WORDS_SOURCE})\\b)[\\w-]+){0,9}` +
+    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE}|${CODERABBIT_ACK_CONJUNCTION_WORDS_SOURCE}|${CODERABBIT_ACK_MATCHES_TRAILING_EXCLUDED_VERB_SOURCE})\\b)[\\w-]+){0,9}` +
     '\\.\\s*)?' +
     CODERABBIT_ACK_CLOSURE_TAIL_SOURCE,
   'i',
@@ -2924,23 +2961,34 @@ function isKnownAdvisoryAckTemplate(comment: {
     return true;
   }
   // The third (#2858) and fourth (#2927) forms are tried in the order
-  // they were introduced; the first one whose closure regex matches
-  // wins, and its own opening-to-closure gap is checked against the
-  // SAME shared lead-in whitelist below (both forms' real observed
-  // lead-ins already fit it unchanged). No real sample matches both
-  // regexes at once, so this ordering has no observed effect on the
-  // result -- it is deterministic either way, matching the "checked
-  // only after [the earlier form] fail[s]" comment above
-  // `CODERABBIT_ACK_ADDRESSES_CLOSURE_RE`.
-  const weakClosureMatch =
-    CODERABBIT_ACK_ADDRESSES_CLOSURE_RE.exec(body) ??
-    CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE.exec(body);
-  if (!weakClosureMatch) {
-    return false;
-  }
+  // they were introduced, each independently: a structural match whose
+  // own opening-to-closure gap fails the shared lead-in whitelist below
+  // does NOT disqualify a later form from also being tried, since that
+  // whitelist is a per-match check, not a whole-body verdict. Committing
+  // to the first structural match regardless of its own lead-in outcome
+  // was a real bug (Copilot review, #2927): an unrelated
+  // `CODERABBIT_ACK_ADDRESSES_CLOSURE_RE` match elsewhere in the body,
+  // with its own lead-in failing, used to short-circuit this whole
+  // function to `false` without ever trying this fourth shape's own,
+  // separately valid, match. See the doc comment above
+  // `CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE` for the full example
+  // and why the trailing-sentence grammar there is ALSO tightened
+  // rather than relying on this loop fix alone.
   const openingEnd = openingMatch.index + openingMatch[0].length;
-  const gapToClosure = body.slice(openingEnd, weakClosureMatch.index);
-  return CODERABBIT_ACK_CLOSURE_LEADIN_RE.test(gapToClosure);
+  for (const closureRe of [
+    CODERABBIT_ACK_ADDRESSES_CLOSURE_RE,
+    CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE,
+  ]) {
+    const closureMatch = closureRe.exec(body);
+    if (!closureMatch) {
+      continue;
+    }
+    const gapToClosure = body.slice(openingEnd, closureMatch.index);
+    if (CODERABBIT_ACK_CLOSURE_LEADIN_RE.test(gapToClosure)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 // Codex usage / quota exhaustion for code reviews. Token-anchored on all

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2245,9 +2245,14 @@ const CODERABBIT_ACK_OPENING_RE = new RegExp(
 // #2927: a FOURTH shape, weaker-in-kind the same way -- "The fix
 // matches the requested behavior." rather than "addresses the ...
 // concern/finding" -- documented separately, below the lead-in
-// whitelist, as `CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE`, tested
-// only after this third form's own regex fails to match (see
-// `isKnownAdvisoryAckTemplate` below). Mentioned here only as an index
+// whitelist, as `CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE`, tried
+// after this third form in `isKnownAdvisoryAckTemplate` below --
+// including when this third form's own regex DOES structurally match
+// but that match's own lead-in then fails, not only when this third
+// form's regex fails to match at all (Copilot review, #2927, round 2,
+// on an earlier revision of this sentence that understated it). Each
+// form is checked against its own lead-in independently; see that
+// function's own comment for why. Mentioned here only as an index
 // pointer so this comment block's forward references stay coherent;
 // its own reasoning lives with its own regex, not duplicated into this
 // third form's guard history below.
@@ -2828,13 +2833,33 @@ const CODERABBIT_ACK_CLOSURE_LEADIN_RE = new RegExp(
 // "This never matches...", and "This supposedly matches..." to still
 // read as withheld/uncertain, not confirmed. The same closed hedge/
 // negation/epistemic enumerations are reused via an identical negative
-// lookbehind immediately before "matches". A hedge/negation/epistemic
-// word hiding in the LEAD-IN noun phrase instead ("The temporary fix
-// matches...") is already excluded for free by reusing
-// `CODERABBIT_ACK_CLOSURE_LEADIN_RE` unchanged below (guard 7's own
-// exclusions apply there) -- the real sample's lead-in, "The fix",
-// already fits that regex's existing "the" + one-word alternative with
-// no changes needed.
+// lookbehind immediately before "matches".
+//
+// A first attempt reused `CODERABBIT_ACK_CLOSURE_LEADIN_RE` unchanged
+// for the opening-to-closure gap, on the theory that the real sample's
+// lead-in, "The fix", already fits that regex's existing "the" + one-
+// word alternative. Copilot review (#2927, round 2) found this reuse
+// carries over a pre-existing gap in that shared regex's OWN "the ..."
+// branch: it excludes hedge/negation/epistemic words (guard 7) but not
+// CONTRASTIVE adjectives, the same residual gap (a) documented above
+// `CODERABBIT_ACK_STRONG_CLOSURE_RE` for the third shape's internal
+// gap. "`@user`, thanks. The wrong fix matches the requested
+// behavior.\n\n🐇 ✅" passes that branch ("the" + "wrong" + "fix", two
+// words, within budget) even though "wrong fix" plausibly signals a
+// substantive problem. For the third shape this gap was accepted as
+// residual risk (no sampled reply has used it); reusing the same
+// broad "the" + 1-2 arbitrary words shape here would import that same
+// risk into a SECOND caller with no sample-based justification of its
+// own. With only ONE real sample and no evidence this shape needs
+// anything broader than the exact phrase actually observed,
+// `CODERABBIT_ACK_MATCHES_LEADIN_RE` below gives this fourth shape its
+// OWN, much narrower lead-in check instead of reusing the shared one:
+// a bare pronoun (`this`/`that`/`it`, the same closed, modifier-free
+// words the shared regex also uses, so no NEW gap there) or the exact
+// literal phrase "the fix" -- not "the" plus any word. This closes the
+// contrastive-adjective gap completely for this shape ("the wrong
+// fix" no longer matches "the fix" literally) without touching the
+// shared regex or the third shape's own established behavior.
 //
 // New wrinkle this shape introduces: the real sample above has ONE
 // more free-text sentence ("The default fixture now uses...") between
@@ -2890,6 +2915,17 @@ const CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE = new RegExp(
   'i',
 );
 
+// This fourth shape's own opening-to-closure lead-in check (Copilot
+// review, #2927, round 2) -- deliberately NOT `CODERABBIT_ACK_CLOSURE_
+// LEADIN_RE`; see the doc comment above `CODERABBIT_ACK_MATCHES_
+// BEHAVIOR_CLOSURE_RE` for why reusing that shared regex's broader
+// "the" + 1-2 arbitrary words branch would import its known
+// contrastive-adjective gap into a second caller with no sample-based
+// justification. A bare pronoun or the exact literal phrase "the fix"
+// -- the only lead-in actually observed -- and nothing else.
+const CODERABBIT_ACK_MATCHES_LEADIN_RE =
+  /^[.!]\s+(?:this|that|it|the\s+fix)\s+$/i;
+
 function isKnownAdvisoryAckTemplate(comment: {
   author?: { login?: string | null } | null;
   body?: string | null;
@@ -2914,30 +2950,42 @@ function isKnownAdvisoryAckTemplate(comment: {
     return true;
   }
   // The third (#2858) and fourth (#2927) forms are tried in the order
-  // they were introduced, each independently: a structural match whose
-  // own opening-to-closure gap fails the shared lead-in whitelist below
-  // does NOT disqualify a later form from also being tried, since that
-  // whitelist is a per-match check, not a whole-body verdict. Committing
-  // to the first structural match regardless of its own lead-in outcome
-  // was a real bug (Copilot review, #2927): an unrelated
-  // `CODERABBIT_ACK_ADDRESSES_CLOSURE_RE` match elsewhere in the body,
-  // with its own lead-in failing, used to short-circuit this whole
-  // function to `false` without ever trying this fourth shape's own,
-  // separately valid, match. See the doc comment above
-  // `CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE` for the full example
-  // and why its trailing-sentence slot is ALSO narrowed to an exact
-  // literal match rather than relying on this loop fix alone.
+  // they were introduced, each independently and each against its OWN
+  // lead-in check (the third shape's shared `CODERABBIT_ACK_CLOSURE_
+  // LEADIN_RE`; the fourth shape's own, narrower `CODERABBIT_ACK_
+  // MATCHES_LEADIN_RE` -- see that constant's doc comment for why it is
+  // not the shared one). A structural match whose own lead-in fails
+  // does NOT disqualify a later form from also being tried, since a
+  // lead-in check is a per-match verdict, not a whole-body one.
+  // Committing to the first structural match regardless of its own
+  // lead-in outcome was a real bug (Copilot review, #2927, round 1): an
+  // unrelated `CODERABBIT_ACK_ADDRESSES_CLOSURE_RE` match elsewhere in
+  // the body, with its own lead-in failing, used to short-circuit this
+  // whole function to `false` without ever trying this fourth shape's
+  // own, separately valid, match -- not only when the third shape's
+  // regex fails to match at all, contrary to an earlier revision of the
+  // index comment above `CODERABBIT_ACK_STRONG_CLOSURE_RE` (Copilot
+  // review, #2927, round 2). See the doc comment above `CODERABBIT_ACK_
+  // MATCHES_BEHAVIOR_CLOSURE_RE` for why its trailing-sentence slot is
+  // ALSO narrowed to an exact literal match rather than relying on this
+  // loop fix alone.
   const openingEnd = openingMatch.index + openingMatch[0].length;
-  for (const closureRe of [
-    CODERABBIT_ACK_ADDRESSES_CLOSURE_RE,
-    CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE,
+  for (const { closureRe, leadinRe } of [
+    {
+      closureRe: CODERABBIT_ACK_ADDRESSES_CLOSURE_RE,
+      leadinRe: CODERABBIT_ACK_CLOSURE_LEADIN_RE,
+    },
+    {
+      closureRe: CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE,
+      leadinRe: CODERABBIT_ACK_MATCHES_LEADIN_RE,
+    },
   ]) {
     const closureMatch = closureRe.exec(body);
     if (!closureMatch) {
       continue;
     }
     const gapToClosure = body.slice(openingEnd, closureMatch.index);
-    if (CODERABBIT_ACK_CLOSURE_LEADIN_RE.test(gapToClosure)) {
+    if (leadinRe.test(gapToClosure)) {
       return true;
     }
   }

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2379,8 +2379,19 @@ const CODERABBIT_ACK_OPENING_RE = new RegExp(
 const CODERABBIT_ACK_STRONG_CLOSURE_RE =
   /✅\s*Review thread resolved\.|I couldn't resolve this review thread on the repository platform/i;
 
+// Widened to add `almost`/`nearly` (Copilot review, #2927, round 4): a
+// proximity adverb -- "close to, but short of, complete" -- is the same
+// hedged/non-committal degree semantic this enumeration already covers
+// ("partially", "mostly", "largely"), just a different lexical subclass
+// (proximity rather than partiality). "`@user`, thanks. The fix almost
+// matches the requested behavior.\n\n🐇 ✅" states an explicitly
+// INCOMPLETE fix -- the same class of risk guard 5's own reasoning
+// already established for this whole enumeration -- and previously
+// passed the pre-"matches" lookbehind unnoticed, wired into this shared
+// constant so both the third and fourth shapes benefit without
+// duplication.
 const CODERABBIT_ACK_HEDGE_WORDS_SOURCE =
-  'partially|partly|somewhat|mostly|largely|barely|slightly|arguably|in\\s+part|to\\s+some\\s+extent|not\\s+(?:fully|entirely|completely|really)';
+  'partially|partly|somewhat|mostly|largely|barely|slightly|arguably|almost|nearly|in\\s+part|to\\s+some\\s+extent|not\\s+(?:fully|entirely|completely|really)';
 
 // Sibling enumeration to the degree-adverb list above, for the SAME
 // hedged/non-committal semantic class but the ADJECTIVE part of speech

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2242,6 +2242,16 @@ const CODERABBIT_ACK_OPENING_RE = new RegExp(
 // across three rounds of Codex/Copilot review on this same PR (#2858,
 // PR #2868) -- never apply to the two strong, structurally-safe forms:
 //
+// #2927: a FOURTH shape, weaker-in-kind the same way -- "The fix
+// matches the requested behavior." rather than "addresses the ...
+// concern/finding" -- documented separately, below the lead-in
+// whitelist, as `CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE`, tested
+// only after this third form's own regex fails to match (see
+// `isKnownAdvisoryAckTemplate` below). Mentioned here only as an index
+// pointer so this comment block's forward references stay coherent;
+// its own reasoning lives with its own regex, not duplicated into this
+// third form's guard history below.
+//
 // Guard history below reflects the CURRENT implementation as of round 7
 // (Codex/CodeRabbit review on PR #2868) -- Copilot's round-8 review
 // flagged an earlier revision of this comment block for still describing
@@ -2275,8 +2285,9 @@ const CODERABBIT_ACK_OPENING_RE = new RegExp(
 //    Codex): the closure sentence must end in a period immediately
 //    followed by the complete recognized boilerplate shape (see
 //    `CODERABBIT_ACK_CLOSURE_TAIL_SOURCE` below), not merely start with
-//    one of its markers. Every sampled reply (all 20: the original 18
-//    plus these 2) carries real trailing boilerplate, so requiring it
+//    one of its markers. Every sampled reply (all 21: the original 18,
+//    these 2, plus #2927's own sample below) carries real trailing
+//    boilerplate, so requiring it
 //    unconditionally costs no real match; this also rejects a single-
 //    sentence reply with nothing following it at all, such as "`@user`,
 //    confirmed. This partially addresses the concern." with no footer --
@@ -2533,7 +2544,16 @@ const CODERABBIT_ACK_CONJUNCTION_WORDS_SOURCE = 'for|and|nor|but|or|yet|so';
 // sandwiched between the two as if it were all one details block's
 // content. The per-character negative lookahead forbids consuming past
 // the first "</details>" at all, so no such backtrack is possible.
-const CODERABBIT_ACK_CLOSURE_SIGNOFF_SOURCE = '🐇(?:\\s*✓)?';
+// Widened to also accept the ✅ (U+2705, "white heavy check mark")
+// emoji alongside the existing ✓ (U+2713, "check mark") (#2927): the
+// fourth ack shape's real observed sample, documented below
+// `CODERABBIT_ACK_CLOSURE_LEADIN_RE`, signs off with "🐇 ✅" rather
+// than "🐇 ✓" (confirmed byte-exact via the REST comments API, no
+// variation selector). Purely additive -- the ✓ alternative, and every
+// existing regression sample that uses it, still matches unchanged, so
+// this costs nothing against the unchanged-regression requirement
+// (AC2, #2927).
+const CODERABBIT_ACK_CLOSURE_SIGNOFF_SOURCE = '🐇(?:\\s*(?:✓|✅))?';
 const CODERABBIT_ACK_CLOSURE_DETAILS_SOURCE =
   '---\\s*<details>(?:(?!<\\/details>)[\\s\\S])*<\\/details>';
 const CODERABBIT_ACK_CLOSURE_DISCLAIMER_SOURCE =
@@ -2769,6 +2789,117 @@ const CODERABBIT_ACK_CLOSURE_LEADIN_RE = new RegExp(
   'i',
 );
 
+// #2927: a FOURTH ack shape, observed on kurone-kito/idd-skill#2921's
+// review thread `discussion_r3989223825`
+// (<https://github.com/kurone-kito/idd-skill/pull/2921#discussion_r3989223825>),
+// fetched byte-exact via the pulls/comments REST API (the same
+// byte-exact-fixture discipline #2858's own comment above already
+// established for its two samples):
+//
+//   `@kurone-kito`, thanks. The fix matches the requested behavior. The
+//   default fixture now uses the permissive zero-parseable-run-ID path.
+//
+//   🐇 ✅
+//
+//   _You are interacting with an AI system._
+//
+//   <!-- This is an auto-generated reply by CodeRabbit -->
+//
+// Same root cause as the third shape above: this thread was already
+// resolved independently (by this repository's own
+// resolve-review-thread.mjs) before CodeRabbit replied, so it had no
+// resolve-attempt of its own to report -- neither
+// `CODERABBIT_ACK_STRONG_CLOSURE_RE` nor
+// `CODERABBIT_ACK_ADDRESSES_CLOSURE_RE` match it: no "Review thread
+// resolved" trailer, and its verb phrase is "matches the requested
+// behavior" rather than "addresses the ... concern/finding".
+//
+// Structurally SIMPLER than the third shape in one respect: "matches
+// the requested behavior" is a fixed, closed phrase with no internal
+// noun-phrase gap to police, unlike "addresses the [1-3 modifier
+// tokens] concern/finding". Guards 1, 2, 4, and 10 above exist only to
+// bound that internal gap, so none of them apply here -- a contrastive
+// insertion such as "matches a different requested behavior" (AC3,
+// #2927's own contrastive example) simply fails to match the fixed
+// phrase at all, rather than needing its own guard.
+//
+// What DOES transfer, for the identical reason guards 5/8/9 exist on
+// the third shape: AC3 (#2927) requires "This partially matches...",
+// "This never matches...", and "This supposedly matches..." to still
+// read as withheld/uncertain, not confirmed. The same closed hedge/
+// negation/epistemic enumerations are reused via an identical negative
+// lookbehind immediately before "matches". A hedge/negation/epistemic
+// word hiding in the LEAD-IN noun phrase instead ("The temporary fix
+// matches...") is already excluded for free by reusing
+// `CODERABBIT_ACK_CLOSURE_LEADIN_RE` unchanged below (guard 7's own
+// exclusions apply there) -- the real sample's lead-in, "The fix",
+// already fits that regex's existing "the" + one-word alternative with
+// no changes needed.
+//
+// New wrinkle this shape introduces: the real sample above has ONE
+// more free-text sentence ("The default fixture now uses...") between
+// the closure verb phrase and the boilerplate tail. The third shape's
+// guard 3 requires the boilerplate immediately after its closure
+// sentence, with no bare trailing content allowed at all; reusing that
+// requirement unchanged here would reject the real sample and fail AC1
+// (#2927). The trailing sentence is therefore permitted, but bounded
+// with the SAME token-capped, positive-shape grammar guard 1 uses for
+// the third shape's internal gap -- not a free `[^.!?]` skip, which
+// this file's own history (guard 2's comment above) already found
+// insufficient once:
+//   - at most 10 space-separated `[\w-]+` tokens total (the real
+//     sample's trailing sentence needs 9: "The default fixture now
+//     uses the permissive zero-parseable-run-ID path"; one token of
+//     headroom, the same ratio guard 1 uses for its own cap);
+//   - the FIRST token must be one of the same closed determiner/
+//     pronoun set the lead-in whitelist already uses (`this`/`that`/
+//     `it`/`the`) -- free against the real sample (its trailing
+//     sentence starts with "The"), and rejects the most natural
+//     new-feedback openers ("Still", "Note", "Please", "However",
+//     "One");
+//   - every token (including the first) is excluded from the same
+//     closed hedge/negation/epistemic/conjunction enumerations already
+//     used throughout this file;
+//   - no comma, semicolon, apostrophe, or sentence terminator may
+//     appear anywhere inside it: `[\w-]+` tokens separated only by
+//     `\s+` cannot cross any of those characters, so a second, joined
+//     clause ("...behavior. The fix, however, breaks other tests.")
+//     breaks the token chain and the whole optional group fails to
+//     match, falling through to requiring the boilerplate immediately
+//     after "behavior." instead (guard 3's original requirement,
+//     unchanged as the fallback);
+//   - exactly one trailing `.` immediately followed by the same
+//     boilerplate tail is mandatory whenever the group is present at
+//     all -- a SECOND free sentence between this one and the tail is
+//     not reachable within the token cap without crossing a sentence
+//     terminator, which breaks the token chain the same way.
+//
+// Residual risk, stated rather than papered over, the same standard as
+// every guard above: within the 10-token cap, the determiner-first-
+// token requirement, and the closed-class exclusions, a syntactically
+// clean, unhedged sentence with no excluded vocabulary -- e.g. "The
+// null-check still remains unresolved in the other branch." (9 tokens,
+// starts with "The", no hedge/negation/epistemic/conjunction word) --
+// would still be accepted as the permitted trailing sentence and
+// misclassify. This is narrower than the round-6 bypass guard 3 closed
+// for the third shape (that gap was an unbounded `---\n\n`-delimited
+// prose span; this one is capped at 10 clean tokens with a restricted
+// opener), but it is not eliminated -- the same "no sampled reply has
+// used this position to hide substantive feedback" standard as
+// residual gap (a) above. A future sample demonstrating this bypass is
+// a design question for a follow-up issue, the same escalation path
+// residual gap (a) already uses -- not something to chase further
+// here.
+const CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE = new RegExp(
+  `(?<!\\b(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE})\\s+)` +
+    '\\bmatches\\s+the\\s+requested\\s+behavior\\b\\.\\s*' +
+    '(?:\\b(?:this|that|it|the)\\b' +
+    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE}|${CODERABBIT_ACK_CONJUNCTION_WORDS_SOURCE})\\b)[\\w-]+){0,9}` +
+    '\\.\\s*)?' +
+    CODERABBIT_ACK_CLOSURE_TAIL_SOURCE,
+  'i',
+);
+
 function isKnownAdvisoryAckTemplate(comment: {
   author?: { login?: string | null } | null;
   body?: string | null;
@@ -2785,19 +2916,30 @@ function isKnownAdvisoryAckTemplate(comment: {
   // The two strong forms (CodeRabbit's own resolve-attempt decision) are
   // checked on the whole body with no further guard -- see the comment
   // above `CODERABBIT_ACK_STRONG_CLOSURE_RE` for why the weaker third
-  // form's guards (locality, sentence-boundary, hedge-adverb, opening-
-  // to-closure lead-in whitelist) must never apply here, even when
-  // unrelated hedge-shaped wording happens to appear elsewhere in the
-  // same reply (e.g. a Learnings-used block).
+  // and fourth forms' guards (locality, sentence-boundary, hedge-adverb,
+  // opening-to-closure lead-in whitelist) must never apply here, even
+  // when unrelated hedge-shaped wording happens to appear elsewhere in
+  // the same reply (e.g. a Learnings-used block).
   if (CODERABBIT_ACK_STRONG_CLOSURE_RE.test(body)) {
     return true;
   }
-  const addressesMatch = CODERABBIT_ACK_ADDRESSES_CLOSURE_RE.exec(body);
-  if (!addressesMatch) {
+  // The third (#2858) and fourth (#2927) forms are tried in the order
+  // they were introduced; the first one whose closure regex matches
+  // wins, and its own opening-to-closure gap is checked against the
+  // SAME shared lead-in whitelist below (both forms' real observed
+  // lead-ins already fit it unchanged). No real sample matches both
+  // regexes at once, so this ordering has no observed effect on the
+  // result -- it is deterministic either way, matching the "checked
+  // only after [the earlier form] fail[s]" comment above
+  // `CODERABBIT_ACK_ADDRESSES_CLOSURE_RE`.
+  const weakClosureMatch =
+    CODERABBIT_ACK_ADDRESSES_CLOSURE_RE.exec(body) ??
+    CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE.exec(body);
+  if (!weakClosureMatch) {
     return false;
   }
   const openingEnd = openingMatch.index + openingMatch[0].length;
-  const gapToClosure = body.slice(openingEnd, addressesMatch.index);
+  const gapToClosure = body.slice(openingEnd, weakClosureMatch.index);
   return CODERABBIT_ACK_CLOSURE_LEADIN_RE.test(gapToClosure);
 }
 

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2842,97 +2842,50 @@ const CODERABBIT_ACK_CLOSURE_LEADIN_RE = new RegExp(
 // guard 3 requires the boilerplate immediately after its closure
 // sentence, with no bare trailing content allowed at all; reusing that
 // requirement unchanged here would reject the real sample and fail AC1
-// (#2927). The trailing sentence is therefore permitted, but bounded
-// with the SAME token-capped, positive-shape grammar guard 1 uses for
-// the third shape's internal gap -- not a free `[^.!?]` skip, which
-// this file's own history (guard 2's comment above) already found
-// insufficient once:
-//   - at most 10 space-separated `[\w-]+` tokens total (the real
-//     sample's trailing sentence needs 9: "The default fixture now
-//     uses the permissive zero-parseable-run-ID path"; one token of
-//     headroom, the same ratio guard 1 uses for its own cap);
-//   - the FIRST token must be one of the same closed determiner/
-//     pronoun set the lead-in whitelist already uses (`this`/`that`/
-//     `it`/`the`) -- free against the real sample (its trailing
-//     sentence starts with "The"), and rejects the most natural
-//     new-feedback openers ("Still", "Note", "Please", "However",
-//     "One");
-//   - every token (including the first) is excluded from the same
-//     closed hedge/negation/epistemic/conjunction enumerations already
-//     used throughout this file, PLUS the third shape's own trigger
-//     verb (see `CODERABBIT_ACK_MATCHES_TRAILING_EXCLUDED_VERB_SOURCE`
-//     below);
-//   - no comma, semicolon, apostrophe, or sentence terminator may
-//     appear anywhere inside it: `[\w-]+` tokens separated only by
-//     `\s+` cannot cross any of those characters, so a second, joined
-//     clause ("...behavior. The fix, however, breaks other tests.")
-//     breaks the token chain and the whole optional group fails to
-//     match, falling through to requiring the boilerplate immediately
-//     after "behavior." instead (guard 3's original requirement,
-//     unchanged as the fallback);
-//   - exactly one trailing `.` immediately followed by the same
-//     boilerplate tail is mandatory whenever the group is present at
-//     all -- a SECOND free sentence between this one and the tail is
-//     not reachable within the token cap without crossing a sentence
-//     terminator, which breaks the token chain the same way.
+// (#2927).
 //
-// Copilot review (#2927) found a genuine interaction bug this trailing
-// sentence's grammar makes possible: "The fix matches the requested
-// behavior. The default fixture addresses the security concern.\n\n🐇
-// ✅" -- the trailing sentence, unrestricted, happily absorbs
-// "addresses the security concern." as innocuous filler, but that exact
-// substring is ALSO a structurally valid `CODERABBIT_ACK_ADDRESSES_
-// CLOSURE_RE` match (genuine boilerplate immediately follows it). Two
-// problems compounded: (1) `isKnownAdvisoryAckTemplate` tried the third
-// shape first and committed to its structural match even though that
-// match's OWN lead-in (spanning the whole preceding "matches the
-// requested behavior" sentence) then failed the whitelist, never
-// falling through to try this fourth shape's own, separately valid,
-// match -- fixed below by trying each form independently instead of
-// short-circuiting; (2) even with that fixed, a reply combining BOTH
-// shapes' closure vocabulary in one body is exactly the ambiguous case
-// this file's fail-closed philosophy exists for -- it makes two
-// separate, sequential outcome claims, not a single benign courtesy
-// summary. Rather than accept it once the control-flow bug is fixed,
-// `CODERABBIT_ACK_MATCHES_TRAILING_EXCLUDED_VERB_SOURCE` below excludes
-// the third shape's own trigger verb from this trailing sentence's
-// tokens too, so this exact combination is REJECTED for a principled,
-// closed-class reason (ambiguous cross-shape vocabulary) rather than
-// silently accepted as "purely descriptive" filler.
+// A first attempt permitted this trailing sentence via a token-capped,
+// positive-shape grammar (10 `[\w-]+` tokens, closed-class-excluded,
+// determiner-first-token restricted) -- the same STYLE as guard 1's
+// internal "addresses the ... concern" gap. Copilot review (#2927)
+// correctly rejected this as still too permissive: the grammar's own
+// documented residual risk -- a syntactically clean, unhedged,
+// determiner-led sentence with no excluded vocabulary, e.g. "The
+// null-check still remains unresolved in the other branch." (9 tokens,
+// "The" opener, no excluded word) -- structurally satisfies ANY such
+// bounded-but-general grammar while stating a genuine new blocker, and
+// would suppress the merge gate exactly the way this file's fail-closed
+// philosophy exists to prevent. Unlike gap (a) above (contrastive
+// adjectives inside an already-narrow noun-phrase slot, genuinely
+// irreducible without recreating the open-ended "new concern"
+// blocklist), an open determiner-led sentence is not a narrow residual
+// edge -- it is most of the risk surface a "positive-shape grammar"
+// was supposed to close in the first place. The SAME review also found
+// this permissive grammar could absorb the third shape's own "addresses
+// the ... concern/finding" vocabulary as innocuous filler, which could
+// then interact badly with `isKnownAdvisoryAckTemplate`'s own
+// closure-form selection (see that function's own comment for the
+// control-flow half of that fix).
 //
-// Residual risk, stated rather than papered over, the same standard as
-// every guard above: within the 10-token cap, the determiner-first-
-// token requirement, and the closed-class exclusions (including the
-// address-verb exclusion above), a syntactically clean, unhedged
-// sentence with no excluded vocabulary -- e.g. "The null-check still
-// remains unresolved in the other branch." (9 tokens, starts with
-// "The", no hedge/negation/epistemic/conjunction/address-verb word) --
-// would still be accepted as the permitted trailing sentence and
-// misclassify. This is narrower than the round-6 bypass guard 3 closed
-// for the third shape (that gap was an unbounded `---\n\n`-delimited
-// prose span; this one is capped at 10 clean tokens with a restricted
-// opener and now two excluded vocabulary families), but it is not
-// eliminated -- the same "no sampled reply has used this position to
-// hide substantive feedback" standard as residual gap (a) above. A
-// future sample demonstrating this bypass is a design question for a
-// follow-up issue, the same escalation path residual gap (a) already
-// uses -- not something to chase further here.
-//
-// The third shape's own trigger verb ("addresses"), excluded from this
-// trailing sentence's tokens for the reason above (Copilot review,
-// #2927). `CODERABBIT_ACK_ADDRESSES_CLOSURE_RE` only ever matches the
-// literal token "addresses" (not "address"/"addressed"/"addressing"),
-// but the closed word-family is excluded rather than only that one
-// inflection, for the same defense-in-depth reasoning this file applies
-// to its other closed enumerations.
-const CODERABBIT_ACK_MATCHES_TRAILING_EXCLUDED_VERB_SOURCE =
-  'address(?:es|ed|ing)?';
+// With only ONE real observed sample and no broader pattern to derive a
+// general grammar FROM, the trailing sentence is instead permitted only
+// as an EXACT literal match of that one sample's own continuation text
+// -- the same resolution guard 6's lead-in whitelist already applies
+// (enumerate the exact observed shape(s), fail closed on everything
+// else, widen later only when a new real sample demonstrates a genuine
+// second shape) -- rather than a grammar general enough to also accept
+// prose no sample has ever produced. This has no residual risk in this
+// slot at all (a fixed string cannot admit arbitrary new content), and
+// incidentally also closes the cross-shape-vocabulary concern above for
+// free: the literal sample text contains neither "addresses" nor
+// "concern"/"finding".
+const CODERABBIT_ACK_MATCHES_TRAILING_OBSERVED_SENTENCE_SOURCE = escapeRegExp(
+  'The default fixture now uses the permissive zero-parseable-run-ID path.',
+);
 const CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE = new RegExp(
   `(?<!\\b(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE})\\s+)` +
     '\\bmatches\\s+the\\s+requested\\s+behavior\\b\\.\\s*' +
-    '(?:\\b(?:this|that|it|the)\\b' +
-    `(?:\\s+(?!(?:${CODERABBIT_ACK_HEDGE_WORDS_SOURCE}|${CODERABBIT_ACK_NEGATION_WORDS_SOURCE}|${CODERABBIT_ACK_EPISTEMIC_WORDS_SOURCE}|${CODERABBIT_ACK_CONJUNCTION_WORDS_SOURCE}|${CODERABBIT_ACK_MATCHES_TRAILING_EXCLUDED_VERB_SOURCE})\\b)[\\w-]+){0,9}` +
-    '\\.\\s*)?' +
+    `(?:${CODERABBIT_ACK_MATCHES_TRAILING_OBSERVED_SENTENCE_SOURCE}\\s*)?` +
     CODERABBIT_ACK_CLOSURE_TAIL_SOURCE,
   'i',
 );
@@ -2972,8 +2925,8 @@ function isKnownAdvisoryAckTemplate(comment: {
   // function to `false` without ever trying this fourth shape's own,
   // separately valid, match. See the doc comment above
   // `CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE` for the full example
-  // and why the trailing-sentence grammar there is ALSO tightened
-  // rather than relying on this loop fix alone.
+  // and why its trailing-sentence slot is ALSO narrowed to an exact
+  // literal match rather than relying on this loop fix alone.
   const openingEnd = openingMatch.index + openingMatch[0].length;
   for (const closureRe of [
     CODERABBIT_ACK_ADDRESSES_CLOSURE_RE,

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -2578,17 +2578,17 @@ test('classifyThreadAckOnlyPostDisposition rejects a contrastive-adjective varia
   assert.equal(classification.ackOnlyPostDisposition, false);
 });
 
-test('classifyThreadAckOnlyPostDisposition rejects a trailing sentence over the 10-token cap after "matches the requested behavior" (#2927)', () => {
-  // The trailing free-text sentence permitted after the closure phrase
-  // is capped at 10 space-separated `[\w-]+` tokens (one more than the
-  // real #2921 sample's 9), the same token-capped positive-shape
-  // grammar as guard 1's internal "addresses the ... concern" gap. An
-  // 11-token sentence -- otherwise clean, no excluded vocabulary -- has
-  // no way to reach its own terminating period within the cap, so the
-  // whole optional group fails to match; this fixture has no boilerplate
-  // immediately after "behavior." either, so the fallback also misses.
+test('classifyThreadAckOnlyPostDisposition rejects an unrelated trailing sentence after "matches the requested behavior" (#2927)', () => {
+  // The trailing sentence permitted after the closure phrase is an
+  // EXACT literal match of the one real #2921 sample's own continuation
+  // text, not a general grammar (Copilot review, #2927 -- see the doc
+  // comment above `CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE`). A
+  // completely unrelated sentence, however clean, simply is not that
+  // literal string, so the optional group fails to match; this fixture
+  // has no boilerplate immediately after "behavior." either, so the
+  // immediate-tail fallback also misses.
   const thread = {
-    id: 'thread-matches-trailing-over-cap',
+    id: 'thread-matches-trailing-unrelated',
     isResolved: true,
     updatedAt: '',
     comments: {
@@ -2623,12 +2623,12 @@ test('classifyThreadAckOnlyPostDisposition rejects a trailing sentence over the 
   assert.equal(classification.ackOnlyPostDisposition, false);
 });
 
-test('classifyThreadAckOnlyPostDisposition rejects a trailing sentence containing a comma after "matches the requested behavior" (#2927)', () => {
-  // The trailing sentence's `[\w-]+` tokens are separated only by
-  // `\s+`; a comma is neither a word/hyphen character nor whitespace,
-  // so it breaks the token chain outright, the same reasoning guard 2's
-  // "word/hyphen-only tokens" comment already established for the third
-  // shape's internal gap.
+test('classifyThreadAckOnlyPostDisposition rejects a differently-worded trailing sentence after "matches the requested behavior" (#2927)', () => {
+  // A paraphrased trailing sentence -- plausible, similar topic, but not
+  // byte-identical to the one real sample's literal continuation text
+  // -- is rejected the same way any other non-matching text is: the
+  // literal match requires the exact observed string, not "a sentence
+  // about the fix" in general.
   const thread = {
     id: 'thread-matches-trailing-comma',
     isResolved: true,
@@ -2665,15 +2665,16 @@ test('classifyThreadAckOnlyPostDisposition rejects a trailing sentence containin
   assert.equal(classification.ackOnlyPostDisposition, false);
 });
 
-test('classifyThreadAckOnlyPostDisposition rejects a second free sentence appended after the permitted trailing sentence, before the boilerplate tail (#2927)', () => {
-  // The permitted trailing sentence must be immediately followed by the
-  // boilerplate tail -- exactly one more sentence, not two. A second
-  // sentence ("However, a related issue remains.") sitting between the
-  // first trailing sentence and the tail is not reachable within the
-  // token cap without crossing the first sentence's own terminating
-  // period, which the token grammar cannot cross either -- the same
-  // "no bare end-of-body fallback" discipline guard 3 established for
-  // the third shape.
+test('classifyThreadAckOnlyPostDisposition rejects a second free sentence appended after a would-be trailing sentence, before the boilerplate tail (#2927)', () => {
+  // Even a body that starts its post-closure text with words resembling
+  // the real sample ("The default fixture now uses...") is rejected the
+  // moment it diverges into a second, genuinely new sentence ("However,
+  // a related issue remains.") before the boilerplate tail: the
+  // permitted trailing text is the ONE exact literal sentence, followed
+  // immediately by the tail, with nothing else admitted in between --
+  // the same "no bare end-of-body fallback" discipline guard 3
+  // established for the third shape, now enforced by exact-match rather
+  // than a general grammar.
   const thread = {
     id: 'thread-matches-trailing-second-sentence',
     isResolved: true,
@@ -2757,22 +2758,23 @@ test('classifyThreadAckOnlyPostDisposition recognizes the "matches the requested
 });
 
 test("classifyThreadAckOnlyPostDisposition rejects a reply combining both the third and fourth shapes' closure vocabulary in one body (Copilot review, #2927)", () => {
-  // Copilot's finding on this PR: the trailing sentence permitted after
-  // "matches the requested behavior." could, before this fix, absorb
-  // "addresses the security concern." as innocuous filler -- but that
-  // exact substring is ALSO a structurally valid
-  // `CODERABBIT_ACK_ADDRESSES_CLOSURE_RE` match (genuine boilerplate
-  // immediately follows it). `isKnownAdvisoryAckTemplate` used to
-  // commit to that first structural match, whose own lead-in (spanning
-  // the entire preceding "matches..." sentence) then failed the
-  // whitelist, short-circuiting to `false` without ever trying the
-  // fourth shape's own, separately valid, match. Now fixed two ways:
-  // `isKnownAdvisoryAckTemplate` tries each closure form independently,
-  // AND the trailing sentence additionally excludes the third shape's
-  // own trigger verb ("addresses"), so this specific combination stays
-  // rejected for a principled, closed-class reason (ambiguous
-  // cross-shape vocabulary in one body) rather than being silently
-  // accepted once the control-flow bug alone is fixed.
+  // Copilot's original finding on this PR (round 1): a permissive
+  // trailing-sentence GRAMMAR could absorb "addresses the security
+  // concern." as innocuous filler -- but that exact substring is ALSO a
+  // structurally valid `CODERABBIT_ACK_ADDRESSES_CLOSURE_RE` match
+  // (genuine boilerplate immediately follows it), and
+  // `isKnownAdvisoryAckTemplate` used to commit to that first
+  // structural match, whose own lead-in (spanning the entire preceding
+  // "matches..." sentence) then failed the whitelist, short-circuiting
+  // to `false` without ever trying the fourth shape's own, separately
+  // valid, match. Now fixed two ways that both hold even after round 2
+  // replaced the trailing-sentence grammar with an exact literal match
+  // (see the doc comment above `CODERABBIT_ACK_MATCHES_BEHAVIOR_
+  // CLOSURE_RE`): `isKnownAdvisoryAckTemplate` tries each closure form
+  // independently (still relevant on its own terms), and "The default
+  // fixture addresses the security concern." is simply not the one
+  // literal sentence the trailing slot now accepts, so this combination
+  // stays rejected for two independent reasons.
   const thread = {
     id: 'thread-matches-combined-with-addresses',
     isResolved: true,

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -2498,6 +2498,49 @@ test('classifyThreadAckOnlyPostDisposition rejects a hedge adverb immediately be
   assert.equal(classification.ackOnlyPostDisposition, false);
 });
 
+test('classifyThreadAckOnlyPostDisposition rejects a proximity-adverb hedge ("almost") immediately before "matches" (Copilot review, #2927, round 4)', () => {
+  // Copilot's round-4 finding: `CODERABBIT_ACK_HEDGE_WORDS_SOURCE`
+  // omitted proximity adverbs ("almost"/"nearly") -- the same hedged,
+  // non-committal degree semantic as "partially"/"mostly" already in
+  // the enumeration, just a different lexical subclass. "The fix
+  // almost matches the requested behavior." states an explicitly
+  // incomplete fix and previously passed the pre-"matches" lookbehind
+  // unnoticed.
+  const thread = {
+    id: 'thread-matches-hedge-almost',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'MA-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'MA-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@kurone-kito`, thanks. The fix almost matches the ' +
+            'requested behavior.\n\n🐇 ✅',
+          createdAt: '2026-09-11T00:50:00Z',
+          updatedAt: '2026-09-11T00:50:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
 test('classifyThreadAckOnlyPostDisposition rejects a negation adverb immediately before "matches" (AC3, #2927)', () => {
   const thread = {
     id: 'thread-matches-negation-never',

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -2756,6 +2756,59 @@ test('classifyThreadAckOnlyPostDisposition recognizes the "matches the requested
   assert.equal(classification.ackOnlyPostDisposition, true);
 });
 
+test("classifyThreadAckOnlyPostDisposition rejects a reply combining both the third and fourth shapes' closure vocabulary in one body (Copilot review, #2927)", () => {
+  // Copilot's finding on this PR: the trailing sentence permitted after
+  // "matches the requested behavior." could, before this fix, absorb
+  // "addresses the security concern." as innocuous filler -- but that
+  // exact substring is ALSO a structurally valid
+  // `CODERABBIT_ACK_ADDRESSES_CLOSURE_RE` match (genuine boilerplate
+  // immediately follows it). `isKnownAdvisoryAckTemplate` used to
+  // commit to that first structural match, whose own lead-in (spanning
+  // the entire preceding "matches..." sentence) then failed the
+  // whitelist, short-circuiting to `false` without ever trying the
+  // fourth shape's own, separately valid, match. Now fixed two ways:
+  // `isKnownAdvisoryAckTemplate` tries each closure form independently,
+  // AND the trailing sentence additionally excludes the third shape's
+  // own trigger verb ("addresses"), so this specific combination stays
+  // rejected for a principled, closed-class reason (ambiguous
+  // cross-shape vocabulary in one body) rather than being silently
+  // accepted once the control-flow bug alone is fixed.
+  const thread = {
+    id: 'thread-matches-combined-with-addresses',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'MX-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'MX-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@kurone-kito`, thanks. The fix matches the requested ' +
+            'behavior. The default fixture addresses the security ' +
+            'concern.\n\n🐇 ✅',
+          createdAt: '2026-09-11T00:40:00Z',
+          updatedAt: '2026-09-11T00:40:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
 // Codex review findings on this PR (#2014), both verified against source
 // before accepting.
 

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -2411,6 +2411,351 @@ test('classifyThreadAckOnlyPostDisposition rejects a 2-token conjunction bypass 
   assert.equal(classification.ackOnlyPostDisposition, false);
 });
 
+// #2927: a FOURTH ack shape -- observed byte-exact (fetched via the REST
+// pulls/comments API) on kurone-kito/idd-skill#2921's review thread
+// `discussion_r3989223825`, already resolved independently by this
+// repository's own resolve-review-thread.mjs before CodeRabbit replied,
+// so (like the third shape's #2853 samples above) it carries no "Review
+// thread resolved" trailer of its own. See the doc comment above
+// `CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE` for the full reasoning.
+
+test('classifyThreadAckOnlyPostDisposition recognizes the "matches the requested behavior" closure shape (kurone-kito/idd-skill#2921, #2927)', () => {
+  const thread = {
+    id: 'thread-matches-requested-behavior',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'MB-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'MB-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@kurone-kito`, thanks. The fix matches the requested ' +
+            'behavior. The default fixture now uses the permissive ' +
+            'zero-parseable-run-ID path.\n\n🐇 ✅\n\n_You are ' +
+            'interacting with an AI system._\n\n<!-- This is an ' +
+            'auto-generated reply by CodeRabbit -->',
+          createdAt: '2026-09-11T00:00:00Z',
+          updatedAt: '2026-09-11T00:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, true);
+});
+
+test('classifyThreadAckOnlyPostDisposition rejects a hedge adverb immediately before "matches" (AC3, #2927)', () => {
+  // AC3 (#2927): a reply using similar vocabulary but actually hedging
+  // the outcome must not be misclassified as ack-only. Reuses the same
+  // closed hedge-adverb enumeration guards 5/8/9 already apply before
+  // "addresses", via an identical negative lookbehind before "matches".
+  const thread = {
+    id: 'thread-matches-hedge-partially',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'MH-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'MH-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@kurone-kito`, thanks. This partially matches the ' +
+            'requested behavior.\n\n🐇 ✅',
+          createdAt: '2026-09-11T00:05:00Z',
+          updatedAt: '2026-09-11T00:05:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
+test('classifyThreadAckOnlyPostDisposition rejects a negation adverb immediately before "matches" (AC3, #2927)', () => {
+  const thread = {
+    id: 'thread-matches-negation-never',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'MN-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'MN-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@kurone-kito`, thanks. This never matches the requested ' +
+            'behavior.\n\n🐇 ✅',
+          createdAt: '2026-09-11T00:10:00Z',
+          updatedAt: '2026-09-11T00:10:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
+test('classifyThreadAckOnlyPostDisposition rejects a contrastive-adjective variant that no longer matches the fixed closure phrase (AC3, #2927)', () => {
+  // AC3 (#2927)'s own named example: "matches a different requested
+  // behavior" is not a hedge or negation word immediately before
+  // "matches", but the fixed phrase `CODERABBIT_ACK_MATCHES_BEHAVIOR_
+  // CLOSURE_RE` requires ("matches the requested behavior") has no
+  // internal gap for "different" to occupy -- the substitution simply
+  // fails to match the literal phrase at all, unlike the third shape's
+  // "addresses the [gap] concern", which needs an explicit guard for
+  // this same class (residual gap (a) above).
+  const thread = {
+    id: 'thread-matches-contrastive-different',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'MC-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'MC-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@kurone-kito`, thanks. This matches a different ' +
+            'requested behavior.\n\n🐇 ✅',
+          createdAt: '2026-09-11T00:15:00Z',
+          updatedAt: '2026-09-11T00:15:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
+test('classifyThreadAckOnlyPostDisposition rejects a trailing sentence over the 10-token cap after "matches the requested behavior" (#2927)', () => {
+  // The trailing free-text sentence permitted after the closure phrase
+  // is capped at 10 space-separated `[\w-]+` tokens (one more than the
+  // real #2921 sample's 9), the same token-capped positive-shape
+  // grammar as guard 1's internal "addresses the ... concern" gap. An
+  // 11-token sentence -- otherwise clean, no excluded vocabulary -- has
+  // no way to reach its own terminating period within the cap, so the
+  // whole optional group fails to match; this fixture has no boilerplate
+  // immediately after "behavior." either, so the fallback also misses.
+  const thread = {
+    id: 'thread-matches-trailing-over-cap',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'MT-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'MT-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@kurone-kito`, thanks. The fix matches the requested ' +
+            'behavior. The quick brown fox jumps over the lazy dog ' +
+            'again today.\n\n🐇 ✅',
+          createdAt: '2026-09-11T00:20:00Z',
+          updatedAt: '2026-09-11T00:20:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
+test('classifyThreadAckOnlyPostDisposition rejects a trailing sentence containing a comma after "matches the requested behavior" (#2927)', () => {
+  // The trailing sentence's `[\w-]+` tokens are separated only by
+  // `\s+`; a comma is neither a word/hyphen character nor whitespace,
+  // so it breaks the token chain outright, the same reasoning guard 2's
+  // "word/hyphen-only tokens" comment already established for the third
+  // shape's internal gap.
+  const thread = {
+    id: 'thread-matches-trailing-comma',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'MG-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'MG-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@kurone-kito`, thanks. The fix matches the requested ' +
+            'behavior. The default fixture, unfortunately, still ' +
+            'needs a follow-up.\n\n🐇 ✅',
+          createdAt: '2026-09-11T00:25:00Z',
+          updatedAt: '2026-09-11T00:25:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
+test('classifyThreadAckOnlyPostDisposition rejects a second free sentence appended after the permitted trailing sentence, before the boilerplate tail (#2927)', () => {
+  // The permitted trailing sentence must be immediately followed by the
+  // boilerplate tail -- exactly one more sentence, not two. A second
+  // sentence ("However, a related issue remains.") sitting between the
+  // first trailing sentence and the tail is not reachable within the
+  // token cap without crossing the first sentence's own terminating
+  // period, which the token grammar cannot cross either -- the same
+  // "no bare end-of-body fallback" discipline guard 3 established for
+  // the third shape.
+  const thread = {
+    id: 'thread-matches-trailing-second-sentence',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'MS-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'MS-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@kurone-kito`, thanks. The fix matches the requested ' +
+            'behavior. The default fixture now uses a workaround. ' +
+            'However, a related issue remains.\n\n🐇 ✅',
+          createdAt: '2026-09-11T00:30:00Z',
+          updatedAt: '2026-09-11T00:30:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
+test('classifyThreadAckOnlyPostDisposition recognizes the "matches the requested behavior" closure with no trailing sentence at all ("this" lead-in, #2927)', () => {
+  // Variant of the real #2921 sample with no trailing sentence between
+  // the closure phrase and the tail (guard 3's original immediate-
+  // boilerplate fallback still applies when the optional trailing-
+  // sentence group is absent), and the lead-in whitelist's bare "this"
+  // pronoun branch instead of "The fix" -- both already supported
+  // unchanged by the reused `CODERABBIT_ACK_CLOSURE_LEADIN_RE`. Also
+  // exercises the pre-existing ✓ sign-off variant alongside this shape,
+  // confirming the ✅ widening above did not narrow it.
+  const thread = {
+    id: 'thread-matches-no-trailing-sentence',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'ML-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'ML-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@kurone-kito`, thanks. This matches the requested ' +
+            'behavior.\n\n🐇 ✓\n\n_You are interacting with an AI ' +
+            'system._\n\n<!-- This is an auto-generated reply by ' +
+            'CodeRabbit -->',
+          createdAt: '2026-09-11T00:35:00Z',
+          updatedAt: '2026-09-11T00:35:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, true);
+});
+
 // Codex review findings on this PR (#2014), both verified against source
 // before accepting.
 

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -2811,6 +2811,53 @@ test("classifyThreadAckOnlyPostDisposition rejects a reply combining both the th
   assert.equal(classification.ackOnlyPostDisposition, false);
 });
 
+test("classifyThreadAckOnlyPostDisposition rejects a contrastive adjective inside the fourth shape's own lead-in (Copilot review, #2927, round 2)", () => {
+  // Copilot's round-2 finding: reusing the shared
+  // `CODERABBIT_ACK_CLOSURE_LEADIN_RE` for this fourth shape would
+  // import that regex's own pre-existing gap (guard 7 excludes hedge/
+  // negation/epistemic words from its "the ..." branch but not
+  // CONTRASTIVE adjectives -- the same residual gap (a) documented for
+  // the third shape). "The wrong fix" would otherwise pass that shared
+  // branch ("the" + "wrong" + "fix", within its 1-2 word budget) even
+  // though "wrong fix" plausibly signals a substantive problem. This
+  // fourth shape now uses its own, narrower `CODERABBIT_ACK_MATCHES_
+  // LEADIN_RE` (bare pronoun or the exact literal "the fix" only), so
+  // "The wrong fix" fails to match that literal phrase at all.
+  const thread = {
+    id: 'thread-matches-leadin-contrastive-wrong',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'MW-1',
+          author: { login: 'idd-bot' },
+          body: '**Accepted** — done.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'MW-2',
+          author: { login: 'coderabbitai[bot]' },
+          body:
+            '`@kurone-kito`, thanks. The wrong fix matches the ' +
+            'requested behavior.\n\n🐇 ✅',
+          createdAt: '2026-09-11T00:45:00Z',
+          updatedAt: '2026-09-11T00:45:00Z',
+        },
+      ],
+    },
+  };
+
+  const classification = classifyThreadAckOnlyPostDisposition(thread, {
+    iddAgentLogins: ['idd-bot'],
+    advisoryBotLogins: ['coderabbitai[bot]'],
+  });
+
+  assert.equal(classification.ackOnlyPostDisposition, false);
+});
+
 // Codex review findings on this PR (#2014), both verified against source
 // before accepting.
 


### PR DESCRIPTION
## Summary

- Add `CODERABBIT_ACK_MATCHES_BEHAVIOR_CLOSURE_RE`, a fourth recognized
  CodeRabbit courtesy-ack closure shape ("The fix matches the requested
  behavior.") for `isKnownAdvisoryAckTemplate` in
  `src/scripts/protocol-helpers.mts`, following the same fail-closed,
  positively-enumerated methodology as the prior three shapes (#2710,
  #2858, #2641).
- The real sample, observed on kurone-kito/idd-skill#2921's review
  thread `discussion_r3989223825`, has one extra free-text sentence
  before the boilerplate tail. After a review round found a bounded
  token-capped grammar for that slot still too permissive, it is
  instead permitted only as an **exact literal match** of that one
  sample's own continuation text -- no residual risk left in that
  slot, since a fixed string admits no new content.
- The fourth shape gets its own, narrower opening-to-closure lead-in
  check (`CODERABBIT_ACK_MATCHES_LEADIN_RE`: a bare pronoun or the
  exact literal phrase "the fix") rather than reusing the third
  shape's shared lead-in whitelist, which has a known (accepted,
  documented) contrastive-adjective gap in its "the ..." branch that
  reuse would otherwise have imported into a second caller.
- `isKnownAdvisoryAckTemplate` now tries the third (#2858) and fourth
  (#2927) closure forms independently, in introduction order, each
  checked against its own lead-in -- fixing a control-flow bug where
  committing to the first structurally-matching regex, even when that
  match's own lead-in then failed, could short-circuit the whole
  function without ever trying the other form.
- Widened `CODERABBIT_ACK_CLOSURE_SIGNOFF_SOURCE` to also accept the
  "white heavy check mark" emoji alongside the existing "check mark",
  since the real sample's sign-off uses that variant. Purely additive;
  existing regression samples using the other variant are unaffected.
- Widened the shared `CODERABBIT_ACK_HEDGE_WORDS_SOURCE` enumeration to
  also cover proximity adverbs ("almost"/"nearly"), the same hedged
  degree semantic as "partially"/"mostly" already there -- benefits
  both the third and fourth closure forms.
- Regenerated `scripts/protocol-helpers.mjs` via `pnpm run build`.

## Test plan

- [x] `node --experimental-strip-types --test tests/protocol-helpers.test.mts`
      -- all 77 tests pass, including 11 new ones: a positive
      regression for the exact quoted reply; adversarial negatives for
      a hedge, proximity-hedge ("almost"), negation, and
      contrastive-adjective qualifier before "matches"; an unrelated
      trailing sentence, a differently-worded trailing sentence, and a
      trailing sentence followed by a second free sentence (all
      rejected as non-exact-match); a no-trailing-sentence + `this`
      lead-in + pre-existing sign-off variant (accepted); a reply
      combining both the third and fourth shapes' closure vocabulary in
      one body (rejected); and a contrastive adjective inside the
      fourth shape's own lead-in (rejected)
- [x] `pnpm run test` (full suite) -- 6221 passed, 3 skipped (pre-existing), 0 failed
- [x] `fix-validate` (`biome check --write && dprint fmt && markdownlint-cli2 --fix && markdownlint-cli2`) -- clean, no unrelated files touched

Closes #2927

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013MS7r6EVLb1kWoNKnr2PG6
