### PR TITLE
fix(ci): grant pull-requests:write to advisory self-waiver job

### DIFF
--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -488,12 +488,19 @@ jobs:
     # comment` (a different, higher-level code path) rather than this
     # job's direct `gh api ... --method POST`, so that comparison alone
     # is circumstantial, not proof. The actual proof is a live A/B test
-    # dispatched against this exact job on this branch before this fix
-    # merged: run 34697203153 reproduced the 403 under the then-current
-    # permissions (`pull-requests: read` instead of `write`); run
-    # 34697250102, identical in every other respect, succeeded
-    # immediately after changing only `pull-requests: read` to `write`,
-    # posting (then deleting) a throwaway comment on PR #2949. GitHub's
+    # dispatched on this branch before this fix merged, using a temporary
+    # `diag-2951-permission-probe` job -- an equivalent probe carrying
+    # the same job-level permissions block and posting to the same
+    # `issues/<PR_NUMBER>/comments` endpoint as this job, committed and
+    # removed before this fix landed; this job itself is
+    # `pull_request_target`-gated (see the `if:` above) and so was
+    # skipped under the `workflow_dispatch` trigger the probe used
+    # (kurone-kito/idd-skill#2954 Copilot review): run 34697203153
+    # reproduced the 403 under the then-current permissions
+    # (`pull-requests: read` instead of `write`); run 34697250102,
+    # identical in every other respect, succeeded immediately after
+    # changing only `pull-requests: read` to `write`, posting (then
+    # deleting) a throwaway comment on PR #2949. GitHub's
     # own docs list this endpoint under the Issues permission category
     # alone (https://docs.github.com/rest/issues/comments#create-an-issue-comment),
     # but that does not hold in practice for a `pull_request_target`

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -682,36 +682,3 @@ jobs:
           # outlives a short artifact retention -- keep the repository
           # default so the artifact stays listable for the marker's full
           # validity window.
-
-  # TEMPORARY diagnostic probe for kurone-kito/idd-skill#2951 -- NOT part
-  # of the shipped fix. Reproduces the exact failing REST call
-  # (`external-check-waiver.mts`'s `issues/{n}/comments` POST) in
-  # isolation, under the self-waiver job's CURRENT (pre-fix) permissions
-  # only, dispatched via the workflow_dispatch trigger already registered
-  # on `main` so this run reflects THIS branch's copy of the file. Posts
-  # one throwaway comment to the PR named by `pr_number` and reports
-  # success/failure; the comment is deleted immediately after by the
-  # operator. This job is removed before the real fix commit lands --
-  # see the issue for the empirical result.
-  diag-2951-permission-probe:
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-slim
-    timeout-minutes: 5
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-    steps:
-      - name: Attempt the exact failing POST (with pull-requests write added)
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_ENTERPRISE_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ inputs.pr_number }}
-        run: |
-          set +e
-          gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-            --method POST \
-            -f "body=idd-skill#2951 diagnostic permission probe (candidate fix: contents:read, pull-requests:write, issues:write) -- safe to delete"
-          STATUS=$?
-          echo "probe_exit_code=$STATUS" >> "$GITHUB_STEP_SUMMARY"
-          exit $STATUS

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -502,8 +502,10 @@ jobs:
     # `issues: write` (to post the marker, and to read the linked issue's
     # own comment stream to resolve its active claim -- that second call
     # targets a real issue, not a PR, so it only ever needed
-    # `issues: read`; this job keeps `issues: write` unchanged because the
-    # marker POST above still needs it too).
+    # `issues: read`; this job keeps `issues: write` unchanged because
+    # this fix's A/B test held it constant in both runs and so proves
+    # nothing about whether the marker POST also needs it -- narrowing
+    # to `issues: read` would need its own separate live A/B test).
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -699,10 +699,10 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: write
     steps:
-      - name: Attempt the exact failing POST (pre-fix permissions)
+      - name: Attempt the exact failing POST (with pull-requests write added)
         env:
           GH_TOKEN: ${{ github.token }}
           GH_ENTERPRISE_TOKEN: ${{ github.token }}
