### PR TITLE
docs(agents): document the #2547 secondary-bot decline path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,13 @@ layered on top of the distributed IDD defaults:
   full hour -- a HEAD CodeRabbit has not yet reviewed still waits the
   full configured window unchanged, keeping the wait a fallback for
   genuine secondary-bot degradation rather than a tax on every merge.
+  As of #2547, a definitive decline verdict for the current HEAD -- a
+  rate-limit or skip-review notice with no genuine comment after it --
+  is checked before that #2544 short-buffer path and completes the
+  wait immediately -- zero delay, not even the confirmation buffer:
+  once CodeRabbit has conclusively said it will not review this
+  commit, #2335's "might still be mid-review" protection has nothing
+  left to protect.
 - **New-CI-job dispatch-first rollout**: `idd-pr-submit.instructions.md`'s
   D2 "Adding a new CI job" guidance (distributed via `idd-template/`, not
   itself local) requires landing a new CI job `workflow_dispatch`-first.


### PR DESCRIPTION
## Summary

- `AGENTS.md`'s "Secondary-bot quiet window" bullet documented only
  the `#2544` refinement (a genuine review at current HEAD shortens
  the wait to a short confirmation buffer). It never mentioned the
  separate, already-shipped `#2547` refinement: a definitive
  rate-limit or skip-review decline for the current HEAD, with no
  genuine comment after it, completes the wait immediately with zero
  delay -- checked before the `#2544` short-buffer path.
- Adds one clause immediately after the existing `#2544` sentence
  documenting the `#2547` decline path, verified against
  `buildSecondaryQuietWindowStatus` in
  `src/scripts/advisory-wait-policy.mts` (the `secondaryBotDeclined`
  check sits after the `minutes <= 0` short-circuit and before the
  `secondaryBotSettledAt` branch, returning `elapsed: true` /
  `remainingMinutes: 0` unconditionally).
- Scoped to this one bullet only, per the issue's acceptance
  criteria -- no other part of "Key workflow rules" changes. Confirmed
  `AGENTS.md` has no sync-manifest content mirror for this text
  (only a root-markdown-allowlist entry).

## Test plan

- [x] `pnpm run lint:minimum` (biome, dprint, markdownlint-cli2,
      cspell, `audit-docs.mjs --check`, `audit-code-span-wrap.mjs`,
      `node --test tests/*.test.mts` -- 6240 passed / 3 skipped,
      `build:check`, `idd-doctor.mjs` -- passed with pre-existing,
      unrelated warnings, `token-cost-report.mjs --check`)
- [x] Verified no bare `#NNN` reference opens a wrapped line
      (`dprint fmt` made no further changes)
- [x] Verified wording against
      `computeSecondaryAdvisoryReviewSettlement`
      (`src/scripts/protocol-helpers.mts`) directly, not just the
      issue body

Closes #2939

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013MS7r6EVLb1kWoNKnr2PG6