### PR TITLE
chore(release): cut v0.11.0

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://kurone-kito.github.io/idd-skill/schemas/policy.schema.json",
-  "iddVersion": "0.10.0",
+  "iddVersion": "0.11.0",
   "markerPrefix": "idd-skill",
   "mergePolicy": "fully_autonomous_merge",
   "mergePolicyAck": "fully_autonomous_merge",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,68 @@ discipline and has no tag.
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-09-12
+
+CI-check-identity spoofing closures, claim generated-token integrity,
+and issue-authoring marker canonicalization release.
+
+### Added
+
+- `post-idd-marker` posts the issue-authoring skill's `authoring-owner`
+  / `authoring-publication-intent` markers through the same reliable,
+  byte-exact JSON path as every other operational marker, closing a
+  bad hand-computed `body-sha256` and a non-canonical blank-line
+  separator that left acquire markers permanently invisible to the
+  hide-on-supersede sweep (#2931).
+- `sweep-authoring-markers`: a single fetch-driven command performs
+  the issue-authoring contract's mandatory hide-on-supersede sweep for
+  `authoring-owner`/`authoring-publication-intent` markers, replacing
+  an eight-step manual procedure (#2935).
+- `claim-lock` gains a `--backfill-tokens` recovery route that
+  reconstructs a missing generated-tokens record from an existing
+  lock file for a claim made before the record feature existed
+  (#2884).
+
+### Changed
+
+- Documentation precision across `AGENTS.md`, `idd-ci`, `idd-merge`,
+  and `idd-advisory-convergence` guidance: a commitlint
+  footer-misparse warning for bare `token:` commit-body lines, an
+  execution-timeout-override extension to heavy local commands, the
+  `#2547` secondary-bot decline path, the primary-worktree
+  generated-tokens accumulation tradeoff, and a documented GHES
+  `upload-artifact` version limitation (#2918, #2933, #2939, #2943,
+  #2944).
+
 ### Fixed
 
+- `acquireClaimLock` and the `instructions-only` helper-free fallback
+  recipe both close the same torn-read false-collision class: a
+  concurrent `--acquire` racing the same `claim-id` against an absent
+  lock could misread a mid-write file as malformed and report a
+  spurious collision (#2920, #2934).
+- `claim-lock` serializes generated-tokens record writes so a
+  concurrent backfill-then-write no longer clobbers a fresher
+  activation nonce (#2922).
+- `protocol-helpers` binds CI check identity to the producing
+  workflow's file path, not only its display name, and
+  `pre-merge-readiness` resolves a check-run's `workflowPath` via its
+  check suite instead of trusting the run's own free-text
+  `detailsUrl` -- closing two ways a same-repository, PR-controlled
+  workflow could forge or mask `idd-advisory-convergence`'s own
+  check-run instances (#2919, #2926).
+- `pre-merge-readiness` gains trustworthy stale-self-waiver detection,
+  and `advisory-convergence` binds an auto-waiver marker to the run
+  that actually posted it rather than only checking the cited run's
+  path/SHA/repository/event shape, closing a forgeable-marker gap
+  (#2911, #2912).
+- `protocol-helpers` recognizes a fourth CodeRabbit courtesy-ack
+  closure shape as an exact literal match (#2927).
+- `idd-critique-telemetry-hook` delivers stdin through a relay hop on
+  native Windows, where a detached `cmd.exe` wrapper could not
+  otherwise relay piped stdin to its child process, and stops
+  orphaned processes on Windows using `taskkill` instead of a POSIX
+  process-group signal (#2892, #2910).
 - `discover-orphan-filter`'s `blocked_references_closed` orphan reason
   is renamed to `references_non_blocking`: the old name read as
   "currently blocked" even though it fires once every blocking/

--- a/idd-template/.github/idd/config.json
+++ b/idd-template/.github/idd/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://kurone-kito.github.io/idd-skill/schemas/policy.schema.json",
-  "iddVersion": "0.10.0",
+  "iddVersion": "0.11.0",
   "markerPrefix": "{{PROJECT_MARKER_PREFIX}}",
   "mergePolicy": "human_merge",
   "reviewPolicy": "copilot-advisory",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kurone-kito/idd-skill",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "description": "Issue-Driven Development workflow assets",
   "author": "kurone-kito <krone@kit.black> (https://kit.black/)",


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Cuts the `v0.11.0` release now that this release's two explicit
blockers, issues #2943 and #2944, have both drained (closed/merged).
`#2886` stays out of scope for this release per #2945's own text and
is not touched here.

- **Version survey** (mechanical, run at implementation time per the
  issue's own instruction rather than reusing its now-stale
  preliminary count): `git log v0.10.0..HEAD --no-merges --format='%s'`
  over the actual window at implementation time -- **113** non-merge
  commits, classified by Conventional Commits type: **71** `fix`,
  **21** `docs`, **11** `test`, **5** `ci`, **3** `feat`, **1**
  `refactor`, **1** `chore`. No `!` / `BREAKING CHANGE:` marker in any
  subject or body. The presence of `feat` commits selects a **minor**
  bump: `0.10.0` -> **`0.11.0`**.
- Bumps `iddVersion` in `.github/idd/config.json` and
  `idd-template/.github/idd/config.json`, and `version` in
  `package.json`, to `0.11.0` in lockstep
  (`tests/consistency.test.mts` pins this alignment and passes
  locally).
- Adds a `## [0.11.0] - 2026-09-12` `CHANGELOG.md` section synthesizing
  the `git log v0.10.0..HEAD --first-parent --merges` window (19
  merged pull requests, cross-checked one-to-one against the merge
  log) into thematic Added/Changed/Fixed clusters at the `[0.10.0]`
  entry's editorial granularity, folds the existing `#2932`-sourced
  `[Unreleased]` entry into the new section, and leaves a fresh, empty
  `[Unreleased]` heading above it.
- A repository-wide grep for the prior version literal `0.10.0` shows
  no live reference remaining outside `pnpm-lock.yaml` (third-party
  dependency `engines` ranges) and `CHANGELOG.md`'s own historical
  `## [0.10.0]` section.

## Linked issue

Closes #2945

## Follow-up issues (if any)

- [x] none filed directly (per this repo's rule against calling `gh
      issue create` from an executing session) -- the required
      post-merge step is the companion tag-push issue #2946 (see
      Background below), not a new follow-up.

## Background / rationale (if material)

Per #2945's acceptance criteria, this PR's merge is the trigger that
unblocks the companion tag-push issue **#2946** (`Blocked by #2945`):
pushing the `v0.11.0` annotated git tag is that issue's own
explicitly maintainer-reserved step (autopilot suitability below this
repository's floor, requiring an explicit maintainer Y/n) and is
**out of scope for this PR** -- this PR only cuts the version bump
and changelog entry that #2946 depends on.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [x] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the 0.11.0 release entry, covering marker posting, authoring-marker sweeping, and claim-token backfill.
  * Documented fixes for consistency, token-record races, check identity spoofing, stale self-waivers, acknowledgements, and native Windows process handling.

* **Chores**
  * Updated the application and policy configuration versions to 0.11.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->