@@ -711,7 +711,7 @@ jobs:
           set +e
           gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
             --method POST \
-            -f "body=idd-skill#2951 diagnostic permission probe (pre-fix: contents:read, pull-requests:read, issues:write) -- safe to delete"
+            -f "body=idd-skill#2951 diagnostic permission probe (candidate fix: contents:read, pull-requests:write, issues:write) -- safe to delete"
           STATUS=$?
           echo "probe_exit_code=$STATUS" >> "$GITHUB_STEP_SUMMARY"
           exit $STATUS

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -476,15 +476,37 @@ jobs:
     runs-on: ubuntu-slim
     timeout-minutes: 10
     # Narrower than the verdict job's read-only posture above: this job
-    # additionally needs `pull-requests: read` (to diff and fetch the PR)
-    # and `issues: write` (to post the marker, and to read the linked
-    # issue's own comment stream to resolve its active claim -- the
-    # PR-conversation-comment endpoint and the linked-issue-comment
-    # endpoint are both gated under the Issues permission category, same
-    # as the verdict job's own header comment already notes for reads).
+    # needs `pull-requests: write` (to diff/fetch the PR, and -- this is
+    # the load-bearing grant -- to actually post the marker below;
+    # kurone-kito/idd-skill#2951: with only `pull-requests: read` +
+    # `issues: write`, as this block originally shipped, the marker POST
+    # to `issues/<PR_NUMBER>/comments` failed with HTTP 403 "Resource not
+    # accessible by integration" on 11/11 real invocations across 3 PRs.
+    # `.github/workflows/post-merge-cleanup.yml` posts to the same
+    # `issues/<PR_NUMBER>/comments` shape successfully and grants both
+    # `issues: write` and `pull-requests: write`, but it posts via `gh pr
+    # comment` (a different, higher-level code path) rather than this
+    # job's direct `gh api ... --method POST`, so that comparison alone
+    # is circumstantial, not proof. The actual proof is a live A/B test
+    # dispatched against this exact job on this branch before this fix
+    # merged: run 34697203153 reproduced the 403 under the then-current
+    # permissions (`pull-requests: read` instead of `write`); run
+    # 34697250102, identical in every other respect, succeeded
+    # immediately after changing only `pull-requests: read` to `write`,
+    # posting (then deleting) a throwaway comment on PR #2949. GitHub's
+    # own docs list this endpoint under the Issues permission category
+    # alone (https://docs.github.com/rest/issues/comments#create-an-issue-comment),
+    # but that does not hold in practice for a `pull_request_target`
+    # `GITHUB_TOKEN` posting to a PR-numbered target -- do not narrow this
+    # back to `read` without re-running the same live test) and
+    # `issues: write` (to post the marker, and to read the linked issue's
+    # own comment stream to resolve its active claim -- that second call
+    # targets a real issue, not a PR, so it only ever needed
+    # `issues: read`; this job keeps `issues: write` unchanged because the
+    # marker POST above still needs it too).
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -682,3 +682,36 @@ jobs:
           # outlives a short artifact retention -- keep the repository
           # default so the artifact stays listable for the marker's full
           # validity window.
+
+  # TEMPORARY diagnostic probe for kurone-kito/idd-skill#2951 -- NOT part
+  # of the shipped fix. Reproduces the exact failing REST call
+  # (`external-check-waiver.mts`'s `issues/{n}/comments` POST) in
+  # isolation, under the self-waiver job's CURRENT (pre-fix) permissions
+  # only, dispatched via the workflow_dispatch trigger already registered
+  # on `main` so this run reflects THIS branch's copy of the file. Posts
+  # one throwaway comment to the PR named by `pr_number` and reports
+  # success/failure; the comment is deleted immediately after by the
+  # operator. This job is removed before the real fix commit lands --
+  # see the issue for the empirical result.
+  diag-2951-permission-probe:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
+    steps:
+      - name: Attempt the exact failing POST (pre-fix permissions)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_ENTERPRISE_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          set +e
+          gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --method POST \
+            -f "body=idd-skill#2951 diagnostic permission probe (pre-fix: contents:read, pull-requests:read, issues:write) -- safe to delete"
+          STATUS=$?
+          echo "probe_exit_code=$STATUS" >> "$GITHUB_STEP_SUMMARY"
+          exit $STATUS

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1441,8 +1441,14 @@ for adopters and gameable via a PR touching a path that does not exist in
 their own checkout at all. `idd-advisory-convergence.yml` detects this
 from a
 separate job with `issues: write` and `pull-requests: write` as its
