### PR TITLE
fix(claim-lock): correct stale cwd-vs-claim phase-list comment

### DIFF
--- a/scripts/claim-lock.mjs
+++ b/scripts/claim-lock.mjs
@@ -160,15 +160,15 @@
 // must resolve `--read-tokens`/`--acquire` against its **own current
 // cwd** (never an explicit different worktree's path): once B1 creates
 // the dedicated worktree, that admin directory is private to the one
-// claim/branch it represents, and the pre-mutation claim revalidation
-// gate (`idd-overview-core.instructions.md`) already scopes its own
-// cwd-vs-claim check to exactly that post-B1 contract (B3, D, E, F2/F3),
-// where this record's guarantee is strongest. The existing GitHub
-// claim-state, branch-collision, and worktree-local-lock checks remain
-// the primary defense against a genuinely different session mutating
-// under a claim-id it never generated; this record's own job is narrower
-// and complementary: helping *this* session's own memory survive its own
-// context compaction, not adjudicating between two sessions.
+// claim/branch it represents, and the pre-mutation claim revalidation gate
+// (`idd-overview-core.instructions.md`) already scopes its own
+// cwd-vs-claim check to exactly that post-B1 contract (B2, B3, C5, D, E,
+// and F2/F3 phases), where this record's guarantee is strongest. The
+// existing GitHub claim-state, branch-collision, and worktree-local-lock
+// checks remain the primary defense against a genuinely different session
+// mutating under a claim-id it never generated; this record's own job is
+// narrower and complementary: helping *this* session's own memory survive
+// its own context compaction, not adjudicating between two sessions.
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import {

--- a/src/scripts/claim-lock.mts
+++ b/src/scripts/claim-lock.mts
@@ -161,15 +161,15 @@
 // must resolve `--read-tokens`/`--acquire` against its **own current
 // cwd** (never an explicit different worktree's path): once B1 creates
 // the dedicated worktree, that admin directory is private to the one
-// claim/branch it represents, and the pre-mutation claim revalidation
-// gate (`idd-overview-core.instructions.md`) already scopes its own
-// cwd-vs-claim check to exactly that post-B1 contract (B3, D, E, F2/F3),
-// where this record's guarantee is strongest. The existing GitHub
-// claim-state, branch-collision, and worktree-local-lock checks remain
-// the primary defense against a genuinely different session mutating
-// under a claim-id it never generated; this record's own job is narrower
-// and complementary: helping *this* session's own memory survive its own
-// context compaction, not adjudicating between two sessions.
+// claim/branch it represents, and the pre-mutation claim revalidation gate
+// (`idd-overview-core.instructions.md`) already scopes its own
+// cwd-vs-claim check to exactly that post-B1 contract (B2, B3, C5, D, E,
+// and F2/F3 phases), where this record's guarantee is strongest. The
+// existing GitHub claim-state, branch-collision, and worktree-local-lock
+// checks remain the primary defense against a genuinely different session
+// mutating under a claim-id it never generated; this record's own job is
+// narrower and complementary: helping *this* session's own memory survive
+// its own context compaction, not adjudicating between two sessions.
 
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

PR #2950 (issue #2886) widened the cwd-vs-claim subgate's documented
scope in `idd-overview-core.instructions.md` to add B2 and C5 alongside
the existing B3, D, E, F2/F3 phases, but a code comment in
`src/scripts/claim-lock.mts` still restated the old, now-superseded
phase list, contradicting the instruction file it cross-references.
This PR updates that comment to match the current wording and
regenerates the generated `scripts/claim-lock.mjs` mirror via
`pnpm run build`. This is a pure comment-text change; no behavior
change is expected or intended.

## Linked issue

Closes #2952

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Process note: the implementation plan for this issue was posted to the
issue retroactively, after the code edit, rather than before it as the
workflow normally requires (a B2/B3 ordering deviation) -- disclosed in
full on the issue itself.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated ownership-proof documentation to cover additional validation phases after B1.
  - Clarified that generated-token records provide supporting evidence for context compaction and are not the sole authority for ownership.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->