### PR TITLE
docs(agents): warn against bare token-colon commit body lines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,6 +288,21 @@ entirely. **Breaking changes must always include a body.**
 
 Wrap body lines at **72 characters**.
 
+- **Avoid a bare `token:` line start**: a body line must not begin
+  with a single (optionally hyphenated) token immediately followed by
+  a colon and a space — for example a line starting `bullet: ...` or
+  `Step-1: ...`. `@commitlint/config-conventional`'s footer/trailer
+  parser misreads that shape as the start of a footer section, even
+  though it is ordinary prose deep in the body, and emits a spurious
+  `footer-leading-blank` warning — a **warning** under this
+  repository's current `.commitlintrc.yml`, not a blocking failure,
+  but still worth avoiding. Reword instead: lead with an article or
+  an extra word (for example "the bullet: ..." or "in step 1: ...")
+  so the line no longer opens with a bare token before the colon.
+  Observed live against this repository's own `.commitlintrc.yml` in
+  commit `bae5e0f1e43b54713f936af6f677773b684dd81e` (PR `#2942`,
+  issue `#2943`).
+
 ### Breaking changes
 
 - Append `!` after the type/scope: `feat!: remove deprecated endpoint`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,7 +296,12 @@ Wrap body lines at **72 characters**.
   though it is ordinary prose deep in the body, and emits a spurious
   `footer-leading-blank` warning — a **warning** under this
   repository's current `.commitlintrc.yml`, not a blocking failure,
-  but still worth avoiding. Reword instead: lead with an article or
+  but still worth avoiding. This does not conflict with the `Why:` /
+  `Context:` / `Change:` labels above: each one only ever opens a
+  fresh, blank-line-separated paragraph, so the blank line already
+  required before it also satisfies `footer-leading-blank`; the trap
+  here is the same shape appearing **without** a preceding blank
+  line, buried mid-paragraph. Reword instead: lead with an article or
   an extra word (for example "the bullet: ..." or "in step 1: ...")
   so the line no longer opens with a bare token before the colon.
   Observed live against this repository's own `.commitlintrc.yml` in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,9 +304,10 @@ Wrap body lines at **72 characters**.
   line, buried mid-paragraph. Reword instead: lead with an article or
   an extra word (for example "the bullet: ..." or "in step 1: ...")
   so the line no longer opens with a bare token before the colon.
-  Observed live against this repository's own `.commitlintrc.yml` in
-  commit `bae5e0f1e43b54713f936af6f677773b684dd81e` (PR `#2942`,
-  issue `#2943`).
+  Observed 2026-09-12, live against this repository's own
+  `.commitlintrc.yml`, in commit
+  `bae5e0f1e43b54713f936af6f677773b684dd81e` (PR `#2942`, issue
+  `#2943`).
 
 ### Breaking changes
 


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

`AGENTS.md`'s Commit rules asked for natural-prose commit bodies but
never warned that a body line opening with a single (optionally
hyphenated) token immediately followed by a colon and a space is
misread by `@commitlint/config-conventional`'s footer parser as a
footer/trailer boundary, producing a spurious `footer-leading-blank`
warning. This was observed live in commit `bae5e0f1e43b54713f936af6f677773b684dd81e`
(PR #2942). This PR adds one bullet to the `### Body (line 3+)`
section documenting the trap, stating it is a warning (not a
blocking failure) under this repository's current `.commitlintrc.yml`,
and giving a concrete rewrite option (lead with an article or an
extra word).

## Linked issue

Closes #2943

## Follow-up issues (if any)

- [ ] none filed directly (per this project's IDD workflow, follow-ups
      route through the `issue-authoring` skill rather than being
      created ad hoc). Worth a maintainer's attention though: while
      verifying this change's own commit message against commitlint,
      I found that `conventional-commits-parser`'s `footerToken` regex
      (`^(?:BREAKING CHANGE|[\w-]+)(?::\s+|\s+(?:#)).+`) also
      misclassifies a body line whose *first word* is immediately
      followed by whitespace then a bare `#NNN` reference (e.g. a
      wrapped line starting `request #2942, so ...`), independent of
      any colon. This issue's own acceptance criteria are scoped to
      the colon-space shape only, so I left that second trap
      undocumented here rather than expanding scope — flagging it in
      case a future issue wants to cover it.

## Background / rationale (if material)

See Summary above; the observed incident and citation form follow
`docs/idd-design-rationale.md#cite-the-observed-incident`, matching
this repository's existing citation precedent in the same file (e.g.
the `(issue #2876)` citation a few paragraphs above, which likewise
omits a date).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
