### PR TITLE
docs(idd-ci): extend execution-timeout override to heavy local commands

### DIFF
--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -389,7 +389,14 @@ condition below accounts for this.
   bound above, and do not fall back to `run_in_background` or another
   detached/backgrounded mechanism just because of the kill. This
   reissue-on-timeout guidance is scoped to an idempotent, read-only
-  remote poll like the watch call above. Never blindly re-issue a
+  remote poll like the watch call above. The same preventive override
+  applies before issuing a heavy local command (a full build, test,
+  lint, or doctor run) expected to run long: set an explicit
+  execution-timeout override at or near the calling tool's own
+  execution-timeout ceiling before the command starts, rather than
+  relying on the tool's default and discovering the auto-background
+  only after the fact — this has repeatedly stalled a session's turn
+  in practice (issue `#2933`). Never blindly re-issue a
   heavy local command (a full build, test, or lint run) that
   auto-backgrounds past the tool's default timeout — being idempotent
   does not make it safe to run twice at once; two concurrent instances

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -384,7 +384,14 @@ condition below accounts for this.
   bound above, and do not fall back to `run_in_background` or another
   detached/backgrounded mechanism just because of the kill. This
   reissue-on-timeout guidance is scoped to an idempotent, read-only
-  remote poll like the watch call above. Never blindly re-issue a
+  remote poll like the watch call above. The same preventive override
+  applies before issuing a heavy local command (a full build, test,
+  lint, or doctor run) expected to run long: set an explicit
+  execution-timeout override at or near the calling tool's own
+  execution-timeout ceiling before the command starts, rather than
+  relying on the tool's default and discovering the auto-background
+  only after the fact — this has repeatedly stalled a session's turn
+  in practice (issue `#2933`). Never blindly re-issue a
   heavy local command (a full build, test, or lint run) that
   auto-backgrounds past the tool's default timeout — being idempotent
   does not make it safe to run twice at once; two concurrent instances


### PR DESCRIPTION
# Summary

Extends `idd-ci.instructions.md`'s "Wake-up discipline" section so the
execution-timeout-override principle already required before the
blocking CI-watch call also applies before issuing a heavy local
command (a full build, test, lint, or doctor run) expected to run
long. Previously that section only gave reactive guidance for such a
command ("never blindly re-issue one that already auto-backgrounded"),
with no instruction to set an override before issuing it in the first
place. Multiple autonomous IDD-loop runs in this repository observed a
delegated worker's turn stall after a heavy local command hit the
calling tool's own default timeout and auto-backgrounded with no
override set.

The new sentence is inserted immediately before the existing reactive
bullet, phrased the same tool-agnostic way as the existing CI-watch
override guidance, and does not name any specific tool's parameter or
a normative millisecond figure. The existing reactive guidance is left
byte-for-byte unchanged, so it still applies as a fallback when the
override was not set or was insufficient.

`.github/instructions/idd-ci.instructions.md` is generated from
`idd-template/.github/instructions/idd-ci.instructions.md` via
`node scripts/sync-docs.mjs --apply`; both files are edited/regenerated
together in this PR.

## Linked issue

Closes #2933

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

See the issue's own Background section for the full field evidence
(thin-runner and orchestrator-fan-out delegation patterns alike hitting
this stall).

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