-write permissions (kurone-kito/idd-skill#2951: the posting call needs
-both -- `issues: write` alone 403s; the verdict job stays read-only; it
+write permissions (kurone-kito/idd-skill#2951: a live A/B test proved
+`pull-requests: write` is the fix -- with only `pull-requests: read`,
+the posting call 403s; adding `pull-requests: write` alone resolves it.
+That test held `issues: write` constant throughout, so it proves the
+posting call needs `pull-requests: write`, but proves nothing about
+whether `issues: write` is also required -- it is retained unchanged
+because narrowing it was never tested, not because it was proven
+necessary; the verdict job stays read-only; it
 additionally gains `actions: read`,
 required for the run-id trust verification's own
 `GET /repos/{owner}/{repo}/actions/runs/{run-id}` call in a private

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1440,8 +1440,10 @@ unconditional match against them left the mechanism both non-functional
 for adopters and gameable via a PR touching a path that does not exist in
 their own checkout at all. `idd-advisory-convergence.yml` detects this
 from a
-separate job with `issues: write` as its only write permission (the
-verdict job stays read-only; it additionally gains `actions: read`,
+separate job with `issues: write` and `pull-requests: write` as its
+write permissions (kurone-kito/idd-skill#2951: the posting call needs
+both -- `issues: write` alone 403s; the verdict job stays read-only; it
+additionally gains `actions: read`,
 required for the run-id trust verification's own
 `GET /repos/{owner}/{repo}/actions/runs/{run-id}` call in a private
 repository) and posts a marker as `github-actions[bot]` via

--- a/idd-template/.github/workflows/idd-advisory-convergence.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence.yml
@@ -431,8 +431,10 @@ jobs:
     # `issues: write` (to post the marker, and to read the linked issue's
     # own comment stream to resolve its active claim -- that second call
     # targets a real issue, not a PR, so it only ever needed
-    # `issues: read`; this job keeps `issues: write` unchanged because the
-    # marker POST above still needs it too).
+    # `issues: read`; this job keeps `issues: write` unchanged because
+    # this fix's A/B test held it constant in both runs and so proves
+    # nothing about whether the marker POST also needs it -- narrowing
+    # to `issues: read` would need its own separate live A/B test).
     permissions:
       contents: read
       pull-requests: write

--- a/idd-template/.github/workflows/idd-advisory-convergence.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence.yml
@@ -411,15 +411,31 @@ jobs:
     runs-on: ${{ inputs.runner || vars.CI_RUNNER_LABEL || 'ubuntu-slim' }}
     timeout-minutes: 10
     # Narrower than the verdict job's read-only posture above: this job
-    # additionally needs `pull-requests: read` (to diff and fetch the PR)
-    # and `issues: write` (to post the marker, and to read the linked
-    # issue's own comment stream to resolve its active claim -- the
-    # PR-conversation-comment endpoint and the linked-issue-comment
-    # endpoint are both gated under the Issues permission category, same
-    # as the verdict job's own header comment already notes for reads).
+    # needs `pull-requests: write` (to diff/fetch the PR, and -- this is
+    # the load-bearing grant -- to actually post the marker below;
+    # kurone-kito/idd-skill#2951: with only `pull-requests: read` +
+    # `issues: write`, as this block originally shipped, the dogfooded
+    # copy of this same job in the upstream source repository's
+    # `.github/workflows/idd-advisory-convergence.yml` failed the marker
+    # POST to `issues/<PR_NUMBER>/comments` with HTTP 403 "Resource not
+    # accessible by integration" on 11/11 real invocations across 3 PRs,
+    # confirmed again by a live A/B test dispatched against that job:
+    # changing only `pull-requests: read` to `write` turned a
+    # reproduced 403 into an immediate success posting (then deleting) a
+    # throwaway comment on a real PR. GitHub's own docs list this
+    # endpoint under the Issues permission category alone
+    # (https://docs.github.com/rest/issues/comments#create-an-issue-comment),
+    # but that does not hold in practice for a `pull_request_target`
+    # `GITHUB_TOKEN` posting to a PR-numbered target -- do not narrow
+    # this back to `read` without re-running an equivalent live test) and
+    # `issues: write` (to post the marker, and to read the linked issue's
+    # own comment stream to resolve its active claim -- that second call
+    # targets a real issue, not a PR, so it only ever needed
+    # `issues: read`; this job keeps `issues: write` unchanged because the
+    # marker POST above still needs it too).
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: write
     steps:
       - uses: actions/checkout@v4

--- a/idd-template/.github/workflows/idd-advisory-convergence.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence.yml
@@ -412,36 +412,16 @@ jobs:
     timeout-minutes: 10
     # Narrower than the verdict job's read-only posture above: this job
     # needs `pull-requests: write` (to diff/fetch the PR, and -- this is
-    # the load-bearing grant -- to actually post the marker below;
-    # kurone-kito/idd-skill#2951: with only `pull-requests: read` +
-    # `issues: write`, as this block originally shipped, the dogfooded
-    # copy of this same job in the upstream source repository's
-    # `.github/workflows/idd-advisory-convergence.yml` failed the marker
-    # POST to `issues/<PR_NUMBER>/comments` with HTTP 403 "Resource not
-    # accessible by integration" on 11/11 real invocations across 3 PRs,
-    # confirmed again by a live A/B test on that job's own upstream
-    # branch, using a temporary `diag-2951-permission-probe` job -- an
-    # equivalent probe carrying the same job-level permissions block and
-    # posting to the same `issues/<PR_NUMBER>/comments` endpoint as this
-    # job, committed and removed before that fix landed; this job itself
-    # is `pull_request_target`-gated (see the `if:` above) and so was
-    # skipped under the `workflow_dispatch` trigger the probe used
-    # (kurone-kito/idd-skill#2954 Copilot review): changing only
-    # `pull-requests: read` to `write` turned a reproduced 403 into an
-    # immediate success posting (then deleting) a throwaway comment on a
-    # real PR. GitHub's own docs list this
-    # endpoint under the Issues permission category alone
-    # (https://docs.github.com/rest/issues/comments#create-an-issue-comment),
-    # but that does not hold in practice for a `pull_request_target`
-    # `GITHUB_TOKEN` posting to a PR-numbered target -- do not narrow
-    # this back to `read` without re-running an equivalent live test) and
+    # the load-bearing grant -- to actually post the marker below) and
     # `issues: write` (to post the marker, and to read the linked issue's
-    # own comment stream to resolve its active claim -- that second call
-    # targets a real issue, not a PR, so it only ever needed
-    # `issues: read`; this job keeps `issues: write` unchanged because
-    # this fix's A/B test held it constant in both runs and so proves
-    # nothing about whether the marker POST also needs it -- narrowing
-    # to `issues: read` would need its own separate live A/B test).
+    # own comment stream to resolve its active claim). kurone-kito/idd-skill#2951:
+    # with only `pull-requests: read`, the marker POST failed with HTTP
+    # 403 "Resource not accessible by integration", confirmed by a live
+    # A/B test -- see this source repository's own dogfooded copy of
+    # this file (.github/workflows/idd-advisory-convergence.yml) for the
+    # full investigation, run evidence, and why `issues: write` stays
+    # unchanged rather than narrowed. Do not narrow `pull-requests` back
+    # to `read` without re-running an equivalent live test.
     permissions:
       contents: read
       pull-requests: write

--- a/idd-template/.github/workflows/idd-advisory-convergence.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence.yml
@@ -419,10 +419,17 @@ jobs:
     # `.github/workflows/idd-advisory-convergence.yml` failed the marker
     # POST to `issues/<PR_NUMBER>/comments` with HTTP 403 "Resource not
     # accessible by integration" on 11/11 real invocations across 3 PRs,
-    # confirmed again by a live A/B test dispatched against that job:
-    # changing only `pull-requests: read` to `write` turned a
-    # reproduced 403 into an immediate success posting (then deleting) a
-    # throwaway comment on a real PR. GitHub's own docs list this
+    # confirmed again by a live A/B test on that job's own upstream
+    # branch, using a temporary `diag-2951-permission-probe` job -- an
+    # equivalent probe carrying the same job-level permissions block and
+    # posting to the same `issues/<PR_NUMBER>/comments` endpoint as this
+    # job, committed and removed before that fix landed; this job itself
+    # is `pull_request_target`-gated (see the `if:` above) and so was
+    # skipped under the `workflow_dispatch` trigger the probe used
+    # (kurone-kito/idd-skill#2954 Copilot review): changing only
+    # `pull-requests: read` to `write` turned a reproduced 403 into an
+    # immediate success posting (then deleting) a throwaway comment on a
+    # real PR. GitHub's own docs list this
     # endpoint under the Issues permission category alone
     # (https://docs.github.com/rest/issues/comments#create-an-issue-comment),
     # but that does not hold in practice for a `pull_request_target`

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1441,8 +1441,14 @@ for adopters and gameable via a PR touching a path that does not exist in
 their own checkout at all. `idd-advisory-convergence.yml` detects this
 from a
 separate job with `issues: write` and `pull-requests: write` as its
-write permissions (kurone-kito/idd-skill#2951: the posting call needs
-both -- `issues: write` alone 403s; the verdict job stays read-only; it
+write permissions (kurone-kito/idd-skill#2951: a live A/B test proved
+`pull-requests: write` is the fix -- with only `pull-requests: read`,
+the posting call 403s; adding `pull-requests: write` alone resolves it.
+That test held `issues: write` constant throughout, so it proves the
+posting call needs `pull-requests: write`, but proves nothing about
+whether `issues: write` is also required -- it is retained unchanged
+because narrowing it was never tested, not because it was proven
+necessary; the verdict job stays read-only; it
 additionally gains `actions: read`,
 required for the run-id trust verification's own
 `GET /repos/{owner}/{repo}/actions/runs/{run-id}` call in a private

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1440,8 +1440,10 @@ unconditional match against them left the mechanism both non-functional
 for adopters and gameable via a PR touching a path that does not exist in
 their own checkout at all. `idd-advisory-convergence.yml` detects this
 from a
-separate job with `issues: write` as its only write permission (the
-verdict job stays read-only; it additionally gains `actions: read`,
+separate job with `issues: write` and `pull-requests: write` as its
+write permissions (kurone-kito/idd-skill#2951: the posting call needs
+both -- `issues: write` alone 403s; the verdict job stays read-only; it
+additionally gains `actions: read`,
 required for the run-id trust verification's own
 `GET /repos/{owner}/{repo}/actions/runs/{run-id}` call in a private
 repository) and posts a marker as `github-actions[bot]` via

--- a/tests/advisory-convergence-comment-workflow.test.mts
+++ b/tests/advisory-convergence-comment-workflow.test.mts
@@ -86,6 +86,41 @@ test('required advisory-convergence workflows add pull_request_target and drop p
   }
 });
 
+// kurone-kito/idd-skill#2951 (Copilot review, PR #2954): a live A/B test
+// proved the idd-advisory-convergence-self-waiver job's marker POST 403s
+// under `pull-requests: read` and succeeds under `pull-requests: write`,
+// but nothing asserted the shipped grant itself -- so a future revert back
+// to `read` (in either copy) would pass every other test in this suite
+// while silently reintroducing the proven HTTP 403.
+test('self-waiver job keeps pull-requests: write in both advisory-convergence workflow copies', () => {
+  for (const path of REQUIRED_PATHS) {
+    const text = readWorkflow(path);
+    const jobMatch = text.match(/^ {2}idd-advisory-convergence-self-waiver:$/m);
+    assert.ok(
+      jobMatch?.index !== undefined,
+      `${path} must keep the idd-advisory-convergence-self-waiver job`,
+    );
+    const afterJob = text.slice(jobMatch.index + jobMatch[0].length);
+    const nextSibling = afterJob.match(/^ {2}\S/m);
+    const jobBody =
+      nextSibling?.index === undefined
+        ? afterJob
+        : afterJob.slice(0, nextSibling.index);
+    const permissionsMatch = jobBody.match(
+      /^ {4}permissions:\n((?: {6}.*\n)+)/m,
+    );
+    assert.ok(
+      permissionsMatch,
+      `${path}: idd-advisory-convergence-self-waiver job must declare a permissions: block`,
+    );
+    assert.match(
+      permissionsMatch[1],
+      /^ {6}pull-requests: write$/m,
+      `${path}: idd-advisory-convergence-self-waiver job must keep pull-requests: write (kurone-kito/idd-skill#2951 -- without it the marker POST 403s)`,
+    );
+  }
+});
+
 test('comment-refresh workflows are non-required and use a different job id', () => {
   for (const path of COMMENT_PATHS) {
     const text = readWorkflow(path);


### PR DESCRIPTION
# Summary

The `idd-advisory-convergence-self-waiver` job's marker POST to
`issues/<PR_NUMBER>/comments` failed with HTTP 403 "Resource not
accessible by integration" on 11/11 real invocations across 3 PRs
(#2945, #2935, #2926), leaving the self-referential-bootstrap-auto
waiver mechanism from #2657 completely non-functional whenever actually
exercised. This adds `pull-requests: write` to that job's `permissions:`
block (previously `contents: read`, `pull-requests: read`,
`issues: write`) and mirrors the identical fix into `idd-template`'s
own dogfooded copy of the same job, plus a stale doc-line correction.

## Root cause and evidence (not assumed from correlation alone)

The issue body proposed two leads: (1) the repository's
`default_workflow_permissions: "read"` setting, and (2) a missing
`pull-requests: write` grant, evidenced by `post-merge-cleanup.yml`
(which posts to the same `issues/<PR_NUMBER>/comments` endpoint
successfully) granting both `issues: write` and `pull-requests: write`.

Lead 1 was not pursued: a job-level `permissions:` block overrides,
rather than being capped by, the repository default (per GitHub's own
docs, already discussed in #2657's history).

Lead 2's `post-merge-cleanup.yml` comparison turned out to be
**circumstantial, not proof** — an independent critique pass found that
`post-merge-cleanup.yml` actually posts via `gh pr comment` (a
different, higher-level code path), and its `pull-requests: write`
grant is independently justified by unrelated `minimizeComment`
mutations against `PullRequestReview`/`PullRequestReviewComment` nodes,
not by the comment-posting call itself. The analogy could not
discriminate between "this scope is what's needed" and "this workflow
just happens to also need it for something else."

**So the actual root cause was established empirically, with a live A/B
test using an equivalent diagnostic probe job** (`diag-2951-permission-probe`,
committed to this branch and removed before this fix landed), before
this fix merged. Copilot's review of this PR correctly caught that the
probe is a separate job, not the real `idd-advisory-convergence-self-waiver`
job itself — that job is `pull_request_target`-gated and so was skipped
in both dispatched runs below; the probe carried the identical
job-level permissions block and posted to the identical
`issues/<PR_NUMBER>/comments` endpoint, making it equivalent evidence
for the permission question, but not literally an execution of the
production job:

- Run [34697203153](https://github.com/kurone-kito/idd-skill/actions/runs/34697203153)
  reproduced the exact 403 (`gh: Resource not accessible by
  integration (HTTP 403)`) under the probe's then-current permissions
  (`pull-requests: read`, copied from the real job), targeting a real,
  closed PR (#2949).
- Run [34697250102](https://github.com/kurone-kito/idd-skill/actions/runs/34697250102),
  identical in every other respect, succeeded immediately after
  changing only `pull-requests: read` to `pull-requests: write`,
  posting a real comment on PR #2949 (deleted immediately after, since
  it was only a diagnostic probe).

This isolates the one variable that actually matters and confirms
`pull-requests: write` is the necessary grant, independent of whatever
`post-merge-cleanup.yml` happens to also need it for.

## Linked issue

Closes #2951

## Follow-up issues (if any)

- [x] none

## Background / rationale

`external-check-waiver.mts` makes two different `issues/{n}/comments`
calls: a `POST` at line ~1445 (posting the waiver marker to the PR —
the one that 403s and that this fix addresses) and a `GET` at line
~2076-2081 (reading a real linked *issue's* own comment stream to
resolve its active claim, unaffected — that call only ever needed
`issues: read`, which `issues: write` already covers). The workflow
comments and doc line are rewritten to describe this accurately instead
of the disproven "both endpoints are gated under the Issues permission
category alone" framing the original comment used.

`idd-template/.github/workflows/idd-advisory-convergence.yml` carries
the identical job/bug. It is not tracked in `audit/sync-manifest.json`
as an auto-synced pair, but `docs/customization.md` explicitly
describes it as "the portable stub this template ships as your
`.github/workflows/idd-advisory-convergence.yml`" — a real,
intentionally hand-maintained distributed copy — so it gets the same
permissions fix directly.

`idd-template/docs/idd-helper-scripts.md` (the `concreted`-mode sync
source for `docs/idd-helper-scripts.md`) described the job as having
"`issues: write` as its only write permission"; corrected and
regenerated via `node scripts/sync-docs.mjs --apply`.

**Live post-merge verification still pending, by design**: `pull_request_target`
evaluates the *base branch's* copy of the workflow file, so this PR's
own `idd-advisory-convergence-self-waiver` run (if it fires) still uses
`main`'s pre-fix permissions and may still 403 — expected, not a fix
failure, since the pre-merge A/B test above already used
`workflow_dispatch` specifically to get around that limitation safely.
Post-merge verification: the next `pull_request_target`-triggered run
whose diff touches the self-waiver job's own trigger-file allowlist
should show the "Post the self-referential-bootstrap-auto waiver" step
actually succeeding — a genuine self-referential run, not another
dispatched probe. If none occurs naturally within a bounded window, a
minimal throwaway test PR touching an allowlisted file will be opened
to force one, then closed unmerged.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed — this widens a
      `GITHUB_TOKEN` permission grant (`pull-requests: read` →
      `pull-requests: write`) for one job, scoped narrowly to a
      `pull_request_target`-triggered job that never checks out or
      executes PR-authored content (checkout is pinned to `main`); see
      the empirical justification above.

## Verification

- [x] `pnpm lint` (biome check, dprint check, markdownlint-cli2, cspell)
- [x] `pnpm test` (`node --test tests/*.test.mts`: 6341 passed, 0 failed, 3 skipped)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (via `node scripts/sync-docs.mjs --apply`, 1 file synced, 0 drift)
- [x] `node scripts/idd-doctor.mjs` (exit 0, passed with 3 warnings,
      all pre-existing/environmental and unrelated to this diff: missing
      non-default adopter profile files, `worktreeGuard` hook-wiring in
      this local environment, and a post-merge cleanup evidence query
      gap for 2 unrelated historical PRs #2647/#2518)
- [x] Live A/B test against an equivalent diagnostic probe job (see Root cause and evidence above) — the actual verification this fix's correctness rests on.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed — no change to merge policy or gating logic; only a permissions grant on one CI job.
- [x] Context budget impact reviewed — no instruction file changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
