### PR TITLE
feat(claim): widen cwd-vs-claim gate scope to B2 and C5

### DIFF
--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -169,8 +169,8 @@ claim-id.
 In addition to the `{claim-id}` check, verify that the mutation is
 about to run from the worktree named in the active claim's `branch:`
 field. This **cwd-vs-claim check** applies only to mutations made
-from inside the implementation worktree contract (B3, D, E, and F2/F3
-phases):
+from inside the implementation worktree contract (B2, B3, C5, D, E,
+and F2/F3 phases):
 
 Scope — the check runs **only** when **all** of the following are
 true:

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -349,11 +349,14 @@ Draft an implementation plan and post it as an issue comment, then run
 a critique pass for correctness and concreteness (see
 `idd-overview-appendix.instructions.md` for per-agent implementation),
 and post the refined final plan as a follow-up or update to the same
-comment. After the final plan comment is posted and claim ownership is
-re-validated, update the issue live status digest: `Phase` is `B2
-planned`, `Open blockers` is `none` unless the plan found a blocker,
-`Next action` is `B3 implement`, and `Authoritative by` points to the
-plan comment and verified claim.
+comment. After the final plan comment is posted, update the issue live
+status digest: `Phase` is `B2 planned`, `Open blockers` is `none`
+unless the plan found a blocker, `Next action` is `B3 implement`, and
+`Authoritative by` points to the plan comment and verified claim.
+
+Claim ownership revalidation needs no separate check here: it already
+applies to every B2 mutation via the
+[claim revalidation gate](idd-overview-core.instructions.md#claim-revalidation-gate).
 
 ## B3 — Implement
 
@@ -575,8 +578,11 @@ anything it reports.
 
 An unmet floor is not a new failure class: run or fix **fix-validate**
 the same way the Project commands table handles a failing
-**pre-push-validate** ("If lint fails, run fix-validate, commit, then
-re-run pre-push-validate").
+**pre-push-validate**.
+
+Claim ownership revalidation needs no separate check here: it already
+applies to every C5 fix commit via the
+[claim revalidation gate](idd-overview-core.instructions.md#claim-revalidation-gate).
 
 If anything changed, commit atomically.
 

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -445,7 +445,7 @@
     "maxBundleLimitBytes": 196000,
     "maxUtilizationPct": 98,
     "noticeUtilizationPct": 95,
-    "exemptBundles": []
+    "exemptBundles": ["bundle-work-phase"]
   },
   "docBudgetGuard": {
     "id": "doc-budget-drift",

--- a/idd-template/.github/instructions/idd-overview-core.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-core.instructions.md
@@ -164,8 +164,8 @@ claim-id.
 In addition to the `{claim-id}` check, verify that the mutation is
 about to run from the worktree named in the active claim's `branch:`
 field. This **cwd-vs-claim check** applies only to mutations made
-from inside the implementation worktree contract (B3, D, E, and F2/F3
-phases):
+from inside the implementation worktree contract (B2, B3, C5, D, E,
+and F2/F3 phases):
 
 Scope — the check runs **only** when **all** of the following are
 true:

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -344,11 +344,14 @@ Draft an implementation plan and post it as an issue comment, then run
 a critique pass for correctness and concreteness (see
 `idd-overview-appendix.instructions.md` for per-agent implementation),
 and post the refined final plan as a follow-up or update to the same
-comment. After the final plan comment is posted and claim ownership is
-re-validated, update the issue live status digest: `Phase` is `B2
-planned`, `Open blockers` is `none` unless the plan found a blocker,
-`Next action` is `B3 implement`, and `Authoritative by` points to the
-plan comment and verified claim.
+comment. After the final plan comment is posted, update the issue live
+status digest: `Phase` is `B2 planned`, `Open blockers` is `none`
+unless the plan found a blocker, `Next action` is `B3 implement`, and
+`Authoritative by` points to the plan comment and verified claim.
+
+Claim ownership revalidation needs no separate check here: it already
+applies to every B2 mutation via the
+[claim revalidation gate](idd-overview-core.instructions.md#claim-revalidation-gate).
 
 ## B3 — Implement
 
@@ -570,8 +573,11 @@ anything it reports.
 
 An unmet floor is not a new failure class: run or fix **fix-validate**
 the same way the Project commands table handles a failing
-**pre-push-validate** ("If lint fails, run fix-validate, commit, then
-re-run pre-push-validate").
+**pre-push-validate**.
+
+Claim ownership revalidation needs no separate check here: it already
+applies to every C5 fix commit via the
+[claim revalidation gate](idd-overview-core.instructions.md#claim-revalidation-gate).
 
 If anything changed, commit atomically.
 


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Widens the claim revalidation gate's cwd-vs-claim subgate
(`idd-overview-core.instructions.md`) so its documented scope names
B2 (plan-comment posting) and C5 (self-review fix commits) alongside
the existing B3/D/E/F2/F3 phases, and adds a matching one-line
cross-reference in `idd-work.instructions.md`'s B2.2 and C5 sections,
mirroring B3 self-check's own existing cross-reference pattern.
Wording-only: the subgate's own structural "Scope" conditions are
unchanged, since B2 and C5 already run from the same B1-created
sibling worktree the check already covers mechanically.

## Linked issue

Closes #2886

## Follow-up issues (if any)

- [ ] `src/scripts/claim-lock.mts` (and its generated mirror
      `scripts/claim-lock.mjs`) still carries a code comment
      restating the old, now-superseded scope list ("...exactly that
      post-B1 contract (B3, D, E, F2/F3)..."), which now factually
      contradicts the doc it cross-references. This PR intentionally
      leaves it unchanged, since this issue's own acceptance criteria
      require no production code changes -- a maintainer may want a
      small follow-up to correct that comment.

## Background / rationale (if material)

`#2719` (PR #2879) added a fail-closed generated-tokens ownership
check to the cwd-vs-claim subgate, but that subgate's documented
scope predated it and never named B2/C5, even though both mutate
git/GitHub state from inside the same sibling worktree B1 already
created. This PR closes that documentation gap per the design
decision already settled in issue #2886's own body -- no new
mechanical logic, since the subgate's structural "Scope" conditions
already hold true for B2/C5 in practice. Two now-redundant sentences
(the B2.2 digest-update clause restating claim revalidation, and a
C5 parenthetical quoting the Project commands table verbatim) were
trimmed to help offset the new cross-references' byte cost.

**Near-ceiling-ratchet override (issue #2886, per its 2026-09-12
Maintainer decision):** even after that trim, the two new
cross-reference sentences still push `bundle-work-phase`
(`.github/instructions/idd-work.instructions.md`) to 98.80%
(29738/30100 bytes), over its 98% hard ceiling. The near-ceiling
ratchet (issue #2697) hard-blocks any `limitBytes` raise on this
bundle while its base-ref utilization stays at or above 95% (measured
97.87% on `main`, unchanged), so raising the limit is not available
here regardless of the target value. Per the issue's Maintainer
decision, this PR instead adds `"bundle-work-phase"` to
`audit/sync-manifest.json`'s `contextCeiling.exemptBundles`, leaving
`bundleBudgets`' `bundle-work-phase` entry's `limitBytes` unchanged at
`30100`. This is a deliberate, explicitly sanctioned **off-label**
use of `exemptBundles`: `docs/policy-constants.md`'s "Exemption
lifecycle" section scopes that mechanism to an active content-trim
diet and says to keep the list empty absent one, but this decision
accepts a standing exemption for this one bundle instead, in
preference to further trimming incident-cited prose or narrowing the
acceptance criteria. Per the ratchet's own override-contract
convention (the same contract a `limitBytes` raise would have to
satisfy), this paragraph is that required PR-description callout.
`node scripts/audit-docs.mjs --check` now reports a **notice** (not
an error) for `bundle-work-phase`.

Full local verification was re-run with the exemption applied and all
passes cleanly: `node --test tests/*.test.mts` (6341 passed, 3
skipped, 0 failed) and `node scripts/idd-doctor.mjs` (passed, 2
pre-existing warnings unrelated to this diff) -- closing the one gap
the prior implementing session's hold comment could not verify locally
under host contention.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [x] Config schema changed
- [x] Security / credential / merge behavior changed -- widens the
      documented scope of the existing claim-ownership (cwd-vs-claim)
      check to two more mutation points (B2, C5); no new mechanism and
      no production code changed.

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs`

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

---

**Commit signing**: Configured GPG signing failed identically with a
pinentry/TTY error (`gpg: signing failed: end of file` after
`PINENTRY_LAUNCHED`) -- no usable interactive prompt in this
environment. Per the repository's bounded signing ladder, this is
category (P) pinentry/TTY, which skips the gpg-agent-restart step
(categories A/U only) and goes straight to the SSH fallback: the
commit is signed via the `git commit-ssh` blessed alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
