### PR TITLE
fix(issue-authoring): make the mandatory hide-on-supersede sweep a single command

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -1646,7 +1646,13 @@ only approval boundary.
     --deadline-ms 300000 --apply
   ```
 
-  Or, for npx/package-manager profiles, the equivalent
+  The journal setting can itself name a **different** repository (a
+  full `owner/repo#number` reference); when it does, pass that shape to
+  `--issue` instead of a bare number -- that one `--issue` is fetched
+  from its own repository while every bare-number `--issue` in the same
+  invocation still uses the current repository (or `--owner`/`--repo`,
+  given together or not at all). Or, for
+  npx/package-manager profiles, the equivalent
   `idd-sweep-authoring-markers` command. One invocation performs the
   whole sweep that used to be an ~8-step manual procedure (#2935): it
   fetches each `--issue`'s comments via GraphQL (selecting `isMinimized`
@@ -1759,7 +1765,7 @@ only approval boundary.
   ```sh
   node scripts/sweep-authoring-markers.mjs --issue <target-1> \
     --issue <target-2> ... --issue <anchor-issue-number> \
-    --issue <journal-issue-number> \
+    --issue <journal-issue-number-or-owner/repo#number> \
     --trusted-marker-logins <trusted-login-1,...> \
     --deadline-ms 300000 --apply
   ```

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -1642,6 +1642,7 @@ only approval boundary.
   ```sh
   node scripts/sweep-authoring-markers.mjs --issue <target-issue-number> \
     --issue <journal-issue-number> \
+    --marker-prefix <resolved-target-prefix> \
     --trusted-marker-logins <trusted-login-1,...> \
     --deadline-ms 300000 --apply
   ```
@@ -1766,6 +1767,7 @@ only approval boundary.
   node scripts/sweep-authoring-markers.mjs --issue <target-1> \
     --issue <target-2> ... --issue <anchor-issue-number> \
     --issue <journal-issue-number-or-owner/repo#number> \
+    --marker-prefix <resolved-target-prefix> \
     --trusted-marker-logins <trusted-login-1,...> \
     --deadline-ms 300000 --apply
   ```

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -1631,63 +1631,55 @@ only approval boundary.
   exception below. Keep the set anchor held until every other
   target's label removal is verified, and remove the anchor label last. For
   every target, first re-fetch owner comments during release-marker preflight.
-  **Mandatory release-time hide-on-supersede sweep (#2896).** At this same
-  point -- before the reuse-or-append decision below, so a retried or
-  resumed release (which reuses an existing `release` marker and never
-  appends a new one) still runs the sweep every time this preflight step
-  is reached -- paginate the full owner-marker log this re-fetch just
-  retrieved, plus the publication-intent log for the journal named in
-  this session's own records, and minimize (classifier `OUTDATED`, via
-  the existing `minimize-superseded-markers.mjs`, reusing
-  `matchCanonicalAuthoringMarkerFamily` unchanged) every byte-exact
-  canonical match that is not the newest **trusted-actor** match for its
-  family, exactly as the opportunistic per-post step above does.
-  **Fetch that paginated log via GraphQL, never a plain REST
-  issue-comments fetch, and skip an already-minimized candidate before
-  submitting it** (#2896 review, Codex): a GraphQL `issueComments` /
-  `comments` query can select `isMinimized` on each node directly,
-  while REST's issue-comments endpoint never carries that field at
-  all, so a REST-fetched snapshot cannot distinguish a comment this
-  sweep already cleared from one it never touched. Use that field to
-  exclude any candidate already `isMinimized: true` **before** it ever
-  reaches the minimize helper's `--subject-ids`, not only when
-  auditing the result afterward. Without this, every historical
-  byte-exact canonical comment on a long-lived shared journal (one can
-  accumulate hundreds over time) gets resubmitted to
-  `minimize-superseded-markers.mjs` on every single sweep invocation
-  across every target, and that helper probes each subject ID serially
-  with no overall deadline -- a degraded GitHub API can then consume
-  its per-call timeout once per historical comment and stall release
-  for many minutes despite the attempted-not-blocking framing below.
-  **Also pass `--deadline-ms`** (#2896 review, Codex, round 8) to
-  every `minimize-superseded-markers.mjs` invocation this sweep makes
-  -- for example `--deadline-ms 300000` (five minutes) -- as a second,
-  independent bound: the `isMinimized` pre-filter above only skips
-  already-cleared candidates cheaply, but a first-ever sweep of a
-  large backlog can still submit many genuinely-not-yet-minimized
-  candidates that each cost a real GitHub API round-trip, and without
-  `--deadline-ms` each one can individually consume the helper's own
-  per-call timeout with no overall cap.
+  **Mandatory release-time hide-on-supersede sweep (#2896, #2935).** At
+  this same point -- before the reuse-or-append decision below, so a
+  retried or resumed release (which reuses an existing `release` marker
+  and never appends a new one) still runs the sweep every time this
+  preflight step is reached -- run the single fetch-driven sweep command
+  against the target issue and the journal issue named in this session's
+  own records:
 
-  Determine "newest" only among candidates from a trusted marker actor
-  (#2896 review, Codex), never from every structural match
-  indiscriminately -- an untrusted actor's byte-exact canonical comment
-  posted after the real newest trusted one must never be treated as the
-  thing to keep visible: `minimize-superseded-markers.mjs` itself
-  refuses to minimize any comment outside `--trusted-marker-logins`
-  regardless of this selection, so naively treating the untrusted
-  comment as newest would instead select the legitimate trusted marker
-  for minimization -- exactly backwards. This mirrors
-  `checkAuthoringMarkerMinimizationBacklog`'s own audit-side fix; keep
-  the two in sync. Attempt this once per target
-  here, and once more on the anchor immediately before the
-  release-complete preflight below; this is the sweep the contract
-  depends on, but "mandatory" means **attempted**, not
-  blocking -- a failed attempt (permission error, an unreadable comment
-  list, or an unavailable helper runtime) skips silently and never stops
-  release, matching the opportunistic step's own best-effort framing. See
-  the **Closing sweep** bullet below for the third sweep point this
-  preflight sweep alone does not cover, and for the explicit
+  ```sh
+  node scripts/sweep-authoring-markers.mjs --issue <target-issue-number> \
+    --issue <journal-issue-number> \
+    --trusted-marker-logins <trusted-login-1,...> \
+    --deadline-ms 300000 --apply
+  ```
+
+  Or, for npx/package-manager profiles, the equivalent
+  `idd-sweep-authoring-markers` command. One invocation performs the
+  whole sweep that used to be an ~8-step manual procedure (#2935): it
+  fetches each `--issue`'s comments via GraphQL (selecting `isMinimized`
+  directly -- REST's issue-comments endpoint never carries that field,
+  so this command never falls back to REST), classifies every comment
+  with `matchCanonicalAuthoringMarkerFamily` (`marker-helpers.mts`,
+  unchanged), determines "newest" only among **trusted-actor** matches
+  per family (#2896 review, Codex -- an untrusted actor's later
+  byte-exact comment must never be mistaken for the live marker to keep,
+  since `minimize-superseded-markers.mjs` itself refuses to minimize any
+  comment outside `--trusted-marker-logins` regardless of this
+  selection, so wrongly treating the untrusted comment as newest would
+  instead select the legitimate trusted marker for minimization --
+  exactly backwards; mirrors `checkAuthoringMarkerMinimizationBacklog`'s
+  own audit-side rule -- the two share one implementation,
+  `classifyAuthoringMarkerFamily` in `marker-helpers.mts`, so they cannot
+  drift), excludes any candidate already `isMinimized: true`, and
+  minimizes (classifier `OUTDATED`) every remaining eligible candidate in
+  one mutation pass -- reusing `minimize-superseded-markers.mjs`'s own
+  `runMinimize` rather than reimplementing the mutation. `--deadline-ms`
+  bounds the WHOLE invocation (every `--issue`'s own GraphQL pagination
+  plus the final minimize pass, for example `--deadline-ms 300000` --
+  five minutes), guarding against the same degraded-GitHub-API risk a
+  large, long-lived shared journal's full history would otherwise pose.
+
+  Attempt this once per target here, and once more on the anchor
+  immediately before the release-complete preflight below; this is the
+  sweep the contract depends on, but "mandatory" means **attempted**, not
+  blocking -- a failed invocation (permission error, an unreadable
+  comment list, or an unavailable helper runtime) skips silently and
+  never stops release, matching the opportunistic step's own best-effort
+  framing. See the **Closing sweep** bullet below for the third sweep
+  point this preflight sweep alone does not cover, and for the explicit
   `authoring-marker-minimization-backlog` invocation that makes each
   sweep attempt's outcome a visible, countable signal instead of silence.
   If a valid current-owner/set `mode=release` marker already exists, reuse the
@@ -1716,7 +1708,9 @@ only approval boundary.
   marker, absent label, and expected body snapshot; any drift leaves the set
   open and prevents completion. Immediately before the release-complete
   reuse-or-append decision below, repeat the same mandatory sweep once
-  more on the anchor's own owner-marker log and the journal's
+  more -- the same `sweep-authoring-markers.mjs` command above, now
+  scoped to `--issue <anchor-issue-number> --issue <journal-issue-number>`
+  -- covering the anchor's own owner-marker log and the journal's
   publication-intent log -- idempotent with every earlier target's own
   sweep above, since a comment either was already minimized or was not
   yet the newest for its family either way. Then reuse the earliest
@@ -1745,11 +1739,11 @@ only approval boundary.
   record a set-level recovery hold and never claim a partial release. Release
   is a human action; nothing in this bundle auto-releases a held issue set,
   except the narrow, marker-scoped exception immediately below.
-- **Closing sweep (after Stage 2 closes, #2896 review, Codex).** The two
-  sweep points above run _before_ Stage 2's own later marker appends for
-  the same generation -- the per-target `release` marker, the
-  pre-label-removal heartbeat each target receives immediately before
-  its own label removal, and (on the anchor) `release-guard` and
+- **Closing sweep (after Stage 2 closes, #2896 review, Codex; #2935).**
+  The two sweep points above run _before_ Stage 2's own later marker
+  appends for the same generation -- the per-target `release` marker,
+  the pre-label-removal heartbeat each target receives immediately
+  before its own label removal, and (on the anchor) `release-guard` and
   `release-complete` itself. None of those markers exist yet when their
   target's preflight sweep runs, so the preflight sweep(s) alone can
   never clear them, and a target's Stage 2 for a given generation runs
@@ -1757,13 +1751,21 @@ only approval boundary.
   revisit them. Once the set-level release actually closes (the
   successful-close branch immediately above: the trusted
   `release-complete` marker is found and every label is confirmed
-  absent), attempt the mandatory sweep one more time: paginate every
-  target's now-final owner-marker log (the anchor's included this time,
-  not just its own) and the journal's publication-intent log, and
-  minimize every byte-exact canonical match that is not the newest for
-  its family, exactly as the preflight sweeps above do. Same
-  attempted-not-blocking framing: a failed attempt here does not reopen
-  the set or roll back the close already recorded above.
+  absent), attempt the mandatory sweep one more time, in a single
+  invocation covering every target's now-final owner-marker log (the
+  anchor's included this time, not just its own) and the journal's
+  publication-intent log:
+
+  ```sh
+  node scripts/sweep-authoring-markers.mjs --issue <target-1> \
+    --issue <target-2> ... --issue <anchor-issue-number> \
+    --issue <journal-issue-number> \
+    --trusted-marker-logins <trusted-login-1,...> \
+    --deadline-ms 300000 --apply
+  ```
+
+  Same attempted-not-blocking framing: a failed invocation here does not
+  reopen the set or roll back the close already recorded above.
 
   **Make every sweep attempt's outcome visible.** Immediately after each
   of the three sweep attempts in this section (per-target preflight,
@@ -1789,12 +1791,13 @@ only approval boundary.
   `--trusted-marker-logins` (that overstates; this understates to
   nothing).
   **Feed it the sweep's own post-mutation result, never the
-  pre-mutation snapshot the sweep read.** The minimize helper mutates
-  GitHub directly; it never updates an in-memory or on-disk comment
+  pre-mutation snapshot the sweep read.** The minimize mutation applies
+  directly to GitHub; it never updates an in-memory or on-disk comment
   snapshot. Before running the check, update the just-fetched snapshot's
-  `isMinimized` field to `true` for every candidate the minimize
-  helper's own report (`minimize-superseded-markers.mjs`'s `items[]`,
-  keyed by subject id) lists with **either** `status: "applied"` **or**
+  `isMinimized` field to `true` for every candidate the sweep command's
+  own report (`sweep-authoring-markers.mjs`'s `items[]`, each entry
+  tagged with the family it belongs to and keyed by subject id) lists
+  with **either** `status: "applied"` **or**
   `status: "skipped", reason: "already-minimized"` -- the latter fires
   whenever the fetched snapshot's own `isMinimized` was already stale or
   absent for a comment GitHub already considers minimized (for example

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -1644,8 +1644,16 @@ only approval boundary.
     --issue <journal-issue-number> \
     --marker-prefix <resolved-target-prefix> \
     --trusted-marker-logins <trusted-login-1,...> \
-    --deadline-ms 300000 --apply
+    --deadline-ms 300000 --apply || true
   ```
+
+  The trailing `|| true` keeps this step's own non-zero exit (a fetch or
+  mutation failure) from aborting an automated `set -e` release script:
+  the sweep's exit code exists for a caller that wants to check its
+  outcome directly, not to make this attempted-not-blocking step itself
+  block release when run inline (#2935 review, round 5, Copilot) --
+  read the sweep's own JSON/table report, not its exit status, to see
+  whether anything needs a human look.
 
   The journal setting can itself name a **different** repository (a
   full `owner/repo#number` reference); when it does, pass that shape to
@@ -1769,11 +1777,12 @@ only approval boundary.
     --issue <journal-issue-number-or-owner/repo#number> \
     --marker-prefix <resolved-target-prefix> \
     --trusted-marker-logins <trusted-login-1,...> \
-    --deadline-ms 300000 --apply
+    --deadline-ms 300000 --apply || true
   ```
 
-  Same attempted-not-blocking framing: a failed invocation here does not
-  reopen the set or roll back the close already recorded above.
+  Same attempted-not-blocking framing (and the same `|| true` reasoning
+  above): a failed invocation here does not reopen the set or roll back
+  the close already recorded above.
 
   **Make every sweep attempt's outcome visible.** Immediately after each
   of the three sweep attempts in this section (per-target preflight,

--- a/.gitattributes
+++ b/.gitattributes
@@ -92,6 +92,7 @@ scripts/stalled-session-quiet-check.mjs linguist-generated=true
 scripts/suitability-close-execute.mjs linguist-generated=true
 scripts/suitability-triage.mjs linguist-generated=true
 scripts/supersession-detection.mjs linguist-generated=true
+scripts/sweep-authoring-markers.mjs linguist-generated=true
 scripts/sync-docs.mjs linguist-generated=true
 scripts/token-cost-adapter-claude.mjs linguist-generated=true
 scripts/token-cost-adapter-codex.mjs linguist-generated=true

--- a/bin/idd-sweep-authoring-markers.mjs
+++ b/bin/idd-sweep-authoring-markers.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-sweep-authoring-markers.mts
+//
+// The bin/idd-sweep-authoring-markers.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+import { runHelper } from './run-helper.mjs';
+
+runHelper('../scripts/sweep-authoring-markers.mjs');

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -409,6 +409,20 @@ in this preamble, since the fallback differs per helper.
   trust explicitly while collaborator-permission trust stays opt-in
   (the `IDD_TRUST_COLLABORATOR_MARKERS` environment variable or the
   `trustCollaboratorMarkers` config field)
+- `scripts/sweep-authoring-markers.mjs` (#2935) for the fetch-driven
+  hide-on-supersede sweep the issue-authoring contract's Stage 2 release
+  flow depends on: given one or more `--issue` targets, it fetches each
+  issue's comments via GraphQL (selecting `isMinimized`, which REST
+  never carries), classifies every comment with
+  `matchCanonicalAuthoringMarkerFamily`, keeps only the newest
+  trusted-actor match per `authoring-owner`/`authoring-publication-intent`
+  family, and minimizes every other eligible candidate in one mutation
+  pass via `minimize-superseded-markers.mjs`'s own `runMinimize` —
+  replacing the ~8-step manual paginate/classify/filter procedure the
+  contract previously described in prose at three separate points. Same
+  mandatory trusted-author gate as `minimize-superseded-markers` (no
+  `--allow-untrusted` escape hatch: this sweep's own "newest"
+  determination depends on the trust filter)
 - `scripts/review-disposition-verify.mjs` for read-only E7 disposition
   marker presence verification across PATH A and PATH B items
 - `scripts/disposition-non-review-notices.mjs` for dry-run/apply

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -1206,63 +1206,54 @@ set anchor held until every other
 target's label removal is verified, and remove the anchor label last. First
 re-fetch owner comments during release-marker preflight.
 
-**Mandatory release-time hide-on-supersede sweep (#2896).** At this same
-point -- before the reuse-or-append decision below, so a retried or
-resumed release (which reuses an existing `release` marker and never
-appends a new one) still runs the sweep every time this preflight step
-is reached -- paginate the full owner-marker log this re-fetch just
-retrieved, plus the publication-intent log for the journal named in this
-session's own records, and minimize (classifier `OUTDATED`, via the
-existing `minimize-superseded-markers.mjs`, reusing
-`matchCanonicalAuthoringMarkerFamily` unchanged) every byte-exact
-canonical match that is not the newest **trusted-actor** match for its
-family, exactly as the opportunistic per-post step above does.
+**Mandatory release-time hide-on-supersede sweep (#2896, #2935).** At
+this same point -- before the reuse-or-append decision below, so a
+retried or resumed release (which reuses an existing `release` marker
+and never appends a new one) still runs the sweep every time this
+preflight step is reached -- run the single fetch-driven sweep command
+against the target issue and the journal issue named in this session's
+own records:
 
-**Fetch that paginated log via GraphQL, never a plain REST
-issue-comments fetch, and skip an already-minimized candidate before
-submitting it** (#2896 review, Codex): a GraphQL `issueComments` /
-`comments` query can select `isMinimized` on each node directly, while
-REST's issue-comments endpoint never carries that field at all, so a
-REST-fetched snapshot cannot distinguish a comment this sweep already
-cleared from one it never touched. Use that field to exclude any
-candidate already `isMinimized: true` **before** it ever reaches the
-minimize helper's `--subject-ids`, not only when auditing the result
-afterward. Without this, every historical byte-exact canonical comment
-on a long-lived shared journal (one can accumulate hundreds over time)
-gets resubmitted to `minimize-superseded-markers.mjs` on every single
-sweep invocation across every target, and that helper probes each
-subject ID serially with no overall deadline -- a degraded GitHub API
-can then consume its per-call timeout once per historical comment and
-stall release for many minutes despite the attempted-not-blocking
-framing below.
+```sh
+node scripts/sweep-authoring-markers.mjs --issue <target-issue-number> \
+  --issue <journal-issue-number> \
+  --trusted-marker-logins <trusted-login-1,...> \
+  --deadline-ms 300000 --apply
+```
 
-**Also pass `--deadline-ms`** (#2896 review, Codex, round 8) to every
-`minimize-superseded-markers.mjs` invocation this sweep makes -- for
-example `--deadline-ms 300000` (five minutes) -- as a second,
-independent bound: the `isMinimized` pre-filter above only skips
-already-cleared candidates cheaply, but a first-ever sweep of a large
-backlog can still submit many genuinely-not-yet-minimized candidates
-that each cost a real GitHub API round-trip, and without
-`--deadline-ms` each one can individually consume the helper's own
-per-call timeout with no overall cap.
-
-Determine
-"newest" only among candidates from a trusted marker actor (#2896
-review, Codex), never from every structural match indiscriminately --
-an untrusted actor's byte-exact canonical comment posted after the real
-newest trusted one must never be treated as the thing to keep visible:
+Or, for npx/package-manager profiles, the equivalent
+`idd-sweep-authoring-markers` command. One invocation performs the whole
+sweep that used to be an ~8-step manual procedure (#2935): it fetches
+each `--issue`'s comments via GraphQL (selecting `isMinimized` directly
+-- REST's issue-comments endpoint never carries that field, so this
+command never falls back to REST), classifies every comment with
+`matchCanonicalAuthoringMarkerFamily` (`marker-helpers.mts`, unchanged),
+determines "newest" only among **trusted-actor** matches per family
+(#2896 review, Codex -- an untrusted actor's later byte-exact comment
+must never be mistaken for the live marker to keep, since
 `minimize-superseded-markers.mjs` itself refuses to minimize any comment
 outside `--trusted-marker-logins` regardless of this selection, so
-naively treating the untrusted comment as newest would instead select
-the legitimate trusted marker for minimization -- exactly backwards.
-This mirrors `checkAuthoringMarkerMinimizationBacklog`'s own audit-side
-fix; keep the two in sync. Attempt this once per target
-here, and once more on the anchor immediately before the release-complete
-preflight below; this is the sweep the contract depends on, but
-"mandatory" means **attempted**, not blocking -- a failed attempt
-(permission error, an unreadable comment list, or an unavailable helper
-runtime) skips silently and never stops release, matching the
-opportunistic step's own best-effort framing. See the
+wrongly treating the untrusted comment as newest would instead select
+the legitimate trusted marker for minimization -- exactly backwards;
+mirrors `checkAuthoringMarkerMinimizationBacklog`'s own audit-side
+rule -- the two share one implementation, `classifyAuthoringMarkerFamily`
+in `marker-helpers.mts`, so they cannot drift), excludes any candidate
+already `isMinimized: true`, and minimizes (classifier `OUTDATED`) every
+remaining eligible candidate in one mutation pass -- reusing
+`minimize-superseded-markers.mjs`'s own `runMinimize` rather than
+reimplementing the mutation. `--deadline-ms` bounds the WHOLE invocation
+(every `--issue`'s own GraphQL pagination plus the final minimize pass,
+for example `--deadline-ms 300000` -- five minutes), guarding against
+the same degraded-GitHub-API risk a large, long-lived shared journal's
+full history would otherwise pose.
+
+Attempt this once per target here, and once more on the anchor
+immediately before the release-complete preflight below; this is the
+sweep the contract depends on, but "mandatory" means **attempted**, not
+blocking -- a failed invocation (permission error, an unreadable comment
+list, or an unavailable helper runtime) skips silently and never stops
+release, matching the opportunistic step's own best-effort framing. See
+the
 [Closing sweep](#closing-sweep-after-stage-2-closes-2896-review-codex)
 section below for the third sweep point this preflight sweep alone does
 not cover, and for the explicit `authoring-marker-minimization-backlog`
@@ -1295,10 +1286,13 @@ final anchor label removal is verified, re-fetch every target and verify its
 current release marker, absent label, and expected body snapshot; any drift
 leaves the set open and prevents completion. Immediately before the
 release-complete reuse-or-append decision below, repeat the same
-mandatory sweep once more on the anchor's own owner-marker log and the
-journal's publication-intent log -- idempotent with every earlier
-target's own sweep above, since a comment either was already minimized
-or was not yet the newest for its family either way. Then reuse or
+mandatory sweep once more -- the same `sweep-authoring-markers.mjs`
+command above, now scoped to `--issue <anchor-issue-number> --issue
+<journal-issue-number>` -- covering the anchor's own owner-marker log
+and the journal's publication-intent log -- idempotent with every
+earlier target's own sweep above, since a comment either was already
+minimized or was not yet the newest for its family either way. Then
+reuse or
 append the anchor-only
 `mode=release-complete` marker and record its comment ID. Reconcile that ID
 and the paginated anchor log with bounded retries; a successful POST or
@@ -1341,13 +1335,21 @@ clear them, and a target's Stage 2 for a given generation runs only
 once -- there is no future preflight sweep that would ever revisit them.
 Once the set-level release actually closes (the successful-close branch
 above: the trusted `release-complete` marker is found and every label is
-confirmed absent), attempt the mandatory sweep one more time: paginate
-every target's now-final owner-marker log (the anchor's included this
-time, not just its own) and the journal's publication-intent log, and
-minimize every byte-exact canonical match that is not the newest for its
-family, exactly as the preflight sweeps above do. Same
-attempted-not-blocking framing: a failed attempt here does not reopen
-the set or roll back the close already recorded above.
+confirmed absent), attempt the mandatory sweep one more time (#2935), in
+a single invocation covering every target's now-final owner-marker log
+(the anchor's included this time, not just its own) and the journal's
+publication-intent log:
+
+```sh
+node scripts/sweep-authoring-markers.mjs --issue <target-1> \
+  --issue <target-2> ... --issue <anchor-issue-number> \
+  --issue <journal-issue-number> \
+  --trusted-marker-logins <trusted-login-1,...> \
+  --deadline-ms 300000 --apply
+```
+
+Same attempted-not-blocking framing: a failed invocation here does not
+reopen the set or roll back the close already recorded above.
 
 **Make every sweep attempt's outcome visible.** Immediately after each
 of the three sweep attempts in this section (per-target preflight,
@@ -1374,12 +1376,13 @@ reports zero backlog even when the sweep was skipped or failed entirely
 (that overstates; this understates to nothing).
 
 **Feed it the sweep's own post-mutation result, never the pre-mutation
-snapshot the sweep read.** The minimize helper mutates GitHub directly;
-it never updates an in-memory or on-disk comment snapshot. Before
-running the check, update the just-fetched snapshot's `isMinimized`
-field to `true` for every candidate the minimize helper's own report
-(`minimize-superseded-markers.mjs`'s `items[]`, keyed by subject id)
-lists with **either** `status: "applied"` **or** `status: "skipped",
+snapshot the sweep read.** The minimize mutation applies directly to
+GitHub; it never updates an in-memory or on-disk comment snapshot.
+Before running the check, update the just-fetched snapshot's
+`isMinimized` field to `true` for every candidate the sweep command's
+own report (`sweep-authoring-markers.mjs`'s `items[]`, each entry tagged
+with the family it belongs to and keyed by subject id) lists with
+**either** `status: "applied"` **or** `status: "skipped",
 reason: "already-minimized"` -- the latter fires whenever the fetched
 snapshot's own `isMinimized` was already stale or absent for a comment
 GitHub already considers minimized (for example one an earlier sweep or

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -1221,7 +1221,13 @@ node scripts/sweep-authoring-markers.mjs --issue <target-issue-number> \
   --deadline-ms 300000 --apply
 ```
 
-Or, for npx/package-manager profiles, the equivalent
+The journal setting can itself name a **different** repository (a full
+`owner/repo#number` reference); when it does, pass that shape to
+`--issue` instead of a bare number -- that one `--issue` is fetched from
+its own repository while every bare-number `--issue` in the same
+invocation still uses the current repository (or `--owner`/`--repo`,
+given together or not at all). Or, for
+npx/package-manager profiles, the equivalent
 `idd-sweep-authoring-markers` command. One invocation performs the whole
 sweep that used to be an ~8-step manual procedure (#2935): it fetches
 each `--issue`'s comments via GraphQL (selecting `isMinimized` directly
@@ -1343,7 +1349,7 @@ publication-intent log:
 ```sh
 node scripts/sweep-authoring-markers.mjs --issue <target-1> \
   --issue <target-2> ... --issue <anchor-issue-number> \
-  --issue <journal-issue-number> \
+  --issue <journal-issue-number-or-owner/repo#number> \
   --trusted-marker-logins <trusted-login-1,...> \
   --deadline-ms 300000 --apply
 ```

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -1219,8 +1219,16 @@ node scripts/sweep-authoring-markers.mjs --issue <target-issue-number> \
   --issue <journal-issue-number> \
   --marker-prefix <resolved-target-prefix> \
   --trusted-marker-logins <trusted-login-1,...> \
-  --deadline-ms 300000 --apply
+  --deadline-ms 300000 --apply || true
 ```
+
+The trailing `|| true` keeps this step's own non-zero exit (a fetch or
+mutation failure) from aborting an automated `set -e` release script:
+the sweep's exit code exists for a caller that wants to check its
+outcome directly, not to make this attempted-not-blocking step itself
+block release when run inline (#2935 review, round 5, Copilot) -- read
+the sweep's own JSON/table report, not its exit status, to see whether
+anything needs a human look.
 
 The journal setting can itself name a **different** repository (a full
 `owner/repo#number` reference); when it does, pass that shape to
@@ -1353,11 +1361,12 @@ node scripts/sweep-authoring-markers.mjs --issue <target-1> \
   --issue <journal-issue-number-or-owner/repo#number> \
   --marker-prefix <resolved-target-prefix> \
   --trusted-marker-logins <trusted-login-1,...> \
-  --deadline-ms 300000 --apply
+  --deadline-ms 300000 --apply || true
 ```
 
-Same attempted-not-blocking framing: a failed invocation here does not
-reopen the set or roll back the close already recorded above.
+Same attempted-not-blocking framing (and the same `|| true` reasoning
+above): a failed invocation here does not reopen the set or roll back
+the close already recorded above.
 
 **Make every sweep attempt's outcome visible.** Immediately after each
 of the three sweep attempts in this section (per-target preflight,

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -1217,6 +1217,7 @@ own records:
 ```sh
 node scripts/sweep-authoring-markers.mjs --issue <target-issue-number> \
   --issue <journal-issue-number> \
+  --marker-prefix <resolved-target-prefix> \
   --trusted-marker-logins <trusted-login-1,...> \
   --deadline-ms 300000 --apply
 ```
@@ -1350,6 +1351,7 @@ publication-intent log:
 node scripts/sweep-authoring-markers.mjs --issue <target-1> \
   --issue <target-2> ... --issue <anchor-issue-number> \
   --issue <journal-issue-number-or-owner/repo#number> \
+  --marker-prefix <resolved-target-prefix> \
   --trusted-marker-logins <trusted-login-1,...> \
   --deadline-ms 300000 --apply
 ```

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -409,6 +409,20 @@ in this preamble, since the fallback differs per helper.
   trust explicitly while collaborator-permission trust stays opt-in
   (the `IDD_TRUST_COLLABORATOR_MARKERS` environment variable or the
   `trustCollaboratorMarkers` config field)
+- `scripts/sweep-authoring-markers.mjs` (#2935) for the fetch-driven
+  hide-on-supersede sweep the issue-authoring contract's Stage 2 release
+  flow depends on: given one or more `--issue` targets, it fetches each
+  issue's comments via GraphQL (selecting `isMinimized`, which REST
+  never carries), classifies every comment with
+  `matchCanonicalAuthoringMarkerFamily`, keeps only the newest
+  trusted-actor match per `authoring-owner`/`authoring-publication-intent`
+  family, and minimizes every other eligible candidate in one mutation
+  pass via `minimize-superseded-markers.mjs`'s own `runMinimize` —
+  replacing the ~8-step manual paginate/classify/filter procedure the
+  contract previously described in prose at three separate points. Same
+  mandatory trusted-author gate as `minimize-superseded-markers` (no
+  `--allow-untrusted` escape hatch: this sweep's own "newest"
+  determination depends on the trust filter)
 - `scripts/review-disposition-verify.mjs` for read-only E7 disposition
   marker presence verification across PATH A and PATH B items
 - `scripts/disposition-non-review-notices.mjs` for dry-run/apply

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "idd-stalled-session-quiet-check": "./bin/idd-stalled-session-quiet-check.mjs",
     "idd-suggest-untrusted-labelers": "./bin/idd-suggest-untrusted-labelers.mjs",
     "idd-suitability-close-execute": "./bin/idd-suitability-close-execute.mjs",
-    "idd-suitability-triage": "./bin/idd-suitability-triage.mjs"
+    "idd-suitability-triage": "./bin/idd-suitability-triage.mjs",
+    "idd-sweep-authoring-markers": "./bin/idd-sweep-authoring-markers.mjs"
   },
   "scripts": {
     "prepare": "husky",

--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -51,7 +51,7 @@ import {
 } from './idd-config.mjs';
 import { stripMarkdownCodeRegions } from './markdown-code.mjs';
 import {
-  matchCanonicalAuthoringMarkerFamily,
+  classifyAuthoringMarkerFamily,
   parseAuthoringOwnerComment,
   parseAuthoringPublicationComment,
   parseAuthoringPublicationIntentComment,
@@ -1440,6 +1440,14 @@ function checkAuthoringOwnerMarkerTrail(text, markerPrefix, labels, options) {
  * fewer than two (trust-filtered, when applicable) candidates exist
  * (nothing can be "superseded" without a later candidate to supersede
  * it).
+ *
+ * Delegates the actual classification to {@link classifyAuthoringMarkerFamily}
+ * (`marker-helpers.mts`, extracted in #2935 alongside `sweep-authoring-
+ * markers.mts`'s fetch-driven sweep, which needs the same newest-per-
+ * family/trust/already-minimized rule but returns the eligible comments
+ * themselves, not just a count) -- kept as a thin count-only wrapper here
+ * so this module's public surface and every existing caller are
+ * unaffected.
  */
 function countEligibleSupersededMarkers(
   comments,
@@ -1450,39 +1458,12 @@ function countEligibleSupersededMarkers(
   if (comments === undefined) {
     return 0;
   }
-  const matchIndexes = [];
-  comments.forEach((comment, index) => {
-    if (
-      matchCanonicalAuthoringMarkerFamily(comment.body, markerPrefix) !== family
-    ) {
-      return;
-    }
-    if (trustedActors !== undefined) {
-      const author = comment.author;
-      if (
-        typeof author !== 'string' ||
-        !trustedActors.has(author.toLowerCase())
-      ) {
-        // Not a real candidate at all when a trust set is supplied:
-        // never counted, and never eligible to be selected as "newest"
-        // either -- syntax alone never grants ownership.
-        return;
-      }
-    }
-    matchIndexes.push(index);
-  });
-  if (matchIndexes.length < 2) {
-    return 0;
-  }
-  const newestIndex = matchIndexes[matchIndexes.length - 1];
-  let count = 0;
-  for (const index of matchIndexes) {
-    if (index === newestIndex || comments[index].isMinimized === true) {
-      continue;
-    }
-    count += 1;
-  }
-  return count;
+  return classifyAuthoringMarkerFamily(
+    comments,
+    markerPrefix,
+    family,
+    trustedActors,
+  ).eligibleIndexes.length;
 }
 /**
  * Reports how many `authoring-owner` (from {@link AuditOptions.comments})

--- a/scripts/gh-exec.mjs
+++ b/scripts/gh-exec.mjs
@@ -15,6 +15,15 @@
 // Consumed by the `src/scripts/*.mts` helpers that shell out to `gh` or
 // need the CLI-entry-point guard.
 import { execFile, execFileSync } from 'node:child_process';
+import {
+  closeSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { promisify } from 'node:util';
 import { deriveGhHttpStatus } from './gh-http-status.mjs';
@@ -84,6 +93,47 @@ export function ghText(args, options = {}) {
       ? { maxBuffer: options.maxBuffer }
       : {}),
   }).trim();
+}
+/**
+ * Sibling of {@link ghText} for a response with no safely-guessable size
+ * ceiling (#2935 review, rounds 4-6): a fixed `maxBuffer` for a large
+ * paginated GraphQL page turned into an escalating, never-fully-provable
+ * guessing game (an initial 10 MiB estimate, then a "proven" 25 MiB
+ * worst-case calculation from GitHub's 65,536-character comment cap and
+ * UTF-8's 4-bytes-per-character ceiling, then a further finding that the
+ * calculation still did not account for `\uXXXX` JSON-escaping, which can
+ * cost up to 12 bytes per character) -- each fix removed one gap but
+ * could not close the class of problem, since the true worst case
+ * depends on exactly how the response is serialized, which this codebase
+ * does not control and should not need to reverse-engineer. This
+ * function removes the ceiling-guessing problem entirely instead of
+ * refining the guess further: it redirects the child process's stdout
+ * directly to a temp file (never through an in-memory pipe with a fixed
+ * cap) and reads that file back, so the only limit is available disk
+ * space -- a categorically different, non-adversarial-input concern.
+ *
+ * Deliberately minimal compared to {@link ghText}: no `stdio`/`input`
+ * override support, since no current caller needs stdin or a custom
+ * stdio shape for a call whose defining trait is "the output size is not
+ * safely boundable" -- add that support only if a real caller needs it.
+ */
+export function ghTextUnbounded(args, options = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'gh-exec-unbounded-'));
+  const outPath = join(dir, 'stdout');
+  try {
+    const fd = openSync(outPath, 'w');
+    try {
+      execFileSync('gh', args, {
+        stdio: ['ignore', fd, 'pipe'],
+        timeout: options.timeout ?? DEFAULT_GH_TIMEOUT_MS,
+      });
+    } finally {
+      closeSync(fd);
+    }
+    return readFileSync(outPath, 'utf8').trim();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 }
 /** {@link ghText}, swallowing any failure and returning `''` instead. */
 export function safeGhText(args, options = {}) {

--- a/scripts/gh-exec.mjs
+++ b/scripts/gh-exec.mjs
@@ -80,6 +80,9 @@ export function ghText(args, options = {}) {
     timeout: options.timeout ?? DEFAULT_GH_TIMEOUT_MS,
     ...(options.stdio ? { stdio: options.stdio } : {}),
     ...(options.input !== undefined ? { input: options.input } : {}),
+    ...(options.maxBuffer !== undefined
+      ? { maxBuffer: options.maxBuffer }
+      : {}),
   }).trim();
 }
 /** {@link ghText}, swallowing any failure and returning `''` instead. */

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -566,6 +566,15 @@ const HELPER_COMMANDS = [
     description:
       'Evaluate A4.5 suitability checks and map deterministic outcomes.',
   },
+  {
+    id: 'sweep-authoring-markers',
+    scriptName: 'idd:sweep-authoring-markers',
+    binName: 'idd-sweep-authoring-markers',
+    entryPath: 'scripts/sweep-authoring-markers.mjs',
+    vendoredCommand: 'node scripts/sweep-authoring-markers.mjs',
+    description:
+      'Fetch-driven hide-on-supersede sweep for authoring-owner / authoring-publication-intent markers: fetches one or more issues via GraphQL, classifies and filters superseded candidates, and minimizes them via minimize-superseded-markers.mjs.',
+  },
 ];
 /**
  * Resolve the invocation string for one helper command under one

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -1525,6 +1525,85 @@ export function matchCanonicalAuthoringMarkerFamily(body, markerPrefix) {
   }
   return null;
 }
+/**
+ * Classify `comments` for exactly one authoring marker `family` (#2935):
+ * find every byte-exact canonical match
+ * (`matchCanonicalAuthoringMarkerFamily`), determine the newest match
+ * among trusted-actor authors only (per the contract's "syntax alone
+ * never grants ownership" rule -- an untrusted actor's later byte-exact
+ * comment must never be mistaken for the live marker to keep), and split
+ * the rest into eligible-for-minimization vs. already-minimized.
+ * `family` is matched against the RAW `comment.body` (never
+ * `stripMarkdownCodeRegions`-masked), matching exactly what a live
+ * `matchCanonicalAuthoringMarkerFamily` call against the real comment
+ * would see. `trustedActors` left `undefined` disables trust filtering
+ * entirely (every byte-exact match counts as a candidate regardless of
+ * author) -- callers that need an author-trust-filtered result (both
+ * current callers do) must pass a `Set` of lowercase logins.
+ */
+export function classifyAuthoringMarkerFamily(
+  comments,
+  markerPrefix,
+  family,
+  trustedActors,
+) {
+  const matchIndexes = [];
+  const untrustedIndexes = [];
+  comments.forEach((comment, index) => {
+    if (
+      matchCanonicalAuthoringMarkerFamily(comment.body, markerPrefix) !== family
+    ) {
+      return;
+    }
+    matchIndexes.push(index);
+    if (trustedActors !== undefined) {
+      const author = comment.author;
+      if (
+        typeof author !== 'string' ||
+        !trustedActors.has(author.toLowerCase())
+      ) {
+        untrustedIndexes.push(index);
+      }
+    }
+  });
+  const untrustedSet = new Set(untrustedIndexes);
+  const trustedMatchIndexes =
+    trustedActors === undefined
+      ? matchIndexes
+      : matchIndexes.filter((index) => !untrustedSet.has(index));
+  if (trustedMatchIndexes.length < 2) {
+    return {
+      matchIndexes,
+      trustedMatchIndexes,
+      newestTrustedIndex: null,
+      eligibleIndexes: [],
+      alreadyMinimizedIndexes: [],
+      untrustedIndexes,
+    };
+  }
+  const newestTrustedIndex =
+    trustedMatchIndexes[trustedMatchIndexes.length - 1];
+  const eligibleIndexes = [];
+  const alreadyMinimizedIndexes = [];
+  for (const index of trustedMatchIndexes) {
+    if (index === newestTrustedIndex) {
+      continue;
+    }
+    if (comments[index].isMinimized === true) {
+      alreadyMinimizedIndexes.push(index);
+    } else {
+      eligibleIndexes.push(index);
+    }
+  }
+  return {
+    matchIndexes,
+    trustedMatchIndexes,
+    newestTrustedIndex,
+    eligibleIndexes,
+    alreadyMinimizedIndexes,
+    untrustedIndexes,
+  };
+}
 // --- Per-cycle marker body renderers (#900) ---
 //
 // Pure, network-free renderers for the three operational markers an agent

--- a/scripts/sweep-authoring-markers.mjs
+++ b/scripts/sweep-authoring-markers.mjs
@@ -64,7 +64,7 @@
 // invocation can freely mix same-repo and cross-repository `--issue`
 // targets.
 import { parseCanonicalIntegerOrThrow, parseCliArgs } from './cli-args.mjs';
-import { ghText } from './gh-exec.mjs';
+import { ghTextUnbounded } from './gh-exec.mjs';
 import { loadIddConfig } from './idd-config.mjs';
 import {
   classifyAuthoringMarkerFamily,
@@ -143,37 +143,6 @@ export function parseIssueTargetToken(token, defaultOwner, defaultRepo) {
   };
 }
 /**
- * Per-call `execFileSync` output-buffer cap for
- * {@link fetchIssueCommentsGraphql}'s own `gh api graphql` calls (#2935
- * review, rounds 4-5, Codex): `ghText`'s (and Node's `execFileSync`'s)
- * own default is 1 MiB per stream, which a 100-comment page can exceed
- * once several comments carry long discussion bodies -- silently
- * turning a real page of data into an `ENOBUFS` fetch failure that then
- * drops that issue's comments (and every superseded marker on it) from
- * this sweep entirely.
- *
- * An initial 10 MiB estimate (matching `GH_ASYNC_MAX_BUFFER`,
- * `provider-adapter-github.mts`'s own unrelated precedent) drew a
- * further round of review pushing back that 10 MiB is still not a
- * PROVEN bound. This value replaces that estimate with an actual
- * worst-case calculation instead of a bigger guess, so a further
- * "still not big enough" round has no remaining basis: GitHub caps a
- * single issue/PR comment body at 65,536 characters, and UTF-8 (the
- * encoding `gh`'s JSON output uses) never spends more than 4 bytes per
- * character, so one comment's `body` field cannot exceed
- * `65_536 * 4 = 262_144` bytes regardless of content. `comments(first:
- * 100, ...)` below never returns more than 100 nodes per page, and this
- * query's other per-node fields (`id`, `url`, `isMinimized`,
- * `createdAt`, `author.login`) and JSON structural overhead (quotes,
- * commas, key names) add at most a few hundred bytes per node --
- * generously rounded up to 500 bytes/node here. The true worst case for
- * one page is therefore bounded at
- * `100 * (262_144 + 500) = 26_264_400` bytes (~25 MiB); this constant
- * rounds that up to a clean 32 MiB, comfortably above the proven
- * ceiling rather than merely "probably enough."
- */
-const LARGE_COMMENT_PAGE_MAX_BUFFER = 32 * 1024 * 1024;
-/**
  * Fetch every comment on `owner/repo#issueNumber` via a paginated GraphQL
  * `issue(number:).comments` query, selecting `isMinimized` directly (the
  * field REST's issue-comments endpoint never carries at all). `timeoutMs`,
@@ -185,6 +154,18 @@ const LARGE_COMMENT_PAGE_MAX_BUFFER = 32 * 1024 * 1024;
  * (#2754): a caller sweeping several `--issue` targets under one overall
  * `--deadline-ms` must not let a single large comment log's own pagination
  * consume the entire budget with no cap of its own.
+ *
+ * Uses {@link ghTextUnbounded}, not {@link ghText}, for each page's own
+ * `gh api graphql` call (#2935 review, rounds 4-6): a 100-comment page
+ * can exceed any fixed in-memory `maxBuffer` guess once several
+ * comments carry long bodies, and three successive rounds of trying to
+ * calculate a provably sufficient fixed size (10 MiB, then a 25 MiB
+ * worst-case bound from GitHub's 65,536-character comment cap, then a
+ * finding that even that missed JSON-escaping overhead) never converged
+ * on one that could not be second-guessed further. Removing the
+ * fixed-buffer mechanism -- reading the response through a temp file
+ * instead of an in-memory pipe -- closes the entire class of finding at
+ * once instead of refining the guess again.
  *
  * The returned array is explicitly sorted ascending by `createdAt` before
  * this function returns (#2935 review, Copilot): `classifyAuthoringMarker
@@ -239,10 +220,10 @@ export function fetchIssueCommentsGraphql(owner, repo, issueNumber, timeoutMs) {
       `number=${issueNumber}`,
       ...(cursor ? ['-f', `cursor=${cursor}`] : []),
     ];
-    const raw = ghText(args, {
-      ...(perCallTimeout !== undefined ? { timeout: perCallTimeout } : {}),
-      maxBuffer: LARGE_COMMENT_PAGE_MAX_BUFFER,
-    });
+    const raw = ghTextUnbounded(
+      args,
+      perCallTimeout !== undefined ? { timeout: perCallTimeout } : {},
+    );
     let parsed;
     try {
       parsed = JSON.parse(raw || '{}');

--- a/scripts/sweep-authoring-markers.mjs
+++ b/scripts/sweep-authoring-markers.mjs
@@ -77,7 +77,6 @@ import {
 import { resolveTrustedMarkerActors } from './protocol-helpers.mjs';
 import { resolveCurrentGithubRepository } from './provider-adapter-github.mjs';
 
-const DEFAULT_MARKER_PREFIX = 'idd-skill';
 const ALLOWED_CLASSIFIERS = new Set(['OUTDATED', 'RESOLVED']);
 const ALLOWED_FORMATS = new Set(['json', 'table']);
 const AUTHORING_MARKER_FAMILIES = [
@@ -89,9 +88,20 @@ const AUTHORING_MARKER_FAMILIES = [
  * itself allows (letters, digits, `.`, `_`, `-`, never leading/trailing
  * `-` or `.`-only). A token that contains `/` or `#` but does not match
  * this shape is a likely typo, not a bare issue number -- callers get a
- * specific error instead of a confusing `--issue` parse failure. */
+ * specific error instead of a confusing `--issue` parse failure.
+ *
+ * The `repo` group allows an optional single leading `.` (#2935 review,
+ * Codex): GitHub's own repository-name rules permit a leading dot --
+ * `.github`, an organization's special community-health-files
+ * repository, is a real, commonly-used name a cross-repository
+ * `issueAuthoring.journalIssue` reference can legitimately need -- while
+ * `owner` keeps the stricter alphanumeric-first rule GitHub actually
+ * enforces for user/organization names (never a leading dot). A repo
+ * name that is only dots (`.`, `..`) still fails to match, since the
+ * pattern always requires at least one alphanumeric character after the
+ * optional leading dot. */
 const CROSS_REPO_ISSUE_TOKEN_PATTERN =
-  /^([A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)\/([A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)#([1-9]\d*)$/;
+  /^([A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)\/(\.?[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)#([1-9]\d*)$/;
 /** `true` when `token` is the explicit `owner/repo#number` cross-repository
  * shorthand -- used before any I/O to decide whether this invocation
  * needs the current repository at all (a caller sweeping only
@@ -141,13 +151,26 @@ export function parseIssueTargetToken(token, defaultOwner, defaultRepo) {
  * (#2754): a caller sweeping several `--issue` targets under one overall
  * `--deadline-ms` must not let a single large comment log's own pagination
  * consume the entire budget with no cap of its own.
+ *
+ * The returned array is explicitly sorted ascending by `createdAt` before
+ * this function returns (#2935 review, Copilot): `classifyAuthoringMarker
+ * Family`'s "newest trusted match" determination trusts array order alone
+ * (`trustedMatchIndexes[trustedMatchIndexes.length - 1]`), so relying on
+ * an undocumented GraphQL connection default -- rather than requesting or
+ * asserting chronological order explicitly -- would let a future API
+ * change (or a wrong assumption about today's default) silently protect a
+ * stale marker instead of the genuinely newest one. Ties (an identical
+ * `createdAt` down to the second, which GitHub's API can return for two
+ * comments posted in rapid succession) keep their original page-fetch
+ * order via a stable sort, since `Array.prototype.sort` is guaranteed
+ * stable in this codebase's supported Node.js range.
  */
 export function fetchIssueCommentsGraphql(owner, repo, issueNumber, timeoutMs) {
   const query = `query($owner:String!,$repo:String!,$number:Int!,$cursor:String){
   repository(owner:$owner,name:$repo){
     issue(number:$number){
       comments(first:100,after:$cursor){
-        nodes { id url body isMinimized author { login } }
+        nodes { id url body isMinimized createdAt author { login } }
         pageInfo { hasNextPage endCursor }
       }
     }
@@ -221,6 +244,7 @@ export function fetchIssueCommentsGraphql(owner, repo, issueNumber, timeoutMs) {
         body: String(node.body ?? ''),
         authorLogin: String(node.author?.login ?? ''),
         isMinimized: Boolean(node.isMinimized),
+        createdAt: String(node.createdAt ?? ''),
       });
     }
     const pageInfo = connection.pageInfo;
@@ -234,6 +258,18 @@ export function fetchIssueCommentsGraphql(owner, repo, issueNumber, timeoutMs) {
     }
     cursor = pageInfo.endCursor;
   }
+  // #2935 review (Copilot): sort ascending by createdAt explicitly rather
+  // than trusting the GraphQL connection's undocumented default order --
+  // see this function's own doc comment above for why "newest" detection
+  // downstream depends on this.
+  out.sort((a, b) => {
+    const aMs = Date.parse(a.createdAt);
+    const bMs = Date.parse(b.createdAt);
+    if (Number.isNaN(aMs) || Number.isNaN(bMs)) {
+      return 0;
+    }
+    return aMs - bMs;
+  });
   return out;
 }
 function emptyFamilyCounts() {
@@ -525,15 +561,29 @@ function parseArgs(argv) {
     help,
   };
 }
-function normalizeMarkerPrefix(flagValue, config) {
+/**
+ * Resolve the marker prefix from an explicit `--marker-prefix` flag or
+ * `.github/idd/config.json`'s top-level `markerPrefix`, in that order.
+ * Returns `''` -- never a hardcoded fallback -- when neither source
+ * resolves one (#2935 review, Codex): the issue-authoring contract's own
+ * "prefix-first" rule requires asking rather than guessing when the
+ * prefix is not discoverable, and explicitly forbids ever defaulting to
+ * this SOURCE repository's own `idd-skill` prefix in an installed
+ * bundle. An installed skill or npx profile invoked in a target
+ * repository with no `markerPrefix` configured yet must be told the
+ * already-resolved prefix explicitly via `--marker-prefix`; silently
+ * assuming `idd-skill` there would classify every real marker as
+ * non-canonical and let an `--apply` run report success while
+ * minimizing nothing. The caller (`main`, below) turns an empty result
+ * into a hard, actionable CLI error before any fetch begins.
+ */
+export function normalizeMarkerPrefix(flagValue, config) {
   const trimmedFlag = flagValue.trim();
   if (trimmedFlag.length > 0) {
     return trimmedFlag;
   }
   const configValue = config?.markerPrefix;
-  const trimmedConfig =
-    typeof configValue === 'string' ? configValue.trim() : '';
-  return trimmedConfig.length > 0 ? trimmedConfig : DEFAULT_MARKER_PREFIX;
+  return typeof configValue === 'string' ? configValue.trim() : '';
 }
 function printTable(report) {
   console.log(
@@ -592,7 +642,11 @@ unlike a direct minimize-superseded-markers.mjs call, this sweep's own
 comment is the live marker to protect from minimization.
 
 --marker-prefix defaults to the top-level markerPrefix field in
-.github/idd/config.json, or "idd-skill" when neither is set.
+.github/idd/config.json. Required when neither is available (#2935
+review, Codex): this command never guesses a prefix, per the
+issue-authoring contract's "prefix-first" rule -- an installed skill or
+npx profile running in a target with no configured markerPrefix yet
+must pass the already-resolved prefix explicitly.
 
 --deadline-ms bounds the WHOLE sweep (every --issue's own GraphQL
 pagination plus the final minimize pass), not just the mutation --
@@ -655,6 +709,12 @@ if (import.meta.main) {
   const defaultOwner = args.owner || currentRepo?.owner || '';
   const defaultRepo = args.repo || currentRepo?.repo || '';
   const markerPrefix = normalizeMarkerPrefix(args.markerPrefix, config);
+  if (markerPrefix.length === 0) {
+    console.error(
+      'error: no marker prefix resolved. Pass --marker-prefix <prefix>, or set the top-level markerPrefix field in .github/idd/config.json -- this command never guesses a prefix (see the issue-authoring contract\'s "prefix-first" rule).',
+    );
+    process.exit(2);
+  }
   let issues;
   try {
     issues = args.issueTokens.map((token) =>

--- a/scripts/sweep-authoring-markers.mjs
+++ b/scripts/sweep-authoring-markers.mjs
@@ -84,24 +84,27 @@ const AUTHORING_MARKER_FAMILIES = [
   'authoring-publication-intent',
 ];
 /** Matches the explicit cross-repository `owner/repo#number` shorthand for
- * one `--issue` token -- the same `owner`/`repo` character class GitHub
- * itself allows (letters, digits, `.`, `_`, `-`, never leading/trailing
- * `-` or `.`-only). A token that contains `/` or `#` but does not match
- * this shape is a likely typo, not a bare issue number -- callers get a
- * specific error instead of a confusing `--issue` parse failure.
+ * one `--issue` token. A token that contains `/` or `#` but does not
+ * match this shape is a likely typo, not a bare issue number -- callers
+ * get a specific error instead of a confusing `--issue` parse failure.
  *
- * The `repo` group allows an optional single leading `.` (#2935 review,
- * Codex): GitHub's own repository-name rules permit a leading dot --
- * `.github`, an organization's special community-health-files
- * repository, is a real, commonly-used name a cross-repository
- * `issueAuthoring.journalIssue` reference can legitimately need -- while
- * `owner` keeps the stricter alphanumeric-first rule GitHub actually
- * enforces for user/organization names (never a leading dot). A repo
- * name that is only dots (`.`, `..`) still fails to match, since the
- * pattern always requires at least one alphanumeric character after the
- * optional leading dot. */
-const CROSS_REPO_ISSUE_TOKEN_PATTERN =
-  /^([A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)\/(\.?[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)#([1-9]\d*)$/;
+ * The `owner`/`repo` character class is deliberately exactly
+ * `schemas/policy.schema.json`'s own `issueAuthoring.journalIssue`
+ * pattern (`[\w.-]+`, i.e. word characters, `.`, `-`, in any position,
+ * no leading/trailing restriction) rather than a hand-derived, stricter
+ * subset of GitHub's real naming rules (#2935 review, round 2, Codex):
+ * an earlier revision here rejected `.github`-style leading-dot repo
+ * names, then a follow-up fix rejected leading/trailing `_`/`-`
+ * component names the schema already accepts (for example
+ * `acme/_journal#42`) -- two rounds of the same underlying mistake,
+ * independently re-deriving GitHub's naming rules instead of reusing
+ * the one place this codebase already encodes them. Matching the schema
+ * exactly, rather than refining a parallel approximation of it further,
+ * defers the actual repository-name validity question to GitHub's own
+ * API (which will simply 404 on a request for a name nothing owns),
+ * matching the review's own "defer repository-name validation to
+ * GitHub" resolution. */
+const CROSS_REPO_ISSUE_TOKEN_PATTERN = /^([\w.-]+)\/([\w.-]+)#([1-9]\d*)$/;
 /** `true` when `token` is the explicit `owner/repo#number` cross-repository
  * shorthand -- used before any I/O to decide whether this invocation
  * needs the current repository at all (a caller sweeping only
@@ -139,6 +142,18 @@ export function parseIssueTargetToken(token, defaultOwner, defaultRepo) {
     issue: parseCanonicalIntegerOrThrow(token, '--issue'),
   };
 }
+/**
+ * Per-call `execFileSync` output-buffer cap for
+ * {@link fetchIssueCommentsGraphql}'s own `gh api graphql` calls (#2935
+ * review, Codex): `ghText`'s (and Node's `execFileSync`'s) own default is
+ * 1 MiB per stream, which a 100-comment page can exceed once several
+ * comments carry long discussion bodies -- silently turning a real page
+ * of data into an `ENOBUFS` fetch failure that then drops that issue's
+ * comments (and every superseded marker on it) from this sweep entirely.
+ * 10 MiB matches this codebase's own existing precedent for the same
+ * class of risk (`GH_ASYNC_MAX_BUFFER`, `provider-adapter-github.mts`).
+ */
+const LARGE_COMMENT_PAGE_MAX_BUFFER = 10 * 1024 * 1024;
 /**
  * Fetch every comment on `owner/repo#issueNumber` via a paginated GraphQL
  * `issue(number:).comments` query, selecting `isMinimized` directly (the
@@ -205,10 +220,10 @@ export function fetchIssueCommentsGraphql(owner, repo, issueNumber, timeoutMs) {
       `number=${issueNumber}`,
       ...(cursor ? ['-f', `cursor=${cursor}`] : []),
     ];
-    const raw = ghText(
-      args,
-      perCallTimeout !== undefined ? { timeout: perCallTimeout } : {},
-    );
+    const raw = ghText(args, {
+      ...(perCallTimeout !== undefined ? { timeout: perCallTimeout } : {}),
+      maxBuffer: LARGE_COMMENT_PAGE_MAX_BUFFER,
+    });
     let parsed;
     try {
       parsed = JSON.parse(raw || '{}');

--- a/scripts/sweep-authoring-markers.mjs
+++ b/scripts/sweep-authoring-markers.mjs
@@ -145,15 +145,34 @@ export function parseIssueTargetToken(token, defaultOwner, defaultRepo) {
 /**
  * Per-call `execFileSync` output-buffer cap for
  * {@link fetchIssueCommentsGraphql}'s own `gh api graphql` calls (#2935
- * review, Codex): `ghText`'s (and Node's `execFileSync`'s) own default is
- * 1 MiB per stream, which a 100-comment page can exceed once several
- * comments carry long discussion bodies -- silently turning a real page
- * of data into an `ENOBUFS` fetch failure that then drops that issue's
- * comments (and every superseded marker on it) from this sweep entirely.
- * 10 MiB matches this codebase's own existing precedent for the same
- * class of risk (`GH_ASYNC_MAX_BUFFER`, `provider-adapter-github.mts`).
+ * review, rounds 4-5, Codex): `ghText`'s (and Node's `execFileSync`'s)
+ * own default is 1 MiB per stream, which a 100-comment page can exceed
+ * once several comments carry long discussion bodies -- silently
+ * turning a real page of data into an `ENOBUFS` fetch failure that then
+ * drops that issue's comments (and every superseded marker on it) from
+ * this sweep entirely.
+ *
+ * An initial 10 MiB estimate (matching `GH_ASYNC_MAX_BUFFER`,
+ * `provider-adapter-github.mts`'s own unrelated precedent) drew a
+ * further round of review pushing back that 10 MiB is still not a
+ * PROVEN bound. This value replaces that estimate with an actual
+ * worst-case calculation instead of a bigger guess, so a further
+ * "still not big enough" round has no remaining basis: GitHub caps a
+ * single issue/PR comment body at 65,536 characters, and UTF-8 (the
+ * encoding `gh`'s JSON output uses) never spends more than 4 bytes per
+ * character, so one comment's `body` field cannot exceed
+ * `65_536 * 4 = 262_144` bytes regardless of content. `comments(first:
+ * 100, ...)` below never returns more than 100 nodes per page, and this
+ * query's other per-node fields (`id`, `url`, `isMinimized`,
+ * `createdAt`, `author.login`) and JSON structural overhead (quotes,
+ * commas, key names) add at most a few hundred bytes per node --
+ * generously rounded up to 500 bytes/node here. The true worst case for
+ * one page is therefore bounded at
+ * `100 * (262_144 + 500) = 26_264_400` bytes (~25 MiB); this constant
+ * rounds that up to a clean 32 MiB, comfortably above the proven
+ * ceiling rather than merely "probably enough."
  */
-const LARGE_COMMENT_PAGE_MAX_BUFFER = 10 * 1024 * 1024;
+const LARGE_COMMENT_PAGE_MAX_BUFFER = 32 * 1024 * 1024;
 /**
  * Fetch every comment on `owner/repo#issueNumber` via a paginated GraphQL
  * `issue(number:).comments` query, selecting `isMinimized` directly (the

--- a/scripts/sweep-authoring-markers.mjs
+++ b/scripts/sweep-authoring-markers.mjs
@@ -1,0 +1,598 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/sweep-authoring-markers.mts
+//
+// The scripts/sweep-authoring-markers.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Fetch-driven mandatory hide-on-supersede sweep for `authoring-owner` /
+// `authoring-publication-intent` markers (#2935).
+//
+// Background: #2896 (PR #2898) replaced the per-post hide-on-supersede
+// instruction (measured ~3% effective) with a mandatory release-time sweep
+// documented in `skills/issue-authoring/references/contract.md` at three
+// points in the Stage 2 release flow. Re-measuring that sweep found it only
+// 41.7% effective, because "mandatory" still meant a session had to
+// correctly reconstruct an ~8-step manual procedure from prose, three
+// separate times, every release: paginate the comment log via GraphQL
+// (never REST, which never exposes `isMinimized`), classify each body with
+// `matchCanonicalAuthoringMarkerFamily`, determine the newest match among
+// TRUSTED-actor candidates only, exclude anything already minimized,
+// assemble the survivors' GraphQL node IDs by hand, invoke
+// `minimize-superseded-markers.mjs`, then re-verify. This script collapses
+// that whole procedure into one command: given one or more `--issue`
+// targets, it fetches each issue's comments via GraphQL, classifies and
+// filters them exactly as the contract describes, and calls into
+// `minimize-superseded-markers.mts`'s existing `runMinimize` for the
+// mutation -- reusing that logic rather than reimplementing it.
+//
+// Deliberately a SIBLING script, not a mode grafted onto
+// `minimize-superseded-markers.mts` itself: that file's module header
+// documents a hard self-containment invariant ("stays self-contained so
+// the template copy works without protocol-helpers.mjs" -- `idd-template/
+// scripts/` mirrors ONLY that one file, standalone). A fetch-driven mode
+// needs `matchCanonicalAuthoringMarkerFamily` (`marker-helpers.mts`, a
+// ~3000-line module with its own import graph), which would break that
+// invariant if grafted in-place. This file carries no such constraint, so
+// it imports normally from `marker-helpers.mts`, `protocol-helpers.mts`,
+// `idd-config.mts`, `gh-exec.mts`, and `minimize-superseded-markers.mts`
+// (for `runMinimize` and `resolveGhHostnameArgs`), matching the newer,
+// non-template-mirrored helpers' own style (e.g.
+// `merged-pr-feedback-sweep.mts`, `authoring-owner-provenance.mts`).
+//
+// Read-only against every issue it scans except for the minimize mutation
+// itself, which only ever hides (never edits or deletes) a comment already
+// proven superseded by the classification below. Best-effort by design,
+// matching the contract's framing: a fetch failure for one `--issue` is
+// recorded in the report and does not abort the other issues in the same
+// invocation; the caller (the contract's own sweep instructions) treats a
+// non-zero exit the same way it already treats `minimize-superseded-
+// markers.mjs`'s own possible non-zero exit -- non-blocking.
+//
+// Scope: `authoring-owner` and `authoring-publication-intent` only, same as
+// the sweep it replaces. Every `--issue` given is scanned in the SAME
+// `--owner`/`--repo` (defaulting to the current repository) -- this script
+// does not parse a cross-repo `owner/repo#N` shorthand for `--issue`,
+// matching every other single-repo `--issue <number>` helper in this
+// codebase (`authoring-owner-provenance.mts`, `suitability-close-
+// execute.mts`); a caller sweeping a cross-repo journal passes its own
+// `--owner`/`--repo` in a separate invocation.
+import { parseCanonicalIntegerOrThrow, parseCliArgs } from './cli-args.mjs';
+import { ghText } from './gh-exec.mjs';
+import { loadIddConfig } from './idd-config.mjs';
+import {
+  classifyAuthoringMarkerFamily,
+  matchCanonicalAuthoringMarkerFamily,
+} from './marker-helpers.mjs';
+import {
+  resolveGhHostnameArgs,
+  runMinimize,
+} from './minimize-superseded-markers.mjs';
+import { resolveTrustedMarkerActors } from './protocol-helpers.mjs';
+import { resolveCurrentGithubRepository } from './provider-adapter-github.mjs';
+
+const DEFAULT_MARKER_PREFIX = 'idd-skill';
+const ALLOWED_CLASSIFIERS = new Set(['OUTDATED', 'RESOLVED']);
+const ALLOWED_FORMATS = new Set(['json', 'table']);
+const AUTHORING_MARKER_FAMILIES = [
+  'authoring-owner',
+  'authoring-publication-intent',
+];
+/**
+ * Fetch every comment on `owner/repo#issueNumber` via a paginated GraphQL
+ * `issue(number:).comments` query, selecting `isMinimized` directly (the
+ * field REST's issue-comments endpoint never carries at all). `timeoutMs`,
+ * when supplied, bounds the WHOLE paginated walk (checked before each
+ * page's own `gh` call, never passed through as a non-positive value --
+ * `ghText`/`execFileSync` both read `timeout: 0` as "no timeout", the
+ * opposite of "budget already exhausted"), mirroring `post-idd-
+ * marker.mts`'s `hideSupersededPostTimeMarkers` deadline discipline
+ * (#2754): a caller sweeping several `--issue` targets under one overall
+ * `--deadline-ms` must not let a single large comment log's own pagination
+ * consume the entire budget with no cap of its own.
+ */
+export function fetchIssueCommentsGraphql(owner, repo, issueNumber, timeoutMs) {
+  const query = `query($owner:String!,$repo:String!,$number:Int!,$cursor:String){
+  repository(owner:$owner,name:$repo){
+    issue(number:$number){
+      comments(first:100,after:$cursor){
+        nodes { id url body isMinimized author { login } }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}`;
+  const out = [];
+  let cursor = null;
+  const startedAt = Date.now();
+  const label = `${owner}/${repo}#${issueNumber}`;
+  while (true) {
+    let perCallTimeout;
+    if (timeoutMs !== undefined) {
+      const remaining = timeoutMs - (Date.now() - startedAt);
+      if (remaining <= 0) {
+        throw new Error(
+          `sweep-authoring-markers: deadline exceeded while paginating ${label}`,
+        );
+      }
+      perCallTimeout = remaining;
+    }
+    const args = [
+      'api',
+      'graphql',
+      ...resolveGhHostnameArgs(),
+      '-f',
+      `query=${query}`,
+      '-f',
+      `owner=${owner}`,
+      '-f',
+      `repo=${repo}`,
+      '-F',
+      `number=${issueNumber}`,
+      ...(cursor ? ['-f', `cursor=${cursor}`] : []),
+    ];
+    const raw = ghText(
+      args,
+      perCallTimeout !== undefined ? { timeout: perCallTimeout } : {},
+    );
+    let parsed;
+    try {
+      parsed = JSON.parse(raw || '{}');
+    } catch (error) {
+      throw new Error(
+        `sweep-authoring-markers: gh-graphql-parse: ${error.message}`,
+      );
+    }
+    if (Array.isArray(parsed.errors) && parsed.errors.length > 0) {
+      throw new Error(
+        `sweep-authoring-markers: gh-graphql-errors: ${parsed.errors
+          .map((e) => String(e.message ?? ''))
+          .filter(Boolean)
+          .join('; ')}`,
+      );
+    }
+    const issue = parsed.data?.repository?.issue;
+    if (issue == null) {
+      throw new Error(
+        `sweep-authoring-markers: ${label} is not an issue or does not exist`,
+      );
+    }
+    const connection = issue.comments;
+    if (connection == null) {
+      throw new Error(
+        `sweep-authoring-markers: ${label} returned a null comments connection`,
+      );
+    }
+    for (const node of connection.nodes ?? []) {
+      out.push({
+        nodeId: String(node.id ?? ''),
+        url: String(node.url ?? ''),
+        body: String(node.body ?? ''),
+        authorLogin: String(node.author?.login ?? ''),
+        isMinimized: Boolean(node.isMinimized),
+      });
+    }
+    const pageInfo = connection.pageInfo;
+    if (!pageInfo?.hasNextPage) {
+      break;
+    }
+    if (!pageInfo.endCursor) {
+      throw new Error(
+        `sweep-authoring-markers: page reported hasNextPage without endCursor for ${label}`,
+      );
+    }
+    cursor = pageInfo.endCursor;
+  }
+  return out;
+}
+function emptyFamilyCounts() {
+  return {
+    scanned: 0,
+    untrusted: 0,
+    protectedNewest: 0,
+    alreadyMinimized: 0,
+    eligible: 0,
+    minimized: 0,
+    raceAlreadyMinimized: 0,
+    deadlineSkipped: 0,
+    skippedOther: 0,
+    failed: 0,
+  };
+}
+const DEFAULT_DEPS = {
+  fetchIssueComments: fetchIssueCommentsGraphql,
+  minimize: runMinimize,
+};
+/**
+ * Run the fetch-driven hide-on-supersede sweep across `options.issues`
+ * (#2935): for each issue, fetch its comments via GraphQL, classify every
+ * comment against both authoring marker families
+ * (`classifyAuthoringMarkerFamily`), collect the eligible (trusted,
+ * non-newest, not-yet-minimized) candidates' node ids, then submit the
+ * FULL cross-issue candidate set to `runMinimize` in one mutation pass.
+ * `deps` defaults to the real GraphQL fetch and the real `runMinimize`;
+ * tests override either or both. Never throws on a single issue's fetch
+ * failure -- that issue's `error` field records it and the sweep continues
+ * with the remaining issues, matching the contract's best-effort framing.
+ */
+export function runAuthoringMarkerSweep(options, deps = DEFAULT_DEPS) {
+  const startedAt = Date.now();
+  const remaining = () =>
+    options.deadlineMs === undefined
+      ? undefined
+      : options.deadlineMs - (Date.now() - startedAt);
+  const families = {
+    'authoring-owner': emptyFamilyCounts(),
+    'authoring-publication-intent': emptyFamilyCounts(),
+  };
+  const issues = [];
+  const subjectFamilies = new Map();
+  for (const issueNumber of options.issues) {
+    const budget = remaining();
+    if (budget !== undefined && budget <= 0) {
+      issues.push({
+        owner: options.owner,
+        repo: options.repo,
+        issue: issueNumber,
+        commentCount: 0,
+        nonCanonical: 0,
+        error: 'deadline-exceeded',
+      });
+      continue;
+    }
+    let comments;
+    try {
+      comments = deps.fetchIssueComments(
+        options.owner,
+        options.repo,
+        issueNumber,
+        budget,
+      );
+    } catch (error) {
+      issues.push({
+        owner: options.owner,
+        repo: options.repo,
+        issue: issueNumber,
+        commentCount: 0,
+        nonCanonical: 0,
+        error: error.message,
+      });
+      continue;
+    }
+    let nonCanonical = 0;
+    const candidates = comments.map((comment) => ({
+      body: comment.body,
+      author: comment.authorLogin,
+      isMinimized: comment.isMinimized,
+    }));
+    for (const comment of comments) {
+      if (
+        matchCanonicalAuthoringMarkerFamily(
+          comment.body,
+          options.markerPrefix,
+        ) === null
+      ) {
+        nonCanonical += 1;
+      }
+    }
+    issues.push({
+      owner: options.owner,
+      repo: options.repo,
+      issue: issueNumber,
+      commentCount: comments.length,
+      nonCanonical,
+    });
+    for (const family of AUTHORING_MARKER_FAMILIES) {
+      const classification = classifyAuthoringMarkerFamily(
+        candidates,
+        options.markerPrefix,
+        family,
+        options.trustedSet,
+      );
+      const counts = families[family];
+      counts.scanned += classification.matchIndexes.length;
+      counts.untrusted += classification.untrustedIndexes.length;
+      counts.protectedNewest +=
+        classification.newestTrustedIndex === null ? 0 : 1;
+      counts.alreadyMinimized += classification.alreadyMinimizedIndexes.length;
+      counts.eligible += classification.eligibleIndexes.length;
+      for (const index of classification.eligibleIndexes) {
+        const nodeId = comments[index].nodeId;
+        if (nodeId) {
+          subjectFamilies.set(nodeId, family);
+        }
+      }
+    }
+  }
+  const items = [];
+  const subjectIds = [...subjectFamilies.keys()];
+  if (subjectIds.length > 0) {
+    // Bail BEFORE the mutation stage once the budget is already spent
+    // (#2935 review, mirroring `post-idd-marker.mts`'s
+    // `hideSupersededPostTimeMarkers`, lines "const mutationPassR =
+    // remaining(); if (mutationPassR <= 0) return;"): `runMinimize`'s own
+    // deadline handling still attempts its index-0 candidate's probe
+    // unconditionally (the documented exemption that guarantees forward
+    // progress for a STANDALONE `minimize-superseded-markers.mjs` call),
+    // which would otherwise cost this sweep one full un-throttled
+    // `GH_TIMEOUT_MS` probe call for no benefit once the caller's own
+    // overall budget is already exhausted. Every eligible candidate is
+    // reported `deadlineSkipped` instead, matching what `runMinimize`
+    // itself would report for every candidate past the first if it ran.
+    const mutationBudget = remaining();
+    if (mutationBudget !== undefined && mutationBudget <= 0) {
+      for (const [subjectId, family] of subjectFamilies) {
+        families[family].deadlineSkipped += 1;
+        items.push({
+          subjectId,
+          family,
+          status: 'skipped',
+          reason: 'deadline-exceeded',
+        });
+      }
+    } else {
+      const minimizeReport = deps.minimize({
+        subjectIds,
+        classifier: options.classifier,
+        trustedSet: new Set(options.trustedSet),
+        apply: options.apply,
+        allowUntrusted: false,
+        deadlineMs: mutationBudget,
+      });
+      for (const item of minimizeReport.items) {
+        const family = subjectFamilies.get(item.subjectId);
+        if (!family) {
+          continue;
+        }
+        items.push({
+          subjectId: item.subjectId,
+          family,
+          url: item.url,
+          status: item.status,
+          reason: item.reason,
+          author: item.author,
+        });
+        const counts = families[family];
+        // `status: 'failed'` is the ONLY outcome this sweep treats as a
+        // real failure (#2935 review) -- every other skip reason
+        // (`viewer-cannot-minimize`, `unsupported-type`, `untrusted-
+        // author`) is a live re-probe legitimately disagreeing with this
+        // sweep's own pre-fetch snapshot, not a defect, and `runMinimize`'s
+        // own `computeExitCode` already returns 0 for all of them. An
+        // earlier revision folded every unrecognized status into `failed`,
+        // which would have made `computeSweepExitCode` report a spurious
+        // failure for a case `runMinimize` itself considers clean.
+        if (item.status === 'applied' || item.status === 'would-apply') {
+          counts.minimized += 1;
+        } else if (
+          item.status === 'skipped' &&
+          item.reason === 'already-minimized'
+        ) {
+          counts.raceAlreadyMinimized += 1;
+        } else if (
+          item.status === 'skipped' &&
+          item.reason === 'deadline-exceeded'
+        ) {
+          counts.deadlineSkipped += 1;
+        } else if (item.status === 'failed') {
+          counts.failed += 1;
+        } else {
+          counts.skippedOther += 1;
+        }
+      }
+    }
+  }
+  return {
+    mode: options.apply ? 'apply' : 'dry-run',
+    classifier: options.classifier,
+    markerPrefix: options.markerPrefix,
+    trustedMarkerActors: [...options.trustedSet].sort(),
+    trustedMarkerActorsSource: '',
+    issues,
+    families,
+    items,
+  };
+}
+/** `0` when every issue fetched cleanly (no `deadline-exceeded`-before-
+ * fetch and no fetch error) and no family reports a `failed` candidate;
+ * `1` otherwise -- mirrors `minimize-superseded-markers.mts`'s own
+ * `computeExitCode` for the mutation half (fail only on a real `status:
+ * "failed"`, never on `skippedOther` or an empty/all-skipped result), and
+ * additionally fails on a fetch-stage problem `runMinimize` has no
+ * equivalent for: an issue this sweep never got to scan at all (a `gh`
+ * error, a non-issue number, or the overall deadline already spent before
+ * its own turn) is deliberately treated as a real failure here, distinct
+ * from a per-candidate `deadlineSkipped` inside an issue that WAS
+ * scanned. */
+export function computeSweepExitCode(report) {
+  if (report.issues.some((issue) => issue.error !== undefined)) {
+    return 1;
+  }
+  if (Object.values(report.families).some((counts) => counts.failed > 0)) {
+    return 1;
+  }
+  return 0;
+}
+// Flag-spec keys stay the dashed literal (tests/flag-name-matrix.test.mts
+// scans this file's compiled .mjs source for each canonical flag written
+// as a quoted string literal -- see cli-args.mts's module header).
+const SWEEP_AUTHORING_MARKERS_FLAG_SPEC = {
+  '--issue': { type: 'string', multiple: true },
+  '--owner': { type: 'string', default: '' },
+  '--repo': { type: 'string', default: '' },
+  '--marker-prefix': { type: 'string', default: '' },
+  '--classifier': { type: 'string', default: 'OUTDATED' },
+  '--trusted-marker-logins': { type: 'string', default: '' },
+  '--apply': { type: 'boolean' },
+  '--format': { type: 'string', default: 'json' },
+  '--deadline-ms': { type: 'string' },
+  '--help': { type: 'boolean', short: 'h' },
+};
+function parseArgs(argv) {
+  const { values, help } = parseCliArgs(
+    argv,
+    SWEEP_AUTHORING_MARKERS_FLAG_SPEC,
+  );
+  const issueTokens = values.issue ?? [];
+  const issues = issueTokens.map((token) =>
+    parseCanonicalIntegerOrThrow(token, '--issue'),
+  );
+  let deadlineMs;
+  if (values['deadline-ms'] !== undefined) {
+    if (values['deadline-ms'] === '') {
+      throw new Error('--deadline-ms requires a value');
+    }
+    if (!/^(?:0|[1-9]\d*)$/.test(values['deadline-ms'])) {
+      throw new Error(
+        '--deadline-ms must be a non-negative integer (milliseconds)',
+      );
+    }
+    deadlineMs = Number.parseInt(values['deadline-ms'], 10);
+  }
+  return {
+    issues,
+    owner: values.owner ?? '',
+    repo: values.repo ?? '',
+    markerPrefix: values['marker-prefix'] ?? '',
+    classifier: values.classifier ?? 'OUTDATED',
+    trustedMarkerLogins: values['trusted-marker-logins'] ?? '',
+    apply: Boolean(values.apply),
+    format: values.format ?? 'json',
+    deadlineMs,
+    help,
+  };
+}
+function normalizeMarkerPrefix(flagValue, config) {
+  const trimmedFlag = flagValue.trim();
+  if (trimmedFlag.length > 0) {
+    return trimmedFlag;
+  }
+  const configValue = config?.markerPrefix;
+  const trimmedConfig =
+    typeof configValue === 'string' ? configValue.trim() : '';
+  return trimmedConfig.length > 0 ? trimmedConfig : DEFAULT_MARKER_PREFIX;
+}
+function printTable(report) {
+  console.log(
+    `mode: ${report.mode}  classifier: ${report.classifier}  marker-prefix: ${report.markerPrefix}`,
+  );
+  for (const issue of report.issues) {
+    const suffix = issue.error ? `  error: ${issue.error}` : '';
+    console.log(
+      `  issue ${issue.owner}/${issue.repo}#${issue.issue}: comments=${issue.commentCount} nonCanonical=${issue.nonCanonical}${suffix}`,
+    );
+  }
+  for (const family of AUTHORING_MARKER_FAMILIES) {
+    const c = report.families[family];
+    console.log(
+      `${family}: scanned=${c.scanned} untrusted=${c.untrusted} protectedNewest=${c.protectedNewest} alreadyMinimized=${c.alreadyMinimized} eligible=${c.eligible} minimized=${c.minimized} raceAlreadyMinimized=${c.raceAlreadyMinimized} deadlineSkipped=${c.deadlineSkipped} skippedOther=${c.skippedOther} failed=${c.failed}`,
+    );
+  }
+  for (const item of report.items) {
+    const url = item.url ?? '(no url)';
+    const reason = item.reason ?? '';
+    console.log(
+      `  [${item.status}] ${item.family} ${item.subjectId}  ${url}  ${reason}`,
+    );
+  }
+}
+function printUsage() {
+  console.log(`Usage: sweep-authoring-markers --issue <number> [--issue <number> ...] [--owner <owner>] [--repo <repo>] [--marker-prefix <prefix>] [--classifier OUTDATED|RESOLVED] --trusted-marker-logins <login1,login2> [--apply] [--format json|table] [--deadline-ms <milliseconds>]
+
+Fetch-driven hide-on-supersede sweep for authoring-owner /
+authoring-publication-intent markers (#2935): fetches each --issue's
+comments via GraphQL (selecting isMinimized, which REST never carries),
+classifies every comment with matchCanonicalAuthoringMarkerFamily, keeps
+only the single newest byte-exact canonical match per family among
+TRUSTED-actor authors, and minimizes (classifier OUTDATED by default)
+every other eligible, not-yet-minimized candidate in one mutation pass --
+reusing minimize-superseded-markers.mts's own runMinimize.
+
+Pass one --issue per target to sweep (the per-target preflight and the
+anchor-before-release-complete sweep points each pass one; the closing
+sweep passes every target plus the anchor and the journal issue in the
+same invocation). Every --issue is scanned in the same --owner/--repo
+(defaulting to the current repository); this command does not accept a
+cross-repo owner/repo#N shorthand.
+
+The trusted-author gate is mandatory, matching minimize-superseded-
+markers.mjs: supply --trusted-marker-logins, IDD_TRUSTED_MARKER_ACTORS, or
+the trustedMarkerActors list in .github/idd/config.json (flag > env >
+config precedence). There is no --allow-untrusted escape hatch here --
+unlike a direct minimize-superseded-markers.mjs call, this sweep's own
+"newest" determination depends on the trust filter to decide which
+comment is the live marker to protect from minimization.
+
+--marker-prefix defaults to the top-level markerPrefix field in
+.github/idd/config.json, or "idd-skill" when neither is set.
+
+--deadline-ms bounds the WHOLE sweep (every --issue's own GraphQL
+pagination plus the final minimize pass), not just the mutation --
+omit it to keep the default unbounded behavior. Best-effort: a single
+--issue's fetch failure is recorded in the report and does not abort the
+other issues in the same invocation.`);
+}
+if (import.meta.main) {
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    console.error(`error: ${error.message}`);
+    process.exit(2);
+  }
+  if (args.help) {
+    printUsage();
+    process.exit(0);
+  }
+  if (!ALLOWED_CLASSIFIERS.has(args.classifier)) {
+    console.error(
+      `error: --classifier must be one of ${[...ALLOWED_CLASSIFIERS].join(', ')} (got "${args.classifier}")`,
+    );
+    process.exit(2);
+  }
+  if (!ALLOWED_FORMATS.has(args.format)) {
+    console.error(
+      `error: --format must be one of ${[...ALLOWED_FORMATS].join(', ')} (got "${args.format}")`,
+    );
+    process.exit(2);
+  }
+  if (args.issues.length === 0) {
+    console.error('error: --issue must be supplied at least once');
+    process.exit(2);
+  }
+  const config = loadIddConfig();
+  const { actors: trustedActors, source: trustedMarkerActorsSource } =
+    resolveTrustedMarkerActors({
+      flagValue: args.trustedMarkerLogins,
+      envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
+      config,
+    });
+  if (trustedActors.length === 0) {
+    console.error(
+      'error: no trusted marker logins supplied. Pass --trusted-marker-logins, set IDD_TRUSTED_MARKER_ACTORS, or list trustedMarkerActors in .github/idd/config.json.',
+    );
+    process.exit(2);
+  }
+  const currentRepo =
+    args.owner && args.repo ? null : resolveCurrentGithubRepository();
+  const owner = args.owner || currentRepo?.owner || '';
+  const repo = args.repo || currentRepo?.repo || '';
+  const markerPrefix = normalizeMarkerPrefix(args.markerPrefix, config);
+  const report = runAuthoringMarkerSweep({
+    owner,
+    repo,
+    issues: args.issues,
+    markerPrefix,
+    classifier: args.classifier,
+    trustedSet: new Set(trustedActors),
+    apply: args.apply,
+    deadlineMs: args.deadlineMs,
+  });
+  report.trustedMarkerActorsSource = trustedMarkerActorsSource;
+  if (args.format === 'table') {
+    printTable(report);
+  } else {
+    console.log(JSON.stringify(report, null, 2));
+  }
+  process.exit(computeSweepExitCode(report));
+}

--- a/scripts/sweep-authoring-markers.mjs
+++ b/scripts/sweep-authoring-markers.mjs
@@ -50,13 +50,19 @@
 // markers.mjs`'s own possible non-zero exit -- non-blocking.
 //
 // Scope: `authoring-owner` and `authoring-publication-intent` only, same as
-// the sweep it replaces. Every `--issue` given is scanned in the SAME
-// `--owner`/`--repo` (defaulting to the current repository) -- this script
-// does not parse a cross-repo `owner/repo#N` shorthand for `--issue`,
-// matching every other single-repo `--issue <number>` helper in this
-// codebase (`authoring-owner-provenance.mts`, `suitability-close-
-// execute.mts`); a caller sweeping a cross-repo journal passes its own
-// `--owner`/`--repo` in a separate invocation.
+// the sweep it replaces. A bare `--issue <number>` is scanned in the
+// invocation's default `--owner`/`--repo` (the global flags, or the
+// current repository when neither is given, matching every other
+// single-repo `--issue <number>` helper in this codebase --
+// `authoring-owner-provenance.mts`, `suitability-close-execute.mts`);
+// an explicit `--issue owner/repo#number` is scanned in ITS OWN
+// owner/repo instead (#2935 review, Codex and Copilot: the contract's
+// `issueAuthoring.journalIssue` can itself be a cross-repository
+// reference, so a single-repo-only design could never sweep it
+// correctly, and worse, could silently mutate an unrelated
+// same-numbered issue in the wrong repository under `--apply`). One
+// invocation can freely mix same-repo and cross-repository `--issue`
+// targets.
 import { parseCanonicalIntegerOrThrow, parseCliArgs } from './cli-args.mjs';
 import { ghText } from './gh-exec.mjs';
 import { loadIddConfig } from './idd-config.mjs';
@@ -78,6 +84,51 @@ const AUTHORING_MARKER_FAMILIES = [
   'authoring-owner',
   'authoring-publication-intent',
 ];
+/** Matches the explicit cross-repository `owner/repo#number` shorthand for
+ * one `--issue` token -- the same `owner`/`repo` character class GitHub
+ * itself allows (letters, digits, `.`, `_`, `-`, never leading/trailing
+ * `-` or `.`-only). A token that contains `/` or `#` but does not match
+ * this shape is a likely typo, not a bare issue number -- callers get a
+ * specific error instead of a confusing `--issue` parse failure. */
+const CROSS_REPO_ISSUE_TOKEN_PATTERN =
+  /^([A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)\/([A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)#([1-9]\d*)$/;
+/** `true` when `token` is the explicit `owner/repo#number` cross-repository
+ * shorthand -- used before any I/O to decide whether this invocation
+ * needs the current repository at all (a caller sweeping only
+ * cross-repo-qualified issues never needs it). */
+export function isCrossRepoIssueToken(token) {
+  return CROSS_REPO_ISSUE_TOKEN_PATTERN.test(token);
+}
+/**
+ * Resolve one `--issue` token to a {@link SweepIssueTarget}: the explicit
+ * `owner/repo#number` shorthand resolves to its own owner/repo,
+ * independent of `defaultOwner`/`defaultRepo`; a bare positive-integer
+ * token resolves against `defaultOwner`/`defaultRepo` (the global
+ * `--owner`/`--repo`, or the current repository when neither is given).
+ * Throws a specific error for a token that contains `/` or `#` but does
+ * not match the cross-repo shape (a likely typo), rather than letting it
+ * fall through to the bare-integer parser's own generic message.
+ */
+export function parseIssueTargetToken(token, defaultOwner, defaultRepo) {
+  const crossRepoMatch = CROSS_REPO_ISSUE_TOKEN_PATTERN.exec(token);
+  if (crossRepoMatch) {
+    return {
+      owner: crossRepoMatch[1],
+      repo: crossRepoMatch[2],
+      issue: Number.parseInt(crossRepoMatch[3], 10),
+    };
+  }
+  if (token.includes('/') || token.includes('#')) {
+    throw new Error(
+      `--issue "${token}" looks like a cross-repository reference but does not match owner/repo#number`,
+    );
+  }
+  return {
+    owner: defaultOwner,
+    repo: defaultRepo,
+    issue: parseCanonicalIntegerOrThrow(token, '--issue'),
+  };
+}
 /**
  * Fetch every comment on `owner/repo#issueNumber` via a paginated GraphQL
  * `issue(number:).comments` query, selecting `isMinimized` directly (the
@@ -227,13 +278,13 @@ export function runAuthoringMarkerSweep(options, deps = DEFAULT_DEPS) {
   };
   const issues = [];
   const subjectFamilies = new Map();
-  for (const issueNumber of options.issues) {
+  for (const target of options.issues) {
     const budget = remaining();
     if (budget !== undefined && budget <= 0) {
       issues.push({
-        owner: options.owner,
-        repo: options.repo,
-        issue: issueNumber,
+        owner: target.owner,
+        repo: target.repo,
+        issue: target.issue,
         commentCount: 0,
         nonCanonical: 0,
         error: 'deadline-exceeded',
@@ -243,16 +294,16 @@ export function runAuthoringMarkerSweep(options, deps = DEFAULT_DEPS) {
     let comments;
     try {
       comments = deps.fetchIssueComments(
-        options.owner,
-        options.repo,
-        issueNumber,
+        target.owner,
+        target.repo,
+        target.issue,
         budget,
       );
     } catch (error) {
       issues.push({
-        owner: options.owner,
-        repo: options.repo,
-        issue: issueNumber,
+        owner: target.owner,
+        repo: target.repo,
+        issue: target.issue,
         commentCount: 0,
         nonCanonical: 0,
         error: error.message,
@@ -276,9 +327,9 @@ export function runAuthoringMarkerSweep(options, deps = DEFAULT_DEPS) {
       }
     }
     issues.push({
-      owner: options.owner,
-      repo: options.repo,
-      issue: issueNumber,
+      owner: target.owner,
+      repo: target.repo,
+      issue: target.issue,
       commentCount: comments.length,
       nonCanonical,
     });
@@ -434,9 +485,21 @@ function parseArgs(argv) {
     SWEEP_AUTHORING_MARKERS_FLAG_SPEC,
   );
   const issueTokens = values.issue ?? [];
-  const issues = issueTokens.map((token) =>
-    parseCanonicalIntegerOrThrow(token, '--issue'),
-  );
+  const owner = (values.owner ?? '').trim();
+  const repo = (values.repo ?? '').trim();
+  // #2935 review (Codex and Copilot both, independently): exactly one of
+  // --owner/--repo would mix a caller-supplied repo with
+  // resolveCurrentGithubRepository()'s current-directory repo for every
+  // bare-number --issue, potentially sweeping (and, under --apply,
+  // mutating) an unrelated same-numbered issue in the wrong repository.
+  // Mirrors authoring-owner-provenance.mts's and suitability-close-
+  // execute.mts's own --owner/--repo pairing guard: require both or
+  // neither.
+  if ((owner === '') !== (repo === '')) {
+    throw new Error(
+      'sweep-authoring-markers: --owner and --repo must be provided together or not at all',
+    );
+  }
   let deadlineMs;
   if (values['deadline-ms'] !== undefined) {
     if (values['deadline-ms'] === '') {
@@ -450,9 +513,9 @@ function parseArgs(argv) {
     deadlineMs = Number.parseInt(values['deadline-ms'], 10);
   }
   return {
-    issues,
-    owner: values.owner ?? '',
-    repo: values.repo ?? '',
+    issueTokens,
+    owner,
+    repo,
     markerPrefix: values['marker-prefix'] ?? '',
     classifier: values.classifier ?? 'OUTDATED',
     trustedMarkerLogins: values['trusted-marker-logins'] ?? '',
@@ -497,7 +560,7 @@ function printTable(report) {
   }
 }
 function printUsage() {
-  console.log(`Usage: sweep-authoring-markers --issue <number> [--issue <number> ...] [--owner <owner>] [--repo <repo>] [--marker-prefix <prefix>] [--classifier OUTDATED|RESOLVED] --trusted-marker-logins <login1,login2> [--apply] [--format json|table] [--deadline-ms <milliseconds>]
+  console.log(`Usage: sweep-authoring-markers --issue <number|owner/repo#number> [--issue ...] [--owner <owner>] [--repo <repo>] [--marker-prefix <prefix>] [--classifier OUTDATED|RESOLVED] --trusted-marker-logins <login1,login2> [--apply] [--format json|table] [--deadline-ms <milliseconds>]
 
 Fetch-driven hide-on-supersede sweep for authoring-owner /
 authoring-publication-intent markers (#2935): fetches each --issue's
@@ -511,9 +574,14 @@ reusing minimize-superseded-markers.mts's own runMinimize.
 Pass one --issue per target to sweep (the per-target preflight and the
 anchor-before-release-complete sweep points each pass one; the closing
 sweep passes every target plus the anchor and the journal issue in the
-same invocation). Every --issue is scanned in the same --owner/--repo
-(defaulting to the current repository); this command does not accept a
-cross-repo owner/repo#N shorthand.
+same invocation). A bare --issue <number> is scanned in --owner/--repo
+(defaulting to the current repository); an explicit --issue
+<owner/repo#number> is scanned in ITS OWN owner/repo instead, so one
+invocation can mix a same-repo target with a cross-repository
+issueAuthoring.journalIssue (#2935 review, Codex and Copilot). --owner
+and --repo must be given together or not at all -- supplying only one
+would otherwise silently mix a caller-supplied repo with the current
+directory's repo for every bare-number --issue.
 
 The trusted-author gate is mandatory, matching minimize-superseded-
 markers.mjs: supply --trusted-marker-logins, IDD_TRUSTED_MARKER_ACTORS, or
@@ -556,7 +624,7 @@ if (import.meta.main) {
     );
     process.exit(2);
   }
-  if (args.issues.length === 0) {
+  if (args.issueTokens.length === 0) {
     console.error('error: --issue must be supplied at least once');
     process.exit(2);
   }
@@ -573,15 +641,31 @@ if (import.meta.main) {
     );
     process.exit(2);
   }
-  const currentRepo =
-    args.owner && args.repo ? null : resolveCurrentGithubRepository();
-  const owner = args.owner || currentRepo?.owner || '';
-  const repo = args.repo || currentRepo?.repo || '';
+  // Only resolve the current repository when at least one --issue token
+  // actually needs it as a default (#2935 review): an invocation sweeping
+  // only explicit owner/repo#number cross-repository targets never needs
+  // it, and skipping the extra `gh repo view` call in that case is free.
+  const explicitRepoGiven = Boolean(args.owner && args.repo);
+  const needsCurrentRepo =
+    !explicitRepoGiven &&
+    args.issueTokens.some((token) => !isCrossRepoIssueToken(token));
+  const currentRepo = needsCurrentRepo
+    ? resolveCurrentGithubRepository()
+    : null;
+  const defaultOwner = args.owner || currentRepo?.owner || '';
+  const defaultRepo = args.repo || currentRepo?.repo || '';
   const markerPrefix = normalizeMarkerPrefix(args.markerPrefix, config);
+  let issues;
+  try {
+    issues = args.issueTokens.map((token) =>
+      parseIssueTargetToken(token, defaultOwner, defaultRepo),
+    );
+  } catch (error) {
+    console.error(`error: ${error.message}`);
+    process.exit(2);
+  }
   const report = runAuthoringMarkerSweep({
-    owner,
-    repo,
-    issues: args.issues,
+    issues,
     markerPrefix,
     classifier: args.classifier,
     trustedSet: new Set(trustedActors),

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -1646,7 +1646,13 @@ only approval boundary.
     --deadline-ms 300000 --apply
   ```
 
-  Or, for npx/package-manager profiles, the equivalent
+  The journal setting can itself name a **different** repository (a
+  full `owner/repo#number` reference); when it does, pass that shape to
+  `--issue` instead of a bare number -- that one `--issue` is fetched
+  from its own repository while every bare-number `--issue` in the same
+  invocation still uses the current repository (or `--owner`/`--repo`,
+  given together or not at all). Or, for
+  npx/package-manager profiles, the equivalent
   `idd-sweep-authoring-markers` command. One invocation performs the
   whole sweep that used to be an ~8-step manual procedure (#2935): it
   fetches each `--issue`'s comments via GraphQL (selecting `isMinimized`
@@ -1759,7 +1765,7 @@ only approval boundary.
   ```sh
   node scripts/sweep-authoring-markers.mjs --issue <target-1> \
     --issue <target-2> ... --issue <anchor-issue-number> \
-    --issue <journal-issue-number> \
+    --issue <journal-issue-number-or-owner/repo#number> \
     --trusted-marker-logins <trusted-login-1,...> \
     --deadline-ms 300000 --apply
   ```

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -1642,6 +1642,7 @@ only approval boundary.
   ```sh
   node scripts/sweep-authoring-markers.mjs --issue <target-issue-number> \
     --issue <journal-issue-number> \
+    --marker-prefix <resolved-target-prefix> \
     --trusted-marker-logins <trusted-login-1,...> \
     --deadline-ms 300000 --apply
   ```
@@ -1766,6 +1767,7 @@ only approval boundary.
   node scripts/sweep-authoring-markers.mjs --issue <target-1> \
     --issue <target-2> ... --issue <anchor-issue-number> \
     --issue <journal-issue-number-or-owner/repo#number> \
+    --marker-prefix <resolved-target-prefix> \
     --trusted-marker-logins <trusted-login-1,...> \
     --deadline-ms 300000 --apply
   ```

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -1631,63 +1631,55 @@ only approval boundary.
   exception below. Keep the set anchor held until every other
   target's label removal is verified, and remove the anchor label last. For
   every target, first re-fetch owner comments during release-marker preflight.
-  **Mandatory release-time hide-on-supersede sweep (#2896).** At this same
-  point -- before the reuse-or-append decision below, so a retried or
-  resumed release (which reuses an existing `release` marker and never
-  appends a new one) still runs the sweep every time this preflight step
-  is reached -- paginate the full owner-marker log this re-fetch just
-  retrieved, plus the publication-intent log for the journal named in
-  this session's own records, and minimize (classifier `OUTDATED`, via
-  the existing `minimize-superseded-markers.mjs`, reusing
-  `matchCanonicalAuthoringMarkerFamily` unchanged) every byte-exact
-  canonical match that is not the newest **trusted-actor** match for its
-  family, exactly as the opportunistic per-post step above does.
-  **Fetch that paginated log via GraphQL, never a plain REST
-  issue-comments fetch, and skip an already-minimized candidate before
-  submitting it** (#2896 review, Codex): a GraphQL `issueComments` /
-  `comments` query can select `isMinimized` on each node directly,
-  while REST's issue-comments endpoint never carries that field at
-  all, so a REST-fetched snapshot cannot distinguish a comment this
-  sweep already cleared from one it never touched. Use that field to
-  exclude any candidate already `isMinimized: true` **before** it ever
-  reaches the minimize helper's `--subject-ids`, not only when
-  auditing the result afterward. Without this, every historical
-  byte-exact canonical comment on a long-lived shared journal (one can
-  accumulate hundreds over time) gets resubmitted to
-  `minimize-superseded-markers.mjs` on every single sweep invocation
-  across every target, and that helper probes each subject ID serially
-  with no overall deadline -- a degraded GitHub API can then consume
-  its per-call timeout once per historical comment and stall release
-  for many minutes despite the attempted-not-blocking framing below.
-  **Also pass `--deadline-ms`** (#2896 review, Codex, round 8) to
-  every `minimize-superseded-markers.mjs` invocation this sweep makes
-  -- for example `--deadline-ms 300000` (five minutes) -- as a second,
-  independent bound: the `isMinimized` pre-filter above only skips
-  already-cleared candidates cheaply, but a first-ever sweep of a
-  large backlog can still submit many genuinely-not-yet-minimized
-  candidates that each cost a real GitHub API round-trip, and without
-  `--deadline-ms` each one can individually consume the helper's own
-  per-call timeout with no overall cap.
+  **Mandatory release-time hide-on-supersede sweep (#2896, #2935).** At
+  this same point -- before the reuse-or-append decision below, so a
+  retried or resumed release (which reuses an existing `release` marker
+  and never appends a new one) still runs the sweep every time this
+  preflight step is reached -- run the single fetch-driven sweep command
+  against the target issue and the journal issue named in this session's
+  own records:
 
-  Determine "newest" only among candidates from a trusted marker actor
-  (#2896 review, Codex), never from every structural match
-  indiscriminately -- an untrusted actor's byte-exact canonical comment
-  posted after the real newest trusted one must never be treated as the
-  thing to keep visible: `minimize-superseded-markers.mjs` itself
-  refuses to minimize any comment outside `--trusted-marker-logins`
-  regardless of this selection, so naively treating the untrusted
-  comment as newest would instead select the legitimate trusted marker
-  for minimization -- exactly backwards. This mirrors
-  `checkAuthoringMarkerMinimizationBacklog`'s own audit-side fix; keep
-  the two in sync. Attempt this once per target
-  here, and once more on the anchor immediately before the
-  release-complete preflight below; this is the sweep the contract
-  depends on, but "mandatory" means **attempted**, not
-  blocking -- a failed attempt (permission error, an unreadable comment
-  list, or an unavailable helper runtime) skips silently and never stops
-  release, matching the opportunistic step's own best-effort framing. See
-  the **Closing sweep** bullet below for the third sweep point this
-  preflight sweep alone does not cover, and for the explicit
+  ```sh
+  node scripts/sweep-authoring-markers.mjs --issue <target-issue-number> \
+    --issue <journal-issue-number> \
+    --trusted-marker-logins <trusted-login-1,...> \
+    --deadline-ms 300000 --apply
+  ```
+
+  Or, for npx/package-manager profiles, the equivalent
+  `idd-sweep-authoring-markers` command. One invocation performs the
+  whole sweep that used to be an ~8-step manual procedure (#2935): it
+  fetches each `--issue`'s comments via GraphQL (selecting `isMinimized`
+  directly -- REST's issue-comments endpoint never carries that field,
+  so this command never falls back to REST), classifies every comment
+  with `matchCanonicalAuthoringMarkerFamily` (`marker-helpers.mts`,
+  unchanged), determines "newest" only among **trusted-actor** matches
+  per family (#2896 review, Codex -- an untrusted actor's later
+  byte-exact comment must never be mistaken for the live marker to keep,
+  since `minimize-superseded-markers.mjs` itself refuses to minimize any
+  comment outside `--trusted-marker-logins` regardless of this
+  selection, so wrongly treating the untrusted comment as newest would
+  instead select the legitimate trusted marker for minimization --
+  exactly backwards; mirrors `checkAuthoringMarkerMinimizationBacklog`'s
+  own audit-side rule -- the two share one implementation,
+  `classifyAuthoringMarkerFamily` in `marker-helpers.mts`, so they cannot
+  drift), excludes any candidate already `isMinimized: true`, and
+  minimizes (classifier `OUTDATED`) every remaining eligible candidate in
+  one mutation pass -- reusing `minimize-superseded-markers.mjs`'s own
+  `runMinimize` rather than reimplementing the mutation. `--deadline-ms`
+  bounds the WHOLE invocation (every `--issue`'s own GraphQL pagination
+  plus the final minimize pass, for example `--deadline-ms 300000` --
+  five minutes), guarding against the same degraded-GitHub-API risk a
+  large, long-lived shared journal's full history would otherwise pose.
+
+  Attempt this once per target here, and once more on the anchor
+  immediately before the release-complete preflight below; this is the
+  sweep the contract depends on, but "mandatory" means **attempted**, not
+  blocking -- a failed invocation (permission error, an unreadable
+  comment list, or an unavailable helper runtime) skips silently and
+  never stops release, matching the opportunistic step's own best-effort
+  framing. See the **Closing sweep** bullet below for the third sweep
+  point this preflight sweep alone does not cover, and for the explicit
   `authoring-marker-minimization-backlog` invocation that makes each
   sweep attempt's outcome a visible, countable signal instead of silence.
   If a valid current-owner/set `mode=release` marker already exists, reuse the
@@ -1716,7 +1708,9 @@ only approval boundary.
   marker, absent label, and expected body snapshot; any drift leaves the set
   open and prevents completion. Immediately before the release-complete
   reuse-or-append decision below, repeat the same mandatory sweep once
-  more on the anchor's own owner-marker log and the journal's
+  more -- the same `sweep-authoring-markers.mjs` command above, now
+  scoped to `--issue <anchor-issue-number> --issue <journal-issue-number>`
+  -- covering the anchor's own owner-marker log and the journal's
   publication-intent log -- idempotent with every earlier target's own
   sweep above, since a comment either was already minimized or was not
   yet the newest for its family either way. Then reuse the earliest
@@ -1745,11 +1739,11 @@ only approval boundary.
   record a set-level recovery hold and never claim a partial release. Release
   is a human action; nothing in this bundle auto-releases a held issue set,
   except the narrow, marker-scoped exception immediately below.
-- **Closing sweep (after Stage 2 closes, #2896 review, Codex).** The two
-  sweep points above run _before_ Stage 2's own later marker appends for
-  the same generation -- the per-target `release` marker, the
-  pre-label-removal heartbeat each target receives immediately before
-  its own label removal, and (on the anchor) `release-guard` and
+- **Closing sweep (after Stage 2 closes, #2896 review, Codex; #2935).**
+  The two sweep points above run _before_ Stage 2's own later marker
+  appends for the same generation -- the per-target `release` marker,
+  the pre-label-removal heartbeat each target receives immediately
+  before its own label removal, and (on the anchor) `release-guard` and
   `release-complete` itself. None of those markers exist yet when their
   target's preflight sweep runs, so the preflight sweep(s) alone can
   never clear them, and a target's Stage 2 for a given generation runs
@@ -1757,13 +1751,21 @@ only approval boundary.
   revisit them. Once the set-level release actually closes (the
   successful-close branch immediately above: the trusted
   `release-complete` marker is found and every label is confirmed
-  absent), attempt the mandatory sweep one more time: paginate every
-  target's now-final owner-marker log (the anchor's included this time,
-  not just its own) and the journal's publication-intent log, and
-  minimize every byte-exact canonical match that is not the newest for
-  its family, exactly as the preflight sweeps above do. Same
-  attempted-not-blocking framing: a failed attempt here does not reopen
-  the set or roll back the close already recorded above.
+  absent), attempt the mandatory sweep one more time, in a single
+  invocation covering every target's now-final owner-marker log (the
+  anchor's included this time, not just its own) and the journal's
+  publication-intent log:
+
+  ```sh
+  node scripts/sweep-authoring-markers.mjs --issue <target-1> \
+    --issue <target-2> ... --issue <anchor-issue-number> \
+    --issue <journal-issue-number> \
+    --trusted-marker-logins <trusted-login-1,...> \
+    --deadline-ms 300000 --apply
+  ```
+
+  Same attempted-not-blocking framing: a failed invocation here does not
+  reopen the set or roll back the close already recorded above.
 
   **Make every sweep attempt's outcome visible.** Immediately after each
   of the three sweep attempts in this section (per-target preflight,
@@ -1789,12 +1791,13 @@ only approval boundary.
   `--trusted-marker-logins` (that overstates; this understates to
   nothing).
   **Feed it the sweep's own post-mutation result, never the
-  pre-mutation snapshot the sweep read.** The minimize helper mutates
-  GitHub directly; it never updates an in-memory or on-disk comment
+  pre-mutation snapshot the sweep read.** The minimize mutation applies
+  directly to GitHub; it never updates an in-memory or on-disk comment
   snapshot. Before running the check, update the just-fetched snapshot's
-  `isMinimized` field to `true` for every candidate the minimize
-  helper's own report (`minimize-superseded-markers.mjs`'s `items[]`,
-  keyed by subject id) lists with **either** `status: "applied"` **or**
+  `isMinimized` field to `true` for every candidate the sweep command's
+  own report (`sweep-authoring-markers.mjs`'s `items[]`, each entry
+  tagged with the family it belongs to and keyed by subject id) lists
+  with **either** `status: "applied"` **or**
   `status: "skipped", reason: "already-minimized"` -- the latter fires
   whenever the fetched snapshot's own `isMinimized` was already stale or
   absent for a comment GitHub already considers minimized (for example

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -1644,8 +1644,16 @@ only approval boundary.
     --issue <journal-issue-number> \
     --marker-prefix <resolved-target-prefix> \
     --trusted-marker-logins <trusted-login-1,...> \
-    --deadline-ms 300000 --apply
+    --deadline-ms 300000 --apply || true
   ```
+
+  The trailing `|| true` keeps this step's own non-zero exit (a fetch or
+  mutation failure) from aborting an automated `set -e` release script:
+  the sweep's exit code exists for a caller that wants to check its
+  outcome directly, not to make this attempted-not-blocking step itself
+  block release when run inline (#2935 review, round 5, Copilot) --
+  read the sweep's own JSON/table report, not its exit status, to see
+  whether anything needs a human look.
 
   The journal setting can itself name a **different** repository (a
   full `owner/repo#number` reference); when it does, pass that shape to
@@ -1769,11 +1777,12 @@ only approval boundary.
     --issue <journal-issue-number-or-owner/repo#number> \
     --marker-prefix <resolved-target-prefix> \
     --trusted-marker-logins <trusted-login-1,...> \
-    --deadline-ms 300000 --apply
+    --deadline-ms 300000 --apply || true
   ```
 
-  Same attempted-not-blocking framing: a failed invocation here does not
-  reopen the set or roll back the close already recorded above.
+  Same attempted-not-blocking framing (and the same `|| true` reasoning
+  above): a failed invocation here does not reopen the set or roll back
+  the close already recorded above.
 
   **Make every sweep attempt's outcome visible.** Immediately after each
   of the three sweep attempts in this section (per-target preflight,

--- a/src/bin/idd-sweep-authoring-markers.mts
+++ b/src/bin/idd-sweep-authoring-markers.mts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-sweep-authoring-markers.mts
+//
+// The bin/idd-sweep-authoring-markers.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+
+import { runHelper } from './run-helper.mts';
+
+runHelper('../scripts/sweep-authoring-markers.mjs');

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -58,7 +58,7 @@ import type {
   ParsedAuthoringPublicationMarker,
 } from './marker-helpers.mts';
 import {
-  matchCanonicalAuthoringMarkerFamily,
+  classifyAuthoringMarkerFamily,
   parseAuthoringOwnerComment,
   parseAuthoringPublicationComment,
   parseAuthoringPublicationIntentComment,
@@ -1770,6 +1770,14 @@ function checkAuthoringOwnerMarkerTrail(
  * fewer than two (trust-filtered, when applicable) candidates exist
  * (nothing can be "superseded" without a later candidate to supersede
  * it).
+ *
+ * Delegates the actual classification to {@link classifyAuthoringMarkerFamily}
+ * (`marker-helpers.mts`, extracted in #2935 alongside `sweep-authoring-
+ * markers.mts`'s fetch-driven sweep, which needs the same newest-per-
+ * family/trust/already-minimized rule but returns the eligible comments
+ * themselves, not just a count) -- kept as a thin count-only wrapper here
+ * so this module's public surface and every existing caller are
+ * unaffected.
  */
 function countEligibleSupersededMarkers(
   comments: readonly AuthoringCommentInput[] | undefined,
@@ -1780,39 +1788,12 @@ function countEligibleSupersededMarkers(
   if (comments === undefined) {
     return 0;
   }
-  const matchIndexes: number[] = [];
-  comments.forEach((comment, index) => {
-    if (
-      matchCanonicalAuthoringMarkerFamily(comment.body, markerPrefix) !== family
-    ) {
-      return;
-    }
-    if (trustedActors !== undefined) {
-      const author = comment.author;
-      if (
-        typeof author !== 'string' ||
-        !trustedActors.has(author.toLowerCase())
-      ) {
-        // Not a real candidate at all when a trust set is supplied:
-        // never counted, and never eligible to be selected as "newest"
-        // either -- syntax alone never grants ownership.
-        return;
-      }
-    }
-    matchIndexes.push(index);
-  });
-  if (matchIndexes.length < 2) {
-    return 0;
-  }
-  const newestIndex = matchIndexes[matchIndexes.length - 1];
-  let count = 0;
-  for (const index of matchIndexes) {
-    if (index === newestIndex || comments[index].isMinimized === true) {
-      continue;
-    }
-    count += 1;
-  }
-  return count;
+  return classifyAuthoringMarkerFamily(
+    comments,
+    markerPrefix,
+    family,
+    trustedActors,
+  ).eligibleIndexes.length;
 }
 
 /**

--- a/src/scripts/gh-exec.mts
+++ b/src/scripts/gh-exec.mts
@@ -83,6 +83,14 @@ export interface GhTextOptions {
    * conflict (CodeRabbit review, #1784).
    */
   input?: string;
+  /**
+   * Override the per-stream buffer cap (bytes), mirroring
+   * {@link GhTextAsyncOptions.maxBuffer}. `execFileSync`'s own default is
+   * 1 MiB; a caller expecting a larger response (a paginated GraphQL page
+   * with many or long comments, for example) raises this explicitly
+   * rather than risking an `ENOBUFS` failure (#2935 review, Codex).
+   */
+  maxBuffer?: number;
 }
 
 /**
@@ -121,6 +129,9 @@ export function ghText(args: string[], options: GhTextOptions = {}): string {
     timeout: options.timeout ?? DEFAULT_GH_TIMEOUT_MS,
     ...(options.stdio ? { stdio: options.stdio } : {}),
     ...(options.input !== undefined ? { input: options.input } : {}),
+    ...(options.maxBuffer !== undefined
+      ? { maxBuffer: options.maxBuffer }
+      : {}),
   }).trim();
 }
 

--- a/src/scripts/gh-exec.mts
+++ b/src/scripts/gh-exec.mts
@@ -17,6 +17,15 @@
 
 import type { StdioOptions } from 'node:child_process';
 import { execFile, execFileSync } from 'node:child_process';
+import {
+  closeSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { promisify } from 'node:util';
 
@@ -133,6 +142,51 @@ export function ghText(args: string[], options: GhTextOptions = {}): string {
       ? { maxBuffer: options.maxBuffer }
       : {}),
   }).trim();
+}
+
+/**
+ * Sibling of {@link ghText} for a response with no safely-guessable size
+ * ceiling (#2935 review, rounds 4-6): a fixed `maxBuffer` for a large
+ * paginated GraphQL page turned into an escalating, never-fully-provable
+ * guessing game (an initial 10 MiB estimate, then a "proven" 25 MiB
+ * worst-case calculation from GitHub's 65,536-character comment cap and
+ * UTF-8's 4-bytes-per-character ceiling, then a further finding that the
+ * calculation still did not account for `\uXXXX` JSON-escaping, which can
+ * cost up to 12 bytes per character) -- each fix removed one gap but
+ * could not close the class of problem, since the true worst case
+ * depends on exactly how the response is serialized, which this codebase
+ * does not control and should not need to reverse-engineer. This
+ * function removes the ceiling-guessing problem entirely instead of
+ * refining the guess further: it redirects the child process's stdout
+ * directly to a temp file (never through an in-memory pipe with a fixed
+ * cap) and reads that file back, so the only limit is available disk
+ * space -- a categorically different, non-adversarial-input concern.
+ *
+ * Deliberately minimal compared to {@link ghText}: no `stdio`/`input`
+ * override support, since no current caller needs stdin or a custom
+ * stdio shape for a call whose defining trait is "the output size is not
+ * safely boundable" -- add that support only if a real caller needs it.
+ */
+export function ghTextUnbounded(
+  args: string[],
+  options: Pick<GhTextOptions, 'timeout'> = {},
+): string {
+  const dir = mkdtempSync(join(tmpdir(), 'gh-exec-unbounded-'));
+  const outPath = join(dir, 'stdout');
+  try {
+    const fd = openSync(outPath, 'w');
+    try {
+      execFileSync('gh', args, {
+        stdio: ['ignore', fd, 'pipe'],
+        timeout: options.timeout ?? DEFAULT_GH_TIMEOUT_MS,
+      });
+    } finally {
+      closeSync(fd);
+    }
+    return readFileSync(outPath, 'utf8').trim();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 }
 
 /** {@link ghText}, swallowing any failure and returning `''` instead. */

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -650,6 +650,15 @@ const HELPER_COMMANDS: HelperCommand[] = [
     description:
       'Evaluate A4.5 suitability checks and map deterministic outcomes.',
   },
+  {
+    id: 'sweep-authoring-markers',
+    scriptName: 'idd:sweep-authoring-markers',
+    binName: 'idd-sweep-authoring-markers',
+    entryPath: 'scripts/sweep-authoring-markers.mjs',
+    vendoredCommand: 'node scripts/sweep-authoring-markers.mjs',
+    description:
+      'Fetch-driven hide-on-supersede sweep for authoring-owner / authoring-publication-intent markers: fetches one or more issues via GraphQL, classifies and filters superseded candidates, and minimizes them via minimize-superseded-markers.mjs.',
+  },
 ];
 
 /**

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -2085,6 +2085,139 @@ export function matchCanonicalAuthoringMarkerFamily(
   return null;
 }
 
+export type AuthoringMarkerFamily =
+  | 'authoring-owner'
+  | 'authoring-publication-intent';
+
+/** One comment as {@link classifyAuthoringMarkerFamily} needs it -- the
+ * narrowest shape common to both of its callers (#2935): `audit-authored-
+ * issue.mts`'s network-free `AuthoringCommentInput` and `sweep-authoring-
+ * markers.mts`'s GraphQL-fetched candidates each carry additional fields
+ * this function never reads. */
+export interface AuthoringMarkerCandidateInput {
+  body: string;
+  author?: string;
+  isMinimized?: boolean;
+}
+
+/**
+ * Result of classifying `comments` against one marker `family` for the
+ * hide-on-supersede sweep (#2935; extracted from `audit-authored-
+ * issue.mts`'s original `countEligibleSupersededMarkers`, which returned
+ * only `eligibleIndexes.length`, so the two never drift on this rule).
+ * Every field is an array of INDEXES into the original `comments` array,
+ * not comments themselves, so a caller that needs the full comment (e.g.
+ * to resolve a GraphQL node id for the minimize mutation) can index back
+ * into its own array.
+ */
+export interface AuthoringMarkerFamilyClassification {
+  /** Byte-exact canonical matches for `family`, in input order, regardless
+   * of trust or minimization state. */
+  matchIndexes: number[];
+  /** Subset of {@link matchIndexes} authored by a member of
+   * `trustedActors` (case-insensitive); equal to `matchIndexes` when
+   * `trustedActors` is `undefined` (trust filtering disabled). */
+  trustedMatchIndexes: number[];
+  /** The single newest (last, in input order) entry of
+   * {@link trustedMatchIndexes} -- the one live marker this sweep must
+   * never minimize -- or `null` when fewer than two trusted matches exist
+   * (nothing can be "superseded" without a later candidate). */
+  newestTrustedIndex: number | null;
+  /** {@link trustedMatchIndexes} minus {@link newestTrustedIndex}, further
+   * excluding any candidate whose `isMinimized` is already `true`: the
+   * actual hide-on-supersede backlog. */
+  eligibleIndexes: number[];
+  /** {@link trustedMatchIndexes} minus {@link newestTrustedIndex} that are
+   * already `isMinimized: true` -- not backlog, already handled. */
+  alreadyMinimizedIndexes: number[];
+  /** {@link matchIndexes} excluded from {@link trustedMatchIndexes} because
+   * their author is missing or not a member of `trustedActors`. Always
+   * empty when `trustedActors` is `undefined`: syntax alone never grants
+   * ownership, so this set is only meaningful once a trust policy is
+   * actually supplied. */
+  untrustedIndexes: number[];
+}
+
+/**
+ * Classify `comments` for exactly one authoring marker `family` (#2935):
+ * find every byte-exact canonical match
+ * (`matchCanonicalAuthoringMarkerFamily`), determine the newest match
+ * among trusted-actor authors only (per the contract's "syntax alone
+ * never grants ownership" rule -- an untrusted actor's later byte-exact
+ * comment must never be mistaken for the live marker to keep), and split
+ * the rest into eligible-for-minimization vs. already-minimized.
+ * `family` is matched against the RAW `comment.body` (never
+ * `stripMarkdownCodeRegions`-masked), matching exactly what a live
+ * `matchCanonicalAuthoringMarkerFamily` call against the real comment
+ * would see. `trustedActors` left `undefined` disables trust filtering
+ * entirely (every byte-exact match counts as a candidate regardless of
+ * author) -- callers that need an author-trust-filtered result (both
+ * current callers do) must pass a `Set` of lowercase logins.
+ */
+export function classifyAuthoringMarkerFamily(
+  comments: readonly AuthoringMarkerCandidateInput[],
+  markerPrefix: string,
+  family: AuthoringMarkerFamily,
+  trustedActors: ReadonlySet<string> | undefined,
+): AuthoringMarkerFamilyClassification {
+  const matchIndexes: number[] = [];
+  const untrustedIndexes: number[] = [];
+  comments.forEach((comment, index) => {
+    if (
+      matchCanonicalAuthoringMarkerFamily(comment.body, markerPrefix) !== family
+    ) {
+      return;
+    }
+    matchIndexes.push(index);
+    if (trustedActors !== undefined) {
+      const author = comment.author;
+      if (
+        typeof author !== 'string' ||
+        !trustedActors.has(author.toLowerCase())
+      ) {
+        untrustedIndexes.push(index);
+      }
+    }
+  });
+  const untrustedSet = new Set(untrustedIndexes);
+  const trustedMatchIndexes =
+    trustedActors === undefined
+      ? matchIndexes
+      : matchIndexes.filter((index) => !untrustedSet.has(index));
+  if (trustedMatchIndexes.length < 2) {
+    return {
+      matchIndexes,
+      trustedMatchIndexes,
+      newestTrustedIndex: null,
+      eligibleIndexes: [],
+      alreadyMinimizedIndexes: [],
+      untrustedIndexes,
+    };
+  }
+  const newestTrustedIndex =
+    trustedMatchIndexes[trustedMatchIndexes.length - 1];
+  const eligibleIndexes: number[] = [];
+  const alreadyMinimizedIndexes: number[] = [];
+  for (const index of trustedMatchIndexes) {
+    if (index === newestTrustedIndex) {
+      continue;
+    }
+    if (comments[index].isMinimized === true) {
+      alreadyMinimizedIndexes.push(index);
+    } else {
+      eligibleIndexes.push(index);
+    }
+  }
+  return {
+    matchIndexes,
+    trustedMatchIndexes,
+    newestTrustedIndex,
+    eligibleIndexes,
+    alreadyMinimizedIndexes,
+    untrustedIndexes,
+  };
+}
+
 // --- Per-cycle marker body renderers (#900) ---
 //
 // Pure, network-free renderers for the three operational markers an agent

--- a/src/scripts/sweep-authoring-markers.mts
+++ b/src/scripts/sweep-authoring-markers.mts
@@ -203,15 +203,34 @@ interface SweepGraphqlCommentsPayload {
 /**
  * Per-call `execFileSync` output-buffer cap for
  * {@link fetchIssueCommentsGraphql}'s own `gh api graphql` calls (#2935
- * review, Codex): `ghText`'s (and Node's `execFileSync`'s) own default is
- * 1 MiB per stream, which a 100-comment page can exceed once several
- * comments carry long discussion bodies -- silently turning a real page
- * of data into an `ENOBUFS` fetch failure that then drops that issue's
- * comments (and every superseded marker on it) from this sweep entirely.
- * 10 MiB matches this codebase's own existing precedent for the same
- * class of risk (`GH_ASYNC_MAX_BUFFER`, `provider-adapter-github.mts`).
+ * review, rounds 4-5, Codex): `ghText`'s (and Node's `execFileSync`'s)
+ * own default is 1 MiB per stream, which a 100-comment page can exceed
+ * once several comments carry long discussion bodies -- silently
+ * turning a real page of data into an `ENOBUFS` fetch failure that then
+ * drops that issue's comments (and every superseded marker on it) from
+ * this sweep entirely.
+ *
+ * An initial 10 MiB estimate (matching `GH_ASYNC_MAX_BUFFER`,
+ * `provider-adapter-github.mts`'s own unrelated precedent) drew a
+ * further round of review pushing back that 10 MiB is still not a
+ * PROVEN bound. This value replaces that estimate with an actual
+ * worst-case calculation instead of a bigger guess, so a further
+ * "still not big enough" round has no remaining basis: GitHub caps a
+ * single issue/PR comment body at 65,536 characters, and UTF-8 (the
+ * encoding `gh`'s JSON output uses) never spends more than 4 bytes per
+ * character, so one comment's `body` field cannot exceed
+ * `65_536 * 4 = 262_144` bytes regardless of content. `comments(first:
+ * 100, ...)` below never returns more than 100 nodes per page, and this
+ * query's other per-node fields (`id`, `url`, `isMinimized`,
+ * `createdAt`, `author.login`) and JSON structural overhead (quotes,
+ * commas, key names) add at most a few hundred bytes per node --
+ * generously rounded up to 500 bytes/node here. The true worst case for
+ * one page is therefore bounded at
+ * `100 * (262_144 + 500) = 26_264_400` bytes (~25 MiB); this constant
+ * rounds that up to a clean 32 MiB, comfortably above the proven
+ * ceiling rather than merely "probably enough."
  */
-const LARGE_COMMENT_PAGE_MAX_BUFFER = 10 * 1024 * 1024;
+const LARGE_COMMENT_PAGE_MAX_BUFFER = 32 * 1024 * 1024;
 
 /**
  * Fetch every comment on `owner/repo#issueNumber` via a paginated GraphQL

--- a/src/scripts/sweep-authoring-markers.mts
+++ b/src/scripts/sweep-authoring-markers.mts
@@ -50,13 +50,19 @@
 // markers.mjs`'s own possible non-zero exit -- non-blocking.
 //
 // Scope: `authoring-owner` and `authoring-publication-intent` only, same as
-// the sweep it replaces. Every `--issue` given is scanned in the SAME
-// `--owner`/`--repo` (defaulting to the current repository) -- this script
-// does not parse a cross-repo `owner/repo#N` shorthand for `--issue`,
-// matching every other single-repo `--issue <number>` helper in this
-// codebase (`authoring-owner-provenance.mts`, `suitability-close-
-// execute.mts`); a caller sweeping a cross-repo journal passes its own
-// `--owner`/`--repo` in a separate invocation.
+// the sweep it replaces. A bare `--issue <number>` is scanned in the
+// invocation's default `--owner`/`--repo` (the global flags, or the
+// current repository when neither is given, matching every other
+// single-repo `--issue <number>` helper in this codebase --
+// `authoring-owner-provenance.mts`, `suitability-close-execute.mts`);
+// an explicit `--issue owner/repo#number` is scanned in ITS OWN
+// owner/repo instead (#2935 review, Codex and Copilot: the contract's
+// `issueAuthoring.journalIssue` can itself be a cross-repository
+// reference, so a single-repo-only design could never sweep it
+// correctly, and worse, could silently mutate an unrelated
+// same-numbered issue in the wrong repository under `--apply`). One
+// invocation can freely mix same-repo and cross-repository `--issue`
+// targets.
 
 import { parseCanonicalIntegerOrThrow, parseCliArgs } from './cli-args.mts';
 import { ghText } from './gh-exec.mts';
@@ -80,6 +86,73 @@ const AUTHORING_MARKER_FAMILIES: readonly AuthoringMarkerFamily[] = [
   'authoring-owner',
   'authoring-publication-intent',
 ];
+
+/** One resolved `--issue` target: the repository to fetch from plus the
+ * issue number (#2935 review, Codex and Copilot both independently
+ * flagged the original single-repo-per-invocation design as unable to
+ * correctly sweep a cross-repository `issueAuthoring.journalIssue`
+ * reference -- worse, applying the wrong owner/repo to a same-numbered
+ * issue in an unrelated repository could silently minimize markers
+ * there while still reporting success). Every `--issue` now resolves to
+ * one of these independently, so a single invocation can mix a
+ * same-repo target with a cross-repo journal. */
+export interface SweepIssueTarget {
+  owner: string;
+  repo: string;
+  issue: number;
+}
+
+/** Matches the explicit cross-repository `owner/repo#number` shorthand for
+ * one `--issue` token -- the same `owner`/`repo` character class GitHub
+ * itself allows (letters, digits, `.`, `_`, `-`, never leading/trailing
+ * `-` or `.`-only). A token that contains `/` or `#` but does not match
+ * this shape is a likely typo, not a bare issue number -- callers get a
+ * specific error instead of a confusing `--issue` parse failure. */
+const CROSS_REPO_ISSUE_TOKEN_PATTERN =
+  /^([A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)\/([A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)#([1-9]\d*)$/;
+
+/** `true` when `token` is the explicit `owner/repo#number` cross-repository
+ * shorthand -- used before any I/O to decide whether this invocation
+ * needs the current repository at all (a caller sweeping only
+ * cross-repo-qualified issues never needs it). */
+export function isCrossRepoIssueToken(token: string): boolean {
+  return CROSS_REPO_ISSUE_TOKEN_PATTERN.test(token);
+}
+
+/**
+ * Resolve one `--issue` token to a {@link SweepIssueTarget}: the explicit
+ * `owner/repo#number` shorthand resolves to its own owner/repo,
+ * independent of `defaultOwner`/`defaultRepo`; a bare positive-integer
+ * token resolves against `defaultOwner`/`defaultRepo` (the global
+ * `--owner`/`--repo`, or the current repository when neither is given).
+ * Throws a specific error for a token that contains `/` or `#` but does
+ * not match the cross-repo shape (a likely typo), rather than letting it
+ * fall through to the bare-integer parser's own generic message.
+ */
+export function parseIssueTargetToken(
+  token: string,
+  defaultOwner: string,
+  defaultRepo: string,
+): SweepIssueTarget {
+  const crossRepoMatch = CROSS_REPO_ISSUE_TOKEN_PATTERN.exec(token);
+  if (crossRepoMatch) {
+    return {
+      owner: crossRepoMatch[1],
+      repo: crossRepoMatch[2],
+      issue: Number.parseInt(crossRepoMatch[3], 10),
+    };
+  }
+  if (token.includes('/') || token.includes('#')) {
+    throw new Error(
+      `--issue "${token}" looks like a cross-repository reference but does not match owner/repo#number`,
+    );
+  }
+  return {
+    owner: defaultOwner,
+    repo: defaultRepo,
+    issue: parseCanonicalIntegerOrThrow(token, '--issue'),
+  };
+}
 
 /** One issue comment as fetched via GraphQL -- `isMinimized` is the field
  * REST's issue-comments endpoint never carries, which is why this script
@@ -342,9 +415,11 @@ const DEFAULT_DEPS: AuthoringMarkerSweepDeps = {
 };
 
 export interface AuthoringMarkerSweepOptions {
-  owner: string;
-  repo: string;
-  issues: readonly number[];
+  /** Each target's own owner/repo/issue (#2935 review): a bare `--issue`
+   * number and an explicit cross-repository `owner/repo#number` reference
+   * can both appear in the same invocation, so there is no single
+   * invocation-wide owner/repo any more -- see {@link SweepIssueTarget}. */
+  issues: readonly SweepIssueTarget[];
   markerPrefix: string;
   classifier: string;
   trustedSet: ReadonlySet<string>;
@@ -390,13 +465,13 @@ export function runAuthoringMarkerSweep(
   const issues: AuthoringMarkerSweepIssueResult[] = [];
   const subjectFamilies = new Map<string, AuthoringMarkerFamily>();
 
-  for (const issueNumber of options.issues) {
+  for (const target of options.issues) {
     const budget = remaining();
     if (budget !== undefined && budget <= 0) {
       issues.push({
-        owner: options.owner,
-        repo: options.repo,
-        issue: issueNumber,
+        owner: target.owner,
+        repo: target.repo,
+        issue: target.issue,
         commentCount: 0,
         nonCanonical: 0,
         error: 'deadline-exceeded',
@@ -406,16 +481,16 @@ export function runAuthoringMarkerSweep(
     let comments: SweepGraphqlComment[];
     try {
       comments = deps.fetchIssueComments(
-        options.owner,
-        options.repo,
-        issueNumber,
+        target.owner,
+        target.repo,
+        target.issue,
         budget,
       );
     } catch (error) {
       issues.push({
-        owner: options.owner,
-        repo: options.repo,
-        issue: issueNumber,
+        owner: target.owner,
+        repo: target.repo,
+        issue: target.issue,
         commentCount: 0,
         nonCanonical: 0,
         error: (error as Error).message,
@@ -440,9 +515,9 @@ export function runAuthoringMarkerSweep(
       }
     }
     issues.push({
-      owner: options.owner,
-      repo: options.repo,
-      issue: issueNumber,
+      owner: target.owner,
+      repo: target.repo,
+      issue: target.issue,
       commentCount: comments.length,
       nonCanonical,
     });
@@ -589,7 +664,12 @@ export function computeSweepExitCode(
 // ---------------------------------------------------------------------------
 
 interface SweepCliArgs {
-  issues: number[];
+  /** Raw `--issue` tokens, not yet resolved: resolving a bare number
+   * against the right default owner/repo needs `resolveCurrentGithub
+   * Repository()`, an I/O call this pure parse step must not make (only
+   * `main()` below, after validating everything else, decides whether
+   * that call is even needed). */
+  issueTokens: string[];
   owner: string;
   repo: string;
   markerPrefix: string;
@@ -624,9 +704,22 @@ function parseArgs(argv: string[]): SweepCliArgs {
   );
 
   const issueTokens = (values.issue as string[] | undefined) ?? [];
-  const issues = issueTokens.map((token) =>
-    parseCanonicalIntegerOrThrow(token, '--issue'),
-  );
+
+  const owner = ((values.owner as string) ?? '').trim();
+  const repo = ((values.repo as string) ?? '').trim();
+  // #2935 review (Codex and Copilot both, independently): exactly one of
+  // --owner/--repo would mix a caller-supplied repo with
+  // resolveCurrentGithubRepository()'s current-directory repo for every
+  // bare-number --issue, potentially sweeping (and, under --apply,
+  // mutating) an unrelated same-numbered issue in the wrong repository.
+  // Mirrors authoring-owner-provenance.mts's and suitability-close-
+  // execute.mts's own --owner/--repo pairing guard: require both or
+  // neither.
+  if ((owner === '') !== (repo === '')) {
+    throw new Error(
+      'sweep-authoring-markers: --owner and --repo must be provided together or not at all',
+    );
+  }
 
   let deadlineMs: number | undefined;
   if (values['deadline-ms'] !== undefined) {
@@ -642,9 +735,9 @@ function parseArgs(argv: string[]): SweepCliArgs {
   }
 
   return {
-    issues,
-    owner: (values.owner as string) ?? '',
-    repo: (values.repo as string) ?? '',
+    issueTokens,
+    owner,
+    repo,
     markerPrefix: (values['marker-prefix'] as string) ?? '',
     classifier: (values.classifier as string) ?? 'OUTDATED',
     trustedMarkerLogins: (values['trusted-marker-logins'] as string) ?? '',
@@ -694,7 +787,7 @@ function printTable(report: AuthoringMarkerSweepReport): void {
 
 function printUsage(): void {
   console.log(
-    `Usage: sweep-authoring-markers --issue <number> [--issue <number> ...] [--owner <owner>] [--repo <repo>] [--marker-prefix <prefix>] [--classifier OUTDATED|RESOLVED] --trusted-marker-logins <login1,login2> [--apply] [--format json|table] [--deadline-ms <milliseconds>]
+    `Usage: sweep-authoring-markers --issue <number|owner/repo#number> [--issue ...] [--owner <owner>] [--repo <repo>] [--marker-prefix <prefix>] [--classifier OUTDATED|RESOLVED] --trusted-marker-logins <login1,login2> [--apply] [--format json|table] [--deadline-ms <milliseconds>]
 
 Fetch-driven hide-on-supersede sweep for authoring-owner /
 authoring-publication-intent markers (#2935): fetches each --issue's
@@ -708,9 +801,14 @@ reusing minimize-superseded-markers.mts's own runMinimize.
 Pass one --issue per target to sweep (the per-target preflight and the
 anchor-before-release-complete sweep points each pass one; the closing
 sweep passes every target plus the anchor and the journal issue in the
-same invocation). Every --issue is scanned in the same --owner/--repo
-(defaulting to the current repository); this command does not accept a
-cross-repo owner/repo#N shorthand.
+same invocation). A bare --issue <number> is scanned in --owner/--repo
+(defaulting to the current repository); an explicit --issue
+<owner/repo#number> is scanned in ITS OWN owner/repo instead, so one
+invocation can mix a same-repo target with a cross-repository
+issueAuthoring.journalIssue (#2935 review, Codex and Copilot). --owner
+and --repo must be given together or not at all -- supplying only one
+would otherwise silently mix a caller-supplied repo with the current
+directory's repo for every bare-number --issue.
 
 The trusted-author gate is mandatory, matching minimize-superseded-
 markers.mjs: supply --trusted-marker-logins, IDD_TRUSTED_MARKER_ACTORS, or
@@ -759,7 +857,7 @@ if (import.meta.main) {
     process.exit(2);
   }
 
-  if (args.issues.length === 0) {
+  if (args.issueTokens.length === 0) {
     console.error('error: --issue must be supplied at least once');
     process.exit(2);
   }
@@ -778,16 +876,33 @@ if (import.meta.main) {
     process.exit(2);
   }
 
-  const currentRepo =
-    args.owner && args.repo ? null : resolveCurrentGithubRepository();
-  const owner = args.owner || currentRepo?.owner || '';
-  const repo = args.repo || currentRepo?.repo || '';
+  // Only resolve the current repository when at least one --issue token
+  // actually needs it as a default (#2935 review): an invocation sweeping
+  // only explicit owner/repo#number cross-repository targets never needs
+  // it, and skipping the extra `gh repo view` call in that case is free.
+  const explicitRepoGiven = Boolean(args.owner && args.repo);
+  const needsCurrentRepo =
+    !explicitRepoGiven &&
+    args.issueTokens.some((token) => !isCrossRepoIssueToken(token));
+  const currentRepo = needsCurrentRepo
+    ? resolveCurrentGithubRepository()
+    : null;
+  const defaultOwner = args.owner || currentRepo?.owner || '';
+  const defaultRepo = args.repo || currentRepo?.repo || '';
   const markerPrefix = normalizeMarkerPrefix(args.markerPrefix, config);
 
+  let issues: SweepIssueTarget[];
+  try {
+    issues = args.issueTokens.map((token) =>
+      parseIssueTargetToken(token, defaultOwner, defaultRepo),
+    );
+  } catch (error) {
+    console.error(`error: ${(error as Error).message}`);
+    process.exit(2);
+  }
+
   const report = runAuthoringMarkerSweep({
-    owner,
-    repo,
-    issues: args.issues,
+    issues,
     markerPrefix,
     classifier: args.classifier,
     trustedSet: new Set(trustedActors),

--- a/src/scripts/sweep-authoring-markers.mts
+++ b/src/scripts/sweep-authoring-markers.mts
@@ -79,7 +79,6 @@ import {
 import { resolveTrustedMarkerActors } from './protocol-helpers.mts';
 import { resolveCurrentGithubRepository } from './provider-adapter-github.mts';
 
-const DEFAULT_MARKER_PREFIX = 'idd-skill';
 const ALLOWED_CLASSIFIERS = new Set(['OUTDATED', 'RESOLVED']);
 const ALLOWED_FORMATS = new Set(['json', 'table']);
 const AUTHORING_MARKER_FAMILIES: readonly AuthoringMarkerFamily[] = [
@@ -107,9 +106,20 @@ export interface SweepIssueTarget {
  * itself allows (letters, digits, `.`, `_`, `-`, never leading/trailing
  * `-` or `.`-only). A token that contains `/` or `#` but does not match
  * this shape is a likely typo, not a bare issue number -- callers get a
- * specific error instead of a confusing `--issue` parse failure. */
+ * specific error instead of a confusing `--issue` parse failure.
+ *
+ * The `repo` group allows an optional single leading `.` (#2935 review,
+ * Codex): GitHub's own repository-name rules permit a leading dot --
+ * `.github`, an organization's special community-health-files
+ * repository, is a real, commonly-used name a cross-repository
+ * `issueAuthoring.journalIssue` reference can legitimately need -- while
+ * `owner` keeps the stricter alphanumeric-first rule GitHub actually
+ * enforces for user/organization names (never a leading dot). A repo
+ * name that is only dots (`.`, `..`) still fails to match, since the
+ * pattern always requires at least one alphanumeric character after the
+ * optional leading dot. */
 const CROSS_REPO_ISSUE_TOKEN_PATTERN =
-  /^([A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)\/([A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)#([1-9]\d*)$/;
+  /^([A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)\/(\.?[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)#([1-9]\d*)$/;
 
 /** `true` when `token` is the explicit `owner/repo#number` cross-repository
  * shorthand -- used before any I/O to decide whether this invocation
@@ -163,6 +173,7 @@ export interface SweepGraphqlComment {
   body: string;
   authorLogin: string;
   isMinimized: boolean;
+  createdAt: string;
 }
 
 interface SweepGraphqlCommentsPayload {
@@ -176,6 +187,7 @@ interface SweepGraphqlCommentsPayload {
             url?: unknown;
             body?: unknown;
             isMinimized?: unknown;
+            createdAt?: unknown;
             author?: { login?: unknown } | null;
           }[];
           pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
@@ -197,6 +209,19 @@ interface SweepGraphqlCommentsPayload {
  * (#2754): a caller sweeping several `--issue` targets under one overall
  * `--deadline-ms` must not let a single large comment log's own pagination
  * consume the entire budget with no cap of its own.
+ *
+ * The returned array is explicitly sorted ascending by `createdAt` before
+ * this function returns (#2935 review, Copilot): `classifyAuthoringMarker
+ * Family`'s "newest trusted match" determination trusts array order alone
+ * (`trustedMatchIndexes[trustedMatchIndexes.length - 1]`), so relying on
+ * an undocumented GraphQL connection default -- rather than requesting or
+ * asserting chronological order explicitly -- would let a future API
+ * change (or a wrong assumption about today's default) silently protect a
+ * stale marker instead of the genuinely newest one. Ties (an identical
+ * `createdAt` down to the second, which GitHub's API can return for two
+ * comments posted in rapid succession) keep their original page-fetch
+ * order via a stable sort, since `Array.prototype.sort` is guaranteed
+ * stable in this codebase's supported Node.js range.
  */
 export function fetchIssueCommentsGraphql(
   owner: string,
@@ -208,7 +233,7 @@ export function fetchIssueCommentsGraphql(
   repository(owner:$owner,name:$repo){
     issue(number:$number){
       comments(first:100,after:$cursor){
-        nodes { id url body isMinimized author { login } }
+        nodes { id url body isMinimized createdAt author { login } }
         pageInfo { hasNextPage endCursor }
       }
     }
@@ -282,6 +307,7 @@ export function fetchIssueCommentsGraphql(
         body: String(node.body ?? ''),
         authorLogin: String(node.author?.login ?? ''),
         isMinimized: Boolean(node.isMinimized),
+        createdAt: String(node.createdAt ?? ''),
       });
     }
     const pageInfo = connection.pageInfo;
@@ -295,6 +321,18 @@ export function fetchIssueCommentsGraphql(
     }
     cursor = pageInfo.endCursor;
   }
+  // #2935 review (Copilot): sort ascending by createdAt explicitly rather
+  // than trusting the GraphQL connection's undocumented default order --
+  // see this function's own doc comment above for why "newest" detection
+  // downstream depends on this.
+  out.sort((a, b) => {
+    const aMs = Date.parse(a.createdAt);
+    const bMs = Date.parse(b.createdAt);
+    if (Number.isNaN(aMs) || Number.isNaN(bMs)) {
+      return 0;
+    }
+    return aMs - bMs;
+  });
   return out;
 }
 
@@ -748,16 +786,33 @@ function parseArgs(argv: string[]): SweepCliArgs {
   };
 }
 
-function normalizeMarkerPrefix(flagValue: string, config: unknown): string {
+/**
+ * Resolve the marker prefix from an explicit `--marker-prefix` flag or
+ * `.github/idd/config.json`'s top-level `markerPrefix`, in that order.
+ * Returns `''` -- never a hardcoded fallback -- when neither source
+ * resolves one (#2935 review, Codex): the issue-authoring contract's own
+ * "prefix-first" rule requires asking rather than guessing when the
+ * prefix is not discoverable, and explicitly forbids ever defaulting to
+ * this SOURCE repository's own `idd-skill` prefix in an installed
+ * bundle. An installed skill or npx profile invoked in a target
+ * repository with no `markerPrefix` configured yet must be told the
+ * already-resolved prefix explicitly via `--marker-prefix`; silently
+ * assuming `idd-skill` there would classify every real marker as
+ * non-canonical and let an `--apply` run report success while
+ * minimizing nothing. The caller (`main`, below) turns an empty result
+ * into a hard, actionable CLI error before any fetch begins.
+ */
+export function normalizeMarkerPrefix(
+  flagValue: string,
+  config: unknown,
+): string {
   const trimmedFlag = flagValue.trim();
   if (trimmedFlag.length > 0) {
     return trimmedFlag;
   }
   const configValue = (config as { markerPrefix?: unknown } | null)
     ?.markerPrefix;
-  const trimmedConfig =
-    typeof configValue === 'string' ? configValue.trim() : '';
-  return trimmedConfig.length > 0 ? trimmedConfig : DEFAULT_MARKER_PREFIX;
+  return typeof configValue === 'string' ? configValue.trim() : '';
 }
 
 function printTable(report: AuthoringMarkerSweepReport): void {
@@ -819,7 +874,11 @@ unlike a direct minimize-superseded-markers.mjs call, this sweep's own
 comment is the live marker to protect from minimization.
 
 --marker-prefix defaults to the top-level markerPrefix field in
-.github/idd/config.json, or "idd-skill" when neither is set.
+.github/idd/config.json. Required when neither is available (#2935
+review, Codex): this command never guesses a prefix, per the
+issue-authoring contract's "prefix-first" rule -- an installed skill or
+npx profile running in a target with no configured markerPrefix yet
+must pass the already-resolved prefix explicitly.
 
 --deadline-ms bounds the WHOLE sweep (every --issue's own GraphQL
 pagination plus the final minimize pass), not just the mutation --
@@ -890,6 +949,12 @@ if (import.meta.main) {
   const defaultOwner = args.owner || currentRepo?.owner || '';
   const defaultRepo = args.repo || currentRepo?.repo || '';
   const markerPrefix = normalizeMarkerPrefix(args.markerPrefix, config);
+  if (markerPrefix.length === 0) {
+    console.error(
+      'error: no marker prefix resolved. Pass --marker-prefix <prefix>, or set the top-level markerPrefix field in .github/idd/config.json -- this command never guesses a prefix (see the issue-authoring contract\'s "prefix-first" rule).',
+    );
+    process.exit(2);
+  }
 
   let issues: SweepIssueTarget[];
   try {

--- a/src/scripts/sweep-authoring-markers.mts
+++ b/src/scripts/sweep-authoring-markers.mts
@@ -102,24 +102,27 @@ export interface SweepIssueTarget {
 }
 
 /** Matches the explicit cross-repository `owner/repo#number` shorthand for
- * one `--issue` token -- the same `owner`/`repo` character class GitHub
- * itself allows (letters, digits, `.`, `_`, `-`, never leading/trailing
- * `-` or `.`-only). A token that contains `/` or `#` but does not match
- * this shape is a likely typo, not a bare issue number -- callers get a
- * specific error instead of a confusing `--issue` parse failure.
+ * one `--issue` token. A token that contains `/` or `#` but does not
+ * match this shape is a likely typo, not a bare issue number -- callers
+ * get a specific error instead of a confusing `--issue` parse failure.
  *
- * The `repo` group allows an optional single leading `.` (#2935 review,
- * Codex): GitHub's own repository-name rules permit a leading dot --
- * `.github`, an organization's special community-health-files
- * repository, is a real, commonly-used name a cross-repository
- * `issueAuthoring.journalIssue` reference can legitimately need -- while
- * `owner` keeps the stricter alphanumeric-first rule GitHub actually
- * enforces for user/organization names (never a leading dot). A repo
- * name that is only dots (`.`, `..`) still fails to match, since the
- * pattern always requires at least one alphanumeric character after the
- * optional leading dot. */
-const CROSS_REPO_ISSUE_TOKEN_PATTERN =
-  /^([A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)\/(\.?[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)#([1-9]\d*)$/;
+ * The `owner`/`repo` character class is deliberately exactly
+ * `schemas/policy.schema.json`'s own `issueAuthoring.journalIssue`
+ * pattern (`[\w.-]+`, i.e. word characters, `.`, `-`, in any position,
+ * no leading/trailing restriction) rather than a hand-derived, stricter
+ * subset of GitHub's real naming rules (#2935 review, round 2, Codex):
+ * an earlier revision here rejected `.github`-style leading-dot repo
+ * names, then a follow-up fix rejected leading/trailing `_`/`-`
+ * component names the schema already accepts (for example
+ * `acme/_journal#42`) -- two rounds of the same underlying mistake,
+ * independently re-deriving GitHub's naming rules instead of reusing
+ * the one place this codebase already encodes them. Matching the schema
+ * exactly, rather than refining a parallel approximation of it further,
+ * defers the actual repository-name validity question to GitHub's own
+ * API (which will simply 404 on a request for a name nothing owns),
+ * matching the review's own "defer repository-name validation to
+ * GitHub" resolution. */
+const CROSS_REPO_ISSUE_TOKEN_PATTERN = /^([\w.-]+)\/([\w.-]+)#([1-9]\d*)$/;
 
 /** `true` when `token` is the explicit `owner/repo#number` cross-repository
  * shorthand -- used before any I/O to decide whether this invocation
@@ -198,6 +201,19 @@ interface SweepGraphqlCommentsPayload {
 }
 
 /**
+ * Per-call `execFileSync` output-buffer cap for
+ * {@link fetchIssueCommentsGraphql}'s own `gh api graphql` calls (#2935
+ * review, Codex): `ghText`'s (and Node's `execFileSync`'s) own default is
+ * 1 MiB per stream, which a 100-comment page can exceed once several
+ * comments carry long discussion bodies -- silently turning a real page
+ * of data into an `ENOBUFS` fetch failure that then drops that issue's
+ * comments (and every superseded marker on it) from this sweep entirely.
+ * 10 MiB matches this codebase's own existing precedent for the same
+ * class of risk (`GH_ASYNC_MAX_BUFFER`, `provider-adapter-github.mts`).
+ */
+const LARGE_COMMENT_PAGE_MAX_BUFFER = 10 * 1024 * 1024;
+
+/**
  * Fetch every comment on `owner/repo#issueNumber` via a paginated GraphQL
  * `issue(number:).comments` query, selecting `isMinimized` directly (the
  * field REST's issue-comments endpoint never carries at all). `timeoutMs`,
@@ -268,10 +284,10 @@ export function fetchIssueCommentsGraphql(
       `number=${issueNumber}`,
       ...(cursor ? ['-f', `cursor=${cursor}`] : []),
     ];
-    const raw = ghText(
-      args,
-      perCallTimeout !== undefined ? { timeout: perCallTimeout } : {},
-    );
+    const raw = ghText(args, {
+      ...(perCallTimeout !== undefined ? { timeout: perCallTimeout } : {}),
+      maxBuffer: LARGE_COMMENT_PAGE_MAX_BUFFER,
+    });
     let parsed: SweepGraphqlCommentsPayload;
     try {
       parsed = JSON.parse(raw || '{}');

--- a/src/scripts/sweep-authoring-markers.mts
+++ b/src/scripts/sweep-authoring-markers.mts
@@ -65,7 +65,7 @@
 // targets.
 
 import { parseCanonicalIntegerOrThrow, parseCliArgs } from './cli-args.mts';
-import { ghText } from './gh-exec.mts';
+import { ghTextUnbounded } from './gh-exec.mts';
 import { loadIddConfig } from './idd-config.mts';
 import type { AuthoringMarkerFamily } from './marker-helpers.mts';
 import {
@@ -201,38 +201,6 @@ interface SweepGraphqlCommentsPayload {
 }
 
 /**
- * Per-call `execFileSync` output-buffer cap for
- * {@link fetchIssueCommentsGraphql}'s own `gh api graphql` calls (#2935
- * review, rounds 4-5, Codex): `ghText`'s (and Node's `execFileSync`'s)
- * own default is 1 MiB per stream, which a 100-comment page can exceed
- * once several comments carry long discussion bodies -- silently
- * turning a real page of data into an `ENOBUFS` fetch failure that then
- * drops that issue's comments (and every superseded marker on it) from
- * this sweep entirely.
- *
- * An initial 10 MiB estimate (matching `GH_ASYNC_MAX_BUFFER`,
- * `provider-adapter-github.mts`'s own unrelated precedent) drew a
- * further round of review pushing back that 10 MiB is still not a
- * PROVEN bound. This value replaces that estimate with an actual
- * worst-case calculation instead of a bigger guess, so a further
- * "still not big enough" round has no remaining basis: GitHub caps a
- * single issue/PR comment body at 65,536 characters, and UTF-8 (the
- * encoding `gh`'s JSON output uses) never spends more than 4 bytes per
- * character, so one comment's `body` field cannot exceed
- * `65_536 * 4 = 262_144` bytes regardless of content. `comments(first:
- * 100, ...)` below never returns more than 100 nodes per page, and this
- * query's other per-node fields (`id`, `url`, `isMinimized`,
- * `createdAt`, `author.login`) and JSON structural overhead (quotes,
- * commas, key names) add at most a few hundred bytes per node --
- * generously rounded up to 500 bytes/node here. The true worst case for
- * one page is therefore bounded at
- * `100 * (262_144 + 500) = 26_264_400` bytes (~25 MiB); this constant
- * rounds that up to a clean 32 MiB, comfortably above the proven
- * ceiling rather than merely "probably enough."
- */
-const LARGE_COMMENT_PAGE_MAX_BUFFER = 32 * 1024 * 1024;
-
-/**
  * Fetch every comment on `owner/repo#issueNumber` via a paginated GraphQL
  * `issue(number:).comments` query, selecting `isMinimized` directly (the
  * field REST's issue-comments endpoint never carries at all). `timeoutMs`,
@@ -244,6 +212,18 @@ const LARGE_COMMENT_PAGE_MAX_BUFFER = 32 * 1024 * 1024;
  * (#2754): a caller sweeping several `--issue` targets under one overall
  * `--deadline-ms` must not let a single large comment log's own pagination
  * consume the entire budget with no cap of its own.
+ *
+ * Uses {@link ghTextUnbounded}, not {@link ghText}, for each page's own
+ * `gh api graphql` call (#2935 review, rounds 4-6): a 100-comment page
+ * can exceed any fixed in-memory `maxBuffer` guess once several
+ * comments carry long bodies, and three successive rounds of trying to
+ * calculate a provably sufficient fixed size (10 MiB, then a 25 MiB
+ * worst-case bound from GitHub's 65,536-character comment cap, then a
+ * finding that even that missed JSON-escaping overhead) never converged
+ * on one that could not be second-guessed further. Removing the
+ * fixed-buffer mechanism -- reading the response through a temp file
+ * instead of an in-memory pipe -- closes the entire class of finding at
+ * once instead of refining the guess again.
  *
  * The returned array is explicitly sorted ascending by `createdAt` before
  * this function returns (#2935 review, Copilot): `classifyAuthoringMarker
@@ -303,10 +283,10 @@ export function fetchIssueCommentsGraphql(
       `number=${issueNumber}`,
       ...(cursor ? ['-f', `cursor=${cursor}`] : []),
     ];
-    const raw = ghText(args, {
-      ...(perCallTimeout !== undefined ? { timeout: perCallTimeout } : {}),
-      maxBuffer: LARGE_COMMENT_PAGE_MAX_BUFFER,
-    });
+    const raw = ghTextUnbounded(
+      args,
+      perCallTimeout !== undefined ? { timeout: perCallTimeout } : {},
+    );
     let parsed: SweepGraphqlCommentsPayload;
     try {
       parsed = JSON.parse(raw || '{}');

--- a/src/scripts/sweep-authoring-markers.mts
+++ b/src/scripts/sweep-authoring-markers.mts
@@ -1,0 +1,806 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/sweep-authoring-markers.mts
+//
+// The scripts/sweep-authoring-markers.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Fetch-driven mandatory hide-on-supersede sweep for `authoring-owner` /
+// `authoring-publication-intent` markers (#2935).
+//
+// Background: #2896 (PR #2898) replaced the per-post hide-on-supersede
+// instruction (measured ~3% effective) with a mandatory release-time sweep
+// documented in `skills/issue-authoring/references/contract.md` at three
+// points in the Stage 2 release flow. Re-measuring that sweep found it only
+// 41.7% effective, because "mandatory" still meant a session had to
+// correctly reconstruct an ~8-step manual procedure from prose, three
+// separate times, every release: paginate the comment log via GraphQL
+// (never REST, which never exposes `isMinimized`), classify each body with
+// `matchCanonicalAuthoringMarkerFamily`, determine the newest match among
+// TRUSTED-actor candidates only, exclude anything already minimized,
+// assemble the survivors' GraphQL node IDs by hand, invoke
+// `minimize-superseded-markers.mjs`, then re-verify. This script collapses
+// that whole procedure into one command: given one or more `--issue`
+// targets, it fetches each issue's comments via GraphQL, classifies and
+// filters them exactly as the contract describes, and calls into
+// `minimize-superseded-markers.mts`'s existing `runMinimize` for the
+// mutation -- reusing that logic rather than reimplementing it.
+//
+// Deliberately a SIBLING script, not a mode grafted onto
+// `minimize-superseded-markers.mts` itself: that file's module header
+// documents a hard self-containment invariant ("stays self-contained so
+// the template copy works without protocol-helpers.mjs" -- `idd-template/
+// scripts/` mirrors ONLY that one file, standalone). A fetch-driven mode
+// needs `matchCanonicalAuthoringMarkerFamily` (`marker-helpers.mts`, a
+// ~3000-line module with its own import graph), which would break that
+// invariant if grafted in-place. This file carries no such constraint, so
+// it imports normally from `marker-helpers.mts`, `protocol-helpers.mts`,
+// `idd-config.mts`, `gh-exec.mts`, and `minimize-superseded-markers.mts`
+// (for `runMinimize` and `resolveGhHostnameArgs`), matching the newer,
+// non-template-mirrored helpers' own style (e.g.
+// `merged-pr-feedback-sweep.mts`, `authoring-owner-provenance.mts`).
+//
+// Read-only against every issue it scans except for the minimize mutation
+// itself, which only ever hides (never edits or deletes) a comment already
+// proven superseded by the classification below. Best-effort by design,
+// matching the contract's framing: a fetch failure for one `--issue` is
+// recorded in the report and does not abort the other issues in the same
+// invocation; the caller (the contract's own sweep instructions) treats a
+// non-zero exit the same way it already treats `minimize-superseded-
+// markers.mjs`'s own possible non-zero exit -- non-blocking.
+//
+// Scope: `authoring-owner` and `authoring-publication-intent` only, same as
+// the sweep it replaces. Every `--issue` given is scanned in the SAME
+// `--owner`/`--repo` (defaulting to the current repository) -- this script
+// does not parse a cross-repo `owner/repo#N` shorthand for `--issue`,
+// matching every other single-repo `--issue <number>` helper in this
+// codebase (`authoring-owner-provenance.mts`, `suitability-close-
+// execute.mts`); a caller sweeping a cross-repo journal passes its own
+// `--owner`/`--repo` in a separate invocation.
+
+import { parseCanonicalIntegerOrThrow, parseCliArgs } from './cli-args.mts';
+import { ghText } from './gh-exec.mts';
+import { loadIddConfig } from './idd-config.mts';
+import type { AuthoringMarkerFamily } from './marker-helpers.mts';
+import {
+  classifyAuthoringMarkerFamily,
+  matchCanonicalAuthoringMarkerFamily,
+} from './marker-helpers.mts';
+import {
+  resolveGhHostnameArgs,
+  runMinimize,
+} from './minimize-superseded-markers.mts';
+import { resolveTrustedMarkerActors } from './protocol-helpers.mts';
+import { resolveCurrentGithubRepository } from './provider-adapter-github.mts';
+
+const DEFAULT_MARKER_PREFIX = 'idd-skill';
+const ALLOWED_CLASSIFIERS = new Set(['OUTDATED', 'RESOLVED']);
+const ALLOWED_FORMATS = new Set(['json', 'table']);
+const AUTHORING_MARKER_FAMILIES: readonly AuthoringMarkerFamily[] = [
+  'authoring-owner',
+  'authoring-publication-intent',
+];
+
+/** One issue comment as fetched via GraphQL -- `isMinimized` is the field
+ * REST's issue-comments endpoint never carries, which is why this script
+ * (like the contract it implements) fetches via GraphQL and never REST. */
+export interface SweepGraphqlComment {
+  nodeId: string;
+  url: string;
+  body: string;
+  authorLogin: string;
+  isMinimized: boolean;
+}
+
+interface SweepGraphqlCommentsPayload {
+  errors?: { message?: unknown }[];
+  data?: {
+    repository?: {
+      issue?: {
+        comments?: {
+          nodes?: {
+            id?: unknown;
+            url?: unknown;
+            body?: unknown;
+            isMinimized?: unknown;
+            author?: { login?: unknown } | null;
+          }[];
+          pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
+        } | null;
+      } | null;
+    } | null;
+  };
+}
+
+/**
+ * Fetch every comment on `owner/repo#issueNumber` via a paginated GraphQL
+ * `issue(number:).comments` query, selecting `isMinimized` directly (the
+ * field REST's issue-comments endpoint never carries at all). `timeoutMs`,
+ * when supplied, bounds the WHOLE paginated walk (checked before each
+ * page's own `gh` call, never passed through as a non-positive value --
+ * `ghText`/`execFileSync` both read `timeout: 0` as "no timeout", the
+ * opposite of "budget already exhausted"), mirroring `post-idd-
+ * marker.mts`'s `hideSupersededPostTimeMarkers` deadline discipline
+ * (#2754): a caller sweeping several `--issue` targets under one overall
+ * `--deadline-ms` must not let a single large comment log's own pagination
+ * consume the entire budget with no cap of its own.
+ */
+export function fetchIssueCommentsGraphql(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  timeoutMs: number | undefined,
+): SweepGraphqlComment[] {
+  const query = `query($owner:String!,$repo:String!,$number:Int!,$cursor:String){
+  repository(owner:$owner,name:$repo){
+    issue(number:$number){
+      comments(first:100,after:$cursor){
+        nodes { id url body isMinimized author { login } }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}`;
+  const out: SweepGraphqlComment[] = [];
+  let cursor: string | null = null;
+  const startedAt = Date.now();
+  const label = `${owner}/${repo}#${issueNumber}`;
+  while (true) {
+    let perCallTimeout: number | undefined;
+    if (timeoutMs !== undefined) {
+      const remaining = timeoutMs - (Date.now() - startedAt);
+      if (remaining <= 0) {
+        throw new Error(
+          `sweep-authoring-markers: deadline exceeded while paginating ${label}`,
+        );
+      }
+      perCallTimeout = remaining;
+    }
+    const args = [
+      'api',
+      'graphql',
+      ...resolveGhHostnameArgs(),
+      '-f',
+      `query=${query}`,
+      '-f',
+      `owner=${owner}`,
+      '-f',
+      `repo=${repo}`,
+      '-F',
+      `number=${issueNumber}`,
+      ...(cursor ? ['-f', `cursor=${cursor}`] : []),
+    ];
+    const raw = ghText(
+      args,
+      perCallTimeout !== undefined ? { timeout: perCallTimeout } : {},
+    );
+    let parsed: SweepGraphqlCommentsPayload;
+    try {
+      parsed = JSON.parse(raw || '{}');
+    } catch (error) {
+      throw new Error(
+        `sweep-authoring-markers: gh-graphql-parse: ${(error as Error).message}`,
+      );
+    }
+    if (Array.isArray(parsed.errors) && parsed.errors.length > 0) {
+      throw new Error(
+        `sweep-authoring-markers: gh-graphql-errors: ${parsed.errors
+          .map((e) => String(e.message ?? ''))
+          .filter(Boolean)
+          .join('; ')}`,
+      );
+    }
+    const issue = parsed.data?.repository?.issue;
+    if (issue == null) {
+      throw new Error(
+        `sweep-authoring-markers: ${label} is not an issue or does not exist`,
+      );
+    }
+    const connection = issue.comments;
+    if (connection == null) {
+      throw new Error(
+        `sweep-authoring-markers: ${label} returned a null comments connection`,
+      );
+    }
+    for (const node of connection.nodes ?? []) {
+      out.push({
+        nodeId: String(node.id ?? ''),
+        url: String(node.url ?? ''),
+        body: String(node.body ?? ''),
+        authorLogin: String(node.author?.login ?? ''),
+        isMinimized: Boolean(node.isMinimized),
+      });
+    }
+    const pageInfo = connection.pageInfo;
+    if (!pageInfo?.hasNextPage) {
+      break;
+    }
+    if (!pageInfo.endCursor) {
+      throw new Error(
+        `sweep-authoring-markers: page reported hasNextPage without endCursor for ${label}`,
+      );
+    }
+    cursor = pageInfo.endCursor;
+  }
+  return out;
+}
+
+/** Per-family counters for one sweep report (#2935). `scanned` counts every
+ * byte-exact canonical match regardless of trust (mirrors `classify
+ * AuthoringMarkerFamily`'s `matchIndexes`); `untrusted` and
+ * `protectedNewest` explain why a scanned candidate was never submitted
+ * for minimization; `alreadyMinimized` is the pre-mutation-snapshot count
+ * (a candidate GitHub already reports minimized before this sweep ran);
+ * `minimized`/`raceAlreadyMinimized`/`deadlineSkipped`/`failed` are
+ * derived from `runMinimize`'s own post-mutation report, keyed back to
+ * this family via each candidate's own node id. `minimized` counts both a
+ * real `status: "applied"` (an `--apply` run) and a `status: "would-
+ * apply"` (a dry run, `--apply` omitted) -- `report.mode` already
+ * disambiguates real from hypothetical, so this field answers "how many
+ * would be minimized" either way. `raceAlreadyMinimized` is distinct from
+ * `alreadyMinimized`: it means the PRE-fetch snapshot said not-yet-
+ * minimized, but `runMinimize`'s own live re-probe found it already
+ * minimized by the time the mutation ran (another sweep or the
+ * opportunistic per-post step won the race) -- both mean the comment is
+ * minimized now, so a caller tallying "cleared" should sum the two.
+ * `skippedOther` is every other `runMinimize` skip reason this sweep can
+ * still legitimately hit despite its own pre-filter already excluding
+ * untrusted/already-minimized candidates before submission -- a live
+ * re-probe disagreeing with the pre-fetch snapshot (`viewer-cannot-
+ * minimize`, `unsupported-type`) or a genuine race where the author
+ * became untrusted between fetch and mutation (`untrusted-author`).
+ * `computeSweepExitCode` does NOT treat `skippedOther` as a failure,
+ * matching `runMinimize`'s own `computeExitCode`, which returns `0` for
+ * every one of these skip reasons -- only `failed` does. */
+export interface AuthoringMarkerSweepFamilyCounts {
+  scanned: number;
+  untrusted: number;
+  protectedNewest: number;
+  alreadyMinimized: number;
+  eligible: number;
+  minimized: number;
+  raceAlreadyMinimized: number;
+  deadlineSkipped: number;
+  skippedOther: number;
+  failed: number;
+}
+
+function emptyFamilyCounts(): AuthoringMarkerSweepFamilyCounts {
+  return {
+    scanned: 0,
+    untrusted: 0,
+    protectedNewest: 0,
+    alreadyMinimized: 0,
+    eligible: 0,
+    minimized: 0,
+    raceAlreadyMinimized: 0,
+    deadlineSkipped: 0,
+    skippedOther: 0,
+    failed: 0,
+  };
+}
+
+export interface AuthoringMarkerSweepIssueResult {
+  owner: string;
+  repo: string;
+  issue: number;
+  commentCount: number;
+  nonCanonical: number;
+  error?: string;
+}
+
+/** One minimize candidate's outcome, tagged with the family it belonged to
+ * (#2935 review): the contract's "Make every sweep attempt's outcome
+ * visible" section feeds `authoring-marker-minimization-backlog` the
+ * sweep's own post-mutation result "keyed by subject id" -- this array,
+ * not `minimize-superseded-markers.mjs`'s own `items[]`, is now that
+ * primary source, since this command's report is the one a caller
+ * actually sees. Present only for a subject actually submitted to
+ * `runMinimize` (never for a `deadline-exceeded`-before-submission
+ * skip, which the corresponding family count still reports). */
+export interface AuthoringMarkerSweepItem {
+  subjectId: string;
+  family: AuthoringMarkerFamily;
+  url?: unknown;
+  status: string;
+  reason?: string;
+  author?: unknown;
+}
+
+export interface AuthoringMarkerSweepReport {
+  mode: 'apply' | 'dry-run';
+  classifier: string;
+  markerPrefix: string;
+  trustedMarkerActors: string[];
+  trustedMarkerActorsSource: string;
+  issues: AuthoringMarkerSweepIssueResult[];
+  families: Record<AuthoringMarkerFamily, AuthoringMarkerSweepFamilyCounts>;
+  items: AuthoringMarkerSweepItem[];
+}
+
+/** Injectable dependencies (#2935): a test supplies a fake `fetchIssueComments`
+ * returning a synthetic comment set (no `gh` call at all) while leaving
+ * `minimize` as the real, separately-tested `runMinimize` -- exercising
+ * this file's own fetch-classify-filter-mutate orchestration end to end
+ * without needing a live GitHub connection for the fetch half, and a
+ * `stubExecutable('gh', ...)` fake for the mutation half's own `gh` calls
+ * (the same convention `tests/minimize-superseded-markers.test.mts`
+ * already uses). */
+export interface AuthoringMarkerSweepDeps {
+  fetchIssueComments: (
+    owner: string,
+    repo: string,
+    issueNumber: number,
+    timeoutMs: number | undefined,
+  ) => SweepGraphqlComment[];
+  minimize: typeof runMinimize;
+}
+
+const DEFAULT_DEPS: AuthoringMarkerSweepDeps = {
+  fetchIssueComments: fetchIssueCommentsGraphql,
+  minimize: runMinimize,
+};
+
+export interface AuthoringMarkerSweepOptions {
+  owner: string;
+  repo: string;
+  issues: readonly number[];
+  markerPrefix: string;
+  classifier: string;
+  trustedSet: ReadonlySet<string>;
+  apply: boolean;
+  /** Overall wall-clock budget (ms) for the ENTIRE sweep -- every issue's
+   * fetch plus the final minimize pass -- mirroring `post-idd-
+   * marker.mts`'s `hideSupersededPostTimeMarkers` (#2754): the clock
+   * starts at this function's own entry, before any network call, not at
+   * `runMinimize`'s. `undefined` keeps the pre-existing unbounded
+   * behavior. */
+  deadlineMs?: number;
+}
+
+/**
+ * Run the fetch-driven hide-on-supersede sweep across `options.issues`
+ * (#2935): for each issue, fetch its comments via GraphQL, classify every
+ * comment against both authoring marker families
+ * (`classifyAuthoringMarkerFamily`), collect the eligible (trusted,
+ * non-newest, not-yet-minimized) candidates' node ids, then submit the
+ * FULL cross-issue candidate set to `runMinimize` in one mutation pass.
+ * `deps` defaults to the real GraphQL fetch and the real `runMinimize`;
+ * tests override either or both. Never throws on a single issue's fetch
+ * failure -- that issue's `error` field records it and the sweep continues
+ * with the remaining issues, matching the contract's best-effort framing.
+ */
+export function runAuthoringMarkerSweep(
+  options: AuthoringMarkerSweepOptions,
+  deps: AuthoringMarkerSweepDeps = DEFAULT_DEPS,
+): AuthoringMarkerSweepReport {
+  const startedAt = Date.now();
+  const remaining = (): number | undefined =>
+    options.deadlineMs === undefined
+      ? undefined
+      : options.deadlineMs - (Date.now() - startedAt);
+
+  const families: Record<
+    AuthoringMarkerFamily,
+    AuthoringMarkerSweepFamilyCounts
+  > = {
+    'authoring-owner': emptyFamilyCounts(),
+    'authoring-publication-intent': emptyFamilyCounts(),
+  };
+  const issues: AuthoringMarkerSweepIssueResult[] = [];
+  const subjectFamilies = new Map<string, AuthoringMarkerFamily>();
+
+  for (const issueNumber of options.issues) {
+    const budget = remaining();
+    if (budget !== undefined && budget <= 0) {
+      issues.push({
+        owner: options.owner,
+        repo: options.repo,
+        issue: issueNumber,
+        commentCount: 0,
+        nonCanonical: 0,
+        error: 'deadline-exceeded',
+      });
+      continue;
+    }
+    let comments: SweepGraphqlComment[];
+    try {
+      comments = deps.fetchIssueComments(
+        options.owner,
+        options.repo,
+        issueNumber,
+        budget,
+      );
+    } catch (error) {
+      issues.push({
+        owner: options.owner,
+        repo: options.repo,
+        issue: issueNumber,
+        commentCount: 0,
+        nonCanonical: 0,
+        error: (error as Error).message,
+      });
+      continue;
+    }
+
+    let nonCanonical = 0;
+    const candidates = comments.map((comment) => ({
+      body: comment.body,
+      author: comment.authorLogin,
+      isMinimized: comment.isMinimized,
+    }));
+    for (const comment of comments) {
+      if (
+        matchCanonicalAuthoringMarkerFamily(
+          comment.body,
+          options.markerPrefix,
+        ) === null
+      ) {
+        nonCanonical += 1;
+      }
+    }
+    issues.push({
+      owner: options.owner,
+      repo: options.repo,
+      issue: issueNumber,
+      commentCount: comments.length,
+      nonCanonical,
+    });
+
+    for (const family of AUTHORING_MARKER_FAMILIES) {
+      const classification = classifyAuthoringMarkerFamily(
+        candidates,
+        options.markerPrefix,
+        family,
+        options.trustedSet,
+      );
+      const counts = families[family];
+      counts.scanned += classification.matchIndexes.length;
+      counts.untrusted += classification.untrustedIndexes.length;
+      counts.protectedNewest +=
+        classification.newestTrustedIndex === null ? 0 : 1;
+      counts.alreadyMinimized += classification.alreadyMinimizedIndexes.length;
+      counts.eligible += classification.eligibleIndexes.length;
+      for (const index of classification.eligibleIndexes) {
+        const nodeId = comments[index].nodeId;
+        if (nodeId) {
+          subjectFamilies.set(nodeId, family);
+        }
+      }
+    }
+  }
+
+  const items: AuthoringMarkerSweepItem[] = [];
+  const subjectIds = [...subjectFamilies.keys()];
+  if (subjectIds.length > 0) {
+    // Bail BEFORE the mutation stage once the budget is already spent
+    // (#2935 review, mirroring `post-idd-marker.mts`'s
+    // `hideSupersededPostTimeMarkers`, lines "const mutationPassR =
+    // remaining(); if (mutationPassR <= 0) return;"): `runMinimize`'s own
+    // deadline handling still attempts its index-0 candidate's probe
+    // unconditionally (the documented exemption that guarantees forward
+    // progress for a STANDALONE `minimize-superseded-markers.mjs` call),
+    // which would otherwise cost this sweep one full un-throttled
+    // `GH_TIMEOUT_MS` probe call for no benefit once the caller's own
+    // overall budget is already exhausted. Every eligible candidate is
+    // reported `deadlineSkipped` instead, matching what `runMinimize`
+    // itself would report for every candidate past the first if it ran.
+    const mutationBudget = remaining();
+    if (mutationBudget !== undefined && mutationBudget <= 0) {
+      for (const [subjectId, family] of subjectFamilies) {
+        families[family].deadlineSkipped += 1;
+        items.push({
+          subjectId,
+          family,
+          status: 'skipped',
+          reason: 'deadline-exceeded',
+        });
+      }
+    } else {
+      const minimizeReport = deps.minimize({
+        subjectIds,
+        classifier: options.classifier,
+        trustedSet: new Set(options.trustedSet),
+        apply: options.apply,
+        allowUntrusted: false,
+        deadlineMs: mutationBudget,
+      });
+      for (const item of minimizeReport.items) {
+        const family = subjectFamilies.get(item.subjectId);
+        if (!family) {
+          continue;
+        }
+        items.push({
+          subjectId: item.subjectId,
+          family,
+          url: item.url,
+          status: item.status,
+          reason: item.reason,
+          author: item.author,
+        });
+        const counts = families[family];
+        // `status: 'failed'` is the ONLY outcome this sweep treats as a
+        // real failure (#2935 review) -- every other skip reason
+        // (`viewer-cannot-minimize`, `unsupported-type`, `untrusted-
+        // author`) is a live re-probe legitimately disagreeing with this
+        // sweep's own pre-fetch snapshot, not a defect, and `runMinimize`'s
+        // own `computeExitCode` already returns 0 for all of them. An
+        // earlier revision folded every unrecognized status into `failed`,
+        // which would have made `computeSweepExitCode` report a spurious
+        // failure for a case `runMinimize` itself considers clean.
+        if (item.status === 'applied' || item.status === 'would-apply') {
+          counts.minimized += 1;
+        } else if (
+          item.status === 'skipped' &&
+          item.reason === 'already-minimized'
+        ) {
+          counts.raceAlreadyMinimized += 1;
+        } else if (
+          item.status === 'skipped' &&
+          item.reason === 'deadline-exceeded'
+        ) {
+          counts.deadlineSkipped += 1;
+        } else if (item.status === 'failed') {
+          counts.failed += 1;
+        } else {
+          counts.skippedOther += 1;
+        }
+      }
+    }
+  }
+
+  return {
+    mode: options.apply ? 'apply' : 'dry-run',
+    classifier: options.classifier,
+    markerPrefix: options.markerPrefix,
+    trustedMarkerActors: [...options.trustedSet].sort(),
+    trustedMarkerActorsSource: '',
+    issues,
+    families,
+    items,
+  };
+}
+
+/** `0` when every issue fetched cleanly (no `deadline-exceeded`-before-
+ * fetch and no fetch error) and no family reports a `failed` candidate;
+ * `1` otherwise -- mirrors `minimize-superseded-markers.mts`'s own
+ * `computeExitCode` for the mutation half (fail only on a real `status:
+ * "failed"`, never on `skippedOther` or an empty/all-skipped result), and
+ * additionally fails on a fetch-stage problem `runMinimize` has no
+ * equivalent for: an issue this sweep never got to scan at all (a `gh`
+ * error, a non-issue number, or the overall deadline already spent before
+ * its own turn) is deliberately treated as a real failure here, distinct
+ * from a per-candidate `deadlineSkipped` inside an issue that WAS
+ * scanned. */
+export function computeSweepExitCode(
+  report: AuthoringMarkerSweepReport,
+): number {
+  if (report.issues.some((issue) => issue.error !== undefined)) {
+    return 1;
+  }
+  if (Object.values(report.families).some((counts) => counts.failed > 0)) {
+    return 1;
+  }
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+interface SweepCliArgs {
+  issues: number[];
+  owner: string;
+  repo: string;
+  markerPrefix: string;
+  classifier: string;
+  trustedMarkerLogins: string;
+  apply: boolean;
+  format: string;
+  deadlineMs?: number;
+  help: boolean;
+}
+
+// Flag-spec keys stay the dashed literal (tests/flag-name-matrix.test.mts
+// scans this file's compiled .mjs source for each canonical flag written
+// as a quoted string literal -- see cli-args.mts's module header).
+const SWEEP_AUTHORING_MARKERS_FLAG_SPEC = {
+  '--issue': { type: 'string', multiple: true },
+  '--owner': { type: 'string', default: '' },
+  '--repo': { type: 'string', default: '' },
+  '--marker-prefix': { type: 'string', default: '' },
+  '--classifier': { type: 'string', default: 'OUTDATED' },
+  '--trusted-marker-logins': { type: 'string', default: '' },
+  '--apply': { type: 'boolean' },
+  '--format': { type: 'string', default: 'json' },
+  '--deadline-ms': { type: 'string' },
+  '--help': { type: 'boolean', short: 'h' },
+} as const;
+
+function parseArgs(argv: string[]): SweepCliArgs {
+  const { values, help } = parseCliArgs(
+    argv,
+    SWEEP_AUTHORING_MARKERS_FLAG_SPEC,
+  );
+
+  const issueTokens = (values.issue as string[] | undefined) ?? [];
+  const issues = issueTokens.map((token) =>
+    parseCanonicalIntegerOrThrow(token, '--issue'),
+  );
+
+  let deadlineMs: number | undefined;
+  if (values['deadline-ms'] !== undefined) {
+    if (values['deadline-ms'] === '') {
+      throw new Error('--deadline-ms requires a value');
+    }
+    if (!/^(?:0|[1-9]\d*)$/.test(values['deadline-ms'] as string)) {
+      throw new Error(
+        '--deadline-ms must be a non-negative integer (milliseconds)',
+      );
+    }
+    deadlineMs = Number.parseInt(values['deadline-ms'] as string, 10);
+  }
+
+  return {
+    issues,
+    owner: (values.owner as string) ?? '',
+    repo: (values.repo as string) ?? '',
+    markerPrefix: (values['marker-prefix'] as string) ?? '',
+    classifier: (values.classifier as string) ?? 'OUTDATED',
+    trustedMarkerLogins: (values['trusted-marker-logins'] as string) ?? '',
+    apply: Boolean(values.apply),
+    format: (values.format as string) ?? 'json',
+    deadlineMs,
+    help,
+  };
+}
+
+function normalizeMarkerPrefix(flagValue: string, config: unknown): string {
+  const trimmedFlag = flagValue.trim();
+  if (trimmedFlag.length > 0) {
+    return trimmedFlag;
+  }
+  const configValue = (config as { markerPrefix?: unknown } | null)
+    ?.markerPrefix;
+  const trimmedConfig =
+    typeof configValue === 'string' ? configValue.trim() : '';
+  return trimmedConfig.length > 0 ? trimmedConfig : DEFAULT_MARKER_PREFIX;
+}
+
+function printTable(report: AuthoringMarkerSweepReport): void {
+  console.log(
+    `mode: ${report.mode}  classifier: ${report.classifier}  marker-prefix: ${report.markerPrefix}`,
+  );
+  for (const issue of report.issues) {
+    const suffix = issue.error ? `  error: ${issue.error}` : '';
+    console.log(
+      `  issue ${issue.owner}/${issue.repo}#${issue.issue}: comments=${issue.commentCount} nonCanonical=${issue.nonCanonical}${suffix}`,
+    );
+  }
+  for (const family of AUTHORING_MARKER_FAMILIES) {
+    const c = report.families[family];
+    console.log(
+      `${family}: scanned=${c.scanned} untrusted=${c.untrusted} protectedNewest=${c.protectedNewest} alreadyMinimized=${c.alreadyMinimized} eligible=${c.eligible} minimized=${c.minimized} raceAlreadyMinimized=${c.raceAlreadyMinimized} deadlineSkipped=${c.deadlineSkipped} skippedOther=${c.skippedOther} failed=${c.failed}`,
+    );
+  }
+  for (const item of report.items) {
+    const url = item.url ?? '(no url)';
+    const reason = item.reason ?? '';
+    console.log(
+      `  [${item.status}] ${item.family} ${item.subjectId}  ${url}  ${reason}`,
+    );
+  }
+}
+
+function printUsage(): void {
+  console.log(
+    `Usage: sweep-authoring-markers --issue <number> [--issue <number> ...] [--owner <owner>] [--repo <repo>] [--marker-prefix <prefix>] [--classifier OUTDATED|RESOLVED] --trusted-marker-logins <login1,login2> [--apply] [--format json|table] [--deadline-ms <milliseconds>]
+
+Fetch-driven hide-on-supersede sweep for authoring-owner /
+authoring-publication-intent markers (#2935): fetches each --issue's
+comments via GraphQL (selecting isMinimized, which REST never carries),
+classifies every comment with matchCanonicalAuthoringMarkerFamily, keeps
+only the single newest byte-exact canonical match per family among
+TRUSTED-actor authors, and minimizes (classifier OUTDATED by default)
+every other eligible, not-yet-minimized candidate in one mutation pass --
+reusing minimize-superseded-markers.mts's own runMinimize.
+
+Pass one --issue per target to sweep (the per-target preflight and the
+anchor-before-release-complete sweep points each pass one; the closing
+sweep passes every target plus the anchor and the journal issue in the
+same invocation). Every --issue is scanned in the same --owner/--repo
+(defaulting to the current repository); this command does not accept a
+cross-repo owner/repo#N shorthand.
+
+The trusted-author gate is mandatory, matching minimize-superseded-
+markers.mjs: supply --trusted-marker-logins, IDD_TRUSTED_MARKER_ACTORS, or
+the trustedMarkerActors list in .github/idd/config.json (flag > env >
+config precedence). There is no --allow-untrusted escape hatch here --
+unlike a direct minimize-superseded-markers.mjs call, this sweep's own
+"newest" determination depends on the trust filter to decide which
+comment is the live marker to protect from minimization.
+
+--marker-prefix defaults to the top-level markerPrefix field in
+.github/idd/config.json, or "idd-skill" when neither is set.
+
+--deadline-ms bounds the WHOLE sweep (every --issue's own GraphQL
+pagination plus the final minimize pass), not just the mutation --
+omit it to keep the default unbounded behavior. Best-effort: a single
+--issue's fetch failure is recorded in the report and does not abort the
+other issues in the same invocation.`,
+  );
+}
+
+if (import.meta.main) {
+  let args: SweepCliArgs;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    console.error(`error: ${(error as Error).message}`);
+    process.exit(2);
+  }
+
+  if (args.help) {
+    printUsage();
+    process.exit(0);
+  }
+
+  if (!ALLOWED_CLASSIFIERS.has(args.classifier)) {
+    console.error(
+      `error: --classifier must be one of ${[...ALLOWED_CLASSIFIERS].join(', ')} (got "${args.classifier}")`,
+    );
+    process.exit(2);
+  }
+
+  if (!ALLOWED_FORMATS.has(args.format)) {
+    console.error(
+      `error: --format must be one of ${[...ALLOWED_FORMATS].join(', ')} (got "${args.format}")`,
+    );
+    process.exit(2);
+  }
+
+  if (args.issues.length === 0) {
+    console.error('error: --issue must be supplied at least once');
+    process.exit(2);
+  }
+
+  const config = loadIddConfig();
+  const { actors: trustedActors, source: trustedMarkerActorsSource } =
+    resolveTrustedMarkerActors({
+      flagValue: args.trustedMarkerLogins,
+      envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
+      config,
+    });
+  if (trustedActors.length === 0) {
+    console.error(
+      'error: no trusted marker logins supplied. Pass --trusted-marker-logins, set IDD_TRUSTED_MARKER_ACTORS, or list trustedMarkerActors in .github/idd/config.json.',
+    );
+    process.exit(2);
+  }
+
+  const currentRepo =
+    args.owner && args.repo ? null : resolveCurrentGithubRepository();
+  const owner = args.owner || currentRepo?.owner || '';
+  const repo = args.repo || currentRepo?.repo || '';
+  const markerPrefix = normalizeMarkerPrefix(args.markerPrefix, config);
+
+  const report = runAuthoringMarkerSweep({
+    owner,
+    repo,
+    issues: args.issues,
+    markerPrefix,
+    classifier: args.classifier,
+    trustedSet: new Set(trustedActors),
+    apply: args.apply,
+    deadlineMs: args.deadlineMs,
+  });
+  report.trustedMarkerActorsSource = trustedMarkerActorsSource;
+
+  if (args.format === 'table') {
+    printTable(report);
+  } else {
+    console.log(JSON.stringify(report, null, 2));
+  }
+
+  process.exit(computeSweepExitCode(report));
+}

--- a/tests/gh-exec.test.mts
+++ b/tests/gh-exec.test.mts
@@ -14,6 +14,7 @@ import {
   ghGraphql,
   ghText,
   ghTextAsync,
+  ghTextUnbounded,
   resolveGhApiHostname,
   resolveViewerLogin,
   safeGhText,
@@ -136,6 +137,54 @@ test('ghText throws ENOBUFS on output exceeding the default 1 MiB buffer, but su
       maxBuffer: 10 * 1024 * 1024,
     });
     assert.equal(result.length, 2 * 1024 * 1024);
+  } finally {
+    restore();
+  }
+});
+
+test('ghTextUnbounded reads a response far larger than any fixed maxBuffer guess, via a temp file (#2935 review, rounds 4-6)', () => {
+  // 40 MiB: bigger than ghText's default 1 MiB AND bigger than every
+  // fixed maxBuffer this codebase tried and had second-guessed away
+  // during review (10 MiB, then 32 MiB) -- the point of this function
+  // is that no such number needs to be picked at all.
+  const size = 40 * 1024 * 1024;
+  const restore = stubGh(`process.stdout.write('y'.repeat(${size}));`);
+  try {
+    const result = ghTextUnbounded(['repo', 'view']);
+    assert.equal(result.length, size);
+  } finally {
+    restore();
+  }
+});
+
+test('ghTextUnbounded trims trailing whitespace, matching ghText', () => {
+  const restore = stubGh(`process.stdout.write('  trimmed  \\n');`);
+  try {
+    assert.equal(ghTextUnbounded(['repo', 'view']), 'trimmed');
+  } finally {
+    restore();
+  }
+});
+
+test('ghTextUnbounded throws on a non-zero gh exit and still cleans up its temp file', () => {
+  const restore = stubGh(`
+process.stderr.write('boom');
+process.exit(1);
+`);
+  try {
+    assert.throws(() => ghTextUnbounded(['repo', 'view']));
+  } finally {
+    restore();
+  }
+});
+
+test('ghTextUnbounded forwards a timeout override', () => {
+  const restore = stubGh(`process.stdout.write('fast');`);
+  try {
+    assert.equal(
+      ghTextUnbounded(['repo', 'view'], { timeout: 30_000 }),
+      'fast',
+    );
   } finally {
     restore();
   }

--- a/tests/gh-exec.test.mts
+++ b/tests/gh-exec.test.mts
@@ -125,6 +125,22 @@ test('ghText forwards a timeout override and still returns the trimmed result wh
   }
 });
 
+test('ghText throws ENOBUFS on output exceeding the default 1 MiB buffer, but succeeds with an explicit maxBuffer override (#2935 review, Codex)', () => {
+  const restore = stubGh(`process.stdout.write('x'.repeat(2 * 1024 * 1024));`);
+  try {
+    assert.throws(
+      () => ghText(['repo', 'view']),
+      (error: unknown) => (error as { code?: string }).code === 'ENOBUFS',
+    );
+    const result = ghText(['repo', 'view'], {
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    assert.equal(result.length, 2 * 1024 * 1024);
+  } finally {
+    restore();
+  }
+});
+
 test('ghText times out (throws) when gh exceeds the configured timeout', () => {
   const restore = stubGh(`
 // Block synchronously well past the configured timeout so execFileSync's

--- a/tests/help-text-flags.test.mts
+++ b/tests/help-text-flags.test.mts
@@ -155,6 +155,13 @@ const CROSS_REFERENCE_FLAGS: Readonly<Record<string, readonly string[]>> = {
     // verify-install-deps.mjs itself parses.
     '--frozen-lockfile',
   ],
+  'sweep-authoring-markers': [
+    // minimize-superseded-markers.mjs's own flag, cited by contrast: this
+    // helper's --help explains it has no --allow-untrusted escape hatch of
+    // its own (its "newest" determination depends on the trust filter),
+    // unlike a direct minimize-superseded-markers.mjs call.
+    '--allow-untrusted',
+  ],
 };
 
 // Explicit covered-helper list (mirrors tests/flag-name-matrix.test.mts's
@@ -211,6 +218,7 @@ const COVERED_HELPERS = [
   'stalled-session-quiet-check',
   'suitability-close-execute',
   'suitability-triage',
+  'sweep-authoring-markers',
   'verify-install-deps',
   'verify-workshop-integrity',
 ] as const;

--- a/tests/sweep-authoring-markers.test.mts
+++ b/tests/sweep-authoring-markers.test.mts
@@ -14,6 +14,8 @@ import { runMinimize } from '../src/scripts/minimize-superseded-markers.mts';
 import {
   computeSweepExitCode,
   fetchIssueCommentsGraphql,
+  isCrossRepoIssueToken,
+  parseIssueTargetToken,
   runAuthoringMarkerSweep,
   type SweepGraphqlComment,
 } from '../src/scripts/sweep-authoring-markers.mts';
@@ -96,6 +98,88 @@ if (queryArg.includes('minimizeComment')) {
 }
 `;
 
+test('isCrossRepoIssueToken recognizes owner/repo#number and rejects a bare number', () => {
+  assert.equal(isCrossRepoIssueToken('kurone-kito/idd-skill#2935'), true);
+  assert.equal(isCrossRepoIssueToken('2935'), false);
+});
+
+test('parseIssueTargetToken resolves a bare number against the given defaults', () => {
+  assert.deepEqual(parseIssueTargetToken('2935', 'kurone-kito', 'idd-skill'), {
+    owner: 'kurone-kito',
+    repo: 'idd-skill',
+    issue: 2935,
+  });
+});
+
+test('parseIssueTargetToken resolves an explicit owner/repo#number against its OWN repository, ignoring the defaults', () => {
+  assert.deepEqual(
+    parseIssueTargetToken(
+      'other-owner/other-repo#42',
+      'kurone-kito',
+      'idd-skill',
+    ),
+    { owner: 'other-owner', repo: 'other-repo', issue: 42 },
+  );
+});
+
+test('parseIssueTargetToken rejects a malformed cross-repository-looking token instead of misparsing it as a bare number', () => {
+  assert.throws(
+    () =>
+      parseIssueTargetToken(
+        'kurone-kito/idd-skill',
+        'kurone-kito',
+        'idd-skill',
+      ),
+    /looks like a cross-repository reference but does not match owner\/repo#number/,
+  );
+  assert.throws(
+    () => parseIssueTargetToken('#2935', 'kurone-kito', 'idd-skill'),
+    /looks like a cross-repository reference/,
+  );
+});
+
+test('runAuthoringMarkerSweep mixes a same-repo bare-number target with a cross-repository journal in one invocation, fetching each from its own owner/repo', () => {
+  const seen: { owner: string; repo: string; issue: number }[] = [];
+  const report = runAuthoringMarkerSweep(
+    {
+      issues: [
+        parseIssueTargetToken('100', 'kurone-kito', 'idd-skill'),
+        parseIssueTargetToken(
+          'other-owner/other-repo#200',
+          'kurone-kito',
+          'idd-skill',
+        ),
+      ],
+      markerPrefix: MARKER_PREFIX,
+      classifier: 'OUTDATED',
+      trustedSet: new Set(['trusted-bot']),
+      apply: true,
+    },
+    {
+      fetchIssueComments: (owner, repo, issue) => {
+        seen.push({ owner, repo, issue });
+        return [];
+      },
+      minimize: runMinimize,
+    },
+  );
+  assert.deepEqual(seen, [
+    { owner: 'kurone-kito', repo: 'idd-skill', issue: 100 },
+    { owner: 'other-owner', repo: 'other-repo', issue: 200 },
+  ]);
+  assert.deepEqual(
+    report.issues.map((i) => ({
+      owner: i.owner,
+      repo: i.repo,
+      issue: i.issue,
+    })),
+    [
+      { owner: 'kurone-kito', repo: 'idd-skill', issue: 100 },
+      { owner: 'other-owner', repo: 'other-repo', issue: 200 },
+    ],
+  );
+});
+
 test('runAuthoringMarkerSweep classifies both families independently per issue and minimizes exactly the eligible candidates', () => {
   const targetComments: SweepGraphqlComment[] = [
     comment('IC_t0', ownerMarker('acquire', 'owner-1'), 'trusted-bot'), // eligible
@@ -129,9 +213,10 @@ test('runAuthoringMarkerSweep classifies both families independently per issue a
   try {
     const report = runAuthoringMarkerSweep(
       {
-        owner: 'kurone-kito',
-        repo: 'idd-skill',
-        issues: [100, 200],
+        issues: [
+          { owner: 'kurone-kito', repo: 'idd-skill', issue: 100 },
+          { owner: 'kurone-kito', repo: 'idd-skill', issue: 200 },
+        ],
         markerPrefix: MARKER_PREFIX,
         classifier: 'OUTDATED',
         trustedSet: new Set(['trusted-bot']),
@@ -189,9 +274,7 @@ test('runAuthoringMarkerSweep treats a drifted (non-byte-exact) marker body as n
   try {
     const report = runAuthoringMarkerSweep(
       {
-        owner: 'kurone-kito',
-        repo: 'idd-skill',
-        issues: [100],
+        issues: [{ owner: 'kurone-kito', repo: 'idd-skill', issue: 100 }],
         markerPrefix: MARKER_PREFIX,
         classifier: 'OUTDATED',
         trustedSet: new Set(['trusted-bot']),
@@ -224,9 +307,7 @@ test('runAuthoringMarkerSweep skips the mutation entirely once the deadline is a
   try {
     const report = runAuthoringMarkerSweep(
       {
-        owner: 'kurone-kito',
-        repo: 'idd-skill',
-        issues: [100],
+        issues: [{ owner: 'kurone-kito', repo: 'idd-skill', issue: 100 }],
         markerPrefix: MARKER_PREFIX,
         classifier: 'OUTDATED',
         trustedSet: new Set(['trusted-bot']),
@@ -271,9 +352,7 @@ test('runAuthoringMarkerSweep dry run (apply omitted) still reports a would-be m
   try {
     const report = runAuthoringMarkerSweep(
       {
-        owner: 'kurone-kito',
-        repo: 'idd-skill',
-        issues: [100],
+        issues: [{ owner: 'kurone-kito', repo: 'idd-skill', issue: 100 }],
         markerPrefix: MARKER_PREFIX,
         classifier: 'OUTDATED',
         trustedSet: new Set(['trusted-bot']),
@@ -299,9 +378,10 @@ test('runAuthoringMarkerSweep records a fetch failure for one issue without abor
   ];
   const report = runAuthoringMarkerSweep(
     {
-      owner: 'kurone-kito',
-      repo: 'idd-skill',
-      issues: [100, 200],
+      issues: [
+        { owner: 'kurone-kito', repo: 'idd-skill', issue: 100 },
+        { owner: 'kurone-kito', repo: 'idd-skill', issue: 200 },
+      ],
       markerPrefix: MARKER_PREFIX,
       classifier: 'OUTDATED',
       trustedSet: new Set(['trusted-bot']),
@@ -325,9 +405,7 @@ test('runAuthoringMarkerSweep records a fetch failure for one issue without abor
 test('computeSweepExitCode returns 0 for a clean report with no candidates', () => {
   const clean = runAuthoringMarkerSweep(
     {
-      owner: 'o',
-      repo: 'r',
-      issues: [1],
+      issues: [{ owner: 'o', repo: 'r', issue: 1 }],
       markerPrefix: MARKER_PREFIX,
       classifier: 'OUTDATED',
       trustedSet: new Set(['trusted-bot']),
@@ -370,9 +448,7 @@ if (queryArg.includes('minimizeComment')) {
   try {
     const report = runAuthoringMarkerSweep(
       {
-        owner: 'kurone-kito',
-        repo: 'idd-skill',
-        issues: [100],
+        issues: [{ owner: 'kurone-kito', repo: 'idd-skill', issue: 100 }],
         markerPrefix: MARKER_PREFIX,
         classifier: 'OUTDATED',
         trustedSet: new Set(['trusted-bot']),
@@ -405,9 +481,7 @@ process.stdout.write(JSON.stringify({
   try {
     const report = runAuthoringMarkerSweep(
       {
-        owner: 'kurone-kito',
-        repo: 'idd-skill',
-        issues: [100],
+        issues: [{ owner: 'kurone-kito', repo: 'idd-skill', issue: 100 }],
         markerPrefix: MARKER_PREFIX,
         classifier: 'OUTDATED',
         trustedSet: new Set(['trusted-bot']),
@@ -559,6 +633,36 @@ test('an omitted --issue is rejected by name', () => {
   assert.equal(
     result.stderr.trim(),
     'error: --issue must be supplied at least once',
+  );
+});
+
+test('a lone --owner without --repo (or vice versa) is rejected before resolving the current repository', () => {
+  const lonelyOwner = runCli([
+    '--issue',
+    '1',
+    '--trusted-marker-logins',
+    'kurone-kito',
+    '--owner',
+    'kurone-kito',
+  ]);
+  assert.equal(lonelyOwner.status, 2);
+  assert.equal(
+    lonelyOwner.stderr.trim(),
+    'error: sweep-authoring-markers: --owner and --repo must be provided together or not at all',
+  );
+
+  const lonelyRepo = runCli([
+    '--issue',
+    '1',
+    '--trusted-marker-logins',
+    'kurone-kito',
+    '--repo',
+    'idd-skill',
+  ]);
+  assert.equal(lonelyRepo.status, 2);
+  assert.equal(
+    lonelyRepo.stderr.trim(),
+    'error: sweep-authoring-markers: --owner and --repo must be provided together or not at all',
   );
 });
 

--- a/tests/sweep-authoring-markers.test.mts
+++ b/tests/sweep-authoring-markers.test.mts
@@ -1,0 +1,593 @@
+import assert from 'node:assert/strict';
+import { type SpawnSyncReturns, spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  renderAuthoringOwnerMarker,
+  renderAuthoringPublicationIntentMarker,
+} from '../src/scripts/marker-helpers.mts';
+import { runMinimize } from '../src/scripts/minimize-superseded-markers.mts';
+import {
+  computeSweepExitCode,
+  fetchIssueCommentsGraphql,
+  runAuthoringMarkerSweep,
+  type SweepGraphqlComment,
+} from '../src/scripts/sweep-authoring-markers.mts';
+import { stubExecutable } from './test-utils.mts';
+
+const MARKER_PREFIX = 'idd-skill';
+const SCRIPT = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'scripts',
+  'sweep-authoring-markers.mjs',
+);
+
+function ownerMarker(mode: string, owner: string): string {
+  return renderAuthoringOwnerMarker({
+    markerPrefix: MARKER_PREFIX,
+    target: 'kurone-kito/idd-skill#100',
+    anchor: 'kurone-kito/idd-skill#100',
+    mode,
+    owner,
+    set: 'set-1',
+    session: 'session-1',
+    bodySha256: 'none',
+    snapshotSha256: 'none',
+    supersedes: 'none',
+  });
+}
+
+function intentMarker(state: string, issue: string): string {
+  return renderAuthoringPublicationIntentMarker({
+    markerPrefix: MARKER_PREFIX,
+    target: 'kurone-kito/idd-skill#100',
+    anchor: 'kurone-kito/idd-skill#100',
+    set: 'set-1',
+    session: 'session-1',
+    token: 'pub-1',
+    journal: 'kurone-kito/idd-skill#200',
+    issue,
+    actor: 'kurone-kito',
+    state,
+  });
+}
+
+function comment(
+  nodeId: string,
+  body: string,
+  authorLogin: string,
+  isMinimized = false,
+): SweepGraphqlComment {
+  return {
+    nodeId,
+    url: `https://example.invalid/${nodeId}`,
+    body,
+    authorLogin,
+    isMinimized,
+  };
+}
+
+// Stub gh so runMinimize's own probe+apply calls are deterministic and
+// offline: every probe reports a trusted, minimizable IssueComment; every
+// apply mutation confirms isMinimized: true. This is deliberately
+// coarse -- the point of these tests is sweep-authoring-markers.mts's OWN
+// classify/filter/aggregate logic, not runMinimize's already-covered
+// probe/apply behavior (tests/minimize-superseded-markers.test.mts) -- and
+// it is safe here because this file's own pre-filter (classifyAuthoring
+// MarkerFamily) already restricts every subjectId reaching runMinimize to
+// an already-known-trusted, not-yet-minimized candidate.
+const GH_MINIMIZE_STUB = `
+const argv = process.argv.slice(2);
+const queryArg = argv.find((a) => a.startsWith('query=')) || '';
+const idArg = (argv.find((a) => a.startsWith('id=')) || '').slice(3);
+if (queryArg.includes('minimizeComment')) {
+  process.stdout.write(JSON.stringify({
+    data: { minimizeComment: { minimizedComment: { __typename: 'IssueComment', id: idArg, isMinimized: true, minimizedReason: 'OUTDATED' } } },
+  }));
+} else {
+  process.stdout.write(JSON.stringify({
+    data: { node: { __typename: 'IssueComment', url: 'https://example.invalid/' + idArg, isMinimized: false, minimizedReason: null, viewerCanMinimize: true, author: { login: 'trusted-bot' } } },
+  }));
+}
+`;
+
+test('runAuthoringMarkerSweep classifies both families independently per issue and minimizes exactly the eligible candidates', () => {
+  const targetComments: SweepGraphqlComment[] = [
+    comment('IC_t0', ownerMarker('acquire', 'owner-1'), 'trusted-bot'), // eligible
+    comment('IC_t1', ownerMarker('heartbeat', 'owner-1'), 'trusted-bot', true), // already-minimized
+    comment('IC_t2', ownerMarker('release', 'owner-1'), 'untrusted-user'), // untrusted
+    comment('IC_t3', 'just some prose, not a marker at all', 'trusted-bot'), // non-canonical
+    comment('IC_t4', ownerMarker('release-guard', 'owner-1'), 'trusted-bot'), // newest trusted -> protected
+  ];
+  const journalComments: SweepGraphqlComment[] = [
+    comment('IC_j0', intentMarker('pending', 'none'), 'trusted-bot'), // eligible
+    comment('IC_j1', intentMarker('member', '2935'), 'trusted-bot'), // newest trusted -> protected
+  ];
+
+  const fetchIssueComments = (
+    owner: string,
+    repo: string,
+    issueNumber: number,
+  ): SweepGraphqlComment[] => {
+    assert.equal(owner, 'kurone-kito');
+    assert.equal(repo, 'idd-skill');
+    if (issueNumber === 100) {
+      return targetComments;
+    }
+    if (issueNumber === 200) {
+      return journalComments;
+    }
+    throw new Error(`unexpected issue ${issueNumber}`);
+  };
+
+  const restore = stubExecutable('gh', GH_MINIMIZE_STUB);
+  try {
+    const report = runAuthoringMarkerSweep(
+      {
+        owner: 'kurone-kito',
+        repo: 'idd-skill',
+        issues: [100, 200],
+        markerPrefix: MARKER_PREFIX,
+        classifier: 'OUTDATED',
+        trustedSet: new Set(['trusted-bot']),
+        apply: true,
+      },
+      { fetchIssueComments, minimize: runMinimize },
+    );
+
+    assert.equal(computeSweepExitCode(report), 0);
+    assert.equal(report.mode, 'apply');
+    assert.deepEqual(
+      report.issues.map((entry) => ({
+        issue: entry.issue,
+        commentCount: entry.commentCount,
+        nonCanonical: entry.nonCanonical,
+        error: entry.error,
+      })),
+      [
+        { issue: 100, commentCount: 5, nonCanonical: 1, error: undefined },
+        { issue: 200, commentCount: 2, nonCanonical: 0, error: undefined },
+      ],
+    );
+
+    const owner = report.families['authoring-owner'];
+    assert.equal(owner.scanned, 4);
+    assert.equal(owner.untrusted, 1);
+    assert.equal(owner.protectedNewest, 1);
+    assert.equal(owner.alreadyMinimized, 1);
+    assert.equal(owner.eligible, 1);
+    assert.equal(owner.minimized, 1);
+    assert.equal(owner.raceAlreadyMinimized, 0);
+    assert.equal(owner.deadlineSkipped, 0);
+    assert.equal(owner.failed, 0);
+
+    const intent = report.families['authoring-publication-intent'];
+    assert.equal(intent.scanned, 2);
+    assert.equal(intent.untrusted, 0);
+    assert.equal(intent.protectedNewest, 1);
+    assert.equal(intent.alreadyMinimized, 0);
+    assert.equal(intent.eligible, 1);
+    assert.equal(intent.minimized, 1);
+    assert.equal(intent.failed, 0);
+  } finally {
+    restore();
+  }
+});
+
+test('runAuthoringMarkerSweep treats a drifted (non-byte-exact) marker body as non-canonical, never counting or submitting it', () => {
+  const drifted = `${ownerMarker('acquire', 'owner-1')} `; // trailing space breaks the byte-exact re-render match
+  const targetComments: SweepGraphqlComment[] = [
+    comment('IC_r0', drifted, 'trusted-bot'),
+    comment('IC_r1', ownerMarker('heartbeat', 'owner-1'), 'trusted-bot'),
+  ];
+  const restore = stubExecutable('gh', 'process.exit(1);\n');
+  try {
+    const report = runAuthoringMarkerSweep(
+      {
+        owner: 'kurone-kito',
+        repo: 'idd-skill',
+        issues: [100],
+        markerPrefix: MARKER_PREFIX,
+        classifier: 'OUTDATED',
+        trustedSet: new Set(['trusted-bot']),
+        apply: true,
+      },
+      { fetchIssueComments: () => targetComments, minimize: runMinimize },
+    );
+    assert.equal(report.issues[0].nonCanonical, 1);
+    // Only one real owner-family match (IC_r1) -- fewer than two, so
+    // nothing is "superseded" and nothing is submitted; the drifted
+    // comment is never even a candidate.
+    assert.equal(report.families['authoring-owner'].scanned, 1);
+    assert.equal(report.families['authoring-owner'].eligible, 0);
+    assert.equal(report.items.length, 0);
+    assert.equal(computeSweepExitCode(report), 0);
+  } finally {
+    restore();
+  }
+});
+
+test('runAuthoringMarkerSweep skips the mutation entirely once the deadline is already spent before it, marking every eligible candidate deadlineSkipped', () => {
+  const targetComments: SweepGraphqlComment[] = [
+    comment('IC_e0', ownerMarker('acquire', 'owner-1'), 'trusted-bot'),
+    comment('IC_e1', ownerMarker('heartbeat', 'owner-1'), 'trusted-bot'),
+  ];
+  // gh must never be invoked here: a stub that exits non-zero proves the
+  // mutation call never happened (the deadline is checked BEFORE calling
+  // deps.minimize, not left to runMinimize's own index-0 exemption).
+  const restore = stubExecutable('gh', 'process.exit(1);\n');
+  try {
+    const report = runAuthoringMarkerSweep(
+      {
+        owner: 'kurone-kito',
+        repo: 'idd-skill',
+        issues: [100],
+        markerPrefix: MARKER_PREFIX,
+        classifier: 'OUTDATED',
+        trustedSet: new Set(['trusted-bot']),
+        apply: true,
+        deadlineMs: 10,
+      },
+      {
+        // Busy-wait past the 10ms budget before returning, so the
+        // post-fetch `remaining()` check before the mutation stage is
+        // deterministically negative, without relying on flaky real gh
+        // latency.
+        fetchIssueComments: () => {
+          const until = Date.now() + 30;
+          while (Date.now() < until) {
+            // busy-wait
+          }
+          return targetComments;
+        },
+        minimize: runMinimize,
+      },
+    );
+    assert.equal(report.issues[0].error, undefined);
+    const owner = report.families['authoring-owner'];
+    assert.equal(owner.eligible, 1);
+    assert.equal(owner.deadlineSkipped, 1);
+    assert.equal(owner.minimized, 0);
+    assert.equal(owner.failed, 0);
+    assert.equal(report.items.length, 1);
+    assert.equal(report.items[0].status, 'skipped');
+    assert.equal(report.items[0].reason, 'deadline-exceeded');
+  } finally {
+    restore();
+  }
+});
+
+test('runAuthoringMarkerSweep dry run (apply omitted) still reports a would-be minimize count without mutating', () => {
+  const targetComments: SweepGraphqlComment[] = [
+    comment('IC_d0', ownerMarker('acquire', 'owner-1'), 'trusted-bot'),
+    comment('IC_d1', ownerMarker('heartbeat', 'owner-1'), 'trusted-bot'),
+  ];
+  const restore = stubExecutable('gh', GH_MINIMIZE_STUB);
+  try {
+    const report = runAuthoringMarkerSweep(
+      {
+        owner: 'kurone-kito',
+        repo: 'idd-skill',
+        issues: [100],
+        markerPrefix: MARKER_PREFIX,
+        classifier: 'OUTDATED',
+        trustedSet: new Set(['trusted-bot']),
+        apply: false,
+      },
+      {
+        fetchIssueComments: () => targetComments,
+        minimize: runMinimize,
+      },
+    );
+    assert.equal(report.mode, 'dry-run');
+    assert.equal(report.families['authoring-owner'].eligible, 1);
+    assert.equal(report.families['authoring-owner'].minimized, 1);
+    assert.equal(computeSweepExitCode(report), 0);
+  } finally {
+    restore();
+  }
+});
+
+test('runAuthoringMarkerSweep records a fetch failure for one issue without aborting the others', () => {
+  const otherComments: SweepGraphqlComment[] = [
+    comment('IC_o0', ownerMarker('acquire', 'owner-1'), 'trusted-bot'),
+  ];
+  const report = runAuthoringMarkerSweep(
+    {
+      owner: 'kurone-kito',
+      repo: 'idd-skill',
+      issues: [100, 200],
+      markerPrefix: MARKER_PREFIX,
+      classifier: 'OUTDATED',
+      trustedSet: new Set(['trusted-bot']),
+      apply: true,
+    },
+    {
+      fetchIssueComments: (_owner, _repo, issueNumber) => {
+        if (issueNumber === 100) {
+          throw new Error('gh-graphql-error: boom');
+        }
+        return otherComments;
+      },
+      minimize: runMinimize,
+    },
+  );
+  assert.equal(report.issues[0].error, 'gh-graphql-error: boom');
+  assert.equal(report.issues[1].error, undefined);
+  assert.equal(computeSweepExitCode(report), 1);
+});
+
+test('computeSweepExitCode returns 0 for a clean report with no candidates', () => {
+  const clean = runAuthoringMarkerSweep(
+    {
+      owner: 'o',
+      repo: 'r',
+      issues: [1],
+      markerPrefix: MARKER_PREFIX,
+      classifier: 'OUTDATED',
+      trustedSet: new Set(['trusted-bot']),
+      apply: true,
+    },
+    {
+      fetchIssueComments: () => [],
+      minimize: runMinimize,
+    },
+  );
+  assert.equal(computeSweepExitCode(clean), 0);
+});
+
+test('computeSweepExitCode returns 1 when the mutation genuinely fails for a candidate, but a non-failure skip alone stays 0', () => {
+  const targetComments: SweepGraphqlComment[] = [
+    comment('IC_f0', ownerMarker('acquire', 'owner-1'), 'trusted-bot'),
+    comment('IC_f1', ownerMarker('heartbeat', 'owner-1'), 'trusted-bot'),
+  ];
+  // Probe succeeds normally (trusted, minimizable, not yet minimized), but
+  // the minimizeComment mutation itself returns a GraphQL error -- a
+  // genuine `status: "failed"` from runMinimize, distinct from every
+  // other skip reason this sweep's own pre-filter can still let through
+  // to runMinimize (viewer-cannot-minimize, unsupported-type,
+  // untrusted-author), none of which should ever flip the exit code.
+  const restore = stubExecutable(
+    'gh',
+    `
+const argv = process.argv.slice(2);
+const queryArg = argv.find((a) => a.startsWith('query=')) || '';
+const idArg = (argv.find((a) => a.startsWith('id=')) || '').slice(3);
+if (queryArg.includes('minimizeComment')) {
+  process.stdout.write(JSON.stringify({ errors: [{ message: 'boom' }] }));
+} else {
+  process.stdout.write(JSON.stringify({
+    data: { node: { __typename: 'IssueComment', url: 'https://example.invalid/' + idArg, isMinimized: false, minimizedReason: null, viewerCanMinimize: true, author: { login: 'trusted-bot' } } },
+  }));
+}
+`,
+  );
+  try {
+    const report = runAuthoringMarkerSweep(
+      {
+        owner: 'kurone-kito',
+        repo: 'idd-skill',
+        issues: [100],
+        markerPrefix: MARKER_PREFIX,
+        classifier: 'OUTDATED',
+        trustedSet: new Set(['trusted-bot']),
+        apply: true,
+      },
+      { fetchIssueComments: () => targetComments, minimize: runMinimize },
+    );
+    assert.equal(report.families['authoring-owner'].failed, 1);
+    assert.equal(report.families['authoring-owner'].skippedOther, 0);
+    assert.equal(report.items[0].status, 'failed');
+    assert.equal(computeSweepExitCode(report), 1);
+  } finally {
+    restore();
+  }
+});
+
+test('a live re-probe skip (viewer-cannot-minimize) counts as skippedOther, not failed, and never flips the exit code', () => {
+  const targetComments: SweepGraphqlComment[] = [
+    comment('IC_s0', ownerMarker('acquire', 'owner-1'), 'trusted-bot'),
+    comment('IC_s1', ownerMarker('heartbeat', 'owner-1'), 'trusted-bot'),
+  ];
+  const restore = stubExecutable(
+    'gh',
+    `
+process.stdout.write(JSON.stringify({
+  data: { node: { __typename: 'IssueComment', url: 'https://example.invalid/x', isMinimized: false, minimizedReason: null, viewerCanMinimize: false, author: { login: 'trusted-bot' } } },
+}));
+`,
+  );
+  try {
+    const report = runAuthoringMarkerSweep(
+      {
+        owner: 'kurone-kito',
+        repo: 'idd-skill',
+        issues: [100],
+        markerPrefix: MARKER_PREFIX,
+        classifier: 'OUTDATED',
+        trustedSet: new Set(['trusted-bot']),
+        apply: true,
+      },
+      { fetchIssueComments: () => targetComments, minimize: runMinimize },
+    );
+    assert.equal(report.families['authoring-owner'].skippedOther, 1);
+    assert.equal(report.families['authoring-owner'].failed, 0);
+    assert.equal(report.items[0].status, 'skipped');
+    assert.equal(report.items[0].reason, 'viewer-cannot-minimize');
+    assert.equal(computeSweepExitCode(report), 0);
+  } finally {
+    restore();
+  }
+});
+
+test('fetchIssueCommentsGraphql walks every page and selects isMinimized', () => {
+  const restore = stubExecutable(
+    'gh',
+    `
+const argv = process.argv.slice(2);
+const hasCursor = argv.some((a) => a.startsWith('cursor='));
+if (!hasCursor) {
+  process.stdout.write(JSON.stringify({
+    data: { repository: { issue: { comments: {
+      nodes: [{ id: 'IC_p0', url: 'https://x/0', body: 'body-0', isMinimized: false, author: { login: 'a' } }],
+      pageInfo: { hasNextPage: true, endCursor: 'CURSOR1' },
+    } } } },
+  }));
+} else {
+  process.stdout.write(JSON.stringify({
+    data: { repository: { issue: { comments: {
+      nodes: [{ id: 'IC_p1', url: 'https://x/1', body: 'body-1', isMinimized: true, author: { login: 'b' } }],
+      pageInfo: { hasNextPage: false, endCursor: null },
+    } } } },
+  }));
+}
+`,
+  );
+  try {
+    const result = fetchIssueCommentsGraphql(
+      'kurone-kito',
+      'idd-skill',
+      100,
+      undefined,
+    );
+    assert.deepEqual(result, [
+      {
+        nodeId: 'IC_p0',
+        url: 'https://x/0',
+        body: 'body-0',
+        authorLogin: 'a',
+        isMinimized: false,
+      },
+      {
+        nodeId: 'IC_p1',
+        url: 'https://x/1',
+        body: 'body-1',
+        authorLogin: 'b',
+        isMinimized: true,
+      },
+    ]);
+  } finally {
+    restore();
+  }
+});
+
+test('fetchIssueCommentsGraphql throws a clear error when the number is not an issue', () => {
+  const restore = stubExecutable(
+    'gh',
+    `process.stdout.write(JSON.stringify({ data: { repository: { issue: null } } }));`,
+  );
+  try {
+    assert.throws(
+      () =>
+        fetchIssueCommentsGraphql('kurone-kito', 'idd-skill', 999, undefined),
+      /is not an issue or does not exist/,
+    );
+  } finally {
+    restore();
+  }
+});
+
+test('fetchIssueCommentsGraphql bails before any gh call once the deadline is already exhausted', () => {
+  const restore = stubExecutable('gh', 'process.exit(1);\n');
+  try {
+    assert.throws(
+      () => fetchIssueCommentsGraphql('kurone-kito', 'idd-skill', 100, 0),
+      /deadline exceeded/,
+    );
+  } finally {
+    restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+// Runs the CLI from a fresh, empty sandbox directory (never this repo's
+// own working directory): this repository's real `.github/idd/config.json`
+// configures a real `trustedMarkerActors` list, which would otherwise let
+// a CLI-parse-error test silently pass validation and go on to attempt a
+// real, uncontrolled `gh` network call against the live repository --
+// exactly the failure `tests/minimize-superseded-markers.test.mts`'s own
+// "config-only resolution" test isolates against the same way.
+function runCli(args: string[]): SpawnSyncReturns<string> {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-sweep-authoring-'));
+  try {
+    return spawnSync(process.execPath, [SCRIPT, ...args], {
+      cwd: sandbox,
+      encoding: 'utf8',
+      env: { ...process.env, IDD_TRUSTED_MARKER_ACTORS: '' },
+    });
+  } finally {
+    rmSync(sandbox, { recursive: true, force: true });
+  }
+}
+
+test('--help exits 0 and documents every flag the contract worked examples use', () => {
+  const result = runCli(['--help']);
+  assert.equal(result.status, 0, result.stderr);
+  for (const flag of [
+    '--issue',
+    '--owner',
+    '--repo',
+    '--marker-prefix',
+    '--classifier',
+    '--trusted-marker-logins',
+    '--apply',
+    '--format',
+    '--deadline-ms',
+  ]) {
+    assert.match(result.stdout, new RegExp(flag.replace('-', '\\-')));
+  }
+});
+
+test('an omitted --issue is rejected by name', () => {
+  const result = runCli([
+    '--trusted-marker-logins',
+    'kurone-kito',
+    '--owner',
+    'kurone-kito',
+    '--repo',
+    'idd-skill',
+  ]);
+  assert.equal(result.status, 2);
+  assert.equal(
+    result.stderr.trim(),
+    'error: --issue must be supplied at least once',
+  );
+});
+
+test('a missing trusted-marker-logins source is rejected with no --allow-untrusted escape hatch', () => {
+  const result = runCli([
+    '--issue',
+    '1',
+    '--owner',
+    'kurone-kito',
+    '--repo',
+    'idd-skill',
+  ]);
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /no trusted marker logins supplied/);
+});
+
+test('an invalid --classifier is rejected before any network call', () => {
+  const result = runCli([
+    '--issue',
+    '1',
+    '--owner',
+    'kurone-kito',
+    '--repo',
+    'idd-skill',
+    '--trusted-marker-logins',
+    'kurone-kito',
+    '--classifier',
+    'BOGUS',
+  ]);
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /--classifier must be one of/);
+});

--- a/tests/sweep-authoring-markers.test.mts
+++ b/tests/sweep-authoring-markers.test.mts
@@ -117,6 +117,24 @@ test('parseIssueTargetToken resolves a dot-prefixed repository name', () => {
   );
 });
 
+test('isCrossRepoIssueToken accepts every owner/repo shape schemas/policy.schema.json itself accepts for issueAuthoring.journalIssue (#2935 review, round 2, Codex)', () => {
+  // Mirrors the schema's own `^[\w.-]+/[\w.-]+#[1-9][0-9]*$` pattern
+  // exactly: leading/trailing underscore, leading/trailing hyphen, and a
+  // leading dot are all schema-valid and must all parse here too.
+  assert.equal(isCrossRepoIssueToken('acme/_journal#42'), true);
+  assert.equal(isCrossRepoIssueToken('acme/journal_#42'), true);
+  assert.equal(isCrossRepoIssueToken('acme/-journal#42'), true);
+  assert.equal(isCrossRepoIssueToken('acme/journal-#42'), true);
+  assert.equal(isCrossRepoIssueToken('_acme/journal#42'), true);
+});
+
+test('parseIssueTargetToken resolves a leading-underscore repository name', () => {
+  assert.deepEqual(
+    parseIssueTargetToken('acme/_journal#42', 'kurone-kito', 'idd-skill'),
+    { owner: 'acme', repo: '_journal', issue: 42 },
+  );
+});
+
 test('normalizeMarkerPrefix prefers an explicit --marker-prefix flag over config', () => {
   assert.equal(
     normalizeMarkerPrefix('flag-prefix', { markerPrefix: 'config-prefix' }),

--- a/tests/sweep-authoring-markers.test.mts
+++ b/tests/sweep-authoring-markers.test.mts
@@ -15,6 +15,7 @@ import {
   computeSweepExitCode,
   fetchIssueCommentsGraphql,
   isCrossRepoIssueToken,
+  normalizeMarkerPrefix,
   parseIssueTargetToken,
   runAuthoringMarkerSweep,
   type SweepGraphqlComment,
@@ -64,6 +65,7 @@ function comment(
   body: string,
   authorLogin: string,
   isMinimized = false,
+  createdAt = '',
 ): SweepGraphqlComment {
   return {
     nodeId,
@@ -71,6 +73,7 @@ function comment(
     body,
     authorLogin,
     isMinimized,
+    createdAt,
   };
 }
 
@@ -101,6 +104,37 @@ if (queryArg.includes('minimizeComment')) {
 test('isCrossRepoIssueToken recognizes owner/repo#number and rejects a bare number', () => {
   assert.equal(isCrossRepoIssueToken('kurone-kito/idd-skill#2935'), true);
   assert.equal(isCrossRepoIssueToken('2935'), false);
+});
+
+test('isCrossRepoIssueToken accepts a dot-prefixed repository name (#2935 review, Codex)', () => {
+  assert.equal(isCrossRepoIssueToken('some-org/.github#42'), true);
+});
+
+test('parseIssueTargetToken resolves a dot-prefixed repository name', () => {
+  assert.deepEqual(
+    parseIssueTargetToken('some-org/.github#42', 'kurone-kito', 'idd-skill'),
+    { owner: 'some-org', repo: '.github', issue: 42 },
+  );
+});
+
+test('normalizeMarkerPrefix prefers an explicit --marker-prefix flag over config', () => {
+  assert.equal(
+    normalizeMarkerPrefix('flag-prefix', { markerPrefix: 'config-prefix' }),
+    'flag-prefix',
+  );
+});
+
+test('normalizeMarkerPrefix falls back to config.markerPrefix when no flag is given', () => {
+  assert.equal(
+    normalizeMarkerPrefix('', { markerPrefix: 'config-prefix' }),
+    'config-prefix',
+  );
+});
+
+test('normalizeMarkerPrefix resolves to empty -- never a hardcoded default -- when neither a flag nor config is given (#2935 review, Codex)', () => {
+  assert.equal(normalizeMarkerPrefix('', null), '');
+  assert.equal(normalizeMarkerPrefix('', {}), '');
+  assert.equal(normalizeMarkerPrefix('   ', { markerPrefix: '   ' }), '');
 });
 
 test('parseIssueTargetToken resolves a bare number against the given defaults', () => {
@@ -508,14 +542,14 @@ const hasCursor = argv.some((a) => a.startsWith('cursor='));
 if (!hasCursor) {
   process.stdout.write(JSON.stringify({
     data: { repository: { issue: { comments: {
-      nodes: [{ id: 'IC_p0', url: 'https://x/0', body: 'body-0', isMinimized: false, author: { login: 'a' } }],
+      nodes: [{ id: 'IC_p0', url: 'https://x/0', body: 'body-0', isMinimized: false, createdAt: '2026-01-01T00:00:00Z', author: { login: 'a' } }],
       pageInfo: { hasNextPage: true, endCursor: 'CURSOR1' },
     } } } },
   }));
 } else {
   process.stdout.write(JSON.stringify({
     data: { repository: { issue: { comments: {
-      nodes: [{ id: 'IC_p1', url: 'https://x/1', body: 'body-1', isMinimized: true, author: { login: 'b' } }],
+      nodes: [{ id: 'IC_p1', url: 'https://x/1', body: 'body-1', isMinimized: true, createdAt: '2026-01-02T00:00:00Z', author: { login: 'b' } }],
       pageInfo: { hasNextPage: false, endCursor: null },
     } } } },
   }));
@@ -536,6 +570,7 @@ if (!hasCursor) {
         body: 'body-0',
         authorLogin: 'a',
         isMinimized: false,
+        createdAt: '2026-01-01T00:00:00Z',
       },
       {
         nodeId: 'IC_p1',
@@ -543,8 +578,40 @@ if (!hasCursor) {
         body: 'body-1',
         authorLogin: 'b',
         isMinimized: true,
+        createdAt: '2026-01-02T00:00:00Z',
       },
     ]);
+  } finally {
+    restore();
+  }
+});
+
+test('fetchIssueCommentsGraphql sorts ascending by createdAt, correcting an out-of-order API response (#2935 review)', () => {
+  const restore = stubExecutable(
+    'gh',
+    `
+process.stdout.write(JSON.stringify({
+  data: { repository: { issue: { comments: {
+    nodes: [
+      { id: 'IC_newer', url: 'https://x/newer', body: 'newer', isMinimized: false, createdAt: '2026-02-02T00:00:00Z', author: { login: 'a' } },
+      { id: 'IC_older', url: 'https://x/older', body: 'older', isMinimized: false, createdAt: '2026-02-01T00:00:00Z', author: { login: 'b' } }
+    ],
+    pageInfo: { hasNextPage: false, endCursor: null },
+  } } } },
+}));
+`,
+  );
+  try {
+    const result = fetchIssueCommentsGraphql(
+      'kurone-kito',
+      'idd-skill',
+      100,
+      undefined,
+    );
+    assert.deepEqual(
+      result.map((c) => c.nodeId),
+      ['IC_older', 'IC_newer'],
+    );
   } finally {
     restore();
   }
@@ -664,6 +731,22 @@ test('a lone --owner without --repo (or vice versa) is rejected before resolving
     lonelyRepo.stderr.trim(),
     'error: sweep-authoring-markers: --owner and --repo must be provided together or not at all',
   );
+});
+
+test('a missing --marker-prefix with no config markerPrefix is rejected before any network call (#2935 review, Codex)', () => {
+  const result = runCli([
+    '--issue',
+    '1',
+    '--owner',
+    'kurone-kito',
+    '--repo',
+    'idd-skill',
+    '--trusted-marker-logins',
+    'kurone-kito',
+  ]);
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /no marker prefix resolved/);
+  assert.match(result.stderr, /--marker-prefix/);
 });
 
 test('a missing trusted-marker-logins source is rejected with no --allow-untrusted escape hatch', () => {


### PR DESCRIPTION
## Summary

- Adds `scripts/sweep-authoring-markers.mjs` (built from
  `src/scripts/sweep-authoring-markers.mts`), a single fetch-driven
  command that performs the issue-authoring contract's mandatory
  hide-on-supersede sweep for `authoring-owner` /
  `authoring-publication-intent` markers: it fetches one or more
  `--issue` targets' comments via GraphQL (selecting `isMinimized`,
  which REST never carries), classifies each with the existing
  `matchCanonicalAuthoringMarkerFamily`, keeps only the newest
  trusted-actor match per family, and minimizes every other eligible
  candidate via `minimize-superseded-markers.mts`'s existing
  `runMinimize` -- replacing the ~8-step manual procedure a session
  previously had to reconstruct from prose at three separate points,
  measured at only 41.7% effective.
- Extracts the shared newest-per-family/trust/already-minimized
  selection rule into a new `classifyAuthoringMarkerFamily` in
  `marker-helpers.mts`, reused by both the new sweep script and
  `audit-authored-issue.mts`'s existing backlog check (behavior
  preserving refactor).
- Updates `skills/issue-authoring/references/contract.md`'s three
  sweep-point sections (and its generated mirror, `docs/issue-authoring-
  skill.md`, and the `idd-template`/`docs` helper-scripts catalog) to
  reference the new single command.
- Adds `ghTextUnbounded` (`src/scripts/gh-exec.mts`), which reads a
  `gh` subprocess's stdout via a temp file instead of an in-memory
  buffer with a fixed cap, and uses it for this sweep's own
  paginated-comment fetch (review rounds 4-6 found a fixed-size
  `maxBuffer` estimate could never be proven sufficient; this removes
  the class of finding instead of refining the estimate further).

## Test plan

- [x] `pnpm run build` / `pnpm run typecheck` -- clean
- [x] `pnpm run build:check` -- clean (post-commit)
- [x] `node --test tests/*.test.mts` -- 6279 passed, 0 failed
- [x] `pnpm run lint` (audit-docs, typecheck, build:check, biome, dprint,
      full test suite, verify-workshop-integrity, cspell, markdownlint)
      -- clean
- [x] `node scripts/idd-doctor.mjs` -- passed (3 pre-existing,
      unrelated warnings: adopter-only profile files, worktreeGuard
      hook wiring in this environment, release-tag drift)
- [x] New unit + CLI tests in `tests/sweep-authoring-markers.test.mts`
      and `tests/gh-exec.test.mts` cover: multi-family/multi-issue
      classification, dry-run vs apply, drifted (non-byte-exact) marker
      exclusion, deadline exhaustion before the mutation stage, a
      genuine mutation failure vs. a benign live-reprobe skip, GraphQL
      pagination and explicit chronological sort, cross-repository
      owner/repo shapes matching `schemas/policy.schema.json`, CLI flag
      validation, and `ghTextUnbounded`'s temp-file-backed read/cleanup.

## Recommended follow-up issues (not filed; noted per review, round 6)

- **Revalidate a marker's live body immediately before minimizing.**
  `minimize-superseded-markers.mts`'s `probeSubject` re-checks a
  subject's author and minimization capability live before mutating,
  but not its body -- if a trusted actor edits a comment between this
  sweep's initial fetch/classification and the mutation call (a narrow
  window, widest during a multi-issue closing sweep), it could
  minimize a comment that no longer satisfies the byte-exact canonical
  marker shape. Pre-existing in `runMinimize`'s own probe design
  (shared by every other caller, not introduced by this PR); worth
  hardening separately rather than expanding this PR's own scope
  (collapsing the sweep into one command).
- **Expose this sweep's fetched comments for the mandatory backlog
  audit.** `skills/issue-authoring/references/contract.md`'s "Make
  every sweep attempt's outcome visible" step separately requires
  running `audit-authored-issue.mjs`'s
  `authoring-marker-minimization-backlog` check with
  `--comments-file`/`--journal-comments-file`; this sweep's own report
  exposes only aggregates and mutation items, so that check still
  needs its own separate fetch today. A future change could have this
  command also emit (or directly run) that backlog audit from the
  comments it already fetched.

Refs #2896, #2898, #2931
Closes #2935

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013MS7r6EVLb1kWoNKnr2PG6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013MS7r6EVLb1kWoNKnr2PG6
