### PR TITLE
fix(discover-orphan-filter): rename misleading blocked reason code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,12 @@ discipline and has no tag.
 ### Fixed
 
 - `discover-orphan-filter`'s `blocked_references_closed` orphan reason
-  is renamed to `references_resolved`: the old name read as "currently
-  blocked" even though it fires only once every blocking/dependency
-  reference has resolved, which was especially misleading for an
-  entry also routed to `routed_to_human` for an unrelated sub-floor
-  autopilot-suitability score (#2932).
+  is renamed to `references_non_blocking`: the old name read as
+  "currently blocked" even though it fires once every blocking/
+  dependency reference is closed or exempt (an open parent epic), which
+  was especially misleading for an entry also routed to
+  `routed_to_human` for an unrelated sub-floor autopilot-suitability
+  score (#2932).
 
 ## [0.10.0] - 2026-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ discipline and has no tag.
 
 ## [Unreleased]
 
+### Fixed
+
+- `discover-orphan-filter`'s `blocked_references_closed` orphan reason
+  is renamed to `references_resolved`: the old name read as "currently
+  blocked" even though it fires only once every blocking/dependency
+  reference has resolved, which was especially misleading for an
+  entry also routed to `routed_to_human` for an unrelated sub-floor
+  autopilot-suitability score (#2932).
+
 ## [0.10.0] - 2026-09-11
 
 Structural-evidence precision, self-service advisory-convergence

--- a/scripts/discover-orphan-filter.mjs
+++ b/scripts/discover-orphan-filter.mjs
@@ -521,17 +521,21 @@ export function classifyIssue(issue, options) {
   }
   // Reaching here means blockedRefs/dependencyRefs was non-empty (the
   // earlier both-empty check already returned `orphan`) and every ref
-  // resolved to a non-open, non-unresolvable state (closed, or an
-  // exempt open parent epic) -- never "no refs at all" again. Named
-  // `references_resolved` rather than a "blocked"-sounding name: this
-  // condition means the issue's blocking/dependency references are ALL
-  // resolved (i.e. NOT currently blocked), and a "blocked"-sounding
-  // reason string was observed to read as the opposite of its actual
-  // meaning when an issue also landed in `routed_to_human` for an
-  // unrelated reason (#2932, illustrated on #2781).
+  // resolved to a non-open, non-unresolvable state -- either genuinely
+  // closed, or an open parent epic exempted by isDependencyEpicExempt
+  // above (the `continue` a few lines up) -- never "no refs at all"
+  // again. Named `references_non_blocking` rather than a
+  // "blocked"-sounding name (originally `blocked_references_closed`):
+  // that name read as the opposite of its actual meaning once an
+  // issue also landed in `routed_to_human` for an unrelated reason
+  // (#2932, illustrated on #2781). `references_non_blocking` also
+  // covers the exempt-open-epic path correctly, unlike an interim
+  // `references_resolved` name would have (Copilot/Codex review, PR
+  // #2936): an exempt epic reference has not resolved/closed, it is
+  // merely non-blocking.
   return {
     orphan: true,
-    reason: 'references_resolved',
+    reason: 'references_non_blocking',
     ...demotionWarning,
   };
 }
@@ -1099,7 +1103,7 @@ Output schema:
   "repository": {"owner": "...", "repo": "..."},
   "diagnostics": {"pr": 404},
   "policy": {"source": "...", "orphanFirstPolicy": "none|maintainer-approved|public-disabled", "markerPrefix": "...", "authoringLabelName": "...", "authoringStaleAge": "...", "autopilotSuitabilityFloor": 3, "autopilotSuitabilityEnabled": true},
-  "orphans": [{"number": 1, "title": "...", "state": "OPEN", "reason": "orphan|references_resolved", "url": "...", "autopilotSuitability": 4, "effort": "S|M|L|null", "milestone": "v0.8.0|null"}],
+  "orphans": [{"number": 1, "title": "...", "state": "OPEN", "reason": "orphan|references_non_blocking", "url": "...", "autopilotSuitability": 4, "effort": "S|M|L|null", "milestone": "v0.8.0|null"}],
   "routed_to_human": [{"number": 2, "title": "...", "state": "OPEN", "reason": "orphan", "url": "...", "autopilotSuitability": 1, "effort": "S|M|L|null", "milestone": "v0.8.0|null"}],
   "filtered": {
     "provider_outage_target": [...],

--- a/scripts/discover-orphan-filter.mjs
+++ b/scripts/discover-orphan-filter.mjs
@@ -522,10 +522,16 @@ export function classifyIssue(issue, options) {
   // Reaching here means blockedRefs/dependencyRefs was non-empty (the
   // earlier both-empty check already returned `orphan`) and every ref
   // resolved to a non-open, non-unresolvable state (closed, or an
-  // exempt open parent epic) -- never "no refs at all" again.
+  // exempt open parent epic) -- never "no refs at all" again. Named
+  // `references_resolved` rather than a "blocked"-sounding name: this
+  // condition means the issue's blocking/dependency references are ALL
+  // resolved (i.e. NOT currently blocked), and a "blocked"-sounding
+  // reason string was observed to read as the opposite of its actual
+  // meaning when an issue also landed in `routed_to_human` for an
+  // unrelated reason (#2932, illustrated on #2781).
   return {
     orphan: true,
-    reason: 'blocked_references_closed',
+    reason: 'references_resolved',
     ...demotionWarning,
   };
 }
@@ -1093,7 +1099,7 @@ Output schema:
   "repository": {"owner": "...", "repo": "..."},
   "diagnostics": {"pr": 404},
   "policy": {"source": "...", "orphanFirstPolicy": "none|maintainer-approved|public-disabled", "markerPrefix": "...", "authoringLabelName": "...", "authoringStaleAge": "...", "autopilotSuitabilityFloor": 3, "autopilotSuitabilityEnabled": true},
-  "orphans": [{"number": 1, "title": "...", "state": "OPEN", "reason": "orphan|blocked_references_closed", "url": "...", "autopilotSuitability": 4, "effort": "S|M|L|null", "milestone": "v0.8.0|null"}],
+  "orphans": [{"number": 1, "title": "...", "state": "OPEN", "reason": "orphan|references_resolved", "url": "...", "autopilotSuitability": 4, "effort": "S|M|L|null", "milestone": "v0.8.0|null"}],
   "routed_to_human": [{"number": 2, "title": "...", "state": "OPEN", "reason": "orphan", "url": "...", "autopilotSuitability": 1, "effort": "S|M|L|null", "milestone": "v0.8.0|null"}],
   "filtered": {
     "provider_outage_target": [...],

--- a/src/scripts/discover-orphan-filter.mts
+++ b/src/scripts/discover-orphan-filter.mts
@@ -189,7 +189,7 @@ export type OrphanFilteredReason =
 export type OrphanClassification =
   | {
       orphan: true;
-      reason: 'orphan' | 'blocked_references_closed';
+      reason: 'orphan' | 'references_resolved';
       details?: undefined;
       /** #2767: present only when a runtime-observation-precondition hit
        * was demoted (every structural-evidence signal held) rather than
@@ -815,10 +815,16 @@ export function classifyIssue(
   // Reaching here means blockedRefs/dependencyRefs was non-empty (the
   // earlier both-empty check already returned `orphan`) and every ref
   // resolved to a non-open, non-unresolvable state (closed, or an
-  // exempt open parent epic) -- never "no refs at all" again.
+  // exempt open parent epic) -- never "no refs at all" again. Named
+  // `references_resolved` rather than a "blocked"-sounding name: this
+  // condition means the issue's blocking/dependency references are ALL
+  // resolved (i.e. NOT currently blocked), and a "blocked"-sounding
+  // reason string was observed to read as the opposite of its actual
+  // meaning when an issue also landed in `routed_to_human` for an
+  // unrelated reason (#2932, illustrated on #2781).
   return {
     orphan: true,
-    reason: 'blocked_references_closed',
+    reason: 'references_resolved',
     ...demotionWarning,
   };
 }
@@ -1427,7 +1433,7 @@ Output schema:
   "repository": {"owner": "...", "repo": "..."},
   "diagnostics": {"pr": 404},
   "policy": {"source": "...", "orphanFirstPolicy": "none|maintainer-approved|public-disabled", "markerPrefix": "...", "authoringLabelName": "...", "authoringStaleAge": "...", "autopilotSuitabilityFloor": 3, "autopilotSuitabilityEnabled": true},
-  "orphans": [{"number": 1, "title": "...", "state": "OPEN", "reason": "orphan|blocked_references_closed", "url": "...", "autopilotSuitability": 4, "effort": "S|M|L|null", "milestone": "v0.8.0|null"}],
+  "orphans": [{"number": 1, "title": "...", "state": "OPEN", "reason": "orphan|references_resolved", "url": "...", "autopilotSuitability": 4, "effort": "S|M|L|null", "milestone": "v0.8.0|null"}],
   "routed_to_human": [{"number": 2, "title": "...", "state": "OPEN", "reason": "orphan", "url": "...", "autopilotSuitability": 1, "effort": "S|M|L|null", "milestone": "v0.8.0|null"}],
   "filtered": {
     "provider_outage_target": [...],

--- a/src/scripts/discover-orphan-filter.mts
+++ b/src/scripts/discover-orphan-filter.mts
@@ -189,7 +189,7 @@ export type OrphanFilteredReason =
 export type OrphanClassification =
   | {
       orphan: true;
-      reason: 'orphan' | 'references_resolved';
+      reason: 'orphan' | 'references_non_blocking';
       details?: undefined;
       /** #2767: present only when a runtime-observation-precondition hit
        * was demoted (every structural-evidence signal held) rather than
@@ -814,17 +814,21 @@ export function classifyIssue(
 
   // Reaching here means blockedRefs/dependencyRefs was non-empty (the
   // earlier both-empty check already returned `orphan`) and every ref
-  // resolved to a non-open, non-unresolvable state (closed, or an
-  // exempt open parent epic) -- never "no refs at all" again. Named
-  // `references_resolved` rather than a "blocked"-sounding name: this
-  // condition means the issue's blocking/dependency references are ALL
-  // resolved (i.e. NOT currently blocked), and a "blocked"-sounding
-  // reason string was observed to read as the opposite of its actual
-  // meaning when an issue also landed in `routed_to_human` for an
-  // unrelated reason (#2932, illustrated on #2781).
+  // resolved to a non-open, non-unresolvable state -- either genuinely
+  // closed, or an open parent epic exempted by isDependencyEpicExempt
+  // above (the `continue` a few lines up) -- never "no refs at all"
+  // again. Named `references_non_blocking` rather than a
+  // "blocked"-sounding name (originally `blocked_references_closed`):
+  // that name read as the opposite of its actual meaning once an
+  // issue also landed in `routed_to_human` for an unrelated reason
+  // (#2932, illustrated on #2781). `references_non_blocking` also
+  // covers the exempt-open-epic path correctly, unlike an interim
+  // `references_resolved` name would have (Copilot/Codex review, PR
+  // #2936): an exempt epic reference has not resolved/closed, it is
+  // merely non-blocking.
   return {
     orphan: true,
-    reason: 'references_resolved',
+    reason: 'references_non_blocking',
     ...demotionWarning,
   };
 }
@@ -1433,7 +1437,7 @@ Output schema:
   "repository": {"owner": "...", "repo": "..."},
   "diagnostics": {"pr": 404},
   "policy": {"source": "...", "orphanFirstPolicy": "none|maintainer-approved|public-disabled", "markerPrefix": "...", "authoringLabelName": "...", "authoringStaleAge": "...", "autopilotSuitabilityFloor": 3, "autopilotSuitabilityEnabled": true},
-  "orphans": [{"number": 1, "title": "...", "state": "OPEN", "reason": "orphan|references_resolved", "url": "...", "autopilotSuitability": 4, "effort": "S|M|L|null", "milestone": "v0.8.0|null"}],
+  "orphans": [{"number": 1, "title": "...", "state": "OPEN", "reason": "orphan|references_non_blocking", "url": "...", "autopilotSuitability": 4, "effort": "S|M|L|null", "milestone": "v0.8.0|null"}],
   "routed_to_human": [{"number": 2, "title": "...", "state": "OPEN", "reason": "orphan", "url": "...", "autopilotSuitability": 1, "effort": "S|M|L|null", "milestone": "v0.8.0|null"}],
   "filtered": {
     "provider_outage_target": [...],

--- a/tests/discover-orphan-filter.test.mts
+++ b/tests/discover-orphan-filter.test.mts
@@ -631,10 +631,10 @@ test('filterOrphanIssues keeps closed-blocker issues as orphan candidates', asyn
   });
 
   assert.equal(result.orphans.length, 1);
-  assert.equal(result.orphans[0].reason, 'references_resolved');
+  assert.equal(result.orphans[0].reason, 'references_non_blocking');
 });
 
-test('filterOrphanIssues keeps the references_resolved reason legible when a closed-blocker issue is routed to a human for an unrelated sub-floor score (#2932)', async () => {
+test('filterOrphanIssues keeps the references_non_blocking reason legible when a closed-blocker issue is routed to a human for an unrelated sub-floor score (#2932)', async () => {
   const issues = [
     {
       number: 32,
@@ -659,7 +659,7 @@ test('filterOrphanIssues keeps the references_resolved reason legible when a clo
   // as "still blocked" once it lands in routed_to_human.
   assert.equal(result.orphans.length, 0);
   assert.equal(result.routed_to_human.length, 1);
-  assert.equal(result.routed_to_human[0].reason, 'references_resolved');
+  assert.equal(result.routed_to_human[0].reason, 'references_non_blocking');
 });
 
 test('filterOrphanIssues reports unresolvable and circular references', async () => {
@@ -790,7 +790,7 @@ test('filterOrphanIssues handles pagination with PR-heavy pages', async () => {
     1,
     'Issue should be orphan when blocker is closed',
   );
-  assert.equal(result.orphans[0].reason, 'references_resolved');
+  assert.equal(result.orphans[0].reason, 'references_non_blocking');
 });
 
 test('filterOrphanIssues ranks orphans by autopilot-suitability and routes below-floor to humans (autopilot)', async () => {
@@ -1354,7 +1354,7 @@ test('filterOrphanIssues exempts an open Depends-on reference to a parent epic b
   );
   assert.equal(
     result.orphans.find((o) => o.number === 80)?.reason,
-    'references_resolved',
+    'references_non_blocking',
   );
 });
 
@@ -1389,7 +1389,7 @@ test('filterOrphanIssues exempts an open Depends-on reference to a configured ro
   assert.equal(result.filtered.open_dependency_reference.length, 0);
   assert.equal(
     result.orphans.find((o) => o.number === 90)?.reason,
-    'references_resolved',
+    'references_non_blocking',
   );
 });
 
@@ -1439,7 +1439,7 @@ test('filterOrphanIssues keeps a closed Depends-on reference as an orphan candid
   });
 
   assert.equal(result.orphans.length, 1);
-  assert.equal(result.orphans[0].reason, 'references_resolved');
+  assert.equal(result.orphans[0].reason, 'references_non_blocking');
 });
 
 test('classifyIssue routes runtime/production-observation prose to runtime_observation_precondition (#2467)', () => {

--- a/tests/discover-orphan-filter.test.mts
+++ b/tests/discover-orphan-filter.test.mts
@@ -631,7 +631,35 @@ test('filterOrphanIssues keeps closed-blocker issues as orphan candidates', asyn
   });
 
   assert.equal(result.orphans.length, 1);
-  assert.equal(result.orphans[0].reason, 'blocked_references_closed');
+  assert.equal(result.orphans[0].reason, 'references_resolved');
+});
+
+test('filterOrphanIssues keeps the references_resolved reason legible when a closed-blocker issue is routed to a human for an unrelated sub-floor score (#2932)', async () => {
+  const issues = [
+    {
+      number: 32,
+      title: 'blocked by closed issue but below the autopilot floor',
+      state: 'OPEN',
+      labels: [],
+      body: 'Blocked by #33\n\n<!-- idd-skill-autopilot-suitability: 2 -->',
+      url: 'https://example.com/32',
+    },
+  ];
+
+  const result = await filterOrphanIssues(issues, {
+    issueStateByNumber: new Map([[33, 'CLOSED']]),
+    fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    autopilot: true,
+    autopilotSuitabilityFloor: 3,
+  });
+
+  // The now-resolved blocking reference makes this orphan-eligible, but
+  // its sub-floor autopilot score (independently) routes it to a human --
+  // the two mechanisms are unrelated, and the reason string must not read
+  // as "still blocked" once it lands in routed_to_human.
+  assert.equal(result.orphans.length, 0);
+  assert.equal(result.routed_to_human.length, 1);
+  assert.equal(result.routed_to_human[0].reason, 'references_resolved');
 });
 
 test('filterOrphanIssues reports unresolvable and circular references', async () => {
@@ -762,7 +790,7 @@ test('filterOrphanIssues handles pagination with PR-heavy pages', async () => {
     1,
     'Issue should be orphan when blocker is closed',
   );
-  assert.equal(result.orphans[0].reason, 'blocked_references_closed');
+  assert.equal(result.orphans[0].reason, 'references_resolved');
 });
 
 test('filterOrphanIssues ranks orphans by autopilot-suitability and routes below-floor to humans (autopilot)', async () => {
@@ -1326,7 +1354,7 @@ test('filterOrphanIssues exempts an open Depends-on reference to a parent epic b
   );
   assert.equal(
     result.orphans.find((o) => o.number === 80)?.reason,
-    'blocked_references_closed',
+    'references_resolved',
   );
 });
 
@@ -1361,7 +1389,7 @@ test('filterOrphanIssues exempts an open Depends-on reference to a configured ro
   assert.equal(result.filtered.open_dependency_reference.length, 0);
   assert.equal(
     result.orphans.find((o) => o.number === 90)?.reason,
-    'blocked_references_closed',
+    'references_resolved',
   );
 });
 
@@ -1411,7 +1439,7 @@ test('filterOrphanIssues keeps a closed Depends-on reference as an orphan candid
   });
 
   assert.equal(result.orphans.length, 1);
-  assert.equal(result.orphans[0].reason, 'blocked_references_closed');
+  assert.equal(result.orphans[0].reason, 'references_resolved');
 });
 
 test('classifyIssue routes runtime/production-observation prose to runtime_observation_precondition (#2467)', () => {


### PR DESCRIPTION
# Summary

`discover-orphan-filter`'s `classifyIssue` returned
`reason: 'blocked_references_closed'` precisely when an issue's
blocking/dependency references were all resolved to a non-open state
-- i.e. the issue is **not** currently blocked. `rankAndRouteBySuitability`
routes an entry to `routed_to_human` purely on its autopilot-suitability
score and never reads or rewrites `reason`, so an issue with a closed
dependency reference and a sub-floor score landed in `routed_to_human`
still carrying a reason string that reads as "still blocked" -- the
opposite of its actual meaning (observed on #2781 before it closed).

This renames the reason code to `references_non_blocking`, preserving
its exact triggering condition while no longer reading as a current
block. `classifyIssue`'s classification logic and
`rankAndRouteBySuitability`'s routing logic are unchanged -- this is a
diagnostics/naming fix only.

## Linked issue

Closes #2932

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

- Renamed to `references_non_blocking` -- not `references_resolved`,
  an interim name this PR briefly used -- because the condition also
  fires when the only remaining dependency reference is an **open**
  parent epic exempted by `isDependencyEpicExempt`; that reference
  has not resolved or closed, it is merely non-blocking.
  `references_resolved` would have misstated that path the same way
  the original `blocked_references_closed` misstated the closed-
  reference path (Copilot/Codex review of this PR).
- Added a regression test (`filterOrphanIssues keeps the
  references_non_blocking reason legible when a closed-blocker issue
  is routed to a human for an unrelated sub-floor score (#2932)`) that
  reproduces the exact combination from the issue's background: a
  closed blocking reference plus a sub-floor autopilot-suitability
  score, asserting the entry lands in `routed_to_human` with the new
  reason string. The two existing epic-exemption tests already
  exercised the open-epic path and now assert the corrected name too.
- Recorded the rename in `CHANGELOG.md` under `Unreleased` /
  `Fixed`, since the `reason` value is part of
  `discover-orphan-filter`'s documented output schema.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013MS7r6EVLb1kWoNKnr2PG6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Renamed the orphan classification reason from `blocked_references_closed` to `references_non_blocking`.
  - Updated CLI help and output documentation to reflect the new reason.

- **Tests**
  - Updated coverage for non-blocking references, including cases routed for human review.

- **Documentation**
  - Added an unreleased changelog entry documenting the terminology update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
