### PR TITLE
docs(idd-merge): resolve the primary-worktree generated-tokens cleanup gap

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -2199,7 +2199,12 @@ close.
   worktree exists) is not cleaned up by that removal — an accepted
   residual, since giving this record cross-worktree, pre-acquisition
   visibility is explicitly out of scope (see the lock file's own
-  cross-worktree-visibility note above).
+  cross-worktree-visibility note above). This is a deliberate choice,
+  not an oversight: the file is a few hundred bytes, untracked (never
+  shown by `git status`), and has no working-tree impact, so leaving it
+  in place is cheaper than adding narrowly-scoped cleanup machinery for
+  it. See issue `#2944` for the full reasoning record and the
+  cleanup-vs-document-intent tradeoff it considered.
 - **`instructions-only` helper-free fallback, write side** (no helper
   runtime available — `instructions-only` is the distributed default
   profile, see

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -2203,8 +2203,11 @@ close.
   not an oversight: the file is a few hundred bytes, untracked (never
   shown by `git status`), and has no working-tree impact, so leaving it
   in place is cheaper than adding narrowly-scoped cleanup machinery for
-  it. See issue `#2944` for the full reasoning record and the
-  cleanup-vs-document-intent tradeoff it considered.
+  it. See issue `kurone-kito/idd-skill#2944` for the full reasoning
+  record and the cleanup-vs-document-intent tradeoff it considered —
+  qualified with the owner/repo here since this file is distributed
+  via `idd-template/`, where a bare `#2944` would resolve against
+  whichever repository copied it in.
 - **`instructions-only` helper-free fallback, write side** (no helper
   runtime available — `instructions-only` is the distributed default
   profile, see

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -2199,7 +2199,12 @@ close.
   worktree exists) is not cleaned up by that removal — an accepted
   residual, since giving this record cross-worktree, pre-acquisition
   visibility is explicitly out of scope (see the lock file's own
-  cross-worktree-visibility note above).
+  cross-worktree-visibility note above). This is a deliberate choice,
+  not an oversight: the file is a few hundred bytes, untracked (never
+  shown by `git status`), and has no working-tree impact, so leaving it
+  in place is cheaper than adding narrowly-scoped cleanup machinery for
+  it. See issue `#2944` for the full reasoning record and the
+  cleanup-vs-document-intent tradeoff it considered.
 - **`instructions-only` helper-free fallback, write side** (no helper
   runtime available — `instructions-only` is the distributed default
   profile, see

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -2203,8 +2203,11 @@ close.
   not an oversight: the file is a few hundred bytes, untracked (never
   shown by `git status`), and has no working-tree impact, so leaving it
   in place is cheaper than adding narrowly-scoped cleanup machinery for
-  it. See issue `#2944` for the full reasoning record and the
-  cleanup-vs-document-intent tradeoff it considered.
+  it. See issue `kurone-kito/idd-skill#2944` for the full reasoning
+  record and the cleanup-vs-document-intent tradeoff it considered —
+  qualified with the owner/repo here since this file is distributed
+  via `idd-template/`, where a bare `#2944` would resolve against
+  whichever repository copied it in.
 - **`instructions-only` helper-free fallback, write side** (no helper
   runtime available — `instructions-only` is the distributed default
   profile, see


### PR DESCRIPTION
# Summary

`idd-claim.instructions.md`'s A5 claim-time generated-tokens write
targets the **primary** worktree (before the B1 sibling worktree
exists), and F4's cleanup only removes the **sibling** worktree — so
the primary worktree's own copy has no owning worktree to be removed
alongside, and accumulates without bound (15 leftover files observed
in this repository's own primary worktree). This picks option (a) from
the issue: document the accumulation as an intentional, cheap tradeoff
rather than adding cleanup machinery, since the existing "accepted
residual" note already covers the architectural reason
(cross-worktree visibility is out of scope) but never stated the
simpler cost/benefit reason the file is left alone at all.

Extends the "Worktree-local generated-tokens record" bullet in the
canonical `idd-template/docs/idd-helper-scripts.md` source with 1-2
sentences: the file is a few hundred bytes, untracked, and has no
working-tree impact, so a bounded cleanup step (which would also need
to reason about the `.writelock` write-lock coordination guard from
`#2922`) is not worth the added complexity. Cites this issue as the
reasoning record. Resyncs the generated `docs/idd-helper-scripts.md`
mirror via `node scripts/sync-docs.mjs --apply` in the same commit.

No code, helper-script, or other instruction-file changes.

## Linked issue

Closes #2944

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Option (b) (a bounded F4 cleanup step) was considered and rejected:
it would reverse the existing recorded "accepted residual" policy
rather than extend it, and would not actually bound accumulation in
the case that matters most — a crash or abort before F4's cleanup
step still orphans the file regardless of any new step. It would also
add surface area to reason about the write-lock guard file that
protects concurrent writers to this same record. Given Effort: S and
the issue's own "pick whichever is cheaper/safer" framing, documenting
intent is the lower-risk change.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (biome check, dprint check, markdownlint-cli2 — all clean; pre-existing unrelated biome warnings in untouched files)
- [x] `pnpm test` (`node --test tests/*.test.mts` — 6341 passed, 0 failed)
- [x] `node scripts/audit-docs.mjs --check` (passed)
- [x] `pnpm run docs:sync:check` (`sync-docs.mjs --apply` regenerated `docs/idd-helper-scripts.md` identically; no drift)
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none — docs-only)
- [x] Context budget impact reviewed (adds 5 lines to one doc section; no bundle threshold changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that generated-token records remain in the primary worktree after sibling worktrees are removed.
  * Documented the record’s small untracked footprint and lack of impact on working-tree changes.
  * Added a reference to issue `#2944` regarding the cleanup and documentation tradeoff.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->