### PR TITLE
chore(ci): throwaway post-merge verification for #2951 (do not merge)

### DIFF
--- a/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/.github/workflows/idd-advisory-convergence-comment.yml
@@ -1,4 +1,7 @@
 # Non-required companion to idd-advisory-convergence.yml (#2136, #2411).
+# (kurone-kito/idd-skill#2951 post-merge verification: this comment-only
+# touch exercises the self-waiver job's allowlist detection on a real
+# pull_request_target run against the fixed main copy; safe to ignore.)
 #
 # Human review-thread and regular-comment chatter must not create or
 # cancel the required `idd-advisory-convergence` check-run. This


### PR DESCRIPTION
Throwaway, comment-only touch of `.github/workflows/idd-advisory-convergence-comment.yml` (on the self-waiver job's own trigger-file allowlist) to exercise a real `pull_request_target` run of `idd-advisory-convergence-self-waiver` against `main`'s now-merged permissions fix (#2954, closing #2951). This confirms the "Post the self-referential-bootstrap-auto waiver" step actually succeeds on the fixed copy, not just a dispatched A/B probe. Will be closed unmerged once confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)